### PR TITLE
Allow kind aware scope calculation of ComponentInstances

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
@@ -8,7 +8,6 @@
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="-1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="-1" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="-1" />
-    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -253,11 +252,19 @@
       <concept id="5858074156537516430" name="jetbrains.mps.baseLanguage.javadoc.structure.ReturnBlockDocTag" flags="ng" index="x79VA">
         <property id="5858074156537516431" name="text" index="x79VB" />
       </concept>
+      <concept id="6832197706140518104" name="jetbrains.mps.baseLanguage.javadoc.structure.DocMethodParameterReference" flags="ng" index="zr_55" />
+      <concept id="6832197706140518103" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseParameterReference" flags="ng" index="zr_5a">
+        <reference id="6832197706140518108" name="param" index="zr_51" />
+      </concept>
       <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
         <child id="8465538089690331502" name="body" index="TZ5H$" />
         <child id="5383422241790532083" name="tags" index="3nqlJM" />
       </concept>
       <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690881930" name="jetbrains.mps.baseLanguage.javadoc.structure.ParameterBlockDocTag" flags="ng" index="TUZQ0">
+        <property id="8465538089690881934" name="text" index="TUZQ4" />
+        <child id="6832197706140518123" name="parameter" index="zr_5Q" />
+      </concept>
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
         <child id="8970989240999019149" name="part" index="1dT_Ay" />
       </concept>
@@ -322,6 +329,7 @@
       <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
         <reference id="1139877738879" name="concept" index="1A0vxQ" />
       </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1240170042401" name="jetbrains.mps.lang.smodel.structure.SEnumMemberType" flags="in" index="2ZThk1">
         <reference id="1240170836027" name="enum" index="2ZWj4r" />
       </concept>
@@ -341,6 +349,9 @@
       </concept>
       <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
@@ -358,6 +369,9 @@
         <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
       <concept id="1172420572800" name="jetbrains.mps.lang.smodel.structure.ConceptNodeType" flags="in" index="3THzug" />
+      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
+        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -2083,6 +2097,188 @@
               </node>
             </node>
           </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="3gB6VSKScig" role="13h7CS">
+      <property role="TrG5h" value="visibleComponents" />
+      <property role="13i0it" value="true" />
+      <node concept="3Tm1VV" id="3gB6VSKScih" role="1B3o_S" />
+      <node concept="3clFbS" id="3gB6VSKScij" role="3clF47">
+        <node concept="3cpWs8" id="3gB6VSKSsjS" role="3cqZAp">
+          <node concept="3cpWsn" id="3gB6VSKSsjT" role="3cpWs9">
+            <property role="TrG5h" value="ctxtComp" />
+            <node concept="3Tqbb2" id="3gB6VSKSsjR" role="1tU5fm">
+              <ref role="ehGHo" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+            </node>
+            <node concept="2OqwBi" id="3gB6VSKSsjU" role="33vP2m">
+              <node concept="13iPFW" id="3gB6VSKSsjV" role="2Oq$k0" />
+              <node concept="2Xjw5R" id="3gB6VSKSsjW" role="2OqNvi">
+                <node concept="1xMEDy" id="3gB6VSKSsjX" role="1xVPHs">
+                  <node concept="chp4Y" id="3gB6VSKSsjY" role="ri$Ld">
+                    <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3gB6VSKSytG" role="3cqZAp">
+          <node concept="3cpWsn" id="3gB6VSKSytH" role="3cpWs9">
+            <property role="TrG5h" value="visibleComps" />
+            <node concept="A3Dl8" id="3gB6VSKSytd" role="1tU5fm">
+              <node concept="3Tqbb2" id="3gB6VSKSytg" role="A3Ik2">
+                <ref role="ehGHo" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3gB6VSKSytI" role="33vP2m">
+              <node concept="2OqwBi" id="3gB6VSKSytJ" role="2Oq$k0">
+                <node concept="2OqwBi" id="3gB6VSKSytK" role="2Oq$k0">
+                  <node concept="2OqwBi" id="3gB6VSKSytL" role="2Oq$k0">
+                    <node concept="13iPFW" id="3gB6VSKSytM" role="2Oq$k0" />
+                    <node concept="2Xjw5R" id="3gB6VSKSytN" role="2OqNvi">
+                      <node concept="1xMEDy" id="3gB6VSKSytO" role="1xVPHs">
+                        <node concept="chp4Y" id="3gB6VSKSytP" role="ri$Ld">
+                          <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="3gB6VSKSytQ" role="2OqNvi">
+                    <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
+                    <node concept="3TUQnm" id="3gB6VSKSytR" role="37wK5m">
+                      <ref role="3TV0OU" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3zZkjj" id="3gB6VSKSytS" role="2OqNvi">
+                  <node concept="1bVj0M" id="3gB6VSKSytT" role="23t8la">
+                    <node concept="3clFbS" id="3gB6VSKSytU" role="1bW5cS">
+                      <node concept="3clFbF" id="3gB6VSKSytV" role="3cqZAp">
+                        <node concept="3y3z36" id="3gB6VSKSytW" role="3clFbG">
+                          <node concept="37vLTw" id="3gB6VSKSytX" role="3uHU7w">
+                            <ref role="3cqZAo" node="3gB6VSKSsjT" resolve="ctxtComp" />
+                          </node>
+                          <node concept="37vLTw" id="3gB6VSKSytY" role="3uHU7B">
+                            <ref role="3cqZAo" node="3gB6VSKSytZ" resolve="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="3gB6VSKSytZ" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="3gB6VSKSyu0" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="v3k3i" id="3gB6VSKSyu1" role="2OqNvi">
+                <node concept="chp4Y" id="3gB6VSKSyu2" role="v3oSu">
+                  <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3gB6VSLcFhQ" role="3cqZAp" />
+        <node concept="3cpWs6" id="3gB6VSKSzHU" role="3cqZAp">
+          <node concept="2OqwBi" id="3gB6VSLcIBZ" role="3cqZAk">
+            <node concept="37vLTw" id="3gB6VSLcIC0" role="2Oq$k0">
+              <ref role="3cqZAo" node="3gB6VSKSytH" resolve="visibleComps" />
+            </node>
+            <node concept="3zZkjj" id="3gB6VSLcIC1" role="2OqNvi">
+              <node concept="1bVj0M" id="3gB6VSLcIC2" role="23t8la">
+                <node concept="3clFbS" id="3gB6VSLcIC3" role="1bW5cS">
+                  <node concept="3cpWs8" id="3gB6VSLdyQL" role="3cqZAp">
+                    <node concept="3cpWsn" id="3gB6VSLdyQM" role="3cpWs9">
+                      <property role="TrG5h" value="containerKind" />
+                      <node concept="3Tqbb2" id="3gB6VSLdyQI" role="1tU5fm">
+                        <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
+                      </node>
+                      <node concept="2OqwBi" id="3gB6VSLdyQN" role="33vP2m">
+                        <node concept="37vLTw" id="3gB6VSLdyQO" role="2Oq$k0">
+                          <ref role="3cqZAo" node="3gB6VSLcIC9" resolve="it" />
+                        </node>
+                        <node concept="3TrEf2" id="3gB6VSLdyQP" role="2OqNvi">
+                          <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="3gB6VSLcIC4" role="3cqZAp">
+                    <node concept="2OqwBi" id="3gB6VSLdvJ7" role="3clFbG">
+                      <node concept="13iPFW" id="3gB6VSLdvrI" role="2Oq$k0" />
+                      <node concept="2qgKlT" id="3gB6VSLdwY0" role="2OqNvi">
+                        <ref role="37wK5l" node="3gB6VSKS$k6" resolve="isAllowedContentKind" />
+                        <node concept="37vLTw" id="3gB6VSLdyQQ" role="37wK5m">
+                          <ref role="3cqZAo" node="3gB6VSLdyQM" resolve="containerKind" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="3gB6VSLcIC9" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="3gB6VSLcICa" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="3gB6VSKSqOs" role="3clF45">
+        <node concept="3Tqbb2" id="3gB6VSKSqOv" role="A3Ik2">
+          <ref role="ehGHo" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="3gB6VSKS$6z" role="lGtFl">
+        <node concept="TZ5HA" id="3gB6VSKS$6$" role="TZ5H$">
+          <node concept="1dT_AC" id="3gB6VSKS$6_" role="1dT_Ay">
+            <property role="1dT_AB" value="This method is used in the scope calculation of the ComponentRef." />
+          </node>
+        </node>
+        <node concept="x79VA" id="3gB6VSKS$6A" role="3nqlJM">
+          <property role="x79VB" value="a list of components that should be allowed inside the context component" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="3gB6VSKS$k6" role="13h7CS">
+      <property role="TrG5h" value="isAllowedContentKind" />
+      <property role="13i0it" value="true" />
+      <node concept="37vLTG" id="3gB6VSKS$zj" role="3clF46">
+        <property role="TrG5h" value="compKind" />
+        <node concept="3Tqbb2" id="3gB6VSKTQOY" role="1tU5fm">
+          <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3gB6VSKS$k7" role="1B3o_S" />
+      <node concept="3clFbS" id="3gB6VSKS$k9" role="3clF47">
+        <node concept="3cpWs6" id="3gB6VSKSB$b" role="3cqZAp">
+          <node concept="3clFbT" id="3gB6VSKSB$d" role="3cqZAk">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="3gB6VSKS$z7" role="3clF45" />
+      <node concept="P$JXv" id="3gB6VSKSBA7" role="lGtFl">
+        <node concept="TZ5HA" id="3gB6VSKSBA8" role="TZ5H$">
+          <node concept="1dT_AC" id="3gB6VSKSBA9" role="1dT_Ay">
+            <property role="1dT_AB" value="By default this implementation allows the usage of any kind inside &quot;this&quot; kind." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="3gB6VSLdUMB" role="TZ5H$">
+          <node concept="1dT_AC" id="3gB6VSLdUMC" role="1dT_Ay">
+            <property role="1dT_AB" value="To customize the scope of ComponentRef provide your own implementation." />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="3gB6VSKSBAa" role="3nqlJM">
+          <property role="TUZQ4" value="the component " />
+          <node concept="zr_55" id="3gB6VSKSBAc" role="zr_5Q">
+            <ref role="zr_51" node="3gB6VSKS$zj" resolve="compKind" />
+          </node>
+        </node>
+        <node concept="x79VA" id="3gB6VSKSBAd" role="3nqlJM">
+          <property role="x79VB" value="true if the kind of the passed component is allowed" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
@@ -329,7 +329,6 @@
       <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
         <reference id="1139877738879" name="concept" index="1A0vxQ" />
       </concept>
-      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1240170042401" name="jetbrains.mps.lang.smodel.structure.SEnumMemberType" flags="in" index="2ZThk1">
         <reference id="1240170836027" name="enum" index="2ZWj4r" />
       </concept>
@@ -349,9 +348,6 @@
       </concept>
       <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
-      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
-        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
-      </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
@@ -369,9 +365,6 @@
         <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
       <concept id="1172420572800" name="jetbrains.mps.lang.smodel.structure.ConceptNodeType" flags="in" index="3THzug" />
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
-      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -2055,6 +2048,42 @@
           <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
         </node>
       </node>
+      <node concept="P$JXv" id="2B42b1rDKv9" role="lGtFl">
+        <node concept="TZ5HA" id="2B42b1rDKva" role="TZ5H$">
+          <node concept="1dT_AC" id="2B42b1rDKvb" role="1dT_Ay">
+            <property role="1dT_AB" value="By default only elements with the same component kind can be used." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="2B42b1rDK$9" role="TZ5H$">
+          <node concept="1dT_AC" id="2B42b1rDK$a" role="1dT_Ay">
+            <property role="1dT_AB" value="All other component kinds are resticted away from the scope." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="2B42b1rDK$u" role="TZ5H$">
+          <node concept="1dT_AC" id="2B42b1rDK$v" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="2B42b1rDKzQ" role="TZ5H$">
+          <node concept="1dT_AC" id="2B42b1rDKzR" role="1dT_Ay">
+            <property role="1dT_AB" value="Override this method in specialied ComponentKinds to customize scope " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="2B42b1rDK$P" role="TZ5H$">
+          <node concept="1dT_AC" id="2B42b1rDK$Q" role="1dT_Ay">
+            <property role="1dT_AB" value="calculation" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="2B42b1rDKvc" role="3nqlJM">
+          <property role="TUZQ4" value="kind" />
+          <node concept="zr_55" id="2B42b1rDKve" role="zr_5Q">
+            <ref role="zr_51" node="6LfBX8Yllec" resolve="contextKind" />
+          </node>
+        </node>
+        <node concept="x79VA" id="2B42b1rDKvf" role="3nqlJM">
+          <property role="x79VB" value="evaluated condition under which surcomstances this kind can be used in a context" />
+        </node>
+      </node>
     </node>
     <node concept="13i0hz" id="33B7rHqxSMr" role="13h7CS">
       <property role="TrG5h" value="canBeInContent" />
@@ -2097,188 +2126,6 @@
               </node>
             </node>
           </node>
-        </node>
-      </node>
-    </node>
-    <node concept="13i0hz" id="3gB6VSKScig" role="13h7CS">
-      <property role="TrG5h" value="visibleComponents" />
-      <property role="13i0it" value="true" />
-      <node concept="3Tm1VV" id="3gB6VSKScih" role="1B3o_S" />
-      <node concept="3clFbS" id="3gB6VSKScij" role="3clF47">
-        <node concept="3cpWs8" id="3gB6VSKSsjS" role="3cqZAp">
-          <node concept="3cpWsn" id="3gB6VSKSsjT" role="3cpWs9">
-            <property role="TrG5h" value="ctxtComp" />
-            <node concept="3Tqbb2" id="3gB6VSKSsjR" role="1tU5fm">
-              <ref role="ehGHo" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
-            </node>
-            <node concept="2OqwBi" id="3gB6VSKSsjU" role="33vP2m">
-              <node concept="13iPFW" id="3gB6VSKSsjV" role="2Oq$k0" />
-              <node concept="2Xjw5R" id="3gB6VSKSsjW" role="2OqNvi">
-                <node concept="1xMEDy" id="3gB6VSKSsjX" role="1xVPHs">
-                  <node concept="chp4Y" id="3gB6VSKSsjY" role="ri$Ld">
-                    <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="3gB6VSKSytG" role="3cqZAp">
-          <node concept="3cpWsn" id="3gB6VSKSytH" role="3cpWs9">
-            <property role="TrG5h" value="visibleComps" />
-            <node concept="A3Dl8" id="3gB6VSKSytd" role="1tU5fm">
-              <node concept="3Tqbb2" id="3gB6VSKSytg" role="A3Ik2">
-                <ref role="ehGHo" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="3gB6VSKSytI" role="33vP2m">
-              <node concept="2OqwBi" id="3gB6VSKSytJ" role="2Oq$k0">
-                <node concept="2OqwBi" id="3gB6VSKSytK" role="2Oq$k0">
-                  <node concept="2OqwBi" id="3gB6VSKSytL" role="2Oq$k0">
-                    <node concept="13iPFW" id="3gB6VSKSytM" role="2Oq$k0" />
-                    <node concept="2Xjw5R" id="3gB6VSKSytN" role="2OqNvi">
-                      <node concept="1xMEDy" id="3gB6VSKSytO" role="1xVPHs">
-                        <node concept="chp4Y" id="3gB6VSKSytP" role="ri$Ld">
-                          <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2qgKlT" id="3gB6VSKSytQ" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                    <node concept="3TUQnm" id="3gB6VSKSytR" role="37wK5m">
-                      <ref role="3TV0OU" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3zZkjj" id="3gB6VSKSytS" role="2OqNvi">
-                  <node concept="1bVj0M" id="3gB6VSKSytT" role="23t8la">
-                    <node concept="3clFbS" id="3gB6VSKSytU" role="1bW5cS">
-                      <node concept="3clFbF" id="3gB6VSKSytV" role="3cqZAp">
-                        <node concept="3y3z36" id="3gB6VSKSytW" role="3clFbG">
-                          <node concept="37vLTw" id="3gB6VSKSytX" role="3uHU7w">
-                            <ref role="3cqZAo" node="3gB6VSKSsjT" resolve="ctxtComp" />
-                          </node>
-                          <node concept="37vLTw" id="3gB6VSKSytY" role="3uHU7B">
-                            <ref role="3cqZAo" node="3gB6VSKSytZ" resolve="it" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="Rh6nW" id="3gB6VSKSytZ" role="1bW2Oz">
-                      <property role="TrG5h" value="it" />
-                      <node concept="2jxLKc" id="3gB6VSKSyu0" role="1tU5fm" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="v3k3i" id="3gB6VSKSyu1" role="2OqNvi">
-                <node concept="chp4Y" id="3gB6VSKSyu2" role="v3oSu">
-                  <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="3gB6VSLcFhQ" role="3cqZAp" />
-        <node concept="3cpWs6" id="3gB6VSKSzHU" role="3cqZAp">
-          <node concept="2OqwBi" id="3gB6VSLcIBZ" role="3cqZAk">
-            <node concept="37vLTw" id="3gB6VSLcIC0" role="2Oq$k0">
-              <ref role="3cqZAo" node="3gB6VSKSytH" resolve="visibleComps" />
-            </node>
-            <node concept="3zZkjj" id="3gB6VSLcIC1" role="2OqNvi">
-              <node concept="1bVj0M" id="3gB6VSLcIC2" role="23t8la">
-                <node concept="3clFbS" id="3gB6VSLcIC3" role="1bW5cS">
-                  <node concept="3cpWs8" id="3gB6VSLdyQL" role="3cqZAp">
-                    <node concept="3cpWsn" id="3gB6VSLdyQM" role="3cpWs9">
-                      <property role="TrG5h" value="containerKind" />
-                      <node concept="3Tqbb2" id="3gB6VSLdyQI" role="1tU5fm">
-                        <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
-                      </node>
-                      <node concept="2OqwBi" id="3gB6VSLdyQN" role="33vP2m">
-                        <node concept="37vLTw" id="3gB6VSLdyQO" role="2Oq$k0">
-                          <ref role="3cqZAo" node="3gB6VSLcIC9" resolve="it" />
-                        </node>
-                        <node concept="3TrEf2" id="3gB6VSLdyQP" role="2OqNvi">
-                          <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="3gB6VSLcIC4" role="3cqZAp">
-                    <node concept="2OqwBi" id="3gB6VSLdvJ7" role="3clFbG">
-                      <node concept="13iPFW" id="3gB6VSLdvrI" role="2Oq$k0" />
-                      <node concept="2qgKlT" id="3gB6VSLdwY0" role="2OqNvi">
-                        <ref role="37wK5l" node="3gB6VSKS$k6" resolve="isAllowedContentKind" />
-                        <node concept="37vLTw" id="3gB6VSLdyQQ" role="37wK5m">
-                          <ref role="3cqZAo" node="3gB6VSLdyQM" resolve="containerKind" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="Rh6nW" id="3gB6VSLcIC9" role="1bW2Oz">
-                  <property role="TrG5h" value="it" />
-                  <node concept="2jxLKc" id="3gB6VSLcICa" role="1tU5fm" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="A3Dl8" id="3gB6VSKSqOs" role="3clF45">
-        <node concept="3Tqbb2" id="3gB6VSKSqOv" role="A3Ik2">
-          <ref role="ehGHo" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
-        </node>
-      </node>
-      <node concept="P$JXv" id="3gB6VSKS$6z" role="lGtFl">
-        <node concept="TZ5HA" id="3gB6VSKS$6$" role="TZ5H$">
-          <node concept="1dT_AC" id="3gB6VSKS$6_" role="1dT_Ay">
-            <property role="1dT_AB" value="This method is used in the scope calculation of the ComponentRef." />
-          </node>
-        </node>
-        <node concept="x79VA" id="3gB6VSKS$6A" role="3nqlJM">
-          <property role="x79VB" value="a list of components that should be allowed inside the context component" />
-        </node>
-      </node>
-    </node>
-    <node concept="13i0hz" id="3gB6VSKS$k6" role="13h7CS">
-      <property role="TrG5h" value="isAllowedContentKind" />
-      <property role="13i0it" value="true" />
-      <node concept="37vLTG" id="3gB6VSKS$zj" role="3clF46">
-        <property role="TrG5h" value="compKind" />
-        <node concept="3Tqbb2" id="3gB6VSKTQOY" role="1tU5fm">
-          <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="3gB6VSKS$k7" role="1B3o_S" />
-      <node concept="3clFbS" id="3gB6VSKS$k9" role="3clF47">
-        <node concept="3cpWs6" id="3gB6VSKSB$b" role="3cqZAp">
-          <node concept="3clFbT" id="3gB6VSKSB$d" role="3cqZAk">
-            <property role="3clFbU" value="true" />
-          </node>
-        </node>
-      </node>
-      <node concept="10P_77" id="3gB6VSKS$z7" role="3clF45" />
-      <node concept="P$JXv" id="3gB6VSKSBA7" role="lGtFl">
-        <node concept="TZ5HA" id="3gB6VSKSBA8" role="TZ5H$">
-          <node concept="1dT_AC" id="3gB6VSKSBA9" role="1dT_Ay">
-            <property role="1dT_AB" value="By default this implementation allows the usage of any kind inside &quot;this&quot; kind." />
-          </node>
-        </node>
-        <node concept="TZ5HA" id="3gB6VSLdUMB" role="TZ5H$">
-          <node concept="1dT_AC" id="3gB6VSLdUMC" role="1dT_Ay">
-            <property role="1dT_AB" value="To customize the scope of ComponentRef provide your own implementation." />
-          </node>
-        </node>
-        <node concept="TUZQ0" id="3gB6VSKSBAa" role="3nqlJM">
-          <property role="TUZQ4" value="the component " />
-          <node concept="zr_55" id="3gB6VSKSBAc" role="zr_5Q">
-            <ref role="zr_51" node="3gB6VSKS$zj" resolve="compKind" />
-          </node>
-        </node>
-        <node concept="x79VA" id="3gB6VSKSBAd" role="3nqlJM">
-          <property role="x79VB" value="true if the kind of the passed component is allowed" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/constraints.mps
@@ -13,8 +13,8 @@
     <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
     <import index="gdgh" ref="r:e4d9478b-ae0e-416e-be60-73d136571015(org.iets3.core.base.behavior)" />
     <import index="4kwy" ref="r:657c9fde-2f36-4e61-ae17-20f02b8630ad(org.iets3.core.base.structure)" />
-    <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" implicit="true" />
-    <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" implicit="true" />
+    <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
+    <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
@@ -97,7 +97,6 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
-      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
         <child id="1163668914799" name="condition" index="3K4Cdx" />
         <child id="1163668922816" name="ifTrue" index="3K4E3e" />
@@ -259,64 +258,42 @@
       <ref role="1N5Vy1" to="w9y2:6LfBX8YiQvJ" resolve="ref" />
       <node concept="3dgokm" id="6LfBX8YiYBQ" role="1N6uqs">
         <node concept="3clFbS" id="1F1F0IUZ_5W" role="2VODD2">
+          <node concept="3cpWs8" id="3gB6VSKSqP2" role="3cqZAp">
+            <node concept="3cpWsn" id="3gB6VSKSqP3" role="3cpWs9">
+              <property role="TrG5h" value="seq" />
+              <node concept="A3Dl8" id="3gB6VSKSqOs" role="1tU5fm">
+                <node concept="3Tqbb2" id="3gB6VSKSqOv" role="A3Ik2">
+                  <ref role="ehGHo" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="3gB6VSKSGYA" role="33vP2m">
+                <node concept="2OqwBi" id="3gB6VSKSFRA" role="2Oq$k0">
+                  <node concept="2OqwBi" id="3gB6VSKSF93" role="2Oq$k0">
+                    <node concept="2rP1CM" id="3gB6VSKSEVe" role="2Oq$k0" />
+                    <node concept="2Xjw5R" id="3gB6VSKSFo7" role="2OqNvi">
+                      <node concept="1xMEDy" id="3gB6VSKSFo9" role="1xVPHs">
+                        <node concept="chp4Y" id="3gB6VSKSFtS" role="ri$Ld">
+                          <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3TrEf2" id="3gB6VSKSGlD" role="2OqNvi">
+                    <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="3gB6VSKSHhE" role="2OqNvi">
+                  <ref role="37wK5l" to="3eba:3gB6VSKScig" resolve="visibleComponents" />
+                </node>
+              </node>
+            </node>
+          </node>
           <node concept="3clFbF" id="1F1F0IUZ_5X" role="3cqZAp">
             <node concept="2YIFZM" id="1F1F0IUZ_cW" role="3clFbG">
               <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
               <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
-              <node concept="2OqwBi" id="1F1F0IUZ_cX" role="37wK5m">
-                <node concept="2OqwBi" id="1F1F0IUZ_cY" role="2Oq$k0">
-                  <node concept="2OqwBi" id="1F1F0IUZ_cZ" role="2Oq$k0">
-                    <node concept="2OqwBi" id="1F1F0IUZ_d0" role="2Oq$k0">
-                      <node concept="2rP1CM" id="1F1F0IUZ_d1" role="2Oq$k0" />
-                      <node concept="2Xjw5R" id="1F1F0IUZ_d2" role="2OqNvi">
-                        <node concept="1xMEDy" id="1F1F0IUZ_d3" role="1xVPHs">
-                          <node concept="chp4Y" id="1F1F0IUZ_d4" role="ri$Ld">
-                            <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2qgKlT" id="1F1F0IUZ_d5" role="2OqNvi">
-                      <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                      <node concept="3TUQnm" id="1F1F0IUZ_d6" role="37wK5m">
-                        <ref role="3TV0OU" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="v3k3i" id="1F1F0IUZ_d7" role="2OqNvi">
-                    <node concept="chp4Y" id="1F1F0IUZ_d8" role="v3oSu">
-                      <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3zZkjj" id="1F1F0IUZ_d9" role="2OqNvi">
-                  <node concept="1bVj0M" id="1F1F0IUZ_da" role="23t8la">
-                    <node concept="3clFbS" id="1F1F0IUZ_db" role="1bW5cS">
-                      <node concept="3clFbF" id="1F1F0IUZ_dc" role="3cqZAp">
-                        <node concept="3y3z36" id="1F1F0IUZ_dd" role="3clFbG">
-                          <node concept="2OqwBi" id="1F1F0IUZ_de" role="3uHU7w">
-                            <node concept="2rP1CM" id="1F1F0IUZ_df" role="2Oq$k0" />
-                            <node concept="2Xjw5R" id="1F1F0IUZ_dg" role="2OqNvi">
-                              <node concept="1xMEDy" id="1F1F0IUZ_dh" role="1xVPHs">
-                                <node concept="chp4Y" id="1F1F0IUZ_di" role="ri$Ld">
-                                  <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
-                                </node>
-                              </node>
-                              <node concept="1xIGOp" id="1F1F0IUZ_dj" role="1xVPHs" />
-                            </node>
-                          </node>
-                          <node concept="37vLTw" id="1F1F0IUZ_dk" role="3uHU7B">
-                            <ref role="3cqZAo" node="1F1F0IUZ_dl" resolve="it" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="Rh6nW" id="1F1F0IUZ_dl" role="1bW2Oz">
-                      <property role="TrG5h" value="it" />
-                      <node concept="2jxLKc" id="1F1F0IUZ_dm" role="1tU5fm" />
-                    </node>
-                  </node>
-                </node>
+              <node concept="37vLTw" id="3gB6VSKSqPu" role="37wK5m">
+                <ref role="3cqZAo" node="3gB6VSKSqP3" resolve="seq" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/constraints.mps
@@ -97,6 +97,7 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
         <child id="1163668914799" name="condition" index="3K4Cdx" />
         <child id="1163668922816" name="ifTrue" index="3K4E3e" />
@@ -258,32 +259,155 @@
       <ref role="1N5Vy1" to="w9y2:6LfBX8YiQvJ" resolve="ref" />
       <node concept="3dgokm" id="6LfBX8YiYBQ" role="1N6uqs">
         <node concept="3clFbS" id="1F1F0IUZ_5W" role="2VODD2">
-          <node concept="3cpWs8" id="3gB6VSKSqP2" role="3cqZAp">
-            <node concept="3cpWsn" id="3gB6VSKSqP3" role="3cpWs9">
-              <property role="TrG5h" value="seq" />
-              <node concept="A3Dl8" id="3gB6VSKSqOs" role="1tU5fm">
-                <node concept="3Tqbb2" id="3gB6VSKSqOv" role="A3Ik2">
+          <node concept="3SKdUt" id="2B42b1rCGk_" role="3cqZAp">
+            <node concept="3SKdUq" id="2B42b1rCGkB" role="3SKWNk">
+              <property role="3SKdUp" value="the component where the this ComponentRef is declared" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="2B42b1rCzWV" role="3cqZAp">
+            <node concept="3cpWsn" id="2B42b1rCzWW" role="3cpWs9">
+              <property role="TrG5h" value="containerComp" />
+              <node concept="3Tqbb2" id="2B42b1rCzWT" role="1tU5fm">
+                <ref role="ehGHo" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+              </node>
+              <node concept="2OqwBi" id="2B42b1rCzWX" role="33vP2m">
+                <node concept="2rP1CM" id="2B42b1rCzWY" role="2Oq$k0" />
+                <node concept="2Xjw5R" id="2B42b1rCzWZ" role="2OqNvi">
+                  <node concept="1xMEDy" id="2B42b1rCzX0" role="1xVPHs">
+                    <node concept="chp4Y" id="2B42b1rCzX1" role="ri$Ld">
+                      <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="2B42b1rC_Pf" role="3cqZAp" />
+          <node concept="3SKdUt" id="2B42b1rCHa5" role="3cqZAp">
+            <node concept="3SKdUq" id="2B42b1rCHa7" role="3SKWNk">
+              <property role="3SKdUp" value="all components in scope" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="2B42b1rCqQF" role="3cqZAp">
+            <node concept="3cpWsn" id="2B42b1rCqQG" role="3cpWs9">
+              <property role="TrG5h" value="visibleComps" />
+              <node concept="A3Dl8" id="2B42b1rCqQa" role="1tU5fm">
+                <node concept="3Tqbb2" id="2B42b1rCqQd" role="A3Ik2">
                   <ref role="ehGHo" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
                 </node>
               </node>
-              <node concept="2OqwBi" id="3gB6VSKSGYA" role="33vP2m">
-                <node concept="2OqwBi" id="3gB6VSKSFRA" role="2Oq$k0">
-                  <node concept="2OqwBi" id="3gB6VSKSF93" role="2Oq$k0">
-                    <node concept="2rP1CM" id="3gB6VSKSEVe" role="2Oq$k0" />
-                    <node concept="2Xjw5R" id="3gB6VSKSFo7" role="2OqNvi">
-                      <node concept="1xMEDy" id="3gB6VSKSFo9" role="1xVPHs">
-                        <node concept="chp4Y" id="3gB6VSKSFtS" role="ri$Ld">
-                          <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+              <node concept="2OqwBi" id="2B42b1rCqQH" role="33vP2m">
+                <node concept="2OqwBi" id="2B42b1rCqQI" role="2Oq$k0">
+                  <node concept="2OqwBi" id="2B42b1rCqQJ" role="2Oq$k0">
+                    <node concept="2OqwBi" id="2B42b1rCqQK" role="2Oq$k0">
+                      <node concept="2rP1CM" id="2B42b1rCqQL" role="2Oq$k0" />
+                      <node concept="2Xjw5R" id="2B42b1rCqQM" role="2OqNvi">
+                        <node concept="1xMEDy" id="2B42b1rCqQN" role="1xVPHs">
+                          <node concept="chp4Y" id="2B42b1rCqQO" role="ri$Ld">
+                            <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
+                          </node>
                         </node>
                       </node>
                     </node>
+                    <node concept="2qgKlT" id="2B42b1rCqQP" role="2OqNvi">
+                      <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
+                      <node concept="3TUQnm" id="2B42b1rCqQQ" role="37wK5m">
+                        <ref role="3TV0OU" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+                      </node>
+                    </node>
                   </node>
-                  <node concept="3TrEf2" id="3gB6VSKSGlD" role="2OqNvi">
-                    <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
+                  <node concept="v3k3i" id="2B42b1rCqQR" role="2OqNvi">
+                    <node concept="chp4Y" id="2B42b1rCqQS" role="v3oSu">
+                      <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+                    </node>
                   </node>
                 </node>
-                <node concept="2qgKlT" id="3gB6VSKSHhE" role="2OqNvi">
-                  <ref role="37wK5l" to="3eba:3gB6VSKScig" resolve="visibleComponents" />
+                <node concept="3zZkjj" id="2B42b1rCqQT" role="2OqNvi">
+                  <node concept="1bVj0M" id="2B42b1rCqQU" role="23t8la">
+                    <node concept="3clFbS" id="2B42b1rCqQV" role="1bW5cS">
+                      <node concept="3clFbF" id="2B42b1rCqQW" role="3cqZAp">
+                        <node concept="3y3z36" id="2B42b1rCqQX" role="3clFbG">
+                          <node concept="2OqwBi" id="2B42b1rCqQY" role="3uHU7w">
+                            <node concept="2rP1CM" id="2B42b1rCqQZ" role="2Oq$k0" />
+                            <node concept="2Xjw5R" id="2B42b1rCqR0" role="2OqNvi">
+                              <node concept="1xMEDy" id="2B42b1rCqR1" role="1xVPHs">
+                                <node concept="chp4Y" id="2B42b1rCqR2" role="ri$Ld">
+                                  <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+                                </node>
+                              </node>
+                              <node concept="1xIGOp" id="2B42b1rCqR3" role="1xVPHs" />
+                            </node>
+                          </node>
+                          <node concept="37vLTw" id="2B42b1rCqR4" role="3uHU7B">
+                            <ref role="3cqZAo" node="2B42b1rCqR5" resolve="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="2B42b1rCqR5" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="2B42b1rCqR6" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="2B42b1rCt0U" role="3cqZAp" />
+          <node concept="3SKdUt" id="2B42b1rCH$9" role="3cqZAp">
+            <node concept="3SKdUq" id="2B42b1rCH$b" role="3SKWNk">
+              <property role="3SKdUp" value="all components in scope where the kind of a referenced component" />
+            </node>
+          </node>
+          <node concept="3SKdUt" id="2B42b1rCIoB" role="3cqZAp">
+            <node concept="3SKdUq" id="2B42b1rCIoD" role="3SKWNk">
+              <property role="3SKdUp" value="allows the usage (of an instance with a kind) in a specific context" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="2B42b1rCDhJ" role="3cqZAp">
+            <node concept="3cpWsn" id="2B42b1rCDhK" role="3cpWs9">
+              <property role="TrG5h" value="kindAwareComponents" />
+              <node concept="A3Dl8" id="2B42b1rCDgu" role="1tU5fm">
+                <node concept="3Tqbb2" id="2B42b1rCDgx" role="A3Ik2">
+                  <ref role="ehGHo" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="2B42b1rCDhL" role="33vP2m">
+                <node concept="37vLTw" id="2B42b1rCDhM" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2B42b1rCqQG" resolve="visibleComps" />
+                </node>
+                <node concept="3zZkjj" id="2B42b1rCDhN" role="2OqNvi">
+                  <node concept="1bVj0M" id="2B42b1rCDhO" role="23t8la">
+                    <node concept="3clFbS" id="2B42b1rCDhP" role="1bW5cS">
+                      <node concept="3clFbF" id="2B42b1rCDhQ" role="3cqZAp">
+                        <node concept="2OqwBi" id="2B42b1rCDhR" role="3clFbG">
+                          <node concept="2OqwBi" id="2B42b1rCDhS" role="2Oq$k0">
+                            <node concept="37vLTw" id="2B42b1rCDhT" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2B42b1rCDhZ" resolve="it" />
+                            </node>
+                            <node concept="3TrEf2" id="2B42b1rCDhU" role="2OqNvi">
+                              <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
+                            </node>
+                          </node>
+                          <node concept="2qgKlT" id="2B42b1rCDhV" role="2OqNvi">
+                            <ref role="37wK5l" to="3eba:6LfBX8Ylle0" resolve="canBeInContext" />
+                            <node concept="2OqwBi" id="2B42b1rCDhW" role="37wK5m">
+                              <node concept="37vLTw" id="2B42b1rCDhX" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2B42b1rCzWW" resolve="containerComp" />
+                              </node>
+                              <node concept="3TrEf2" id="2B42b1rCDhY" role="2OqNvi">
+                                <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="2B42b1rCDhZ" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="2B42b1rCDi0" role="1tU5fm" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -292,8 +416,8 @@
             <node concept="2YIFZM" id="1F1F0IUZ_cW" role="3clFbG">
               <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
               <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
-              <node concept="37vLTw" id="3gB6VSKSqPu" role="37wK5m">
-                <ref role="3cqZAo" node="3gB6VSKSqP3" resolve="seq" />
+              <node concept="37vLTw" id="2B42b1rCFzL" role="37wK5m">
+                <ref role="3cqZAo" node="2B42b1rCDhK" resolve="kindAwareComponents" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/plugin.mps
@@ -4,12 +4,8 @@
   <languages>
     <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="2" />
     <use id="f159adf4-3c93-40f9-9c5a-1f245a8697af" name="jetbrains.mps.lang.aspect" version="2" />
-    <use id="47f075a6-558e-4640-a606-7ce0236c8023" name="com.mbeddr.mpsutil.interpreter" version="0" />
-    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
-  <imports>
-    <import index="w9y2" ref="r:b3786745-c763-4a49-a754-f84e15236f18(org.iets3.components.core.structure)" />
-  </imports>
+  <imports />
   <registry />
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/org.iets3.components.core.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/org.iets3.components.core.mpl
@@ -77,7 +77,6 @@
     <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="0" />
     <language slang="l:b4f35ed8-45af-4efa-abe4-00ac26956e69:com.mbeddr.mpsutil.grammarcells.runtimelang" version="0" />
     <language slang="l:b92f861d-0184-446d-b88b-6dcf0e070241:com.mbeddr.mpsutil.intentions" version="0" />
-    <language slang="l:47f075a6-558e-4640-a606-7ce0236c8023:com.mbeddr.mpsutil.interpreter" version="0" />
     <language slang="l:62a3babb-5d40-4920-897f-d4144dc99c9d:com.mbeddr.mpsutil.userstyles" version="0" />
     <language slang="l:fa13cc63-c476-4d46-9c96-d53670abe7bc:de.itemis.mps.editor.diagram" version="0" />
     <language slang="l:8ca79d43-eb45-4791-bdd4-0d6130ff895b:de.itemis.mps.editor.diagram.layout" version="0" />

--- a/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/behavior.mps
@@ -82,12 +82,6 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
-      <concept id="6329021646629104957" name="jetbrains.mps.baseLanguage.structure.TextCommentPart" flags="nn" index="3SKdUq">
-        <property id="6329021646629104958" name="text" index="3SKdUp" />
-      </concept>
-      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
-        <child id="6329021646629175155" name="commentPart" index="3SKWNk" />
-      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
@@ -509,89 +503,51 @@
     <node concept="13hLZK" id="3gB6VSKTNfm" role="13h7CW">
       <node concept="3clFbS" id="3gB6VSKTNfn" role="2VODD2" />
     </node>
-    <node concept="13i0hz" id="3gB6VSLeo_d" role="13h7CS">
+  </node>
+  <node concept="13h7C7" id="3gB6VSLej2x">
+    <ref role="13h7C2" to="xens:3gB6VSKTCP3" resolve="TestKindB" />
+    <node concept="13hLZK" id="3gB6VSLej2y" role="13h7CW">
+      <node concept="3clFbS" id="3gB6VSLej2z" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="2B42b1rEads" role="13h7CS">
       <property role="TrG5h" value="canBeInContext" />
       <property role="13i0it" value="false" />
       <property role="13i0iv" value="false" />
       <ref role="13i0hy" to="3eba:6LfBX8Ylle0" resolve="canBeInContext" />
-      <node concept="3Tm1VV" id="3gB6VSLeo_e" role="1B3o_S" />
-      <node concept="3clFbS" id="3gB6VSLeo_r" role="3clF47">
-        <node concept="3SKdUt" id="3gB6VSLepoY" role="3cqZAp">
-          <node concept="3SKdUq" id="3gB6VSLepp0" role="3SKWNk">
-            <property role="3SKdUp" value="this kind can only be used in TestKindB and TestKindA" />
-          </node>
-        </node>
-        <node concept="3clFbF" id="3gB6VSLeoHD" role="3cqZAp">
-          <node concept="22lmx$" id="3gB6VSLepLg" role="3clFbG">
-            <node concept="2OqwBi" id="3gB6VSLeoRQ" role="3uHU7B">
-              <node concept="37vLTw" id="3gB6VSLeoHz" role="2Oq$k0">
-                <ref role="3cqZAo" node="3gB6VSLeo_s" resolve="contextKind" />
+      <node concept="3Tm1VV" id="2B42b1rEadt" role="1B3o_S" />
+      <node concept="3clFbS" id="2B42b1rEadS" role="3clF47">
+        <node concept="3clFbF" id="2B42b1rEalP" role="3cqZAp">
+          <node concept="22lmx$" id="2B42b1rEd38" role="3clFbG">
+            <node concept="2OqwBi" id="2B42b1rEdkN" role="3uHU7w">
+              <node concept="37vLTw" id="2B42b1rEd8L" role="2Oq$k0">
+                <ref role="3cqZAo" node="2B42b1rEadT" resolve="contextKind" />
               </node>
-              <node concept="1mIQ4w" id="3gB6VSLepaX" role="2OqNvi">
-                <node concept="chp4Y" id="3gB6VSLepg$" role="cj9EA">
-                  <ref role="cht4Q" to="xens:3gB6VSKTCP3" resolve="TestKindB" />
-                </node>
-              </node>
-            </node>
-            <node concept="2OqwBi" id="3gB6VSLepQq" role="3uHU7w">
-              <node concept="37vLTw" id="3gB6VSLepQr" role="2Oq$k0">
-                <ref role="3cqZAo" node="3gB6VSLeo_s" resolve="contextKind" />
-              </node>
-              <node concept="1mIQ4w" id="3gB6VSLepQs" role="2OqNvi">
-                <node concept="chp4Y" id="3gB6VSLepVC" role="cj9EA">
+              <node concept="1mIQ4w" id="2B42b1rEdH5" role="2OqNvi">
+                <node concept="chp4Y" id="2B42b1rEdQc" role="cj9EA">
                   <ref role="cht4Q" to="xens:3QX5db_HNz8" resolve="TestKindA" />
                 </node>
               </node>
             </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="3gB6VSLeo_s" role="3clF46">
-        <property role="TrG5h" value="contextKind" />
-        <node concept="3Tqbb2" id="3gB6VSLeo_t" role="1tU5fm">
-          <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
-        </node>
-      </node>
-      <node concept="10P_77" id="3gB6VSLeo_u" role="3clF45" />
-    </node>
-  </node>
-  <node concept="13h7C7" id="3gB6VSLej2x">
-    <ref role="13h7C2" to="xens:3gB6VSKTCP3" resolve="TestKindB" />
-    <node concept="13i0hz" id="3gB6VSLd693" role="13h7CS">
-      <property role="TrG5h" value="isAllowedContentKind" />
-      <property role="13i0it" value="false" />
-      <property role="13i0iv" value="false" />
-      <ref role="13i0hy" to="3eba:3gB6VSKS$k6" resolve="isAllowedContentKind" />
-      <node concept="3Tm1VV" id="3gB6VSLd696" role="1B3o_S" />
-      <node concept="3clFbS" id="3gB6VSLd69h" role="3clF47">
-        <node concept="3SKdUt" id="3gB6VSLdV5x" role="3cqZAp">
-          <node concept="3SKdUq" id="3gB6VSLdV5z" role="3SKWNk">
-            <property role="3SKdUp" value="can only contain elements of TestKindA" />
-          </node>
-        </node>
-        <node concept="3clFbF" id="3gB6VSLd6hn" role="3cqZAp">
-          <node concept="2OqwBi" id="3gB6VSLd6rG" role="3clFbG">
-            <node concept="37vLTw" id="3gB6VSLd6hh" role="2Oq$k0">
-              <ref role="3cqZAo" node="3gB6VSLd69i" resolve="compKind" />
-            </node>
-            <node concept="1mIQ4w" id="3gB6VSLd6IL" role="2OqNvi">
-              <node concept="chp4Y" id="3gB6VSLejb9" role="cj9EA">
-                <ref role="cht4Q" to="xens:3QX5db_HNz8" resolve="TestKindA" />
+            <node concept="2OqwBi" id="2B42b1rEauq" role="3uHU7B">
+              <node concept="37vLTw" id="2B42b1rEalJ" role="2Oq$k0">
+                <ref role="3cqZAo" node="2B42b1rEadT" resolve="contextKind" />
+              </node>
+              <node concept="1mIQ4w" id="2B42b1rEaLq" role="2OqNvi">
+                <node concept="chp4Y" id="2B42b1rEaQZ" role="cj9EA">
+                  <ref role="cht4Q" to="xens:3gB6VSKTCP3" resolve="TestKindB" />
+                </node>
               </node>
             </node>
           </node>
         </node>
       </node>
-      <node concept="37vLTG" id="3gB6VSLd69i" role="3clF46">
-        <property role="TrG5h" value="compKind" />
-        <node concept="3Tqbb2" id="3gB6VSLd69j" role="1tU5fm">
+      <node concept="37vLTG" id="2B42b1rEadT" role="3clF46">
+        <property role="TrG5h" value="contextKind" />
+        <node concept="3Tqbb2" id="2B42b1rEadU" role="1tU5fm">
           <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
         </node>
       </node>
-      <node concept="10P_77" id="3gB6VSLd69k" role="3clF45" />
-    </node>
-    <node concept="13hLZK" id="3gB6VSLej2y" role="13h7CW">
-      <node concept="3clFbS" id="3gB6VSLej2z" role="2VODD2" />
+      <node concept="10P_77" id="2B42b1rEadV" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/behavior.mps
@@ -34,6 +34,11 @@
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
@@ -45,6 +50,9 @@
       </concept>
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
@@ -67,8 +75,18 @@
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="6329021646629104957" name="jetbrains.mps.baseLanguage.structure.TextCommentPart" flags="nn" index="3SKdUq">
+        <property id="6329021646629104958" name="text" index="3SKdUp" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="6329021646629175155" name="commentPart" index="3SKWNk" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
@@ -81,6 +99,9 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
       <concept id="1240170042401" name="jetbrains.mps.lang.smodel.structure.SEnumMemberType" flags="in" index="2ZThk1">
         <reference id="1240170836027" name="enum" index="2ZWj4r" />
       </concept>
@@ -89,6 +110,9 @@
       </concept>
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz">
         <reference id="6677504323281689839" name="conceptDeclaraton" index="3bZ5Sy" />
+      </concept>
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="1240930118027" name="jetbrains.mps.lang.smodel.structure.SEnumOperationInvocation" flags="nn" index="3HcIyF">
         <reference id="1240930118028" name="enumDeclaration" index="3HcIyG" />
@@ -478,6 +502,96 @@
       <node concept="3Tqbb2" id="48ZWgAGwiVj" role="3clF45">
         <ref role="ehGHo" to="w9y2:4KDeVD8s9RL" resolve="IConnectorType" />
       </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="3gB6VSKTNfl">
+    <ref role="13h7C2" to="xens:3QX5db_HNz8" resolve="TestKindA" />
+    <node concept="13hLZK" id="3gB6VSKTNfm" role="13h7CW">
+      <node concept="3clFbS" id="3gB6VSKTNfn" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="3gB6VSLeo_d" role="13h7CS">
+      <property role="TrG5h" value="canBeInContext" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="3eba:6LfBX8Ylle0" resolve="canBeInContext" />
+      <node concept="3Tm1VV" id="3gB6VSLeo_e" role="1B3o_S" />
+      <node concept="3clFbS" id="3gB6VSLeo_r" role="3clF47">
+        <node concept="3SKdUt" id="3gB6VSLepoY" role="3cqZAp">
+          <node concept="3SKdUq" id="3gB6VSLepp0" role="3SKWNk">
+            <property role="3SKdUp" value="this kind can only be used in TestKindB and TestKindA" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="3gB6VSLeoHD" role="3cqZAp">
+          <node concept="22lmx$" id="3gB6VSLepLg" role="3clFbG">
+            <node concept="2OqwBi" id="3gB6VSLeoRQ" role="3uHU7B">
+              <node concept="37vLTw" id="3gB6VSLeoHz" role="2Oq$k0">
+                <ref role="3cqZAo" node="3gB6VSLeo_s" resolve="contextKind" />
+              </node>
+              <node concept="1mIQ4w" id="3gB6VSLepaX" role="2OqNvi">
+                <node concept="chp4Y" id="3gB6VSLepg$" role="cj9EA">
+                  <ref role="cht4Q" to="xens:3gB6VSKTCP3" resolve="TestKindB" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3gB6VSLepQq" role="3uHU7w">
+              <node concept="37vLTw" id="3gB6VSLepQr" role="2Oq$k0">
+                <ref role="3cqZAo" node="3gB6VSLeo_s" resolve="contextKind" />
+              </node>
+              <node concept="1mIQ4w" id="3gB6VSLepQs" role="2OqNvi">
+                <node concept="chp4Y" id="3gB6VSLepVC" role="cj9EA">
+                  <ref role="cht4Q" to="xens:3QX5db_HNz8" resolve="TestKindA" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3gB6VSLeo_s" role="3clF46">
+        <property role="TrG5h" value="contextKind" />
+        <node concept="3Tqbb2" id="3gB6VSLeo_t" role="1tU5fm">
+          <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
+        </node>
+      </node>
+      <node concept="10P_77" id="3gB6VSLeo_u" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="3gB6VSLej2x">
+    <ref role="13h7C2" to="xens:3gB6VSKTCP3" resolve="TestKindB" />
+    <node concept="13i0hz" id="3gB6VSLd693" role="13h7CS">
+      <property role="TrG5h" value="isAllowedContentKind" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="3eba:3gB6VSKS$k6" resolve="isAllowedContentKind" />
+      <node concept="3Tm1VV" id="3gB6VSLd696" role="1B3o_S" />
+      <node concept="3clFbS" id="3gB6VSLd69h" role="3clF47">
+        <node concept="3SKdUt" id="3gB6VSLdV5x" role="3cqZAp">
+          <node concept="3SKdUq" id="3gB6VSLdV5z" role="3SKWNk">
+            <property role="3SKdUp" value="can only contain elements of TestKindA" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="3gB6VSLd6hn" role="3cqZAp">
+          <node concept="2OqwBi" id="3gB6VSLd6rG" role="3clFbG">
+            <node concept="37vLTw" id="3gB6VSLd6hh" role="2Oq$k0">
+              <ref role="3cqZAo" node="3gB6VSLd69i" resolve="compKind" />
+            </node>
+            <node concept="1mIQ4w" id="3gB6VSLd6IL" role="2OqNvi">
+              <node concept="chp4Y" id="3gB6VSLejb9" role="cj9EA">
+                <ref role="cht4Q" to="xens:3QX5db_HNz8" resolve="TestKindA" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3gB6VSLd69i" role="3clF46">
+        <property role="TrG5h" value="compKind" />
+        <node concept="3Tqbb2" id="3gB6VSLd69j" role="1tU5fm">
+          <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
+        </node>
+      </node>
+      <node concept="10P_77" id="3gB6VSLd69k" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="3gB6VSLej2y" role="13h7CW">
+      <node concept="3clFbS" id="3gB6VSLej2z" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/editor.mps
@@ -167,7 +167,7 @@
     </node>
   </node>
   <node concept="24kQdi" id="3QX5db_HOqv">
-    <ref role="1XX52x" to="xens:3QX5db_HNz8" resolve="TestKind" />
+    <ref role="1XX52x" to="xens:3QX5db_HNz8" resolve="TestKindA" />
     <node concept="PMmxH" id="3QX5db_HOq$" role="2wV5jI">
       <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
     </node>
@@ -175,6 +175,12 @@
   <node concept="24kQdi" id="3QX5db_I9R1">
     <ref role="1XX52x" to="xens:3QX5db_I5bP" resolve="TestPortCategoryOffers" />
     <node concept="PMmxH" id="3QX5db_I9Rk" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="3gB6VSKTCPk">
+    <ref role="1XX52x" to="xens:3gB6VSKTCP3" resolve="TestKindB" />
+    <node concept="PMmxH" id="3gB6VSKTCPm" role="2wV5jI">
       <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/structure.mps
@@ -56,8 +56,8 @@
   </node>
   <node concept="1TIwiD" id="3QX5db_HNz8">
     <property role="EcuMT" value="4448734902941595848" />
-    <property role="TrG5h" value="TestKind" />
-    <property role="34LRSv" value="testKind" />
+    <property role="TrG5h" value="TestKindA" />
+    <property role="34LRSv" value="testKindA" />
     <ref role="1TJDcQ" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
   </node>
   <node concept="1TIwiD" id="3QX5db_I5bP">
@@ -73,6 +73,12 @@
     <node concept="PrWs8" id="48ZWgAGwh6E" role="PzmwI">
       <ref role="PrY4T" to="w9y2:4KDeVD8s9RL" resolve="IConnectorType" />
     </node>
+  </node>
+  <node concept="1TIwiD" id="3gB6VSKTCP3">
+    <property role="EcuMT" value="3758002917742120259" />
+    <property role="TrG5h" value="TestKindB" />
+    <property role="34LRSv" value="testKindB" />
+    <ref role="1TJDcQ" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/solutions/test.ts.components.core/models/tests@tests.mps
+++ b/code/languages/org.iets3.opensource/solutions/test.ts.components.core/models/tests@tests.mps
@@ -11,9 +11,13 @@
   </languages>
   <imports>
     <import index="w9y2" ref="r:b3786745-c763-4a49-a754-f84e15236f18(org.iets3.components.core.structure)" />
+    <import index="5etr" ref="r:769eaa92-d4cb-4fa9-87e4-269f7f35a1eb(org.iets3.components.core.typesystem)" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1215507671101" name="jetbrains.mps.lang.test.structure.NodeErrorCheckOperation" flags="ng" index="1TM$A">
+        <child id="8489045168660938517" name="errorRef" index="3lydEf" />
+      </concept>
       <concept id="1215603922101" name="jetbrains.mps.lang.test.structure.NodeOperationsContainer" flags="ng" index="7CXmI">
         <child id="1215604436604" name="nodeOperations" index="7EUXB" />
       </concept>
@@ -22,6 +26,10 @@
         <reference id="5449224527592117654" name="checkingReference" index="1BTHP0" />
         <child id="3655334166513314307" name="nodes" index="3KTr4d" />
       </concept>
+      <concept id="7691029917083872157" name="jetbrains.mps.lang.test.structure.IRuleReference" flags="ng" index="2u4UPC">
+        <reference id="8333855927540250453" name="declaration" index="39XzEq" />
+      </concept>
+      <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
       <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
       </concept>
@@ -125,6 +133,7 @@
         <child id="8492736225391506814" name="imports" index="38kjvB" />
         <child id="7804632404593342038" name="contents" index="1i1AA4" />
       </concept>
+      <concept id="7804632404593231760" name="org.iets3.components.core.structure.EmptyComponentContent" flags="ng" index="1i1Xx2" />
       <concept id="7804632404593231361" name="org.iets3.components.core.structure.Component" flags="ng" index="1i1XBj">
         <child id="7804632404593514231" name="kind" index="1i0K$_" />
         <child id="7804632404593231452" name="contents" index="1i1XAe" />
@@ -393,7 +402,7 @@
       <node concept="GnABt" id="48ZWgAGs_tL" role="1i1XAe">
         <node concept="1i6xzV" id="48ZWgAGs_tY" role="GnABu">
           <node concept="1i1fwW" id="48ZWgAGs_uh" role="MGl3R">
-            <ref role="1i1fwX" node="48ZWgAGs_tn" resolve="ExternalInnerComp_KindB" />
+            <ref role="1i1fwX" node="48ZWgAGs_tn" resolve="ExternalInnerComp_KindA" />
           </node>
           <node concept="pfQqD" id="48ZWgAGwlhI" role="pfQ1b">
             <property role="pfQqC" value="innerCmp" />
@@ -401,7 +410,7 @@
         </node>
         <node concept="1i6xzV" id="48ZWgAGwlpj" role="GnABu">
           <node concept="1i1fwW" id="48ZWgAGwlpk" role="MGl3R">
-            <ref role="1i1fwX" node="48ZWgAGs_tn" resolve="ExternalInnerComp_KindB" />
+            <ref role="1i1fwX" node="48ZWgAGs_tn" resolve="ExternalInnerComp_KindA" />
           </node>
           <node concept="pfQqD" id="48ZWgAGwlpl" role="pfQ1b">
             <property role="pfQqC" value="innerCmp2" />
@@ -445,7 +454,7 @@
       </node>
     </node>
     <node concept="1i1XBj" id="48ZWgAGs_tn" role="1i1AA4">
-      <property role="TrG5h" value="ExternalInnerComp_KindB" />
+      <property role="TrG5h" value="ExternalInnerComp_KindA" />
       <node concept="3o2yKq" id="48ZWgAGs_tl" role="1i0K$_" />
       <node concept="H_j2F" id="48ZWgAGwgLN" role="1i1XAe">
         <node concept="H_vQO" id="48ZWgAGwgLO" role="H_jLS" />
@@ -459,9 +468,11 @@
       </node>
     </node>
     <node concept="1i1XBj" id="3gB6VSLerpz" role="1i1AA4">
-      <property role="TrG5h" value="ExternalComp_KindA" />
+      <property role="TrG5h" value="ExternalComp_KindB" />
       <property role="13Nl5X" value="true" />
       <node concept="4KprX" id="3gB6VSLerpx" role="1i0K$_" />
+      <node concept="GnABt" id="7Moo7Ldkuf2" role="1i1XAe" />
+      <node concept="1i1Xx2" id="7Moo7Ldkueq" role="1i1XAe" />
     </node>
   </node>
   <node concept="1lH9Xt" id="3gB6VSLekEx">
@@ -470,16 +481,59 @@
       <node concept="1i1ALs" id="3gB6VSLekE_" role="1qenE9">
         <property role="TrG5h" value="chunk" />
         <node concept="1i1XBj" id="3gB6VSLekEE" role="1i1AA4">
-          <property role="TrG5h" value="testComp" />
+          <property role="TrG5h" value="testCompB" />
           <node concept="4KprX" id="3gB6VSLekED" role="1i0K$_" />
           <node concept="GnABt" id="3gB6VSLekFe" role="1i1XAe">
+            <node concept="GnyP7" id="2B42b1rEfz8" role="GnABu" />
             <node concept="1i6xzV" id="3gB6VSLekFl" role="GnABu">
               <node concept="1i1fwW" id="3gB6VSLekFv" role="MGl3R">
                 <ref role="1i1fwX" node="48ZWgAGs_py" resolve="ExternalRootComp_KindA" />
-                <node concept="2rqxmr" id="3gB6VSLeroQ" role="lGtFl">
-                  <ref role="1BTHP0" node="48ZWgAGs_py" resolve="ExternalRootComp_KindA" />
-                  <node concept="3KTrbX" id="3gB6VSLeroR" role="3KTr4d">
+              </node>
+              <node concept="7CXmI" id="2B42b1rEfy7" role="lGtFl">
+                <node concept="1TM$A" id="2B42b1rEfy8" role="7EUXB">
+                  <node concept="2PYRI3" id="2B42b1rEfy9" role="3lydEf">
+                    <ref role="39XzEq" to="5etr:6LfBX8Yll1h" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1z9TsT" id="2B42b1rEfzD" role="lGtFl">
+              <node concept="OjmMv" id="2B42b1rEfzE" role="1w35rA">
+                <node concept="19SGf9" id="2B42b1rEfzF" role="OjmMu">
+                  <node concept="19SUe$" id="2B42b1rEfzG" role="19SJt6">
+                    <property role="19SUeA" value="instances of components with KindA are out of scope" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1i1XBj" id="2B42b1rEfw6" role="1i1AA4">
+          <property role="TrG5h" value="testCompA" />
+          <node concept="3o2yKq" id="2B42b1rEfw4" role="1i0K$_" />
+          <node concept="GnABt" id="2B42b1rEfwz" role="1i1XAe">
+            <node concept="1i6xzV" id="2B42b1rEfwD" role="GnABu">
+              <node concept="1i1fwW" id="2B42b1rEfwL" role="MGl3R">
+                <ref role="1i1fwX" node="3gB6VSLerpz" resolve="ExternalComp_KindB" />
+                <node concept="2rqxmr" id="2B42b1rEfx4" role="lGtFl">
+                  <ref role="1BTHP0" node="3gB6VSLerpz" resolve="ExternalComp_KindB" />
+                  <node concept="3KTrbX" id="2B42b1rEfx5" role="3KTr4d">
+                    <ref role="3AHY9a" node="3gB6VSLekEE" resolve="testCompB" />
+                  </node>
+                  <node concept="3KTrbX" id="2B42b1rEfx6" role="3KTr4d">
                     <ref role="3AHY9a" node="48ZWgAGs_py" resolve="ExternalRootComp_KindA" />
+                  </node>
+                  <node concept="3KTrbX" id="2B42b1rEfx7" role="3KTr4d">
+                    <ref role="3AHY9a" node="3gB6VSLerpz" resolve="ExternalComp_KindB" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1z9TsT" id="2B42b1rEfxw" role="lGtFl">
+                <node concept="OjmMv" id="2B42b1rEfxx" role="1w35rA">
+                  <node concept="19SGf9" id="2B42b1rEfxy" role="OjmMu">
+                    <node concept="19SUe$" id="2B42b1rEfxz" role="19SJt6">
+                      <property role="19SUeA" value="instances of components with TestKindA and TestKindB are visible" />
+                    </node>
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/solutions/test.ts.components.core/models/tests@tests.mps
+++ b/code/languages/org.iets3.opensource/solutions/test.ts.components.core/models/tests@tests.mps
@@ -156,8 +156,9 @@
       </concept>
     </language>
     <language id="3c910f62-7ca9-45f3-a98a-c6239acaa8f1" name="test.iest3.component.attribute">
+      <concept id="3758002917742120259" name="test.iest3.component.attribute.structure.TestKindB" flags="ng" index="4KprX" />
       <concept id="4448734902941668085" name="test.iest3.component.attribute.structure.TestPortCategoryOffers" flags="ng" index="3o1koB" />
-      <concept id="4448734902941595848" name="test.iest3.component.attribute.structure.TestKind" flags="ng" index="3o2yKq" />
+      <concept id="4448734902941595848" name="test.iest3.component.attribute.structure.TestKindA" flags="ng" index="3o2yKq" />
       <concept id="4448734902940615074" name="test.iest3.component.attribute.structure.TestPortCategoryAccepts" flags="ng" index="3o5llK" />
       <concept id="4448734902940638651" name="test.iest3.component.attribute.structure.TestPortType" flags="ng" index="3o5o_D" />
       <concept id="4448734902938442738" name="test.iest3.component.attribute.structure.TestAttribute" flags="ng" index="3oewWw" />
@@ -293,7 +294,7 @@
           <node concept="GnABt" id="48ZWgAGs_vx" role="1i1XAe">
             <node concept="1i6xzV" id="48ZWgAGs_vC" role="GnABu">
               <node concept="1i1fwW" id="48ZWgAGs_vZ" role="MGl3R">
-                <ref role="1i1fwX" node="48ZWgAGs_py" resolve="ExternalRootComp" />
+                <ref role="1i1fwX" node="48ZWgAGs_py" resolve="ExternalRootComp_KindA" />
               </node>
               <node concept="pfQqD" id="48ZWgAGwlh3" role="pfQ1b">
                 <property role="pfQqC" value="extCmp" />
@@ -386,13 +387,13 @@
   <node concept="1i1ALs" id="48ZWgAGs_pv">
     <property role="TrG5h" value="ExternalChunk" />
     <node concept="1i1XBj" id="48ZWgAGs_py" role="1i1AA4">
-      <property role="TrG5h" value="ExternalRootComp" />
+      <property role="TrG5h" value="ExternalRootComp_KindA" />
       <property role="13Nl5X" value="true" />
       <node concept="3o2yKq" id="48ZWgAGs_px" role="1i0K$_" />
       <node concept="GnABt" id="48ZWgAGs_tL" role="1i1XAe">
         <node concept="1i6xzV" id="48ZWgAGs_tY" role="GnABu">
           <node concept="1i1fwW" id="48ZWgAGs_uh" role="MGl3R">
-            <ref role="1i1fwX" node="48ZWgAGs_tn" resolve="ExternalInnerComp" />
+            <ref role="1i1fwX" node="48ZWgAGs_tn" resolve="ExternalInnerComp_KindB" />
           </node>
           <node concept="pfQqD" id="48ZWgAGwlhI" role="pfQ1b">
             <property role="pfQqC" value="innerCmp" />
@@ -400,7 +401,7 @@
         </node>
         <node concept="1i6xzV" id="48ZWgAGwlpj" role="GnABu">
           <node concept="1i1fwW" id="48ZWgAGwlpk" role="MGl3R">
-            <ref role="1i1fwX" node="48ZWgAGs_tn" resolve="ExternalInnerComp" />
+            <ref role="1i1fwX" node="48ZWgAGs_tn" resolve="ExternalInnerComp_KindB" />
           </node>
           <node concept="pfQqD" id="48ZWgAGwlpl" role="pfQ1b">
             <property role="pfQqC" value="innerCmp2" />
@@ -444,7 +445,7 @@
       </node>
     </node>
     <node concept="1i1XBj" id="48ZWgAGs_tn" role="1i1AA4">
-      <property role="TrG5h" value="ExternalInnerComp" />
+      <property role="TrG5h" value="ExternalInnerComp_KindB" />
       <node concept="3o2yKq" id="48ZWgAGs_tl" role="1i0K$_" />
       <node concept="H_j2F" id="48ZWgAGwgLN" role="1i1XAe">
         <node concept="H_vQO" id="48ZWgAGwgLO" role="H_jLS" />
@@ -454,6 +455,39 @@
           <node concept="pfQqD" id="48ZWgAGwgOw" role="pfQ1b">
             <property role="pfQqC" value="a" />
           </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1i1XBj" id="3gB6VSLerpz" role="1i1AA4">
+      <property role="TrG5h" value="ExternalComp_KindA" />
+      <property role="13Nl5X" value="true" />
+      <node concept="4KprX" id="3gB6VSLerpx" role="1i0K$_" />
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="3gB6VSLekEx">
+    <property role="TrG5h" value="componentInstanceRefScope" />
+    <node concept="1qefOq" id="3gB6VSLekEy" role="1SKRRt">
+      <node concept="1i1ALs" id="3gB6VSLekE_" role="1qenE9">
+        <property role="TrG5h" value="chunk" />
+        <node concept="1i1XBj" id="3gB6VSLekEE" role="1i1AA4">
+          <property role="TrG5h" value="testComp" />
+          <node concept="4KprX" id="3gB6VSLekED" role="1i0K$_" />
+          <node concept="GnABt" id="3gB6VSLekFe" role="1i1XAe">
+            <node concept="1i6xzV" id="3gB6VSLekFl" role="GnABu">
+              <node concept="1i1fwW" id="3gB6VSLekFv" role="MGl3R">
+                <ref role="1i1fwX" node="48ZWgAGs_py" resolve="ExternalRootComp_KindA" />
+                <node concept="2rqxmr" id="3gB6VSLeroQ" role="lGtFl">
+                  <ref role="1BTHP0" node="48ZWgAGs_py" resolve="ExternalRootComp_KindA" />
+                  <node concept="3KTrbX" id="3gB6VSLeroR" role="3KTr4d">
+                    <ref role="3AHY9a" node="48ZWgAGs_py" resolve="ExternalRootComp_KindA" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3GEVxB" id="3gB6VSLekEZ" role="38kjvB">
+          <ref role="3GEb4d" node="48ZWgAGs_pv" resolve="ExternalChunk" />
         </node>
       </node>
     </node>


### PR DESCRIPTION
Currently it is not possible to restrict the scope of an <a href="http://127.0.0.1:63320/node?ref=r%3Ab3786745-c763-4a49-a754-f84e15236f18%28org.iets3.components.core.structure%29%2F7804632404593436654&project=org.iets3.opensource">ComponentRef.ref <a/> to specific kinds. By default all components (of all kinds) are in scope of an `AbstractComponentInstance.`
and only an error is show, when for ex.  a `kindB` instance is created inside of a `kindA` component.
```
kindA component A_Comp1 {
instance [ B_Comp and A_Comp2  are in scope ]
}
kindA component A_Comp2 {}

kindB component B_Comp {}
```
The following implementation moves the calculation of all visible components, which are referenced from a `AbstractComponentInstance` to the `ComponentKind` itself. Every kind can then itself decide which components should be used in the scope calculation.

I know that introducing  some new methods to handle this "kind specific" scenario is not the proper solution. Furthermore this pullrequest should be used to discuss how the `ComponentKind `, `IKindSpecific`, `IKindContext` behaviour methods could be refactored to make the usage of kinds (scoping constraints and checking rules) more understandable. 

Opinions/Ideas/Critics are welcome!
  