### PR TITLE
core.base: do not detach the node the comment is applied to

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/editor.mps
@@ -275,6 +275,13 @@
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
+      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
+        <property id="709746936026609031" name="linkId" index="3V$3ak" />
+        <property id="709746936026609029" name="linkRole" index="3V$3am" />
+      </concept>
+      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
+        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
+      </concept>
     </language>
     <language id="62a3babb-5d40-4920-897f-d4144dc99c9d" name="com.mbeddr.mpsutil.userstyles">
       <concept id="8170319964140884845" name="com.mbeddr.mpsutil.userstyles.structure.UserConfigurable" flags="ng" index="1Ex9Rl">
@@ -713,6 +720,26 @@
                   </node>
                 </node>
                 <node concept="10Nm6u" id="3m8H$lmFM7m" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="3SKdUt" id="12ACZ2oNOSk" role="3cqZAp">
+              <node concept="3SKdUq" id="12ACZ2oNOSm" role="3SKWNk">
+                <property role="3SKdUp" value="detach is removed because of https://youtrack.jetbrains.com/issue/MPS-27985" />
+              </node>
+            </node>
+            <node concept="3SKdUt" id="12ACZ2oNP0B" role="3cqZAp">
+              <node concept="3SKdUq" id="12ACZ2oNP0D" role="3SKWNk">
+                <property role="3SKdUp" value="when fixed we can reenable it" />
+              </node>
+            </node>
+            <node concept="1X3_iC" id="12ACZ2oNOO9" role="lGtFl">
+              <property role="3V$3am" value="statement" />
+              <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+              <node concept="3clFbF" id="12ACZ2oNO5H" role="8Wnug">
+                <node concept="2OqwBi" id="12ACZ2oNOgG" role="3clFbG">
+                  <node concept="7Obwk" id="12ACZ2oNO5F" role="2Oq$k0" />
+                  <node concept="3YRAZt" id="12ACZ2oNOHk" role="2OqNvi" />
+                </node>
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/editor.mps
@@ -13,7 +13,6 @@
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
     <import index="4kwy" ref="r:657c9fde-2f36-4e61-ae17-20f02b8630ad(org.iets3.core.base.structure)" implicit="true" />
-    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
@@ -648,19 +647,6 @@
                 </node>
               </node>
             </node>
-            <node concept="3clFbF" id="3m8H$lmFM6Q" role="3cqZAp">
-              <node concept="2OqwBi" id="3m8H$lmFM6R" role="3clFbG">
-                <node concept="2OqwBi" id="3m8H$lmFM6S" role="2Oq$k0">
-                  <node concept="1Q80Hx" id="5c30WK3aGOc" role="2Oq$k0" />
-                  <node concept="liA8E" id="3m8H$lmFM6U" role="2OqNvi">
-                    <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent():jetbrains.mps.openapi.editor.EditorComponent" resolve="getEditorComponent" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="3m8H$lmFM6V" role="2OqNvi">
-                  <ref role="37wK5l" to="cj4x:~EditorComponent.rebuildEditorContent():void" resolve="rebuildEditorContent" />
-                </node>
-              </node>
-            </node>
             <node concept="3clFbH" id="5c30WK3aJ6I" role="3cqZAp" />
             <node concept="3clFbJ" id="3m8H$lmFM6W" role="3cqZAp">
               <node concept="3clFbS" id="3m8H$lmFM6X" role="3clFbx">
@@ -727,12 +713,6 @@
                   </node>
                 </node>
                 <node concept="10Nm6u" id="3m8H$lmFM7m" role="3uHU7w" />
-              </node>
-            </node>
-            <node concept="3clFbF" id="2$ljoeITCmX" role="3cqZAp">
-              <node concept="2OqwBi" id="2$ljoeITCxi" role="3clFbG">
-                <node concept="7Obwk" id="2$ljoeITCmV" role="2Oq$k0" />
-                <node concept="3YRAZt" id="2$ljoeITCMB" role="2OqNvi" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/solutions/test.org.iets3.core.comments/models/tests@tests.mps
+++ b/code/languages/org.iets3.opensource/solutions/test.org.iets3.core.comments/models/tests@tests.mps
@@ -57,7 +57,7 @@
         <child id="596856272727132646" name="content" index="H_jLS" />
       </concept>
       <concept id="596856272727148586" name="org.iets3.components.core.structure.EmptyComponentInterfaceContent" flags="ng" index="H_vQO" />
-      <concept id="3432899422388046302" name="org.iets3.components.core.structure.AbstractComponentInstance" flags="ng" index="MGl88">
+      <concept id="3432899422388046302" name="org.iets3.components.core.structure.AbstractComponentInstanceWithRef" flags="ng" index="MGl88">
         <child id="3432899422388046625" name="component" index="MGl3R" />
       </concept>
       <concept id="7804632404593513952" name="org.iets3.components.core.structure.ComponentKind" flags="ng" index="1i0KCM" />
@@ -112,16 +112,17 @@
     </node>
     <node concept="1i1ALs" id="5kwEgmAi6Gw" role="LiZbd">
       <property role="TrG5h" value="TestChunk" />
+      <node concept="1i1AuW" id="12ACZ2oN$$F" role="1i1AA4" />
       <node concept="1i1XBj" id="5kwEgmAi6Gz" role="1i1AA4">
         <property role="TrG5h" value="CP0" />
         <node concept="H_j2F" id="59rcyU3GDmR" role="1i1XAe">
           <node concept="H_vQO" id="59rcyU3GDmS" role="H_jLS" />
         </node>
         <node concept="1i0KCM" id="5kwEgmAi6G$" role="1i0K$_" />
-        <node concept="1z9TsT" id="5kwEgmAi6GS" role="lGtFl">
-          <node concept="OjmMv" id="5kwEgmAi6GT" role="1w35rA">
-            <node concept="19SGf9" id="5kwEgmAi6GU" role="OjmMu">
-              <node concept="19SUe$" id="5kwEgmAi6GV" role="19SJt6" />
+        <node concept="1z9TsT" id="12ACZ2oN$_u" role="lGtFl">
+          <node concept="OjmMv" id="12ACZ2oN$_v" role="1w35rA">
+            <node concept="19SGf9" id="12ACZ2oN$_w" role="OjmMu">
+              <node concept="19SUe$" id="12ACZ2oN$_x" role="19SJt6" />
             </node>
           </node>
         </node>
@@ -173,14 +174,15 @@
           <node concept="H_vQO" id="59rcyU3GDmY" role="H_jLS" />
         </node>
         <node concept="GnABt" id="5kwEgmAh7si" role="1i1XAe">
+          <node concept="GnyP7" id="12ACZ2oN$KZ" role="GnABu" />
           <node concept="1i6xzV" id="5kwEgmAh7sl" role="GnABu">
             <node concept="1i1fwW" id="5kwEgmAh7sm" role="MGl3R">
               <ref role="1i1fwX" node="5kwEgmAh7sp" resolve="CP1" />
             </node>
-            <node concept="1z9TsT" id="5kwEgmAh7tu" role="lGtFl">
-              <node concept="OjmMv" id="5kwEgmAh7tv" role="1w35rA">
-                <node concept="19SGf9" id="5kwEgmAh7tw" role="OjmMu">
-                  <node concept="19SUe$" id="5kwEgmAh7tx" role="19SJt6" />
+            <node concept="1z9TsT" id="12ACZ2oN$L7" role="lGtFl">
+              <node concept="OjmMv" id="12ACZ2oN$L8" role="1w35rA">
+                <node concept="19SGf9" id="12ACZ2oN$L9" role="OjmMu">
+                  <node concept="19SUe$" id="12ACZ2oN$La" role="19SJt6" />
                 </node>
               </node>
             </node>
@@ -241,11 +243,12 @@
         <node concept="H_j2F" id="59rcyU3GDn3" role="1i1XAe">
           <node concept="H_vQO" id="59rcyU3GDn4" role="H_jLS" />
         </node>
+        <node concept="1i1Xx2" id="12ACZ2oN$Wl" role="1i1XAe" />
         <node concept="GnABt" id="5kwEgmAi6Me" role="1i1XAe">
-          <node concept="1z9TsT" id="5kwEgmAi6Mz" role="lGtFl">
-            <node concept="OjmMv" id="5kwEgmAi6M$" role="1w35rA">
-              <node concept="19SGf9" id="5kwEgmAi6M_" role="OjmMu">
-                <node concept="19SUe$" id="5kwEgmAi6MA" role="19SJt6" />
+          <node concept="1z9TsT" id="12ACZ2oN$Wx" role="lGtFl">
+            <node concept="OjmMv" id="12ACZ2oN$Wy" role="1w35rA">
+              <node concept="19SGf9" id="12ACZ2oN$Wz" role="OjmMu">
+                <node concept="19SUe$" id="12ACZ2oN$W$" role="19SJt6" />
               </node>
             </node>
           </node>


### PR DESCRIPTION
detaching the node in applyCommentsToIDocumentable would sometime cause:

```
java.lang.Throwable
	at jetbrains.mps.nodeEditor.updater.UpdateInfoNode$UpdateInfoNodeAttribute.lambda$validateBeforeReplace$1(UpdateInfoNode.java:180)
	at java.util.Optional.ifPresent(Optional.java:159)
	at jetbrains.mps.nodeEditor.updater.UpdateInfoNode$UpdateInfoNodeAttribute.validateBeforeReplace(UpdateInfoNode.java:177)
	at jetbrains.mps.nodeEditor.updater.UpdateInfoNode.replace(UpdateInfoNode.java:77)
	at jetbrains.mps.nodeEditor.updater.UpdateInfoNode$UpdateInfoNodeAttribute.replace(UpdateInfoNode.java:143)
	at jetbrains.mps.nodeEditor.updater.UpdateSessionImpl.reuseChildInfo(UpdateSessionImpl.java:349)
	at jetbrains.mps.nodeEditor.EditorManager.createEditorCell(EditorManager.java:248)
	at jetbrains.mps.nodeEditor.updater.UpdateSessionImpl.doCreateRoleAttributeCell(UpdateSessionImpl.java:269)
	at jetbrains.mps.nodeEditor.updater.UpdateSessionImpl.lambda$updateAttributeCell$0(UpdateSessionImpl.java:249)
	at jetbrains.mps.nodeEditor.updater.UpdateSessionImpl.runWithExplicitEditorHints(UpdateSessionImpl.java:338)
	at jetbrains.mps.nodeEditor.updater.UpdateSessionImpl.updateAttributeCell(UpdateSessionImpl.java:249)
	at jetbrains.mps.nodeEditor.EditorManager.createNodeRoleAttributeCell(EditorManager.java:151)
	at jetbrains.mps.nodeEditor.EditorManager.createEditorCell(EditorManager.java:214)
	at jetbrains.mps.nodeEditor.updater.UpdateSessionImpl$1.compute(UpdateSessionImpl.java:213)
	at jetbrains.mps.nodeEditor.updater.UpdateSessionImpl$1.compute(UpdateSessionImpl.java:210)
	at jetbrains.mps.nodeEditor.updater.UpdateSessionImpl.runWithExplicitEditorHints(UpdateSessionImpl.java:338)
	at jetbrains.mps.nodeEditor.updater.UpdateSessionImpl.updateChildNodeCell(UpdateSessionImpl.java:210)
	at jetbrains.mps.nodeEditor.updater.UpdateSessionImpl.updateChildNodeCell(UpdateSessionImpl.java:199)
```