### PR TITLE
build.gradle: enabled incremental build for languages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ ext.dependencyRepositories = [
 ]
 
 ext.artifactsDir = new File(rootDir, 'artifacts')
-
+ext.incrementBuild = !project.hasProperty("disableIncrementBuild")
 apply plugin: 'maven-publish'
 apply plugin: 'base'
 
@@ -148,6 +148,7 @@ ant.properties['mps.home'] = resolveMps.destinationDir
 ant.properties['iets3.github.opensource.home'] = rootDir
 ant.properties['build.dir'] = rootDir
 ant.properties['artifacts.root'] = resolveMpsArtifacts.destinationDir
+ant.properties['mps.generator.skipUnmodifiedModels'] = incrementBuild
 ant.properties['version'] = version
 ant.importBuild('code/languages/build.xml') { target -> 'ant-' + target }
 

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ ext.dependencyRepositories = [
 ]
 
 ext.artifactsDir = new File(rootDir, 'artifacts')
-ext.incrementBuild = !project.hasProperty("disableIncrementBuild")
+ext.incrementalBuild = !project.hasProperty("disableIncrementalBuild")
 apply plugin: 'maven-publish'
 apply plugin: 'base'
 
@@ -148,7 +148,7 @@ ant.properties['mps.home'] = resolveMps.destinationDir
 ant.properties['iets3.github.opensource.home'] = rootDir
 ant.properties['build.dir'] = rootDir
 ant.properties['artifacts.root'] = resolveMpsArtifacts.destinationDir
-ant.properties['mps.generator.skipUnmodifiedModels'] = incrementBuild
+ant.properties['mps.generator.skipUnmodifiedModels'] = incrementalBuild
 ant.properties['version'] = version
 ant.importBuild('code/languages/build.xml') { target -> 'ant-' + target }
 


### PR DESCRIPTION
The mentioned change enables the feature: `mps.generator.skipUnmodifiedModels` by default. 
This change reduces the local build time for the command line build extreamly because only the modified models are build locally and not all models/modules by default.
