### PR TITLE
build: remove dependency on mbeddr.platform allScripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,6 @@ configurations {
 
 dependencies {
     mps "com.jetbrains:mps:$mpsVersion"
-    mpsArtifacts "com.mbeddr:allScripts:$mbeddrVersion"
     mpsArtifacts "com.mbeddr:platform:$mbeddrVersion"
 }
 

--- a/build/iets3.opensource.allScripts/build-allScripts.xml
+++ b/build/iets3.opensource.allScripts/build-allScripts.xml
@@ -8,9 +8,9 @@
   <property name="artifacts.root" location="${iets3.github.opensource.home}/artifacts" />
   <property name="iets3.os.home" location="${basedir}/../../code/languages/org.iets3.opensource" />
   <property name="artifacts.mps" location="${mps.home}" />
-  <property name="artifacts.com.mbeddr.allScripts.build" location="${artifacts.root}/com.mbeddr.allScripts.build" />
+  <property name="artifacts.com.mbeddr.platform" location="${artifacts.root}/com.mbeddr.platform" />
   <property file="${artifacts.mps}/build.properties" prefix="import.mps" />
-  <property file="${artifacts.com.mbeddr.allScripts.build}/build.properties" prefix="import.com.mbeddr.allScripts.build" />
+  <property file="${artifacts.com.mbeddr.platform}/build.properties" prefix="import.com.mbeddr.platform" />
   <property name="mps.build.number" value="${import.mps.mps.build.number}" />
   <property name="mps.date" value="${import.mps.mps.date}" />
   <property name="mps.build.vcs.number" value="${import.mps.mps.build.vcs.number}" />
@@ -18,10 +18,11 @@
   <property name="mps.idea.platform.build.number" value="${import.mps.mps.idea.platform.build.number}" />
   <property name="mps.mps.build.counter" value="${import.mps.mps.mps.build.counter}" />
   <property name="mpsBootstrapCore.version" value="${import.mps.mpsBootstrapCore.version}" />
-  <property name="com.mbeddr.allScripts.build.major.version" value="${import.com.mbeddr.allScripts.build.com.mbeddr.allScripts.build.major.version}" />
-  <property name="com.mbeddr.allScripts.build.minor.version" value="${import.com.mbeddr.allScripts.build.com.mbeddr.allScripts.build.minor.version}" />
-  <property name="com.mbeddr.allScripts.build.build" value="${import.com.mbeddr.allScripts.build.com.mbeddr.allScripts.build.build}" />
-  <property name="com.mbeddr.allScripts.build.mbeddr.version" value="${import.com.mbeddr.allScripts.build.com.mbeddr.allScripts.build.mbeddr.version}" />
+  <property name="com.mbeddr.platform.major.version" value="${import.com.mbeddr.platform.com.mbeddr.platform.major.version}" />
+  <property name="com.mbeddr.platform.minor.version" value="${import.com.mbeddr.platform.com.mbeddr.platform.minor.version}" />
+  <property name="com.mbeddr.platform.build" value="${import.com.mbeddr.platform.com.mbeddr.platform.build}" />
+  <property name="com.mbeddr.platform.mbeddr.version" value="${import.com.mbeddr.platform.com.mbeddr.platform.mbeddr.version}" />
+  <property name="mps-sl-all.versionNumber" value="${import.com.mbeddr.platform.mps-sl-all.versionNumber}" />
   <property name="environment" value="env" />
   <property name="env.JAVA_HOME" value="${java.home}/.." />
   <property name="jdk.home" value="${env.JAVA_HOME}" />
@@ -33,52 +34,7 @@
   </path>
   
   <target name="assemble" depends="classes, declare-mps-tasks">
-    <mkdir dir="${build.layout}/org.iets3.opensource.allScripts" />
-    <mkdir dir="${build.layout}/org.iets3.opensource.allScripts/META-INF" />
-    <echoxml file="${build.layout}/org.iets3.opensource.allScripts/META-INF/plugin.xml">
-      <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
-        <id>org.iets3.opensource.allScripts</id>
-        <name>org.iets3.opensource.allScripts</name>
-        <version>1.0</version>
-        <depends>com.mbeddr.allScripts</depends>
-        
-        <extensions defaultExtensionNs="com.intellij">
-          <mps.LanguageLibrary dir="/languages" />
-        </extensions>
-      </idea-plugin>
-    </echoxml>
-    <mkdir dir="${build.layout}/org.iets3.opensource.allScripts/languages" />
-    <mkdir dir="${build.layout}/org.iets3.opensource.allScripts/languages/iets3.build" />
-    <mkdir dir="${build.tmp}/default/org.iets3.opensource.allScripts.build.jar" />
-    <mkdir dir="${build.tmp}/default/org.iets3.opensource.allScripts.build.jar/META-INF" />
-    <echoxml file="${build.tmp}/default/org.iets3.opensource.allScripts.build.jar/META-INF/module.xml">
-      <module namespace="org.iets3.opensource.allScripts.build" type="solution" uuid="ed0abc8f-2bd9-460c-b01c-761f3a610483">
-        <dependencies />
-        <classpath>
-          <entry path="." />
-        </classpath>
-        <sources jar="org.iets3.opensource.allScripts.build-src.jar" descriptor="org.iets3.opensource.allScripts.build.msd" />
-      </module>
-    </echoxml>
-    <jar destfile="${build.layout}/org.iets3.opensource.allScripts/languages/iets3.build/org.iets3.opensource.allScripts.build.jar" duplicate="preserve">
-      <fileset dir="${build.tmp}/java/out/org.iets3.opensource.allScripts.build" />
-      <fileset dir="${iets3.os.home}/solutions/org.iets3.opensource.allScripts.build" includes="icons/**, resources/**" />
-      <fileset dir="${iets3.os.home}/solutions/org.iets3.opensource.allScripts.build/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
-      <fileset dir="${build.tmp}/default/org.iets3.opensource.allScripts.build.jar" />
-    </jar>
-    <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-org.iets3.opensource.allScripts.build-models">
-      <fileset dir="${iets3.os.home}/solutions/org.iets3.opensource.allScripts.build/models" includes="**/*.mps, **/*.metadata, **/*.history, **/*.mpsr, **/.model" />
-    </copyModels>
-    <jar destfile="${build.layout}/org.iets3.opensource.allScripts/languages/iets3.build/org.iets3.opensource.allScripts.build-src.jar" duplicate="preserve">
-      <fileset dir="${iets3.os.home}/solutions/org.iets3.opensource.allScripts.build/source_gen">
-        <exclude name="**/trace.info" />
-        <exclude name="**/exports" />
-        <exclude name="**/checkpoints" />
-        <exclude name="**/*.mps" />
-      </fileset>
-      <zipfileset file="${iets3.os.home}/solutions/org.iets3.opensource.allScripts.build/org.iets3.opensource.allScripts.build.msd" prefix="module" />
-      <zipfileset dir="${build.tmp}/customProcessors/copyModels/solutions-org.iets3.opensource.allScripts.build-models" prefix="module/models" />
-    </jar>
+    <mkdir dir="${build.layout}" />
     <mkdir dir="${build.tmp}/default/org.iets3.opensource.build.jar" />
     <mkdir dir="${build.tmp}/default/org.iets3.opensource.build.jar/META-INF" />
     <echoxml file="${build.tmp}/default/org.iets3.opensource.build.jar/META-INF/module.xml">
@@ -90,7 +46,7 @@
         <sources jar="org.iets3.opensource.build-src.jar" descriptor="org.iets3.opensource.build.msd" />
       </module>
     </echoxml>
-    <jar destfile="${build.layout}/org.iets3.opensource.allScripts/languages/iets3.build/org.iets3.opensource.build.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/org.iets3.opensource.build.jar" duplicate="preserve">
       <fileset dir="${build.tmp}/java/out/org.iets3.opensource.build" />
       <fileset dir="${iets3.os.home}/solutions/org.iets3.opensource.build" includes="icons/**, resources/**" />
       <fileset dir="${iets3.os.home}/solutions/org.iets3.opensource.build/source_gen" includes="**/trace.info, **/exports, **/*.mps, **/checkpoints" />
@@ -99,7 +55,7 @@
     <copyModels todir="${build.tmp}/customProcessors/copyModels/solutions-org.iets3.opensource.build-models">
       <fileset dir="${iets3.os.home}/solutions/org.iets3.opensource.build/models" includes="**/*.mps, **/*.metadata, **/*.history, **/*.mpsr, **/.model" />
     </copyModels>
-    <jar destfile="${build.layout}/org.iets3.opensource.allScripts/languages/iets3.build/org.iets3.opensource.build-src.jar" duplicate="preserve">
+    <jar destfile="${build.layout}/org.iets3.opensource.build-src.jar" duplicate="preserve">
       <fileset dir="${iets3.os.home}/solutions/org.iets3.opensource.build/source_gen">
         <exclude name="**/trace.info" />
         <exclude name="**/exports" />
@@ -109,7 +65,7 @@
       <zipfileset file="${iets3.os.home}/solutions/org.iets3.opensource.build/org.iets3.opensource.build.msd" prefix="module" />
       <zipfileset dir="${build.tmp}/customProcessors/copyModels/solutions-org.iets3.opensource.build-models" prefix="module/models" />
     </jar>
-    <echo file="${build.layout}/build.properties">mps.build.number=${mps.build.number}${line.separator}mps.date=${mps.date}${line.separator}mps.build.vcs.number=${mps.build.vcs.number}${line.separator}mps.teamcity.buildConfName=${mps.teamcity.buildConfName}${line.separator}mps.idea.platform.build.number=${mps.idea.platform.build.number}${line.separator}mps.mps.build.counter=${mps.mps.build.counter}${line.separator}mpsBootstrapCore.version=${mpsBootstrapCore.version}${line.separator}com.mbeddr.allScripts.build.major.version=${com.mbeddr.allScripts.build.major.version}${line.separator}com.mbeddr.allScripts.build.minor.version=${com.mbeddr.allScripts.build.minor.version}${line.separator}com.mbeddr.allScripts.build.build=${com.mbeddr.allScripts.build.build}${line.separator}com.mbeddr.allScripts.build.mbeddr.version=${com.mbeddr.allScripts.build.mbeddr.version}</echo>
+    <echo file="${build.layout}/build.properties">mps.build.number=${mps.build.number}${line.separator}mps.date=${mps.date}${line.separator}mps.build.vcs.number=${mps.build.vcs.number}${line.separator}mps.teamcity.buildConfName=${mps.teamcity.buildConfName}${line.separator}mps.idea.platform.build.number=${mps.idea.platform.build.number}${line.separator}mps.mps.build.counter=${mps.mps.build.counter}${line.separator}mpsBootstrapCore.version=${mpsBootstrapCore.version}${line.separator}com.mbeddr.platform.major.version=${com.mbeddr.platform.major.version}${line.separator}com.mbeddr.platform.minor.version=${com.mbeddr.platform.minor.version}${line.separator}com.mbeddr.platform.build=${com.mbeddr.platform.build}${line.separator}com.mbeddr.platform.mbeddr.version=${com.mbeddr.platform.mbeddr.version}${line.separator}mps-sl-all.versionNumber=${mps-sl-all.versionNumber}</echo>
   </target>
   
   <target name="buildDependents" />
@@ -123,7 +79,7 @@
     <delete dir="${build.layout}" />
   </target>
   
-  <target name="compileJava" depends="java.compile.org.iets3.opensource.allScripts.build, java.compile.org.iets3.opensource.build" />
+  <target name="compileJava" depends="java.compile.org.iets3.opensource.build" />
   
   <target name="processResources" />
   
@@ -136,18 +92,8 @@
   <target name="generate" depends="declare-mps-tasks, fetchDependencies">
     <echo message="generating" />
     <generate strictMode="true" parallelMode="true" parallelThreads="4" useInplaceTransform="true" hideWarnings="false" createStaticRefs="true" fork="true">
-      <plugin path="${artifacts.com.mbeddr.allScripts.build}/mbeddr.allScripts" />
-      <plugin path="${artifacts.mps}/plugins/mps-build" />
-      <plugin path="${artifacts.mps}/plugins/mps-core/META-INF/plugin.xml/../.." />
-      <plugin path="${artifacts.mps}/plugins/mps-debugger-api" />
-      <plugin path="${artifacts.mps}/plugins/mps-debugger-java" />
-      <plugin path="${artifacts.mps}/plugins/mps-execution-api" />
-      <plugin path="${artifacts.mps}/plugins/mps-execution-configurations" />
-      <plugin path="${artifacts.mps}/plugins/mps-execution-languages" />
-      <plugin path="${artifacts.mps}/plugins/mps-testing" />
-      <library file="${artifacts.com.mbeddr.allScripts.build}/mbeddr.allScripts/languages/de.slisson.mps.all.build.jar" />
-      <library file="${artifacts.com.mbeddr.allScripts.build}/mbeddr.allScripts/languages/mbeddr-platform/com.mbeddr.platform.jar" />
-      <library file="${artifacts.com.mbeddr.allScripts.build}/mbeddr.allScripts/languages/mbeddr.allScripts/com.mbeddr.allScripts.jar" />
+      <library file="${artifacts.com.mbeddr.platform}/com.mbeddr.platform.jar" />
+      <library file="${artifacts.com.mbeddr.platform}/de.slisson.mps.all/languages/de.slisson.mps.all/de.slisson.mps.all.build.jar" />
       <library file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.blTypes.jar" />
       <library file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.classifiers.jar" />
       <library file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.closures.jar" />
@@ -195,7 +141,6 @@
       <library file="${artifacts.mps}/languages/make/jetbrains.mps.make.reduced.jar" />
       <library file="${artifacts.mps}/languages/make/jetbrains.mps.tool.gentest.jar" />
       <library file="${artifacts.mps}/languages/text/jetbrains.mps.lang.text.jar" />
-      <library file="${artifacts.mps}/languages/util/jetbrains.mps.execution.util.jar" />
       <library file="${artifacts.mps}/languages/xml/jetbrains.mps.core.xml.jar" />
       <library file="${artifacts.mps}/lib/mps-behavior-api.jar" />
       <library file="${artifacts.mps}/lib/mps-closures.jar" />
@@ -209,35 +154,13 @@
       <library file="${artifacts.mps}/lib/mps-test.jar" />
       <library file="${artifacts.mps}/lib/mps-tool.jar" />
       <library file="${artifacts.mps}/lib/mps-tuples.jar" />
-      <library file="${artifacts.mps}/lib/mps-workbench.jar" />
       <library file="${artifacts.mps}/plugins/mps-build/languages/build/jetbrains.mps.build.jar" />
       <library file="${artifacts.mps}/plugins/mps-build/languages/build/jetbrains.mps.build.mps.jar" />
       <library file="${artifacts.mps}/plugins/mps-build/languages/build/jetbrains.mps.build.mps.tests.jar" />
       <library file="${artifacts.mps}/plugins/mps-build/languages/build/jetbrains.mps.build.workflow.jar" />
       <library file="${artifacts.mps}/plugins/mps-build/languages/build/jetbrains.mps.build.workflow.preset.jar" />
       <library file="${artifacts.mps}/plugins/mps-build/languages/build/jetbrains.mps.ide.build.jar" />
-      <library file="${artifacts.mps}/plugins/mps-debugger-api/languages/mps-debugger-api/jetbrains.mps.debugger.api.lang.jar" />
-      <library file="${artifacts.mps}/plugins/mps-debugger-api/lib/debugger-api.jar" />
-      <library file="${artifacts.mps}/plugins/mps-debugger-java/languages/mps-debugger-java/JDK-tools.jar" />
-      <library file="${artifacts.mps}/plugins/mps-debugger-java/languages/mps-debugger-java/jetbrains.mps.debugger.java.evaluation.jar" />
-      <library file="${artifacts.mps}/plugins/mps-debugger-java/languages/mps-debugger-java/jetbrains.mps.debugger.java.privateMembers.jar" />
-      <library file="${artifacts.mps}/plugins/mps-debugger-java/lib/debugger-java.jar" />
-      <library file="${artifacts.mps}/plugins/mps-execution-api/languages/mps-execution-api/jetbrains.mps.execution.common.jar" />
-      <library file="${artifacts.mps}/plugins/mps-execution-api/languages/mps-execution-api/jetbrains.mps.execution.settings.jar" />
-      <library file="${artifacts.mps}/plugins/mps-execution-api/lib/execution-api.jar" />
-      <library file="${artifacts.mps}/plugins/mps-execution-configurations/languages/mps-execution-configurations/jetbrains.mps.baseLanguage.execution.startup.jar" />
-      <library file="${artifacts.mps}/plugins/mps-execution-configurations/lib/execution-configurations.jar" />
-      <library file="${artifacts.mps}/plugins/mps-execution-languages/languages/mps-execution-languages/jetbrains.mps.execution.commands.jar" />
-      <library file="${artifacts.mps}/plugins/mps-execution-languages/languages/mps-execution-languages/jetbrains.mps.execution.configurations.jar" />
-      <library file="${artifacts.mps}/plugins/mps-execution-languages/languages/mps-execution-languages/jetbrains.mps.execution.configurations.pluginSolution.jar" />
-      <library file="${artifacts.mps}/plugins/mps-execution-languages/lib/execution-languages.jar" />
-      <library file="${artifacts.mps}/plugins/mps-testing/languages/baseLanguage/jetbrains.mps.baseLanguage.unitTest.jar" />
-      <library file="${artifacts.mps}/plugins/mps-testing/languages/languageDesign/jetbrains.mps.lang.test.jar" />
-      <library file="${artifacts.mps}/plugins/mps-testing/languages/languageDesign/jetbrains.mps.lang.test.matcher.jar" />
-      <library file="${artifacts.mps}/plugins/mps-testing/languages/languageDesign/jetbrains.mps.lang.test.runtime.jar" />
-      <library file="${artifacts.mps}/plugins/mps-testing/lib/jetbrains.mps.lang.test.util.jar" />
       <chunk>
-        <module file="${iets3.os.home}/solutions/org.iets3.opensource.allScripts.build/org.iets3.opensource.allScripts.build.msd" />
         <module file="${iets3.os.home}/solutions/org.iets3.opensource.build/org.iets3.opensource.build.msd" />
       </chunk>
       <jvmargs>
@@ -256,26 +179,6 @@
   
   <target name="makeDependents" />
   
-  <target name="java.compile.org.iets3.opensource.allScripts.build">
-    <mkdir dir="${iets3.os.home}/solutions/org.iets3.opensource.allScripts.build/source_gen" />
-    <mkdir dir="${build.tmp}/java/out/org.iets3.opensource.allScripts.build" />
-    <javac destdir="${build.tmp}/java/out/org.iets3.opensource.allScripts.build" fork="false" encoding="utf8" includeantruntime="false" debug="true">
-      <compilerarg value="-Xlint:none" />
-      <src>
-        <path location="${iets3.os.home}/solutions/org.iets3.opensource.allScripts.build/source_gen" />
-      </src>
-      <classpath>
-        <fileset file="${artifacts.com.mbeddr.allScripts.build}/mbeddr.allScripts/languages/mbeddr.allScripts/com.mbeddr.allScripts.jar" />
-        <fileset file="${artifacts.com.mbeddr.allScripts.build}/mbeddr.allScripts/languages/mbeddr-platform/com.mbeddr.platform.jar" />
-      </classpath>
-    </javac>
-    <copy todir="${build.tmp}/java/out/org.iets3.opensource.allScripts.build">
-      <fileset dir="${iets3.os.home}/solutions/org.iets3.opensource.allScripts.build/source_gen">
-        <include name="**/*.info" />
-      </fileset>
-    </copy>
-  </target>
-  
   <target name="java.compile.org.iets3.opensource.build">
     <mkdir dir="${iets3.os.home}/solutions/org.iets3.opensource.build/source_gen" />
     <mkdir dir="${build.tmp}/java/out/org.iets3.opensource.build" />
@@ -285,8 +188,8 @@
         <path location="${iets3.os.home}/solutions/org.iets3.opensource.build/source_gen" />
       </src>
       <classpath>
-        <fileset file="${artifacts.com.mbeddr.allScripts.build}/mbeddr.allScripts/languages/mbeddr-platform/com.mbeddr.platform.jar" />
-        <fileset file="${artifacts.com.mbeddr.allScripts.build}/mbeddr.allScripts/languages/de.slisson.mps.all.build.jar" />
+        <fileset file="${artifacts.com.mbeddr.platform}/com.mbeddr.platform.jar" />
+        <fileset file="${artifacts.com.mbeddr.platform}/de.slisson.mps.all/languages/de.slisson.mps.all/de.slisson.mps.all.build.jar" />
       </classpath>
     </javac>
     <copy todir="${build.tmp}/java/out/org.iets3.opensource.build">
@@ -297,7 +200,6 @@
   </target>
   
   <target name="cleanSources">
-    <delete dir="${iets3.os.home}/solutions/org.iets3.opensource.allScripts.build/source_gen" />
     <delete dir="${iets3.os.home}/solutions/org.iets3.opensource.build/source_gen" />
   </target>
 </project>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.allScripts.build/models/org/iets3/opensource/allScripts/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.allScripts.build/models/org/iets3/opensource/allScripts/build/build.mps
@@ -7,8 +7,8 @@
   </languages>
   <imports>
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
-    <import index="3fk" ref="r:caa661d5-e529-469c-bb25-dfa7a83b768e(com.mbeddr.allScripts.build)" />
     <import index="al5i" ref="r:742f344d-4dc4-4862-992c-4bc94b094870(com.mbeddr.mpsutil.dev.build)" />
+    <import index="90a9" ref="r:fb24ac52-5985-4947-bba9-25be6fd32c1a(de.slisson.mps.all.build)" implicit="true" />
   </imports>
   <registry>
     <language id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build">
@@ -25,9 +25,6 @@
         <property id="927724900262033862" name="copyResources" index="2_Ic$B" />
         <property id="6998860900671147996" name="javaLevel" index="TZNOO" />
         <child id="927724900262033863" name="resourceSelectors" index="2_Ic$A" />
-      </concept>
-      <concept id="4380385936562003279" name="jetbrains.mps.build.structure.BuildString" flags="ng" index="NbPM2">
-        <child id="4903714810883783243" name="parts" index="3MwsjC" />
       </concept>
       <concept id="8618885170173601777" name="jetbrains.mps.build.structure.BuildCompositePath" flags="nn" index="2Ry0Ak">
         <property id="8618885170173601779" name="head" index="2Ry0Am" />
@@ -56,16 +53,12 @@
       <concept id="4701820937132344003" name="jetbrains.mps.build.structure.BuildLayout_Container" flags="ng" index="1y1bJS">
         <child id="7389400916848037006" name="children" index="39821P" />
       </concept>
-      <concept id="841011766566059607" name="jetbrains.mps.build.structure.BuildStringNotEmpty" flags="ng" index="3_J27D" />
       <concept id="5248329904288051100" name="jetbrains.mps.build.structure.BuildFileIncludeSelector" flags="ng" index="3LWZYx">
         <property id="5248329904288051101" name="pattern" index="3LWZYw" />
       </concept>
       <concept id="5248329904287794596" name="jetbrains.mps.build.structure.BuildInputFiles" flags="ng" index="3LXTmp">
         <child id="5248329904287794598" name="dir" index="3LXTmr" />
         <child id="5248329904287794679" name="selectors" index="3LXTna" />
-      </concept>
-      <concept id="4903714810883702019" name="jetbrains.mps.build.structure.BuildTextStringPart" flags="ng" index="3Mxwew">
-        <property id="4903714810883755350" name="text" index="3MwjfP" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -74,25 +67,11 @@
       </concept>
     </language>
     <language id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps">
-      <concept id="6592112598314586625" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPluginGroup" flags="ng" index="m$f5U">
-        <reference id="6592112598314586626" name="group" index="m$f5T" />
-      </concept>
-      <concept id="6592112598314498932" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPlugin" flags="ng" index="m$_wf">
-        <property id="6592112598314498927" name="id" index="m$_wk" />
-        <child id="6592112598314498931" name="version" index="m$_w8" />
-        <child id="6592112598314499050" name="content" index="m$_yh" />
-        <child id="6592112598314499028" name="dependencies" index="m$_yJ" />
-        <child id="6592112598314499021" name="name" index="m$_yQ" />
-        <child id="6592112598314855574" name="containerName" index="m_cZH" />
-      </concept>
-      <concept id="6592112598314498926" name="jetbrains.mps.build.mps.structure.BuildMpsLayout_Plugin" flags="ng" index="m$_wl">
-        <reference id="6592112598314801433" name="plugin" index="m_rDy" />
-      </concept>
-      <concept id="6592112598314499027" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPluginDependency" flags="ng" index="m$_yC">
-        <reference id="6592112598314499066" name="target" index="m$_y1" />
-      </concept>
       <concept id="1500819558095907805" name="jetbrains.mps.build.mps.structure.BuildMps_Group" flags="ng" index="2G$12M">
         <child id="1500819558095907806" name="modules" index="2G$12L" />
+      </concept>
+      <concept id="1265949165890536423" name="jetbrains.mps.build.mps.structure.BuildMpsLayout_ModuleJars" flags="ng" index="L2wRC">
+        <reference id="1265949165890536425" name="module" index="L2wRA" />
       </concept>
       <concept id="868032131020265945" name="jetbrains.mps.build.mps.structure.BuildMPSPlugin" flags="ng" index="3b7kt6" />
       <concept id="5253498789149381388" name="jetbrains.mps.build.mps.structure.BuildMps_Module" flags="ng" index="3bQrTs">
@@ -144,84 +123,8 @@
       <property role="1wOHq$" value="true" />
       <property role="3Ej$Sc" value="true" />
     </node>
-    <node concept="m$_wf" id="Z5OQ302kgm" role="3989C9">
-      <property role="m$_wk" value="org.iets3.opensource.allScripts" />
-      <node concept="m$_yC" id="Z5OQ302khX" role="m$_yJ">
-        <ref role="m$_y1" to="3fk:46zCYP2pxWG" resolve="com.mbeddr.allScripts" />
-      </node>
-      <node concept="3_J27D" id="Z5OQ302kgo" role="m$_yQ">
-        <node concept="3Mxwew" id="Z5OQ302kh7" role="3MwsjC">
-          <property role="3MwjfP" value="org.iets3.opensource.allScripts" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="Z5OQ302kgq" role="m_cZH">
-        <node concept="3Mxwew" id="Z5OQ302kh9" role="3MwsjC">
-          <property role="3MwjfP" value="org.iets3.opensource.allScripts" />
-        </node>
-      </node>
-      <node concept="3_J27D" id="Z5OQ302kgs" role="m$_w8">
-        <node concept="3Mxwew" id="Z5OQ302khm" role="3MwsjC">
-          <property role="3MwjfP" value="1.0" />
-        </node>
-      </node>
-      <node concept="m$f5U" id="Z5OQ302khz" role="m$_yh">
-        <ref role="m$f5T" node="1fXtMa7qkPo" resolve="iets3.build" />
-      </node>
-    </node>
     <node concept="2G$12M" id="1fXtMa7qkPo" role="3989C9">
       <property role="TrG5h" value="iets3.build" />
-      <node concept="1E1JtA" id="1eN0CaCOBKU" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="org.iets3.opensource.allScripts.build" />
-        <property role="3LESm3" value="ed0abc8f-2bd9-460c-b01c-761f3a610483" />
-        <property role="2GAjPV" value="false" />
-        <node concept="398BVA" id="1eN0CaCOBMd" role="3LF7KH">
-          <ref role="398BVh" node="5wLtKNeTaqD" resolve="iets3.os.home" />
-          <node concept="2Ry0Ak" id="1eN0CaCOBMD" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="1eN0CaCOBNf" role="2Ry0An">
-              <property role="2Ry0Am" value="org.iets3.opensource.allScripts.build" />
-              <node concept="2Ry0Ak" id="1eN0CaCOBNE" role="2Ry0An">
-                <property role="2Ry0Am" value="org.iets3.opensource.allScripts.build.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="1eN0CaCOBNR" role="3bR37C">
-          <node concept="3bR9La" id="1eN0CaCOBNS" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="1eN0CaCOBNT" role="3bR37C">
-          <node concept="3bR9La" id="1eN0CaCOBNU" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" to="3fk:1RubBbpfBb$" resolve="com.mbeddr.allScripts" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="1eN0CaCOBNV" role="3bR37C">
-          <node concept="3bR9La" id="1eN0CaCOBNW" role="1SiIV1">
-            <property role="3bR36h" value="false" />
-            <ref role="3bR37D" to="3fk:6ucYLjoxZBc" resolve="com.mbeddr.platform" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="$iFvHj1vpZ" role="3bR31x">
-          <node concept="3LXTmp" id="$iFvHj1vq0" role="3rtmxm">
-            <node concept="3qWCbU" id="$iFvHj1vq1" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="$iFvHj1vq2" role="3LXTmr">
-              <ref role="398BVh" node="5wLtKNeTaqD" resolve="iets3.os.home" />
-              <node concept="2Ry0Ak" id="$iFvHj1vq3" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="$iFvHj1vq4" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.iets3.opensource.allScripts.build" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
       <node concept="1E1JtA" id="1fXtMa7ql1G" role="2G$12L">
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="org.iets3.opensource.build" />
@@ -230,7 +133,7 @@
         <node concept="1SiIV0" id="3cO$6RPVqKk" role="3bR37C">
           <node concept="3bR9La" id="3cO$6RPVqKl" role="1SiIV1">
             <property role="3bR36h" value="false" />
-            <ref role="3bR37D" to="3fk:2e9IswdwtSv" resolve="de.slisson.mps.all.build" />
+            <ref role="3bR37D" to="90a9:2Xjt3l5bx_L" resolve="de.slisson.mps.all.build" />
           </node>
         </node>
         <node concept="398BVA" id="1fXtMa7ql1H" role="3LF7KH">
@@ -253,7 +156,7 @@
         </node>
         <node concept="1SiIV0" id="3cO$6RPVqKo" role="3bR37C">
           <node concept="3bR9La" id="cnGxmGJtdo" role="1SiIV1">
-            <ref role="3bR37D" to="3fk:6ucYLjoxZBc" resolve="com.mbeddr.platform" />
+            <ref role="3bR37D" to="al5i:7Pr7tifzlku" resolve="com.mbeddr.platform" />
           </node>
         </node>
         <node concept="3rtmxn" id="$iFvHj1vpS" role="3bR31x">
@@ -360,18 +263,18 @@
         <ref role="398BVh" node="5wLtKNeSRPo" resolve="mps.home" />
       </node>
     </node>
-    <node concept="2sgV4H" id="1Y5vs7yKcUV" role="1l3spa">
-      <ref role="1l3spb" to="3fk:7uZw0yZ43Jk" resolve="com.mbeddr.allScripts.build" />
-      <node concept="398BVA" id="1Y5vs7yKdW_" role="2JcizS">
+    <node concept="2sgV4H" id="jS_CvxPMqM" role="1l3spa">
+      <ref role="1l3spb" to="al5i:3AVJcIMlF8l" resolve="com.mbeddr.platform" />
+      <node concept="398BVA" id="jS_CvxPMrd" role="2JcizS">
         <ref role="398BVh" node="1Y5vs7yKdNe" resolve="artifacts.root" />
-        <node concept="2Ry0Ak" id="1Y5vs7yKdX5" role="iGT6I">
-          <property role="2Ry0Am" value="com.mbeddr.allScripts.build" />
+        <node concept="2Ry0Ak" id="jS_CvxPMrC" role="iGT6I">
+          <property role="2Ry0Am" value="com.mbeddr.platform" />
         </node>
       </node>
     </node>
     <node concept="1l3spV" id="5wLtKNeSRRM" role="1l3spN">
-      <node concept="m$_wl" id="Z5OQ302kim" role="39821P">
-        <ref role="m_rDy" node="Z5OQ302kgm" resolve="org.iets3.opensource.allScripts" />
+      <node concept="L2wRC" id="jS_CvxPMsL" role="39821P">
+        <ref role="L2wRA" node="1fXtMa7ql1G" resolve="org.iets3.opensource.build" />
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.allScripts.build/org.iets3.opensource.allScripts.build.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.allScripts.build/org.iets3.opensource.allScripts.build.msd
@@ -8,7 +8,6 @@
   <sourcePath />
   <dependencies>
     <dependency reexport="false">422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)</dependency>
-    <dependency reexport="false">752496a0-da43-4b5e-bd15-ea1a5aa211f6(com.mbeddr.allScripts)</dependency>
     <dependency reexport="false">3ae9cfda-f938-4524-b4ca-fbcba3b0525b(com.mbeddr.platform)</dependency>
   </dependencies>
   <languageVersions>
@@ -17,7 +16,6 @@
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="1" />
   </languageVersions>
   <dependencyVersions>
-    <module reference="752496a0-da43-4b5e-bd15-ea1a5aa211f6(com.mbeddr.allScripts)" version="0" />
     <module reference="3ae9cfda-f938-4524-b4ca-fbcba3b0525b(com.mbeddr.platform)" version="0" />
     <module reference="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" version="0" />
     <module reference="ed0abc8f-2bd9-460c-b01c-761f3a610483(org.iets3.opensource.allScripts.build)" version="0" />


### PR DESCRIPTION
We don't need to depend on the allScripts artefact of the upstream dependency we can simply depend on the "normal" build solution to simplify our dependencies. 