### PR TITLE
Logical and structural attribute constraints

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
@@ -5433,6 +5433,44 @@
     <node concept="13hLZK" id="1WCh2th1Bou" role="13h7CW">
       <node concept="3clFbS" id="1WCh2th1Bov" role="2VODD2" />
     </node>
+    <node concept="13i0hz" id="HCbFcONOWD" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="canBeUsedInContext" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" to="soq7:6EQjZsO9evJ" resolve="canBeUsedInContext" />
+      <node concept="3Tm1VV" id="HCbFcONOWE" role="1B3o_S" />
+      <node concept="3clFbS" id="HCbFcONOWM" role="3clF47">
+        <node concept="3cpWs6" id="HCbFcONZe9" role="3cqZAp">
+          <node concept="BsUDl" id="HCbFcONZeb" role="3cqZAk">
+            <ref role="37wK5l" node="1WCh2th1Boz" resolve="canBeUsedUnder" />
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="HCbFcONOWN" role="3clF45">
+        <node concept="3bZ5Sz" id="HCbFcONOWO" role="A3Ik2" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="HCbFcONOWP" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="isUsableInLogicalContext" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" to="soq7:6EQjZsO9eTV" resolve="isUsableInLogicalContext" />
+      <node concept="3Tm1VV" id="HCbFcONOWQ" role="1B3o_S" />
+      <node concept="3clFbS" id="HCbFcONOX1" role="3clF47">
+        <node concept="3clFbF" id="HCbFcONOX6" role="3cqZAp">
+          <node concept="3clFbT" id="HCbFcONOX5" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="HCbFcONOX2" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="HCbFcONOX3" role="1tU5fm" />
+      </node>
+      <node concept="10P_77" id="HCbFcONOX4" role="3clF45" />
+    </node>
   </node>
   <node concept="13h7C7" id="1WCh2th1CjW">
     <property role="3GE5qa" value="attributes.specific" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/constraints.mps
@@ -363,7 +363,7 @@
                 </node>
                 <node concept="3cpWs8" id="6EQjZsOd4j3" role="3cqZAp">
                   <node concept="3cpWsn" id="6EQjZsOd4j4" role="3cpWs9">
-                    <property role="TrG5h" value="isStructurallyValid" />
+                    <property role="TrG5h" value="isStrucValid" />
                     <node concept="10P_77" id="6EQjZsOd4j2" role="1tU5fm" />
                     <node concept="2OqwBi" id="6EQjZsOd4j5" role="33vP2m">
                       <node concept="2OqwBi" id="6EQjZsOd4j6" role="2Oq$k0">
@@ -402,7 +402,7 @@
                 <node concept="3cpWs6" id="6EQjZsOcvEE" role="3cqZAp">
                   <node concept="1Wc70l" id="6EQjZsOcvEG" role="3cqZAk">
                     <node concept="37vLTw" id="6EQjZsOddPb" role="3uHU7B">
-                      <ref role="3cqZAo" node="6EQjZsOd4j4" resolve="isStructurallyValid" />
+                      <ref role="3cqZAo" node="6EQjZsOd4j4" resolve="isStrucValid" />
                     </node>
                     <node concept="2OqwBi" id="6EQjZsOd9cS" role="3uHU7w">
                       <node concept="37vLTw" id="6EQjZsOd8I6" role="2Oq$k0">
@@ -426,18 +426,12 @@
               </node>
             </node>
           </node>
-          <node concept="1Wc70l" id="6EQjZsOcWXh" role="3clFbw">
-            <node concept="17R0WA" id="6EQjZsObXRk" role="3uHU7w">
-              <node concept="359W_D" id="6EQjZsObY97" role="3uHU7w">
-                <ref role="359W_E" to="w9y2:6LfBX8YkpdW" resolve="Port" />
-                <ref role="359W_F" to="138:3NBP8_OgMVe" resolve="attributes" />
-              </node>
-              <node concept="2DA6wF" id="6EQjZsObXc4" role="3uHU7B" />
+          <node concept="17R0WA" id="6EQjZsObXRk" role="3clFbw">
+            <node concept="359W_D" id="6EQjZsObY97" role="3uHU7w">
+              <ref role="359W_E" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+              <ref role="359W_F" to="138:3NBP8_OgMVe" resolve="attributes" />
             </node>
-            <node concept="3clFbC" id="1Ap9E00ArtM" role="3uHU7B">
-              <node concept="2H4GUG" id="1Ap9E00ArtN" role="3uHU7B" />
-              <node concept="10Nm6u" id="1Ap9E00ArtO" role="3uHU7w" />
-            </node>
+            <node concept="2DA6wF" id="6EQjZsObXc4" role="3uHU7B" />
           </node>
         </node>
         <node concept="3cpWs6" id="6EQjZsOcxck" role="3cqZAp">
@@ -666,6 +660,106 @@
                 </node>
               </node>
             </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="9SLcT" id="7FJkYgnXQCu" role="9SGkU">
+      <node concept="3clFbS" id="7FJkYgnXQCv" role="2VODD2">
+        <node concept="3clFbJ" id="7FJkYgnXRel" role="3cqZAp">
+          <node concept="3clFbS" id="7FJkYgnXRem" role="3clFbx">
+            <node concept="3clFbJ" id="7FJkYgnXRen" role="3cqZAp">
+              <node concept="3clFbS" id="7FJkYgnXReo" role="3clFbx">
+                <node concept="3cpWs8" id="7FJkYgnXRep" role="3cqZAp">
+                  <node concept="3cpWsn" id="7FJkYgnXReq" role="3cpWs9">
+                    <property role="TrG5h" value="attrCpt" />
+                    <node concept="3bZ5Sz" id="7FJkYgnXRer" role="1tU5fm">
+                      <ref role="3bZ5Sy" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                    </node>
+                    <node concept="2CBFar" id="7FJkYgnXRes" role="33vP2m">
+                      <node concept="chp4Y" id="7FJkYgnXRet" role="3oSUPX">
+                        <ref role="cht4Q" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                      </node>
+                      <node concept="2DD5aU" id="7FJkYgnXReu" role="1m5AlR" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="7FJkYgnXRev" role="3cqZAp">
+                  <node concept="3cpWsn" id="7FJkYgnXRew" role="3cpWs9">
+                    <property role="TrG5h" value="isStrucValid" />
+                    <node concept="10P_77" id="7FJkYgnXRex" role="1tU5fm" />
+                    <node concept="2OqwBi" id="7FJkYgnXRey" role="33vP2m">
+                      <node concept="2OqwBi" id="7FJkYgnXRez" role="2Oq$k0">
+                        <node concept="37vLTw" id="7FJkYgnXRe$" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7FJkYgnXReq" resolve="attrCpt" />
+                        </node>
+                        <node concept="2qgKlT" id="7FJkYgnXRe_" role="2OqNvi">
+                          <ref role="37wK5l" to="soq7:6EQjZsO9evJ" resolve="canBeUsedInContext" />
+                        </node>
+                      </node>
+                      <node concept="2HwmR7" id="7FJkYgnXReA" role="2OqNvi">
+                        <node concept="1bVj0M" id="7FJkYgnXReB" role="23t8la">
+                          <node concept="3clFbS" id="7FJkYgnXReC" role="1bW5cS">
+                            <node concept="3clFbF" id="7FJkYgnXReD" role="3cqZAp">
+                              <node concept="2OqwBi" id="7FJkYgnXReE" role="3clFbG">
+                                <node concept="EsrRn" id="7FJkYgnXReF" role="2Oq$k0" />
+                                <node concept="1mIQ4w" id="7FJkYgnXReG" role="2OqNvi">
+                                  <node concept="25Kdxt" id="7FJkYgnXReH" role="cj9EA">
+                                    <node concept="37vLTw" id="7FJkYgnXReI" role="25KhWn">
+                                      <ref role="3cqZAo" node="7FJkYgnXReJ" resolve="it" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="7FJkYgnXReJ" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="7FJkYgnXReK" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="7FJkYgnXReL" role="3cqZAp">
+                  <node concept="1Wc70l" id="7FJkYgnXReM" role="3cqZAk">
+                    <node concept="37vLTw" id="7FJkYgnXReN" role="3uHU7B">
+                      <ref role="3cqZAo" node="7FJkYgnXRew" resolve="isStrucValid" />
+                    </node>
+                    <node concept="2OqwBi" id="7FJkYgnXReO" role="3uHU7w">
+                      <node concept="37vLTw" id="7FJkYgnXReP" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7FJkYgnXReq" resolve="attrCpt" />
+                      </node>
+                      <node concept="2qgKlT" id="7FJkYgnXReQ" role="2OqNvi">
+                        <ref role="37wK5l" to="soq7:6EQjZsO9eTV" resolve="isUsableInLogicalContext" />
+                        <node concept="EsrRn" id="7FJkYgnXReR" role="37wK5m" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7FJkYgnXReS" role="3clFbw">
+                <node concept="2DD5aU" id="7FJkYgnXReT" role="2Oq$k0" />
+                <node concept="2Zo12i" id="7FJkYgnXReU" role="2OqNvi">
+                  <node concept="chp4Y" id="7FJkYgnXReV" role="2Zo12j">
+                    <ref role="cht4Q" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="17R0WA" id="7FJkYgnXReW" role="3clFbw">
+            <node concept="359W_D" id="7FJkYgnXReX" role="3uHU7w">
+              <ref role="359W_E" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+              <ref role="359W_F" to="138:3NBP8_OgMVe" resolve="attributes" />
+            </node>
+            <node concept="2DA6wF" id="7FJkYgnXReY" role="3uHU7B" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7FJkYgnXReZ" role="3cqZAp">
+          <node concept="3clFbT" id="7FJkYgnXRf0" role="3cqZAk">
+            <property role="3clFbU" value="true" />
           </node>
         </node>
       </node>
@@ -968,6 +1062,106 @@
         </node>
       </node>
     </node>
+    <node concept="9SLcT" id="7FJkYgnXTDU" role="9SGkU">
+      <node concept="3clFbS" id="7FJkYgnXTDV" role="2VODD2">
+        <node concept="3clFbJ" id="7FJkYgnXUsU" role="3cqZAp">
+          <node concept="3clFbS" id="7FJkYgnXUsV" role="3clFbx">
+            <node concept="3clFbJ" id="7FJkYgnXUsW" role="3cqZAp">
+              <node concept="3clFbS" id="7FJkYgnXUsX" role="3clFbx">
+                <node concept="3cpWs8" id="7FJkYgnXUsY" role="3cqZAp">
+                  <node concept="3cpWsn" id="7FJkYgnXUsZ" role="3cpWs9">
+                    <property role="TrG5h" value="attrCpt" />
+                    <node concept="3bZ5Sz" id="7FJkYgnXUt0" role="1tU5fm">
+                      <ref role="3bZ5Sy" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                    </node>
+                    <node concept="2CBFar" id="7FJkYgnXUt1" role="33vP2m">
+                      <node concept="chp4Y" id="7FJkYgnXUt2" role="3oSUPX">
+                        <ref role="cht4Q" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                      </node>
+                      <node concept="2DD5aU" id="7FJkYgnXUt3" role="1m5AlR" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="7FJkYgnXUt4" role="3cqZAp">
+                  <node concept="3cpWsn" id="7FJkYgnXUt5" role="3cpWs9">
+                    <property role="TrG5h" value="isStrucValid" />
+                    <node concept="10P_77" id="7FJkYgnXUt6" role="1tU5fm" />
+                    <node concept="2OqwBi" id="7FJkYgnXUt7" role="33vP2m">
+                      <node concept="2OqwBi" id="7FJkYgnXUt8" role="2Oq$k0">
+                        <node concept="37vLTw" id="7FJkYgnXUt9" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7FJkYgnXUsZ" resolve="attrCpt" />
+                        </node>
+                        <node concept="2qgKlT" id="7FJkYgnXUta" role="2OqNvi">
+                          <ref role="37wK5l" to="soq7:6EQjZsO9evJ" resolve="canBeUsedInContext" />
+                        </node>
+                      </node>
+                      <node concept="2HwmR7" id="7FJkYgnXUtb" role="2OqNvi">
+                        <node concept="1bVj0M" id="7FJkYgnXUtc" role="23t8la">
+                          <node concept="3clFbS" id="7FJkYgnXUtd" role="1bW5cS">
+                            <node concept="3clFbF" id="7FJkYgnXUte" role="3cqZAp">
+                              <node concept="2OqwBi" id="7FJkYgnXUtf" role="3clFbG">
+                                <node concept="EsrRn" id="7FJkYgnXUtg" role="2Oq$k0" />
+                                <node concept="1mIQ4w" id="7FJkYgnXUth" role="2OqNvi">
+                                  <node concept="25Kdxt" id="7FJkYgnXUti" role="cj9EA">
+                                    <node concept="37vLTw" id="7FJkYgnXUtj" role="25KhWn">
+                                      <ref role="3cqZAo" node="7FJkYgnXUtk" resolve="it" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="7FJkYgnXUtk" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="7FJkYgnXUtl" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="7FJkYgnXUtm" role="3cqZAp">
+                  <node concept="1Wc70l" id="7FJkYgnXUtn" role="3cqZAk">
+                    <node concept="37vLTw" id="7FJkYgnXUto" role="3uHU7B">
+                      <ref role="3cqZAo" node="7FJkYgnXUt5" resolve="isStrucValid" />
+                    </node>
+                    <node concept="2OqwBi" id="7FJkYgnXUtp" role="3uHU7w">
+                      <node concept="37vLTw" id="7FJkYgnXUtq" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7FJkYgnXUsZ" resolve="attrCpt" />
+                      </node>
+                      <node concept="2qgKlT" id="7FJkYgnXUtr" role="2OqNvi">
+                        <ref role="37wK5l" to="soq7:6EQjZsO9eTV" resolve="isUsableInLogicalContext" />
+                        <node concept="EsrRn" id="7FJkYgnXUts" role="37wK5m" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7FJkYgnXUtt" role="3clFbw">
+                <node concept="2DD5aU" id="7FJkYgnXUtu" role="2Oq$k0" />
+                <node concept="2Zo12i" id="7FJkYgnXUtv" role="2OqNvi">
+                  <node concept="chp4Y" id="7FJkYgnXUtw" role="2Zo12j">
+                    <ref role="cht4Q" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="17R0WA" id="7FJkYgnXUtx" role="3clFbw">
+            <node concept="359W_D" id="7FJkYgnXUty" role="3uHU7w">
+              <ref role="359W_E" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+              <ref role="359W_F" to="138:3NBP8_OgMVe" resolve="attributes" />
+            </node>
+            <node concept="2DA6wF" id="7FJkYgnXUtz" role="3uHU7B" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7FJkYgnXUt$" role="3cqZAp">
+          <node concept="3clFbT" id="7FJkYgnXUt_" role="3cqZAk">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1M2fIO" id="cJpacq2_Ch">
     <property role="3GE5qa" value="components.substructure" />
@@ -1171,6 +1365,106 @@
                 </node>
               </node>
             </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="9SLcT" id="7FJkYgnXSzr" role="9SGkU">
+      <node concept="3clFbS" id="7FJkYgnXSzs" role="2VODD2">
+        <node concept="3clFbJ" id="7FJkYgnXTmr" role="3cqZAp">
+          <node concept="3clFbS" id="7FJkYgnXTms" role="3clFbx">
+            <node concept="3clFbJ" id="7FJkYgnXTmt" role="3cqZAp">
+              <node concept="3clFbS" id="7FJkYgnXTmu" role="3clFbx">
+                <node concept="3cpWs8" id="7FJkYgnXTmv" role="3cqZAp">
+                  <node concept="3cpWsn" id="7FJkYgnXTmw" role="3cpWs9">
+                    <property role="TrG5h" value="attrCpt" />
+                    <node concept="3bZ5Sz" id="7FJkYgnXTmx" role="1tU5fm">
+                      <ref role="3bZ5Sy" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                    </node>
+                    <node concept="2CBFar" id="7FJkYgnXTmy" role="33vP2m">
+                      <node concept="chp4Y" id="7FJkYgnXTmz" role="3oSUPX">
+                        <ref role="cht4Q" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                      </node>
+                      <node concept="2DD5aU" id="7FJkYgnXTm$" role="1m5AlR" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="7FJkYgnXTm_" role="3cqZAp">
+                  <node concept="3cpWsn" id="7FJkYgnXTmA" role="3cpWs9">
+                    <property role="TrG5h" value="isStrucValid" />
+                    <node concept="10P_77" id="7FJkYgnXTmB" role="1tU5fm" />
+                    <node concept="2OqwBi" id="7FJkYgnXTmC" role="33vP2m">
+                      <node concept="2OqwBi" id="7FJkYgnXTmD" role="2Oq$k0">
+                        <node concept="37vLTw" id="7FJkYgnXTmE" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7FJkYgnXTmw" resolve="attrCpt" />
+                        </node>
+                        <node concept="2qgKlT" id="7FJkYgnXTmF" role="2OqNvi">
+                          <ref role="37wK5l" to="soq7:6EQjZsO9evJ" resolve="canBeUsedInContext" />
+                        </node>
+                      </node>
+                      <node concept="2HwmR7" id="7FJkYgnXTmG" role="2OqNvi">
+                        <node concept="1bVj0M" id="7FJkYgnXTmH" role="23t8la">
+                          <node concept="3clFbS" id="7FJkYgnXTmI" role="1bW5cS">
+                            <node concept="3clFbF" id="7FJkYgnXTmJ" role="3cqZAp">
+                              <node concept="2OqwBi" id="7FJkYgnXTmK" role="3clFbG">
+                                <node concept="EsrRn" id="7FJkYgnXTmL" role="2Oq$k0" />
+                                <node concept="1mIQ4w" id="7FJkYgnXTmM" role="2OqNvi">
+                                  <node concept="25Kdxt" id="7FJkYgnXTmN" role="cj9EA">
+                                    <node concept="37vLTw" id="7FJkYgnXTmO" role="25KhWn">
+                                      <ref role="3cqZAo" node="7FJkYgnXTmP" resolve="it" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="7FJkYgnXTmP" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="7FJkYgnXTmQ" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="7FJkYgnXTmR" role="3cqZAp">
+                  <node concept="1Wc70l" id="7FJkYgnXTmS" role="3cqZAk">
+                    <node concept="37vLTw" id="7FJkYgnXTmT" role="3uHU7B">
+                      <ref role="3cqZAo" node="7FJkYgnXTmA" resolve="isStrucValid" />
+                    </node>
+                    <node concept="2OqwBi" id="7FJkYgnXTmU" role="3uHU7w">
+                      <node concept="37vLTw" id="7FJkYgnXTmV" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7FJkYgnXTmw" resolve="attrCpt" />
+                      </node>
+                      <node concept="2qgKlT" id="7FJkYgnXTmW" role="2OqNvi">
+                        <ref role="37wK5l" to="soq7:6EQjZsO9eTV" resolve="isUsableInLogicalContext" />
+                        <node concept="EsrRn" id="7FJkYgnXTmX" role="37wK5m" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7FJkYgnXTmY" role="3clFbw">
+                <node concept="2DD5aU" id="7FJkYgnXTmZ" role="2Oq$k0" />
+                <node concept="2Zo12i" id="7FJkYgnXTn0" role="2OqNvi">
+                  <node concept="chp4Y" id="7FJkYgnXTn1" role="2Zo12j">
+                    <ref role="cht4Q" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="17R0WA" id="7FJkYgnXTn2" role="3clFbw">
+            <node concept="359W_D" id="7FJkYgnXTn3" role="3uHU7w">
+              <ref role="359W_E" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+              <ref role="359W_F" to="138:3NBP8_OgMVe" resolve="attributes" />
+            </node>
+            <node concept="2DA6wF" id="7FJkYgnXTn4" role="3uHU7B" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7FJkYgnXTn5" role="3cqZAp">
+          <node concept="3clFbT" id="7FJkYgnXTn6" role="3cqZAk">
+            <property role="3clFbU" value="true" />
           </node>
         </node>
       </node>
@@ -2013,6 +2307,99 @@
             <node concept="2H4GUG" id="6b_jefnKwj9" role="3uHU7B" />
           </node>
         </node>
+        <node concept="3clFbH" id="7FJkYgnXW3Q" role="3cqZAp" />
+        <node concept="3clFbJ" id="7FJkYgnXVcc" role="3cqZAp">
+          <node concept="3clFbS" id="7FJkYgnXVcd" role="3clFbx">
+            <node concept="3clFbJ" id="7FJkYgnXVce" role="3cqZAp">
+              <node concept="3clFbS" id="7FJkYgnXVcf" role="3clFbx">
+                <node concept="3cpWs8" id="7FJkYgnXVcg" role="3cqZAp">
+                  <node concept="3cpWsn" id="7FJkYgnXVch" role="3cpWs9">
+                    <property role="TrG5h" value="attrCpt" />
+                    <node concept="3bZ5Sz" id="7FJkYgnXVci" role="1tU5fm">
+                      <ref role="3bZ5Sy" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                    </node>
+                    <node concept="2CBFar" id="7FJkYgnXVcj" role="33vP2m">
+                      <node concept="chp4Y" id="7FJkYgnXVck" role="3oSUPX">
+                        <ref role="cht4Q" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                      </node>
+                      <node concept="2DD5aU" id="7FJkYgnXVcl" role="1m5AlR" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="7FJkYgnXVcm" role="3cqZAp">
+                  <node concept="3cpWsn" id="7FJkYgnXVcn" role="3cpWs9">
+                    <property role="TrG5h" value="isStrucValid" />
+                    <node concept="10P_77" id="7FJkYgnXVco" role="1tU5fm" />
+                    <node concept="2OqwBi" id="7FJkYgnXVcp" role="33vP2m">
+                      <node concept="2OqwBi" id="7FJkYgnXVcq" role="2Oq$k0">
+                        <node concept="37vLTw" id="7FJkYgnXVcr" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7FJkYgnXVch" resolve="attrCpt" />
+                        </node>
+                        <node concept="2qgKlT" id="7FJkYgnXVcs" role="2OqNvi">
+                          <ref role="37wK5l" to="soq7:6EQjZsO9evJ" resolve="canBeUsedInContext" />
+                        </node>
+                      </node>
+                      <node concept="2HwmR7" id="7FJkYgnXVct" role="2OqNvi">
+                        <node concept="1bVj0M" id="7FJkYgnXVcu" role="23t8la">
+                          <node concept="3clFbS" id="7FJkYgnXVcv" role="1bW5cS">
+                            <node concept="3clFbF" id="7FJkYgnXVcw" role="3cqZAp">
+                              <node concept="2OqwBi" id="7FJkYgnXVcx" role="3clFbG">
+                                <node concept="EsrRn" id="7FJkYgnXVcy" role="2Oq$k0" />
+                                <node concept="1mIQ4w" id="7FJkYgnXVcz" role="2OqNvi">
+                                  <node concept="25Kdxt" id="7FJkYgnXVc$" role="cj9EA">
+                                    <node concept="37vLTw" id="7FJkYgnXVc_" role="25KhWn">
+                                      <ref role="3cqZAo" node="7FJkYgnXVcA" resolve="it" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="7FJkYgnXVcA" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="7FJkYgnXVcB" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="7FJkYgnXVcC" role="3cqZAp">
+                  <node concept="1Wc70l" id="7FJkYgnXVcD" role="3cqZAk">
+                    <node concept="37vLTw" id="7FJkYgnXVcE" role="3uHU7B">
+                      <ref role="3cqZAo" node="7FJkYgnXVcn" resolve="isStrucValid" />
+                    </node>
+                    <node concept="2OqwBi" id="7FJkYgnXVcF" role="3uHU7w">
+                      <node concept="37vLTw" id="7FJkYgnXVcG" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7FJkYgnXVch" resolve="attrCpt" />
+                      </node>
+                      <node concept="2qgKlT" id="7FJkYgnXVcH" role="2OqNvi">
+                        <ref role="37wK5l" to="soq7:6EQjZsO9eTV" resolve="isUsableInLogicalContext" />
+                        <node concept="EsrRn" id="7FJkYgnXVcI" role="37wK5m" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7FJkYgnXVcJ" role="3clFbw">
+                <node concept="2DD5aU" id="7FJkYgnXVcK" role="2Oq$k0" />
+                <node concept="2Zo12i" id="7FJkYgnXVcL" role="2OqNvi">
+                  <node concept="chp4Y" id="7FJkYgnXVcM" role="2Zo12j">
+                    <ref role="cht4Q" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="17R0WA" id="7FJkYgnXVcN" role="3clFbw">
+            <node concept="359W_D" id="7FJkYgnXVcO" role="3uHU7w">
+              <ref role="359W_E" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+              <ref role="359W_F" to="138:3NBP8_OgMVe" resolve="attributes" />
+            </node>
+            <node concept="2DA6wF" id="7FJkYgnXVcP" role="3uHU7B" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="7FJkYgnXUK7" role="3cqZAp" />
         <node concept="3cpWs6" id="6b_jefnKwja" role="3cqZAp">
           <node concept="3clFbT" id="6b_jefnKwjb" role="3cqZAk">
             <property role="3clFbU" value="true" />
@@ -2114,6 +2501,106 @@
   <node concept="1M2fIO" id="4PGMP7y5sdM">
     <property role="3GE5qa" value="components.iface.param" />
     <ref role="1M2myG" to="w9y2:cJpacq6wur" resolve="Parameter" />
+    <node concept="9SLcT" id="7FJkYgnXXcz" role="9SGkU">
+      <node concept="3clFbS" id="7FJkYgnXXc$" role="2VODD2">
+        <node concept="3clFbJ" id="7FJkYgnXXjG" role="3cqZAp">
+          <node concept="3clFbS" id="7FJkYgnXXjH" role="3clFbx">
+            <node concept="3clFbJ" id="7FJkYgnXXjI" role="3cqZAp">
+              <node concept="3clFbS" id="7FJkYgnXXjJ" role="3clFbx">
+                <node concept="3cpWs8" id="7FJkYgnXXjK" role="3cqZAp">
+                  <node concept="3cpWsn" id="7FJkYgnXXjL" role="3cpWs9">
+                    <property role="TrG5h" value="attrCpt" />
+                    <node concept="3bZ5Sz" id="7FJkYgnXXjM" role="1tU5fm">
+                      <ref role="3bZ5Sy" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                    </node>
+                    <node concept="2CBFar" id="7FJkYgnXXjN" role="33vP2m">
+                      <node concept="chp4Y" id="7FJkYgnXXjO" role="3oSUPX">
+                        <ref role="cht4Q" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                      </node>
+                      <node concept="2DD5aU" id="7FJkYgnXXjP" role="1m5AlR" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="7FJkYgnXXjQ" role="3cqZAp">
+                  <node concept="3cpWsn" id="7FJkYgnXXjR" role="3cpWs9">
+                    <property role="TrG5h" value="isStrucValid" />
+                    <node concept="10P_77" id="7FJkYgnXXjS" role="1tU5fm" />
+                    <node concept="2OqwBi" id="7FJkYgnXXjT" role="33vP2m">
+                      <node concept="2OqwBi" id="7FJkYgnXXjU" role="2Oq$k0">
+                        <node concept="37vLTw" id="7FJkYgnXXjV" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7FJkYgnXXjL" resolve="attrCpt" />
+                        </node>
+                        <node concept="2qgKlT" id="7FJkYgnXXjW" role="2OqNvi">
+                          <ref role="37wK5l" to="soq7:6EQjZsO9evJ" resolve="canBeUsedInContext" />
+                        </node>
+                      </node>
+                      <node concept="2HwmR7" id="7FJkYgnXXjX" role="2OqNvi">
+                        <node concept="1bVj0M" id="7FJkYgnXXjY" role="23t8la">
+                          <node concept="3clFbS" id="7FJkYgnXXjZ" role="1bW5cS">
+                            <node concept="3clFbF" id="7FJkYgnXXk0" role="3cqZAp">
+                              <node concept="2OqwBi" id="7FJkYgnXXk1" role="3clFbG">
+                                <node concept="EsrRn" id="7FJkYgnXXk2" role="2Oq$k0" />
+                                <node concept="1mIQ4w" id="7FJkYgnXXk3" role="2OqNvi">
+                                  <node concept="25Kdxt" id="7FJkYgnXXk4" role="cj9EA">
+                                    <node concept="37vLTw" id="7FJkYgnXXk5" role="25KhWn">
+                                      <ref role="3cqZAo" node="7FJkYgnXXk6" resolve="it" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="7FJkYgnXXk6" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="7FJkYgnXXk7" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="7FJkYgnXXk8" role="3cqZAp">
+                  <node concept="1Wc70l" id="7FJkYgnXXk9" role="3cqZAk">
+                    <node concept="37vLTw" id="7FJkYgnXXka" role="3uHU7B">
+                      <ref role="3cqZAo" node="7FJkYgnXXjR" resolve="isStrucValid" />
+                    </node>
+                    <node concept="2OqwBi" id="7FJkYgnXXkb" role="3uHU7w">
+                      <node concept="37vLTw" id="7FJkYgnXXkc" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7FJkYgnXXjL" resolve="attrCpt" />
+                      </node>
+                      <node concept="2qgKlT" id="7FJkYgnXXkd" role="2OqNvi">
+                        <ref role="37wK5l" to="soq7:6EQjZsO9eTV" resolve="isUsableInLogicalContext" />
+                        <node concept="EsrRn" id="7FJkYgnXXke" role="37wK5m" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7FJkYgnXXkf" role="3clFbw">
+                <node concept="2DD5aU" id="7FJkYgnXXkg" role="2Oq$k0" />
+                <node concept="2Zo12i" id="7FJkYgnXXkh" role="2OqNvi">
+                  <node concept="chp4Y" id="7FJkYgnXXki" role="2Zo12j">
+                    <ref role="cht4Q" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="17R0WA" id="7FJkYgnXXkj" role="3clFbw">
+            <node concept="359W_D" id="7FJkYgnXXkk" role="3uHU7w">
+              <ref role="359W_E" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+              <ref role="359W_F" to="138:3NBP8_OgMVe" resolve="attributes" />
+            </node>
+            <node concept="2DA6wF" id="7FJkYgnXXkl" role="3uHU7B" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7FJkYgnXXkm" role="3cqZAp">
+          <node concept="3clFbT" id="7FJkYgnXXkn" role="3cqZAk">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1M2fIO" id="1yY6_Uj8q9A">
     <property role="3GE5qa" value="components.substructure" />
@@ -2293,6 +2780,106 @@
                 </node>
               </node>
             </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="9SLcT" id="7FJkYgnXRxt" role="9SGkU">
+      <node concept="3clFbS" id="7FJkYgnXRxu" role="2VODD2">
+        <node concept="3clFbJ" id="7FJkYgnXSg8" role="3cqZAp">
+          <node concept="3clFbS" id="7FJkYgnXSg9" role="3clFbx">
+            <node concept="3clFbJ" id="7FJkYgnXSga" role="3cqZAp">
+              <node concept="3clFbS" id="7FJkYgnXSgb" role="3clFbx">
+                <node concept="3cpWs8" id="7FJkYgnXSgc" role="3cqZAp">
+                  <node concept="3cpWsn" id="7FJkYgnXSgd" role="3cpWs9">
+                    <property role="TrG5h" value="attrCpt" />
+                    <node concept="3bZ5Sz" id="7FJkYgnXSge" role="1tU5fm">
+                      <ref role="3bZ5Sy" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                    </node>
+                    <node concept="2CBFar" id="7FJkYgnXSgf" role="33vP2m">
+                      <node concept="chp4Y" id="7FJkYgnXSgg" role="3oSUPX">
+                        <ref role="cht4Q" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                      </node>
+                      <node concept="2DD5aU" id="7FJkYgnXSgh" role="1m5AlR" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="7FJkYgnXSgi" role="3cqZAp">
+                  <node concept="3cpWsn" id="7FJkYgnXSgj" role="3cpWs9">
+                    <property role="TrG5h" value="isStrucValid" />
+                    <node concept="10P_77" id="7FJkYgnXSgk" role="1tU5fm" />
+                    <node concept="2OqwBi" id="7FJkYgnXSgl" role="33vP2m">
+                      <node concept="2OqwBi" id="7FJkYgnXSgm" role="2Oq$k0">
+                        <node concept="37vLTw" id="7FJkYgnXSgn" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7FJkYgnXSgd" resolve="attrCpt" />
+                        </node>
+                        <node concept="2qgKlT" id="7FJkYgnXSgo" role="2OqNvi">
+                          <ref role="37wK5l" to="soq7:6EQjZsO9evJ" resolve="canBeUsedInContext" />
+                        </node>
+                      </node>
+                      <node concept="2HwmR7" id="7FJkYgnXSgp" role="2OqNvi">
+                        <node concept="1bVj0M" id="7FJkYgnXSgq" role="23t8la">
+                          <node concept="3clFbS" id="7FJkYgnXSgr" role="1bW5cS">
+                            <node concept="3clFbF" id="7FJkYgnXSgs" role="3cqZAp">
+                              <node concept="2OqwBi" id="7FJkYgnXSgt" role="3clFbG">
+                                <node concept="EsrRn" id="7FJkYgnXSgu" role="2Oq$k0" />
+                                <node concept="1mIQ4w" id="7FJkYgnXSgv" role="2OqNvi">
+                                  <node concept="25Kdxt" id="7FJkYgnXSgw" role="cj9EA">
+                                    <node concept="37vLTw" id="7FJkYgnXSgx" role="25KhWn">
+                                      <ref role="3cqZAo" node="7FJkYgnXSgy" resolve="it" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="7FJkYgnXSgy" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="7FJkYgnXSgz" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="7FJkYgnXSg$" role="3cqZAp">
+                  <node concept="1Wc70l" id="7FJkYgnXSg_" role="3cqZAk">
+                    <node concept="37vLTw" id="7FJkYgnXSgA" role="3uHU7B">
+                      <ref role="3cqZAo" node="7FJkYgnXSgj" resolve="isStrucValid" />
+                    </node>
+                    <node concept="2OqwBi" id="7FJkYgnXSgB" role="3uHU7w">
+                      <node concept="37vLTw" id="7FJkYgnXSgC" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7FJkYgnXSgd" resolve="attrCpt" />
+                      </node>
+                      <node concept="2qgKlT" id="7FJkYgnXSgD" role="2OqNvi">
+                        <ref role="37wK5l" to="soq7:6EQjZsO9eTV" resolve="isUsableInLogicalContext" />
+                        <node concept="EsrRn" id="7FJkYgnXSgE" role="37wK5m" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7FJkYgnXSgF" role="3clFbw">
+                <node concept="2DD5aU" id="7FJkYgnXSgG" role="2Oq$k0" />
+                <node concept="2Zo12i" id="7FJkYgnXSgH" role="2OqNvi">
+                  <node concept="chp4Y" id="7FJkYgnXSgI" role="2Zo12j">
+                    <ref role="cht4Q" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="17R0WA" id="7FJkYgnXSgJ" role="3clFbw">
+            <node concept="359W_D" id="7FJkYgnXSgK" role="3uHU7w">
+              <ref role="359W_E" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+              <ref role="359W_F" to="138:3NBP8_OgMVe" resolve="attributes" />
+            </node>
+            <node concept="2DA6wF" id="7FJkYgnXSgL" role="3uHU7B" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7FJkYgnXSgM" role="3cqZAp">
+          <node concept="3clFbT" id="7FJkYgnXSgN" role="3cqZAk">
+            <property role="3clFbU" value="true" />
           </node>
         </node>
       </node>
@@ -2738,6 +3325,110 @@
                 <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
               </node>
             </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="7FJkYgnXPca">
+    <property role="3GE5qa" value="components.substructure" />
+    <ref role="1M2myG" to="w9y2:6LfBX8YlosD" resolve="ComponentInstance" />
+    <node concept="9SLcT" id="7FJkYgnXPcb" role="9SGkU">
+      <node concept="3clFbS" id="7FJkYgnXPcc" role="2VODD2">
+        <node concept="3clFbJ" id="7FJkYgnXPjk" role="3cqZAp">
+          <node concept="3clFbS" id="7FJkYgnXPjl" role="3clFbx">
+            <node concept="3clFbJ" id="7FJkYgnXPjm" role="3cqZAp">
+              <node concept="3clFbS" id="7FJkYgnXPjn" role="3clFbx">
+                <node concept="3cpWs8" id="7FJkYgnXPjo" role="3cqZAp">
+                  <node concept="3cpWsn" id="7FJkYgnXPjp" role="3cpWs9">
+                    <property role="TrG5h" value="attrCpt" />
+                    <node concept="3bZ5Sz" id="7FJkYgnXPjq" role="1tU5fm">
+                      <ref role="3bZ5Sy" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                    </node>
+                    <node concept="2CBFar" id="7FJkYgnXPjr" role="33vP2m">
+                      <node concept="chp4Y" id="7FJkYgnXPjs" role="3oSUPX">
+                        <ref role="cht4Q" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                      </node>
+                      <node concept="2DD5aU" id="7FJkYgnXPjt" role="1m5AlR" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="7FJkYgnXPju" role="3cqZAp">
+                  <node concept="3cpWsn" id="7FJkYgnXPjv" role="3cpWs9">
+                    <property role="TrG5h" value="isStrucValid" />
+                    <node concept="10P_77" id="7FJkYgnXPjw" role="1tU5fm" />
+                    <node concept="2OqwBi" id="7FJkYgnXPjx" role="33vP2m">
+                      <node concept="2OqwBi" id="7FJkYgnXPjy" role="2Oq$k0">
+                        <node concept="37vLTw" id="7FJkYgnXPjz" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7FJkYgnXPjp" resolve="attrCpt" />
+                        </node>
+                        <node concept="2qgKlT" id="7FJkYgnXPj$" role="2OqNvi">
+                          <ref role="37wK5l" to="soq7:6EQjZsO9evJ" resolve="canBeUsedInContext" />
+                        </node>
+                      </node>
+                      <node concept="2HwmR7" id="7FJkYgnXPj_" role="2OqNvi">
+                        <node concept="1bVj0M" id="7FJkYgnXPjA" role="23t8la">
+                          <node concept="3clFbS" id="7FJkYgnXPjB" role="1bW5cS">
+                            <node concept="3clFbF" id="7FJkYgnXPjC" role="3cqZAp">
+                              <node concept="2OqwBi" id="7FJkYgnXPjD" role="3clFbG">
+                                <node concept="EsrRn" id="7FJkYgnXPjE" role="2Oq$k0" />
+                                <node concept="1mIQ4w" id="7FJkYgnXPjF" role="2OqNvi">
+                                  <node concept="25Kdxt" id="7FJkYgnXPjG" role="cj9EA">
+                                    <node concept="37vLTw" id="7FJkYgnXPjH" role="25KhWn">
+                                      <ref role="3cqZAo" node="7FJkYgnXPjI" resolve="it" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="7FJkYgnXPjI" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="7FJkYgnXPjJ" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="7FJkYgnXPjK" role="3cqZAp">
+                  <node concept="1Wc70l" id="7FJkYgnXPjL" role="3cqZAk">
+                    <node concept="37vLTw" id="7FJkYgnXPjM" role="3uHU7B">
+                      <ref role="3cqZAo" node="7FJkYgnXPjv" resolve="isStrucValid" />
+                    </node>
+                    <node concept="2OqwBi" id="7FJkYgnXPjN" role="3uHU7w">
+                      <node concept="37vLTw" id="7FJkYgnXPjO" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7FJkYgnXPjp" resolve="attrCpt" />
+                      </node>
+                      <node concept="2qgKlT" id="7FJkYgnXPjP" role="2OqNvi">
+                        <ref role="37wK5l" to="soq7:6EQjZsO9eTV" resolve="isUsableInLogicalContext" />
+                        <node concept="EsrRn" id="7FJkYgnXPjQ" role="37wK5m" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7FJkYgnXPjR" role="3clFbw">
+                <node concept="2DD5aU" id="7FJkYgnXPjS" role="2Oq$k0" />
+                <node concept="2Zo12i" id="7FJkYgnXPjT" role="2OqNvi">
+                  <node concept="chp4Y" id="7FJkYgnXPjU" role="2Zo12j">
+                    <ref role="cht4Q" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="17R0WA" id="7FJkYgnXPjV" role="3clFbw">
+            <node concept="359W_D" id="7FJkYgnXPjW" role="3uHU7w">
+              <ref role="359W_E" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+              <ref role="359W_F" to="138:3NBP8_OgMVe" resolve="attributes" />
+            </node>
+            <node concept="2DA6wF" id="7FJkYgnXPjX" role="3uHU7B" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7FJkYgnXPjY" role="3cqZAp">
+          <node concept="3clFbT" id="7FJkYgnXPjZ" role="3cqZAk">
+            <property role="3clFbU" value="true" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/constraints.mps
@@ -14,6 +14,8 @@
     <import index="gdgh" ref="r:e4d9478b-ae0e-416e-be60-73d136571015(org.iets3.core.base.behavior)" />
     <import index="4kwy" ref="r:657c9fde-2f36-4e61-ae17-20f02b8630ad(org.iets3.core.base.structure)" />
     <import index="yv47" ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" />
+    <import index="138" ref="r:2c1007f3-e814-47ba-b729-c3ea0297f627(org.iets3.core.attributes.structure)" />
+    <import index="soq7" ref="r:4d48d56b-d670-4e5b-a763-2232bb0c4f2d(org.iets3.core.attributes.behavior)" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" implicit="true" />
     <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
@@ -46,6 +48,7 @@
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
@@ -57,6 +60,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -113,12 +117,14 @@
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="6329021646629175155" name="commentPart" index="3SKWNk" />
       </concept>
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints">
       <concept id="6702802731807351367" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAChild" flags="in" index="9S07l" />
       <concept id="6702802731807420587" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAParent" flags="ig" index="9SLcT" />
       <concept id="1202989658459" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_parentNode" flags="nn" index="nLn13" />
       <concept id="8966504967485224688" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_contextNode" flags="nn" index="2rP1CM" />
+      <concept id="4303308395523343364" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_link" flags="ng" index="2DA6wF" />
       <concept id="4303308395523096213" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_childConcept" flags="ng" index="2DD5aU" />
       <concept id="1147467115080" name="jetbrains.mps.lang.constraints.structure.NodePropertyConstraint" flags="ng" index="EnEH3">
         <reference id="1147467295099" name="applicableProperty" index="EomxK" />
@@ -186,6 +192,10 @@
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
         <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
+      </concept>
+      <concept id="2644386474301421077" name="jetbrains.mps.lang.smodel.structure.LinkIdRefExpression" flags="nn" index="359W_D">
+        <reference id="2644386474301421078" name="conceptDeclaration" index="359W_E" />
+        <reference id="2644386474301421079" name="linkDeclaration" index="359W_F" />
       </concept>
       <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
         <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
@@ -331,6 +341,112 @@
   <node concept="1M2fIO" id="6LfBX8Yk$v9">
     <property role="3GE5qa" value="components.iface.ports" />
     <ref role="1M2myG" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+    <node concept="9SLcT" id="6EQjZsObX4T" role="9SGkU">
+      <node concept="3clFbS" id="6EQjZsObX4U" role="2VODD2">
+        <node concept="3clFbJ" id="6EQjZsObYRZ" role="3cqZAp">
+          <node concept="3clFbS" id="6EQjZsObYS1" role="3clFbx">
+            <node concept="3clFbJ" id="6EQjZsOdLq8" role="3cqZAp">
+              <node concept="3clFbS" id="6EQjZsOdLqa" role="3clFbx">
+                <node concept="3cpWs8" id="6EQjZsOd72H" role="3cqZAp">
+                  <node concept="3cpWsn" id="6EQjZsOd72I" role="3cpWs9">
+                    <property role="TrG5h" value="attrCpt" />
+                    <node concept="3bZ5Sz" id="6EQjZsOd72F" role="1tU5fm">
+                      <ref role="3bZ5Sy" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                    </node>
+                    <node concept="2CBFar" id="6EQjZsOd72J" role="33vP2m">
+                      <node concept="chp4Y" id="6EQjZsOd72K" role="3oSUPX">
+                        <ref role="cht4Q" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                      </node>
+                      <node concept="2DD5aU" id="6EQjZsOd72L" role="1m5AlR" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="6EQjZsOd4j3" role="3cqZAp">
+                  <node concept="3cpWsn" id="6EQjZsOd4j4" role="3cpWs9">
+                    <property role="TrG5h" value="isStructurallyValid" />
+                    <node concept="10P_77" id="6EQjZsOd4j2" role="1tU5fm" />
+                    <node concept="2OqwBi" id="6EQjZsOd4j5" role="33vP2m">
+                      <node concept="2OqwBi" id="6EQjZsOd4j6" role="2Oq$k0">
+                        <node concept="37vLTw" id="6EQjZsOd72M" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6EQjZsOd72I" resolve="attrCpt" />
+                        </node>
+                        <node concept="2qgKlT" id="6EQjZsOd4ja" role="2OqNvi">
+                          <ref role="37wK5l" to="soq7:6EQjZsO9evJ" resolve="canBeUsedInContext" />
+                        </node>
+                      </node>
+                      <node concept="2HwmR7" id="6EQjZsOd4jb" role="2OqNvi">
+                        <node concept="1bVj0M" id="6EQjZsOd4jc" role="23t8la">
+                          <node concept="3clFbS" id="6EQjZsOd4jd" role="1bW5cS">
+                            <node concept="3clFbF" id="6EQjZsOd4je" role="3cqZAp">
+                              <node concept="2OqwBi" id="6EQjZsOd4jf" role="3clFbG">
+                                <node concept="EsrRn" id="6EQjZsOd4jg" role="2Oq$k0" />
+                                <node concept="1mIQ4w" id="6EQjZsOd4jh" role="2OqNvi">
+                                  <node concept="25Kdxt" id="6EQjZsOd4ji" role="cj9EA">
+                                    <node concept="37vLTw" id="6EQjZsOd4jj" role="25KhWn">
+                                      <ref role="3cqZAo" node="6EQjZsOd4jk" resolve="it" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="6EQjZsOd4jk" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="6EQjZsOd4jl" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="6EQjZsOcvEE" role="3cqZAp">
+                  <node concept="1Wc70l" id="6EQjZsOcvEG" role="3cqZAk">
+                    <node concept="37vLTw" id="6EQjZsOddPb" role="3uHU7B">
+                      <ref role="3cqZAo" node="6EQjZsOd4j4" resolve="isStructurallyValid" />
+                    </node>
+                    <node concept="2OqwBi" id="6EQjZsOd9cS" role="3uHU7w">
+                      <node concept="37vLTw" id="6EQjZsOd8I6" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6EQjZsOd72I" resolve="attrCpt" />
+                      </node>
+                      <node concept="2qgKlT" id="6EQjZsOd9Eo" role="2OqNvi">
+                        <ref role="37wK5l" to="soq7:6EQjZsO9eTV" resolve="isUsableInLogicalContext" />
+                        <node concept="EsrRn" id="6EQjZsOd9Zl" role="37wK5m" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="6EQjZsOdMRz" role="3clFbw">
+                <node concept="2DD5aU" id="6EQjZsOdLEN" role="2Oq$k0" />
+                <node concept="2Zo12i" id="6EQjZsOdNmL" role="2OqNvi">
+                  <node concept="chp4Y" id="6EQjZsOdNCp" role="2Zo12j">
+                    <ref role="cht4Q" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1Wc70l" id="6EQjZsOcWXh" role="3clFbw">
+            <node concept="17R0WA" id="6EQjZsObXRk" role="3uHU7w">
+              <node concept="359W_D" id="6EQjZsObY97" role="3uHU7w">
+                <ref role="359W_E" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+                <ref role="359W_F" to="138:3NBP8_OgMVe" resolve="attributes" />
+              </node>
+              <node concept="2DA6wF" id="6EQjZsObXc4" role="3uHU7B" />
+            </node>
+            <node concept="3clFbC" id="1Ap9E00ArtM" role="3uHU7B">
+              <node concept="2H4GUG" id="1Ap9E00ArtN" role="3uHU7B" />
+              <node concept="10Nm6u" id="1Ap9E00ArtO" role="3uHU7w" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6EQjZsOcxck" role="3cqZAp">
+          <node concept="3clFbT" id="6EQjZsOcxX8" role="3cqZAk">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1M2fIO" id="7Zvsa54vvCe">
     <property role="3GE5qa" value="components.substructure" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.attributes/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.attributes/models/behavior.mps
@@ -21,6 +21,7 @@
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
     <import index="1zby" ref="r:e876148b-672e-4264-9fee-d6d24a2d1223(org.iets3.core.expr.path.behavior)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -165,6 +166,9 @@
       <concept id="767145758118872833" name="jetbrains.mps.lang.actions.structure.NF_LinkList_AddNewChildOperation" flags="nn" index="2DeJg1" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1204834851141" name="jetbrains.mps.lang.smodel.structure.PoundExpression" flags="ng" index="25Kdxt">
+        <child id="1204834868751" name="expression" index="25KhWn" />
+      </concept>
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
@@ -245,7 +249,12 @@
         <child id="1209727996925" name="ascending" index="2Dq5b$" />
       </concept>
       <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
@@ -407,6 +416,40 @@
             </node>
           </node>
         </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="6EQjZsO9evJ" role="13h7CS">
+      <property role="13i0iv" value="true" />
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="canBeUsedInContext" />
+      <property role="2Ki8OM" value="true" />
+      <node concept="3Tm1VV" id="6EQjZsO9evK" role="1B3o_S" />
+      <node concept="A3Dl8" id="6EQjZsO9eTb" role="3clF45">
+        <node concept="3bZ5Sz" id="6EQjZsO9eTo" role="A3Ik2" />
+      </node>
+      <node concept="3clFbS" id="6EQjZsO9evM" role="3clF47" />
+      <node concept="P$JXv" id="6EQjZsO9f8e" role="lGtFl">
+        <node concept="TZ5HA" id="6EQjZsO9f8f" role="TZ5H$">
+          <node concept="1dT_AC" id="6EQjZsO9f8g" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="x79VA" id="6EQjZsO9f8h" role="3nqlJM">
+          <property role="x79VB" value="list of node concepts where an attribute can be structurally used" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="6EQjZsO9eTV" role="13h7CS">
+      <property role="13i0iv" value="true" />
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="isUsableInLogicalContext" />
+      <property role="2Ki8OM" value="true" />
+      <node concept="3Tm1VV" id="6EQjZsO9eTW" role="1B3o_S" />
+      <node concept="10P_77" id="6EQjZsO9f6U" role="3clF45" />
+      <node concept="3clFbS" id="6EQjZsO9eTY" role="3clF47" />
+      <node concept="37vLTG" id="6EQjZsO9f7e" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="6EQjZsO9f7d" role="1tU5fm" />
       </node>
     </node>
     <node concept="13hLZK" id="4A8SzOVam5w" role="13h7CW">
@@ -1203,6 +1246,75 @@
           </node>
         </node>
       </node>
+    </node>
+    <node concept="13i0hz" id="6EQjZsOe5eI" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="canBeUsedInContext" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" node="6EQjZsO9evJ" resolve="canBeUsedInContext" />
+      <node concept="3Tm1VV" id="6EQjZsOe5eJ" role="1B3o_S" />
+      <node concept="3clFbS" id="6EQjZsOe5eR" role="3clF47">
+        <node concept="3clFbF" id="6EQjZsOe5mV" role="3cqZAp">
+          <node concept="2ShNRf" id="6EQjZsOe5mL" role="3clFbG">
+            <node concept="Tc6Ow" id="6EQjZsOe6Uc" role="2ShVmc">
+              <node concept="3bZ5Sz" id="6EQjZsOe7ex" role="HW$YZ" />
+              <node concept="35c_gC" id="6EQjZsOe7nr" role="HW$Y0">
+                <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="6EQjZsOe5eS" role="3clF45">
+        <node concept="3bZ5Sz" id="6EQjZsOe5eT" role="A3Ik2" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="6EQjZsOe5eU" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="isUsableInLogicalContext" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" node="6EQjZsO9eTV" resolve="isUsableInLogicalContext" />
+      <node concept="3Tm1VV" id="6EQjZsOe5eV" role="1B3o_S" />
+      <node concept="3clFbS" id="6EQjZsOe5f0" role="3clF47">
+        <node concept="3cpWs6" id="6EQjZsOe86W" role="3cqZAp">
+          <node concept="2OqwBi" id="6EQjZsOe86Y" role="3cqZAk">
+            <node concept="BsUDl" id="6EQjZsOe86Z" role="2Oq$k0">
+              <ref role="37wK5l" node="6EQjZsO9evJ" resolve="canBeUsedInContext" />
+            </node>
+            <node concept="2HwmR7" id="6EQjZsOe870" role="2OqNvi">
+              <node concept="1bVj0M" id="6EQjZsOe871" role="23t8la">
+                <node concept="3clFbS" id="6EQjZsOe872" role="1bW5cS">
+                  <node concept="3clFbF" id="6EQjZsOe873" role="3cqZAp">
+                    <node concept="2OqwBi" id="6EQjZsOe874" role="3clFbG">
+                      <node concept="37vLTw" id="6EQjZsOe875" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6EQjZsOe5f1" resolve="node" />
+                      </node>
+                      <node concept="1mIQ4w" id="6EQjZsOe876" role="2OqNvi">
+                        <node concept="25Kdxt" id="6EQjZsOe877" role="cj9EA">
+                          <node concept="37vLTw" id="6EQjZsOe878" role="25KhWn">
+                            <ref role="3cqZAo" node="6EQjZsOe879" resolve="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="6EQjZsOe879" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="6EQjZsOe87a" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6EQjZsOe5f1" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="6EQjZsOe5f2" role="1tU5fm" />
+      </node>
+      <node concept="10P_77" id="6EQjZsOe5f3" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="GKE0N8Vkz7">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.attributes/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.attributes/models/behavior.mps
@@ -150,11 +150,19 @@
       <concept id="5858074156537516430" name="jetbrains.mps.baseLanguage.javadoc.structure.ReturnBlockDocTag" flags="ng" index="x79VA">
         <property id="5858074156537516431" name="text" index="x79VB" />
       </concept>
+      <concept id="6832197706140518104" name="jetbrains.mps.baseLanguage.javadoc.structure.DocMethodParameterReference" flags="ng" index="zr_55" />
+      <concept id="6832197706140518103" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseParameterReference" flags="ng" index="zr_5a">
+        <reference id="6832197706140518108" name="param" index="zr_51" />
+      </concept>
       <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
         <child id="8465538089690331502" name="body" index="TZ5H$" />
         <child id="5383422241790532083" name="tags" index="3nqlJM" />
       </concept>
       <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690881930" name="jetbrains.mps.baseLanguage.javadoc.structure.ParameterBlockDocTag" flags="ng" index="TUZQ0">
+        <property id="8465538089690881934" name="text" index="TUZQ4" />
+        <child id="6832197706140518123" name="parameter" index="zr_5Q" />
+      </concept>
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
         <child id="8970989240999019149" name="part" index="1dT_Ay" />
       </concept>
@@ -450,6 +458,20 @@
       <node concept="37vLTG" id="6EQjZsO9f7e" role="3clF46">
         <property role="TrG5h" value="node" />
         <node concept="3Tqbb2" id="6EQjZsO9f7d" role="1tU5fm" />
+      </node>
+      <node concept="P$JXv" id="HCbFcONKBF" role="lGtFl">
+        <node concept="TZ5HA" id="HCbFcONKBG" role="TZ5H$">
+          <node concept="1dT_AC" id="HCbFcONKBH" role="1dT_Ay" />
+        </node>
+        <node concept="TUZQ0" id="HCbFcONKBI" role="3nqlJM">
+          <property role="TUZQ4" value="which should be used for customized logical constraints" />
+          <node concept="zr_55" id="HCbFcONKBK" role="zr_5Q">
+            <ref role="zr_51" node="6EQjZsO9f7e" resolve="node" />
+          </node>
+        </node>
+        <node concept="x79VA" id="HCbFcONKBL" role="3nqlJM">
+          <property role="x79VB" value="true if the passed node is usable in a logical context" />
+        </node>
       </node>
     </node>
     <node concept="13hLZK" id="4A8SzOVam5w" role="13h7CW">
@@ -1363,6 +1385,56 @@
         </node>
       </node>
       <node concept="3Tqbb2" id="GKE0N8Vkzn" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="7FJkYgoeiUJ">
+    <property role="3GE5qa" value="attributes" />
+    <ref role="13h7C2" to="138:4fgA7QrG5LS" resolve="EmptyAttribute" />
+    <node concept="13hLZK" id="7FJkYgoeiUK" role="13h7CW">
+      <node concept="3clFbS" id="7FJkYgoeiUL" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="7FJkYgoeiUU" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="canBeUsedInContext" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" node="6EQjZsO9evJ" resolve="canBeUsedInContext" />
+      <node concept="3Tm1VV" id="7FJkYgoeiUV" role="1B3o_S" />
+      <node concept="3clFbS" id="7FJkYgoeiV3" role="3clF47">
+        <node concept="3clFbF" id="7FJkYgoek_Y" role="3cqZAp">
+          <node concept="2ShNRf" id="7FJkYgoek_Z" role="3clFbG">
+            <node concept="Tc6Ow" id="7FJkYgoekA0" role="2ShVmc">
+              <node concept="3bZ5Sz" id="7FJkYgoekA1" role="HW$YZ" />
+              <node concept="35c_gC" id="7FJkYgoekA2" role="HW$Y0">
+                <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="7FJkYgoeiV4" role="3clF45">
+        <node concept="3bZ5Sz" id="7FJkYgoeiV5" role="A3Ik2" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="7FJkYgoeiV6" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="isUsableInLogicalContext" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" node="6EQjZsO9eTV" resolve="isUsableInLogicalContext" />
+      <node concept="3Tm1VV" id="7FJkYgoeiV7" role="1B3o_S" />
+      <node concept="3clFbS" id="7FJkYgoeiVi" role="3clF47">
+        <node concept="3clFbF" id="7FJkYgoeiW7" role="3cqZAp">
+          <node concept="3clFbT" id="7FJkYgoeiW6" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7FJkYgoeiVj" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="7FJkYgoeiVk" role="1tU5fm" />
+      </node>
+      <node concept="10P_77" id="7FJkYgoeiVl" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.attributes/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.attributes/models/constraints.mps
@@ -9,17 +9,119 @@
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="138" ref="r:2c1007f3-e814-47ba-b729-c3ea0297f627(org.iets3.core.attributes.structure)" implicit="true" />
+    <import index="soq7" ref="r:4d48d56b-d670-4e5b-a763-2232bb0c4f2d(org.iets3.core.attributes.behavior)" implicit="true" />
   </imports>
   <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+    </language>
     <language id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints">
+      <concept id="6702802731807420587" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAParent" flags="ig" index="9SLcT" />
+      <concept id="4303308395523343364" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_link" flags="ng" index="2DA6wF" />
+      <concept id="4303308395523096213" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_childConcept" flags="ng" index="2DD5aU" />
+      <concept id="1147468365020" name="jetbrains.mps.lang.constraints.structure.ConstraintsFunctionParameter_node" flags="nn" index="EsrRn" />
+      <concept id="6738154313879680265" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_childNode" flags="nn" index="2H4GUG" />
       <concept id="1213093968558" name="jetbrains.mps.lang.constraints.structure.ConceptConstraints" flags="ng" index="1M2fIO">
         <reference id="1213093996982" name="concept" index="1M2myG" />
+        <child id="6702802731807532712" name="canBeParent" index="9SGkU" />
+      </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1204834851141" name="jetbrains.mps.lang.smodel.structure.PoundExpression" flags="ng" index="25Kdxt">
+        <child id="1204834868751" name="expression" index="25KhWn" />
+      </concept>
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1761385620274348152" name="jetbrains.mps.lang.smodel.structure.SConceptTypeCastExpression" flags="nn" index="2CBFar" />
+      <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
+        <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
+      </concept>
+      <concept id="2644386474301421077" name="jetbrains.mps.lang.smodel.structure.LinkIdRefExpression" flags="nn" index="359W_D">
+        <reference id="2644386474301421078" name="conceptDeclaration" index="359W_E" />
+        <reference id="2644386474301421079" name="linkDeclaration" index="359W_F" />
+      </concept>
+      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz">
+        <reference id="6677504323281689839" name="conceptDeclaraton" index="3bZ5Sy" />
+      </concept>
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
       </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
     </language>
   </registry>
   <node concept="1M2fIO" id="2JMl1LWVWjM">
@@ -33,6 +135,116 @@
   <node concept="1M2fIO" id="GKE0N8UTGC">
     <property role="3GE5qa" value="attributes" />
     <ref role="1M2myG" to="138:4fgA7QrDo$u" resolve="AttributeContainerWithContext" />
+  </node>
+  <node concept="1M2fIO" id="3DhaOr$RgVI">
+    <property role="3GE5qa" value="attributes" />
+    <ref role="1M2myG" to="138:GKE0N8V88V" resolve="AttributeContainer" />
+    <node concept="9SLcT" id="3DhaOr$RgVJ" role="9SGkU">
+      <node concept="3clFbS" id="3DhaOr$RgVK" role="2VODD2">
+        <node concept="3clFbJ" id="6EQjZsObYRZ" role="3cqZAp">
+          <node concept="3clFbS" id="6EQjZsObYS1" role="3clFbx">
+            <node concept="3clFbJ" id="6EQjZsOdLq8" role="3cqZAp">
+              <node concept="3clFbS" id="6EQjZsOdLqa" role="3clFbx">
+                <node concept="3cpWs8" id="6EQjZsOd72H" role="3cqZAp">
+                  <node concept="3cpWsn" id="6EQjZsOd72I" role="3cpWs9">
+                    <property role="TrG5h" value="attrCpt" />
+                    <node concept="3bZ5Sz" id="6EQjZsOd72F" role="1tU5fm">
+                      <ref role="3bZ5Sy" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                    </node>
+                    <node concept="2CBFar" id="6EQjZsOd72J" role="33vP2m">
+                      <node concept="chp4Y" id="6EQjZsOd72K" role="3oSUPX">
+                        <ref role="cht4Q" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                      </node>
+                      <node concept="2DD5aU" id="6EQjZsOd72L" role="1m5AlR" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="6EQjZsOd4j3" role="3cqZAp">
+                  <node concept="3cpWsn" id="6EQjZsOd4j4" role="3cpWs9">
+                    <property role="TrG5h" value="isStructurallyValid" />
+                    <node concept="10P_77" id="6EQjZsOd4j2" role="1tU5fm" />
+                    <node concept="2OqwBi" id="6EQjZsOd4j5" role="33vP2m">
+                      <node concept="2OqwBi" id="6EQjZsOd4j6" role="2Oq$k0">
+                        <node concept="37vLTw" id="6EQjZsOd72M" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6EQjZsOd72I" resolve="attrCpt" />
+                        </node>
+                        <node concept="2qgKlT" id="6EQjZsOd4ja" role="2OqNvi">
+                          <ref role="37wK5l" to="soq7:6EQjZsO9evJ" resolve="canBeUsedInContext" />
+                        </node>
+                      </node>
+                      <node concept="2HwmR7" id="6EQjZsOd4jb" role="2OqNvi">
+                        <node concept="1bVj0M" id="6EQjZsOd4jc" role="23t8la">
+                          <node concept="3clFbS" id="6EQjZsOd4jd" role="1bW5cS">
+                            <node concept="3clFbF" id="6EQjZsOd4je" role="3cqZAp">
+                              <node concept="2OqwBi" id="6EQjZsOd4jf" role="3clFbG">
+                                <node concept="EsrRn" id="6EQjZsOd4jg" role="2Oq$k0" />
+                                <node concept="1mIQ4w" id="6EQjZsOd4jh" role="2OqNvi">
+                                  <node concept="25Kdxt" id="6EQjZsOd4ji" role="cj9EA">
+                                    <node concept="37vLTw" id="6EQjZsOd4jj" role="25KhWn">
+                                      <ref role="3cqZAo" node="6EQjZsOd4jk" resolve="it" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="6EQjZsOd4jk" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="6EQjZsOd4jl" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="6EQjZsOcvEE" role="3cqZAp">
+                  <node concept="1Wc70l" id="6EQjZsOcvEG" role="3cqZAk">
+                    <node concept="37vLTw" id="6EQjZsOddPb" role="3uHU7B">
+                      <ref role="3cqZAo" node="6EQjZsOd4j4" resolve="isStructurallyValid" />
+                    </node>
+                    <node concept="2OqwBi" id="6EQjZsOd9cS" role="3uHU7w">
+                      <node concept="37vLTw" id="6EQjZsOd8I6" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6EQjZsOd72I" resolve="attrCpt" />
+                      </node>
+                      <node concept="2qgKlT" id="6EQjZsOd9Eo" role="2OqNvi">
+                        <ref role="37wK5l" to="soq7:6EQjZsO9eTV" resolve="isUsableInLogicalContext" />
+                        <node concept="EsrRn" id="6EQjZsOd9Zl" role="37wK5m" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="6EQjZsOdMRz" role="3clFbw">
+                <node concept="2DD5aU" id="6EQjZsOdLEN" role="2Oq$k0" />
+                <node concept="2Zo12i" id="6EQjZsOdNmL" role="2OqNvi">
+                  <node concept="chp4Y" id="6EQjZsOdNCp" role="2Zo12j">
+                    <ref role="cht4Q" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1Wc70l" id="6EQjZsOcWXh" role="3clFbw">
+            <node concept="17R0WA" id="6EQjZsObXRk" role="3uHU7w">
+              <node concept="359W_D" id="6EQjZsObY97" role="3uHU7w">
+                <ref role="359W_E" to="138:GKE0N8V88V" resolve="AttributeContainer" />
+                <ref role="359W_F" to="138:GKE0N8V89c" resolve="nestedAttributes" />
+              </node>
+              <node concept="2DA6wF" id="6EQjZsObXc4" role="3uHU7B" />
+            </node>
+            <node concept="3clFbC" id="1Ap9E00ArtM" role="3uHU7B">
+              <node concept="2H4GUG" id="1Ap9E00ArtN" role="3uHU7B" />
+              <node concept="10Nm6u" id="1Ap9E00ArtO" role="3uHU7w" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6EQjZsOcxck" role="3cqZAp">
+          <node concept="3clFbT" id="6EQjZsOcxX8" role="3cqZAk">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.trace/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.trace/models/behavior.mps
@@ -11,10 +11,11 @@
     <import index="soq7" ref="r:4d48d56b-d670-4e5b-a763-2232bb0c4f2d(org.iets3.core.attributes.behavior)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
-    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
+      <concept id="6496299201655527393" name="jetbrains.mps.lang.behavior.structure.LocalBehaviorMethodCall" flags="nn" index="BsUDl" />
       <concept id="1225194240794" name="jetbrains.mps.lang.behavior.structure.ConceptBehavior" flags="ng" index="13h7C7">
         <reference id="1225194240799" name="concept" index="13h7C2" />
         <child id="1225194240805" name="method" index="13h7CS" />
@@ -33,6 +34,7 @@
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -49,18 +51,21 @@
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
       <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
         <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
       <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
@@ -101,7 +106,16 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1204834851141" name="jetbrains.mps.lang.smodel.structure.PoundExpression" flags="ng" index="25Kdxt">
+        <child id="1204834868751" name="expression" index="25KhWn" />
+      </concept>
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
@@ -119,6 +133,13 @@
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="3562215692195599741" name="jetbrains.mps.lang.smodel.structure.SLinkImplicitSelect" flags="nn" index="13MTOL">
         <reference id="3562215692195600259" name="link" index="13MTZf" />
+      </concept>
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
+      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
@@ -142,9 +163,19 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
     </language>
@@ -206,6 +237,75 @@
       <node concept="3uibUv" id="mhbzaHl1p_" role="3clF45">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
+    </node>
+    <node concept="13i0hz" id="6EQjZsOe5eI" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="canBeUsedInContext" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" to="soq7:6EQjZsO9evJ" resolve="canBeUsedInContext" />
+      <node concept="3Tm1VV" id="6EQjZsOe5eJ" role="1B3o_S" />
+      <node concept="3clFbS" id="6EQjZsOe5eR" role="3clF47">
+        <node concept="3clFbF" id="6EQjZsOe5mV" role="3cqZAp">
+          <node concept="2ShNRf" id="6EQjZsOe5mL" role="3clFbG">
+            <node concept="Tc6Ow" id="6EQjZsOe6Uc" role="2ShVmc">
+              <node concept="3bZ5Sz" id="6EQjZsOe7ex" role="HW$YZ" />
+              <node concept="35c_gC" id="6EQjZsOe7nr" role="HW$Y0">
+                <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="6EQjZsOe5eS" role="3clF45">
+        <node concept="3bZ5Sz" id="6EQjZsOe5eT" role="A3Ik2" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="6EQjZsOe5eU" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="isUsableInLogicalContext" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" to="soq7:6EQjZsO9eTV" resolve="isUsableInLogicalContext" />
+      <node concept="3Tm1VV" id="6EQjZsOe5eV" role="1B3o_S" />
+      <node concept="3clFbS" id="6EQjZsOe5f0" role="3clF47">
+        <node concept="3cpWs6" id="6EQjZsOe86W" role="3cqZAp">
+          <node concept="2OqwBi" id="6EQjZsOe86Y" role="3cqZAk">
+            <node concept="BsUDl" id="6EQjZsOe86Z" role="2Oq$k0">
+              <ref role="37wK5l" to="soq7:6EQjZsO9evJ" resolve="canBeUsedInContext" />
+            </node>
+            <node concept="2HwmR7" id="6EQjZsOe870" role="2OqNvi">
+              <node concept="1bVj0M" id="6EQjZsOe871" role="23t8la">
+                <node concept="3clFbS" id="6EQjZsOe872" role="1bW5cS">
+                  <node concept="3clFbF" id="6EQjZsOe873" role="3cqZAp">
+                    <node concept="2OqwBi" id="6EQjZsOe874" role="3clFbG">
+                      <node concept="37vLTw" id="6EQjZsOe875" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6EQjZsOe5f1" resolve="node" />
+                      </node>
+                      <node concept="1mIQ4w" id="6EQjZsOe876" role="2OqNvi">
+                        <node concept="25Kdxt" id="6EQjZsOe877" role="cj9EA">
+                          <node concept="37vLTw" id="6EQjZsOe878" role="25KhWn">
+                            <ref role="3cqZAo" node="6EQjZsOe879" resolve="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="6EQjZsOe879" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="6EQjZsOe87a" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6EQjZsOe5f1" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="6EQjZsOe5f2" role="1tU5fm" />
+      </node>
+      <node concept="10P_77" id="6EQjZsOe5f3" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="x8tpS_Qfyv">

--- a/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/behavior.mps
@@ -3,6 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="1" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <devkit ref="2677cb18-f558-4e33-bc38-a5139cee06dc(jetbrains.mps.devkit.language-design)" />
   </languages>
   <imports>
@@ -16,7 +17,6 @@
     <import index="soq7" ref="r:4d48d56b-d670-4e5b-a763-2232bb0c4f2d(org.iets3.core.attributes.behavior)" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
     <import index="138" ref="r:2c1007f3-e814-47ba-b729-c3ea0297f627(org.iets3.core.attributes.structure)" />
-    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -243,75 +243,6 @@
       <node concept="A3Dl8" id="3QX5db_xM_O" role="3clF45">
         <node concept="3bZ5Sz" id="3QX5db_xM_P" role="A3Ik2" />
       </node>
-    </node>
-    <node concept="13i0hz" id="6EQjZsOe5eI" role="13h7CS">
-      <property role="13i0iv" value="false" />
-      <property role="13i0it" value="false" />
-      <property role="TrG5h" value="canBeUsedInContext" />
-      <property role="2Ki8OM" value="true" />
-      <ref role="13i0hy" to="soq7:6EQjZsO9evJ" resolve="canBeUsedInContext" />
-      <node concept="3Tm1VV" id="6EQjZsOe5eJ" role="1B3o_S" />
-      <node concept="3clFbS" id="6EQjZsOe5eR" role="3clF47">
-        <node concept="3clFbF" id="6EQjZsOe5mV" role="3cqZAp">
-          <node concept="2ShNRf" id="6EQjZsOe5mL" role="3clFbG">
-            <node concept="Tc6Ow" id="6EQjZsOe6Uc" role="2ShVmc">
-              <node concept="3bZ5Sz" id="6EQjZsOe7ex" role="HW$YZ" />
-              <node concept="35c_gC" id="6EQjZsOe7nr" role="HW$Y0">
-                <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="A3Dl8" id="6EQjZsOe5eS" role="3clF45">
-        <node concept="3bZ5Sz" id="6EQjZsOe5eT" role="A3Ik2" />
-      </node>
-    </node>
-    <node concept="13i0hz" id="6EQjZsOe5eU" role="13h7CS">
-      <property role="13i0iv" value="false" />
-      <property role="13i0it" value="false" />
-      <property role="TrG5h" value="isUsableInLogicalContext" />
-      <property role="2Ki8OM" value="true" />
-      <ref role="13i0hy" to="soq7:6EQjZsO9eTV" resolve="isUsableInLogicalContext" />
-      <node concept="3Tm1VV" id="6EQjZsOe5eV" role="1B3o_S" />
-      <node concept="3clFbS" id="6EQjZsOe5f0" role="3clF47">
-        <node concept="3cpWs6" id="6EQjZsOe86W" role="3cqZAp">
-          <node concept="2OqwBi" id="6EQjZsOe86Y" role="3cqZAk">
-            <node concept="BsUDl" id="6EQjZsOe86Z" role="2Oq$k0">
-              <ref role="37wK5l" to="soq7:6EQjZsO9evJ" resolve="canBeUsedInContext" />
-            </node>
-            <node concept="2HwmR7" id="6EQjZsOe870" role="2OqNvi">
-              <node concept="1bVj0M" id="6EQjZsOe871" role="23t8la">
-                <node concept="3clFbS" id="6EQjZsOe872" role="1bW5cS">
-                  <node concept="3clFbF" id="6EQjZsOe873" role="3cqZAp">
-                    <node concept="2OqwBi" id="6EQjZsOe874" role="3clFbG">
-                      <node concept="37vLTw" id="6EQjZsOe875" role="2Oq$k0">
-                        <ref role="3cqZAo" node="6EQjZsOe5f1" resolve="node" />
-                      </node>
-                      <node concept="1mIQ4w" id="6EQjZsOe876" role="2OqNvi">
-                        <node concept="25Kdxt" id="6EQjZsOe877" role="cj9EA">
-                          <node concept="37vLTw" id="6EQjZsOe878" role="25KhWn">
-                            <ref role="3cqZAo" node="6EQjZsOe879" resolve="it" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="Rh6nW" id="6EQjZsOe879" role="1bW2Oz">
-                  <property role="TrG5h" value="it" />
-                  <node concept="2jxLKc" id="6EQjZsOe87a" role="1tU5fm" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="6EQjZsOe5f1" role="3clF46">
-        <property role="TrG5h" value="node" />
-        <node concept="3Tqbb2" id="6EQjZsOe5f2" role="1tU5fm" />
-      </node>
-      <node concept="10P_77" id="6EQjZsOe5f3" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="3QX5db_E4Iz">
@@ -780,7 +711,7 @@
   </node>
   <node concept="13h7C7" id="6EQjZsO9hkf">
     <property role="3GE5qa" value="attributes" />
-    <ref role="13h7C2" to="xens:6EQjZsO9hjN" resolve="TestKindAPortAttribute" />
+    <ref role="13h7C2" to="xens:6EQjZsO9hjN" resolve="TestKindBPortAttribute" />
     <node concept="13hLZK" id="6EQjZsO9hkg" role="13h7CW">
       <node concept="3clFbS" id="6EQjZsO9hkh" role="2VODD2" />
     </node>
@@ -820,7 +751,6 @@
       <node concept="3clFbS" id="6EQjZsO9hkG" role="3clF47">
         <node concept="3clFbJ" id="6EQjZsO9ojA" role="3cqZAp">
           <node concept="3clFbS" id="6EQjZsO9ojC" role="3clFbx">
-            <node concept="3clFbH" id="3DhaOr$REey" role="3cqZAp" />
             <node concept="3clFbJ" id="3DhaOr$QSPc" role="3cqZAp">
               <node concept="3clFbS" id="3DhaOr$QSPe" role="3clFbx">
                 <node concept="3cpWs8" id="6EQjZsO9wk7" role="3cqZAp">
@@ -1063,6 +993,22 @@
         <node concept="3Tqbb2" id="6EQjZsO9hkI" role="1tU5fm" />
       </node>
       <node concept="10P_77" id="6EQjZsO9hkJ" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="7FJkYgnWa1F" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="isMainAttribute" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" to="soq7:5ZBgTg_IANQ" resolve="isMainAttribute" />
+      <node concept="3Tm1VV" id="7FJkYgnWa1G" role="1B3o_S" />
+      <node concept="3clFbS" id="7FJkYgnWa1P" role="3clF47">
+        <node concept="3clFbF" id="7FJkYgnWaGX" role="3cqZAp">
+          <node concept="3clFbT" id="7FJkYgnWaGW" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="7FJkYgnWa1Q" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/behavior.mps
@@ -13,6 +13,10 @@
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
+    <import index="soq7" ref="r:4d48d56b-d670-4e5b-a763-2232bb0c4f2d(org.iets3.core.attributes.behavior)" />
+    <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
+    <import index="138" ref="r:2c1007f3-e814-47ba-b729-c3ea0297f627(org.iets3.core.attributes.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -24,6 +28,7 @@
       </concept>
     </language>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
+      <concept id="6496299201655527393" name="jetbrains.mps.lang.behavior.structure.LocalBehaviorMethodCall" flags="nn" index="BsUDl" />
       <concept id="1225194240794" name="jetbrains.mps.lang.behavior.structure.ConceptBehavior" flags="ng" index="13h7C7">
         <reference id="1225194240799" name="concept" index="13h7C2" />
         <child id="1225194240805" name="method" index="13h7CS" />
@@ -38,6 +43,7 @@
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -53,6 +59,9 @@
       </concept>
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -69,6 +78,11 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
@@ -77,6 +91,20 @@
       </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
@@ -88,6 +116,13 @@
         <child id="6329021646629175155" name="commentPart" index="3SKWNk" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
@@ -98,9 +133,20 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1204834851141" name="jetbrains.mps.lang.smodel.structure.PoundExpression" flags="ng" index="25Kdxt">
+        <child id="1204834868751" name="expression" index="25KhWn" />
+      </concept>
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1240170042401" name="jetbrains.mps.lang.smodel.structure.SEnumMemberType" flags="in" index="2ZThk1">
         <reference id="1240170836027" name="enum" index="2ZWj4r" />
       </concept>
@@ -113,6 +159,9 @@
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
       <concept id="1240930118027" name="jetbrains.mps.lang.smodel.structure.SEnumOperationInvocation" flags="nn" index="3HcIyF">
         <reference id="1240930118028" name="enumDeclaration" index="3HcIyG" />
         <child id="1240930317927" name="operation" index="3Hdvt7" />
@@ -120,27 +169,42 @@
       <concept id="1240930444945" name="jetbrains.mps.lang.smodel.structure.SEnum_MemberOperation" flags="ng" index="3HdYuL">
         <reference id="1240930444946" name="member" index="3HdYuM" />
       </concept>
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435808" name="initValue" index="HW$Y0" />
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
     </language>
   </registry>
   <node concept="13h7C7" id="3QX5db_xMrK">
+    <property role="3GE5qa" value="attributes" />
     <ref role="13h7C2" to="xens:3QX5db_xLJM" resolve="TestAttribute" />
     <node concept="13hLZK" id="3QX5db_xMrL" role="13h7CW">
       <node concept="3clFbS" id="3QX5db_xMrM" role="2VODD2" />
@@ -180,8 +244,78 @@
         <node concept="3bZ5Sz" id="3QX5db_xM_P" role="A3Ik2" />
       </node>
     </node>
+    <node concept="13i0hz" id="6EQjZsOe5eI" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="canBeUsedInContext" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" to="soq7:6EQjZsO9evJ" resolve="canBeUsedInContext" />
+      <node concept="3Tm1VV" id="6EQjZsOe5eJ" role="1B3o_S" />
+      <node concept="3clFbS" id="6EQjZsOe5eR" role="3clF47">
+        <node concept="3clFbF" id="6EQjZsOe5mV" role="3cqZAp">
+          <node concept="2ShNRf" id="6EQjZsOe5mL" role="3clFbG">
+            <node concept="Tc6Ow" id="6EQjZsOe6Uc" role="2ShVmc">
+              <node concept="3bZ5Sz" id="6EQjZsOe7ex" role="HW$YZ" />
+              <node concept="35c_gC" id="6EQjZsOe7nr" role="HW$Y0">
+                <ref role="35c_gD" to="tpck:gw2VY9q" resolve="BaseConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="6EQjZsOe5eS" role="3clF45">
+        <node concept="3bZ5Sz" id="6EQjZsOe5eT" role="A3Ik2" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="6EQjZsOe5eU" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="isUsableInLogicalContext" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" to="soq7:6EQjZsO9eTV" resolve="isUsableInLogicalContext" />
+      <node concept="3Tm1VV" id="6EQjZsOe5eV" role="1B3o_S" />
+      <node concept="3clFbS" id="6EQjZsOe5f0" role="3clF47">
+        <node concept="3cpWs6" id="6EQjZsOe86W" role="3cqZAp">
+          <node concept="2OqwBi" id="6EQjZsOe86Y" role="3cqZAk">
+            <node concept="BsUDl" id="6EQjZsOe86Z" role="2Oq$k0">
+              <ref role="37wK5l" to="soq7:6EQjZsO9evJ" resolve="canBeUsedInContext" />
+            </node>
+            <node concept="2HwmR7" id="6EQjZsOe870" role="2OqNvi">
+              <node concept="1bVj0M" id="6EQjZsOe871" role="23t8la">
+                <node concept="3clFbS" id="6EQjZsOe872" role="1bW5cS">
+                  <node concept="3clFbF" id="6EQjZsOe873" role="3cqZAp">
+                    <node concept="2OqwBi" id="6EQjZsOe874" role="3clFbG">
+                      <node concept="37vLTw" id="6EQjZsOe875" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6EQjZsOe5f1" resolve="node" />
+                      </node>
+                      <node concept="1mIQ4w" id="6EQjZsOe876" role="2OqNvi">
+                        <node concept="25Kdxt" id="6EQjZsOe877" role="cj9EA">
+                          <node concept="37vLTw" id="6EQjZsOe878" role="25KhWn">
+                            <ref role="3cqZAo" node="6EQjZsOe879" resolve="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="6EQjZsOe879" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="6EQjZsOe87a" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6EQjZsOe5f1" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="6EQjZsOe5f2" role="1tU5fm" />
+      </node>
+      <node concept="10P_77" id="6EQjZsOe5f3" role="3clF45" />
+    </node>
   </node>
   <node concept="13h7C7" id="3QX5db_E4Iz">
+    <property role="3GE5qa" value="categories" />
     <ref role="13h7C2" to="xens:3QX5db_E46y" resolve="TestPortCategoryAccepts" />
     <node concept="13hLZK" id="3QX5db_E4I$" role="13h7CW">
       <node concept="3clFbS" id="3QX5db_E4I_" role="2VODD2" />
@@ -319,6 +453,7 @@
     </node>
   </node>
   <node concept="13h7C7" id="3QX5db_I5cw">
+    <property role="3GE5qa" value="categories" />
     <ref role="13h7C2" to="xens:3QX5db_I5bP" resolve="TestPortCategoryOffers" />
     <node concept="13hLZK" id="3QX5db_I5cx" role="13h7CW">
       <node concept="3clFbS" id="3QX5db_I5cy" role="2VODD2" />
@@ -458,6 +593,7 @@
     </node>
   </node>
   <node concept="13h7C7" id="3QX5db_Ik67">
+    <property role="3GE5qa" value="types" />
     <ref role="13h7C2" to="xens:3QX5db_E9QV" resolve="TestPortType" />
     <node concept="13hLZK" id="3QX5db_Ik68" role="13h7CW">
       <node concept="3clFbS" id="3QX5db_Ik69" role="2VODD2" />
@@ -504,6 +640,7 @@
     </node>
   </node>
   <node concept="13h7C7" id="7LbZKOmOPqW">
+    <property role="3GE5qa" value="kinds" />
     <ref role="13h7C2" to="xens:7LbZKOmHQeu" resolve="TestKindB" />
     <node concept="13hLZK" id="7LbZKOmOPqX" role="13h7CW">
       <node concept="3clFbS" id="7LbZKOmOPqY" role="2VODD2" />
@@ -559,6 +696,7 @@
     </node>
   </node>
   <node concept="13h7C7" id="7LbZKOmT25j">
+    <property role="3GE5qa" value="kinds" />
     <ref role="13h7C2" to="xens:7LbZKOmT25i" resolve="TestKindC" />
     <node concept="13hLZK" id="7LbZKOmT25k" role="13h7CW">
       <node concept="3clFbS" id="7LbZKOmT25l" role="2VODD2" />
@@ -601,6 +739,7 @@
     </node>
   </node>
   <node concept="13h7C7" id="7LbZKOmT6kE">
+    <property role="3GE5qa" value="kinds" />
     <ref role="13h7C2" to="xens:3QX5db_HNz8" resolve="TestKindA" />
     <node concept="13hLZK" id="7LbZKOmT6kF" role="13h7CW">
       <node concept="3clFbS" id="7LbZKOmT6kG" role="2VODD2" />
@@ -637,6 +776,293 @@
         </node>
       </node>
       <node concept="10P_77" id="7LbZKOmT6la" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="6EQjZsO9hkf">
+    <property role="3GE5qa" value="attributes" />
+    <ref role="13h7C2" to="xens:6EQjZsO9hjN" resolve="TestKindAPortAttribute" />
+    <node concept="13hLZK" id="6EQjZsO9hkg" role="13h7CW">
+      <node concept="3clFbS" id="6EQjZsO9hkh" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="6EQjZsO9hkq" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="canBeUsedInContext" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" to="soq7:6EQjZsO9evJ" resolve="canBeUsedInContext" />
+      <node concept="3Tm1VV" id="6EQjZsO9hkr" role="1B3o_S" />
+      <node concept="3clFbS" id="6EQjZsO9hkz" role="3clF47">
+        <node concept="3clFbF" id="6EQjZsO9hlq" role="3cqZAp">
+          <node concept="2ShNRf" id="6EQjZsO9hlo" role="3clFbG">
+            <node concept="Tc6Ow" id="6EQjZsO9lti" role="2ShVmc">
+              <node concept="3bZ5Sz" id="6EQjZsO9lNu" role="HW$YZ" />
+              <node concept="35c_gC" id="6EQjZsO9lYf" role="HW$Y0">
+                <ref role="35c_gD" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+              </node>
+              <node concept="35c_gC" id="3DhaOr$QOFQ" role="HW$Y0">
+                <ref role="35c_gD" to="138:GKE0N8V88V" resolve="AttributeContainer" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="6EQjZsO9hk$" role="3clF45">
+        <node concept="3bZ5Sz" id="6EQjZsO9hk_" role="A3Ik2" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="6EQjZsO9hkA" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="isUsableInLogicalContext" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" to="soq7:6EQjZsO9eTV" resolve="isUsableInLogicalContext" />
+      <node concept="3Tm1VV" id="6EQjZsO9hkB" role="1B3o_S" />
+      <node concept="3clFbS" id="6EQjZsO9hkG" role="3clF47">
+        <node concept="3clFbJ" id="6EQjZsO9ojA" role="3cqZAp">
+          <node concept="3clFbS" id="6EQjZsO9ojC" role="3clFbx">
+            <node concept="3clFbH" id="3DhaOr$REey" role="3cqZAp" />
+            <node concept="3clFbJ" id="3DhaOr$QSPc" role="3cqZAp">
+              <node concept="3clFbS" id="3DhaOr$QSPe" role="3clFbx">
+                <node concept="3cpWs8" id="6EQjZsO9wk7" role="3cqZAp">
+                  <node concept="3cpWsn" id="6EQjZsO9wk8" role="3cpWs9">
+                    <property role="TrG5h" value="portHasKindB" />
+                    <node concept="10P_77" id="6EQjZsO9wjV" role="1tU5fm" />
+                    <node concept="2OqwBi" id="6EQjZsO9wk9" role="33vP2m">
+                      <node concept="2OqwBi" id="6EQjZsO9wka" role="2Oq$k0">
+                        <node concept="2OqwBi" id="6EQjZsO9wkb" role="2Oq$k0">
+                          <node concept="1PxgMI" id="6EQjZsO9wkc" role="2Oq$k0">
+                            <property role="1BlNFB" value="true" />
+                            <node concept="chp4Y" id="6EQjZsO9wkd" role="3oSUPX">
+                              <ref role="cht4Q" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+                            </node>
+                            <node concept="37vLTw" id="6EQjZsO9wke" role="1m5AlR">
+                              <ref role="3cqZAo" node="6EQjZsO9hkH" resolve="node" />
+                            </node>
+                          </node>
+                          <node concept="2Xjw5R" id="6EQjZsO9wkf" role="2OqNvi">
+                            <node concept="1xMEDy" id="6EQjZsO9wkg" role="1xVPHs">
+                              <node concept="chp4Y" id="6EQjZsO9wkh" role="ri$Ld">
+                                <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3TrEf2" id="6EQjZsO9wki" role="2OqNvi">
+                          <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
+                        </node>
+                      </node>
+                      <node concept="1mIQ4w" id="6EQjZsO9wkj" role="2OqNvi">
+                        <node concept="chp4Y" id="3DhaOr$Rd9Q" role="cj9EA">
+                          <ref role="cht4Q" to="xens:7LbZKOmHQeu" resolve="TestKindB" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="6EQjZsO9w53" role="3cqZAp">
+                  <node concept="37vLTw" id="6EQjZsO9wkl" role="3cqZAk">
+                    <ref role="3cqZAo" node="6EQjZsO9wk8" resolve="portHasKindB" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="3DhaOr$QRSP" role="3clFbw">
+                <node concept="37vLTw" id="3DhaOr$QRKm" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6EQjZsO9hkH" resolve="node" />
+                </node>
+                <node concept="1mIQ4w" id="3DhaOr$QSAz" role="2OqNvi">
+                  <node concept="chp4Y" id="3DhaOr$QSFT" role="cj9EA">
+                    <ref role="cht4Q" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="3DhaOr$QUzG" role="3cqZAp">
+              <node concept="3clFbS" id="3DhaOr$QUzI" role="3clFbx">
+                <node concept="3cpWs8" id="3DhaOr$QWW1" role="3cqZAp">
+                  <node concept="3cpWsn" id="3DhaOr$QWW2" role="3cpWs9">
+                    <property role="TrG5h" value="ctx" />
+                    <node concept="3Tqbb2" id="3DhaOr$QWVW" role="1tU5fm">
+                      <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                    </node>
+                    <node concept="2OqwBi" id="3DhaOr$QWW3" role="33vP2m">
+                      <node concept="2OqwBi" id="3DhaOr$RLEj" role="2Oq$k0">
+                        <node concept="37vLTw" id="3DhaOr$QWW6" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6EQjZsO9hkH" resolve="node" />
+                        </node>
+                        <node concept="2Xjw5R" id="3DhaOr$RM8a" role="2OqNvi">
+                          <node concept="1xMEDy" id="3DhaOr$RM8c" role="1xVPHs">
+                            <node concept="chp4Y" id="3DhaOr$RMKc" role="ri$Ld">
+                              <ref role="cht4Q" to="138:4fgA7QrBOmZ" resolve="IAttributeWithContext" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="3DhaOr$QWW7" role="2OqNvi">
+                        <ref role="3Tt5mk" to="138:4fgA7QrBOn0" resolve="ctx" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="3DhaOr$QXcy" role="3cqZAp">
+                  <node concept="3clFbS" id="3DhaOr$QXc$" role="3clFbx">
+                    <node concept="3cpWs8" id="3DhaOr$REsP" role="3cqZAp">
+                      <node concept="3cpWsn" id="3DhaOr$REsQ" role="3cpWs9">
+                        <property role="TrG5h" value="port" />
+                        <node concept="3Tqbb2" id="3DhaOr$REsK" role="1tU5fm">
+                          <ref role="ehGHo" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+                        </node>
+                        <node concept="2OqwBi" id="3DhaOr$REsR" role="33vP2m">
+                          <node concept="1PxgMI" id="3DhaOr$REsS" role="2Oq$k0">
+                            <property role="1BlNFB" value="true" />
+                            <node concept="chp4Y" id="3DhaOr$REsT" role="3oSUPX">
+                              <ref role="cht4Q" to="w9y2:1WAg9Tz2efG" resolve="PortRefTarget" />
+                            </node>
+                            <node concept="2OqwBi" id="3DhaOr$REsU" role="1m5AlR">
+                              <node concept="1PxgMI" id="3DhaOr$REsV" role="2Oq$k0">
+                                <property role="1BlNFB" value="true" />
+                                <node concept="chp4Y" id="3DhaOr$REsW" role="3oSUPX">
+                                  <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+                                </node>
+                                <node concept="37vLTw" id="3DhaOr$REsX" role="1m5AlR">
+                                  <ref role="3cqZAo" node="3DhaOr$QWW2" resolve="ctx" />
+                                </node>
+                              </node>
+                              <node concept="3TrEf2" id="3DhaOr$REsY" role="2OqNvi">
+                                <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3TrEf2" id="3DhaOr$REsZ" role="2OqNvi">
+                            <ref role="3Tt5mk" to="w9y2:1WAg9Tz2efJ" resolve="port" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="3DhaOr$R9V4" role="3cqZAp">
+                      <node concept="3cpWsn" id="3DhaOr$R9V5" role="3cpWs9">
+                        <property role="TrG5h" value="referencedPortHasKindB" />
+                        <node concept="10P_77" id="3DhaOr$R9UP" role="1tU5fm" />
+                        <node concept="2OqwBi" id="3DhaOr$R9V6" role="33vP2m">
+                          <node concept="2OqwBi" id="3DhaOr$R9V7" role="2Oq$k0">
+                            <node concept="2OqwBi" id="3DhaOr$R9V8" role="2Oq$k0">
+                              <node concept="37vLTw" id="3DhaOr$REt0" role="2Oq$k0">
+                                <ref role="3cqZAo" node="3DhaOr$REsQ" resolve="port" />
+                              </node>
+                              <node concept="2Xjw5R" id="3DhaOr$R9Vi" role="2OqNvi">
+                                <node concept="1xMEDy" id="3DhaOr$R9Vj" role="1xVPHs">
+                                  <node concept="chp4Y" id="3DhaOr$R9Vk" role="ri$Ld">
+                                    <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3TrEf2" id="3DhaOr$R9Vl" role="2OqNvi">
+                              <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
+                            </node>
+                          </node>
+                          <node concept="1mIQ4w" id="3DhaOr$R9Vm" role="2OqNvi">
+                            <node concept="chp4Y" id="3DhaOr$RdQ6" role="cj9EA">
+                              <ref role="cht4Q" to="xens:7LbZKOmHQeu" resolve="TestKindB" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs6" id="3DhaOr$Rakc" role="3cqZAp">
+                      <node concept="37vLTw" id="3DhaOr$Rake" role="3cqZAk">
+                        <ref role="3cqZAo" node="3DhaOr$R9V5" resolve="referencedPortHasKindB" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1Wc70l" id="3DhaOr$R2u7" role="3clFbw">
+                    <node concept="2OqwBi" id="3DhaOr$QXnr" role="3uHU7B">
+                      <node concept="37vLTw" id="3DhaOr$QXd6" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3DhaOr$QWW2" resolve="ctx" />
+                      </node>
+                      <node concept="1mIQ4w" id="3DhaOr$QXKV" role="2OqNvi">
+                        <node concept="chp4Y" id="3DhaOr$QXNp" role="cj9EA">
+                          <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="3DhaOr$R2Dd" role="3uHU7w">
+                      <node concept="2OqwBi" id="3DhaOr$R2De" role="2Oq$k0">
+                        <node concept="1PxgMI" id="3DhaOr$R2Df" role="2Oq$k0">
+                          <property role="1BlNFB" value="true" />
+                          <node concept="chp4Y" id="3DhaOr$R2Dg" role="3oSUPX">
+                            <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+                          </node>
+                          <node concept="37vLTw" id="3DhaOr$R2Dh" role="1m5AlR">
+                            <ref role="3cqZAo" node="3DhaOr$QWW2" resolve="ctx" />
+                          </node>
+                        </node>
+                        <node concept="3TrEf2" id="3DhaOr$R2Di" role="2OqNvi">
+                          <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                        </node>
+                      </node>
+                      <node concept="1mIQ4w" id="3DhaOr$R2Dj" role="2OqNvi">
+                        <node concept="chp4Y" id="3DhaOr$R2TU" role="cj9EA">
+                          <ref role="cht4Q" to="w9y2:1WAg9Tz2efG" resolve="PortRefTarget" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="3DhaOr$QUK7" role="3clFbw">
+                <node concept="37vLTw" id="3DhaOr$QUCh" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6EQjZsO9hkH" resolve="node" />
+                </node>
+                <node concept="1mIQ4w" id="3DhaOr$QV0c" role="2OqNvi">
+                  <node concept="chp4Y" id="3DhaOr$RJGo" role="cj9EA">
+                    <ref role="cht4Q" to="138:GKE0N8V88V" resolve="AttributeContainer" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="3DhaOr$QRG4" role="3cqZAp" />
+          </node>
+          <node concept="2OqwBi" id="6EQjZsO9nl2" role="3clFbw">
+            <node concept="BsUDl" id="6EQjZsO9n7u" role="2Oq$k0">
+              <ref role="37wK5l" to="soq7:6EQjZsO9evJ" resolve="canBeUsedInContext" />
+            </node>
+            <node concept="2HwmR7" id="6EQjZsO9ozL" role="2OqNvi">
+              <node concept="1bVj0M" id="6EQjZsO9ozN" role="23t8la">
+                <node concept="3clFbS" id="6EQjZsO9ozO" role="1bW5cS">
+                  <node concept="3clFbF" id="6EQjZsOc909" role="3cqZAp">
+                    <node concept="2OqwBi" id="6EQjZsOc9b0" role="3clFbG">
+                      <node concept="37vLTw" id="6EQjZsOc900" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6EQjZsO9hkH" resolve="node" />
+                      </node>
+                      <node concept="1mIQ4w" id="6EQjZsOc9sr" role="2OqNvi">
+                        <node concept="25Kdxt" id="6EQjZsOc9zK" role="cj9EA">
+                          <node concept="37vLTw" id="6EQjZsOc9BH" role="25KhWn">
+                            <ref role="3cqZAo" node="6EQjZsO9ozP" resolve="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="6EQjZsO9ozP" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="6EQjZsO9ozQ" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6EQjZsO9m_y" role="3cqZAp">
+          <node concept="3clFbT" id="6EQjZsO9m_G" role="3cqZAk">
+            <property role="3clFbU" value="false" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6EQjZsO9hkH" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="6EQjZsO9hkI" role="1tU5fm" />
+      </node>
+      <node concept="10P_77" id="6EQjZsO9hkJ" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/editor.mps
@@ -84,6 +84,9 @@
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -98,6 +101,7 @@
     </language>
   </registry>
   <node concept="24kQdi" id="3QX5db_xZzh">
+    <property role="3GE5qa" value="attributes" />
     <ref role="1XX52x" to="xens:3QX5db_xLJM" resolve="TestAttribute" />
     <node concept="1j7BWu" id="48ZWgAGr5tK" role="2wV5jI">
       <node concept="1HlG4h" id="48ZWgAGr5tV" role="1j7ClA">
@@ -155,38 +159,51 @@
     </node>
   </node>
   <node concept="24kQdi" id="3QX5db_E9M7">
+    <property role="3GE5qa" value="categories" />
     <ref role="1XX52x" to="xens:3QX5db_E46y" resolve="TestPortCategoryAccepts" />
     <node concept="PMmxH" id="3QX5db_E9Mc" role="2wV5jI">
       <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
     </node>
   </node>
   <node concept="24kQdi" id="3QX5db_EawJ">
+    <property role="3GE5qa" value="types" />
     <ref role="1XX52x" to="xens:3QX5db_E9QV" resolve="TestPortType" />
     <node concept="PMmxH" id="3QX5db_EawO" role="2wV5jI">
       <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
     </node>
   </node>
   <node concept="24kQdi" id="3QX5db_I9R1">
+    <property role="3GE5qa" value="categories" />
     <ref role="1XX52x" to="xens:3QX5db_I5bP" resolve="TestPortCategoryOffers" />
     <node concept="PMmxH" id="3QX5db_I9Rk" role="2wV5jI">
       <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
     </node>
   </node>
   <node concept="24kQdi" id="7LbZKOmHRWE">
+    <property role="3GE5qa" value="kinds" />
     <ref role="1XX52x" to="xens:7LbZKOmHQeu" resolve="TestKindB" />
     <node concept="PMmxH" id="7LbZKOmHRWG" role="2wV5jI">
       <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
     </node>
   </node>
   <node concept="24kQdi" id="3QX5db_HOqv">
+    <property role="3GE5qa" value="kinds" />
     <ref role="1XX52x" to="xens:3QX5db_HNz8" resolve="TestKindA" />
     <node concept="PMmxH" id="3QX5db_HOq$" role="2wV5jI">
       <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
     </node>
   </node>
   <node concept="24kQdi" id="7LbZKOmT25A">
+    <property role="3GE5qa" value="kinds" />
     <ref role="1XX52x" to="xens:7LbZKOmT25i" resolve="TestKindC" />
     <node concept="PMmxH" id="7LbZKOmT25F" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="3DhaOr$QMZl">
+    <property role="3GE5qa" value="attributes" />
+    <ref role="1XX52x" to="xens:6EQjZsO9hjN" resolve="TestKindAPortAttribute" />
+    <node concept="PMmxH" id="3DhaOr$QMZn" role="2wV5jI">
       <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/editor.mps
@@ -22,6 +22,13 @@
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
         <reference id="1078939183255" name="editorComponent" index="PMmxG" />
       </concept>
+      <concept id="1186403694788" name="jetbrains.mps.lang.editor.structure.ColorStyleClassItem" flags="ln" index="VaVBg">
+        <property id="1186403713874" name="color" index="Vb096" />
+      </concept>
+      <concept id="1186404549998" name="jetbrains.mps.lang.editor.structure.ForegroundColorStyleClassItem" flags="ln" index="VechU" />
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
+        <child id="1219418656006" name="styleItem" index="3F10Kt" />
+      </concept>
       <concept id="1225898583838" name="jetbrains.mps.lang.editor.structure.ReadOnlyModelAccessor" flags="ng" index="1HfYo3">
         <child id="1225898971709" name="getter" index="1Hhtcw" />
       </concept>
@@ -202,9 +209,12 @@
   </node>
   <node concept="24kQdi" id="3DhaOr$QMZl">
     <property role="3GE5qa" value="attributes" />
-    <ref role="1XX52x" to="xens:6EQjZsO9hjN" resolve="TestKindAPortAttribute" />
+    <ref role="1XX52x" to="xens:6EQjZsO9hjN" resolve="TestKindBPortAttribute" />
     <node concept="PMmxH" id="3DhaOr$QMZn" role="2wV5jI">
       <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      <node concept="VechU" id="7FJkYgnWfvG" role="3F10Kt">
+        <property role="Vb096" value="DARK_MAGENTA" />
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/structure.mps
@@ -9,6 +9,7 @@
   <imports>
     <import index="w9y2" ref="r:b3786745-c763-4a49-a754-f84e15236f18(org.iets3.components.core.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="138" ref="r:2c1007f3-e814-47ba-b729-c3ea0297f627(org.iets3.core.attributes.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
@@ -25,6 +26,9 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -34,6 +38,7 @@
     <property role="EcuMT" value="4448734902938442738" />
     <property role="TrG5h" value="TestAttribute" />
     <property role="34LRSv" value="testattribute" />
+    <property role="3GE5qa" value="attributes" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="PrWs8" id="3QX5db_yno8" role="PzmwI">
       <ref role="PrY4T" to="w9y2:1WCh2th1BnT" resolve="IConceptSpecificAttribute" />
@@ -43,12 +48,14 @@
     <property role="EcuMT" value="4448734902940615074" />
     <property role="TrG5h" value="TestPortCategoryAccepts" />
     <property role="34LRSv" value="testAcc" />
+    <property role="3GE5qa" value="categories" />
     <ref role="1TJDcQ" to="w9y2:siw10H0or2" resolve="PortCategory" />
   </node>
   <node concept="1TIwiD" id="3QX5db_E9QV">
     <property role="EcuMT" value="4448734902940638651" />
     <property role="TrG5h" value="TestPortType" />
     <property role="34LRSv" value="TestPType" />
+    <property role="3GE5qa" value="types" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="PrWs8" id="3QX5db_E9Rb" role="PzmwI">
       <ref role="PrY4T" to="w9y2:6LfBX8YlAdL" resolve="IPortType" />
@@ -58,11 +65,13 @@
     <property role="EcuMT" value="4448734902941668085" />
     <property role="TrG5h" value="TestPortCategoryOffers" />
     <property role="34LRSv" value="testOff" />
+    <property role="3GE5qa" value="categories" />
     <ref role="1TJDcQ" to="w9y2:siw10H0or2" resolve="PortCategory" />
   </node>
   <node concept="1TIwiD" id="48ZWgAGwh6D">
     <property role="EcuMT" value="4773799153887154601" />
     <property role="TrG5h" value="TestConnectorType" />
+    <property role="3GE5qa" value="types" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="PrWs8" id="48ZWgAGwh6E" role="PzmwI">
       <ref role="PrY4T" to="w9y2:4KDeVD8s9RL" resolve="IConnectorType" />
@@ -72,19 +81,32 @@
     <property role="EcuMT" value="8956532715637138334" />
     <property role="TrG5h" value="TestKindB" />
     <property role="34LRSv" value="testKindB" />
+    <property role="3GE5qa" value="kinds" />
     <ref role="1TJDcQ" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
   </node>
   <node concept="1TIwiD" id="3QX5db_HNz8">
     <property role="EcuMT" value="4448734902941595848" />
     <property role="TrG5h" value="TestKindA" />
     <property role="34LRSv" value="testKindA" />
+    <property role="3GE5qa" value="kinds" />
     <ref role="1TJDcQ" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
   </node>
   <node concept="1TIwiD" id="7LbZKOmT25i">
     <property role="EcuMT" value="8956532715640070482" />
     <property role="TrG5h" value="TestKindC" />
     <property role="34LRSv" value="testKindC" />
+    <property role="3GE5qa" value="kinds" />
     <ref role="1TJDcQ" to="w9y2:6LfBX8Yj9nw" resolve="ComponentKind" />
+  </node>
+  <node concept="1TIwiD" id="6EQjZsO9hjN">
+    <property role="EcuMT" value="7689421336932062451" />
+    <property role="3GE5qa" value="attributes" />
+    <property role="TrG5h" value="TestKindAPortAttribute" />
+    <property role="34LRSv" value="KindB_PortTestAttribute" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="6EQjZsO9hjO" role="PzmwI">
+      <ref role="PrY4T" to="138:3NBP8_OgMyV" resolve="IAttribute" />
+    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/models/structure.mps
@@ -15,6 +15,7 @@
     <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <property id="4628067390765907488" name="conceptShortDescription" index="R4oN_" />
         <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
       </concept>
       <concept id="1169127622168" name="jetbrains.mps.lang.structure.structure.InterfaceConceptReference" flags="ig" index="PrWs8">
@@ -101,8 +102,9 @@
   <node concept="1TIwiD" id="6EQjZsO9hjN">
     <property role="EcuMT" value="7689421336932062451" />
     <property role="3GE5qa" value="attributes" />
-    <property role="TrG5h" value="TestKindAPortAttribute" />
+    <property role="TrG5h" value="TestKindBPortAttribute" />
     <property role="34LRSv" value="KindB_PortTestAttribute" />
+    <property role="R4oN_" value="attribute only allowed on ports with TestKindB" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="PrWs8" id="6EQjZsO9hjO" role="PzmwI">
       <ref role="PrY4T" to="138:3NBP8_OgMyV" resolve="IAttribute" />

--- a/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/test.iest3.component.attribute.mpl
+++ b/code/languages/org.iets3.opensource/languages/test.iest3.component.attribute/test.iest3.component.attribute.mpl
@@ -79,6 +79,8 @@
   <dependencies>
     <dependency reexport="false">f0fd486f-8577-43e9-b671-3d118449c6e7(org.iets3.components.core)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">583939be-ded0-4735-a055-a74f8477fc34(org.iets3.core.attributes)</dependency>
+    <dependency reexport="false">cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:a0ab8c10-c118-4755-ba27-3853435cf524:de.itemis.mps.tooltips" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -4585,6 +4585,18 @@
           <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
         </node>
       </node>
+      <node concept="1SiIV0" id="HCbFcOV8q7" role="3bR37C">
+        <node concept="3bR9La" id="HCbFcOV8q8" role="1SiIV1">
+          <property role="3bR36h" value="false" />
+          <ref role="3bR37D" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="HCbFcOV8q9" role="3bR37C">
+        <node concept="3bR9La" id="HCbFcOV8qa" role="1SiIV1">
+          <property role="3bR36h" value="false" />
+          <ref role="3bR37D" node="78hTg1zaYCc" resolve="org.iets3.core.attributes" />
+        </node>
+      </node>
     </node>
     <node concept="2sgV4H" id="OJuIQp$deC" role="1l3spa">
       <ref role="1l3spb" node="5wLtKNeSRPl" resolve="org.iets3.opensource" />

--- a/code/languages/org.iets3.opensource/solutions/test.ts.components.core/models/tests@tests.mps
+++ b/code/languages/org.iets3.opensource/solutions/test.ts.components.core/models/tests@tests.mps
@@ -177,6 +177,7 @@
       <concept id="4448734902940615074" name="test.iest3.component.attribute.structure.TestPortCategoryAccepts" flags="ng" index="3o5llK" />
       <concept id="4448734902940638651" name="test.iest3.component.attribute.structure.TestPortType" flags="ng" index="3o5o_D" />
       <concept id="4448734902938442738" name="test.iest3.component.attribute.structure.TestAttribute" flags="ng" index="3oewWw" />
+      <concept id="7689421336932062451" name="test.iest3.component.attribute.structure.TestKindAPortAttribute" flags="ng" index="1u$PG4" />
       <concept id="8956532715640070482" name="test.iest3.component.attribute.structure.TestKindC" flags="ng" index="1EFXTv" />
       <concept id="8956532715637138334" name="test.iest3.component.attribute.structure.TestKindB" flags="ng" index="1EZ9Mj" />
       <concept id="4773799153887154601" name="test.iest3.component.attribute.structure.TestConnectorType" flags="ng" index="3IJI2w" />
@@ -625,6 +626,88 @@
       <property role="13Nl5X" value="true" />
       <property role="TrG5h" value="CompC" />
       <node concept="1EFXTv" id="7LbZKOmT50n" role="1i0K$_" />
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="6EQjZsOdGV$">
+    <property role="TrG5h" value="LogicalAttributesConstraint" />
+    <node concept="1qefOq" id="6EQjZsOdGZg" role="1SKRRt">
+      <node concept="1i1ALs" id="6EQjZsOdGZj" role="1qenE9">
+        <property role="TrG5h" value="someCHunk" />
+        <node concept="1i1XBj" id="6EQjZsOdGZo" role="1i1AA4">
+          <property role="TrG5h" value="compC" />
+          <node concept="3oth5z" id="3DhaOr$RgTS" role="18DfD7">
+            <node concept="33R2CR" id="3DhaOr$RgTT" role="33Rvbw">
+              <node concept="1u$PG4" id="3DhaOr$RRUs" role="33R2D0" />
+            </node>
+            <node concept="1QScDb" id="3DhaOr$RsxZ" role="3ojXQX">
+              <node concept="1WbEdM" id="3DhaOr$RsyC" role="1QScD9">
+                <ref role="1WbEdL" node="3DhaOr$QKsv" resolve="P2" />
+              </node>
+              <node concept="1QScDb" id="3DhaOr$RgU8" role="30czhm">
+                <node concept="1Wfe8y" id="3DhaOr$RgU_" role="1QScD9">
+                  <ref role="1Wfe8x" node="3DhaOr$Rd6S" resolve="compB" />
+                </node>
+                <node concept="3o4LXa" id="3DhaOr$RgTQ" role="30czhm" />
+              </node>
+            </node>
+          </node>
+          <node concept="3oth5z" id="3DhaOr$RCVo" role="18DfD7">
+            <node concept="33R2CR" id="3DhaOr$RCVp" role="33Rvbw" />
+            <node concept="1QScDb" id="3DhaOr$RCW1" role="3ojXQX">
+              <node concept="1Wfe8y" id="3DhaOr$RCWY" role="1QScD9">
+                <ref role="1Wfe8x" node="3DhaOr$Rd6S" resolve="compB" />
+              </node>
+              <node concept="3o4LXa" id="3DhaOr$RCVm" role="30czhm" />
+            </node>
+          </node>
+          <node concept="1EFXTv" id="3DhaOr$Rd9_" role="1i0K$_" />
+          <node concept="GnABt" id="3DhaOr$Rd6F" role="1i1XAe">
+            <node concept="1i6xzV" id="3DhaOr$Rd6S" role="GnABu">
+              <node concept="1i1fwW" id="3DhaOr$Rd70" role="MGl3R">
+                <ref role="1i1fwX" node="6EQjZsOdKQu" resolve="compB" />
+              </node>
+            </node>
+          </node>
+          <node concept="H_j2F" id="6EQjZsOdGZB" role="1i1XAe">
+            <node concept="H_vQO" id="6EQjZsOdGZC" role="H_jLS" />
+            <node concept="1i7wMI" id="6EQjZsOdGZM" role="IJo7D">
+              <node concept="3o5llK" id="6EQjZsOdGZL" role="1aMMyH" />
+              <node concept="3o5o_D" id="3DhaOr$Q_KA" role="1i6vMw" />
+              <node concept="pfQqD" id="3DhaOr$QEgU" role="pfQ1b">
+                <property role="pfQqC" value="p1" />
+              </node>
+            </node>
+          </node>
+          <node concept="1z9TsT" id="3DhaOr$RSmq" role="lGtFl">
+            <node concept="OjmMv" id="3DhaOr$RSmr" role="1w35rA">
+              <node concept="19SGf9" id="3DhaOr$RSms" role="OjmMu">
+                <node concept="19SUe$" id="3DhaOr$RSmt" role="19SJt6">
+                  <property role="19SUeA" value="the KindB_PortTestAtttribute" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1i1AuW" id="6EQjZsOdKR4" role="1i1AA4" />
+        <node concept="1i1XBj" id="6EQjZsOdKQu" role="1i1AA4">
+          <property role="TrG5h" value="compB" />
+          <node concept="1EZ9Mj" id="3DhaOr$Rd9G" role="1i0K$_" />
+          <node concept="H_j2F" id="3DhaOr$QKo3" role="1i1XAe">
+            <node concept="H_vQO" id="3DhaOr$QKo4" role="H_jLS" />
+            <node concept="1i7wMI" id="3DhaOr$QKsv" role="IJo7D">
+              <node concept="3o5llK" id="3DhaOr$QKsu" role="1aMMyH" />
+              <node concept="3o5o_D" id="3DhaOr$QKsC" role="1i6vMw" />
+              <node concept="1u$PG4" id="3DhaOr$RgTh" role="18DfD7" />
+              <node concept="pfQqD" id="3DhaOr$RgTr" role="pfQ1b">
+                <property role="pfQqC" value="P2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="7CXmI" id="3DhaOr$RS74" role="lGtFl">
+          <node concept="7OXhh" id="3DhaOr$RS77" role="7EUXB" />
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/doc/design/02-logical-attr-constraint.md
+++ b/doc/design/02-logical-attr-constraint.md
@@ -1,0 +1,10 @@
+Design decisions: Concrete attribute should be able to define logical and structural constraints
+
+## Current Situation
+
+## Target Situation
+
+
+## Solutions
+
+#### Possible Solution

--- a/doc/design/02-logical-attr-constraint.md
+++ b/doc/design/02-logical-attr-constraint.md
@@ -1,14 +1,16 @@
 # Design decision
 
-An attribute should be able to define its logical and structural constraints. 
+An attribute should be able to define its logical and structural context. 
 
+**logical context**: Can be expressed by implementing some additional behaviour methods of an attribute. It describes additional constraints provided by a node in the AST. 
+
+**structural context**: Can be expressed with MPS model constrains. It describes where an attribute can be placed in the AST.
 
 # Current Situation
 
 If an attribute wants to define where it is allowed to be used, the language engineer needs to implement a specific interface:  **IConceptSpecificAttribute**. In addtion it is also possible to use one of the specializations of this interfaces which already restricts the usage of the interface to a specific concept (like **Port**). With this approach it is possible to define the *structural constraint* for an attribute. The attribute can define in which structural part of the AST (the instance of a specific concept) it can appear. 
 
 Additional non-structural constraints (the so called *logical constraints*)  can currently not be configured easily with the use of the framework.
-
 
 ## Target Situation
 
@@ -17,22 +19,13 @@ In this case the *logical context* can be retrieved from a node of the AST.
 
 ## Solutions
 
-#### Naiv Solution
-**Constraint Componsition with multiple inheritance**
-To be able to apply several constraints (structural and logical constraints) to a concept in MPS it is possible to implement several interfaces which themselves have a constraint model with specific logic. With this apprach it is possible to compose your constraints with multiple inheritance of interfaces.
-
-|Disadvantages|Advantages|
-|-------------------------------|-----------------------------|
-| Multiple Inheritance can lead to underderministic behaviour (see: `The Diamond Problem`). And the attribute which is implementing several interfaces can easily itself override accidentially the constraints of the interfaces.           |This approach can be used without any adaptions of the iets3 framework            |
-
 #### Improved Solution
-**Structural and Logical Constraints realized by the Attribute itself**
-Every **IAttribute** should be able to define its logical and structural constrainst as part of its behaviour. **IAttribute** would get some overridable methods to define the *structural context* (ex. `list<concept> canBeUsedInContext()`) and the *logical context* (`boolean isUsableInLogicalContext(node<> node)`) where it can be applied. 
-The structural context can define under wich **IAttributed** element this attribute can be used. 
-The logical context could be derived from a node of the AST, which is defined as the structural context and additional conditions can be added by the language engineer as part of the behaviour of an attribute.
+**Logical Constraints realized by the Attribute itself**
+Every **IAttribute** should be able to define its logical constrainst as part of its behaviour. **IAttribute** would get some overridable methods to define the logical context with two additional methods. The method `list<concept> canBeUsedInContext()` 
+would provide a list of concepts which are potentially logically valid. The method `boolean isUsableInLogicalContext(node<T> node)` would be then called with a **potentially logically valid** actual node, where `T` is a concept of the list that was returned by `canBeUsedInContext()`.
+The logical context could be provided from a node of the AST and additional conditions can be added by the language engineer as part of the behaviour of an attribute inside the implementation of `boolean isUsableInLogicalContext(node<T> node)`.
 
 |Disadvantages|Advantages|
 |-------------------------------|-----------------------------|
 |           |An attribute can easily itself defines all kind of conditions under wich it can be used     |
-|           |Multiple inheritance is obsolete     |
 

--- a/doc/design/02-logical-attr-constraint.md
+++ b/doc/design/02-logical-attr-constraint.md
@@ -1,10 +1,38 @@
-Design decisions: Concrete attribute should be able to define logical and structural constraints
+# Design decision
 
-## Current Situation
+An attribute should be able to define its logical and structural constraints. 
+
+
+# Current Situation
+
+If an attribute wants to define where it is allowed to be used, the language engineer needs to implement a specific interface:  **IConceptSpecificAttribute**. In addtion it is also possible to use one of the specializations of this interfaces which already restricts the usage of the interface to a specific concept (like **Port**). With this approach it is possible to define the *structural constraint* for an attribute. The attribute can define in which structural part of the AST (the instance of a specific concept) it can appear. 
+
+Additional non-structural constraints (the so called *logical constraints*)  can currently not be configured easily with the use of the framework.
+
 
 ## Target Situation
 
+In addition to the current situation an attribute should be able to define additional *logical constraints*, that explain under which condition it can be used in some *logical context.*
+In this case the *logical context* can be retrieved from a node of the AST.
 
 ## Solutions
 
-#### Possible Solution
+#### Naiv Solution
+**Constraint Componsition with multiple inheritance**
+To be able to apply several constraints (structural and logical constraints) to a concept in MPS it is possible to implement several interfaces which themselves have a constraint model with specific logic. With this apprach it is possible to compose your constraints with multiple inheritance of interfaces.
+
+|Disadvantages|Advantages|
+|-------------------------------|-----------------------------|
+| Multiple Inheritance can lead to underderministic behaviour (see: `The Diamond Problem`). And the attribute which is implementing several interfaces can easily itself override accidentially the constraints of the interfaces.           |This approach can be used without any adaptions of the iets3 framework            |
+
+#### Improved Solution
+**Structural and Logical Constraints realized by the Attribute itself**
+Every **IAttribute** should be able to define its logical and structural constrainst as part of its behaviour. **IAttribute** would get some overridable methods to define the *structural context* (ex. `list<concept> canBeUsedInContext()`) and the *logical context* (`boolean isUsableInLogicalContext(node<> node)`) where it can be applied. 
+The structural context can define under wich **IAttributed** element this attribute can be used. 
+The logical context could be derived from a node of the AST, which is defined as the structural context and additional conditions can be added by the language engineer as part of the behaviour of an attribute.
+
+|Disadvantages|Advantages|
+|-------------------------------|-----------------------------|
+|           |An attribute can easily itself defines all kind of conditions under wich it can be used     |
+|           |Multiple inheritance is obsolete     |
+


### PR DESCRIPTION
See design decision for this feature: https://github.com/IETS3/iets3.opensource/blob/feature/logicalAttributeConstraints/doc/design/02-logical-attr-constraint.md


**TODO**
- [x] add design decision document 
- [x] add method `static virtual abstract sequence<concept> canBeUsedInContext ` to <a href ="http://127.0.0.1:63320/node?ref=r%3A4d48d56b-d670-4e5b-a763-2232bb0c4f2d%28org.iets3.core.attributes.behavior%29%2F5298733714214838623&project=org.iets3.opensource"> IAttribute</a>
- [x] add additional method `static virtual abstract boolean isUsableInLogicalContext(node<> node)` to <a href ="http://127.0.0.1:63320/node?ref=r%3A4d48d56b-d670-4e5b-a763-2232bb0c4f2d%28org.iets3.core.attributes.behavior%29%2F5298733714214838623&project=org.iets3.opensource"> IAttribute</a>
- [x] add default implementation to the attributes in the framework
- [x]  every <a href="http://127.0.0.1:63320/node?ref=r%3A2c1007f3-e814-47ba-b729-c3ea0297f627%28org.iets3.core.attributes.structure%29%2F4388710048722005709&project=org.iets3.opensource">IAttributed</a> element should implement a `canBeParent` constraint and filter all elements under its <a href="http://127.0.0.1:63320/node?ref=r%3A2c1007f3-e814-47ba-b729-c3ea0297f627(org.iets3.core.attributes.structure)%2F4388710048722005710&project=org.iets3.opensource">attributes role</a> that can be used structurally and logically under this element
- [ ] deprecate the <a href="">IConceptSpecificAttribute <a> interface and all other interfaces that implementing it
