### PR TITLE
Rename all ...Interpeter to ...Interpreter.

### DIFF
--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.adt.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.adt.interpreter/models/plugin.mps
@@ -234,7 +234,7 @@
     </language>
   </registry>
   <node concept="qq9qg" id="uGVYUiiVGW">
-    <property role="TrG5h" value="ExprADTInterpeter" />
+    <property role="TrG5h" value="ExprADTInterpreter" />
     <property role="UYu25" value="arithmetic" />
     <property role="3GE5qa" value="interpreter" />
     <node concept="d$4Dx" id="uGVYUiiVGX" role="d$6nW">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.interpreter/models/plugin.mps
@@ -308,7 +308,7 @@
     </language>
   </registry>
   <node concept="qq9qg" id="uGVYUiiVGW">
-    <property role="TrG5h" value="ExprBaseInterpeter" />
+    <property role="TrG5h" value="ExprBaseInterpreter" />
     <property role="UYu25" value="arithmetic" />
     <property role="3GE5qa" value="interpreter" />
     <node concept="qq9P1" id="24Fec41afHO" role="qq9xR">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.interpreter/models/plugin.mps
@@ -288,7 +288,7 @@
       </concept>
       <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
         <property id="709746936026609031" name="linkId" index="3V$3ak" />
-        <property id="709746936026609029" name="linkRole" index="3V$3am" />
+        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
       </concept>
       <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
         <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
@@ -331,7 +331,7 @@
     </language>
   </registry>
   <node concept="qq9qg" id="7kYh9WsSh7Y">
-    <property role="TrG5h" value="ExprCollectionsInterpeterPCollections" />
+    <property role="TrG5h" value="ExprCollectionsInterpreterPCollections" />
     <property role="UYu25" value="arithmetic" />
     <node concept="qq9P1" id="cHo4qYgDpQ" role="qq9xR">
       <property role="2TnfIJ" value="true" />
@@ -966,10 +966,10 @@
       </node>
     </node>
     <node concept="1J7WVO" id="3_DFadM_bGC" role="1J4apk">
-      <ref role="1J7WVQ" to="rxpb:uGVYUiiVGW" resolve="ExprBaseInterpeter" />
+      <ref role="1J7WVQ" to="rxpb:uGVYUiiVGW" resolve="ExprBaseInterpreter" />
     </node>
     <node concept="1J7WVO" id="3_DFadM_bHk" role="1J4apk">
-      <ref role="1J7WVQ" to="jpzw:uGVYUiiVGW" resolve="ExprLambdaInterpeter" />
+      <ref role="1J7WVQ" to="jpzw:uGVYUiiVGW" resolve="ExprLambdaInterpreter" />
     </node>
     <node concept="d$4Dx" id="7kYh9WsSh7Z" role="d$6nW">
       <node concept="BaHAS" id="7kYh9WsSh80" role="cpn$n">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.dataflow.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.dataflow.interpreter/models/plugin.mps
@@ -226,7 +226,7 @@
     </language>
   </registry>
   <node concept="qq9qg" id="uGVYUiiVGW">
-    <property role="TrG5h" value="ExprDataflowInterpeter" />
+    <property role="TrG5h" value="ExprDataflowInterpreter" />
     <property role="UYu25" value="arithmetic" />
     <node concept="d$4Dx" id="uGVYUiiVGX" role="d$6nW">
       <node concept="BaHAS" id="uGVYUiiVGY" role="cpn$n">
@@ -235,7 +235,7 @@
       </node>
     </node>
     <node concept="1J7WVO" id="1lon7Xl3CPo" role="1J4apk">
-      <ref role="1J7WVQ" to="jpzw:uGVYUiiVGW" resolve="ExprLambdaInterpeter" />
+      <ref role="1J7WVQ" to="jpzw:uGVYUiiVGW" resolve="ExprLambdaInterpreter" />
     </node>
     <node concept="qq9P1" id="2vkvJYTeKUo" role="qq9xR">
       <property role="2TnfIJ" value="true" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.datetime.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.datetime.interpreter/models/plugin.mps
@@ -158,7 +158,7 @@
     </language>
   </registry>
   <node concept="qq9qg" id="uGVYUiiVGW">
-    <property role="TrG5h" value="ExprDatetimeTypesInterpeter" />
+    <property role="TrG5h" value="ExprDatetimeTypesInterpreter" />
     <property role="UYu25" value="arithmetic" />
     <node concept="d$4Dx" id="50smQ1V9EXs" role="d$6nW">
       <node concept="BaHAS" id="50smQ1V9EXt" role="cpn$n">
@@ -253,10 +253,10 @@
       </node>
     </node>
     <node concept="1J7WVO" id="3nGzaxUqYQi" role="1J4apk">
-      <ref role="1J7WVQ" to="rxpb:uGVYUiiVGW" resolve="ExprBaseInterpeter" />
+      <ref role="1J7WVQ" to="rxpb:uGVYUiiVGW" resolve="ExprBaseInterpreter" />
     </node>
     <node concept="1J7WVO" id="3nGzaxUr3fU" role="1J4apk">
-      <ref role="1J7WVQ" to="km5y:uGVYUiiVGW" resolve="ExprSimpleTypesInterpeter" />
+      <ref role="1J7WVQ" to="km5y:uGVYUiiVGW" resolve="ExprSimpleTypesInterpreter" />
     </node>
     <node concept="qq9P1" id="7baKnR5my0Y" role="qq9xR">
       <property role="2TnfIJ" value="true" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.lambda.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.lambda.interpreter/models/plugin.mps
@@ -242,10 +242,10 @@
     </language>
   </registry>
   <node concept="qq9qg" id="uGVYUiiVGW">
-    <property role="TrG5h" value="ExprLambdaInterpeter" />
+    <property role="TrG5h" value="ExprLambdaInterpreter" />
     <property role="UYu25" value="arithmetic" />
     <node concept="1J7WVO" id="3_DFadM_bGC" role="1J4apk">
-      <ref role="1J7WVQ" to="rxpb:uGVYUiiVGW" resolve="ExprBaseInterpeter" />
+      <ref role="1J7WVQ" to="rxpb:uGVYUiiVGW" resolve="ExprBaseInterpreter" />
     </node>
     <node concept="d$4Dx" id="uGVYUiiVGX" role="d$6nW">
       <node concept="BaHAS" id="uGVYUiiVGY" role="cpn$n">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.lookup.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.lookup.interpreter/models/plugin.mps
@@ -174,7 +174,7 @@
     </language>
   </registry>
   <node concept="qq9qg" id="uGVYUiiVGW">
-    <property role="TrG5h" value="LookupInterpeter" />
+    <property role="TrG5h" value="LookupInterpreter" />
     <property role="UYu25" value="arithmetic" />
     <node concept="d$4Dx" id="uGVYUiiVGX" role="d$6nW">
       <node concept="BaHAS" id="uGVYUiiVGY" role="cpn$n">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.math.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.math.interpreter/models/plugin.mps
@@ -157,7 +157,7 @@
     </language>
   </registry>
   <node concept="qq9qg" id="uGVYUiiVGW">
-    <property role="TrG5h" value="MathInterpeter" />
+    <property role="TrG5h" value="MathInterpreter" />
     <property role="UYu25" value="arithmetic" />
     <node concept="d$4Dx" id="uGVYUiiVGX" role="d$6nW">
       <node concept="BaHAS" id="uGVYUiiVGY" role="cpn$n">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.mutable.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.mutable.interpreter/models/plugin.mps
@@ -239,7 +239,7 @@
     </language>
   </registry>
   <node concept="qq9qg" id="uGVYUiiVGW">
-    <property role="TrG5h" value="ExprMutateInterpeter" />
+    <property role="TrG5h" value="ExprMutateInterpreter" />
     <property role="UYu25" value="arithmetic" />
     <property role="3GE5qa" value="" />
     <node concept="qq9P1" id="4IV0h47NsF_" role="qq9xR">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.path.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.path.interpreter/models/plugin.mps
@@ -156,7 +156,7 @@
     </language>
   </registry>
   <node concept="qq9qg" id="2KEm7E5F61K">
-    <property role="TrG5h" value="ExprPathInterpeterPCollections" />
+    <property role="TrG5h" value="ExprPathInterpreterPCollections" />
     <property role="UYu25" value="arithmetic" />
     <node concept="qq9P1" id="2KEm7E5F61L" role="qq9xR">
       <property role="2TnfIJ" value="true" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.process.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.process.interpreter/models/plugin.mps
@@ -172,11 +172,11 @@
     </language>
   </registry>
   <node concept="qq9qg" id="uGVYUiiVGW">
-    <property role="TrG5h" value="ExprProcessInterpeter" />
+    <property role="TrG5h" value="ExprProcessInterpreter" />
     <property role="UYu25" value="arithmetic" />
     <property role="3GE5qa" value="" />
     <node concept="1J7WVO" id="7WFhXJlVIJG" role="1J4apk">
-      <ref role="1J7WVQ" to="u5a1:uGVYUiiVGW" resolve="ExprMutateInterpeter" />
+      <ref role="1J7WVQ" to="u5a1:uGVYUiiVGW" resolve="ExprMutateInterpreter" />
     </node>
     <node concept="d$4Dx" id="uGVYUiiVGX" role="d$6nW">
       <node concept="BaHAS" id="uGVYUiiVGY" role="cpn$n">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.repl.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.repl.interpreter/models/plugin.mps
@@ -211,7 +211,7 @@
     </language>
   </registry>
   <node concept="qq9qg" id="uGVYUiiVGW">
-    <property role="TrG5h" value="ReplInterpeter" />
+    <property role="TrG5h" value="ReplInterpreter" />
     <property role="UYu25" value="arithmetic" />
     <node concept="qq9P1" id="7HzLUeHFrrW" role="qq9xR">
       <property role="2TnfIJ" value="true" />
@@ -832,13 +832,13 @@
       </node>
     </node>
     <node concept="1J7WVO" id="2HpFPvTaXcy" role="1J4apk">
-      <ref role="1J7WVQ" to="rxyl:uGVYUiiVGW" resolve="ExprToplevelInterpeter" />
+      <ref role="1J7WVQ" to="rxyl:uGVYUiiVGW" resolve="ExprToplevelInterpreter" />
     </node>
     <node concept="1J7WVO" id="2HpFPvTaXcU" role="1J4apk">
-      <ref role="1J7WVQ" to="rxpb:uGVYUiiVGW" resolve="ExprBaseInterpeter" />
+      <ref role="1J7WVQ" to="rxpb:uGVYUiiVGW" resolve="ExprBaseInterpreter" />
     </node>
     <node concept="1J7WVO" id="2HpFPvTb2sP" role="1J4apk">
-      <ref role="1J7WVQ" to="km5y:uGVYUiiVGW" resolve="ExprSimpleTypesInterpeter" />
+      <ref role="1J7WVQ" to="km5y:uGVYUiiVGW" resolve="ExprSimpleTypesInterpreter" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.interpreter/models/plugin.mps
@@ -258,7 +258,7 @@
     </language>
   </registry>
   <node concept="qq9qg" id="uGVYUiiVGW">
-    <property role="TrG5h" value="ExprSimpleTypesInterpeter" />
+    <property role="TrG5h" value="ExprSimpleTypesInterpreter" />
     <property role="UYu25" value="arithmetic" />
     <node concept="d$4Dx" id="uGVYUiiVGX" role="d$6nW">
       <node concept="BaHAS" id="uGVYUiiVGY" role="cpn$n">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.statemachines.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.statemachines.interpreter/models/plugin.mps
@@ -155,7 +155,7 @@
     </language>
   </registry>
   <node concept="qq9qg" id="uGVYUiiVGW">
-    <property role="TrG5h" value="ExprStatemachineInterpeter" />
+    <property role="TrG5h" value="ExprStatemachineInterpreter" />
     <property role="UYu25" value="arithmetic" />
     <property role="3GE5qa" value="" />
     <node concept="qq9P1" id="4J6AqiIV05G" role="qq9xR">
@@ -871,7 +871,7 @@
       </node>
     </node>
     <node concept="1J7WVO" id="YMJl2BJE5A" role="1J4apk">
-      <ref role="1J7WVQ" to="u5a1:uGVYUiiVGW" resolve="ExprMutateInterpeter" />
+      <ref role="1J7WVQ" to="u5a1:uGVYUiiVGW" resolve="ExprMutateInterpreter" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.temporal.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.temporal.interpreter/models/plugin.mps
@@ -302,7 +302,7 @@
     </language>
   </registry>
   <node concept="qq9qg" id="uGVYUiiVGW">
-    <property role="TrG5h" value="ExprTemporalTypesInterpeter" />
+    <property role="TrG5h" value="ExprTemporalTypesInterpreter" />
     <property role="UYu25" value="arithmetic" />
     <node concept="d$4Dx" id="50smQ1V9EXs" role="d$6nW">
       <node concept="BaHAS" id="50smQ1V9EXt" role="cpn$n">
@@ -3637,10 +3637,10 @@
       </node>
     </node>
     <node concept="1J7WVO" id="3nGzaxUqYQi" role="1J4apk">
-      <ref role="1J7WVQ" to="rxpb:uGVYUiiVGW" resolve="ExprBaseInterpeter" />
+      <ref role="1J7WVQ" to="rxpb:uGVYUiiVGW" resolve="ExprBaseInterpreter" />
     </node>
     <node concept="1J7WVO" id="3nGzaxUr3fU" role="1J4apk">
-      <ref role="1J7WVQ" to="km5y:uGVYUiiVGW" resolve="ExprSimpleTypesInterpeter" />
+      <ref role="1J7WVQ" to="km5y:uGVYUiiVGW" resolve="ExprSimpleTypesInterpreter" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tests.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tests.interpreter/models/plugin.mps
@@ -155,10 +155,10 @@
     </language>
   </registry>
   <node concept="qq9qg" id="uGVYUiiVGW">
-    <property role="TrG5h" value="TestsInterpeter" />
+    <property role="TrG5h" value="TestsInterpreter" />
     <property role="UYu25" value="arithmetic" />
     <node concept="1J7WVO" id="4H_8WGVp2o4" role="1J4apk">
-      <ref role="1J7WVQ" to="rxpb:uGVYUiiVGW" resolve="ExprBaseInterpeter" />
+      <ref role="1J7WVQ" to="rxpb:uGVYUiiVGW" resolve="ExprBaseInterpreter" />
     </node>
     <node concept="d$4Dx" id="uGVYUiiVGX" role="d$6nW">
       <node concept="BaHAS" id="uGVYUiiVGY" role="cpn$n">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.toplevel.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.toplevel.interpreter/models/plugin.mps
@@ -276,7 +276,7 @@
     </language>
   </registry>
   <node concept="qq9qg" id="uGVYUiiVGW">
-    <property role="TrG5h" value="ExprToplevelInterpeter" />
+    <property role="TrG5h" value="ExprToplevelInterpreter" />
     <property role="UYu25" value="arithmetic" />
     <node concept="d$4Dx" id="uGVYUiiVGX" role="d$6nW">
       <node concept="BaHAS" id="uGVYUiiVGY" role="cpn$n">
@@ -2722,7 +2722,7 @@
       </node>
     </node>
     <node concept="1J7WVO" id="1lon7Xl3CPo" role="1J4apk">
-      <ref role="1J7WVQ" to="jpzw:uGVYUiiVGW" resolve="ExprLambdaInterpeter" />
+      <ref role="1J7WVQ" to="jpzw:uGVYUiiVGW" resolve="ExprLambdaInterpreter" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.util.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.util.interpreter/models/plugin.mps
@@ -293,7 +293,7 @@
     </language>
   </registry>
   <node concept="qq9qg" id="vI4mpo41lz">
-    <property role="TrG5h" value="ExprUtilInterpeter" />
+    <property role="TrG5h" value="ExprUtilInterpreter" />
     <property role="UYu25" value="arithmetic" />
     <node concept="d$4Dx" id="vI4mpo41l$" role="d$6nW">
       <node concept="BaHAS" id="vI4mpo41l_" role="cpn$n">
@@ -1762,7 +1762,7 @@
       </node>
     </node>
     <node concept="1J7WVO" id="vI4mpo42YP" role="1J4apk">
-      <ref role="1J7WVQ" to="km5y:uGVYUiiVGW" resolve="ExprSimpleTypesInterpeter" />
+      <ref role="1J7WVQ" to="km5y:uGVYUiiVGW" resolve="ExprSimpleTypesInterpreter" />
     </node>
   </node>
   <node concept="312cEu" id="7EKPeISP7Do">


### PR DESCRIPTION
Peter is dead, long live Preter :-)

This is just a proper renaming of all interpreters. It is sometimes annoying if names are spelled wrong, esp. when somebody is trying to find it with Cmd-N or full-text search.