### PR TITLE
Generalized component constraint

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/constraints.mps
@@ -167,6 +167,9 @@
       </concept>
       <concept id="8866923313515890008" name="jetbrains.mps.lang.smodel.structure.AsNodeOperation" flags="nn" index="FGMqu" />
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
+        <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
+      </concept>
       <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
         <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
@@ -1657,11 +1660,13 @@
               </node>
             </node>
             <node concept="3clFbJ" id="6b_jefnKwiL" role="3cqZAp">
-              <node concept="3clFbC" id="6b_jefnKwiM" role="3clFbw">
-                <node concept="35c_gC" id="6b_jefnKwjd" role="3uHU7w">
-                  <ref role="35c_gD" to="w9y2:x8tpS_RkkP" resolve="ComponentInterface" />
+              <node concept="2OqwBi" id="t09aXuBOzL" role="3clFbw">
+                <node concept="2DD5aU" id="6b_jefnKwjc" role="2Oq$k0" />
+                <node concept="2Zo12i" id="t09aXuBP7r" role="2OqNvi">
+                  <node concept="chp4Y" id="t09aXuBPtz" role="2Zo12j">
+                    <ref role="cht4Q" to="w9y2:6Y_kjZqWvHl" resolve="AbstractComponentInterface" />
+                  </node>
                 </node>
-                <node concept="2DD5aU" id="6b_jefnKwjc" role="3uHU7B" />
               </node>
               <node concept="3clFbS" id="6b_jefnKwiP" role="3clFbx">
                 <node concept="3cpWs6" id="6b_jefnKwiQ" role="3cqZAp">


### PR DESCRIPTION
In the constraint aspect of the Component concept: 
http://127.0.0.1:63320/node?ref=r%3Aa9d6b037-1504-40b0-9d90-6aed1da43430%28org.iets3.components.core.constraints%29%2F7126186526844781745&project=org.iets3.opensource
**a can be parent** constraint is implemented to restrict the creation of several component substructures inside a component. 
Unfortunatelly the constraint is limited to the concept `ComponentInterface` and not `AbstractComponentInterface`. Because of this the constraint is not working inside of hardware components.

This fix generalizes the check to work on `AbstractComponentInterface`.