### PR TITLE
build: use mps 2017.3.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ def forceLocal = project.hasProperty("forceLocalDependencies")
 
 
 // Dependency versions
-ext.mpsVersion = '2017.3.2'
+ext.mpsVersion = '2017.3.5'
 
 
 // Project version


### PR DESCRIPTION
Some how we must have missed to update to the latest minor versions of mps for quite a while. Using latest stable release now.