### PR TITLE
iets3.component.core: enabled rendering of ParameterValues in diagram

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
@@ -7565,6 +7565,9 @@
             </node>
           </node>
         </node>
+        <node concept="PMmxH" id="6cDi3KAInMq" role="3EZMnx">
+          <ref role="PMmxG" node="3xTZ$YBv7mN" resolve="ComponentInstanceBase_Diagram_Footer" />
+        </node>
         <node concept="2iRkQZ" id="siw10FuWOP" role="2iSdaV" />
         <node concept="VPM3Z" id="siw10FuWOQ" role="3F10Kt">
           <property role="VOm3f" value="false" />


### PR DESCRIPTION
The rendering of ParameterValues was accidentally removed in commit: 5fa5803
This change enables the rendering again.