### PR TITLE
Allow kind aware scope calculation of Component Instances

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
@@ -65,6 +65,9 @@
         <property id="1225194472834" name="isAbstract" index="13i0iv" />
         <reference id="1225194472831" name="overriddenMethod" index="13i0hy" />
       </concept>
+      <concept id="1225194628440" name="jetbrains.mps.lang.behavior.structure.SuperNodeExpression" flags="nn" index="13iAh5">
+        <reference id="5299096511375896640" name="superConcept" index="3eA5LN" />
+      </concept>
       <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -339,7 +342,6 @@
       <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
         <reference id="1139877738879" name="concept" index="1A0vxQ" />
       </concept>
-      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
         <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
       </concept>
@@ -362,13 +364,12 @@
       </concept>
       <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
-      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
-        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
-      </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
-      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -863,63 +864,26 @@
       <ref role="13i0hy" to="hwgx:79$zShlSHxZ" resolve="visibleContentsOfType" />
       <node concept="3Tm1VV" id="5WV8nQbZt_n" role="1B3o_S" />
       <node concept="3clFbS" id="5WV8nQbZt_w" role="3clF47">
-        <node concept="3clFbH" id="5WV8nQc1BTH" role="3cqZAp" />
-        <node concept="3SKdUt" id="5WV8nQc1Ckr" role="3cqZAp">
-          <node concept="3SKdUq" id="5WV8nQc1Ckt" role="3SKWNk">
-            <property role="3SKdUp" value="we do not call the super() implementation to avoid errors when IFunctionContainer is deleted" />
-          </node>
-        </node>
-        <node concept="3cpWs8" id="5WV8nQbZGoB" role="3cqZAp">
-          <node concept="3cpWsn" id="5WV8nQbZGoC" role="3cpWs9">
-            <property role="TrG5h" value="functions" />
-            <node concept="A3Dl8" id="5WV8nQbZGoD" role="1tU5fm">
-              <node concept="3Tqbb2" id="5WV8nQbZGoE" role="A3Ik2" />
+        <node concept="3cpWs8" id="7vIfM9I_b5y" role="3cqZAp">
+          <node concept="3cpWsn" id="7vIfM9I_b5z" role="3cpWs9">
+            <property role="TrG5h" value="parentScope" />
+            <node concept="3uibUv" id="7vIfM9I_b5v" role="1tU5fm">
+              <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
             </node>
-            <node concept="2OqwBi" id="5WV8nQbZGoF" role="33vP2m">
-              <node concept="13iPFW" id="5WV8nQbZGoG" role="2Oq$k0" />
-              <node concept="2qgKlT" id="5WV8nQbZGoH" role="2OqNvi">
-                <ref role="37wK5l" to="nu60:mQGcCvDdEN" resolve="visibleFunctions" />
+            <node concept="2OqwBi" id="7vIfM9I_b5$" role="33vP2m">
+              <node concept="13iAh5" id="7vIfM9I_b5_" role="2Oq$k0">
+                <ref role="3eA5LN" to="yv47:mQGcCvDdrZ" resolve="IFunctionContainer" />
               </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3SKdUt" id="5WV8nQc1c4z" role="3cqZAp">
-          <node concept="3SKdUq" id="5WV8nQc1c4_" role="3SKWNk">
-            <property role="3SKdUp" value="gather all visible elemnts from parent Provider" />
-          </node>
-        </node>
-        <node concept="3cpWs8" id="5WV8nQc1erx" role="3cqZAp">
-          <node concept="3cpWsn" id="5WV8nQc1ery" role="3cpWs9">
-            <property role="TrG5h" value="allVisibleElementsResult" />
-            <node concept="A3Dl8" id="5WV8nQc1ero" role="1tU5fm">
-              <node concept="3Tqbb2" id="5WV8nQc1err" role="A3Ik2" />
-            </node>
-            <node concept="2OqwBi" id="5WV8nQc1erz" role="33vP2m">
-              <node concept="2OqwBi" id="5WV8nQc1er$" role="2Oq$k0">
-                <node concept="13iPFW" id="5WV8nQc1er_" role="2Oq$k0" />
-                <node concept="2Xjw5R" id="5WV8nQc1erA" role="2OqNvi">
-                  <node concept="1xMEDy" id="5WV8nQc1erB" role="1xVPHs">
-                    <node concept="chp4Y" id="5WV8nQc1erC" role="ri$Ld">
-                      <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2qgKlT" id="5WV8nQc1erD" role="2OqNvi">
-                <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
-                <node concept="37vLTw" id="5WV8nQc1erE" role="37wK5m">
+              <node concept="2qgKlT" id="7vIfM9I_b5A" role="2OqNvi">
+                <ref role="37wK5l" to="hwgx:79$zShlSHxZ" resolve="visibleContentsOfType" />
+                <node concept="37vLTw" id="7vIfM9I_b5B" role="37wK5m">
                   <ref role="3cqZAo" node="5WV8nQbZt_x" resolve="targetConcept" />
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="5WV8nQc0PKx" role="3cqZAp" />
-        <node concept="3SKdUt" id="5WV8nQc0Pfu" role="3cqZAp">
-          <node concept="3SKdUq" id="5WV8nQc0Pfv" role="3SKWNk">
-            <property role="3SKdUp" value="consolidate the kind if additional restrictions are needed" />
-          </node>
-        </node>
+        <node concept="3clFbH" id="7vIfM9IH4K4" role="3cqZAp" />
         <node concept="3clFbJ" id="5WV8nQc0Pfw" role="3cqZAp">
           <node concept="3clFbS" id="5WV8nQc0Pfx" role="3clFbx">
             <node concept="3clFbJ" id="5WV8nQc0Pfy" role="3cqZAp">
@@ -934,68 +898,107 @@
                 </node>
               </node>
               <node concept="3clFbS" id="5WV8nQc0PfB" role="3clFbx">
-                <node concept="3clFbF" id="5WV8nQc1txK" role="3cqZAp">
-                  <node concept="37vLTI" id="5WV8nQc1txM" role="3clFbG">
-                    <node concept="2OqwBi" id="5WV8nQc0PfG" role="37vLTx">
-                      <node concept="37vLTw" id="5WV8nQc1nQF" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5WV8nQc1ery" resolve="allVisibleElementsResult" />
-                      </node>
-                      <node concept="3zZkjj" id="5WV8nQc0PfI" role="2OqNvi">
-                        <node concept="1bVj0M" id="5WV8nQc0PfJ" role="23t8la">
-                          <node concept="3clFbS" id="5WV8nQc0PfK" role="1bW5cS">
-                            <node concept="3SKdUt" id="5WV8nQc0PfL" role="3cqZAp">
-                              <node concept="3SKdUq" id="5WV8nQc0PfM" role="3SKWNk">
-                                <property role="3SKdUp" value="ask the kind of the referenced element if it can be in context of the current kind" />
-                              </node>
+                <node concept="3cpWs8" id="2Zn8KedPrHP" role="3cqZAp">
+                  <node concept="3cpWsn" id="2Zn8KedPrHQ" role="3cpWs9">
+                    <property role="TrG5h" value="filteredScope" />
+                    <node concept="3uibUv" id="2Zn8KedPrHO" role="1tU5fm">
+                      <ref role="3uigEE" to="o8zo:3rV3sBXetA0" resolve="FilteringScope" />
+                    </node>
+                    <node concept="2ShNRf" id="2Zn8KedPrHR" role="33vP2m">
+                      <node concept="YeOm9" id="2Zn8KedPrHS" role="2ShVmc">
+                        <node concept="1Y3b0j" id="2Zn8KedPrHT" role="YeSDq">
+                          <property role="2bfB8j" value="true" />
+                          <ref role="1Y3XeK" to="o8zo:3rV3sBXetA0" resolve="FilteringScope" />
+                          <ref role="37wK5l" to="o8zo:3rV3sBXetA2" resolve="FilteringScope" />
+                          <node concept="3Tm1VV" id="2Zn8KedPrHU" role="1B3o_S" />
+                          <node concept="37vLTw" id="2Zn8KedPrHV" role="37wK5m">
+                            <ref role="3cqZAo" node="7vIfM9I_b5z" resolve="parentScope" />
+                          </node>
+                          <node concept="3clFb_" id="2Zn8KedPrHW" role="jymVt">
+                            <property role="TrG5h" value="isExcluded" />
+                            <property role="1EzhhJ" value="false" />
+                            <node concept="10P_77" id="2Zn8KedPrHX" role="3clF45" />
+                            <node concept="3Tm1VV" id="2Zn8KedPrHY" role="1B3o_S" />
+                            <node concept="37vLTG" id="2Zn8KedPrHZ" role="3clF46">
+                              <property role="TrG5h" value="node" />
+                              <node concept="3Tqbb2" id="2Zn8KedPrI0" role="1tU5fm" />
                             </node>
-                            <node concept="3cpWs8" id="5WV8nQc0PfN" role="3cqZAp">
-                              <node concept="3cpWsn" id="5WV8nQc0PfO" role="3cpWs9">
-                                <property role="TrG5h" value="visibleElementsKind" />
-                                <node concept="3Tqbb2" id="5WV8nQc0PfP" role="1tU5fm">
-                                  <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
+                            <node concept="3clFbS" id="2Zn8KedPrI1" role="3clF47">
+                              <node concept="3clFbJ" id="2Zn8KedRiBr" role="3cqZAp">
+                                <node concept="3clFbS" id="2Zn8KedRiBt" role="3clFbx">
+                                  <node concept="3cpWs8" id="2Zn8KedPrI2" role="3cqZAp">
+                                    <node concept="3cpWsn" id="2Zn8KedPrI3" role="3cpWs9">
+                                      <property role="TrG5h" value="visibleElementsKind" />
+                                      <node concept="3Tqbb2" id="2Zn8KedPrI4" role="1tU5fm">
+                                        <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
+                                      </node>
+                                      <node concept="2OqwBi" id="2Zn8KedPrI5" role="33vP2m">
+                                        <node concept="1PxgMI" id="2Zn8KedPrI6" role="2Oq$k0">
+                                          <property role="1BlNFB" value="true" />
+                                          <node concept="chp4Y" id="2Zn8KedPrI7" role="3oSUPX">
+                                            <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+                                          </node>
+                                          <node concept="37vLTw" id="2Zn8KedPrI8" role="1m5AlR">
+                                            <ref role="3cqZAo" node="2Zn8KedPrHZ" resolve="node" />
+                                          </node>
+                                        </node>
+                                        <node concept="3TrEf2" id="2Zn8KedPrI9" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3cpWs6" id="2Zn8KedRk$_" role="3cqZAp">
+                                    <node concept="3fqX7Q" id="2Zn8KedRl9m" role="3cqZAk">
+                                      <node concept="2OqwBi" id="2Zn8KedRl9n" role="3fr31v">
+                                        <node concept="37vLTw" id="2Zn8KedRl9o" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="2Zn8KedPrI3" resolve="visibleElementsKind" />
+                                        </node>
+                                        <node concept="2qgKlT" id="2Zn8KedRl9p" role="2OqNvi">
+                                          <ref role="37wK5l" node="5WV8nQc1dAv" resolve="canBeReferencedInContext" />
+                                          <node concept="2OqwBi" id="2Zn8KedRl9q" role="37wK5m">
+                                            <node concept="13iPFW" id="2Zn8KedRl9r" role="2Oq$k0" />
+                                            <node concept="3TrEf2" id="2Zn8KedRl9s" role="2OqNvi">
+                                              <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
                                 </node>
-                                <node concept="2OqwBi" id="5WV8nQc0PfQ" role="33vP2m">
-                                  <node concept="1PxgMI" id="5WV8nQc0PfR" role="2Oq$k0">
-                                    <node concept="chp4Y" id="5WV8nQc1ofI" role="3oSUPX">
+                                <node concept="2OqwBi" id="2Zn8KedRj5w" role="3clFbw">
+                                  <node concept="37vLTw" id="2Zn8KedRiVU" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="2Zn8KedPrHZ" resolve="node" />
+                                  </node>
+                                  <node concept="1mIQ4w" id="2Zn8KedRjpx" role="2OqNvi">
+                                    <node concept="chp4Y" id="2Zn8KedRjrE" role="cj9EA">
                                       <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
                                     </node>
-                                    <node concept="37vLTw" id="5WV8nQc0PfT" role="1m5AlR">
-                                      <ref role="3cqZAo" node="5WV8nQc0Pg2" resolve="it" />
-                                    </node>
-                                  </node>
-                                  <node concept="2qgKlT" id="5WV8nQc0PfU" role="2OqNvi">
-                                    <ref role="37wK5l" node="6LfBX8Yl7t8" resolve="specifiedKind" />
                                   </node>
                                 </node>
                               </node>
-                            </node>
-                            <node concept="3clFbF" id="5WV8nQc0PfV" role="3cqZAp">
-                              <node concept="2OqwBi" id="5WV8nQc0PfW" role="3clFbG">
-                                <node concept="37vLTw" id="5WV8nQc0PfX" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="5WV8nQc0PfO" resolve="visibleElementsKind" />
-                                </node>
-                                <node concept="2qgKlT" id="5WV8nQc0PfY" role="2OqNvi">
-                                  <ref role="37wK5l" node="5WV8nQc1dAv" resolve="canBeReferencedInContext" />
-                                  <node concept="2OqwBi" id="5WV8nQc0PfZ" role="37wK5m">
-                                    <node concept="13iPFW" id="5WV8nQc0Pg0" role="2Oq$k0" />
-                                    <node concept="3TrEf2" id="5WV8nQc0Pg1" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
-                                    </node>
-                                  </node>
+                              <node concept="3SKdUt" id="2Zn8KedRoDh" role="3cqZAp">
+                                <node concept="3SKdUq" id="2Zn8KedRoDj" role="3SKWNk">
+                                  <property role="3SKdUp" value="any other nodes like Functions are allowed by default" />
                                 </node>
                               </node>
+                              <node concept="3cpWs6" id="2Zn8KedRlZ7" role="3cqZAp">
+                                <node concept="3clFbT" id="2Zn8KedRms6" role="3cqZAk" />
+                              </node>
                             </node>
-                          </node>
-                          <node concept="Rh6nW" id="5WV8nQc0Pg2" role="1bW2Oz">
-                            <property role="TrG5h" value="it" />
-                            <node concept="2jxLKc" id="5WV8nQc0Pg3" role="1tU5fm" />
+                            <node concept="2AHcQZ" id="2Zn8KedPrIh" role="2AJF6D">
+                              <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                            </node>
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="37vLTw" id="5WV8nQc1ui2" role="37vLTJ">
-                      <ref role="3cqZAo" node="5WV8nQc1ery" resolve="allVisibleElementsResult" />
-                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="7vIfM9I_cRL" role="3cqZAp">
+                  <node concept="37vLTw" id="2Zn8KedPrIi" role="3cqZAk">
+                    <ref role="3cqZAo" node="2Zn8KedPrHQ" resolve="filteredScope" />
                   </node>
                 </node>
               </node>
@@ -1014,19 +1017,8 @@
           </node>
         </node>
         <node concept="3cpWs6" id="5WV8nQbZSAs" role="3cqZAp">
-          <node concept="2YIFZM" id="5WV8nQbZT87" role="3cqZAk">
-            <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
-            <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
-            <node concept="2OqwBi" id="5WV8nQc1$t$" role="37wK5m">
-              <node concept="37vLTw" id="5WV8nQc1zT_" role="2Oq$k0">
-                <ref role="3cqZAo" node="5WV8nQc1ery" resolve="allVisibleElementsResult" />
-              </node>
-              <node concept="4Tj9Z" id="5WV8nQc1$Wh" role="2OqNvi">
-                <node concept="37vLTw" id="5WV8nQc1_jW" role="576Qk">
-                  <ref role="3cqZAo" node="5WV8nQbZGoC" resolve="functions" />
-                </node>
-              </node>
-            </node>
+          <node concept="37vLTw" id="7vIfM9IBT6_" role="3cqZAk">
+            <ref role="3cqZAo" node="7vIfM9I_b5z" resolve="parentScope" />
           </node>
         </node>
       </node>
@@ -1040,17 +1032,12 @@
       <node concept="P$JXv" id="5WV8nQc13Hb" role="lGtFl">
         <node concept="TZ5HA" id="5WV8nQc13Hc" role="TZ5H$">
           <node concept="1dT_AC" id="5WV8nQc13Hd" role="1dT_Ay">
-            <property role="1dT_AB" value="Delegates the scope calculation to the ancestor IVisibleElementProvider to retrieve " />
+            <property role="1dT_AB" value="Delegates the scope calculation to the ancestor IFunctionContainer to retrieve " />
           </node>
         </node>
         <node concept="TZ5HA" id="2f6nk2kkh2w" role="TZ5H$">
           <node concept="1dT_AC" id="2f6nk2kkh2x" role="1dT_Ay">
-            <property role="1dT_AB" value="all visible elements. The decision whether the scope should be restricuted is delegated" />
-          </node>
-        </node>
-        <node concept="TZ5HA" id="2f6nk2kkh3t" role="TZ5H$">
-          <node concept="1dT_AC" id="2f6nk2kkh3u" role="1dT_Ay">
-            <property role="1dT_AB" value="to the kind of the component." />
+            <property role="1dT_AB" value="all visible elements and filters it due to the retrictions of the kind." />
           </node>
         </node>
         <node concept="TZ5HA" id="2f6nk2kkh1_" role="TZ5H$">
@@ -1067,6 +1054,7 @@
         <node concept="x79VA" id="5WV8nQc13Hh" role="3nqlJM">
           <property role="x79VB" value="The Scope containing all elements that should be visible" />
         </node>
+        <node concept="1Ciki9" id="2Zn8KedNAtf" role="3nqlJM" />
       </node>
     </node>
     <node concept="13i0hz" id="x8tpSAdLM$" role="13h7CS">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
@@ -34,6 +34,7 @@
     <import index="1zby" ref="r:e876148b-672e-4264-9fee-d6d24a2d1223(org.iets3.core.expr.path.behavior)" />
     <import index="nu60" ref="r:cfd59c48-ecc8-4b0c-8ae8-6d876c46ebbb(org.iets3.core.expr.toplevel.behavior)" />
     <import index="yv47" ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" />
+    <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
     <import index="4kwy" ref="r:657c9fde-2f36-4e61-ae17-20f02b8630ad(org.iets3.core.base.structure)" implicit="true" />
   </imports>
   <registry>
@@ -255,13 +256,27 @@
       <concept id="5858074156537516430" name="jetbrains.mps.baseLanguage.javadoc.structure.ReturnBlockDocTag" flags="ng" index="x79VA">
         <property id="5858074156537516431" name="text" index="x79VB" />
       </concept>
+      <concept id="6832197706140518104" name="jetbrains.mps.baseLanguage.javadoc.structure.DocMethodParameterReference" flags="ng" index="zr_55" />
+      <concept id="6832197706140518103" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseParameterReference" flags="ng" index="zr_5a">
+        <reference id="6832197706140518108" name="param" index="zr_51" />
+      </concept>
       <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
         <child id="8465538089690331502" name="body" index="TZ5H$" />
         <child id="5383422241790532083" name="tags" index="3nqlJM" />
       </concept>
       <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690881930" name="jetbrains.mps.baseLanguage.javadoc.structure.ParameterBlockDocTag" flags="ng" index="TUZQ0">
+        <property id="8465538089690881934" name="text" index="TUZQ4" />
+        <child id="6832197706140518123" name="parameter" index="zr_5Q" />
+      </concept>
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
         <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="2217234381367190443" name="jetbrains.mps.baseLanguage.javadoc.structure.SeeBlockDocTag" flags="ng" index="VUp57">
+        <child id="2217234381367190458" name="reference" index="VUp5m" />
+      </concept>
+      <concept id="2217234381367530195" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocReference" flags="ng" index="VXe0Z">
+        <reference id="2217234381367530196" name="methodDeclaration" index="VXe0S" />
       </concept>
       <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
         <property id="8970989240999019144" name="text" index="1dT_AB" />
@@ -324,6 +339,10 @@
       <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
         <reference id="1139877738879" name="concept" index="1A0vxQ" />
       </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
+        <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
+      </concept>
       <concept id="1240170042401" name="jetbrains.mps.lang.smodel.structure.SEnumMemberType" flags="in" index="2ZThk1">
         <reference id="1240170836027" name="enum" index="2ZWj4r" />
       </concept>
@@ -343,6 +362,9 @@
       </concept>
       <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
@@ -831,6 +853,219 @@
           <node concept="37vLTw" id="x8tpSAdppp" role="3clFbG">
             <ref role="3cqZAo" node="x8tpSAdppg" resolve="ci" />
           </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="5WV8nQbZt_k" role="13h7CS">
+      <property role="TrG5h" value="visibleContentsOfType" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="hwgx:79$zShlSHxZ" resolve="visibleContentsOfType" />
+      <node concept="3Tm1VV" id="5WV8nQbZt_n" role="1B3o_S" />
+      <node concept="3clFbS" id="5WV8nQbZt_w" role="3clF47">
+        <node concept="3clFbH" id="5WV8nQc1BTH" role="3cqZAp" />
+        <node concept="3SKdUt" id="5WV8nQc1Ckr" role="3cqZAp">
+          <node concept="3SKdUq" id="5WV8nQc1Ckt" role="3SKWNk">
+            <property role="3SKdUp" value="we do not call the super() implementation to avoid errors when IFunctionContainer is deleted" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5WV8nQbZGoB" role="3cqZAp">
+          <node concept="3cpWsn" id="5WV8nQbZGoC" role="3cpWs9">
+            <property role="TrG5h" value="functions" />
+            <node concept="A3Dl8" id="5WV8nQbZGoD" role="1tU5fm">
+              <node concept="3Tqbb2" id="5WV8nQbZGoE" role="A3Ik2" />
+            </node>
+            <node concept="2OqwBi" id="5WV8nQbZGoF" role="33vP2m">
+              <node concept="13iPFW" id="5WV8nQbZGoG" role="2Oq$k0" />
+              <node concept="2qgKlT" id="5WV8nQbZGoH" role="2OqNvi">
+                <ref role="37wK5l" to="nu60:mQGcCvDdEN" resolve="visibleFunctions" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="5WV8nQc1c4z" role="3cqZAp">
+          <node concept="3SKdUq" id="5WV8nQc1c4_" role="3SKWNk">
+            <property role="3SKdUp" value="gather all visible elemnts from parent Provider" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5WV8nQc1erx" role="3cqZAp">
+          <node concept="3cpWsn" id="5WV8nQc1ery" role="3cpWs9">
+            <property role="TrG5h" value="allVisibleElementsResult" />
+            <node concept="A3Dl8" id="5WV8nQc1ero" role="1tU5fm">
+              <node concept="3Tqbb2" id="5WV8nQc1err" role="A3Ik2" />
+            </node>
+            <node concept="2OqwBi" id="5WV8nQc1erz" role="33vP2m">
+              <node concept="2OqwBi" id="5WV8nQc1er$" role="2Oq$k0">
+                <node concept="13iPFW" id="5WV8nQc1er_" role="2Oq$k0" />
+                <node concept="2Xjw5R" id="5WV8nQc1erA" role="2OqNvi">
+                  <node concept="1xMEDy" id="5WV8nQc1erB" role="1xVPHs">
+                    <node concept="chp4Y" id="5WV8nQc1erC" role="ri$Ld">
+                      <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2qgKlT" id="5WV8nQc1erD" role="2OqNvi">
+                <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                <node concept="37vLTw" id="5WV8nQc1erE" role="37wK5m">
+                  <ref role="3cqZAo" node="5WV8nQbZt_x" resolve="targetConcept" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5WV8nQc0PKx" role="3cqZAp" />
+        <node concept="3SKdUt" id="5WV8nQc0Pfu" role="3cqZAp">
+          <node concept="3SKdUq" id="5WV8nQc0Pfv" role="3SKWNk">
+            <property role="3SKdUp" value="consolidate the kind if additional restrictions are needed" />
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5WV8nQc0Pfw" role="3cqZAp">
+          <node concept="3clFbS" id="5WV8nQc0Pfx" role="3clFbx">
+            <node concept="3clFbJ" id="5WV8nQc0Pfy" role="3cqZAp">
+              <node concept="2OqwBi" id="5WV8nQc0Pfz" role="3clFbw">
+                <node concept="37vLTw" id="5WV8nQc0Pf$" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5WV8nQbZt_x" resolve="targetConcept" />
+                </node>
+                <node concept="2Zo12i" id="5WV8nQc0Pf_" role="2OqNvi">
+                  <node concept="chp4Y" id="5WV8nQc1df9" role="2Zo12j">
+                    <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="5WV8nQc0PfB" role="3clFbx">
+                <node concept="3clFbF" id="5WV8nQc1txK" role="3cqZAp">
+                  <node concept="37vLTI" id="5WV8nQc1txM" role="3clFbG">
+                    <node concept="2OqwBi" id="5WV8nQc0PfG" role="37vLTx">
+                      <node concept="37vLTw" id="5WV8nQc1nQF" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5WV8nQc1ery" resolve="allVisibleElementsResult" />
+                      </node>
+                      <node concept="3zZkjj" id="5WV8nQc0PfI" role="2OqNvi">
+                        <node concept="1bVj0M" id="5WV8nQc0PfJ" role="23t8la">
+                          <node concept="3clFbS" id="5WV8nQc0PfK" role="1bW5cS">
+                            <node concept="3SKdUt" id="5WV8nQc0PfL" role="3cqZAp">
+                              <node concept="3SKdUq" id="5WV8nQc0PfM" role="3SKWNk">
+                                <property role="3SKdUp" value="ask the kind of the referenced element if it can be in context of the current kind" />
+                              </node>
+                            </node>
+                            <node concept="3cpWs8" id="5WV8nQc0PfN" role="3cqZAp">
+                              <node concept="3cpWsn" id="5WV8nQc0PfO" role="3cpWs9">
+                                <property role="TrG5h" value="visibleElementsKind" />
+                                <node concept="3Tqbb2" id="5WV8nQc0PfP" role="1tU5fm">
+                                  <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
+                                </node>
+                                <node concept="2OqwBi" id="5WV8nQc0PfQ" role="33vP2m">
+                                  <node concept="1PxgMI" id="5WV8nQc0PfR" role="2Oq$k0">
+                                    <node concept="chp4Y" id="5WV8nQc1ofI" role="3oSUPX">
+                                      <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+                                    </node>
+                                    <node concept="37vLTw" id="5WV8nQc0PfT" role="1m5AlR">
+                                      <ref role="3cqZAo" node="5WV8nQc0Pg2" resolve="it" />
+                                    </node>
+                                  </node>
+                                  <node concept="2qgKlT" id="5WV8nQc0PfU" role="2OqNvi">
+                                    <ref role="37wK5l" node="6LfBX8Yl7t8" resolve="specifiedKind" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="5WV8nQc0PfV" role="3cqZAp">
+                              <node concept="2OqwBi" id="5WV8nQc0PfW" role="3clFbG">
+                                <node concept="37vLTw" id="5WV8nQc0PfX" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5WV8nQc0PfO" resolve="visibleElementsKind" />
+                                </node>
+                                <node concept="2qgKlT" id="5WV8nQc0PfY" role="2OqNvi">
+                                  <ref role="37wK5l" node="5WV8nQc1dAv" resolve="canBeReferencedInContext" />
+                                  <node concept="2OqwBi" id="5WV8nQc0PfZ" role="37wK5m">
+                                    <node concept="13iPFW" id="5WV8nQc0Pg0" role="2Oq$k0" />
+                                    <node concept="3TrEf2" id="5WV8nQc0Pg1" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="5WV8nQc0Pg2" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="5WV8nQc0Pg3" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="5WV8nQc1ui2" role="37vLTJ">
+                      <ref role="3cqZAo" node="5WV8nQc1ery" resolve="allVisibleElementsResult" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="5WV8nQc0Pg6" role="3clFbw">
+            <node concept="2OqwBi" id="5WV8nQc0Pg7" role="2Oq$k0">
+              <node concept="13iPFW" id="5WV8nQc0Pg8" role="2Oq$k0" />
+              <node concept="3TrEf2" id="5WV8nQc0Pg9" role="2OqNvi">
+                <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="5WV8nQc0Pga" role="2OqNvi">
+              <ref role="37wK5l" node="5WV8nQbQoYu" resolve="hasRestriction" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5WV8nQbZSAs" role="3cqZAp">
+          <node concept="2YIFZM" id="5WV8nQbZT87" role="3cqZAk">
+            <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
+            <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+            <node concept="2OqwBi" id="5WV8nQc1$t$" role="37wK5m">
+              <node concept="37vLTw" id="5WV8nQc1zT_" role="2Oq$k0">
+                <ref role="3cqZAo" node="5WV8nQc1ery" resolve="allVisibleElementsResult" />
+              </node>
+              <node concept="4Tj9Z" id="5WV8nQc1$Wh" role="2OqNvi">
+                <node concept="37vLTw" id="5WV8nQc1_jW" role="576Qk">
+                  <ref role="3cqZAo" node="5WV8nQbZGoC" resolve="functions" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5WV8nQbZt_x" role="3clF46">
+        <property role="TrG5h" value="targetConcept" />
+        <node concept="3bZ5Sz" id="5WV8nQbZt_y" role="1tU5fm" />
+      </node>
+      <node concept="3uibUv" id="5WV8nQbZt_z" role="3clF45">
+        <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
+      </node>
+      <node concept="P$JXv" id="5WV8nQc13Hb" role="lGtFl">
+        <node concept="TZ5HA" id="5WV8nQc13Hc" role="TZ5H$">
+          <node concept="1dT_AC" id="5WV8nQc13Hd" role="1dT_Ay">
+            <property role="1dT_AB" value="Delegates the scope calculation to the ancestor IVisibleElementProvider to retrieve " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="2f6nk2kkh2w" role="TZ5H$">
+          <node concept="1dT_AC" id="2f6nk2kkh2x" role="1dT_Ay">
+            <property role="1dT_AB" value="all visible elements. The decision whether the scope should be restricuted is delegated" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="2f6nk2kkh3t" role="TZ5H$">
+          <node concept="1dT_AC" id="2f6nk2kkh3u" role="1dT_Ay">
+            <property role="1dT_AB" value="to the kind of the component." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="2f6nk2kkh1_" role="TZ5H$">
+          <node concept="1dT_AC" id="2f6nk2kkh1A" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="5WV8nQc13He" role="3nqlJM">
+          <property role="TUZQ4" value="targetConcept" />
+          <node concept="zr_55" id="5WV8nQc13Hg" role="zr_5Q">
+            <ref role="zr_51" node="5WV8nQbZt_x" resolve="targetConcept" />
+          </node>
+        </node>
+        <node concept="x79VA" id="5WV8nQc13Hh" role="3nqlJM">
+          <property role="x79VB" value="The Scope containing all elements that should be visible" />
         </node>
       </node>
     </node>
@@ -2119,6 +2354,97 @@
               </node>
             </node>
           </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="5WV8nQbQoYu" role="13h7CS">
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="hasRestriction" />
+      <node concept="3Tm1VV" id="5WV8nQbQoYv" role="1B3o_S" />
+      <node concept="10P_77" id="5WV8nQbQp0S" role="3clF45" />
+      <node concept="3clFbS" id="5WV8nQbQoYx" role="3clF47">
+        <node concept="3clFbF" id="5WV8nQbR3NM" role="3cqZAp">
+          <node concept="3clFbT" id="5WV8nQbR3NL" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="5WV8nQbQpJ5" role="lGtFl">
+        <node concept="TZ5HA" id="5WV8nQbQpJ6" role="TZ5H$">
+          <node concept="1dT_AC" id="5WV8nQbQpJ7" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="5WV8nQbU2EA" role="TZ5H$">
+          <node concept="1dT_AC" id="5WV8nQbU2EB" role="1dT_Ay">
+            <property role="1dT_AB" value="By default no opt-in restrictions are available. " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="5WV8nQbU2HJ" role="TZ5H$">
+          <node concept="1dT_AC" id="5WV8nQbU2HK" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="5WV8nQbU2Gr" role="TZ5H$">
+          <node concept="1dT_AC" id="5WV8nQbU2Gs" role="1dT_Ay">
+            <property role="1dT_AB" value="If you want to enable the special kind restritions override this method and return true." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="2f6nk2kjSJN" role="TZ5H$">
+          <node concept="1dT_AC" id="2f6nk2kjSJO" role="1dT_Ay">
+            <property role="1dT_AB" value="In addtion provide a own implementation of canBeReferencedInContext" />
+          </node>
+        </node>
+        <node concept="x79VA" id="5WV8nQbQpJb" role="3nqlJM">
+          <property role="x79VB" value="false by default: no restrictions implemented by default " />
+        </node>
+        <node concept="VUp57" id="2f6nk2kjSKm" role="3nqlJM">
+          <node concept="VXe0Z" id="2f6nk2kk2$m" role="VUp5m">
+            <ref role="VXe0S" node="5WV8nQc1dAv" resolve="canBeReferencedInContext" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="5WV8nQc1dAv" role="13h7CS">
+      <property role="TrG5h" value="canBeReferencedInContext" />
+      <property role="13i0it" value="true" />
+      <node concept="3Tm1VV" id="5WV8nQc1dAw" role="1B3o_S" />
+      <node concept="10P_77" id="5WV8nQc1dCZ" role="3clF45" />
+      <node concept="3clFbS" id="5WV8nQc1dAy" role="3clF47">
+        <node concept="3clFbF" id="5WV8nQc1dDO" role="3cqZAp">
+          <node concept="3clFbT" id="5WV8nQc1dDN" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5WV8nQc1dI9" role="3clF46">
+        <property role="TrG5h" value="contextKind" />
+        <node concept="3Tqbb2" id="5WV8nQc1dI8" role="1tU5fm">
+          <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="5WV8nQc3X76" role="lGtFl">
+        <node concept="TZ5HA" id="5WV8nQc3X77" role="TZ5H$">
+          <node concept="1dT_AC" id="5WV8nQc3X78" role="1dT_Ay">
+            <property role="1dT_AB" value="By default any element with any kind can be referenced in a context." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="5WV8nQc41l2" role="TZ5H$">
+          <node concept="1dT_AC" id="5WV8nQc41l3" role="1dT_Ay">
+            <property role="1dT_AB" value="Override this method to customize the kind-relation conditions to restrict elements of specific" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="5WV8nQc41lm" role="TZ5H$">
+          <node concept="1dT_AC" id="5WV8nQc41ln" role="1dT_Ay">
+            <property role="1dT_AB" value="kinds from scope calculation" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="5WV8nQc3X79" role="3nqlJM">
+          <property role="TUZQ4" value="the kind of the context element" />
+          <node concept="zr_55" id="5WV8nQc3X7b" role="zr_5Q">
+            <ref role="zr_51" node="5WV8nQc1dI9" resolve="contextKind" />
+          </node>
+        </node>
+        <node concept="x79VA" id="5WV8nQc3X7c" role="3nqlJM">
+          <property role="x79VB" value="true by default: all elements with any kind are by default in allowed" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
@@ -924,67 +924,45 @@
                               <node concept="3Tqbb2" id="2Zn8KedPrI0" role="1tU5fm" />
                             </node>
                             <node concept="3clFbS" id="2Zn8KedPrI1" role="3clF47">
-                              <node concept="3clFbJ" id="2Zn8KedRiBr" role="3cqZAp">
-                                <node concept="3clFbS" id="2Zn8KedRiBt" role="3clFbx">
-                                  <node concept="3cpWs8" id="2Zn8KedPrI2" role="3cqZAp">
-                                    <node concept="3cpWsn" id="2Zn8KedPrI3" role="3cpWs9">
-                                      <property role="TrG5h" value="visibleElementsKind" />
-                                      <node concept="3Tqbb2" id="2Zn8KedPrI4" role="1tU5fm">
-                                        <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
+                              <node concept="3cpWs8" id="2Zn8KedPrI2" role="3cqZAp">
+                                <node concept="3cpWsn" id="2Zn8KedPrI3" role="3cpWs9">
+                                  <property role="TrG5h" value="visibleElementsKind" />
+                                  <node concept="3Tqbb2" id="2Zn8KedPrI4" role="1tU5fm">
+                                    <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
+                                  </node>
+                                  <node concept="2OqwBi" id="2Zn8KedPrI5" role="33vP2m">
+                                    <node concept="1PxgMI" id="2Zn8KedPrI6" role="2Oq$k0">
+                                      <property role="1BlNFB" value="true" />
+                                      <node concept="chp4Y" id="2Zn8KedPrI7" role="3oSUPX">
+                                        <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
                                       </node>
-                                      <node concept="2OqwBi" id="2Zn8KedPrI5" role="33vP2m">
-                                        <node concept="1PxgMI" id="2Zn8KedPrI6" role="2Oq$k0">
-                                          <property role="1BlNFB" value="true" />
-                                          <node concept="chp4Y" id="2Zn8KedPrI7" role="3oSUPX">
-                                            <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
-                                          </node>
-                                          <node concept="37vLTw" id="2Zn8KedPrI8" role="1m5AlR">
-                                            <ref role="3cqZAo" node="2Zn8KedPrHZ" resolve="node" />
-                                          </node>
-                                        </node>
-                                        <node concept="3TrEf2" id="2Zn8KedPrI9" role="2OqNvi">
+                                      <node concept="37vLTw" id="2Zn8KedPrI8" role="1m5AlR">
+                                        <ref role="3cqZAo" node="2Zn8KedPrHZ" resolve="node" />
+                                      </node>
+                                    </node>
+                                    <node concept="3TrEf2" id="2Zn8KedPrI9" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3cpWs6" id="2Zn8KedRk$_" role="3cqZAp">
+                                <node concept="3fqX7Q" id="2Zn8KedRl9m" role="3cqZAk">
+                                  <node concept="2OqwBi" id="2Zn8KedRl9n" role="3fr31v">
+                                    <node concept="37vLTw" id="2Zn8KedRl9o" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="2Zn8KedPrI3" resolve="visibleElementsKind" />
+                                    </node>
+                                    <node concept="2qgKlT" id="2Zn8KedRl9p" role="2OqNvi">
+                                      <ref role="37wK5l" node="5WV8nQc1dAv" resolve="canBeReferencedInContext" />
+                                      <node concept="2OqwBi" id="2Zn8KedRl9q" role="37wK5m">
+                                        <node concept="13iPFW" id="2Zn8KedRl9r" role="2Oq$k0" />
+                                        <node concept="3TrEf2" id="2Zn8KedRl9s" role="2OqNvi">
                                           <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
                                         </node>
                                       </node>
                                     </node>
                                   </node>
-                                  <node concept="3cpWs6" id="2Zn8KedRk$_" role="3cqZAp">
-                                    <node concept="3fqX7Q" id="2Zn8KedRl9m" role="3cqZAk">
-                                      <node concept="2OqwBi" id="2Zn8KedRl9n" role="3fr31v">
-                                        <node concept="37vLTw" id="2Zn8KedRl9o" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="2Zn8KedPrI3" resolve="visibleElementsKind" />
-                                        </node>
-                                        <node concept="2qgKlT" id="2Zn8KedRl9p" role="2OqNvi">
-                                          <ref role="37wK5l" node="5WV8nQc1dAv" resolve="canBeReferencedInContext" />
-                                          <node concept="2OqwBi" id="2Zn8KedRl9q" role="37wK5m">
-                                            <node concept="13iPFW" id="2Zn8KedRl9r" role="2Oq$k0" />
-                                            <node concept="3TrEf2" id="2Zn8KedRl9s" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
                                 </node>
-                                <node concept="2OqwBi" id="2Zn8KedRj5w" role="3clFbw">
-                                  <node concept="37vLTw" id="2Zn8KedRiVU" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="2Zn8KedPrHZ" resolve="node" />
-                                  </node>
-                                  <node concept="1mIQ4w" id="2Zn8KedRjpx" role="2OqNvi">
-                                    <node concept="chp4Y" id="2Zn8KedRjrE" role="cj9EA">
-                                      <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3SKdUt" id="2Zn8KedRoDh" role="3cqZAp">
-                                <node concept="3SKdUq" id="2Zn8KedRoDj" role="3SKWNk">
-                                  <property role="3SKdUp" value="any other nodes like Functions are allowed by default" />
-                                </node>
-                              </node>
-                              <node concept="3cpWs6" id="2Zn8KedRlZ7" role="3cqZAp">
-                                <node concept="3clFbT" id="2Zn8KedRms6" role="3cqZAk" />
                               </node>
                             </node>
                             <node concept="2AHcQZ" id="2Zn8KedPrIh" role="2AJF6D">
@@ -1012,7 +990,7 @@
               </node>
             </node>
             <node concept="2qgKlT" id="5WV8nQc0Pga" role="2OqNvi">
-              <ref role="37wK5l" node="5WV8nQbQoYu" resolve="hasRestriction" />
+              <ref role="37wK5l" node="5WV8nQbQoYu" resolve="restrictScope" />
             </node>
           </node>
         </node>
@@ -2347,7 +2325,7 @@
     </node>
     <node concept="13i0hz" id="5WV8nQbQoYu" role="13h7CS">
       <property role="13i0it" value="true" />
-      <property role="TrG5h" value="hasRestriction" />
+      <property role="TrG5h" value="restrictScope" />
       <node concept="3Tm1VV" id="5WV8nQbQoYv" role="1B3o_S" />
       <node concept="10P_77" id="5WV8nQbQp0S" role="3clF45" />
       <node concept="3clFbS" id="5WV8nQbQoYx" role="3clF47">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -5807,61 +5807,62 @@
       <ref role="13i0hy" to="hwgx:79$zShlSHxZ" resolve="visibleContentsOfType" />
       <node concept="3Tm1VV" id="5WV8nQbZt_n" role="1B3o_S" />
       <node concept="3clFbS" id="5WV8nQbZt_w" role="3clF47">
-        <node concept="3cpWs8" id="5WV8nQbZGoB" role="3cqZAp">
-          <node concept="3cpWsn" id="5WV8nQbZGoC" role="3cpWs9">
-            <property role="TrG5h" value="functions" />
-            <node concept="A3Dl8" id="5WV8nQbZGoD" role="1tU5fm">
-              <node concept="3Tqbb2" id="5WV8nQbZGoE" role="A3Ik2" />
+        <node concept="3cpWs8" id="2Zn8KedPNX2" role="3cqZAp">
+          <node concept="3cpWsn" id="2Zn8KedPNX3" role="3cpWs9">
+            <property role="TrG5h" value="parentScope" />
+            <node concept="3uibUv" id="2Zn8KedPNX0" role="1tU5fm">
+              <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
             </node>
-            <node concept="2OqwBi" id="5WV8nQbZGoF" role="33vP2m">
-              <node concept="13iPFW" id="5WV8nQbZGoG" role="2Oq$k0" />
-              <node concept="2qgKlT" id="5WV8nQbZGoH" role="2OqNvi">
-                <ref role="37wK5l" node="mQGcCvDdEN" resolve="visibleFunctions" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="5WV8nQbZTP7" role="3cqZAp">
-          <node concept="3cpWsn" id="5WV8nQbZTP8" role="3cpWs9">
-            <property role="TrG5h" value="allElements" />
-            <node concept="A3Dl8" id="5WV8nQbZTOD" role="1tU5fm">
-              <node concept="3Tqbb2" id="5WV8nQbZTOG" role="A3Ik2" />
-            </node>
-            <node concept="2OqwBi" id="5WV8nQbZTP9" role="33vP2m">
-              <node concept="37vLTw" id="5WV8nQbZTPa" role="2Oq$k0">
-                <ref role="3cqZAo" node="5WV8nQbZGoC" resolve="functions" />
-              </node>
-              <node concept="4Tj9Z" id="5WV8nQbZTPb" role="2OqNvi">
-                <node concept="2OqwBi" id="5WV8nQbZTPc" role="576Qk">
-                  <node concept="2OqwBi" id="5WV8nQbZTPd" role="2Oq$k0">
-                    <node concept="13iPFW" id="5WV8nQbZTPe" role="2Oq$k0" />
-                    <node concept="2Xjw5R" id="5WV8nQbZTPf" role="2OqNvi">
-                      <node concept="1xMEDy" id="5WV8nQbZTPg" role="1xVPHs">
-                        <node concept="chp4Y" id="5WV8nQbZTPh" role="ri$Ld">
-                          <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
-                        </node>
-                      </node>
+            <node concept="2OqwBi" id="2Zn8KedPNX4" role="33vP2m">
+              <node concept="2OqwBi" id="2Zn8KedPNX5" role="2Oq$k0">
+                <node concept="13iPFW" id="2Zn8KedPNX6" role="2Oq$k0" />
+                <node concept="2Xjw5R" id="2Zn8KedPNX7" role="2OqNvi">
+                  <node concept="1xMEDy" id="2Zn8KedPNX8" role="1xVPHs">
+                    <node concept="chp4Y" id="2Zn8KedPNX9" role="ri$Ld">
+                      <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
                     </node>
                   </node>
-                  <node concept="2qgKlT" id="5WV8nQbZTPi" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
-                    <node concept="37vLTw" id="5WV8nQbZTPj" role="37wK5m">
-                      <ref role="3cqZAo" node="5WV8nQbZt_x" resolve="targetConcept" />
-                    </node>
-                  </node>
+                </node>
+              </node>
+              <node concept="2qgKlT" id="2Zn8KedPNXa" role="2OqNvi">
+                <ref role="37wK5l" to="hwgx:79$zShlSHxZ" resolve="visibleContentsOfType" />
+                <node concept="37vLTw" id="2Zn8KedPNXb" role="37wK5m">
+                  <ref role="3cqZAo" node="5WV8nQbZt_x" resolve="targetConcept" />
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="5WV8nQbZVgo" role="3cqZAp" />
-        <node concept="3cpWs6" id="5WV8nQbZSAs" role="3cqZAp">
-          <node concept="2YIFZM" id="5WV8nQbZT87" role="3cqZAk">
-            <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
-            <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
-            <node concept="37vLTw" id="5WV8nQbZTPk" role="37wK5m">
-              <ref role="3cqZAo" node="5WV8nQbZTP8" resolve="allElements" />
+        <node concept="3cpWs8" id="7vIfM9IBEH$" role="3cqZAp">
+          <node concept="3cpWsn" id="7vIfM9IBEH_" role="3cpWs9">
+            <property role="TrG5h" value="compositeScope" />
+            <node concept="3uibUv" id="7vIfM9IBEHy" role="1tU5fm">
+              <ref role="3uigEE" to="o8zo:7ipADkTevLt" resolve="CompositeScope" />
             </node>
+            <node concept="2ShNRf" id="7vIfM9IBEHA" role="33vP2m">
+              <node concept="1pGfFk" id="7vIfM9IBEHB" role="2ShVmc">
+                <ref role="37wK5l" to="o8zo:7ipADkTevLv" resolve="CompositeScope" />
+                <node concept="2YIFZM" id="7vIfM9IBEHC" role="37wK5m">
+                  <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
+                  <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+                  <node concept="2OqwBi" id="7vIfM9IBEHD" role="37wK5m">
+                    <node concept="13iPFW" id="7vIfM9IBEHE" role="2Oq$k0" />
+                    <node concept="2qgKlT" id="7vIfM9IBEHF" role="2OqNvi">
+                      <ref role="37wK5l" node="mQGcCvDdEN" resolve="visibleFunctions" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="2Zn8KedPNXc" role="37wK5m">
+                  <ref role="3cqZAo" node="2Zn8KedPNX3" resolve="parentScope" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2Zn8KedPOFP" role="3cqZAp" />
+        <node concept="3cpWs6" id="5WV8nQbZSAs" role="3cqZAp">
+          <node concept="37vLTw" id="7vIfM9IBFf2" role="3cqZAk">
+            <ref role="3cqZAo" node="7vIfM9IBEH_" resolve="compositeScope" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -32,6 +32,7 @@
     <import index="pu3r" ref="r:9e94dd0f-9221-4302-af65-0a889986fe22(com.mbeddr.mpsutil.traceExplorer.plugin)" />
     <import index="oq0c" ref="r:6c6155f0-4bbe-4af5-8c26-244d570e21e4(org.iets3.core.expr.base.plugin)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
@@ -114,6 +115,7 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
@@ -240,10 +242,12 @@
       <concept id="3562215692195599741" name="jetbrains.mps.lang.smodel.structure.SLinkImplicitSelect" flags="nn" index="13MTOL">
         <reference id="3562215692195600259" name="link" index="13MTZf" />
       </concept>
+      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
+      <concept id="334628810661441841" name="jetbrains.mps.lang.smodel.structure.AsSConcept" flags="nn" index="1rGIog" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
@@ -5776,44 +5780,14 @@
         <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
       <node concept="3clFbS" id="mQGcCvAz0X" role="3clF47">
-        <node concept="3cpWs8" id="mQGcCvAKBk" role="3cqZAp">
-          <node concept="3cpWsn" id="mQGcCvAKBl" role="3cpWs9">
-            <property role="TrG5h" value="local" />
-            <node concept="A3Dl8" id="mQGcCvAKB1" role="1tU5fm">
-              <node concept="3Tqbb2" id="mQGcCvAKB4" role="A3Ik2" />
-            </node>
-            <node concept="2OqwBi" id="mQGcCvDe1G" role="33vP2m">
-              <node concept="13iPFW" id="mQGcCvDdQL" role="2Oq$k0" />
-              <node concept="2qgKlT" id="mQGcCvDehy" role="2OqNvi">
-                <ref role="37wK5l" node="mQGcCvDdEN" resolve="visibleFunctions" />
+        <node concept="3clFbF" id="5WV8nQbZGH$" role="3cqZAp">
+          <node concept="BsUDl" id="5WV8nQbZGHz" role="3clFbG">
+            <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+            <node concept="2OqwBi" id="5WV8nQbZRJF" role="37wK5m">
+              <node concept="37vLTw" id="5WV8nQbZRzW" role="2Oq$k0">
+                <ref role="3cqZAo" node="mQGcCvAz0Y" resolve="targetConcept" />
               </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="mQGcCvAzFr" role="3cqZAp">
-          <node concept="2OqwBi" id="mQGcCvALAd" role="3clFbG">
-            <node concept="37vLTw" id="mQGcCvAKBu" role="2Oq$k0">
-              <ref role="3cqZAo" node="mQGcCvAKBl" resolve="local" />
-            </node>
-            <node concept="4Tj9Z" id="mQGcCvALMc" role="2OqNvi">
-              <node concept="2OqwBi" id="mQGcCvAMJ0" role="576Qk">
-                <node concept="2OqwBi" id="mQGcCvAM50" role="2Oq$k0">
-                  <node concept="13iPFW" id="mQGcCvALN$" role="2Oq$k0" />
-                  <node concept="2Xjw5R" id="mQGcCvAMwh" role="2OqNvi">
-                    <node concept="1xMEDy" id="mQGcCvAMwj" role="1xVPHs">
-                      <node concept="chp4Y" id="mQGcCvAMzx" role="ri$Ld">
-                        <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="2qgKlT" id="mQGcCvAMU_" role="2OqNvi">
-                  <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                  <node concept="37vLTw" id="mQGcCvAN1g" role="37wK5m">
-                    <ref role="3cqZAo" node="mQGcCvAz0Y" resolve="targetConcept" />
-                  </node>
-                </node>
-              </node>
+              <node concept="1rGIog" id="5WV8nQbZRYn" role="2OqNvi" />
             </node>
           </node>
         </node>
@@ -5824,6 +5798,79 @@
       </node>
       <node concept="A3Dl8" id="mQGcCvAz10" role="3clF45">
         <node concept="3Tqbb2" id="mQGcCvAz11" role="A3Ik2" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="5WV8nQbZt_k" role="13h7CS">
+      <property role="TrG5h" value="visibleContentsOfType" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="hwgx:79$zShlSHxZ" resolve="visibleContentsOfType" />
+      <node concept="3Tm1VV" id="5WV8nQbZt_n" role="1B3o_S" />
+      <node concept="3clFbS" id="5WV8nQbZt_w" role="3clF47">
+        <node concept="3cpWs8" id="5WV8nQbZGoB" role="3cqZAp">
+          <node concept="3cpWsn" id="5WV8nQbZGoC" role="3cpWs9">
+            <property role="TrG5h" value="functions" />
+            <node concept="A3Dl8" id="5WV8nQbZGoD" role="1tU5fm">
+              <node concept="3Tqbb2" id="5WV8nQbZGoE" role="A3Ik2" />
+            </node>
+            <node concept="2OqwBi" id="5WV8nQbZGoF" role="33vP2m">
+              <node concept="13iPFW" id="5WV8nQbZGoG" role="2Oq$k0" />
+              <node concept="2qgKlT" id="5WV8nQbZGoH" role="2OqNvi">
+                <ref role="37wK5l" node="mQGcCvDdEN" resolve="visibleFunctions" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5WV8nQbZTP7" role="3cqZAp">
+          <node concept="3cpWsn" id="5WV8nQbZTP8" role="3cpWs9">
+            <property role="TrG5h" value="allElements" />
+            <node concept="A3Dl8" id="5WV8nQbZTOD" role="1tU5fm">
+              <node concept="3Tqbb2" id="5WV8nQbZTOG" role="A3Ik2" />
+            </node>
+            <node concept="2OqwBi" id="5WV8nQbZTP9" role="33vP2m">
+              <node concept="37vLTw" id="5WV8nQbZTPa" role="2Oq$k0">
+                <ref role="3cqZAo" node="5WV8nQbZGoC" resolve="functions" />
+              </node>
+              <node concept="4Tj9Z" id="5WV8nQbZTPb" role="2OqNvi">
+                <node concept="2OqwBi" id="5WV8nQbZTPc" role="576Qk">
+                  <node concept="2OqwBi" id="5WV8nQbZTPd" role="2Oq$k0">
+                    <node concept="13iPFW" id="5WV8nQbZTPe" role="2Oq$k0" />
+                    <node concept="2Xjw5R" id="5WV8nQbZTPf" role="2OqNvi">
+                      <node concept="1xMEDy" id="5WV8nQbZTPg" role="1xVPHs">
+                        <node concept="chp4Y" id="5WV8nQbZTPh" role="ri$Ld">
+                          <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="5WV8nQbZTPi" role="2OqNvi">
+                    <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                    <node concept="37vLTw" id="5WV8nQbZTPj" role="37wK5m">
+                      <ref role="3cqZAo" node="5WV8nQbZt_x" resolve="targetConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5WV8nQbZVgo" role="3cqZAp" />
+        <node concept="3cpWs6" id="5WV8nQbZSAs" role="3cqZAp">
+          <node concept="2YIFZM" id="5WV8nQbZT87" role="3cqZAk">
+            <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
+            <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+            <node concept="37vLTw" id="5WV8nQbZTPk" role="37wK5m">
+              <ref role="3cqZAo" node="5WV8nQbZTP8" resolve="allElements" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5WV8nQbZt_x" role="3clF46">
+        <property role="TrG5h" value="targetConcept" />
+        <node concept="3bZ5Sz" id="5WV8nQbZt_y" role="1tU5fm" />
+      </node>
+      <node concept="3uibUv" id="5WV8nQbZt_z" role="3clF45">
+        <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
       </node>
     </node>
     <node concept="13hLZK" id="mQGcCvDdtf" role="13h7CW">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -239,6 +239,9 @@
         <child id="1145567471833" name="createdType" index="2T96Bj" />
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
+        <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
+      </concept>
       <concept id="3562215692195599741" name="jetbrains.mps.lang.smodel.structure.SLinkImplicitSelect" flags="nn" index="13MTOL">
         <reference id="3562215692195600259" name="link" index="13MTZf" />
       </concept>
@@ -5833,36 +5836,55 @@
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="7vIfM9IBEH$" role="3cqZAp">
-          <node concept="3cpWsn" id="7vIfM9IBEH_" role="3cpWs9">
-            <property role="TrG5h" value="compositeScope" />
-            <node concept="3uibUv" id="7vIfM9IBEHy" role="1tU5fm">
-              <ref role="3uigEE" to="o8zo:7ipADkTevLt" resolve="CompositeScope" />
-            </node>
-            <node concept="2ShNRf" id="7vIfM9IBEHA" role="33vP2m">
-              <node concept="1pGfFk" id="7vIfM9IBEHB" role="2ShVmc">
-                <ref role="37wK5l" to="o8zo:7ipADkTevLv" resolve="CompositeScope" />
-                <node concept="2YIFZM" id="7vIfM9IBEHC" role="37wK5m">
-                  <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
-                  <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
-                  <node concept="2OqwBi" id="7vIfM9IBEHD" role="37wK5m">
-                    <node concept="13iPFW" id="7vIfM9IBEHE" role="2Oq$k0" />
-                    <node concept="2qgKlT" id="7vIfM9IBEHF" role="2OqNvi">
-                      <ref role="37wK5l" node="mQGcCvDdEN" resolve="visibleFunctions" />
+        <node concept="3clFbH" id="7LbZKOmGCHO" role="3cqZAp" />
+        <node concept="3clFbJ" id="7LbZKOmGxxV" role="3cqZAp">
+          <node concept="3clFbS" id="7LbZKOmGxxX" role="3clFbx">
+            <node concept="3cpWs8" id="7vIfM9IBEH$" role="3cqZAp">
+              <node concept="3cpWsn" id="7vIfM9IBEH_" role="3cpWs9">
+                <property role="TrG5h" value="compositeScope" />
+                <node concept="3uibUv" id="7vIfM9IBEHy" role="1tU5fm">
+                  <ref role="3uigEE" to="o8zo:7ipADkTevLt" resolve="CompositeScope" />
+                </node>
+                <node concept="2ShNRf" id="7vIfM9IBEHA" role="33vP2m">
+                  <node concept="1pGfFk" id="7vIfM9IBEHB" role="2ShVmc">
+                    <ref role="37wK5l" to="o8zo:7ipADkTevLv" resolve="CompositeScope" />
+                    <node concept="2YIFZM" id="7vIfM9IBEHC" role="37wK5m">
+                      <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
+                      <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+                      <node concept="2OqwBi" id="7vIfM9IBEHD" role="37wK5m">
+                        <node concept="13iPFW" id="7vIfM9IBEHE" role="2Oq$k0" />
+                        <node concept="2qgKlT" id="7vIfM9IBEHF" role="2OqNvi">
+                          <ref role="37wK5l" node="mQGcCvDdEN" resolve="visibleFunctions" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="2Zn8KedPNXc" role="37wK5m">
+                      <ref role="3cqZAo" node="2Zn8KedPNX3" resolve="parentScope" />
                     </node>
                   </node>
                 </node>
-                <node concept="37vLTw" id="2Zn8KedPNXc" role="37wK5m">
-                  <ref role="3cqZAo" node="2Zn8KedPNX3" resolve="parentScope" />
-                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="7LbZKOmGB_8" role="3cqZAp">
+              <node concept="37vLTw" id="7LbZKOmGBJn" role="3cqZAk">
+                <ref role="3cqZAo" node="7vIfM9IBEH_" resolve="compositeScope" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7LbZKOmGy0c" role="3clFbw">
+            <node concept="37vLTw" id="7LbZKOmGxGj" role="2Oq$k0">
+              <ref role="3cqZAo" node="5WV8nQbZt_x" resolve="targetConcept" />
+            </node>
+            <node concept="2Zo12i" id="7LbZKOmGBit" role="2OqNvi">
+              <node concept="chp4Y" id="7LbZKOmGBlw" role="2Zo12j">
+                <ref role="cht4Q" to="yv47:49WTic8f4iz" resolve="Function" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="2Zn8KedPOFP" role="3cqZAp" />
         <node concept="3cpWs6" id="5WV8nQbZSAs" role="3cqZAp">
-          <node concept="37vLTw" id="7vIfM9IBFf2" role="3cqZAk">
-            <ref role="3cqZAo" node="7vIfM9IBEH_" resolve="compositeScope" />
+          <node concept="37vLTw" id="7LbZKOmGCp_" role="3cqZAk">
+            <ref role="3cqZAo" node="2Zn8KedPNX3" resolve="parentScope" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/behavior.mps
@@ -9,6 +9,10 @@
     <import index="3eba" ref="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
     <import index="w9y2" ref="r:b3786745-c763-4a49-a754-f84e15236f18(org.iets3.components.core.structure)" />
     <import index="xens" ref="r:e2f731a4-551a-400e-a547-ea954abd0c47(test.iest3.component.attribute.structure)" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -34,6 +38,10 @@
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
@@ -45,6 +53,9 @@
       </concept>
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
@@ -70,6 +81,12 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
+      <concept id="6329021646629104957" name="jetbrains.mps.baseLanguage.structure.TextCommentPart" flags="nn" index="3SKdUq">
+        <property id="6329021646629104958" name="text" index="3SKdUp" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="6329021646629175155" name="commentPart" index="3SKWNk" />
+      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
@@ -81,6 +98,9 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
       <concept id="1240170042401" name="jetbrains.mps.lang.smodel.structure.SEnumMemberType" flags="in" index="2ZThk1">
         <reference id="1240170836027" name="enum" index="2ZWj4r" />
       </concept>
@@ -89,6 +109,9 @@
       </concept>
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz">
         <reference id="6677504323281689839" name="conceptDeclaraton" index="3bZ5Sy" />
+      </concept>
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="1240930118027" name="jetbrains.mps.lang.smodel.structure.SEnumOperationInvocation" flags="nn" index="3HcIyF">
         <reference id="1240930118028" name="enumDeclaration" index="3HcIyG" />
@@ -144,7 +167,7 @@
                 <ref role="35c_gD" to="w9y2:6LfBX8YlosD" resolve="ComponentInstance" />
               </node>
               <node concept="35c_gC" id="3QX5db_yp1N" role="HW$Y0">
-                <ref role="35c_gD" to="w9y2:mIQkxg5ZSA" resolve="AbstractConnector" />
+                <ref role="35c_gD" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
               </node>
               <node concept="35c_gC" id="3QX5db_ypsv" role="HW$Y0">
                 <ref role="35c_gD" to="w9y2:6LfBX8YkpdW" resolve="Port" />
@@ -478,6 +501,142 @@
       <node concept="3Tqbb2" id="48ZWgAGwiVj" role="3clF45">
         <ref role="ehGHo" to="w9y2:4KDeVD8s9RL" resolve="IConnectorType" />
       </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="7LbZKOmOPqW">
+    <ref role="13h7C2" to="xens:7LbZKOmHQeu" resolve="TestKindB" />
+    <node concept="13hLZK" id="7LbZKOmOPqX" role="13h7CW">
+      <node concept="3clFbS" id="7LbZKOmOPqY" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="7LbZKOmP4U0" role="13h7CS">
+      <property role="TrG5h" value="canBeReferencedInContext" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="3eba:5WV8nQc1dAv" resolve="canBeReferencedInContext" />
+      <node concept="3Tm1VV" id="7LbZKOmP4U1" role="1B3o_S" />
+      <node concept="3clFbS" id="7LbZKOmP4Ui" role="3clF47">
+        <node concept="3clFbF" id="7LbZKOmPg3Z" role="3cqZAp">
+          <node concept="2OqwBi" id="7LbZKOmPh27" role="3clFbG">
+            <node concept="37vLTw" id="7LbZKOmPh28" role="2Oq$k0">
+              <ref role="3cqZAo" node="7LbZKOmP4Uj" resolve="contextKind" />
+            </node>
+            <node concept="1mIQ4w" id="7LbZKOmPh29" role="2OqNvi">
+              <node concept="chp4Y" id="7LbZKOmT2so" role="cj9EA">
+                <ref role="cht4Q" to="xens:7LbZKOmT25i" resolve="TestKindC" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7LbZKOmP4Uj" role="3clF46">
+        <property role="TrG5h" value="contextKind" />
+        <node concept="3Tqbb2" id="7LbZKOmP4Uk" role="1tU5fm">
+          <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
+        </node>
+      </node>
+      <node concept="10P_77" id="7LbZKOmP4Ul" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="7LbZKOmT50L" role="13h7CS">
+      <property role="TrG5h" value="canBeInContext" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="3eba:6LfBX8Ylle0" resolve="canBeInContext" />
+      <node concept="3Tm1VV" id="7LbZKOmT50M" role="1B3o_S" />
+      <node concept="3clFbS" id="7LbZKOmT50Z" role="3clF47">
+        <node concept="3clFbF" id="7LbZKOmT5bx" role="3cqZAp">
+          <node concept="3clFbT" id="7LbZKOmT5bw" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7LbZKOmT510" role="3clF46">
+        <property role="TrG5h" value="contextKind" />
+        <node concept="3Tqbb2" id="7LbZKOmT511" role="1tU5fm">
+          <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
+        </node>
+      </node>
+      <node concept="10P_77" id="7LbZKOmT512" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="7LbZKOmT25j">
+    <ref role="13h7C2" to="xens:7LbZKOmT25i" resolve="TestKindC" />
+    <node concept="13hLZK" id="7LbZKOmT25k" role="13h7CW">
+      <node concept="3clFbS" id="7LbZKOmT25l" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="7LbZKOmT25H" role="13h7CS">
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="restrictScope" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="3eba:5WV8nQbQoYu" resolve="restrictScope" />
+      <node concept="3Tm1VV" id="7LbZKOmT25I" role="1B3o_S" />
+      <node concept="3clFbS" id="7LbZKOmT261" role="3clF47">
+        <node concept="3clFbF" id="7LbZKOmT2ae" role="3cqZAp">
+          <node concept="3clFbT" id="7LbZKOmT2ad" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="7LbZKOmT262" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="7LbZKOmT2ep" role="13h7CS">
+      <property role="TrG5h" value="canBeReferencedInContext" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="3eba:5WV8nQc1dAv" resolve="canBeReferencedInContext" />
+      <node concept="3Tm1VV" id="7LbZKOmT2eq" role="1B3o_S" />
+      <node concept="3clFbS" id="7LbZKOmT2eF" role="3clF47">
+        <node concept="3clFbF" id="7LbZKOmT2j5" role="3cqZAp">
+          <node concept="3clFbT" id="7LbZKOmT2j4" role="3clFbG">
+            <property role="3clFbU" value="false" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7LbZKOmT2eG" role="3clF46">
+        <property role="TrG5h" value="contextKind" />
+        <node concept="3Tqbb2" id="7LbZKOmT2eH" role="1tU5fm">
+          <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
+        </node>
+      </node>
+      <node concept="10P_77" id="7LbZKOmT2eI" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="7LbZKOmT6kE">
+    <ref role="13h7C2" to="xens:3QX5db_HNz8" resolve="TestKindA" />
+    <node concept="13hLZK" id="7LbZKOmT6kF" role="13h7CW">
+      <node concept="3clFbS" id="7LbZKOmT6kG" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="7LbZKOmT6kP" role="13h7CS">
+      <property role="TrG5h" value="canBeReferencedInContext" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="3eba:5WV8nQc1dAv" resolve="canBeReferencedInContext" />
+      <node concept="3Tm1VV" id="7LbZKOmT6kQ" role="1B3o_S" />
+      <node concept="3clFbS" id="7LbZKOmT6l7" role="3clF47">
+        <node concept="3SKdUt" id="7LbZKOmT72h" role="3cqZAp">
+          <node concept="3SKdUq" id="7LbZKOmT72j" role="3SKWNk">
+            <property role="3SKdUp" value="only used in the same kind" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="7LbZKOmT6sS" role="3cqZAp">
+          <node concept="2OqwBi" id="7LbZKOmT6__" role="3clFbG">
+            <node concept="37vLTw" id="7LbZKOmT6sM" role="2Oq$k0">
+              <ref role="3cqZAo" node="7LbZKOmT6l8" resolve="contextKind" />
+            </node>
+            <node concept="1mIQ4w" id="7LbZKOmT6St" role="2OqNvi">
+              <node concept="chp4Y" id="7LbZKOmT6XY" role="cj9EA">
+                <ref role="cht4Q" to="xens:3QX5db_HNz8" resolve="TestKindA" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7LbZKOmT6l8" role="3clF46">
+        <property role="TrG5h" value="contextKind" />
+        <node concept="3Tqbb2" id="7LbZKOmT6l9" role="1tU5fm">
+          <ref role="ehGHo" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
+        </node>
+      </node>
+      <node concept="10P_77" id="7LbZKOmT6la" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/editor.mps
@@ -166,15 +166,27 @@
       <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
     </node>
   </node>
+  <node concept="24kQdi" id="3QX5db_I9R1">
+    <ref role="1XX52x" to="xens:3QX5db_I5bP" resolve="TestPortCategoryOffers" />
+    <node concept="PMmxH" id="3QX5db_I9Rk" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="7LbZKOmHRWE">
+    <ref role="1XX52x" to="xens:7LbZKOmHQeu" resolve="TestKindB" />
+    <node concept="PMmxH" id="7LbZKOmHRWG" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+    </node>
+  </node>
   <node concept="24kQdi" id="3QX5db_HOqv">
-    <ref role="1XX52x" to="xens:3QX5db_HNz8" resolve="TestKind" />
+    <ref role="1XX52x" to="xens:3QX5db_HNz8" resolve="TestKindA" />
     <node concept="PMmxH" id="3QX5db_HOq$" role="2wV5jI">
       <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
     </node>
   </node>
-  <node concept="24kQdi" id="3QX5db_I9R1">
-    <ref role="1XX52x" to="xens:3QX5db_I5bP" resolve="TestPortCategoryOffers" />
-    <node concept="PMmxH" id="3QX5db_I9Rk" role="2wV5jI">
+  <node concept="24kQdi" id="7LbZKOmT25A">
+    <ref role="1XX52x" to="xens:7LbZKOmT25i" resolve="TestKindC" />
+    <node concept="PMmxH" id="7LbZKOmT25F" role="2wV5jI">
       <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/structure.mps
@@ -54,12 +54,6 @@
       <ref role="PrY4T" to="w9y2:6LfBX8YlAdL" resolve="IPortType" />
     </node>
   </node>
-  <node concept="1TIwiD" id="3QX5db_HNz8">
-    <property role="EcuMT" value="4448734902941595848" />
-    <property role="TrG5h" value="TestKind" />
-    <property role="34LRSv" value="testKind" />
-    <ref role="1TJDcQ" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
-  </node>
   <node concept="1TIwiD" id="3QX5db_I5bP">
     <property role="EcuMT" value="4448734902941668085" />
     <property role="TrG5h" value="TestPortCategoryOffers" />
@@ -73,6 +67,24 @@
     <node concept="PrWs8" id="48ZWgAGwh6E" role="PzmwI">
       <ref role="PrY4T" to="w9y2:4KDeVD8s9RL" resolve="IConnectorType" />
     </node>
+  </node>
+  <node concept="1TIwiD" id="7LbZKOmHQeu">
+    <property role="EcuMT" value="8956532715637138334" />
+    <property role="TrG5h" value="TestKindB" />
+    <property role="34LRSv" value="testKindB" />
+    <ref role="1TJDcQ" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
+  </node>
+  <node concept="1TIwiD" id="3QX5db_HNz8">
+    <property role="EcuMT" value="4448734902941595848" />
+    <property role="TrG5h" value="TestKindA" />
+    <property role="34LRSv" value="testKindA" />
+    <ref role="1TJDcQ" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
+  </node>
+  <node concept="1TIwiD" id="7LbZKOmT25i">
+    <property role="EcuMT" value="8956532715640070482" />
+    <property role="TrG5h" value="TestKindC" />
+    <property role="34LRSv" value="testKindC" />
+    <ref role="1TJDcQ" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/test.iest3.component.attribute.mpl
+++ b/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/test.iest3.component.attribute.mpl
@@ -77,6 +77,7 @@
   <sourcePath />
   <dependencies>
     <dependency reexport="false">f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:a0ab8c10-c118-4755-ba27-3853435cf524:de.itemis.mps.tooltips" version="0" />
@@ -152,6 +153,7 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="5" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="0" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="2" />
     <module reference="3c910f62-7ca9-45f3-a98a-c6239acaa8f1(test.iest3.component.attribute)" version="0" />
   </dependencyVersions>
   <extendedLanguages>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -4533,6 +4533,12 @@
           <ref role="3bR37D" node="5wLtKNeSRRr" resolve="org.iets3.components.core" />
         </node>
       </node>
+      <node concept="1SiIV0" id="7LbZKOmTk98" role="3bR37C">
+        <node concept="3bR9La" id="7LbZKOmTk99" role="1SiIV1">
+          <property role="3bR36h" value="false" />
+          <ref role="3bR37D" node="48ZWgAGrsoI" resolve="test.iest3.component.attribute" />
+        </node>
+      </node>
     </node>
     <node concept="1E1JtD" id="48ZWgAGrsoI" role="3989C9">
       <property role="BnDLt" value="true" />
@@ -4566,6 +4572,12 @@
         <property role="TrG5h" value="test.iest3.component.attribute#4448734902938436413" />
         <property role="3LESm3" value="b1c91bbf-bb96-4211-940e-f2ad74935cfa" />
         <property role="2GAjPV" value="false" />
+      </node>
+      <node concept="1SiIV0" id="7LbZKOmTk9s" role="3bR37C">
+        <node concept="3bR9La" id="7LbZKOmTk9t" role="1SiIV1">
+          <property role="3bR36h" value="false" />
+          <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+        </node>
       </node>
     </node>
     <node concept="2sgV4H" id="OJuIQp$deC" role="1l3spa">

--- a/code/languages/org.iets3.opensource/solutions/test.ts.components.core/models/tests@tests.mps
+++ b/code/languages/org.iets3.opensource/solutions/test.ts.components.core/models/tests@tests.mps
@@ -10,10 +10,14 @@
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="1" />
   </languages>
   <imports>
-    <import index="w9y2" ref="r:b3786745-c763-4a49-a754-f84e15236f18(org.iets3.components.core.structure)" />
+    <import index="xens" ref="r:e2f731a4-551a-400e-a547-ea954abd0c47(test.iest3.component.attribute.structure)" />
+    <import index="5etr" ref="r:769eaa92-d4cb-4fa9-87e4-269f7f35a1eb(org.iets3.components.core.typesystem)" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1215507671101" name="jetbrains.mps.lang.test.structure.NodeErrorCheckOperation" flags="ng" index="1TM$A">
+        <child id="8489045168660938517" name="errorRef" index="3lydEf" />
+      </concept>
       <concept id="1215603922101" name="jetbrains.mps.lang.test.structure.NodeOperationsContainer" flags="ng" index="7CXmI">
         <child id="1215604436604" name="nodeOperations" index="7EUXB" />
       </concept>
@@ -22,6 +26,10 @@
         <reference id="5449224527592117654" name="checkingReference" index="1BTHP0" />
         <child id="3655334166513314307" name="nodes" index="3KTr4d" />
       </concept>
+      <concept id="7691029917083872157" name="jetbrains.mps.lang.test.structure.IRuleReference" flags="ng" index="2u4UPC">
+        <reference id="8333855927540250453" name="declaration" index="39XzEq" />
+      </concept>
+      <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
       <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
       </concept>
@@ -44,6 +52,7 @@
       </concept>
     </language>
     <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
+      <concept id="2807135271608265973" name="org.iets3.core.expr.base.structure.NoneLiteral" flags="ng" index="UmHTt" />
       <concept id="5115872837156802409" name="org.iets3.core.expr.base.structure.UnaryExpression" flags="ng" index="30czhk">
         <child id="5115872837156802411" name="expr" index="30czhm" />
       </concept>
@@ -77,6 +86,12 @@
       <concept id="4886573260946639134" name="org.iets3.core.attributes.structure.AttributeContainerWithContext" flags="ng" index="3oth5z">
         <child id="806329106163391212" name="container" index="33Rvbw" />
       </concept>
+    </language>
+    <language id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel">
+      <concept id="411710798111762102" name="org.iets3.core.expr.toplevel.structure.AbstractFunctionAdapter" flags="ng" index="q4_pW">
+        <child id="411710798109576791" name="fun" index="qdjUt" />
+      </concept>
+      <concept id="4790956042240148643" name="org.iets3.core.expr.toplevel.structure.Function" flags="ng" index="1aga60" />
     </language>
     <language id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base">
       <concept id="8375407818529178006" name="com.mbeddr.core.base.structure.TextBlock" flags="ng" index="OjmMv">
@@ -137,8 +152,9 @@
       <concept id="227686178023855820" name="org.iets3.components.core.structure.AbstractConnectorRefTarget" flags="ng" index="1yi36j">
         <reference id="227686178023855923" name="connector" index="1yi31G" />
       </concept>
-      <concept id="4217735156746120255" name="" flags="ng" index="1O3KJS">
-        <child id="4217735156746171148" name="" index="1O05jb" />
+      <concept id="3177368305997534653" name="org.iets3.components.core.structure.CompFunctionAdapter" flags="ng" index="3zyh8u" />
+      <concept id="4217735156746120255" name="org.iets3.components.core.structure.AbstractConnectorBase" flags="ng" index="1O3KJS">
+        <child id="4217735156746171148" name="connectorType" index="1O05jb" />
       </concept>
       <concept id="2244552513301308396" name="org.iets3.components.core.structure.PortRefTarget" flags="ng" index="1WbEdM">
         <reference id="2244552513301308399" name="port" index="1WbEdL" />
@@ -157,11 +173,18 @@
     </language>
     <language id="3c910f62-7ca9-45f3-a98a-c6239acaa8f1" name="test.iest3.component.attribute">
       <concept id="4448734902941668085" name="test.iest3.component.attribute.structure.TestPortCategoryOffers" flags="ng" index="3o1koB" />
-      <concept id="4448734902941595848" name="test.iest3.component.attribute.structure.TestKind" flags="ng" index="3o2yKq" />
+      <concept id="4448734902941595848" name="test.iest3.component.attribute.structure.TestKindA" flags="ng" index="3o2yKq" />
       <concept id="4448734902940615074" name="test.iest3.component.attribute.structure.TestPortCategoryAccepts" flags="ng" index="3o5llK" />
       <concept id="4448734902940638651" name="test.iest3.component.attribute.structure.TestPortType" flags="ng" index="3o5o_D" />
       <concept id="4448734902938442738" name="test.iest3.component.attribute.structure.TestAttribute" flags="ng" index="3oewWw" />
+      <concept id="8956532715640070482" name="test.iest3.component.attribute.structure.TestKindC" flags="ng" index="1EFXTv" />
+      <concept id="8956532715637138334" name="test.iest3.component.attribute.structure.TestKindB" flags="ng" index="1EZ9Mj" />
       <concept id="4773799153887154601" name="test.iest3.component.attribute.structure.TestConnectorType" flags="ng" index="3IJI2w" />
+    </language>
+    <language id="9464fa06-5ab9-409b-9274-64ab29588457" name="org.iets3.core.expr.lambda">
+      <concept id="4790956042240100911" name="org.iets3.core.expr.lambda.structure.IFunctionLike" flags="ng" index="1ahQWc">
+        <child id="4790956042240100950" name="body" index="1ahQXP" />
+      </concept>
     </language>
   </registry>
   <node concept="2XOHcx" id="4rZeNQ6M9GV">
@@ -456,6 +479,152 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="7LbZKOmHCtv">
+    <property role="TrG5h" value="ComponentInstanceScopeCalculation" />
+    <node concept="1qefOq" id="7LbZKOmHCtw" role="1SKRRt">
+      <node concept="1i1ALs" id="7LbZKOmHCty" role="1qenE9">
+        <property role="TrG5h" value="someChunk" />
+        <node concept="1i1XBj" id="7LbZKOmHCt_" role="1i1AA4">
+          <property role="TrG5h" value="RootA" />
+          <node concept="GnABt" id="7LbZKOmHTHd" role="1i1XAe">
+            <node concept="1i6xzV" id="7LbZKOmHTHk" role="GnABu">
+              <node concept="1i1fwW" id="7LbZKOmHTHs" role="MGl3R">
+                <ref role="1i1fwX" node="7LbZKOmHOcg" resolve="CompA" />
+                <node concept="2rqxmr" id="7LbZKOmT8dZ" role="lGtFl">
+                  <ref role="1BTHP0" node="7LbZKOmHOcg" resolve="CompA" />
+                  <node concept="3KTrbX" id="7LbZKOmT8e0" role="3KTr4d">
+                    <ref role="3AHY9a" node="7LbZKOmHOcg" resolve="CompA" />
+                  </node>
+                  <node concept="3KTrbX" id="7LbZKOmT8e1" role="3KTr4d">
+                    <ref role="3AHY9a" node="7LbZKOmHRWj" resolve="CompB" />
+                  </node>
+                  <node concept="3KTrbX" id="7LbZKOmT8e2" role="3KTr4d">
+                    <ref role="3AHY9a" node="7LbZKOmT4ZF" resolve="CompC" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1z9TsT" id="7LbZKOmT8e_" role="lGtFl">
+                <node concept="OjmMv" id="7LbZKOmT8eA" role="1w35rA">
+                  <node concept="19SGf9" id="7LbZKOmT8eB" role="OjmMu">
+                    <node concept="19SUe$" id="7LbZKOmT8eC" role="19SJt6">
+                      <property role="19SUeA" value="testkindA can only be referenced in Component.Kind == testKindA&#10;In addition all other componentents with all kinds are in scope" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1i6xzV" id="7LbZKOmHTHC" role="GnABu">
+              <node concept="1i1fwW" id="7LbZKOmTgkO" role="MGl3R">
+                <ref role="1i1fwX" node="7LbZKOmT4ZF" resolve="CompC" />
+              </node>
+              <node concept="1z9TsT" id="7LbZKOmHTLg" role="lGtFl">
+                <node concept="OjmMv" id="7LbZKOmHTLh" role="1w35rA">
+                  <node concept="19SGf9" id="7LbZKOmHTLi" role="OjmMu">
+                    <node concept="19SUe$" id="7LbZKOmHTLj" role="19SJt6">
+                      <property role="19SUeA" value="generic error appears cause instance.kind(testKindC) != comp.kind(testKindA)" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="7CXmI" id="7LbZKOmT4YT" role="lGtFl">
+                <node concept="1TM$A" id="7LbZKOmT4YU" role="7EUXB">
+                  <node concept="2PYRI3" id="7LbZKOmT4YV" role="3lydEf">
+                    <ref role="39XzEq" to="5etr:6LfBX8Yll1h" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3o2yKq" id="7LbZKOmHCtH" role="1i0K$_" />
+          <node concept="1z9TsT" id="7LbZKOmHTI9" role="lGtFl">
+            <node concept="OjmMv" id="7LbZKOmHTIa" role="1w35rA">
+              <node concept="19SGf9" id="7LbZKOmHTIb" role="OjmMu">
+                <node concept="19SUe$" id="7LbZKOmHTIc" role="19SJt6">
+                  <property role="19SUeA" value="default behavior. testKindA does not constraint the scope of &#10;component instances according to their kinds. Everything is in scope." />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3GEVxB" id="7LbZKOmHTGn" role="38kjvB">
+          <ref role="3GEb4d" node="7LbZKOmHKL1" resolve="ExternalChunkForScopeTest" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="7LbZKOmHXzo" role="1SKRRt">
+      <node concept="1i1ALs" id="7LbZKOmHXzM" role="1qenE9">
+        <property role="TrG5h" value="somechunk2" />
+        <node concept="1i1XBj" id="7LbZKOmHXzQ" role="1i1AA4">
+          <property role="TrG5h" value="CompWithRestrictedScopeC" />
+          <node concept="1EFXTv" id="7LbZKOmT4WD" role="1i0K$_" />
+          <node concept="GnABt" id="7LbZKOmHX$f" role="1i1XAe">
+            <node concept="1i6xzV" id="7LbZKOmHX$o" role="GnABu">
+              <node concept="1i1fwW" id="7LbZKOmT50E" role="MGl3R">
+                <ref role="1i1fwX" node="7LbZKOmHRWj" resolve="CompB" />
+                <node concept="2rqxmr" id="7LbZKOmT6kr" role="lGtFl">
+                  <ref role="1BTHP0" node="7LbZKOmHRWj" resolve="CompB" />
+                  <node concept="3KTrbX" id="7LbZKOmT6ku" role="3KTr4d">
+                    <ref role="3AHY9a" node="7LbZKOmHRWj" resolve="CompB" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1z9TsT" id="7LbZKOmTe1P" role="lGtFl">
+                <node concept="OjmMv" id="7LbZKOmTe1Q" role="1w35rA">
+                  <node concept="19SGf9" id="7LbZKOmTe1R" role="OjmMu">
+                    <node concept="19SUe$" id="7LbZKOmTe1S" role="19SJt6">
+                      <property role="19SUeA" value="testKindB allows to be referenced in testKindC" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1z9TsT" id="7LbZKOmHX$H" role="lGtFl">
+            <node concept="OjmMv" id="7LbZKOmHX$I" role="1w35rA">
+              <node concept="19SGf9" id="7LbZKOmHX$J" role="OjmMu">
+                <node concept="19SUe$" id="7LbZKOmHX$K" role="19SJt6">
+                  <property role="19SUeA" value="testKindC restrict the scope of its ComponentInstances" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3GEVxB" id="7LbZKOmHX$l" role="38kjvB">
+          <ref role="3GEb4d" node="7LbZKOmHKL1" resolve="ExternalChunkForScopeTest" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1i1ALs" id="7LbZKOmHKL1">
+    <property role="TrG5h" value="ExternalChunkForScopeTest" />
+    <node concept="1i1XBj" id="7LbZKOmHOcg" role="1i1AA4">
+      <property role="TrG5h" value="CompA" />
+      <property role="13Nl5X" value="true" />
+      <node concept="3zyh8u" id="7LbZKOmHXBr" role="1i1XAe">
+        <node concept="1aga60" id="7LbZKOmHXBs" role="qdjUt">
+          <property role="TrG5h" value="funcInKindA" />
+          <node concept="UmHTt" id="7LbZKOmHXBt" role="1ahQXP" />
+        </node>
+      </node>
+      <node concept="3o2yKq" id="7LbZKOmHOcf" role="1i0K$_" />
+    </node>
+    <node concept="1i1XBj" id="7LbZKOmHRWj" role="1i1AA4">
+      <property role="TrG5h" value="CompB" />
+      <property role="13Nl5X" value="true" />
+      <node concept="1EZ9Mj" id="7LbZKOmHRWh" role="1i0K$_" />
+      <node concept="3zyh8u" id="7LbZKOmHX_l" role="1i1XAe">
+        <node concept="1aga60" id="7LbZKOmHX_m" role="qdjUt">
+          <property role="TrG5h" value="funcInKindB" />
+          <node concept="UmHTt" id="7LbZKOmHXB5" role="1ahQXP" />
+        </node>
+      </node>
+    </node>
+    <node concept="1i1XBj" id="7LbZKOmT4ZF" role="1i1AA4">
+      <property role="13Nl5X" value="true" />
+      <property role="TrG5h" value="CompC" />
+      <node concept="1EFXTv" id="7LbZKOmT50n" role="1i0K$_" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/solutions/test.ts.components.core/test.ts.components.core.msd
+++ b/code/languages/org.iets3.opensource/solutions/test.ts.components.core/test.ts.components.core.msd
@@ -9,6 +9,7 @@
   <dependencies>
     <dependency reexport="false">f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">3c910f62-7ca9-45f3-a98a-c6239acaa8f1(test.iest3.component.attribute)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="5" />
@@ -38,6 +39,7 @@
     <language slang="l:9464fa06-5ab9-409b-9274-64ab29588457:org.iets3.core.expr.lambda" version="0" />
     <language slang="l:f3eafff0-30d2-46d6-9150-f0f3b880ce27:org.iets3.core.expr.path" version="0" />
     <language slang="l:6b277d9a-d52d-416f-a209-1919bd737f50:org.iets3.core.expr.simpleTypes" version="1" />
+    <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="4" />
     <language slang="l:3c910f62-7ca9-45f3-a98a-c6239acaa8f1:test.iest3.component.attribute" version="0" />
   </languageVersions>
   <dependencyVersions>
@@ -77,6 +79,8 @@
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="5" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="0" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="2" />
+    <module reference="3c910f62-7ca9-45f3-a98a-c6239acaa8f1(test.iest3.component.attribute)" version="0" />
     <module reference="8239233b-13cc-4bd1-842b-cf2561ff9a12(test.ts.components.core)" version="0" />
   </dependencyVersions>
 </solution>

--- a/doc/design/01-kindaware-scope.md
+++ b/doc/design/01-kindaware-scope.md
@@ -40,7 +40,7 @@ The ComponentRef.ref should find (during scope calculation) its context-componen
 
 #### Improved Solution
 
-Instead of searching for the correct context from a Component.Ref, the Component.Ref should not be changed. It will still look for an  IVisibleElementsProvider to deliver a list of visible components for its scope. In addition the Component itself should be an IVisibleElementsProvider. It overrides the **visibleContentsOfType()** method and delegates the decision if elements list should be restricted to its kind. The ComponentKind shall have a method **virtual boolean hasRestriction()**, which returns by default false and a method  **virtual boolean canBeReferencedInContext() **which is true by default. So we don’t have any restrictions and allow any context-kind inside a "container"-kind.
+Instead of searching for the correct context from a Component.Ref, the Component.Ref should not be changed. It will still look for an  IVisibleElementsProvider to deliver a list of visible components for its scope. In addition the Component itself should be an IVisibleElementsProvider. It overrides the **visibleContentsOfType()** method and delegates the decision if elements list should be restricted to its kind. The ComponentKind shall have a method **virtual boolean restrictScope()**, which returns by default false and a method  **virtual boolean canBeReferencedInContext() **which is true by default. So we don’t have any restrictions and allow any context-kind inside a "container"-kind.
 
 <table>
   <tr>

--- a/doc/design/01-kindaware-scope.md
+++ b/doc/design/01-kindaware-scope.md
@@ -1,0 +1,64 @@
+Design decisions: Allow kind aware scope calculation of Component Instances
+
+## Current Situation
+
+### AbstractComponentInstance
+
+Assume you have the following model: 
+
+**kindA **component A_Comp1 {
+
+--------------------substructure--------------------	instance [ B_Comp and A_Comp2 are in scope ]}
+
+**kindA **component A_Comp2 {}**kindB **component B_Comp {}
+
+Currently when you create a component instance inside of a component substructure, every component regardless of its kind is in scope. There is only a generic error message that indicates that an instance where the kind is not the same as the parent component kind can not be used.
+
+There is currently no possibility to restrict this scope.
+
+## Target Situation
+
+Customer language should be able to decide if "additional" constraints should be applied to restrict the scope of such component refs.
+
+## Solutions
+
+#### Naiv Solution
+
+The ComponentRef.ref should find (during scope calculation) its context-component by traversing its parent hierarchy and consolidate if the kind of the instance allowes the usage of this instance in the current parent component. Here the **canBeInContext()** implementation of a ComponentKind is consolidated.
+
+<table>
+  <tr>
+    <td>Disadvantages</td>
+    <td>Advantages</td>
+  </tr>
+  <tr>
+    <td>ComponenRef.ref relies on a component context, which is not always the case. </td>
+    <td>It is obvious by looking into the code that the component is used as a context</td>
+  </tr>
+</table>
+
+
+#### Improved Solution
+
+Instead of searching for the correct context from a Component.Ref, the Component.Ref should not be changed. It will still look for an  IVisibleElementsProvider to deliver a list of visible components for its scope. In addition the Component itself should be an IVisibleElementsProvider. It overrides the **visibleContentsOfType()** method and delegates the decision if elements list should be restricted to its kind. The ComponentKind shall have a method **virtual boolean hasRestriction()**, which returns by default false and a method  **virtual boolean canBeReferencedInContext() **which is true by default. So we don’t have any restrictions and allow any context-kind inside a "container"-kind.
+
+<table>
+  <tr>
+    <td>Disadvantages</td>
+    <td>Advantages</td>
+  </tr>
+  <tr>
+    <td>More generic solution than changing only the ComponentRef.ref</td>
+    <td>Scope calculation isn’t that obvious </td>
+  </tr>
+  <tr>
+    <td>ComponentRef.ref is decoupled from the kind</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Less invasive because we do not need to change the contexts (component, mapping eetc.)</td>
+    <td></td>
+  </tr>
+</table>
+
+


### PR DESCRIPTION
### Current Situation

Assume you have the following model: 
```
kindA component A_Comp1 {
--------------------substructure--------------------
    instance [ B_Comp and A_Comp2 are in scope ]
}

kindA component A_Comp2 {}

kindB component B_Comp {}
```
Currently when you create a component instance inside of a component substructure, every component regardless of its kind is in scope. There is only a generic error message that indicates that an instance where the kind is not the same as the parent component kind can not be used.
There is currently no possibility to restrict this scope.

### Target Situation
Customer language should be able to decide if “additional” constraints should be applied to restrict the scope of such component refs.