### PR TITLE
IRecordMembers can now be L-values

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.path/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.path/models/behavior.mps
@@ -2,7 +2,7 @@
 <model ref="r:e876148b-672e-4264-9fee-d6d24a2d1223(org.iets3.core.expr.path.behavior)">
   <persistence version="9" />
   <languages>
-    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="-1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -10,6 +10,7 @@
     <import index="lmd" ref="r:a6074908-e483-4c8e-80b5-5dbf8b24df4c(org.iets3.core.expr.path.structure)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="gdgh" ref="r:e4d9478b-ae0e-416e-be60-73d136571015(org.iets3.core.base.behavior)" />
+    <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
@@ -29,6 +30,9 @@
       <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -55,11 +59,19 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
@@ -297,6 +309,114 @@
       </node>
       <node concept="3Tqbb2" id="4fgA7QrEF$_" role="3clF45" />
       <node concept="3Tm1VV" id="4fgA7QrEF$A" role="1B3o_S" />
+    </node>
+    <node concept="13i0hz" id="2bmnJndGu1O" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="isLValue" />
+      <ref role="13i0hy" to="pbu6:aPhVmWYjn5" resolve="isLValue" />
+      <node concept="3Tm1VV" id="2bmnJndGu1P" role="1B3o_S" />
+      <node concept="3clFbS" id="2bmnJndGu1U" role="3clF47">
+        <node concept="3clFbJ" id="5IrXfgcUhav" role="3cqZAp">
+          <node concept="3clFbS" id="5IrXfgcUhax" role="3clFbx">
+            <node concept="3cpWs6" id="5IrXfgcUivp" role="3cqZAp">
+              <node concept="2OqwBi" id="5IrXfgcUjKG" role="3cqZAk">
+                <node concept="1PxgMI" id="5IrXfgcUjsJ" role="2Oq$k0">
+                  <node concept="chp4Y" id="5IrXfgcUjyD" role="3oSUPX">
+                    <ref role="cht4Q" to="hm2y:aPhVmWYjmk" resolve="ICanBeLValue" />
+                  </node>
+                  <node concept="2OqwBi" id="5IrXfgcUiHL" role="1m5AlR">
+                    <node concept="13iPFW" id="5IrXfgcUivx" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="2bmnJndGytI" role="2OqNvi">
+                      <ref role="3Tt5mk" to="lmd:6LLGpXJ4YDM" resolve="member" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="5IrXfgcUjXu" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:aPhVmWYjn5" resolve="isLValue" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="5IrXfgcUi13" role="3clFbw">
+            <node concept="2OqwBi" id="5IrXfgcUhp6" role="2Oq$k0">
+              <node concept="13iPFW" id="5IrXfgcUhaU" role="2Oq$k0" />
+              <node concept="3TrEf2" id="2bmnJndGx_9" role="2OqNvi">
+                <ref role="3Tt5mk" to="lmd:6LLGpXJ4YDM" resolve="member" />
+              </node>
+            </node>
+            <node concept="1mIQ4w" id="5IrXfgcUilp" role="2OqNvi">
+              <node concept="chp4Y" id="5IrXfgcUiqo" role="cj9EA">
+                <ref role="cht4Q" to="hm2y:aPhVmWYjmk" resolve="ICanBeLValue" />
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="5IrXfgcUk6A" role="9aQIa">
+            <node concept="3clFbS" id="5IrXfgcUk6B" role="9aQI4">
+              <node concept="3cpWs6" id="5IrXfgcUkfH" role="3cqZAp">
+                <node concept="3clFbT" id="5IrXfgcUkg4" role="3cqZAk">
+                  <property role="3clFbU" value="false" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="2bmnJndGu1V" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="2bmnJndGuo$" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="isUsedAsLValue" />
+      <ref role="13i0hy" to="pbu6:YMJl2BJIOO" resolve="isUsedAsLValue" />
+      <node concept="3Tm1VV" id="2bmnJndGuo_" role="1B3o_S" />
+      <node concept="3clFbS" id="2bmnJndGuoC" role="3clF47">
+        <node concept="3clFbJ" id="5IrXfgd3gXq" role="3cqZAp">
+          <node concept="3clFbS" id="5IrXfgd3gXr" role="3clFbx">
+            <node concept="3cpWs6" id="5IrXfgd3gXs" role="3cqZAp">
+              <node concept="2OqwBi" id="5IrXfgd3gXt" role="3cqZAk">
+                <node concept="1PxgMI" id="5IrXfgd3gXu" role="2Oq$k0">
+                  <node concept="chp4Y" id="5IrXfgd3gXv" role="3oSUPX">
+                    <ref role="cht4Q" to="hm2y:aPhVmWYjmk" resolve="ICanBeLValue" />
+                  </node>
+                  <node concept="2OqwBi" id="5IrXfgd3gXw" role="1m5AlR">
+                    <node concept="13iPFW" id="5IrXfgd3gXx" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="2bmnJndGwKq" role="2OqNvi">
+                      <ref role="3Tt5mk" to="lmd:6LLGpXJ4YDM" resolve="member" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="5IrXfgd3hlh" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:YMJl2BJIOO" resolve="isUsedAsLValue" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="5IrXfgd3gX$" role="3clFbw">
+            <node concept="2OqwBi" id="5IrXfgd3gX_" role="2Oq$k0">
+              <node concept="13iPFW" id="5IrXfgd3gXA" role="2Oq$k0" />
+              <node concept="3TrEf2" id="2bmnJndGwqL" role="2OqNvi">
+                <ref role="3Tt5mk" to="lmd:6LLGpXJ4YDM" resolve="member" />
+              </node>
+            </node>
+            <node concept="1mIQ4w" id="5IrXfgd3gXC" role="2OqNvi">
+              <node concept="chp4Y" id="5IrXfgd3gXD" role="cj9EA">
+                <ref role="cht4Q" to="hm2y:aPhVmWYjmk" resolve="ICanBeLValue" />
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="5IrXfgd3gXE" role="9aQIa">
+            <node concept="3clFbS" id="5IrXfgd3gXF" role="9aQI4">
+              <node concept="3cpWs6" id="5IrXfgd3gXG" role="3cqZAp">
+                <node concept="3clFbT" id="5IrXfgd3gXH" role="3cqZAk">
+                  <property role="3clFbU" value="false" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="2bmnJndGuoD" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="4o9aP47qdi_">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.path/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.path/models/structure.mps
@@ -71,6 +71,9 @@
     <node concept="PrWs8" id="4o9aP47qdjx" role="PzmwI">
       <ref role="PrY4T" node="4o9aP47qdic" resolve="IComparablePathPart" />
     </node>
+    <node concept="PrWs8" id="2bmnJndGtf5" role="PzmwI">
+      <ref role="PrY4T" to="hm2y:aPhVmWYjmk" resolve="ICanBeLValue" />
+    </node>
   </node>
   <node concept="PlHQZ" id="4o9aP47qdic">
     <property role="TrG5h" value="IComparablePathPart" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -2,12 +2,12 @@
 <model ref="r:cfd59c48-ecc8-4b0c-8ae8-6d876c46ebbb(org.iets3.core.expr.toplevel.behavior)">
   <persistence version="9" />
   <languages>
-    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="-1" />
-    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="-1" />
-    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="-1" />
-    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="-1" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="-1" />
-    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="-1" />
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="8" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="1" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="13" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -175,6 +175,7 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -5460,11 +5461,11 @@
         </node>
         <node concept="3clFbF" id="5eKs1GS7ScI" role="3cqZAp">
           <node concept="2OqwBi" id="5eKs1GS7SMZ" role="3clFbG">
-            <node concept="TSZUe" id="1D8fMMrKjdJ" role="2OqNvi">
-              <node concept="13iPFW" id="1D8fMMrKjdI" role="25WWJ7" />
-            </node>
             <node concept="37vLTw" id="5eKs1GS7ScG" role="2Oq$k0">
               <ref role="3cqZAo" node="4ISByPoXvbt" resolve="result" />
+            </node>
+            <node concept="TSZUe" id="1D8fMMrKjdJ" role="2OqNvi">
+              <node concept="13iPFW" id="1D8fMMrKjdI" role="25WWJ7" />
             </node>
           </node>
         </node>
@@ -6739,6 +6740,20 @@
         </node>
       </node>
     </node>
+    <node concept="13i0hz" id="2bmnJndHt8k" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="canMemberBeLValue" />
+      <node concept="3Tm1VV" id="2bmnJndHt8l" role="1B3o_S" />
+      <node concept="10P_77" id="2bmnJndHtXs" role="3clF45" />
+      <node concept="3clFbS" id="2bmnJndHt8n" role="3clF47">
+        <node concept="3cpWs6" id="2bmnJndHypw" role="3cqZAp">
+          <node concept="3clFbT" id="2bmnJndHyq0" role="3cqZAk">
+            <property role="3clFbU" value="false" />
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="13h7C7" id="5ElkanPSLzW">
     <property role="3GE5qa" value="enum" />
@@ -7695,6 +7710,92 @@
         </node>
       </node>
       <node concept="10P_77" id="5YygIlbmK__" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="2bmnJndG_4z" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="isLValue" />
+      <ref role="13i0hy" to="pbu6:aPhVmWYjn5" resolve="isLValue" />
+      <node concept="3Tm1VV" id="2bmnJndG_4$" role="1B3o_S" />
+      <node concept="3clFbS" id="2bmnJndG_4D" role="3clF47">
+        <node concept="3clFbJ" id="2bmnJndHys1" role="3cqZAp">
+          <node concept="3clFbS" id="2bmnJndHys3" role="3clFbx">
+            <node concept="3cpWs6" id="2bmnJndH$h6" role="3cqZAp">
+              <node concept="2OqwBi" id="2bmnJndHAIM" role="3cqZAk">
+                <node concept="1PxgMI" id="2bmnJndHA6c" role="2Oq$k0">
+                  <node concept="chp4Y" id="2bmnJndHAer" role="3oSUPX">
+                    <ref role="cht4Q" to="yv47:xu7xcKinTJ" resolve="IRecordDeclaration" />
+                  </node>
+                  <node concept="2OqwBi" id="2bmnJndH$GZ" role="1m5AlR">
+                    <node concept="13iPFW" id="2bmnJndH$oP" role="2Oq$k0" />
+                    <node concept="1mfA1w" id="2bmnJndH_vI" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="2bmnJndHBlY" role="2OqNvi">
+                  <ref role="37wK5l" node="2bmnJndHt8k" resolve="canMemberBeLValue" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="2bmnJndHzTy" role="3clFbw">
+            <node concept="2OqwBi" id="2bmnJndHyHp" role="2Oq$k0">
+              <node concept="13iPFW" id="2bmnJndHysM" role="2Oq$k0" />
+              <node concept="1mfA1w" id="2bmnJndHzpq" role="2OqNvi" />
+            </node>
+            <node concept="1mIQ4w" id="2bmnJndH$5v" role="2OqNvi">
+              <node concept="chp4Y" id="2bmnJndH$a6" role="cj9EA">
+                <ref role="cht4Q" to="yv47:xu7xcKinTJ" resolve="IRecordDeclaration" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2bmnJndG_sY" role="3cqZAp">
+          <node concept="3clFbT" id="2bmnJndG_sX" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="10P_77" id="2bmnJndG_4E" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="2bmnJndG_4J" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="isUsedAsLValue" />
+      <ref role="13i0hy" to="pbu6:YMJl2BJIOO" resolve="isUsedAsLValue" />
+      <node concept="3Tm1VV" id="2bmnJndG_4K" role="1B3o_S" />
+      <node concept="3clFbS" id="2bmnJndG_4N" role="3clF47">
+        <node concept="3clFbF" id="2bmnJndIDj$" role="3cqZAp">
+          <node concept="1Wc70l" id="1VmWkC0_NAO" role="3clFbG">
+            <node concept="3clFbC" id="1VmWkC0_QIU" role="3uHU7w">
+              <node concept="13iPFW" id="1VmWkC0_QYx" role="3uHU7w" />
+              <node concept="2OqwBi" id="1VmWkC0_PzP" role="3uHU7B">
+                <node concept="1PxgMI" id="1VmWkC0_P9k" role="2Oq$k0">
+                  <node concept="chp4Y" id="1VmWkC0_PHc" role="3oSUPX">
+                    <ref role="cht4Q" to="hm2y:aPhVmWYxIJ" resolve="AssignmentExpr" />
+                  </node>
+                  <node concept="2OqwBi" id="1VmWkC0_NUL" role="1m5AlR">
+                    <node concept="13iPFW" id="1VmWkC0_NFW" role="2Oq$k0" />
+                    <node concept="1mfA1w" id="1VmWkC0_Ocp" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="3TrEf2" id="1VmWkC0_Q9i" role="2OqNvi">
+                  <ref role="3Tt5mk" to="hm2y:4rZeNQ6MpKm" resolve="left" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1VmWkC0_N0c" role="3uHU7B">
+              <node concept="2OqwBi" id="1VmWkC0_Muq" role="2Oq$k0">
+                <node concept="13iPFW" id="1VmWkC0_Miz" role="2Oq$k0" />
+                <node concept="1mfA1w" id="1VmWkC0_MFo" role="2OqNvi" />
+              </node>
+              <node concept="1mIQ4w" id="1VmWkC0_Nb7" role="2OqNvi">
+                <node concept="chp4Y" id="1VmWkC0_NgI" role="cj9EA">
+                  <ref role="cht4Q" to="hm2y:aPhVmWYxIJ" resolve="AssignmentExpr" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="2bmnJndG_4O" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="4ptnK4jbra4">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/structure.mps
@@ -2,7 +2,7 @@
 <model ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)">
   <persistence version="9" />
   <languages>
-    <use id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources" version="2" />
+    <use id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources" version="-1" />
     <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="-1" />
     <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
@@ -699,6 +699,9 @@
     </node>
     <node concept="PrWs8" id="4AahbtVqNUR" role="PrDN$">
       <ref role="PrY4T" to="hm2y:4AahbtUNHrQ" resolve="IProgramLocationProvider" />
+    </node>
+    <node concept="PrWs8" id="2bmnJndGteE" role="PrDN$">
+      <ref role="PrY4T" to="hm2y:aPhVmWYjmk" resolve="ICanBeLValue" />
     </node>
   </node>
   <node concept="PlHQZ" id="xu7xcKinTJ">


### PR DESCRIPTION
This pull request actually depends on #161. It adds the canMemberBeLValue() function to the behaviour of the IRecordDeclaration. A IRecordMember can be a L-value if this functions returns true.

I'm happy to hear feedback regarding this pull request.