### PR TITLE
build scripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,11 +17,7 @@ if (project.hasProperty("forceCI")) {
     ext.ciBuild = true
 } else {
     //on teamcity we are in a CI build
-    if (project.hasProperty("teamcity")) {
-        ext.ciBuild = true
-    } else {
-        ext.ciBuild = false
-    }
+    ext.ciBuild = project.hasProperty("teamcity")
 }
 
 
@@ -30,6 +26,20 @@ def forceLocal = project.hasProperty("forceLocalDependencies")
 
 // Dependency versions
 ext.mpsVersion = '2017.3.5'
+
+def mbeddrVersion = "1.0+"
+
+// if building a against a special branch from mbeddr is required add the name here
+// the name is enough no trailing "." is required, also the plain name from git can
+// be used here. No need to convert "/" the script will take care of that.
+def mbeddrBranch = ""
+
+
+if (mbeddrBranch != null && !mbeddrBranch.trim().isEmpty()) {
+    ext.mbeddrVersionSelector = "${mbeddrBranch.replace("/", "-")}.${mbeddrVersion}"
+} else {
+    ext.mbeddrVersionSelector = mbeddrVersion
+}
 
 
 // Project version
@@ -47,13 +57,12 @@ if (project.hasProperty('iets3OpenSourceVersion')) {
 
 if (!project.hasProperty("mbeddrVersion")) {
     if (forceLocal) {
-        println "Local SNAPSHOT version forced"
-        ext.mbeddrVersion = '1.0-SNAPSHOT'
+        logger.log(LogLevel.WARN, "Local SNAPSHOT version forced")
+        ext.mbeddrVersionSelector = '1.0-SNAPSHOT'
     }
-    else {
-        //default version
-        ext.mbeddrVersion = '1.0.+'
-    }
+} else {
+    logger.log(LogLevel.WARN, "mbeddr version externally overwritten to $ext.mbeddrVersion")
+    ext.mbeddrVersionSelector = ext.mbeddrVersion
 }
 
 
@@ -83,7 +92,7 @@ configurations {
 
 dependencies {
     mps "com.jetbrains:mps:$mpsVersion"
-    mpsArtifacts "com.mbeddr:platform:$mbeddrVersion"
+    mpsArtifacts "com.mbeddr:platform:$mbeddrVersionSelector"
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 import de.itemis.mps.gradle.GenerateLibrariesXml
 import de.itemis.mps.gradle.GitBasedVersioning
 
+import java.time.LocalDateTime
+
 
 //will pull the groovy classes/types from nexus to the classpath
 buildscript {
@@ -10,6 +12,10 @@ buildscript {
     dependencies {
         classpath 'de.itemis.mps:mps-gradle-plugin:1.0.55.678ba7a'
     }
+}
+
+plugins {
+    id "co.riiid.gradle" version "0.4.2"
 }
 
 // detect if we are in a CI build
@@ -79,6 +85,7 @@ ext.artifactsDir = new File(rootDir, 'artifacts')
 
 apply plugin: 'maven-publish'
 apply plugin: 'base'
+
 
 task wrapper(type: Wrapper) {
     gradleVersion '4.4.1'
@@ -252,3 +259,20 @@ task setup {
 
 defaultTasks 'ant-clean-and-build'
 
+LocalDateTime t = LocalDateTime.now()
+
+def releaseNotes = """Automated Nighly build from ${t as String}."""
+
+github {
+    owner = 'IETS3'
+    repo = 'iets3.opensource'
+    token = rootProject.hasProperty("github.token") ? rootProject.getProperty("github.token") : "empty"
+    tagName = 'nightly-release-' + version
+    targetCommitish = GitBasedVersioning.getGitCommitHash()
+    name = 'Nighly Build ' + version
+    body = releaseNotes
+    prerelease = true
+    assets = packageOpenSource.outputs.files
+}
+
+githubRelease.dependsOn packageOpenSource


### PR DESCRIPTION
Simplified some of the parts of the builds scripts. Added a variable where people can simply put the mbeddr branch name they would like to build against. The script will take care of escaping the name etc. 

Also replaced some `println` with `logger.log` calls. 

Added the github release plugin to be able to push releases to github automatically. 