### PR TITLE
build gradle: use latest version from mps gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         maven { url 'https://projects.itemis.de/nexus/content/repositories/mbeddr' }
     }
     dependencies {
-        classpath 'de.itemis.mps:mps-gradle-plugin:1.0.55.678ba7a'
+        classpath 'de.itemis.mps:mps-gradle-plugin:1.0.+'
     }
 }
 


### PR DESCRIPTION
I think the fixed version of mps gradle plugin ended up in master by mistake. Can you ckeck?