### PR TITLE
show comprehensible error message if not building with java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,9 @@ import java.time.LocalDateTime
 
 //will pull the groovy classes/types from nexus to the classpath
 buildscript {
+    if(JavaVersion.current() != JavaVersion.VERSION_1_8){
+        throw new GradleException("This build script requires java " + JavaVersion.VERSION_1_8 + ", but you are currently using " + JavaVersion.current())
+    }
     repositories {
         maven { url 'https://projects.itemis.de/nexus/content/repositories/mbeddr' }
     }


### PR DESCRIPTION
@bkolb Maybe you'd like to merge [mbeddr.core#1976](https://github.com/mbeddr/mbeddr.core/pull/1976) as well:

When trying to build iets3 with java 10, I get an error message that doesn't give me much clue on what's actually wrong.

```
> Task :ant-clean-and-build
Trying to override old definition of datatype module
[ant:echo] generating
import de.itemis.mps.gradle.GenerateLibrariesXml

[ant:generate] java.lang.NoClassDefFoundError: sun/misc/Launcher
[ant:generate]  at jetbrains.mps.reloading.CommonPaths.findBootstrapJarByName(CommonPaths.java:180)
[ant:generate]  at jetbrains.mps.reloading.CommonPaths.addJarForName(CommonPaths.java:171)
[ant:generate]  at jetbrains.mps.reloading.CommonPaths.getJDKClassPath(CommonPaths.java:165)
[ant:generate]  at jetbrains.mps.reloading.CommonPaths.getJDKPath(CommonPaths.java:86)
[ant:generate]  at jetbrains.mps.reloading.CommonPaths.getMPSPaths(CommonPaths.java:54)
[ant:generate]  at jetbrains.mps.project.Solution.updateBootstrapSolutionLibraries(Solution.java:201)
[ant:generate]  at jetbrains.mps.project.Solution.updateModelsSet(Solution.java:187)
[ant:generate]  at jetbrains.mps.project.AbstractModule.initFacetsAndModels(AbstractModule.java:549)
[ant:generate]  at jetbrains.mps.project.AbstractModule.attach(AbstractModule.java:726)
[ant:generate]  at jetbrains.mps.smodel.MPSModuleRepository.registerModule(MPSModuleRepository.java:142)
[ant:generate]  at jetbrains.mps.smodel.ModuleRepositoryFacade.registerModule(ModuleRepositoryFacade.java:361)
[ant:generate]  at jetbrains.mps.smodel.ModuleRepositoryFacade.instantiateModule(ModuleRepositoryFacade.java:311)
[ant:generate]  at jetbrains.mps.library.SLibrary.collectAndRegisterModules(SLibrary.java:131)
[ant:generate]  at jetbrains.mps.library.SLibrary.attach(SLibrary.java:97)
[ant:generate]  at jetbrains.mps.library.LibraryInitializer.updateState(LibraryInitializer.java:159)
[ant:generate]  at jetbrains.mps.library.LibraryInitializer.access$300(LibraryInitializer.java:46)
[ant:generate]  at jetbrains.mps.library.LibraryInitializer$1.run(LibraryInitializer.java:136)
[ant:generate]  at jetbrains.mps.smodel.WriteActionDispatcher.run(WriteActionDispatcher.java:41)
[ant:generate]  at jetbrains.mps.smodel.DefaultModelAccess.runWriteAction(DefaultModelAccess.java:63)
[ant:generate]  at jetbrains.mps.smodel.ModelAccessBase.runWriteAction(ModelAccessBase.java:63)
[ant:generate]  at jetbrains.mps.library.LibraryInitializer.update(LibraryInitializer.java:122)
[ant:generate]  at jetbrains.mps.library.LibraryInitializer.load(LibraryInitializer.java:94)
[ant:generate]  at jetbrains.mps.tool.environment.EnvironmentBase.initLibraries(EnvironmentBase.java:112)
[ant:generate]  at jetbrains.mps.tool.environment.EnvironmentBase.init(EnvironmentBase.java:70)
[ant:generate]  at jetbrains.mps.tool.environment.MpsEnvironment.init(MpsEnvironment.java:66)
[ant:generate]  at jetbrains.mps.tool.builder.make.GeneratorWorker.createEnvironment(GeneratorWorker.java:75)
[ant:generate]  at jetbrains.mps.tool.builder.MpsWorker.workFromMain(MpsWorker.java:134)
[ant:generate]  at jetbrains.mps.tool.builder.make.GeneratorWorker.main(GeneratorWorker.java:81)
[ant:generate]  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[ant:generate]  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[ant:generate]  at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[ant:generate]  at java.base/java.lang.reflect.Method.invoke(Method.java:564)
[ant:generate]  at jetbrains.mps.tool.builder.AntBootstrap.main(AntBootstrap.java:29)
[ant:generate] Caused by: java.lang.ClassNotFoundException: sun.misc.Launcher
[ant:generate]  at jetbrains.mps.core.tool.environment.classloading.UrlClassLoader.findClass(UrlClassLoader.java:52)
[ant:generate]  at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:566)
[ant:generate]  at jetbrains.mps.core.tool.environment.classloading.UrlClassLoader.loadClass(UrlClassLoader.java:62)
[ant:generate]  at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:499)
[ant:generate]  ... 33 more
[ant:generate]

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':ant-clean-and-build'.
> The following error occurred while executing this line:
  /Users/bkruck/iets3.opensource/code/languages/build.xml:81: The following error occurred while executing this line:
  /Users/bkruck/iets3.opensource/build/iets3.opensource.allScripts/build-allScripts.xml:94: Process exited with code 1.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 51s
4 actionable tasks: 3 executed, 1 up-to-date
```