### PR TITLE
components.core: IBusInstanceAttribute added

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
@@ -6744,5 +6744,35 @@
       <node concept="17QB3L" id="1yY6_Uj8$j$" role="3clF45" />
     </node>
   </node>
+  <node concept="13h7C7" id="5J1JIMjI3Ax">
+    <property role="3GE5qa" value="attributes.specific" />
+    <ref role="13h7C2" to="w9y2:5J1JIMjI3Au" resolve="IBusInstanceAttribute" />
+    <node concept="13hLZK" id="5J1JIMjI3Ay" role="13h7CW">
+      <node concept="3clFbS" id="5J1JIMjI3Az" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="5J1JIMjI3AG" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="canBeUsedUnder" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" node="1WCh2th1Boz" resolve="canBeUsedUnder" />
+      <node concept="3Tm1VV" id="5J1JIMjI3AH" role="1B3o_S" />
+      <node concept="3clFbS" id="5J1JIMjI3AL" role="3clF47">
+        <node concept="3clFbF" id="5J1JIMjI3D1" role="3cqZAp">
+          <node concept="2ShNRf" id="5J1JIMjI3D3" role="3clFbG">
+            <node concept="2HTt$P" id="5J1JIMjI3D4" role="2ShVmc">
+              <node concept="35c_gC" id="5J1JIMjI3D5" role="2HTEbv">
+                <ref role="35c_gD" to="w9y2:5J1JIMjI3Au" resolve="IBusInstanceAttribute" />
+              </node>
+              <node concept="3bZ5Sz" id="5J1JIMjI3D6" role="2HTBi0" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="5J1JIMjI3AM" role="3clF45">
+        <node concept="3bZ5Sz" id="5J1JIMjI3AN" role="A3Ik2" />
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/structure.mps
@@ -1235,5 +1235,13 @@
       <ref role="20lvS9" node="6LfBX8YkpdW" resolve="Port" />
     </node>
   </node>
+  <node concept="PlHQZ" id="5J1JIMjI3Au">
+    <property role="EcuMT" value="6611775651256482206" />
+    <property role="3GE5qa" value="attributes.specific" />
+    <property role="TrG5h" value="IBusInstanceAttribute" />
+    <node concept="PrWs8" id="5J1JIMjI3Av" role="PrDN$">
+      <ref role="PrY4T" node="1WCh2th1BnT" resolve="IConceptSpecificAttribute" />
+    </node>
+  </node>
 </model>
 


### PR DESCRIPTION
Currently there is no interface that allows easily to create attributes which should appear on bus instances. 
This interface can then be easily used for IAttributes, which should be applicable on bus instances.