### PR TITLE
comp: add parameter dependencies for ports

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
@@ -7423,7 +7423,7 @@
   </node>
   <node concept="13h7C7" id="6P1C6lFyl17">
     <property role="3GE5qa" value="components" />
-    <ref role="13h7C2" to="w9y2:4kCIAUZDmGW" resolve="PortWithConfiguraion" />
+    <ref role="13h7C2" to="w9y2:4kCIAUZDmGW" resolve="PortWithConfiguration" />
     <node concept="13hLZK" id="6P1C6lFyl18" role="13h7CW">
       <node concept="3clFbS" id="6P1C6lFyl19" role="2VODD2" />
     </node>
@@ -7444,7 +7444,7 @@
               <node concept="1PxgMI" id="6P1C6lFLVaJ" role="2Oq$k0">
                 <property role="1BlNFB" value="true" />
                 <node concept="chp4Y" id="6P1C6lFLVaK" role="3oSUPX">
-                  <ref role="cht4Q" to="w9y2:4kCIAUZDmGW" resolve="PortWithConfiguraion" />
+                  <ref role="cht4Q" to="w9y2:4kCIAUZDmGW" resolve="PortWithConfiguration" />
                 </node>
                 <node concept="37vLTw" id="6P1C6lFLVaL" role="1m5AlR">
                   <ref role="3cqZAo" node="6P1C6lFyl1r" resolve="governingPortType" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
@@ -8,7 +8,7 @@
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="-1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="-1" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="-1" />
-    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="1" />
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="-1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -7418,6 +7418,92 @@
           <property role="x79VB" value="the target for the connection. " />
         </node>
         <node concept="1Ciki9" id="430dwquwTKx" role="3nqlJM" />
+      </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="6P1C6lFyl17">
+    <property role="3GE5qa" value="components" />
+    <ref role="13h7C2" to="w9y2:4kCIAUZDmGW" resolve="PortWithConfiguraion" />
+    <node concept="13hLZK" id="6P1C6lFyl18" role="13h7CW">
+      <node concept="3clFbS" id="6P1C6lFyl19" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="6P1C6lFyl1i" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="isCompatibleWithGoverningType" />
+      <ref role="13i0hy" node="cJpacq1kKx" resolve="isCompatibleWithGoverningType" />
+      <node concept="3Tm1VV" id="6P1C6lFyl1j" role="1B3o_S" />
+      <node concept="3clFbS" id="6P1C6lFyl1q" role="3clF47">
+        <node concept="3cpWs8" id="6P1C6lFLVaG" role="3cqZAp">
+          <node concept="3cpWsn" id="6P1C6lFLVaH" role="3cpWs9">
+            <property role="TrG5h" value="wrapped" />
+            <node concept="3Tqbb2" id="6P1C6lFLVaA" role="1tU5fm">
+              <ref role="ehGHo" to="w9y2:6LfBX8YlAdL" resolve="IPortType" />
+            </node>
+            <node concept="2OqwBi" id="6P1C6lFLVaI" role="33vP2m">
+              <node concept="1PxgMI" id="6P1C6lFLVaJ" role="2Oq$k0">
+                <property role="1BlNFB" value="true" />
+                <node concept="chp4Y" id="6P1C6lFLVaK" role="3oSUPX">
+                  <ref role="cht4Q" to="w9y2:4kCIAUZDmGW" resolve="PortWithConfiguraion" />
+                </node>
+                <node concept="37vLTw" id="6P1C6lFLVaL" role="1m5AlR">
+                  <ref role="3cqZAo" node="6P1C6lFyl1r" resolve="governingPortType" />
+                </node>
+              </node>
+              <node concept="3TrEf2" id="6P1C6lFLVaM" role="2OqNvi">
+                <ref role="3Tt5mk" to="w9y2:4kCIAUZDmHT" resolve="wrapped" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6P1C6lFylP2" role="3cqZAp">
+          <node concept="2OqwBi" id="6P1C6lFymyf" role="3clFbG">
+            <node concept="2OqwBi" id="6P1C6lFym0K" role="2Oq$k0">
+              <node concept="13iPFW" id="6P1C6lFylP1" role="2Oq$k0" />
+              <node concept="3TrEf2" id="6P1C6lFymcc" role="2OqNvi">
+                <ref role="3Tt5mk" to="w9y2:4kCIAUZDmHT" resolve="wrapped" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="6P1C6lFymGq" role="2OqNvi">
+              <ref role="37wK5l" node="cJpacq1kKx" resolve="isCompatibleWithGoverningType" />
+              <node concept="37vLTw" id="6P1C6lFLVrQ" role="37wK5m">
+                <ref role="3cqZAo" node="6P1C6lFLVaH" resolve="wrapped" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6P1C6lFyl1r" role="3clF46">
+        <property role="TrG5h" value="governingPortType" />
+        <node concept="3Tqbb2" id="6P1C6lFyl1s" role="1tU5fm">
+          <ref role="ehGHo" to="w9y2:6LfBX8YlAdL" resolve="IPortType" />
+        </node>
+      </node>
+      <node concept="10P_77" id="6P1C6lFyl1t" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="6P1C6lFyn7B" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="createConnectorType" />
+      <ref role="13i0hy" node="4KDeVD8s9TJ" resolve="createConnectorType" />
+      <node concept="3Tm1VV" id="6P1C6lFyn7C" role="1B3o_S" />
+      <node concept="3clFbS" id="6P1C6lFyn7H" role="3clF47">
+        <node concept="3clFbF" id="6P1C6lFyneu" role="3cqZAp">
+          <node concept="2OqwBi" id="6P1C6lFyo6C" role="3clFbG">
+            <node concept="2OqwBi" id="6P1C6lFynqc" role="2Oq$k0">
+              <node concept="13iPFW" id="6P1C6lFynet" role="2Oq$k0" />
+              <node concept="3TrEf2" id="6P1C6lFynK_" role="2OqNvi">
+                <ref role="3Tt5mk" to="w9y2:4kCIAUZDmHT" resolve="wrapped" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="6P1C6lFyonV" role="2OqNvi">
+              <ref role="37wK5l" node="4KDeVD8s9TJ" resolve="createConnectorType" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="6P1C6lFyn7I" role="3clF45">
+        <ref role="ehGHo" to="w9y2:4KDeVD8s9RL" resolve="IConnectorType" />
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
@@ -430,7 +430,6 @@
       </concept>
     </language>
     <language id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells">
-      <concept id="1984422498402698431" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell_Condition" flags="ig" index="2e7140" />
       <concept id="5083944728300220902" name="com.mbeddr.mpsutil.grammarcells.structure.SubstituteCell" flags="ng" index="yw3OH">
         <child id="5083944728300220903" name="wrapped" index="yw3OG" />
       </concept>
@@ -441,7 +440,6 @@
       <concept id="8945098465480383073" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell_TransformationText" flags="ig" index="ZYGn8" />
       <concept id="7363578995839203705" name="com.mbeddr.mpsutil.grammarcells.structure.FlagCell" flags="sg" stub="1984422498400729024" index="1kHk_G" />
       <concept id="7363578995839435357" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell" flags="ng" index="1kIj98">
-        <child id="1984422498402083610" name="sideTransformationCondition" index="2e1Fq_" />
         <child id="7363578995839435358" name="wrapped" index="1kIj9b" />
       </concept>
     </language>
@@ -13656,34 +13654,11 @@
   </node>
   <node concept="24kQdi" id="4kCIAUZDmJh">
     <property role="3GE5qa" value="components" />
-    <ref role="1XX52x" to="w9y2:4kCIAUZDmGW" resolve="PortWithConfiguraion" />
+    <ref role="1XX52x" to="w9y2:4kCIAUZDmGW" resolve="PortWithConfiguration" />
     <node concept="3EZMnI" id="4kCIAUZDmJr" role="2wV5jI">
       <node concept="1kIj98" id="4kCIAUZDmJy" role="3EZMnx">
         <node concept="3F1sOY" id="4kCIAUZDmJC" role="1kIj9b">
           <ref role="1NtTu8" to="w9y2:4kCIAUZDmHT" resolve="wrapped" />
-        </node>
-        <node concept="2e7140" id="4kCIAUZKn$G" role="2e1Fq_">
-          <node concept="3clFbS" id="4kCIAUZKn$H" role="2VODD2">
-            <node concept="3clFbF" id="4kCIAUZKnFS" role="3cqZAp">
-              <node concept="2OqwBi" id="4kCIAUZKnFP" role="3clFbG">
-                <node concept="10M0yZ" id="4kCIAUZKnFQ" role="2Oq$k0">
-                  <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-                  <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
-                </node>
-                <node concept="liA8E" id="4kCIAUZKnFR" role="2OqNvi">
-                  <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String):void" resolve="println" />
-                  <node concept="Xl_RD" id="4kCIAUZKo6r" role="37wK5m">
-                    <property role="Xl_RC" value="ST" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="4kCIAUZKnYL" role="3cqZAp">
-              <node concept="3clFbT" id="4kCIAUZKnYK" role="3clFbG">
-                <property role="3clFbU" value="true" />
-              </node>
-            </node>
-          </node>
         </node>
       </node>
       <node concept="yw3OH" id="4kCIAUZEeK7" role="3EZMnx">
@@ -13692,10 +13667,8 @@
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
         </node>
       </node>
-      <node concept="1kIj98" id="4kCIAUZDCn$" role="3EZMnx">
-        <node concept="3F1sOY" id="4kCIAUZDCw_" role="1kIj9b">
-          <ref role="1NtTu8" to="w9y2:4kCIAUZDpkP" resolve="value" />
-        </node>
+      <node concept="3F1sOY" id="5aaqidNQeT0" role="3EZMnx">
+        <ref role="1NtTu8" to="w9y2:4kCIAUZDpkP" resolve="value" />
       </node>
       <node concept="2iRfu4" id="4kCIAUZDmJu" role="2iSdaV" />
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
@@ -430,6 +430,10 @@
       </concept>
     </language>
     <language id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells">
+      <concept id="1984422498402698431" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell_Condition" flags="ig" index="2e7140" />
+      <concept id="5083944728300220902" name="com.mbeddr.mpsutil.grammarcells.structure.SubstituteCell" flags="ng" index="yw3OH">
+        <child id="5083944728300220903" name="wrapped" index="yw3OG" />
+      </concept>
       <concept id="5083944728298846680" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell" flags="ng" index="_tjkj">
         <child id="5083944728298846681" name="option" index="_tjki" />
         <child id="8945098465480008160" name="transformationText" index="ZWbT9" />
@@ -437,6 +441,7 @@
       <concept id="8945098465480383073" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell_TransformationText" flags="ig" index="ZYGn8" />
       <concept id="7363578995839203705" name="com.mbeddr.mpsutil.grammarcells.structure.FlagCell" flags="sg" stub="1984422498400729024" index="1kHk_G" />
       <concept id="7363578995839435357" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell" flags="ng" index="1kIj98">
+        <child id="1984422498402083610" name="sideTransformationCondition" index="2e1Fq_" />
         <child id="7363578995839435358" name="wrapped" index="1kIj9b" />
       </concept>
     </language>
@@ -13647,6 +13652,52 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="4kCIAUZDmJh">
+    <property role="3GE5qa" value="components" />
+    <ref role="1XX52x" to="w9y2:4kCIAUZDmGW" resolve="PortWithConfiguraion" />
+    <node concept="3EZMnI" id="4kCIAUZDmJr" role="2wV5jI">
+      <node concept="1kIj98" id="4kCIAUZDmJy" role="3EZMnx">
+        <node concept="3F1sOY" id="4kCIAUZDmJC" role="1kIj9b">
+          <ref role="1NtTu8" to="w9y2:4kCIAUZDmHT" resolve="wrapped" />
+        </node>
+        <node concept="2e7140" id="4kCIAUZKn$G" role="2e1Fq_">
+          <node concept="3clFbS" id="4kCIAUZKn$H" role="2VODD2">
+            <node concept="3clFbF" id="4kCIAUZKnFS" role="3cqZAp">
+              <node concept="2OqwBi" id="4kCIAUZKnFP" role="3clFbG">
+                <node concept="10M0yZ" id="4kCIAUZKnFQ" role="2Oq$k0">
+                  <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                  <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+                </node>
+                <node concept="liA8E" id="4kCIAUZKnFR" role="2OqNvi">
+                  <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String):void" resolve="println" />
+                  <node concept="Xl_RD" id="4kCIAUZKo6r" role="37wK5m">
+                    <property role="Xl_RC" value="ST" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4kCIAUZKnYL" role="3cqZAp">
+              <node concept="3clFbT" id="4kCIAUZKnYK" role="3clFbG">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yw3OH" id="4kCIAUZEeK7" role="3EZMnx">
+        <node concept="3F0ifn" id="4kCIAUZEeKh" role="yw3OG">
+          <property role="3F0ifm" value="with" />
+          <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
+        </node>
+      </node>
+      <node concept="1kIj98" id="4kCIAUZDCn$" role="3EZMnx">
+        <node concept="3F1sOY" id="4kCIAUZDCw_" role="1kIj9b">
+          <ref role="1NtTu8" to="w9y2:4kCIAUZDpkP" resolve="value" />
+        </node>
+      </node>
+      <node concept="2iRfu4" id="4kCIAUZDmJu" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/structure.mps
@@ -1368,7 +1368,7 @@
   </node>
   <node concept="1TIwiD" id="4kCIAUZDmGW">
     <property role="EcuMT" value="4983437972509911868" />
-    <property role="TrG5h" value="PortWithConfiguraion" />
+    <property role="TrG5h" value="PortWithConfiguration" />
     <property role="34LRSv" value="with" />
     <property role="3GE5qa" value="components" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/structure.mps
@@ -1366,5 +1366,49 @@
       <ref role="PrY4T" to="4kwy:cJpacq5T0O" resolve="IValidNamedConcept" />
     </node>
   </node>
+  <node concept="1TIwiD" id="4kCIAUZDmGW">
+    <property role="EcuMT" value="4983437972509911868" />
+    <property role="TrG5h" value="PortWithConfiguraion" />
+    <property role="34LRSv" value="with" />
+    <property role="3GE5qa" value="components" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="4kCIAUZDmHG" role="PzmwI">
+      <ref role="PrY4T" node="6LfBX8YlAdL" resolve="IPortType" />
+    </node>
+    <node concept="1TJgyj" id="4kCIAUZDmHT" role="1TKVEi">
+      <property role="IQ2ns" value="4983437972509911929" />
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="wrapped" />
+      <property role="20lbJX" value="1" />
+      <ref role="20lvS9" node="6LfBX8YlAdL" resolve="IPortType" />
+    </node>
+    <node concept="1TJgyj" id="4kCIAUZDpkP" role="1TKVEi">
+      <property role="IQ2ns" value="4983437972509922613" />
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="value" />
+      <property role="20lbJX" value="1" />
+      <ref role="20lvS9" to="hm2y:6sdnDbSla17" resolve="Expression" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="6P1C6lFyRUR">
+    <property role="EcuMT" value="7872749981076782775" />
+    <property role="3GE5qa" value="components" />
+    <property role="TrG5h" value="ConfiguredPortType" />
+    <ref role="1TJDcQ" to="hm2y:6sdnDbSlaok" resolve="Type" />
+    <node concept="1TJgyj" id="6P1C6lFyRUS" role="1TKVEi">
+      <property role="IQ2ns" value="7872749981076782776" />
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="portType" />
+      <property role="20lbJX" value="1" />
+      <ref role="20lvS9" to="hm2y:6sdnDbSlaok" resolve="Type" />
+    </node>
+    <node concept="1TJgyj" id="6P1C6lFyRUU" role="1TKVEi">
+      <property role="IQ2ns" value="7872749981076782778" />
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="configurationType" />
+      <property role="20lbJX" value="1" />
+      <ref role="20lvS9" to="hm2y:6sdnDbSlaok" resolve="Type" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/typesystem.mps
@@ -56,7 +56,7 @@
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
-      <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -2702,7 +2702,7 @@
     </node>
     <node concept="1YaCAy" id="6P1C6lFyRV6" role="1YuTPh">
       <property role="TrG5h" value="portWithConfiguraion" />
-      <ref role="1YaFvo" to="w9y2:4kCIAUZDmGW" resolve="PortWithConfiguraion" />
+      <ref role="1YaFvo" to="w9y2:4kCIAUZDmGW" resolve="PortWithConfiguration" />
     </node>
   </node>
   <node concept="312cEu" id="3mxHOBiEhok">
@@ -2859,7 +2859,7 @@
                   </node>
                 </node>
               </node>
-              <node concept="17QLQc" id="3mxHOBiEmtk" role="3clFbw">
+              <node concept="17R0WA" id="5aaqidNQ2Wt" role="3clFbw">
                 <node concept="2OqwBi" id="3mxHOBiEk9C" role="3uHU7B">
                   <node concept="37vLTw" id="3mxHOBiEoJI" role="2Oq$k0">
                     <ref role="3cqZAo" node="3mxHOBiEoJC" resolve="leftConfigType" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/typesystem.mps
@@ -109,6 +109,11 @@
       <concept id="1185788614172" name="jetbrains.mps.lang.typesystem.structure.NormalTypeClause" flags="ng" index="mw_s8">
         <child id="1185788644032" name="normalType" index="mwGJk" />
       </concept>
+      <concept id="1185805035213" name="jetbrains.mps.lang.typesystem.structure.WhenConcreteStatement" flags="nn" index="nvevp">
+        <child id="1185805047793" name="body" index="nvhr_" />
+        <child id="1185805056450" name="argument" index="nvjzm" />
+        <child id="1205761991995" name="argumentRepresentator" index="2X0Ygz" />
+      </concept>
       <concept id="1175517400280" name="jetbrains.mps.lang.typesystem.structure.AssertStatement" flags="nn" index="2Mj0R9">
         <child id="1175517761460" name="condition" index="2MkoU_" />
       </concept>
@@ -132,6 +137,10 @@
         <reference id="1216390348810" name="quickFixArgument" index="QwW4h" />
       </concept>
       <concept id="1216390987552" name="jetbrains.mps.lang.typesystem.structure.QuickFixDescriptionBlock" flags="in" index="QznSV" />
+      <concept id="1205762105978" name="jetbrains.mps.lang.typesystem.structure.WhenConcreteVariableDeclaration" flags="ng" index="2X1qdy" />
+      <concept id="1205762656241" name="jetbrains.mps.lang.typesystem.structure.WhenConcreteVariableReference" flags="nn" index="2X3wrD">
+        <reference id="1205762683928" name="whenConcreteVar" index="2X3Bk0" />
+      </concept>
       <concept id="1195213580585" name="jetbrains.mps.lang.typesystem.structure.AbstractCheckingRule" flags="ig" index="18hYwZ">
         <child id="1195213635060" name="body" index="18ibNy" />
       </concept>
@@ -163,8 +172,14 @@
         <property id="1206359757216" name="checkOnly" index="3wDh2S" />
         <child id="1174660783413" name="leftExpression" index="1ZfhK$" />
         <child id="1174660783414" name="rightExpression" index="1ZfhKB" />
+        <child id="1174662598553" name="nodeToCheck" index="1ZmcU8" />
       </concept>
+      <concept id="1174663118805" name="jetbrains.mps.lang.typesystem.structure.CreateLessThanInequationStatement" flags="nn" index="1ZobV4" />
       <concept id="1174663239020" name="jetbrains.mps.lang.typesystem.structure.CreateGreaterThanInequationStatement" flags="nn" index="1ZoDhX" />
+      <concept id="1174665551739" name="jetbrains.mps.lang.typesystem.structure.TypeVarDeclaration" flags="ng" index="1ZxtTE" />
+      <concept id="1174666260556" name="jetbrains.mps.lang.typesystem.structure.TypeVarReference" flags="nn" index="1Z$b5t">
+        <reference id="1174666276259" name="typeVarDeclaration" index="1Z$eMM" />
+      </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1204834851141" name="jetbrains.mps.lang.smodel.structure.PoundExpression" flags="ng" index="25Kdxt">
@@ -187,6 +202,10 @@
       </concept>
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="1173122760281" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorsOperation" flags="nn" index="z$bX8" />
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
@@ -199,6 +218,7 @@
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
       <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -215,9 +235,17 @@
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
+        <property id="709746936026609031" name="linkId" index="3V$3ak" />
+        <property id="709746936026609029" name="linkRole" index="3V$3am" />
+      </concept>
+      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
+        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
@@ -952,34 +980,38 @@
     <property role="TrG5h" value="check_ParameterValue" />
     <property role="3GE5qa" value="components.substructure" />
     <node concept="3clFbS" id="3NBP8_O5pBe" role="18ibNy">
-      <node concept="3clFbJ" id="3NBP8_O5pBn" role="3cqZAp">
-        <node concept="3clFbS" id="3NBP8_O5pBo" role="3clFbx">
-          <node concept="2MkqsV" id="3NBP8_O5pRC" role="3cqZAp">
-            <node concept="2OqwBi" id="3NBP8_O5qcL" role="2OEOjV">
-              <node concept="1YBJjd" id="3NBP8_O5qaS" role="2Oq$k0">
-                <ref role="1YBMHb" node="3NBP8_O5pBg" resolve="pv" />
+      <node concept="1X3_iC" id="3xMjepApaJA" role="lGtFl">
+        <property role="3V$3am" value="statement" />
+        <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+        <node concept="3clFbJ" id="3NBP8_O5pBn" role="8Wnug">
+          <node concept="3clFbS" id="3NBP8_O5pBo" role="3clFbx">
+            <node concept="2MkqsV" id="3NBP8_O5pRC" role="3cqZAp">
+              <node concept="2OqwBi" id="3NBP8_O5qcL" role="2OEOjV">
+                <node concept="1YBJjd" id="3NBP8_O5qaS" role="2Oq$k0">
+                  <ref role="1YBMHb" node="3NBP8_O5pBg" resolve="pv" />
+                </node>
+                <node concept="3TrEf2" id="3NBP8_O5qh0" role="2OqNvi">
+                  <ref role="3Tt5mk" to="w9y2:4UgzZxsF_xC" resolve="value" />
+                </node>
               </node>
-              <node concept="3TrEf2" id="3NBP8_O5qh0" role="2OqNvi">
-                <ref role="3Tt5mk" to="w9y2:4UgzZxsF_xC" resolve="value" />
+              <node concept="Xl_RD" id="3NBP8_O5pRO" role="2MkJ7o">
+                <property role="Xl_RC" value="value cannot be statically evaluated (not constant)" />
               </node>
-            </node>
-            <node concept="Xl_RD" id="3NBP8_O5pRO" role="2MkJ7o">
-              <property role="Xl_RC" value="value cannot be statically evaluated (not constant)" />
             </node>
           </node>
-        </node>
-        <node concept="3fqX7Q" id="3NBP8_O5pBz" role="3clFbw">
-          <node concept="2OqwBi" id="3NBP8_O5pKq" role="3fr31v">
-            <node concept="2OqwBi" id="3NBP8_O5pDq" role="2Oq$k0">
-              <node concept="1YBJjd" id="3NBP8_O5pBN" role="2Oq$k0">
-                <ref role="1YBMHb" node="3NBP8_O5pBg" resolve="pv" />
+          <node concept="3fqX7Q" id="3NBP8_O5pBz" role="3clFbw">
+            <node concept="2OqwBi" id="3NBP8_O5pKq" role="3fr31v">
+              <node concept="2OqwBi" id="3NBP8_O5pDq" role="2Oq$k0">
+                <node concept="1YBJjd" id="3NBP8_O5pBN" role="2Oq$k0">
+                  <ref role="1YBMHb" node="3NBP8_O5pBg" resolve="pv" />
+                </node>
+                <node concept="3TrEf2" id="3NBP8_O5pGi" role="2OqNvi">
+                  <ref role="3Tt5mk" to="w9y2:4UgzZxsF_xC" resolve="value" />
+                </node>
               </node>
-              <node concept="3TrEf2" id="3NBP8_O5pGi" role="2OqNvi">
-                <ref role="3Tt5mk" to="w9y2:4UgzZxsF_xC" resolve="value" />
+              <node concept="2qgKlT" id="3NBP8_O5pQ8" role="2OqNvi">
+                <ref role="37wK5l" to="pbu6:3NBP8_O4e8l" resolve="isStaticallyEvaluatable" />
               </node>
-            </node>
-            <node concept="2qgKlT" id="3NBP8_O5pQ8" role="2OqNvi">
-              <ref role="37wK5l" to="pbu6:3NBP8_O4e8l" resolve="isStaticallyEvaluatable" />
             </node>
           </node>
         </node>
@@ -2527,6 +2559,265 @@
     <node concept="1YaCAy" id="cCTPXxsOGZ" role="1YuTPh">
       <property role="TrG5h" value="abstractConnectorRefTarget" />
       <ref role="1YaFvo" to="w9y2:cCTPXxodrc" resolve="AbstractConnectorRefTarget" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="6P1C6lFyEKP">
+    <property role="3GE5qa" value="components" />
+    <property role="TrG5h" value="typeof_AssemblyConnector" />
+    <node concept="3clFbS" id="6P1C6lFyEKQ" role="18ibNy">
+      <node concept="1ZxtTE" id="6P1C6lFyFsj" role="3cqZAp">
+        <property role="TrG5h" value="targetPort" />
+      </node>
+      <node concept="1ZxtTE" id="6P1C6lFyFsu" role="3cqZAp">
+        <property role="TrG5h" value="sourcePort" />
+      </node>
+      <node concept="1ZxtTE" id="6P1C6lFyIct" role="3cqZAp">
+        <property role="TrG5h" value="connection" />
+      </node>
+      <node concept="3clFbH" id="6P1C6lFyFsR" role="3cqZAp" />
+      <node concept="1Z5TYs" id="6P1C6lFyFS4" role="3cqZAp">
+        <node concept="mw_s8" id="6P1C6lFyFSp" role="1ZfhKB">
+          <node concept="1Z2H0r" id="6P1C6lFyFSl" role="mwGJk">
+            <node concept="2OqwBi" id="6P1C6lFyGsl" role="1Z2MuG">
+              <node concept="1YBJjd" id="6P1C6lFyFSE" role="2Oq$k0">
+                <ref role="1YBMHb" node="6P1C6lFyEKS" resolve="assemblyConnector" />
+              </node>
+              <node concept="3TrEf2" id="6P1C6lFyGFC" role="2OqNvi">
+                <ref role="3Tt5mk" to="w9y2:cJpacq1tkk" resolve="targetPort" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="6P1C6lFyFS7" role="1ZfhK$">
+          <node concept="1Z$b5t" id="6P1C6lFyFt0" role="mwGJk">
+            <ref role="1Z$eMM" node="6P1C6lFyFsj" resolve="targetPort" />
+          </node>
+        </node>
+      </node>
+      <node concept="1Z5TYs" id="6P1C6lFyH8S" role="3cqZAp">
+        <node concept="mw_s8" id="6P1C6lFyH9l" role="1ZfhKB">
+          <node concept="1Z2H0r" id="6P1C6lFyH9h" role="mwGJk">
+            <node concept="2OqwBi" id="6P1C6lFyHlx" role="1Z2MuG">
+              <node concept="1YBJjd" id="6P1C6lFyH9A" role="2Oq$k0">
+                <ref role="1YBMHb" node="6P1C6lFyEKS" resolve="assemblyConnector" />
+              </node>
+              <node concept="3TrEf2" id="6P1C6lFyHCF" role="2OqNvi">
+                <ref role="3Tt5mk" to="w9y2:cJpacq1tk2" resolve="sourcePort" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="6P1C6lFyH8V" role="1ZfhK$">
+          <node concept="1Z$b5t" id="6P1C6lFyGJP" role="mwGJk">
+            <ref role="1Z$eMM" node="6P1C6lFyFsu" resolve="sourcePort" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="6P1C6lFyHGU" role="3cqZAp" />
+      <node concept="1Z5TYs" id="6P1C6lFyHXF" role="3cqZAp">
+        <property role="3wDh2S" value="true" />
+        <node concept="mw_s8" id="6P1C6lFyHYf" role="1ZfhKB">
+          <node concept="1Z$b5t" id="6P1C6lFyHYd" role="mwGJk">
+            <ref role="1Z$eMM" node="6P1C6lFyFsj" resolve="targetPort" />
+          </node>
+        </node>
+        <node concept="mw_s8" id="6P1C6lFyHXI" role="1ZfhK$">
+          <node concept="1Z$b5t" id="6P1C6lFyHH_" role="mwGJk">
+            <ref role="1Z$eMM" node="6P1C6lFyFsu" resolve="sourcePort" />
+          </node>
+        </node>
+        <node concept="1YBJjd" id="6P1C6lFIate" role="1ZmcU8">
+          <ref role="1YBMHb" node="6P1C6lFyEKS" resolve="assemblyConnector" />
+        </node>
+      </node>
+      <node concept="3clFbH" id="6P1C6lFyI7k" role="3cqZAp" />
+      <node concept="1ZobV4" id="6P1C6lFyIax" role="3cqZAp">
+        <node concept="mw_s8" id="6P1C6lFyIbf" role="1ZfhKB">
+          <node concept="1Z$b5t" id="6P1C6lFyIbd" role="mwGJk">
+            <ref role="1Z$eMM" node="6P1C6lFyFsj" resolve="targetPort" />
+          </node>
+        </node>
+        <node concept="mw_s8" id="6P1C6lFyIa$" role="1ZfhK$">
+          <node concept="1Z$b5t" id="6P1C6lFyIi0" role="mwGJk">
+            <ref role="1Z$eMM" node="6P1C6lFyIct" resolve="connection" />
+          </node>
+        </node>
+      </node>
+      <node concept="1ZobV4" id="6P1C6lFyIiF" role="3cqZAp">
+        <node concept="mw_s8" id="6P1C6lFyIjk" role="1ZfhK$">
+          <node concept="1Z$b5t" id="6P1C6lFyIji" role="mwGJk">
+            <ref role="1Z$eMM" node="6P1C6lFyIct" resolve="connection" />
+          </node>
+        </node>
+        <node concept="mw_s8" id="6P1C6lFyIjv" role="1ZfhKB">
+          <node concept="1Z$b5t" id="6P1C6lFyIjt" role="mwGJk">
+            <ref role="1Z$eMM" node="6P1C6lFyFsu" resolve="sourcePort" />
+          </node>
+        </node>
+      </node>
+      <node concept="1X3_iC" id="6P1C6lFyRo1" role="lGtFl">
+        <property role="3V$3am" value="statement" />
+        <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+        <node concept="nvevp" id="6P1C6lFyKeR" role="8Wnug">
+          <node concept="3clFbS" id="6P1C6lFyKeT" role="nvhr_">
+            <node concept="3clFbJ" id="6P1C6lFyLh8" role="3cqZAp">
+              <node concept="2OqwBi" id="6P1C6lFyM5s" role="3clFbw">
+                <node concept="2X3wrD" id="6P1C6lFyLhk" role="2Oq$k0">
+                  <ref role="2X3Bk0" node="6P1C6lFyKeX" resolve="connector" />
+                </node>
+                <node concept="3x8VRR" id="6P1C6lFyMfm" role="2OqNvi" />
+              </node>
+              <node concept="3clFbS" id="6P1C6lFyLha" role="3clFbx">
+                <node concept="1ZobV4" id="6P1C6lFyJjt" role="3cqZAp">
+                  <node concept="mw_s8" id="6P1C6lFyJkb" role="1ZfhK$">
+                    <node concept="1Z$b5t" id="6P1C6lFyJk9" role="mwGJk">
+                      <ref role="1Z$eMM" node="6P1C6lFyIct" resolve="connection" />
+                    </node>
+                  </node>
+                  <node concept="mw_s8" id="6P1C6lFyJko" role="1ZfhKB">
+                    <node concept="1Z2H0r" id="6P1C6lFyJkk" role="mwGJk">
+                      <node concept="2OqwBi" id="6P1C6lFyJw$" role="1Z2MuG">
+                        <node concept="1YBJjd" id="6P1C6lFyJkD" role="2Oq$k0">
+                          <ref role="1YBMHb" node="6P1C6lFyEKS" resolve="assemblyConnector" />
+                        </node>
+                        <node concept="3TrEf2" id="6P1C6lFyJNX" role="2OqNvi">
+                          <ref role="3Tt5mk" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1Z2H0r" id="6P1C6lFyKgx" role="nvjzm">
+            <node concept="2OqwBi" id="6P1C6lFyKCt" role="1Z2MuG">
+              <node concept="1YBJjd" id="6P1C6lFyKgX" role="2Oq$k0">
+                <ref role="1YBMHb" node="6P1C6lFyEKS" resolve="assemblyConnector" />
+              </node>
+              <node concept="3TrEf2" id="6P1C6lFyLbB" role="2OqNvi">
+                <ref role="3Tt5mk" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
+              </node>
+            </node>
+          </node>
+          <node concept="2X1qdy" id="6P1C6lFyKeX" role="2X0Ygz">
+            <property role="TrG5h" value="connector" />
+            <node concept="2jxLKc" id="6P1C6lFyKeY" role="1tU5fm" />
+          </node>
+        </node>
+      </node>
+      <node concept="1X3_iC" id="6P1C6lFIan4" role="lGtFl">
+        <property role="3V$3am" value="statement" />
+        <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+        <node concept="1Z5TYs" id="6P1C6lFyKa2" role="8Wnug">
+          <node concept="mw_s8" id="6P1C6lFyKb2" role="1ZfhKB">
+            <node concept="1Z$b5t" id="6P1C6lFyKb0" role="mwGJk">
+              <ref role="1Z$eMM" node="6P1C6lFyIct" resolve="connection" />
+            </node>
+          </node>
+          <node concept="mw_s8" id="6P1C6lFyKa5" role="1ZfhK$">
+            <node concept="1Z2H0r" id="6P1C6lFyJTi" role="mwGJk">
+              <node concept="1YBJjd" id="6P1C6lFyJVM" role="1Z2MuG">
+                <ref role="1YBMHb" node="6P1C6lFyEKS" resolve="assemblyConnector" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="6P1C6lFyI5J" role="3cqZAp" />
+    </node>
+    <node concept="1YaCAy" id="6P1C6lFyEKS" role="1YuTPh">
+      <property role="TrG5h" value="assemblyConnector" />
+      <ref role="1YaFvo" to="w9y2:7Zvsa54vnWq" resolve="AssemblyConnector" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="6P1C6lFyRV3">
+    <property role="TrG5h" value="typeof_PortWithConfiguraion" />
+    <property role="3GE5qa" value="components" />
+    <node concept="3clFbS" id="6P1C6lFyRV4" role="18ibNy">
+      <node concept="3clFbH" id="6P1C6lFErAd" role="3cqZAp" />
+      <node concept="nvevp" id="6P1C6lFErB0" role="3cqZAp">
+        <node concept="3clFbS" id="6P1C6lFErB2" role="nvhr_">
+          <node concept="nvevp" id="6P1C6lFErJf" role="3cqZAp">
+            <node concept="3clFbS" id="6P1C6lFErJg" role="nvhr_">
+              <node concept="1Z5TYs" id="6P1C6lFySbh" role="3cqZAp">
+                <node concept="mw_s8" id="6P1C6lFySb_" role="1ZfhKB">
+                  <node concept="2pJPEk" id="6P1C6lFySbx" role="mwGJk">
+                    <node concept="2pJPED" id="6P1C6lFySbK" role="2pJPEn">
+                      <ref role="2pJxaS" to="w9y2:6P1C6lFyRUR" resolve="ConfiguredPortType" />
+                      <node concept="2pIpSj" id="6P1C6lFyScb" role="2pJxcM">
+                        <ref role="2pIpSl" to="w9y2:6P1C6lFyRUU" resolve="configurationType" />
+                        <node concept="36biLy" id="6P1C6lFyScE" role="2pJxcZ">
+                          <node concept="1PxgMI" id="6P1C6lFyTFZ" role="36biLW">
+                            <node concept="chp4Y" id="6P1C6lFyTKQ" role="3oSUPX">
+                              <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                            </node>
+                            <node concept="2X3wrD" id="6P1C6lFEs1v" role="1m5AlR">
+                              <ref role="2X3Bk0" node="6P1C6lFErB6" resolve="configType" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2pIpSj" id="6P1C6lFySDT" role="2pJxcM">
+                        <ref role="2pIpSl" to="w9y2:6P1C6lFyRUS" resolve="portType" />
+                        <node concept="36biLy" id="6P1C6lFySEy" role="2pJxcZ">
+                          <node concept="1PxgMI" id="6P1C6lFyTdT" role="36biLW">
+                            <node concept="chp4Y" id="6P1C6lFyTjz" role="3oSUPX">
+                              <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                            </node>
+                            <node concept="2X3wrD" id="6P1C6lFEs6p" role="1m5AlR">
+                              <ref role="2X3Bk0" node="6P1C6lFErJi" resolve="portType" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="mw_s8" id="6P1C6lFySbk" role="1ZfhK$">
+                  <node concept="1Z2H0r" id="6P1C6lFyRVa" role="mwGJk">
+                    <node concept="1YBJjd" id="6P1C6lFyRWU" role="1Z2MuG">
+                      <ref role="1YBMHb" node="6P1C6lFyRV6" resolve="portWithConfiguraion" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2X1qdy" id="6P1C6lFErJi" role="2X0Ygz">
+              <property role="TrG5h" value="portType" />
+              <node concept="2jxLKc" id="6P1C6lFErJj" role="1tU5fm" />
+            </node>
+            <node concept="1Z2H0r" id="6P1C6lFySEH" role="nvjzm">
+              <node concept="2OqwBi" id="6P1C6lFySQ3" role="1Z2MuG">
+                <node concept="1YBJjd" id="6P1C6lFySGt" role="2Oq$k0">
+                  <ref role="1YBMHb" node="6P1C6lFyRV6" resolve="portWithConfiguraion" />
+                </node>
+                <node concept="3TrEf2" id="6P1C6lFyT2u" role="2OqNvi">
+                  <ref role="3Tt5mk" to="w9y2:4kCIAUZDmHT" resolve="wrapped" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2X1qdy" id="6P1C6lFErB6" role="2X0Ygz">
+          <property role="TrG5h" value="configType" />
+          <node concept="2jxLKc" id="6P1C6lFErB7" role="1tU5fm" />
+        </node>
+        <node concept="1Z2H0r" id="6P1C6lFyScP" role="nvjzm">
+          <node concept="2OqwBi" id="6P1C6lFySob" role="1Z2MuG">
+            <node concept="1YBJjd" id="6P1C6lFySe_" role="2Oq$k0">
+              <ref role="1YBMHb" node="6P1C6lFyRV6" resolve="portWithConfiguraion" />
+            </node>
+            <node concept="3TrEf2" id="6P1C6lFySxU" role="2OqNvi">
+              <ref role="3Tt5mk" to="w9y2:4kCIAUZDpkP" resolve="value" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="6P1C6lFyRV6" role="1YuTPh">
+      <property role="TrG5h" value="portWithConfiguraion" />
+      <ref role="1YaFvo" to="w9y2:4kCIAUZDmGW" resolve="PortWithConfiguraion" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/typesystem.mps
@@ -8,11 +8,21 @@
     <import index="w9y2" ref="r:b3786745-c763-4a49-a754-f84e15236f18(org.iets3.components.core.structure)" />
     <import index="3eba" ref="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
     <import index="700h" ref="r:61b1de80-490d-4fee-8e95-b956503290e9(org.iets3.core.expr.collections.structure)" />
+    <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
-    <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
+    <import index="yv47" ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" implicit="true" />
   </imports>
   <registry>
+    <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
+      <concept id="1238852151516" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleType" flags="in" index="1LlUBW">
+        <child id="1238852204892" name="componentType" index="1Lm7xW" />
+      </concept>
+      <concept id="1238857743184" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleMemberAccessExpression" flags="nn" index="1LFfDK">
+        <child id="1238857764950" name="tuple" index="1LFl5Q" />
+        <child id="1238857834412" name="index" index="1LF_Uc" />
+      </concept>
+    </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
@@ -31,16 +41,31 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <property id="4276006055363816570" name="isSynchronized" index="od$2w" />
+        <property id="1181808852946" name="isFinal" index="DiZV1" />
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
       </concept>
       <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
@@ -59,6 +84,9 @@
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
@@ -74,11 +102,27 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
+        <property id="8355037393041754995" name="isNative" index="2aFKle" />
+      </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="6329021646629104957" name="jetbrains.mps.baseLanguage.structure.TextCommentPart" flags="nn" index="3SKdUq">
+        <property id="6329021646629104958" name="text" index="3SKdUp" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="6329021646629175155" name="commentPart" index="3SKWNk" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
@@ -170,16 +214,13 @@
       <concept id="1174658326157" name="jetbrains.mps.lang.typesystem.structure.CreateEquationStatement" flags="nn" index="1Z5TYs" />
       <concept id="1174660718586" name="jetbrains.mps.lang.typesystem.structure.AbstractEquationStatement" flags="nn" index="1Zf1VF">
         <property id="1206359757216" name="checkOnly" index="3wDh2S" />
+        <child id="1180447237840" name="errorString" index="3o8Qv2" />
         <child id="1174660783413" name="leftExpression" index="1ZfhK$" />
         <child id="1174660783414" name="rightExpression" index="1ZfhKB" />
         <child id="1174662598553" name="nodeToCheck" index="1ZmcU8" />
       </concept>
-      <concept id="1174663118805" name="jetbrains.mps.lang.typesystem.structure.CreateLessThanInequationStatement" flags="nn" index="1ZobV4" />
       <concept id="1174663239020" name="jetbrains.mps.lang.typesystem.structure.CreateGreaterThanInequationStatement" flags="nn" index="1ZoDhX" />
       <concept id="1174665551739" name="jetbrains.mps.lang.typesystem.structure.TypeVarDeclaration" flags="ng" index="1ZxtTE" />
-      <concept id="1174666260556" name="jetbrains.mps.lang.typesystem.structure.TypeVarReference" flags="nn" index="1Z$b5t">
-        <reference id="1174666276259" name="typeVarDeclaration" index="1Z$eMM" />
-      </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1204834851141" name="jetbrains.mps.lang.smodel.structure.PoundExpression" flags="ng" index="25Kdxt">
@@ -210,6 +251,9 @@
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
         <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
+      </concept>
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
@@ -2565,165 +2609,6 @@
     <property role="3GE5qa" value="components" />
     <property role="TrG5h" value="typeof_AssemblyConnector" />
     <node concept="3clFbS" id="6P1C6lFyEKQ" role="18ibNy">
-      <node concept="1ZxtTE" id="6P1C6lFyFsj" role="3cqZAp">
-        <property role="TrG5h" value="targetPort" />
-      </node>
-      <node concept="1ZxtTE" id="6P1C6lFyFsu" role="3cqZAp">
-        <property role="TrG5h" value="sourcePort" />
-      </node>
-      <node concept="1ZxtTE" id="6P1C6lFyIct" role="3cqZAp">
-        <property role="TrG5h" value="connection" />
-      </node>
-      <node concept="3clFbH" id="6P1C6lFyFsR" role="3cqZAp" />
-      <node concept="1Z5TYs" id="6P1C6lFyFS4" role="3cqZAp">
-        <node concept="mw_s8" id="6P1C6lFyFSp" role="1ZfhKB">
-          <node concept="1Z2H0r" id="6P1C6lFyFSl" role="mwGJk">
-            <node concept="2OqwBi" id="6P1C6lFyGsl" role="1Z2MuG">
-              <node concept="1YBJjd" id="6P1C6lFyFSE" role="2Oq$k0">
-                <ref role="1YBMHb" node="6P1C6lFyEKS" resolve="assemblyConnector" />
-              </node>
-              <node concept="3TrEf2" id="6P1C6lFyGFC" role="2OqNvi">
-                <ref role="3Tt5mk" to="w9y2:cJpacq1tkk" resolve="targetPort" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="mw_s8" id="6P1C6lFyFS7" role="1ZfhK$">
-          <node concept="1Z$b5t" id="6P1C6lFyFt0" role="mwGJk">
-            <ref role="1Z$eMM" node="6P1C6lFyFsj" resolve="targetPort" />
-          </node>
-        </node>
-      </node>
-      <node concept="1Z5TYs" id="6P1C6lFyH8S" role="3cqZAp">
-        <node concept="mw_s8" id="6P1C6lFyH9l" role="1ZfhKB">
-          <node concept="1Z2H0r" id="6P1C6lFyH9h" role="mwGJk">
-            <node concept="2OqwBi" id="6P1C6lFyHlx" role="1Z2MuG">
-              <node concept="1YBJjd" id="6P1C6lFyH9A" role="2Oq$k0">
-                <ref role="1YBMHb" node="6P1C6lFyEKS" resolve="assemblyConnector" />
-              </node>
-              <node concept="3TrEf2" id="6P1C6lFyHCF" role="2OqNvi">
-                <ref role="3Tt5mk" to="w9y2:cJpacq1tk2" resolve="sourcePort" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="mw_s8" id="6P1C6lFyH8V" role="1ZfhK$">
-          <node concept="1Z$b5t" id="6P1C6lFyGJP" role="mwGJk">
-            <ref role="1Z$eMM" node="6P1C6lFyFsu" resolve="sourcePort" />
-          </node>
-        </node>
-      </node>
-      <node concept="3clFbH" id="6P1C6lFyHGU" role="3cqZAp" />
-      <node concept="1Z5TYs" id="6P1C6lFyHXF" role="3cqZAp">
-        <property role="3wDh2S" value="true" />
-        <node concept="mw_s8" id="6P1C6lFyHYf" role="1ZfhKB">
-          <node concept="1Z$b5t" id="6P1C6lFyHYd" role="mwGJk">
-            <ref role="1Z$eMM" node="6P1C6lFyFsj" resolve="targetPort" />
-          </node>
-        </node>
-        <node concept="mw_s8" id="6P1C6lFyHXI" role="1ZfhK$">
-          <node concept="1Z$b5t" id="6P1C6lFyHH_" role="mwGJk">
-            <ref role="1Z$eMM" node="6P1C6lFyFsu" resolve="sourcePort" />
-          </node>
-        </node>
-        <node concept="1YBJjd" id="6P1C6lFIate" role="1ZmcU8">
-          <ref role="1YBMHb" node="6P1C6lFyEKS" resolve="assemblyConnector" />
-        </node>
-      </node>
-      <node concept="3clFbH" id="6P1C6lFyI7k" role="3cqZAp" />
-      <node concept="1ZobV4" id="6P1C6lFyIax" role="3cqZAp">
-        <node concept="mw_s8" id="6P1C6lFyIbf" role="1ZfhKB">
-          <node concept="1Z$b5t" id="6P1C6lFyIbd" role="mwGJk">
-            <ref role="1Z$eMM" node="6P1C6lFyFsj" resolve="targetPort" />
-          </node>
-        </node>
-        <node concept="mw_s8" id="6P1C6lFyIa$" role="1ZfhK$">
-          <node concept="1Z$b5t" id="6P1C6lFyIi0" role="mwGJk">
-            <ref role="1Z$eMM" node="6P1C6lFyIct" resolve="connection" />
-          </node>
-        </node>
-      </node>
-      <node concept="1ZobV4" id="6P1C6lFyIiF" role="3cqZAp">
-        <node concept="mw_s8" id="6P1C6lFyIjk" role="1ZfhK$">
-          <node concept="1Z$b5t" id="6P1C6lFyIji" role="mwGJk">
-            <ref role="1Z$eMM" node="6P1C6lFyIct" resolve="connection" />
-          </node>
-        </node>
-        <node concept="mw_s8" id="6P1C6lFyIjv" role="1ZfhKB">
-          <node concept="1Z$b5t" id="6P1C6lFyIjt" role="mwGJk">
-            <ref role="1Z$eMM" node="6P1C6lFyFsu" resolve="sourcePort" />
-          </node>
-        </node>
-      </node>
-      <node concept="1X3_iC" id="6P1C6lFyRo1" role="lGtFl">
-        <property role="3V$3am" value="statement" />
-        <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-        <node concept="nvevp" id="6P1C6lFyKeR" role="8Wnug">
-          <node concept="3clFbS" id="6P1C6lFyKeT" role="nvhr_">
-            <node concept="3clFbJ" id="6P1C6lFyLh8" role="3cqZAp">
-              <node concept="2OqwBi" id="6P1C6lFyM5s" role="3clFbw">
-                <node concept="2X3wrD" id="6P1C6lFyLhk" role="2Oq$k0">
-                  <ref role="2X3Bk0" node="6P1C6lFyKeX" resolve="connector" />
-                </node>
-                <node concept="3x8VRR" id="6P1C6lFyMfm" role="2OqNvi" />
-              </node>
-              <node concept="3clFbS" id="6P1C6lFyLha" role="3clFbx">
-                <node concept="1ZobV4" id="6P1C6lFyJjt" role="3cqZAp">
-                  <node concept="mw_s8" id="6P1C6lFyJkb" role="1ZfhK$">
-                    <node concept="1Z$b5t" id="6P1C6lFyJk9" role="mwGJk">
-                      <ref role="1Z$eMM" node="6P1C6lFyIct" resolve="connection" />
-                    </node>
-                  </node>
-                  <node concept="mw_s8" id="6P1C6lFyJko" role="1ZfhKB">
-                    <node concept="1Z2H0r" id="6P1C6lFyJkk" role="mwGJk">
-                      <node concept="2OqwBi" id="6P1C6lFyJw$" role="1Z2MuG">
-                        <node concept="1YBJjd" id="6P1C6lFyJkD" role="2Oq$k0">
-                          <ref role="1YBMHb" node="6P1C6lFyEKS" resolve="assemblyConnector" />
-                        </node>
-                        <node concept="3TrEf2" id="6P1C6lFyJNX" role="2OqNvi">
-                          <ref role="3Tt5mk" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="1Z2H0r" id="6P1C6lFyKgx" role="nvjzm">
-            <node concept="2OqwBi" id="6P1C6lFyKCt" role="1Z2MuG">
-              <node concept="1YBJjd" id="6P1C6lFyKgX" role="2Oq$k0">
-                <ref role="1YBMHb" node="6P1C6lFyEKS" resolve="assemblyConnector" />
-              </node>
-              <node concept="3TrEf2" id="6P1C6lFyLbB" role="2OqNvi">
-                <ref role="3Tt5mk" to="w9y2:3E8pWtey3cc" resolve="connectorType" />
-              </node>
-            </node>
-          </node>
-          <node concept="2X1qdy" id="6P1C6lFyKeX" role="2X0Ygz">
-            <property role="TrG5h" value="connector" />
-            <node concept="2jxLKc" id="6P1C6lFyKeY" role="1tU5fm" />
-          </node>
-        </node>
-      </node>
-      <node concept="1X3_iC" id="6P1C6lFIan4" role="lGtFl">
-        <property role="3V$3am" value="statement" />
-        <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-        <node concept="1Z5TYs" id="6P1C6lFyKa2" role="8Wnug">
-          <node concept="mw_s8" id="6P1C6lFyKb2" role="1ZfhKB">
-            <node concept="1Z$b5t" id="6P1C6lFyKb0" role="mwGJk">
-              <ref role="1Z$eMM" node="6P1C6lFyIct" resolve="connection" />
-            </node>
-          </node>
-          <node concept="mw_s8" id="6P1C6lFyKa5" role="1ZfhK$">
-            <node concept="1Z2H0r" id="6P1C6lFyJTi" role="mwGJk">
-              <node concept="1YBJjd" id="6P1C6lFyJVM" role="1Z2MuG">
-                <ref role="1YBMHb" node="6P1C6lFyEKS" resolve="assemblyConnector" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
       <node concept="3clFbH" id="6P1C6lFyI5J" role="3cqZAp" />
     </node>
     <node concept="1YaCAy" id="6P1C6lFyEKS" role="1YuTPh">
@@ -2818,6 +2703,324 @@
     <node concept="1YaCAy" id="6P1C6lFyRV6" role="1YuTPh">
       <property role="TrG5h" value="portWithConfiguraion" />
       <ref role="1YaFvo" to="w9y2:4kCIAUZDmGW" resolve="PortWithConfiguraion" />
+    </node>
+  </node>
+  <node concept="312cEu" id="3mxHOBiEhok">
+    <property role="3GE5qa" value="components" />
+    <property role="TrG5h" value="ConnectorErrorMsgHelper" />
+    <node concept="2YIFZL" id="3mxHOBiEhp_" role="jymVt">
+      <property role="TrG5h" value="getConnectorErrMsg" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="3mxHOBiEhpC" role="3clF47">
+        <node concept="3clFbJ" id="3mxHOBiEhrn" role="3cqZAp">
+          <node concept="1Wc70l" id="3mxHOBiEiCN" role="3clFbw">
+            <node concept="2OqwBi" id="3mxHOBiEiSv" role="3uHU7w">
+              <node concept="37vLTw" id="3mxHOBiEiHH" role="2Oq$k0">
+                <ref role="3cqZAo" node="3mxHOBiEhqq" resolve="right" />
+              </node>
+              <node concept="1mIQ4w" id="3mxHOBiEj6w" role="2OqNvi">
+                <node concept="chp4Y" id="3mxHOBiEjbe" role="cj9EA">
+                  <ref role="cht4Q" to="w9y2:6P1C6lFyRUR" resolve="ConfiguredPortType" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3mxHOBiEh$6" role="3uHU7B">
+              <node concept="37vLTw" id="3mxHOBiEhrV" role="2Oq$k0">
+                <ref role="3cqZAo" node="3mxHOBiEhpW" resolve="left" />
+              </node>
+              <node concept="1mIQ4w" id="3mxHOBiEhHS" role="2OqNvi">
+                <node concept="chp4Y" id="3mxHOBiEhJN" role="cj9EA">
+                  <ref role="cht4Q" to="w9y2:6P1C6lFyRUR" resolve="ConfiguredPortType" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="3mxHOBiEhrp" role="3clFbx">
+            <node concept="3cpWs8" id="3mxHOBiEoJB" role="3cqZAp">
+              <node concept="3cpWsn" id="3mxHOBiEoJC" role="3cpWs9">
+                <property role="TrG5h" value="leftConfigType" />
+                <node concept="3Tqbb2" id="3mxHOBiEoJz" role="1tU5fm">
+                  <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                </node>
+                <node concept="2OqwBi" id="3mxHOBiEoJD" role="33vP2m">
+                  <node concept="1PxgMI" id="3mxHOBiEoJE" role="2Oq$k0">
+                    <node concept="chp4Y" id="3mxHOBiEoJF" role="3oSUPX">
+                      <ref role="cht4Q" to="w9y2:6P1C6lFyRUR" resolve="ConfiguredPortType" />
+                    </node>
+                    <node concept="37vLTw" id="3mxHOBiEoJG" role="1m5AlR">
+                      <ref role="3cqZAo" node="3mxHOBiEhpW" resolve="left" />
+                    </node>
+                  </node>
+                  <node concept="3TrEf2" id="3mxHOBiEoJH" role="2OqNvi">
+                    <ref role="3Tt5mk" to="w9y2:6P1C6lFyRUU" resolve="configurationType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="3mxHOBiEp8L" role="3cqZAp">
+              <node concept="3cpWsn" id="3mxHOBiEp8M" role="3cpWs9">
+                <property role="TrG5h" value="rightConfigType" />
+                <node concept="3Tqbb2" id="3mxHOBiEp8H" role="1tU5fm">
+                  <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                </node>
+                <node concept="2OqwBi" id="3mxHOBiEp8N" role="33vP2m">
+                  <node concept="1PxgMI" id="3mxHOBiEp8O" role="2Oq$k0">
+                    <node concept="chp4Y" id="3mxHOBiEp8P" role="3oSUPX">
+                      <ref role="cht4Q" to="w9y2:6P1C6lFyRUR" resolve="ConfiguredPortType" />
+                    </node>
+                    <node concept="37vLTw" id="3mxHOBiEp8Q" role="1m5AlR">
+                      <ref role="3cqZAo" node="3mxHOBiEhqq" resolve="right" />
+                    </node>
+                  </node>
+                  <node concept="3TrEf2" id="3mxHOBiEp8R" role="2OqNvi">
+                    <ref role="3Tt5mk" to="w9y2:6P1C6lFyRUU" resolve="configurationType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="3mxHOBiEmJW" role="3cqZAp">
+              <node concept="3clFbS" id="3mxHOBiEmJY" role="3clFbx">
+                <node concept="3clFbJ" id="3mxHOBiEpld" role="3cqZAp">
+                  <node concept="1Wc70l" id="3mxHOBiEqbD" role="3clFbw">
+                    <node concept="2OqwBi" id="3mxHOBiEqz8" role="3uHU7w">
+                      <node concept="37vLTw" id="3mxHOBiEqiA" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3mxHOBiEp8M" resolve="rightConfigType" />
+                      </node>
+                      <node concept="1mIQ4w" id="3mxHOBiEqUx" role="2OqNvi">
+                        <node concept="chp4Y" id="3mxHOBiEr0X" role="cj9EA">
+                          <ref role="cht4Q" to="yv47:7D7uZV2dYz2" resolve="RecordType" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="3mxHOBiEpwK" role="3uHU7B">
+                      <node concept="37vLTw" id="3mxHOBiEpma" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3mxHOBiEoJC" resolve="leftConfigType" />
+                      </node>
+                      <node concept="1mIQ4w" id="3mxHOBiEpMd" role="2OqNvi">
+                        <node concept="chp4Y" id="3mxHOBiEpOB" role="cj9EA">
+                          <ref role="cht4Q" to="yv47:7D7uZV2dYz2" resolve="RecordType" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="3mxHOBiEplf" role="3clFbx">
+                    <node concept="3cpWs6" id="3mxHOBiEr7E" role="3cqZAp">
+                      <node concept="3cpWs3" id="3mxHOBiEx3y" role="3cqZAk">
+                        <node concept="2OqwBi" id="3mxHOBiE$fW" role="3uHU7w">
+                          <node concept="2OqwBi" id="3mxHOBiEyXj" role="2Oq$k0">
+                            <node concept="1PxgMI" id="3mxHOBiEy6e" role="2Oq$k0">
+                              <node concept="chp4Y" id="3mxHOBiEyiy" role="3oSUPX">
+                                <ref role="cht4Q" to="yv47:7D7uZV2dYz2" resolve="RecordType" />
+                              </node>
+                              <node concept="37vLTw" id="3mxHOBiExgA" role="1m5AlR">
+                                <ref role="3cqZAo" node="3mxHOBiEp8M" resolve="rightConfigType" />
+                              </node>
+                            </node>
+                            <node concept="3TrEf2" id="3mxHOBiEzn8" role="2OqNvi">
+                              <ref role="3Tt5mk" to="yv47:7D7uZV2dYz3" resolve="record" />
+                            </node>
+                          </node>
+                          <node concept="3TrcHB" id="3mxHOBiE$PH" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                        <node concept="3cpWs3" id="3mxHOBiEvJV" role="3uHU7B">
+                          <node concept="3cpWs3" id="3mxHOBiEstX" role="3uHU7B">
+                            <node concept="Xl_RD" id="3mxHOBiEr8d" role="3uHU7B">
+                              <property role="Xl_RC" value="Record used for configurations isn't compatilbe. left: " />
+                            </node>
+                            <node concept="2OqwBi" id="3mxHOBiEtJe" role="3uHU7w">
+                              <node concept="2OqwBi" id="3mxHOBiEsXd" role="2Oq$k0">
+                                <node concept="1PxgMI" id="3mxHOBiEsG2" role="2Oq$k0">
+                                  <node concept="chp4Y" id="3mxHOBiEsH3" role="3oSUPX">
+                                    <ref role="cht4Q" to="yv47:7D7uZV2dYz2" resolve="RecordType" />
+                                  </node>
+                                  <node concept="37vLTw" id="3mxHOBiEsv0" role="1m5AlR">
+                                    <ref role="3cqZAo" node="3mxHOBiEoJC" resolve="leftConfigType" />
+                                  </node>
+                                </node>
+                                <node concept="3TrEf2" id="3mxHOBiEtcC" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="yv47:7D7uZV2dYz3" resolve="record" />
+                                </node>
+                              </node>
+                              <node concept="3TrcHB" id="3mxHOBiEucU" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Xl_RD" id="3mxHOBiEvKe" role="3uHU7w">
+                            <property role="Xl_RC" value=" right: " />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="17QLQc" id="3mxHOBiEmtk" role="3clFbw">
+                <node concept="2OqwBi" id="3mxHOBiEk9C" role="3uHU7B">
+                  <node concept="37vLTw" id="3mxHOBiEoJI" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3mxHOBiEoJC" resolve="leftConfigType" />
+                  </node>
+                  <node concept="2yIwOk" id="3mxHOBiEkwR" role="2OqNvi" />
+                </node>
+                <node concept="2OqwBi" id="3mxHOBiEnKO" role="3uHU7w">
+                  <node concept="37vLTw" id="3mxHOBiEp8S" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3mxHOBiEp8M" resolve="rightConfigType" />
+                  </node>
+                  <node concept="2yIwOk" id="3mxHOBiEo6d" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="3mxHOBiE_fx" role="3cqZAp">
+              <node concept="3cpWs3" id="3mxHOBiEHgi" role="3cqZAk">
+                <node concept="37vLTw" id="3mxHOBiEHSt" role="3uHU7w">
+                  <ref role="3cqZAo" node="3mxHOBiEp8M" resolve="rightConfigType" />
+                </node>
+                <node concept="3cpWs3" id="3mxHOBiEE7W" role="3uHU7B">
+                  <node concept="37vLTw" id="3mxHOBiEDrc" role="3uHU7B">
+                    <ref role="3cqZAo" node="3mxHOBiEoJC" resolve="leftConfigType" />
+                  </node>
+                  <node concept="Xl_RD" id="3mxHOBiEED1" role="3uHU7w">
+                    <property role="Xl_RC" value=" is incompatible with " />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="3mxHOBiEIr5" role="3cqZAp">
+          <node concept="3cpWs3" id="3mxHOBiEPBK" role="3cqZAk">
+            <node concept="37vLTw" id="3mxHOBiEPVZ" role="3uHU7w">
+              <ref role="3cqZAo" node="3mxHOBiEhqq" resolve="right" />
+            </node>
+            <node concept="3cpWs3" id="3mxHOBiELN9" role="3uHU7B">
+              <node concept="37vLTw" id="3mxHOBiELkr" role="3uHU7B">
+                <ref role="3cqZAo" node="3mxHOBiEhpW" resolve="left" />
+              </node>
+              <node concept="Xl_RD" id="3mxHOBiEM4d" role="3uHU7w">
+                <property role="Xl_RC" value=" is incompatible with " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3mxHOBiEhpe" role="1B3o_S" />
+      <node concept="17QB3L" id="3mxHOBiEhpu" role="3clF45" />
+      <node concept="37vLTG" id="3mxHOBiEhpW" role="3clF46">
+        <property role="TrG5h" value="left" />
+        <node concept="3Tqbb2" id="3mxHOBiEhpV" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="3mxHOBiEhqq" role="3clF46">
+        <property role="TrG5h" value="right" />
+        <node concept="3Tqbb2" id="3mxHOBiEhqK" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="3mxHOBiEhol" role="1B3o_S" />
+  </node>
+  <node concept="1YbPZF" id="3mxHOBiKjyu">
+    <property role="3GE5qa" value="components" />
+    <property role="TrG5h" value="typeof_AbstractPortToPortConnector" />
+    <node concept="3clFbS" id="3mxHOBiKjyv" role="18ibNy">
+      <node concept="1ZxtTE" id="3mxHOBiKjyy" role="3cqZAp">
+        <property role="TrG5h" value="connection" />
+      </node>
+      <node concept="3cpWs8" id="3mxHOBiKjyz" role="3cqZAp">
+        <node concept="3cpWsn" id="3mxHOBiKjy$" role="3cpWs9">
+          <property role="TrG5h" value="ports" />
+          <property role="3TUv4t" value="true" />
+          <node concept="1LlUBW" id="3mxHOBiKjy_" role="1tU5fm">
+            <node concept="3Tqbb2" id="3mxHOBiKjyA" role="1Lm7xW">
+              <ref role="ehGHo" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+            </node>
+            <node concept="3Tqbb2" id="3mxHOBiKjyB" role="1Lm7xW">
+              <ref role="ehGHo" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="3mxHOBiKjyC" role="33vP2m">
+            <node concept="1YBJjd" id="3mxHOBiKjyD" role="2Oq$k0">
+              <ref role="1YBMHb" node="3mxHOBiKjzE" resolve="aptpc" />
+            </node>
+            <node concept="2qgKlT" id="3mxHOBiKjyE" role="2OqNvi">
+              <ref role="37wK5l" to="3eba:mIQkxg5ZT6" resolve="getPorts" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="3mxHOBiKjyF" role="3cqZAp" />
+      <node concept="3SKdUt" id="3mxHOBiOgM9" role="3cqZAp">
+        <node concept="3SKdUq" id="3mxHOBiOgMb" role="3SKWNk">
+          <property role="3SKdUp" value="to get a sane error message on the check for the user we have to wait until both types are solved" />
+        </node>
+      </node>
+      <node concept="nvevp" id="3mxHOBiOfm8" role="3cqZAp">
+        <node concept="3clFbS" id="3mxHOBiOfma" role="nvhr_">
+          <node concept="nvevp" id="3mxHOBiOfLy" role="3cqZAp">
+            <node concept="3clFbS" id="3mxHOBiOfLz" role="nvhr_">
+              <node concept="1Z5TYs" id="3mxHOBiKjyX" role="3cqZAp">
+                <property role="3wDh2S" value="true" />
+                <node concept="mw_s8" id="3mxHOBiKjyY" role="1ZfhKB">
+                  <node concept="2X3wrD" id="3mxHOBiOpxq" role="mwGJk">
+                    <ref role="2X3Bk0" node="3mxHOBiOfme" resolve="left" />
+                  </node>
+                </node>
+                <node concept="mw_s8" id="3mxHOBiKjz0" role="1ZfhK$">
+                  <node concept="2X3wrD" id="3mxHOBiOpxs" role="mwGJk">
+                    <ref role="2X3Bk0" node="3mxHOBiOfL_" resolve="right" />
+                  </node>
+                </node>
+                <node concept="1YBJjd" id="3mxHOBiKjz2" role="1ZmcU8">
+                  <ref role="1YBMHb" node="3mxHOBiKjzE" resolve="aptpc" />
+                </node>
+                <node concept="2YIFZM" id="3mxHOBiKkGf" role="3o8Qv2">
+                  <ref role="37wK5l" node="3mxHOBiEhp_" resolve="getConnectorErrMsg" />
+                  <ref role="1Pybhc" node="3mxHOBiEhok" resolve="ConnectorErrorMsgHelper" />
+                  <node concept="2X3wrD" id="3mxHOBiOpL$" role="37wK5m">
+                    <ref role="2X3Bk0" node="3mxHOBiOfme" resolve="left" />
+                  </node>
+                  <node concept="2X3wrD" id="3mxHOBiOpLY" role="37wK5m">
+                    <ref role="2X3Bk0" node="3mxHOBiOfL_" resolve="right" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2X1qdy" id="3mxHOBiOfL_" role="2X0Ygz">
+              <property role="TrG5h" value="right" />
+              <node concept="2jxLKc" id="3mxHOBiOfLA" role="1tU5fm" />
+            </node>
+            <node concept="1Z2H0r" id="3mxHOBiKjyQ" role="nvjzm">
+              <node concept="1LFfDK" id="3mxHOBiKjyR" role="1Z2MuG">
+                <node concept="3cmrfG" id="3mxHOBiKjyS" role="1LF_Uc">
+                  <property role="3cmrfH" value="1" />
+                </node>
+                <node concept="37vLTw" id="3mxHOBiKjyT" role="1LFl5Q">
+                  <ref role="3cqZAo" node="3mxHOBiKjy$" resolve="ports" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2X1qdy" id="3mxHOBiOfme" role="2X0Ygz">
+          <property role="TrG5h" value="left" />
+          <node concept="2jxLKc" id="3mxHOBiOfmf" role="1tU5fm" />
+        </node>
+        <node concept="1Z2H0r" id="3mxHOBiKjyI" role="nvjzm">
+          <node concept="1LFfDK" id="3mxHOBiKjyJ" role="1Z2MuG">
+            <node concept="3cmrfG" id="3mxHOBiKjyK" role="1LF_Uc">
+              <property role="3cmrfH" value="0" />
+            </node>
+            <node concept="37vLTw" id="3mxHOBiKjyL" role="1LFl5Q">
+              <ref role="3cqZAo" node="3mxHOBiKjy$" resolve="ports" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="3mxHOBiKjzE" role="1YuTPh">
+      <property role="TrG5h" value="aptpc" />
+      <ref role="1YaFvo" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
     </node>
   </node>
 </model>

--- a/doc/design/02-ports-with-dependencies.md
+++ b/doc/design/02-ports-with-dependencies.md
@@ -1,0 +1,165 @@
+# Port with Configuration
+We want to allow to associate port with a configuration parameter. And we want to ensure that ports are only connected to ports where these parameters are compatible. 
+
+## Motivation
+
+Given the following context:
+
+```
+enum Resolution {
+    4K
+    1080p 
+}
+
+typedef byte
+
+enum Codec {
+    H264 -> 8
+    H265 -> 16
+}
+
+record ImageStreamConfig {
+    frameRes: Resolution
+    frameRate: number
+    encoding: Codec
+}
+
+record MyRecord {
+
+}
+
+record ImageStreamFrame {
+    data: list<list<byte>>
+}
+
+component Server {
+    param config: ImageStreamConfig
+    port stream: ImageStreamFrame
+}
+
+component Client {
+    param config: MyRecord
+    port stream: ImageStreamFrame
+}
+```
+
+We instantiate these two components, pass in a configuration and connect the two ports:
+
+```
+val config4k = build<ImageStreamConfig>(frameRes = 4K, frameRate = 10fps, encoding = H264)
+val fullHd = build<MyRecord>()
+
+instance Server(config4k) as s
+instance Client(fullHd) as c
+
+s.stream                    ->                  c.stream
+```
+In this case we want the system to present an error to the user. The error should be present on the connector and tell the user that the configurations are invalid because the types used for the configuration are different.
+
+
+## Implementation
+### The `with` keyword
+We will introduce a new keyword that is usable in the context of the type of a port and allows to reference a specific parameter that should get used for the configuration of this port.
+
+```
+component Server {
+    param config: ImageStreamConfig
+    port stream: ImageStreamFrame with config
+}
+
+component Client {
+    param config: ImageStreamConfig
+    port stream: ImageStreamFrame with config 
+}
+```
+
+The same parameter is usable for multiple ports but only on parameter is assignable to a port.
+### The Typesystem
+From a typesystem perspective we can now ensure that the two configuration types are compatible by inferring it from the referenced parameter. It also allows an analysis to check if two ports have compatible configurations because don’t just only express the type dependency but a data dependency. Details on the proposed verification later in the document. 
+#### Details
+The `ConfiguredPortType` will look like this:
+
+```
+component Client {
+    param config: ImageStreamConfig
+    port stream: ImageStreamFrame of config 
+                    |              |     |
+                    | ConfiguredPortType |
+                 PayloadType             |
+                                 ConfigurationType
+}
+```
+The of basically wraps the already existing port type and uses the as the payload type. The second part of the PortType is the reference to the used configuration parameter. This can be used to infer the type from it but also for calculating the dependant value for it later.
+
+Types for the connector:
+
+```
+s.stream                    ->                  c.stream
+    |                                               |
+ConfiguredPortType<PayloadType = ImageStreamFrame,  |
+		     ConfigurationType =                    |
+			       ImageStreamConfig <- config4k>   |
+                                ConfiguredPortType<PayloadType = ImageStreamFrame,
+                                         ConfigurationType = ImageStreamConfig <- fullHd>
+```
+
+Both types have the same port type with the two parts (`PayloadType` and `ConfigurationType`) bound to the same types. We might also want to encode the origin of `ConfigurationType` which is handy in the context analysing the if the assigned values to these parameters are compatible. But this is not part of this document.
+
+## Considered Alternatives
+### *Generics* on the payload
+
+The first idea was to introduce something like a generic type parameter on the payload. It would not have any actual use like in java generics but would be used to associate the two types.
+
+```
+record ImageStreamFrame<T> {
+    data: list<list<byte>>
+}
+```
+
+And then in the components assign that type:
+
+```
+component Server {
+    param config: ImageStreamConfig
+    port stream: ImageStreamFrame<ImageStreamConfig>
+}
+
+component Client {
+    param config: ImageStreamConfig
+    port stream: ImageStreamFrame<ImageStreamConfig>
+}
+```
+
+This would solve the problem to some degree. At least our example wouldn’t work anymore because passing the instance of `MyRecord` into the initialiser would cause an error. But we need to be aware of the fact that the type ImageStreamFrame has a generic parameter which isn’t even used in the actual type when we declare it. This wouldn’t work for primitive types or other already defined types which are not under the control of the user that defines the component.
+
+### Separate Port Types
+Another alternative was to define the port type separately in the model like this:
+
+```
+type PortType<TPayload, TConfig>
+```
+This type would be used in the component for the ports:
+
+```
+component Server {
+    param config: ImageStreamConfig
+    port stream: PortType<TPayload = ImageStreamFrame, TConfig = ImageStreamConfig>
+}
+
+component Client {
+    param config: ImageStreamConfig
+    port stream: PortType<TPayload = ImageStreamFrame, TConfig = ImageStreamConfig>
+}
+```
+
+This way we could express the type dependency without requiring any changes to the type that is used as a payload. But this feels pretty unnatural to the user of the components language because the type information is specified on a pretty low level and it wouldn’t allow us to potentially spot errors like this as we don't know which parameter is used to configure the payload: 
+
+```
+val config = build<ImageStreamConfig>(frameRes = 4K, frameRate = 10fps, encoding = H264)
+val fullHd = build<ImageStreamConfig>(frameRes = 1080p, frameRate = 10fps, encoding = H264)
+
+instance Server(config) as s
+instance Client(fullHd) as c
+
+s.stream                    ->                  c.stream
+```


### PR DESCRIPTION
Includes a new port type that can wrap a IPortType. It can reference a parameter. When using these ports in connectors the type system ensures that only ports with same payload and configuration can be connected.

I removed the for "is statically evaluatable" from the checking rule of a component instance. Since that property of an expression in not maintained at all it will produce a lot of false positives.

This PR doesn't contain any of the static checking of the values. It is only the type system to specify the dependency from the port to the parameter.

WIP:
 - [x] Error message form the type system need to be better
 - [x] Typesystem for other connectors than `AssemblyConnector`s 
- [x] Testing this on OS is pretty cumbersome, I added the tests in core
 - [ ] ~~Restrict Port with configuration to only reference parameters~~
- [ ] ~~Restriction on how to pass values to a parameter~~
- [ ]  ~~allow to associate the configuration type on dataitem level~~
- [ ]  ~~check if ports that require a configuration actually have one~~
- [ ] ~~_optionally: add a error intention that adds the `with` clause and references the correct parameter (if possible)_~~