### PR TITLE
Issue 92: Making an integer constant assignable to number{inf}

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/typesystem.mps
@@ -2439,6 +2439,59 @@
                   </node>
                 </node>
               </node>
+              <node concept="3clFbH" id="AYZEgqdxjn" role="3cqZAp" />
+              <node concept="3SKdUt" id="AYZEgqdCQO" role="3cqZAp">
+                <node concept="3SKdUq" id="AYZEgqdCQQ" role="3SKWNk">
+                  <property role="3SKdUp" value="Probably a number should be a subtype of all numbers with the same" />
+                </node>
+              </node>
+              <node concept="3SKdUt" id="AYZEgqdD3N" role="3cqZAp">
+                <node concept="3SKdUq" id="AYZEgqdD3P" role="3SKWNk">
+                  <property role="3SKdUp" value="range or larger range and the same or higher precision" />
+                </node>
+              </node>
+              <node concept="3SKdUt" id="AYZEgqdDeK" role="3cqZAp">
+                <node concept="3SKdUq" id="AYZEgqdDeM" role="3SKWNk">
+                  <property role="3SKdUp" value="however I am not sure it is possible to represent that in MPS" />
+                </node>
+              </node>
+              <node concept="3cpWs8" id="AYZEgqdxtu" role="3cqZAp">
+                <node concept="3cpWsn" id="AYZEgqdxtv" role="3cpWs9">
+                  <property role="TrG5h" value="ntWithInfinitePrecision" />
+                  <node concept="3Tqbb2" id="AYZEgqdxtw" role="1tU5fm">
+                    <ref role="ehGHo" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                  </node>
+                  <node concept="2ShNRf" id="AYZEgqdxtx" role="33vP2m">
+                    <node concept="3zrR0B" id="AYZEgqdxty" role="2ShVmc">
+                      <node concept="3Tqbb2" id="AYZEgqdxtz" role="3zrR0E">
+                        <ref role="ehGHo" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="AYZEgqdzlo" role="3cqZAp">
+                <node concept="2OqwBi" id="AYZEgqdzK1" role="3clFbG">
+                  <node concept="37vLTw" id="AYZEgqdzlm" role="2Oq$k0">
+                    <ref role="3cqZAo" node="AYZEgqdxtv" resolve="ntWithInfinitePrecision" />
+                  </node>
+                  <node concept="2qgKlT" id="AYZEgqd$00" role="2OqNvi">
+                    <ref role="37wK5l" to="b1h1:7Wa2sv3G6bK" resolve="setInfinitePrecision" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="AYZEgqdxtC" role="3cqZAp">
+                <node concept="2OqwBi" id="AYZEgqdxtD" role="3clFbG">
+                  <node concept="37vLTw" id="AYZEgqdxtE" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7Wa2sv3FXgQ" resolve="supers" />
+                  </node>
+                  <node concept="TSZUe" id="AYZEgqdxtF" role="2OqNvi">
+                    <node concept="37vLTw" id="AYZEgqdxtG" role="25WWJ7">
+                      <ref role="3cqZAo" node="AYZEgqdxtv" resolve="ntWithInfinitePrecision" />
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
             <node concept="2OqwBi" id="3gjm1nJOgVi" role="3clFbw">
               <node concept="1YBJjd" id="3gjm1nJOgVj" role="2Oq$k0">

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -4323,8 +4323,30 @@
             </node>
           </node>
         </node>
+        <node concept="_ixoA" id="AYZEgqaDv0" role="_iOnC" />
+        <node concept="2zPypq" id="AYZEgqaDqi" role="_iOnC">
+          <property role="TrG5h" value="n1" />
+          <node concept="30bXRB" id="AYZEgqaD$$" role="2zPyp_">
+            <property role="30bXRw" value="10" />
+          </node>
+          <node concept="mLuIC" id="AYZEgqaDzT" role="2zM23F">
+            <node concept="2gteS_" id="AYZEgqaD$5" role="2gteVg">
+              <property role="2gteVv" value="inf" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="AYZEgqaD_h" role="_iOnC">
+          <property role="TrG5h" value="n2" />
+          <node concept="30bXRB" id="AYZEgqaD_i" role="2zPyp_">
+            <property role="30bXRw" value="10.1" />
+          </node>
+          <node concept="mLuIC" id="AYZEgqaD_j" role="2zM23F">
+            <node concept="2gteS_" id="AYZEgqaD_k" role="2gteVg">
+              <property role="2gteVv" value="inf" />
+            </node>
+          </node>
+        </node>
         <node concept="_ixoA" id="7Wa2sv469fk" role="_iOnC" />
-        <node concept="_ixoA" id="12X4Ue62huo" role="_iOnC" />
         <node concept="1aga60" id="12X4Ue62hAJ" role="_iOnC">
           <property role="TrG5h" value="minus1" />
           <node concept="1ahQXy" id="12X4Ue62hF3" role="1ahQWs">


### PR DESCRIPTION
Fix #92

Currently a number with decimal digits is assignable to number{inf} while an integer number is not.  