### PR TITLE
Add AbstractConnectorBase as common super concept for all connectors

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
@@ -1627,7 +1627,7 @@
                             </node>
                             <node concept="v3k3i" id="7Atos1yb5cG" role="2OqNvi">
                               <node concept="chp4Y" id="7Atos1yb5j6" role="v3oSu">
-                                <ref role="cht4Q" to="w9y2:mIQkxg5ZSA" resolve="AbstractConnector" />
+                                <ref role="cht4Q" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
                               </node>
                             </node>
                           </node>
@@ -1688,7 +1688,7 @@
                               </node>
                               <node concept="v3k3i" id="7Atos1ybakX" role="2OqNvi">
                                 <node concept="chp4Y" id="7Atos1ybasL" role="v3oSu">
-                                  <ref role="cht4Q" to="w9y2:mIQkxg5ZSA" resolve="AbstractConnector" />
+                                  <ref role="cht4Q" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
                                 </node>
                               </node>
                             </node>
@@ -2563,7 +2563,7 @@
                                 </node>
                               </node>
                               <node concept="2pIpSj" id="1WCh2thaYZ6" role="2pJxcM">
-                                <ref role="2pIpSl" to="w9y2:4KDeVD8s9U_" resolve="connectorType" />
+                                <ref role="2pIpSl" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
                                 <node concept="36biLy" id="1WCh2thaZhb" role="2pJxcZ">
                                   <node concept="2OqwBi" id="1WCh2thb08z" role="36biLW">
                                     <node concept="2OqwBi" id="1WCh2thaZmG" role="2Oq$k0">
@@ -2657,7 +2657,7 @@
                                   </node>
                                 </node>
                                 <node concept="2pIpSj" id="1WCh2thdtc9" role="2pJxcM">
-                                  <ref role="2pIpSl" to="w9y2:4KDeVD8s9U_" resolve="connectorType" />
+                                  <ref role="2pIpSl" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
                                   <node concept="36biLy" id="1WCh2thdtca" role="2pJxcZ">
                                     <node concept="2OqwBi" id="1WCh2thdtcb" role="36biLW">
                                       <node concept="2OqwBi" id="1WCh2thdtcc" role="2Oq$k0">
@@ -3560,7 +3560,7 @@
             <property role="TrG5h" value="connectedToMe" />
             <node concept="A3Dl8" id="7Atos1y665p" role="1tU5fm">
               <node concept="3Tqbb2" id="7Atos1y665s" role="A3Ik2">
-                <ref role="ehGHo" to="w9y2:mIQkxg5ZSA" resolve="AbstractConnector" />
+                <ref role="ehGHo" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
               </node>
             </node>
             <node concept="2OqwBi" id="7Atos1y666w" role="33vP2m">
@@ -3756,7 +3756,7 @@
         <property role="TrG5h" value="allConnectors" />
         <node concept="A3Dl8" id="7Atos1y641D" role="1tU5fm">
           <node concept="3Tqbb2" id="7Atos1y641P" role="A3Ik2">
-            <ref role="ehGHo" to="w9y2:mIQkxg5ZSA" resolve="AbstractConnector" />
+            <ref role="ehGHo" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
           </node>
         </node>
       </node>
@@ -4242,7 +4242,7 @@
   </node>
   <node concept="13h7C7" id="mIQkxg5ZT3">
     <property role="3GE5qa" value="components.substructure" />
-    <ref role="13h7C2" to="w9y2:mIQkxg5ZSA" resolve="AbstractConnector" />
+    <ref role="13h7C2" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
     <node concept="13i0hz" id="mIQkxg5ZT6" role="13h7CS">
       <property role="TrG5h" value="getPorts" />
       <property role="13i0it" value="true" />
@@ -4257,16 +4257,6 @@
         </node>
       </node>
       <node concept="3clFbS" id="mIQkxg5ZT9" role="3clF47" />
-    </node>
-    <node concept="13i0hz" id="mIQkxg5V$2" role="13h7CS">
-      <property role="TrG5h" value="getGoverningPort" />
-      <property role="13i0it" value="true" />
-      <property role="13i0iv" value="true" />
-      <node concept="3Tm1VV" id="mIQkxg5V$3" role="1B3o_S" />
-      <node concept="3Tqbb2" id="mIQkxg5V_E" role="3clF45">
-        <ref role="ehGHo" to="w9y2:6LfBX8YkpdW" resolve="Port" />
-      </node>
-      <node concept="3clFbS" id="mIQkxg5V$5" role="3clF47" />
     </node>
     <node concept="13i0hz" id="7nsgDAXAO1M" role="13h7CS">
       <property role="TrG5h" value="getOtherPort" />
@@ -4358,101 +4348,26 @@
         </node>
       </node>
     </node>
-    <node concept="13i0hz" id="7Atos1ybm9U" role="13h7CS">
-      <property role="TrG5h" value="treeViewLabel" />
-      <property role="13i0it" value="true" />
-      <property role="13i0iv" value="true" />
-      <node concept="3Tm1VV" id="7Atos1ybm9V" role="1B3o_S" />
-      <node concept="17QB3L" id="7Atos1ybmer" role="3clF45" />
-      <node concept="3clFbS" id="7Atos1ybm9X" role="3clF47" />
-    </node>
-    <node concept="13hLZK" id="mIQkxg5ZT4" role="13h7CW">
-      <node concept="3clFbS" id="mIQkxg5ZT5" role="2VODD2" />
-    </node>
-    <node concept="13i0hz" id="7Atos1yb6nQ" role="13h7CS">
-      <property role="13i0iv" value="false" />
+    <node concept="13i0hz" id="3E8pWteyfZc" role="13h7CS">
       <property role="13i0it" value="false" />
-      <property role="TrG5h" value="getTreeNode" />
-      <ref role="13i0hy" to="hwgx:7NyyyjNtbn2" resolve="getTreeNode" />
-      <node concept="3Tm1VV" id="7Atos1yb6nR" role="1B3o_S" />
-      <node concept="3clFbS" id="7Atos1yb6nW" role="3clF47">
-        <node concept="3clFbF" id="7Atos1yb6px" role="3cqZAp">
-          <node concept="2ShNRf" id="7Atos1yb6pr" role="3clFbG">
-            <node concept="YeOm9" id="7Atos1yb6V5" role="2ShVmc">
-              <node concept="1Y3b0j" id="7Atos1yb6V8" role="YeSDq">
-                <property role="2bfB8j" value="true" />
-                <ref role="1Y3XeK" to="hwgx:7NyyyjNtce8" resolve="NodeTreeViewNode" />
-                <ref role="37wK5l" to="hwgx:9MiAwFBo2R" resolve="NodeTreeViewNode" />
-                <node concept="3Tm1VV" id="7Atos1yb6V9" role="1B3o_S" />
-                <node concept="3clFb_" id="7Atos1yb6Va" role="jymVt">
-                  <property role="TrG5h" value="getChildCountFromModel" />
-                  <property role="1EzhhJ" value="false" />
-                  <node concept="10Oyi0" id="7Atos1yb6Vb" role="3clF45" />
-                  <node concept="3Tm1VV" id="7Atos1yb6Vc" role="1B3o_S" />
-                  <node concept="3clFbS" id="7Atos1yb6Ve" role="3clF47">
-                    <node concept="3clFbF" id="7Atos1yb9my" role="3cqZAp">
-                      <node concept="3cmrfG" id="7Atos1yb9mx" role="3clFbG">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFb_" id="7Atos1yb6Vg" role="jymVt">
-                  <property role="TrG5h" value="getChildrenFromModel" />
-                  <property role="1EzhhJ" value="false" />
-                  <node concept="_YKpA" id="7Atos1yb6Vh" role="3clF45">
-                    <node concept="3uibUv" id="7Atos1yb6Vi" role="_ZDj9">
-                      <ref role="3uigEE" to="hwgx:2bPPn51Sxsu" resolve="AbstractTreeViewNode" />
-                    </node>
-                  </node>
-                  <node concept="3Tm1VV" id="7Atos1yb6Vj" role="1B3o_S" />
-                  <node concept="3clFbS" id="7Atos1yb6Vl" role="3clF47">
-                    <node concept="3clFbF" id="7Atos1yb9Av" role="3cqZAp">
-                      <node concept="10Nm6u" id="7Atos1yb9Au" role="3clFbG" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="13iPFW" id="7Atos1yb7fr" role="37wK5m" />
-                <node concept="BsUDl" id="7Atos1ybmzs" role="37wK5m">
-                  <ref role="37wK5l" node="7Atos1ybm9U" resolve="treeViewLabel" />
-                </node>
-                <node concept="37vLTw" id="7Atos1yb81m" role="37wK5m">
-                  <ref role="3cqZAo" node="7Atos1yb6nX" resolve="cat" />
-                </node>
-                <node concept="2ShNRf" id="7Atos1yb8gS" role="37wK5m">
-                  <node concept="3g6Rrh" id="7Atos1yb914" role="2ShVmc">
-                    <node concept="Xl_RD" id="7Atos1yb8Rr" role="3g7hyw">
-                      <property role="Xl_RC" value="structure" />
-                    </node>
-                    <node concept="17QB3L" id="7Atos1yb8Du" role="3g7fb8" />
-                  </node>
-                </node>
-              </node>
+      <property role="13i0iv" value="false" />
+      <property role="TrG5h" value="getTarget" />
+      <ref role="13i0hy" node="3E8pWteyf_5" resolve="getTarget" />
+      <node concept="3Tm1VV" id="3E8pWteyfZd" role="1B3o_S" />
+      <node concept="3clFbS" id="3E8pWteyfZg" role="3clF47">
+        <node concept="3clFbF" id="3E8pWteyg8d" role="3cqZAp">
+          <node concept="BsUDl" id="3E8pWteyg8c" role="3clFbG">
+            <ref role="37wK5l" node="7nsgDAXAO1M" resolve="getOtherPort" />
+            <node concept="BsUDl" id="3E8pWteyg9v" role="37wK5m">
+              <ref role="37wK5l" node="mIQkxg5V$2" resolve="getGoverningPort" />
             </node>
           </node>
         </node>
       </node>
-      <node concept="37vLTG" id="7Atos1yb6nX" role="3clF46">
-        <property role="TrG5h" value="cat" />
-        <property role="3TUv4t" value="true" />
-        <node concept="17QB3L" id="7Atos1yb6nY" role="1tU5fm" />
-      </node>
-      <node concept="3uibUv" id="3RyTuhdwXQ_" role="3clF45">
-        <ref role="3uigEE" to="hwgx:2bPPn51Sxsu" resolve="AbstractTreeViewNode" />
-      </node>
+      <node concept="3Tqbb2" id="3E8pWteyfZh" role="3clF45" />
     </node>
-    <node concept="13i0hz" id="sTlw1X$JD" role="13h7CS">
-      <property role="13i0iv" value="false" />
-      <property role="13i0it" value="false" />
-      <property role="TrG5h" value="getTypedContextNode" />
-      <ref role="13i0hy" to="pbu6:4fgA7QrKR89" resolve="getTypedContextNode" />
-      <node concept="3Tm1VV" id="sTlw1X$JI" role="1B3o_S" />
-      <node concept="3clFbS" id="sTlw1X$JL" role="3clF47">
-        <node concept="3clFbF" id="sTlw1X_5e" role="3cqZAp">
-          <node concept="13iPFW" id="sTlw1X_5d" role="3clFbG" />
-        </node>
-      </node>
-      <node concept="3Tqbb2" id="sTlw1X$JM" role="3clF45" />
+    <node concept="13hLZK" id="mIQkxg5ZT4" role="13h7CW">
+      <node concept="3clFbS" id="mIQkxg5ZT5" role="2VODD2" />
     </node>
   </node>
   <node concept="13h7C7" id="mIQkxg62Iq">
@@ -5386,7 +5301,7 @@
           <node concept="2ShNRf" id="1WCh2th1D4K" role="3clFbG">
             <node concept="2HTt$P" id="1WCh2th1D4L" role="2ShVmc">
               <node concept="35c_gC" id="1WCh2th1D4M" role="2HTEbv">
-                <ref role="35c_gD" to="w9y2:mIQkxg5ZSA" resolve="AbstractConnector" />
+                <ref role="35c_gD" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
               </node>
               <node concept="3bZ5Sz" id="1WCh2th1D4N" role="2HTBi0" />
             </node>
@@ -6295,7 +6210,7 @@
                             </node>
                             <node concept="v3k3i" id="7Atos1ybSdT" role="2OqNvi">
                               <node concept="chp4Y" id="7Atos1ybSdU" role="v3oSu">
-                                <ref role="cht4Q" to="w9y2:mIQkxg5ZSA" resolve="AbstractConnector" />
+                                <ref role="cht4Q" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
                               </node>
                             </node>
                           </node>
@@ -6376,7 +6291,7 @@
                               </node>
                               <node concept="v3k3i" id="7Atos1ybVRF" role="2OqNvi">
                                 <node concept="chp4Y" id="7Atos1ybVRG" role="v3oSu">
-                                  <ref role="cht4Q" to="w9y2:mIQkxg5ZSA" resolve="AbstractConnector" />
+                                  <ref role="cht4Q" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
                                 </node>
                               </node>
                             </node>
@@ -7032,6 +6947,124 @@
         </node>
       </node>
       <node concept="3Tqbb2" id="cCTPXxodsa" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="3E8pWtexQMI">
+    <property role="3GE5qa" value="components.substructure" />
+    <ref role="13h7C2" to="w9y2:3E8pWtexQKZ" resolve="AbstractConnectorBase" />
+    <node concept="13hLZK" id="3E8pWtexQMJ" role="13h7CW">
+      <node concept="3clFbS" id="3E8pWtexQMK" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="7Atos1ybm9U" role="13h7CS">
+      <property role="TrG5h" value="treeViewLabel" />
+      <property role="13i0it" value="true" />
+      <property role="13i0iv" value="true" />
+      <node concept="3Tm1VV" id="7Atos1ybm9V" role="1B3o_S" />
+      <node concept="17QB3L" id="7Atos1ybmer" role="3clF45" />
+      <node concept="3clFbS" id="7Atos1ybm9X" role="3clF47" />
+    </node>
+    <node concept="13i0hz" id="7Atos1yb6nQ" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="getTreeNode" />
+      <ref role="13i0hy" to="hwgx:7NyyyjNtbn2" resolve="getTreeNode" />
+      <node concept="3Tm1VV" id="7Atos1yb6nR" role="1B3o_S" />
+      <node concept="3clFbS" id="7Atos1yb6nW" role="3clF47">
+        <node concept="3clFbF" id="7Atos1yb6px" role="3cqZAp">
+          <node concept="2ShNRf" id="7Atos1yb6pr" role="3clFbG">
+            <node concept="YeOm9" id="7Atos1yb6V5" role="2ShVmc">
+              <node concept="1Y3b0j" id="7Atos1yb6V8" role="YeSDq">
+                <property role="2bfB8j" value="true" />
+                <ref role="1Y3XeK" to="hwgx:7NyyyjNtce8" resolve="NodeTreeViewNode" />
+                <ref role="37wK5l" to="hwgx:9MiAwFBo2R" resolve="NodeTreeViewNode" />
+                <node concept="3Tm1VV" id="7Atos1yb6V9" role="1B3o_S" />
+                <node concept="3clFb_" id="7Atos1yb6Va" role="jymVt">
+                  <property role="TrG5h" value="getChildCountFromModel" />
+                  <property role="1EzhhJ" value="false" />
+                  <node concept="10Oyi0" id="7Atos1yb6Vb" role="3clF45" />
+                  <node concept="3Tm1VV" id="7Atos1yb6Vc" role="1B3o_S" />
+                  <node concept="3clFbS" id="7Atos1yb6Ve" role="3clF47">
+                    <node concept="3clFbF" id="7Atos1yb9my" role="3cqZAp">
+                      <node concept="3cmrfG" id="7Atos1yb9mx" role="3clFbG">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFb_" id="7Atos1yb6Vg" role="jymVt">
+                  <property role="TrG5h" value="getChildrenFromModel" />
+                  <property role="1EzhhJ" value="false" />
+                  <node concept="_YKpA" id="7Atos1yb6Vh" role="3clF45">
+                    <node concept="3uibUv" id="7Atos1yb6Vi" role="_ZDj9">
+                      <ref role="3uigEE" to="hwgx:2bPPn51Sxsu" resolve="AbstractTreeViewNode" />
+                    </node>
+                  </node>
+                  <node concept="3Tm1VV" id="7Atos1yb6Vj" role="1B3o_S" />
+                  <node concept="3clFbS" id="7Atos1yb6Vl" role="3clF47">
+                    <node concept="3clFbF" id="7Atos1yb9Av" role="3cqZAp">
+                      <node concept="10Nm6u" id="7Atos1yb9Au" role="3clFbG" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="13iPFW" id="7Atos1yb7fr" role="37wK5m" />
+                <node concept="BsUDl" id="7Atos1ybmzs" role="37wK5m">
+                  <ref role="37wK5l" node="7Atos1ybm9U" resolve="treeViewLabel" />
+                </node>
+                <node concept="37vLTw" id="7Atos1yb81m" role="37wK5m">
+                  <ref role="3cqZAo" node="7Atos1yb6nX" resolve="cat" />
+                </node>
+                <node concept="2ShNRf" id="7Atos1yb8gS" role="37wK5m">
+                  <node concept="3g6Rrh" id="7Atos1yb914" role="2ShVmc">
+                    <node concept="Xl_RD" id="7Atos1yb8Rr" role="3g7hyw">
+                      <property role="Xl_RC" value="structure" />
+                    </node>
+                    <node concept="17QB3L" id="7Atos1yb8Du" role="3g7fb8" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7Atos1yb6nX" role="3clF46">
+        <property role="TrG5h" value="cat" />
+        <property role="3TUv4t" value="true" />
+        <node concept="17QB3L" id="7Atos1yb6nY" role="1tU5fm" />
+      </node>
+      <node concept="3uibUv" id="3RyTuhdwXQ_" role="3clF45">
+        <ref role="3uigEE" to="hwgx:2bPPn51Sxsu" resolve="AbstractTreeViewNode" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="sTlw1X$JD" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="getTypedContextNode" />
+      <ref role="13i0hy" to="pbu6:4fgA7QrKR89" resolve="getTypedContextNode" />
+      <node concept="3Tm1VV" id="sTlw1X$JI" role="1B3o_S" />
+      <node concept="3clFbS" id="sTlw1X$JL" role="3clF47">
+        <node concept="3clFbF" id="sTlw1X_5e" role="3cqZAp">
+          <node concept="13iPFW" id="sTlw1X_5d" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="sTlw1X$JM" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="mIQkxg5V$2" role="13h7CS">
+      <property role="TrG5h" value="getGoverningPort" />
+      <property role="13i0it" value="true" />
+      <property role="13i0iv" value="true" />
+      <node concept="3Tm1VV" id="mIQkxg5V$3" role="1B3o_S" />
+      <node concept="3Tqbb2" id="mIQkxg5V_E" role="3clF45">
+        <ref role="ehGHo" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+      </node>
+      <node concept="3clFbS" id="mIQkxg5V$5" role="3clF47" />
+    </node>
+    <node concept="13i0hz" id="3E8pWteyf_5" role="13h7CS">
+      <property role="13i0it" value="true" />
+      <property role="13i0iv" value="true" />
+      <property role="TrG5h" value="getTarget" />
+      <node concept="3Tm1VV" id="3E8pWteyf_6" role="1B3o_S" />
+      <node concept="3Tqbb2" id="3E8pWteyfJt" role="3clF45" />
+      <node concept="3clFbS" id="3E8pWteyf_8" role="3clF47" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
@@ -7078,12 +7078,12 @@
       <node concept="P$JXv" id="430dwquwLvB" role="lGtFl">
         <node concept="TZ5HA" id="430dwquwLvC" role="TZ5H$">
           <node concept="1dT_AC" id="430dwquwLvD" role="1dT_Ay">
-            <property role="1dT_AB" value="Gets the connection target Incase it is a point to point connection this will be a " />
+            <property role="1dT_AB" value="Gets the connection target. In case it is a point to point connection, this will be a " />
           </node>
         </node>
         <node concept="TZ5HA" id="430dwquwTMW" role="TZ5H$">
           <node concept="1dT_AC" id="430dwquwTMX" role="1dT_Ay">
-            <property role="1dT_AB" value="port but it could be an arbitrary target like a bus depending on the connector." />
+            <property role="1dT_AB" value="port, but it could be an arbitrary target like a bus, depending on the connector." />
           </node>
         </node>
         <node concept="x79VA" id="430dwquwLvE" role="3nqlJM">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
@@ -7057,6 +7057,16 @@
         <ref role="ehGHo" to="w9y2:6LfBX8YkpdW" resolve="Port" />
       </node>
       <node concept="3clFbS" id="mIQkxg5V$5" role="3clF47" />
+      <node concept="P$JXv" id="430dwquwUak" role="lGtFl">
+        <node concept="TZ5HA" id="430dwquwUal" role="TZ5H$">
+          <node concept="1dT_AC" id="430dwquwUam" role="1dT_Ay">
+            <property role="1dT_AB" value="Gets the source of the connection. This has to be a port." />
+          </node>
+        </node>
+        <node concept="x79VA" id="430dwquwUan" role="3nqlJM">
+          <property role="x79VB" value="the source port of the connection" />
+        </node>
+      </node>
     </node>
     <node concept="13i0hz" id="3E8pWteyf_5" role="13h7CS">
       <property role="13i0it" value="true" />
@@ -7065,6 +7075,22 @@
       <node concept="3Tm1VV" id="3E8pWteyf_6" role="1B3o_S" />
       <node concept="3Tqbb2" id="3E8pWteyfJt" role="3clF45" />
       <node concept="3clFbS" id="3E8pWteyf_8" role="3clF47" />
+      <node concept="P$JXv" id="430dwquwLvB" role="lGtFl">
+        <node concept="TZ5HA" id="430dwquwLvC" role="TZ5H$">
+          <node concept="1dT_AC" id="430dwquwLvD" role="1dT_Ay">
+            <property role="1dT_AB" value="Gets the connection target Incase it is a point to point connection this will be a " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="430dwquwTMW" role="TZ5H$">
+          <node concept="1dT_AC" id="430dwquwTMX" role="1dT_Ay">
+            <property role="1dT_AB" value="port but it could be an arbitrary target like a bus depending on the connector." />
+          </node>
+        </node>
+        <node concept="x79VA" id="430dwquwLvE" role="3nqlJM">
+          <property role="x79VB" value="the target for the connection. " />
+        </node>
+        <node concept="1Ciki9" id="430dwquwTKx" role="3nqlJM" />
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/constraints.mps
@@ -390,7 +390,7 @@
               <node concept="2OqwBi" id="4KDeVD8sagU" role="37vLTJ">
                 <node concept="3kakTB" id="4KDeVD8saee" role="2Oq$k0" />
                 <node concept="3TrEf2" id="4KDeVD8sanu" role="2OqNvi">
-                  <ref role="3Tt5mk" to="w9y2:4KDeVD8s9U_" resolve="connectorType" />
+                  <ref role="3Tt5mk" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
                 </node>
               </node>
             </node>
@@ -472,7 +472,7 @@
               <node concept="2OqwBi" id="4KDeVD8sbyr" role="37vLTJ">
                 <node concept="3kakTB" id="4KDeVD8sbys" role="2Oq$k0" />
                 <node concept="3TrEf2" id="4KDeVD8sbyt" role="2OqNvi">
-                  <ref role="3Tt5mk" to="w9y2:4KDeVD8s9U_" resolve="connectorType" />
+                  <ref role="3Tt5mk" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
                 </node>
               </node>
             </node>
@@ -691,7 +691,7 @@
               <node concept="2OqwBi" id="4KDeVD8scFE" role="37vLTJ">
                 <node concept="3kakTB" id="4KDeVD8scFF" role="2Oq$k0" />
                 <node concept="3TrEf2" id="4KDeVD8scFG" role="2OqNvi">
-                  <ref role="3Tt5mk" to="w9y2:4KDeVD8s9U_" resolve="connectorType" />
+                  <ref role="3Tt5mk" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
                 </node>
               </node>
             </node>
@@ -772,7 +772,7 @@
               <node concept="2OqwBi" id="4KDeVD8scJS" role="37vLTJ">
                 <node concept="3kakTB" id="4KDeVD8scJT" role="2Oq$k0" />
                 <node concept="3TrEf2" id="4KDeVD8scJU" role="2OqNvi">
-                  <ref role="3Tt5mk" to="w9y2:4KDeVD8s9U_" resolve="connectorType" />
+                  <ref role="3Tt5mk" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
                 </node>
               </node>
             </node>
@@ -898,7 +898,7 @@
               <node concept="2OqwBi" id="4KDeVD8sbZH" role="37vLTJ">
                 <node concept="3kakTB" id="4KDeVD8sbZI" role="2Oq$k0" />
                 <node concept="3TrEf2" id="4KDeVD8sbZJ" role="2OqNvi">
-                  <ref role="3Tt5mk" to="w9y2:4KDeVD8s9U_" resolve="connectorType" />
+                  <ref role="3Tt5mk" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
                 </node>
               </node>
             </node>
@@ -1007,7 +1007,7 @@
               <node concept="2OqwBi" id="4KDeVD8scjO" role="37vLTJ">
                 <node concept="3kakTB" id="4KDeVD8scjP" role="2Oq$k0" />
                 <node concept="3TrEf2" id="4KDeVD8scjQ" role="2OqNvi">
-                  <ref role="3Tt5mk" to="w9y2:4KDeVD8s9U_" resolve="connectorType" />
+                  <ref role="3Tt5mk" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
                 </node>
               </node>
             </node>
@@ -2018,7 +2018,7 @@
               <node concept="2OqwBi" id="1yY6_Uj8qjI" role="37vLTJ">
                 <node concept="3kakTB" id="1yY6_Uj8qjJ" role="2Oq$k0" />
                 <node concept="3TrEf2" id="1yY6_Uj8qjK" role="2OqNvi">
-                  <ref role="3Tt5mk" to="w9y2:4KDeVD8s9U_" resolve="connectorType" />
+                  <ref role="3Tt5mk" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
                 </node>
               </node>
             </node>
@@ -2129,7 +2129,7 @@
               <node concept="2OqwBi" id="1yY6_Uj8svV" role="37vLTJ">
                 <node concept="3kakTB" id="1yY6_Uj8svW" role="2Oq$k0" />
                 <node concept="3TrEf2" id="1yY6_Uj8svX" role="2OqNvi">
-                  <ref role="3Tt5mk" to="w9y2:4KDeVD8s9U_" resolve="connectorType" />
+                  <ref role="3Tt5mk" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
                 </node>
               </node>
             </node>
@@ -2561,8 +2561,8 @@
                   </node>
                 </node>
                 <node concept="v3k3i" id="5$ENVmWEijI" role="2OqNvi">
-                  <node concept="chp4Y" id="5$ENVmWEiBl" role="v3oSu">
-                    <ref role="cht4Q" to="w9y2:mIQkxg5ZSA" resolve="AbstractConnector" />
+                  <node concept="chp4Y" id="3E8pWteB3fG" role="v3oSu">
+                    <ref role="cht4Q" to="w9y2:3E8pWtexQKZ" resolve="AbstractConnectorBase" />
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
@@ -2550,7 +2550,7 @@
                                 <node concept="2pJPED" id="5aWcZMNoPmw" role="2pJPEn">
                                   <ref role="2pJxaS" to="w9y2:7Zvsa54vnWq" resolve="AssemblyConnector" />
                                   <node concept="2pIpSj" id="5aWcZMNoPmx" role="2pJxcM">
-                                    <ref role="2pIpSl" to="w9y2:4KDeVD8s9U_" resolve="connectorType" />
+                                    <ref role="2pIpSl" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
                                     <node concept="36biLy" id="5aWcZMNoPmy" role="2pJxcZ">
                                       <node concept="2OqwBi" id="5aWcZMNoPmz" role="36biLW">
                                         <node concept="2OqwBi" id="5aWcZMNoPm$" role="2Oq$k0">
@@ -2680,7 +2680,7 @@
                                   <node concept="2pJPED" id="5aWcZMNoQfw" role="2pJPEn">
                                     <ref role="2pJxaS" to="w9y2:7Zvsa54vnWq" resolve="AssemblyConnector" />
                                     <node concept="2pIpSj" id="5aWcZMNoQfx" role="2pJxcM">
-                                      <ref role="2pIpSl" to="w9y2:4KDeVD8s9U_" resolve="connectorType" />
+                                      <ref role="2pIpSl" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
                                       <node concept="36biLy" id="5aWcZMNoQfy" role="2pJxcZ">
                                         <node concept="2OqwBi" id="5aWcZMNoQfz" role="36biLW">
                                           <node concept="2OqwBi" id="5aWcZMNoQf$" role="2Oq$k0">
@@ -5703,7 +5703,7 @@
                                   <node concept="2pJPED" id="5aWcZMNs1ko" role="2pJPEn">
                                     <ref role="2pJxaS" to="w9y2:7Zvsa54vnWq" resolve="AssemblyConnector" />
                                     <node concept="2pIpSj" id="5aWcZMNs1kp" role="2pJxcM">
-                                      <ref role="2pIpSl" to="w9y2:4KDeVD8s9U_" resolve="connectorType" />
+                                      <ref role="2pIpSl" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
                                       <node concept="36biLy" id="5aWcZMNs1kq" role="2pJxcZ">
                                         <node concept="2OqwBi" id="5aWcZMNs1kr" role="36biLW">
                                           <node concept="2OqwBi" id="5aWcZMNs1ks" role="2Oq$k0">
@@ -5833,7 +5833,7 @@
                                     <node concept="2pJPED" id="5aWcZMNs1zL" role="2pJPEn">
                                       <ref role="2pJxaS" to="w9y2:7Zvsa54vnWq" resolve="AssemblyConnector" />
                                       <node concept="2pIpSj" id="5aWcZMNs1zM" role="2pJxcM">
-                                        <ref role="2pIpSl" to="w9y2:4KDeVD8s9U_" resolve="connectorType" />
+                                        <ref role="2pIpSl" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
                                         <node concept="36biLy" id="5aWcZMNs1zN" role="2pJxcZ">
                                           <node concept="2OqwBi" id="5aWcZMNs1zO" role="36biLW">
                                             <node concept="2OqwBi" id="5aWcZMNs1zP" role="2Oq$k0">
@@ -11525,7 +11525,7 @@
                       <node concept="2pJPED" id="5aWcZMNfXhx" role="2pJPEn">
                         <ref role="2pJxaS" to="w9y2:cJpacq1tb1" resolve="ImportConnector" />
                         <node concept="2pIpSj" id="5aWcZMNfXhy" role="2pJxcM">
-                          <ref role="2pIpSl" to="w9y2:4KDeVD8s9U_" resolve="connectorType" />
+                          <ref role="2pIpSl" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
                           <node concept="36biLy" id="5aWcZMNfXhz" role="2pJxcZ">
                             <node concept="2OqwBi" id="5aWcZMNfXh$" role="36biLW">
                               <node concept="2OqwBi" id="5aWcZMNfXh_" role="2Oq$k0">
@@ -11643,7 +11643,7 @@
                         <node concept="2pJPED" id="5aWcZMNfZm6" role="2pJPEn">
                           <ref role="2pJxaS" to="w9y2:cJpacq2_os" resolve="ExportConnector" />
                           <node concept="2pIpSj" id="5aWcZMNfZm7" role="2pJxcM">
-                            <ref role="2pIpSl" to="w9y2:4KDeVD8s9U_" resolve="connectorType" />
+                            <ref role="2pIpSl" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
                             <node concept="36biLy" id="5aWcZMNfZm8" role="2pJxcZ">
                               <node concept="2OqwBi" id="5aWcZMNfZm9" role="36biLW">
                                 <node concept="2OqwBi" id="5aWcZMNfZma" role="2Oq$k0">
@@ -11762,7 +11762,7 @@
                     <node concept="2pJPED" id="5aWcZMNfZUR" role="2pJPEn">
                       <ref role="2pJxaS" to="w9y2:1yY6_Uj8oYm" resolve="DelegateConnector" />
                       <node concept="2pIpSj" id="5aWcZMNfZUS" role="2pJxcM">
-                        <ref role="2pIpSl" to="w9y2:4KDeVD8s9U_" resolve="connectorType" />
+                        <ref role="2pIpSl" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
                         <node concept="36biLy" id="5aWcZMNfZUT" role="2pJxcZ">
                           <node concept="2OqwBi" id="5aWcZMNfZUU" role="36biLW">
                             <node concept="2OqwBi" id="5aWcZMNfZUV" role="2Oq$k0">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/migration.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/migration.mps
@@ -5,6 +5,7 @@
     <use id="90746344-04fd-4286-97d5-b46ae6a81709" name="jetbrains.mps.lang.migration" version="0" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="0" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="8" />
+    <use id="9882f4ad-1955-46fe-8269-94189e5dbbf2" name="jetbrains.mps.lang.migration.util" version="0" />
   </languages>
   <imports>
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
@@ -124,6 +125,11 @@
         <child id="6911370362349121514" name="languageIdentity" index="2x4n5j" />
       </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="8415841354032330471" name="jetbrains.mps.lang.smodel.structure.ContainmentLinkId" flags="ng" index="HUanS">
+        <property id="8415841354032330474" name="linkName" index="HUanP" />
+        <property id="8415841354032330473" name="linkId" index="HUanQ" />
+        <child id="8415841354032330472" name="conceptIdentity" index="HUanR" />
+      </concept>
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
@@ -154,7 +160,10 @@
       </concept>
     </language>
     <language id="90746344-04fd-4286-97d5-b46ae6a81709" name="jetbrains.mps.lang.migration">
-      <concept id="3116305438947623354" name="jetbrains.mps.lang.migration.structure.MoveContainmentLink" flags="ng" index="7a1rN" />
+      <concept id="3116305438947623354" name="jetbrains.mps.lang.migration.structure.MoveContainmentLink" flags="ng" index="7a1rN">
+        <child id="8415841354033040054" name="targetId" index="HTpAD" />
+        <child id="8415841354033040053" name="sourceId" index="HTpAE" />
+      </concept>
       <concept id="3116305438947623350" name="jetbrains.mps.lang.migration.structure.MoveConcept" flags="ng" index="7a1rZ">
         <child id="8415841354030700269" name="targetId" index="HKsnM" />
         <child id="8415841354030700266" name="sourceId" index="HKsnP" />
@@ -1065,6 +1074,751 @@
     <node concept="3tTeZs" id="x8tpSAX$so" role="jymVt">
       <property role="3tTeZt" value="&lt;no result checking&gt;" />
       <ref role="3tTeZr" to="slm6:1JWcQ2VeXpD" resolve="check" />
+    </node>
+  </node>
+  <node concept="W$Crc" id="3E8pWtey2he">
+    <property role="3GE5qa" value="refactoring" />
+    <property role="W$Cri" value="2" />
+    <property role="TrG5h" value="RefactoringLog_2" />
+    <node concept="1w76tK" id="3E8pWtey2hf" role="1w76sc">
+      <node concept="1w76tN" id="3E8pWtey2hg" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.updateModelImports" />
+        <property role="1w7ld4" value="Update model imports" />
+      </node>
+      <node concept="1w76tN" id="3E8pWtey2hh" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.updateReferencesParticipant" />
+        <property role="1w7ld4" value="Update references" />
+      </node>
+      <node concept="1w76tN" id="3E8pWtey2hi" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.writeRefactoringLog" />
+        <property role="1w7ld4" value="Write refactoring log" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2hk" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2h6" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841609850" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="treeViewLabel" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2hj" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841609850" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="treeViewLabel" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2hm" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2h7" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841609851" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="PublicVisibility@8043" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2hl" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841609851" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="PublicVisibility@8043" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2ho" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2h8" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841610139" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="StringType@7691" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2hn" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841610139" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="StringType@7691" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2hq" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2h9" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841609853" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="StatementList@8045" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2hp" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841609853" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="StatementList@8045" />
+      </node>
+    </node>
+  </node>
+  <node concept="W$Crc" id="3E8pWtey2$N">
+    <property role="3GE5qa" value="refactoring" />
+    <property role="W$Cri" value="3" />
+    <property role="TrG5h" value="RefactoringLog_3" />
+    <node concept="1w76tK" id="3E8pWtey2$O" role="1w76sc">
+      <node concept="1w76tN" id="3E8pWtey2$P" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.updateModelImports" />
+        <property role="1w7ld4" value="Update model imports" />
+      </node>
+      <node concept="1w76tN" id="3E8pWtey2$Q" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.updateReferencesParticipant" />
+        <property role="1w7ld4" value="Update references" />
+      </node>
+      <node concept="1w76tN" id="3E8pWtey2$R" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.writeRefactoringLog" />
+        <property role="1w7ld4" value="Write refactoring log" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2$T" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2zP" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841545206" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="getTreeNode" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2$S" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841545206" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="getTreeNode" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2$V" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2zQ" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841545207" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="PublicVisibility@8168" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2$U" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841545207" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="PublicVisibility@8168" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2$X" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2zR" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841545212" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="StatementList@8173" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2$W" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841545212" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="StatementList@8173" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2$Z" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2zS" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841545313" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ExpressionStatement@9042" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2$Y" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841545313" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ExpressionStatement@9042" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_1" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2zT" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841545307" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="GenericNewExpression@9036" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_0" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841545307" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="GenericNewExpression@9036" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_3" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2zU" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841547461" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="AnonymousClassCreator@10934" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_2" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841547461" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="AnonymousClassCreator@10934" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_5" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2zV" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841547464" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="NodeTreeViewNode$anonymous" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_4" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841547464" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="NodeTreeViewNode$anonymous" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_7" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2zW" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841547465" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="PublicVisibility@10938" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_6" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841547465" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="PublicVisibility@10938" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_9" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2zX" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841547466" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="getChildCountFromModel" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_8" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841547466" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="getChildCountFromModel" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_b" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2zY" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841547467" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="IntegerType@10940" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_a" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841547467" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="IntegerType@10940" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_d" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2zZ" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841547468" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="PublicVisibility@10941" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_c" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841547468" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="PublicVisibility@10941" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_f" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$0" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841547470" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="StatementList@10943" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_e" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841547470" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="StatementList@10943" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_h" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$1" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841557410" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ExpressionStatement@69651" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_g" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841557410" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ExpressionStatement@69651" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_j" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$2" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841557409" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="IntegerConstant@69650" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_i" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841557409" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="IntegerConstant@69650" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_l" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$3" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841547472" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="getChildrenFromModel" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_k" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841547472" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="getChildrenFromModel" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_n" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$4" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841547473" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ListType@10946" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_m" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841547473" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ListType@10946" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_p" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$5" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841547474" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ClassifierType@10947" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_o" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841547474" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ClassifierType@10947" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_r" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$6" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841547475" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="PublicVisibility@10948" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_q" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841547475" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="PublicVisibility@10948" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_t" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$7" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841547477" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="StatementList@10950" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_s" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841547477" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="StatementList@10950" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_v" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$8" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841558431" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ExpressionStatement@70672" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_u" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841558431" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ExpressionStatement@70672" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_x" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$9" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841558430" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="NullLiteral@70671" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_w" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841558430" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="NullLiteral@70671" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_z" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$a" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841548763" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ThisNodeExpression@11724" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_y" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841548763" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ThisNodeExpression@11724" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2__" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$b" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841611484" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="LocalBehaviorMethodCall@9420" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_$" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841611484" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="LocalBehaviorMethodCall@9420" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_B" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$c" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841551958" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="VariableReference@64839" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_A" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841551958" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="VariableReference@64839" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_D" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$d" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841552952" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="GenericNewExpression@65961" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_C" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841552952" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="GenericNewExpression@65961" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_F" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$e" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841556036" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ArrayCreatorWithInitializer@68917" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_E" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841556036" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ArrayCreatorWithInitializer@68917" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_H" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$f" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841555419" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="structure" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_G" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841555419" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="structure" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_J" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$g" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841554526" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="StringType@67407" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_I" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841554526" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="StringType@67407" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_L" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$h" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841545213" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="cat" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_K" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841545213" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="cat" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_N" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$i" role="hSBgu">
+        <property role="2pBcoG" value="8763267928841545214" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="StringType@8175" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_M" role="hSBgs">
+        <property role="2pBcoG" value="8763267928841545214" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="StringType@8175" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2_P" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2$j" role="hSBgu">
+        <property role="2pBcoG" value="4459379349766004133" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ClassifierType@43170" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2_O" role="hSBgs">
+        <property role="2pBcoG" value="4459379349766004133" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ClassifierType@43170" />
+      </node>
+    </node>
+  </node>
+  <node concept="W$Crc" id="3E8pWtey2JS">
+    <property role="3GE5qa" value="refactoring" />
+    <property role="W$Cri" value="4" />
+    <property role="TrG5h" value="RefactoringLog_4" />
+    <node concept="1w76tK" id="3E8pWtey2JT" role="1w76sc">
+      <node concept="1w76tN" id="3E8pWtey2JU" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.updateModelImports" />
+        <property role="1w7ld4" value="Update model imports" />
+      </node>
+      <node concept="1w76tN" id="3E8pWtey2JV" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.updateReferencesParticipant" />
+        <property role="1w7ld4" value="Update references" />
+      </node>
+      <node concept="1w76tN" id="3E8pWtey2JW" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.writeRefactoringLog" />
+        <property role="1w7ld4" value="Write refactoring log" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2JY" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2JG" role="hSBgu">
+        <property role="2pBcoG" value="8133465500699625" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="getTypedContextNode" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2JX" role="hSBgs">
+        <property role="2pBcoG" value="8133465500699625" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="getTypedContextNode" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2K0" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2JH" role="hSBgu">
+        <property role="2pBcoG" value="8133465500699630" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="PublicVisibility@45216" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2JZ" role="hSBgs">
+        <property role="2pBcoG" value="8133465500699630" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="PublicVisibility@45216" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2K2" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2JI" role="hSBgu">
+        <property role="2pBcoG" value="8133465500699633" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="StatementList@45203" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2K1" role="hSBgs">
+        <property role="2pBcoG" value="8133465500699633" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="StatementList@45203" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2K4" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2JJ" role="hSBgu">
+        <property role="2pBcoG" value="8133465500701006" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ExpressionStatement@46592" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2K3" role="hSBgs">
+        <property role="2pBcoG" value="8133465500701006" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ExpressionStatement@46592" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2K6" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2JK" role="hSBgu">
+        <property role="2pBcoG" value="8133465500701005" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ThisNodeExpression@46591" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2K5" role="hSBgs">
+        <property role="2pBcoG" value="8133465500701005" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="ThisNodeExpression@46591" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2K8" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2JL" role="hSBgu">
+        <property role="2pBcoG" value="8133465500699634" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="SNodeType@45204" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2K7" role="hSBgs">
+        <property role="2pBcoG" value="8133465500699634" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="SNodeType@45204" />
+      </node>
+    </node>
+  </node>
+  <node concept="W$Crc" id="3E8pWtey2T4">
+    <property role="3GE5qa" value="refactoring" />
+    <property role="W$Cri" value="5" />
+    <property role="TrG5h" value="RefactoringLog_5" />
+    <node concept="1w76tK" id="3E8pWtey2T5" role="1w76sc">
+      <node concept="1w76tN" id="3E8pWtey2T6" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.updateModelImports" />
+        <property role="1w7ld4" value="Update model imports" />
+      </node>
+      <node concept="1w76tN" id="3E8pWtey2T7" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.updateReferencesParticipant" />
+        <property role="1w7ld4" value="Update references" />
+      </node>
+      <node concept="1w76tN" id="3E8pWtey2T8" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.writeRefactoringLog" />
+        <property role="1w7ld4" value="Write refactoring log" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2Ta" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2SW" role="hSBgu">
+        <property role="2pBcoG" value="409503520741898498" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="getGoverningPort" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2T9" role="hSBgs">
+        <property role="2pBcoG" value="409503520741898498" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="getGoverningPort" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2Tc" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2SX" role="hSBgu">
+        <property role="2pBcoG" value="409503520741898499" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="PublicVisibility@46596" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2Tb" role="hSBgs">
+        <property role="2pBcoG" value="409503520741898499" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="PublicVisibility@46596" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2Te" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2SY" role="hSBgu">
+        <property role="2pBcoG" value="409503520741898602" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="SNodeType@46555" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2Td" role="hSBgs">
+        <property role="2pBcoG" value="409503520741898602" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="SNodeType@46555" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey2Tg" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey2SZ" role="hSBgu">
+        <property role="2pBcoG" value="409503520741898501" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="StatementList@46598" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey2Tf" role="hSBgs">
+        <property role="2pBcoG" value="409503520741898501" />
+        <property role="2pBcow" value="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
+        <property role="2pBc3U" value="StatementList@46598" />
+      </node>
+    </node>
+  </node>
+  <node concept="Z5qvL" id="3E8pWtey3cd">
+    <property role="Z5qvQ" value="6" />
+    <property role="TrG5h" value="MigrationScript_6" />
+    <node concept="Z4OXk" id="3E8pWtey3co" role="Z5rET">
+      <node concept="2pBcaW" id="3E8pWtey3cm" role="Z5P1v">
+        <property role="2pBcoG" value="5487983292192956069" />
+        <property role="2pBcow" value="r:b3786745-c763-4a49-a754-f84e15236f18(org.iets3.components.core.structure)" />
+        <property role="2pBc3U" value="connectorType_old" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey3cn" role="Z5P1t">
+        <property role="2pBcoG" value="4217735156746171148" />
+        <property role="2pBcow" value="r:b3786745-c763-4a49-a754-f84e15236f18(org.iets3.components.core.structure)" />
+        <property role="2pBc3U" value="connectorType" />
+      </node>
+      <node concept="7a1rN" id="3E8pWtey3cl" role="7agGg">
+        <node concept="HUanS" id="3E8pWtey3cf" role="HTpAE">
+          <property role="HUanP" value="connectorType" />
+          <property role="HUanQ" value="15p0vprmq3545" />
+          <node concept="2x4n5u" id="3E8pWtey3cg" role="HUanR">
+            <property role="2x4mPI" value="AbstractConnector" />
+            <property role="2x4o5l" value="false" />
+            <property role="2x4n5l" value="3404vscu5j52" />
+            <node concept="2V$Bhx" id="3E8pWtey3ch" role="2x4n5j">
+              <property role="2V$B1T" value="f0fd486f-8577-43e9-b671-3d118449c6e7" />
+              <property role="2V$B1Q" value="org.iets3.components.core" />
+            </node>
+          </node>
+        </node>
+        <node concept="HUanS" id="3E8pWtey3ci" role="HTpAD">
+          <property role="HUanP" value="connectorType" />
+          <property role="HUanQ" value="w1liby4g0zd8" />
+          <node concept="2x4n5u" id="3E8pWtey3cj" role="HUanR">
+            <property role="2x4mPI" value="AbstractConnectorBase" />
+            <property role="2x4o5l" value="false" />
+            <property role="2x4n5l" value="w1liby4fzw3j" />
+            <node concept="2V$Bhx" id="3E8pWtey3ck" role="2x4n5j">
+              <property role="2V$B1T" value="f0fd486f-8577-43e9-b671-3d118449c6e7" />
+              <property role="2V$B1Q" value="org.iets3.components.core" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="W$Crc" id="3E8pWtey3cp">
+    <property role="3GE5qa" value="refactoring" />
+    <property role="W$Cri" value="6" />
+    <property role="TrG5h" value="RefactoringLog_6" />
+    <node concept="1w76tK" id="3E8pWtey3cq" role="1w76sc">
+      <node concept="1w76tN" id="3E8pWtey3cr" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.updateLocalInstances" />
+        <property role="1w7ld4" value="Update instances in current project" />
+      </node>
+      <node concept="1w76tN" id="3E8pWtey3cs" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.updateModelImports" />
+        <property role="1w7ld4" value="Update model imports" />
+      </node>
+      <node concept="1w76tN" id="3E8pWtey3ct" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.updateReferencesParticipant" />
+        <property role="1w7ld4" value="Update references" />
+      </node>
+      <node concept="1w76tN" id="3E8pWtey3cu" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.writeMigrationScript" />
+        <property role="1w7ld4" value="Write migration script" />
+      </node>
+      <node concept="1w76tN" id="3E8pWtey3cv" role="1w76tQ">
+        <property role="1w76tO" value="moveNode.options.writeRefactoringLog" />
+        <property role="1w7ld4" value="Write refactoring log" />
+      </node>
+    </node>
+    <node concept="7amoh" id="3E8pWtey3cx" role="W$Crh">
+      <property role="hSBgo" value="moveNode.updateReferences" />
+      <node concept="2pBcaW" id="3E8pWtey3ca" role="hSBgu">
+        <property role="2pBcoG" value="5487983292192956069" />
+        <property role="2pBcow" value="r:b3786745-c763-4a49-a754-f84e15236f18(org.iets3.components.core.structure)" />
+        <property role="2pBc3U" value="connectorType" />
+      </node>
+      <node concept="2pBcaW" id="3E8pWtey3cw" role="hSBgs">
+        <property role="2pBcoG" value="4217735156746171148" />
+        <property role="2pBcow" value="r:b3786745-c763-4a49-a754-f84e15236f18(org.iets3.components.core.structure)" />
+        <property role="2pBc3U" value="connectorType" />
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/structure.mps
@@ -3,6 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources" version="2" />
+    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="6" />
     <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
   <imports>
@@ -37,6 +38,7 @@
       </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <property id="4628067390765907488" name="conceptShortDescription" index="R4oN_" />
         <property id="4628067390765956807" name="final" index="R5$K2" />
         <property id="4628067390765956802" name="abstract" index="R5$K7" />
         <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
@@ -377,7 +379,7 @@
     <property role="TrG5h" value="AssemblyConnector" />
     <property role="34LRSv" value="connect" />
     <property role="EcuMT" value="9214207200564444954" />
-    <ref role="1TJDcQ" node="mIQkxg5ZSA" resolve="AbstractConnector" />
+    <ref role="1TJDcQ" node="mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
     <node concept="1TJgyj" id="7Zvsa54vwqx" role="1TKVEi">
       <property role="20lmBu" value="aggregation" />
       <property role="20kJfa" value="sourceInstance" />
@@ -429,7 +431,7 @@
     <property role="R5$K7" value="true" />
     <property role="R5$K2" value="false" />
     <property role="EcuMT" value="229512757698220727" />
-    <ref role="1TJDcQ" node="mIQkxg5ZSA" resolve="AbstractConnector" />
+    <ref role="1TJDcQ" node="mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
   </node>
   <node concept="1TIwiD" id="cJpacq6wur">
     <property role="TrG5h" value="Parameter" />
@@ -735,32 +737,21 @@
   </node>
   <node concept="1TIwiD" id="mIQkxg5ZSA">
     <property role="3GE5qa" value="components.substructure" />
-    <property role="TrG5h" value="AbstractConnector" />
+    <property role="TrG5h" value="AbstractPortToPortConnector" />
     <property role="R5$K7" value="true" />
     <property role="R5$K2" value="false" />
     <property role="EcuMT" value="409503520741916198" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <property role="R4oN_" value="base conecpt for all port to port connections" />
+    <ref role="1TJDcQ" node="3E8pWtexQKZ" resolve="AbstractConnectorBase" />
     <node concept="1TJgyj" id="4KDeVD8s9U_" role="1TKVEi">
       <property role="20lmBu" value="aggregation" />
-      <property role="20kJfa" value="connectorType" />
-      <property role="20lbJX" value="1" />
+      <property role="20kJfa" value="connectorType_old" />
+      <property role="20lbJX" value="0..1" />
       <property role="IQ2ns" value="5487983292192956069" />
       <ref role="20lvS9" node="4KDeVD8s9RL" resolve="IConnectorType" />
-    </node>
-    <node concept="PrWs8" id="mIQkxg5ZSB" role="PzmwI">
-      <ref role="PrY4T" node="siw10FiR6c" resolve="ISubstructureContent" />
-    </node>
-    <node concept="PrWs8" id="mIQkxg5ZSC" role="PzmwI">
-      <ref role="PrY4T" to="138:3NBP8_OgMVd" resolve="IAttributed" />
-    </node>
-    <node concept="PrWs8" id="7Atos1yb6hI" role="PzmwI">
-      <ref role="PrY4T" to="vs0r:7NyyyjNt9Bq" resolve="ITreeViewable" />
-    </node>
-    <node concept="PrWs8" id="181CQfpgIRw" role="PzmwI">
-      <ref role="PrY4T" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
-    </node>
-    <node concept="PrWs8" id="1sE2eU6FIup" role="PzmwI">
-      <ref role="PrY4T" to="hm2y:4fgA7QrKSas" resolve="IContextTypeProvider" />
+      <node concept="asaX9" id="3E8pWtey3ce" role="lGtFl">
+        <property role="YLQ7P" value="The link was moved to concept &quot;org.iets3.components.core.structure.AbstractConnectorBase&quot;" />
+      </node>
     </node>
   </node>
   <node concept="PlHQZ" id="4KDeVD8s9RL">
@@ -1287,7 +1278,7 @@
       <property role="IQ2ns" value="7538439817525137839" />
       <property role="20lmBu" value="reference" />
       <property role="20kJfa" value="abstractConnector" />
-      <ref role="20lvS9" node="mIQkxg5ZSA" resolve="AbstractConnector" />
+      <ref role="20lvS9" node="3E8pWtexQKZ" resolve="AbstractConnectorBase" />
     </node>
     <node concept="PrWs8" id="6ytULbsfL6F" role="PzmwI">
       <ref role="PrY4T" node="6ytULbseDPa" resolve="IConnectorExprType" />
@@ -1302,7 +1293,7 @@
       <property role="20lmBu" value="reference" />
       <property role="20kJfa" value="connector" />
       <property role="20lbJX" value="1" />
-      <ref role="20lvS9" node="mIQkxg5ZSA" resolve="AbstractConnector" />
+      <ref role="20lvS9" node="3E8pWtexQKZ" resolve="AbstractConnectorBase" />
     </node>
     <node concept="PrWs8" id="cCTPXxodrj" role="PzmwI">
       <ref role="PrY4T" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
@@ -1325,6 +1316,37 @@
     <property role="TrG5h" value="IConnectorExprType" />
     <node concept="PrWs8" id="5$ENVmWE4en" role="PrDN$">
       <ref role="PrY4T" to="4kwy:3QX5db_zRnt" resolve="ITypeWithTarget" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="3E8pWtexQKZ">
+    <property role="EcuMT" value="4217735156746120255" />
+    <property role="3GE5qa" value="components.substructure" />
+    <property role="TrG5h" value="AbstractConnectorBase" />
+    <property role="R5$K7" value="true" />
+    <property role="R5$K2" value="false" />
+    <property role="R4oN_" value="generic connector for all kinds of connections that at least have source port" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="3E8pWtexQLM" role="PzmwI">
+      <ref role="PrY4T" node="siw10FiR6c" resolve="ISubstructureContent" />
+    </node>
+    <node concept="PrWs8" id="3E8pWtexQLN" role="PzmwI">
+      <ref role="PrY4T" to="138:3NBP8_OgMVd" resolve="IAttributed" />
+    </node>
+    <node concept="PrWs8" id="3E8pWtexQLO" role="PzmwI">
+      <ref role="PrY4T" to="vs0r:7NyyyjNt9Bq" resolve="ITreeViewable" />
+    </node>
+    <node concept="PrWs8" id="3E8pWtexQLP" role="PzmwI">
+      <ref role="PrY4T" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+    </node>
+    <node concept="PrWs8" id="3E8pWtexQLQ" role="PzmwI">
+      <ref role="PrY4T" to="hm2y:4fgA7QrKSas" resolve="IContextTypeProvider" />
+    </node>
+    <node concept="1TJgyj" id="3E8pWtey3cc" role="1TKVEi">
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="connectorType" />
+      <property role="20lbJX" value="1" />
+      <property role="IQ2ns" value="4217735156746171148" />
+      <ref role="20lvS9" node="4KDeVD8s9RL" resolve="IConnectorType" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/structure.mps
@@ -741,7 +741,7 @@
     <property role="R5$K7" value="true" />
     <property role="R5$K2" value="false" />
     <property role="EcuMT" value="409503520741916198" />
-    <property role="R4oN_" value="base conecpt for all port to port connections" />
+    <property role="R4oN_" value="base connector for all port to port connections" />
     <ref role="1TJDcQ" node="3E8pWtexQKZ" resolve="AbstractConnectorBase" />
     <node concept="1TJgyj" id="4KDeVD8s9U_" role="1TKVEi">
       <property role="20lmBu" value="aggregation" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/typesystem.mps
@@ -1061,6 +1061,29 @@
         </node>
       </node>
       <node concept="3clFbJ" id="cJpacq1X9h" role="3cqZAp">
+        <node concept="3fqX7Q" id="cJpacq1X9m" role="3clFbw">
+          <node concept="2OqwBi" id="cJpacq1X9n" role="3fr31v">
+            <node concept="2OqwBi" id="cJpacq1X9o" role="2Oq$k0">
+              <node concept="37vLTw" id="7nsgDAXAPVC" role="2Oq$k0">
+                <ref role="3cqZAo" node="7nsgDAXAPzA" resolve="o" />
+              </node>
+              <node concept="3TrEf2" id="cJpacq1X9s" role="2OqNvi">
+                <ref role="3Tt5mk" to="w9y2:6LfBX8YlAdM" resolve="type" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="cJpacq1X9t" role="2OqNvi">
+              <ref role="37wK5l" to="3eba:cJpacq1kKx" resolve="isCompatibleWithGoverningType" />
+              <node concept="2OqwBi" id="cJpacq1X9u" role="37wK5m">
+                <node concept="37vLTw" id="7nsgDAXAPXU" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7nsgDAXAPpv" resolve="g" />
+                </node>
+                <node concept="3TrEf2" id="cJpacq1X9y" role="2OqNvi">
+                  <ref role="3Tt5mk" to="w9y2:6LfBX8YlAdM" resolve="type" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbS" id="cJpacq1X9i" role="3clFbx">
           <node concept="2MkqsV" id="cJpacq1X9j" role="3cqZAp">
             <node concept="1YBJjd" id="7nsgDAXAQsB" role="2OEOjV">
@@ -1096,34 +1119,11 @@
             </node>
           </node>
         </node>
-        <node concept="3fqX7Q" id="cJpacq1X9m" role="3clFbw">
-          <node concept="2OqwBi" id="cJpacq1X9n" role="3fr31v">
-            <node concept="2OqwBi" id="cJpacq1X9o" role="2Oq$k0">
-              <node concept="37vLTw" id="7nsgDAXAPVC" role="2Oq$k0">
-                <ref role="3cqZAo" node="7nsgDAXAPzA" resolve="o" />
-              </node>
-              <node concept="3TrEf2" id="cJpacq1X9s" role="2OqNvi">
-                <ref role="3Tt5mk" to="w9y2:6LfBX8YlAdM" resolve="type" />
-              </node>
-            </node>
-            <node concept="2qgKlT" id="cJpacq1X9t" role="2OqNvi">
-              <ref role="37wK5l" to="3eba:cJpacq1kKx" resolve="isCompatibleWithGoverningType" />
-              <node concept="2OqwBi" id="cJpacq1X9u" role="37wK5m">
-                <node concept="37vLTw" id="7nsgDAXAPXU" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7nsgDAXAPpv" resolve="g" />
-                </node>
-                <node concept="3TrEf2" id="cJpacq1X9y" role="2OqNvi">
-                  <ref role="3Tt5mk" to="w9y2:6LfBX8YlAdM" resolve="type" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
       </node>
     </node>
     <node concept="1YaCAy" id="7nsgDAXAQl0" role="1YuTPh">
       <property role="TrG5h" value="c" />
-      <ref role="1YaFvo" to="w9y2:mIQkxg5ZSA" resolve="AbstractConnector" />
+      <ref role="1YaFvo" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
     </node>
   </node>
   <node concept="18kY7G" id="1WCh2theaXm">
@@ -2281,7 +2281,7 @@
           <property role="TrG5h" value="allConnectors" />
           <node concept="A3Dl8" id="PFqDnRU9qm" role="1tU5fm">
             <node concept="3Tqbb2" id="PFqDnRU9qp" role="A3Ik2">
-              <ref role="ehGHo" to="w9y2:mIQkxg5ZSA" resolve="AbstractConnector" />
+              <ref role="ehGHo" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
             </node>
           </node>
           <node concept="2OqwBi" id="PFqDnRU9q$" role="33vP2m">
@@ -2293,7 +2293,7 @@
             </node>
             <node concept="v3k3i" id="PFqDnRU9qC" role="2OqNvi">
               <node concept="chp4Y" id="PFqDnRU9qD" role="v3oSu">
-                <ref role="cht4Q" to="w9y2:mIQkxg5ZSA" resolve="AbstractConnector" />
+                <ref role="cht4Q" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
               </node>
             </node>
           </node>
@@ -2465,7 +2465,7 @@
     </node>
   </node>
   <node concept="1YbPZF" id="6ytULbsfLwI">
-    <property role="TrG5h" value="typeof_AbstractConnector" />
+    <property role="TrG5h" value="typeof_AbstractConnectorBase" />
     <property role="3GE5qa" value="components.substructure" />
     <node concept="3clFbS" id="6ytULbsfLwJ" role="18ibNy">
       <node concept="1Z5TYs" id="6ytULbsfLP1" role="3cqZAp">
@@ -2477,7 +2477,7 @@
                 <ref role="2pIpSl" to="w9y2:6ytULbsfL6J" resolve="abstractConnector" />
                 <node concept="36biLy" id="6ytULbsfLTi" role="2pJxcZ">
                   <node concept="1YBJjd" id="6ytULbsfLTx" role="36biLW">
-                    <ref role="1YBMHb" node="6ytULbsfLwL" resolve="abstractConnector" />
+                    <ref role="1YBMHb" node="6ytULbsfLwL" resolve="abstractConnectorBase" />
                   </node>
                 </node>
               </node>
@@ -2487,15 +2487,15 @@
         <node concept="mw_s8" id="6ytULbsfLP4" role="1ZfhK$">
           <node concept="1Z2H0r" id="6ytULbsfLxd" role="mwGJk">
             <node concept="1YBJjd" id="6ytULbsfLz3" role="1Z2MuG">
-              <ref role="1YBMHb" node="6ytULbsfLwL" resolve="abstractConnector" />
+              <ref role="1YBMHb" node="6ytULbsfLwL" resolve="abstractConnectorBase" />
             </node>
           </node>
         </node>
       </node>
     </node>
     <node concept="1YaCAy" id="6ytULbsfLwL" role="1YuTPh">
-      <property role="TrG5h" value="abstractConnector" />
-      <ref role="1YaFvo" to="w9y2:mIQkxg5ZSA" resolve="AbstractConnector" />
+      <property role="TrG5h" value="abstractConnectorBase" />
+      <ref role="1YaFvo" to="w9y2:3E8pWtexQKZ" resolve="AbstractConnectorBase" />
     </node>
   </node>
   <node concept="1YbPZF" id="cCTPXxsOGW">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/org.iets3.components.core.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/org.iets3.components.core.mpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<language namespace="org.iets3.components.core" uuid="f0fd486f-8577-43e9-b671-3d118449c6e7" languageVersion="6" moduleVersion="2">
+<language namespace="org.iets3.components.core" uuid="f0fd486f-8577-43e9-b671-3d118449c6e7" languageVersion="7" moduleVersion="7">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
@@ -45,7 +45,7 @@
         <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
         <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
         <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="0" />
-        <module reference="f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)" version="2" />
+        <module reference="f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)" version="7" />
         <module reference="67d267be-0b8c-4abc-b09c-4f514397ea65(org.iets3.components.core#7804632404593231268)" version="0" />
         <module reference="583939be-ded0-4735-a055-a74f8477fc34(org.iets3.core.attributes)" version="0" />
         <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
@@ -158,7 +158,7 @@
     <module reference="8fe4c62a-2020-4ff4-8eda-f322a55bdc9f(jetbrains.mps.refactoring.runtime)" version="0" />
     <module reference="e6368d5c-b931-4d4d-9941-07b7da7d2e2d(jetbrains.mps.tool.builder)" version="0" />
     <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="0" />
-    <module reference="f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)" version="2" />
+    <module reference="f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)" version="7" />
     <module reference="583939be-ded0-4735-a055-a74f8477fc34(org.iets3.core.attributes)" version="0" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
     <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.plugin/org.iets3.components.plugin.msd
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.plugin/org.iets3.components.plugin.msd
@@ -58,7 +58,7 @@
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
     <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="0" />
-    <module reference="f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)" version="2" />
+    <module reference="f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)" version="7" />
     <module reference="7e09f312-66d1-4b1d-91cb-92e8984cbbe2(org.iets3.components.plugin)" version="0" />
     <module reference="583939be-ded0-4735-a055-a74f8477fc34(org.iets3.core.attributes)" version="0" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.req/org.iets3.components.req.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.req/org.iets3.components.req.mpl
@@ -137,7 +137,7 @@
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
     <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="0" />
-    <module reference="f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)" version="2" />
+    <module reference="f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)" version="7" />
     <module reference="49321c7a-31be-4a86-8e8e-5cdcee1237ba(org.iets3.components.req)" version="0" />
     <module reference="583939be-ded0-4735-a055-a74f8477fc34(org.iets3.core.attributes)" version="0" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/test.iest3.component.attribute.mpl
+++ b/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/test.iest3.component.attribute.mpl
@@ -61,7 +61,7 @@
         <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
         <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
         <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="0" />
-        <module reference="f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)" version="2" />
+        <module reference="f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)" version="7" />
         <module reference="583939be-ded0-4735-a055-a74f8477fc34(org.iets3.core.attributes)" version="0" />
         <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
         <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="0" />
@@ -145,7 +145,7 @@
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
     <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="0" />
-    <module reference="f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)" version="2" />
+    <module reference="f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)" version="7" />
     <module reference="583939be-ded0-4735-a055-a74f8477fc34(org.iets3.core.attributes)" version="0" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
     <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/test.iets3.core.assessment/test.iets3.core.tracequery.msd
+++ b/code/languages/org.iets3.opensource/solutions/test.iets3.core.assessment/test.iets3.core.tracequery.msd
@@ -75,7 +75,7 @@
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
     <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="0" />
-    <module reference="f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)" version="2" />
+    <module reference="f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)" version="7" />
     <module reference="be5191a9-3476-47ca-b2a7-a426623add55(org.iets3.core.assessment)" version="0" />
     <module reference="583939be-ded0-4735-a055-a74f8477fc34(org.iets3.core.attributes)" version="0" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/test.ts.components.core/models/tests@tests.mps
+++ b/code/languages/org.iets3.opensource/solutions/test.ts.components.core/models/tests@tests.mps
@@ -134,11 +134,11 @@
         <child id="409503520730247653" name="category" index="1aMMyH" />
         <child id="7804632404594156402" name="type" index="1i6vMw" />
       </concept>
-      <concept id="409503520741916198" name="org.iets3.components.core.structure.AbstractConnector" flags="ng" index="1lIitI">
-        <child id="5487983292192956069" name="connectorType" index="4mqkv" />
-      </concept>
       <concept id="227686178023855820" name="org.iets3.components.core.structure.AbstractConnectorRefTarget" flags="ng" index="1yi36j">
         <reference id="227686178023855923" name="connector" index="1yi31G" />
+      </concept>
+      <concept id="4217735156746120255" name="" flags="ng" index="1O3KJS">
+        <child id="4217735156746171148" name="" index="1O05jb" />
       </concept>
       <concept id="2244552513301308396" name="org.iets3.components.core.structure.PortRefTarget" flags="ng" index="1WbEdM">
         <reference id="2244552513301308399" name="port" index="1WbEdL" />
@@ -413,7 +413,7 @@
           <node concept="VCwY8" id="48ZWgAGwl4P" role="2bBTn9">
             <ref role="VCwYn" node="48ZWgAGs_tY" resolve="innerCmp" />
           </node>
-          <node concept="3IJI2w" id="48ZWgAGwl52" role="4mqkv" />
+          <node concept="3IJI2w" id="48ZWgAGwl52" role="1O05jb" />
         </node>
         <node concept="2bBTn8" id="48ZWgAGwlq1" role="GnABu">
           <ref role="2bBTn4" node="48ZWgAGwgMh" resolve="a" />
@@ -421,7 +421,7 @@
           <node concept="VCwY8" id="48ZWgAGwlqn" role="2bBTn9">
             <ref role="VCwYn" node="48ZWgAGwlpj" resolve="innerCmp2" />
           </node>
-          <node concept="3IJI2w" id="48ZWgAGwlq3" role="4mqkv" />
+          <node concept="3IJI2w" id="48ZWgAGwlq3" role="1O05jb" />
         </node>
         <node concept="GnyP7" id="48ZWgAGwgKy" role="GnABu" />
       </node>

--- a/code/languages/org.iets3.opensource/solutions/test.ts.components.core/test.ts.components.core.msd
+++ b/code/languages/org.iets3.opensource/solutions/test.ts.components.core/test.ts.components.core.msd
@@ -70,7 +70,7 @@
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
     <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="0" />
-    <module reference="f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)" version="2" />
+    <module reference="f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)" version="7" />
     <module reference="583939be-ded0-4735-a055-a74f8477fc34(org.iets3.core.attributes)" version="0" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
     <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="0" />


### PR DESCRIPTION
comp: introduce base concept for all kind of connectors  …
In order to allow a more abstract representation of connectors for a new
connector `AbstractConnectorBase` was introduced. This concept assumes
that at least a source port (governing port) exists. The target for this
connector is still a abstract node. It is usefull in cases where a the
target of the connection is a bus or some other target that is not a port.

In additon the `AbstractConnector` was renamed to `AbstractPortToPortConnector`
It is a specialisation of the `AbstractConnectorBase` which asumes a that
the connection is made between two ports. Most of the behaviour methods
and interface implementations have been moved up to `AbstractConnectorBase`.

The `AbstractConnectorRefTarget` was changed to point to a `AbstractConnectorBase`.

Also the typesystem rules from `AbstractConnector` are moved up to the
`AbstractConnectorBase` except for the checking rule that checks the port
to port connection.