### PR TITLE
make makeRefType intention configurable by implmenting isApplicable

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/intentions.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/intentions.mps
@@ -1661,6 +1661,20 @@
     <node concept="1SWQZ3" id="6JZACDWSJIe" role="lGtFl">
       <property role="1SWRpm" value="EXPRESSIONS" />
     </node>
+    <node concept="2SaL7w" id="8MK7XGGW7h" role="2ZfVeh">
+      <node concept="3clFbS" id="8MK7XGGW7i" role="2VODD2">
+        <node concept="3clFbF" id="8MK7XGHzZ5" role="3cqZAp">
+          <node concept="2YIFZM" id="8MK7XGH$Tz" role="3clFbG">
+            <ref role="37wK5l" node="4FREEt6vhDG" resolve="canReplaceNodeWithConcept" />
+            <ref role="1Pybhc" node="4FREEt6wJnq" resolve="ConstraintHelper" />
+            <node concept="2Sf5sV" id="8MK7XGH_GF" role="37wK5m" />
+            <node concept="35c_gC" id="8MK7XGHA99" role="37wK5m">
+              <ref role="35c_gD" to="hm2y:6JZACDWIfNW" resolve="ReferenceType" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="2S6QgY" id="1vJWYavjAiu">
     <property role="3GE5qa" value="contract" />


### PR DESCRIPTION
The feature makes the makeTypeRef intention of IReferencableType configurable by checking whether the Type ReferenceType is applicable for a node.