### PR TITLE
Introduce ITypeable interface concept

### DIFF
--- a/build/iets3.opensource.allScripts/build-allScripts.xml
+++ b/build/iets3.opensource.allScripts/build-allScripts.xml
@@ -258,7 +258,7 @@
         <fileset file="${artifacts.mps}/lib/log4j.jar" />
         <fileset file="${artifacts.mps}/lib/jdom.jar" />
         <fileset file="${artifacts.mps}/lib/trove4j.jar" />
-        <fileset file="${artifacts.mps}/lib/ecj-4.7.2.jar" />
+        <fileset file="${artifacts.mps}/lib/ecj-4.10.jar" />
         <fileset dir="${artifacts.mps}/lib" includes="*.jar" />
         <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.logging.runtime.jar" />
         <fileset file="${artifacts.mps}/plugins/mps-build/languages/build/jetbrains.mps.build.jar" />
@@ -309,7 +309,7 @@
         <fileset file="${artifacts.mps}/lib/log4j.jar" />
         <fileset file="${artifacts.mps}/lib/jdom.jar" />
         <fileset file="${artifacts.mps}/lib/trove4j.jar" />
-        <fileset file="${artifacts.mps}/lib/ecj-4.7.2.jar" />
+        <fileset file="${artifacts.mps}/lib/ecj-4.10.jar" />
         <fileset dir="${artifacts.mps}/lib" includes="*.jar" />
         <fileset file="${artifacts.mps}/languages/baseLanguage/jetbrains.mps.baseLanguage.logging.runtime.jar" />
         <fileset file="${artifacts.mps}/plugins/mps-build/languages/build/jetbrains.mps.build.jar" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -22827,6 +22827,24 @@
     <node concept="13hLZK" id="33mFrumAAsU" role="13h7CW">
       <node concept="3clFbS" id="33mFrumAAsV" role="2VODD2" />
     </node>
+    <node concept="13i0hz" id="4WLweXm3TXc" role="13h7CS">
+      <property role="TrG5h" value="type" />
+      <ref role="13i0hy" node="4WLweXm3SW5" resolve="type" />
+      <node concept="3Tm1VV" id="4WLweXm3TXd" role="1B3o_S" />
+      <node concept="3clFbS" id="4WLweXm3TXg" role="3clF47">
+        <node concept="3cpWs6" id="4WLweXm3TX$" role="3cqZAp">
+          <node concept="2OqwBi" id="4WLweXm3U9V" role="3cqZAk">
+            <node concept="13iPFW" id="4WLweXm3TXF" role="2Oq$k0" />
+            <node concept="3TrEf2" id="4WLweXm3UDt" role="2OqNvi">
+              <ref role="3Tt5mk" to="hm2y:7D7uZV2iYAD" resolve="type" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="4WLweXm3TXh" role="3clF45">
+        <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+      </node>
+    </node>
   </node>
   <node concept="13h7C7" id="60Qa1k_r2m4">
     <ref role="13h7C2" to="hm2y:60Qa1k_nMSK" resolve="DefaultValueExpression" />
@@ -24413,6 +24431,25 @@
         </node>
       </node>
       <node concept="10Oyi0" id="5Iz9nTHIbAh" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4WLweXm3SVU">
+    <ref role="13h7C2" to="hm2y:4WLweXm3SVw" resolve="ITypeable" />
+    <node concept="13i0hz" id="4WLweXm3SW5" role="13h7CS">
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="type" />
+      <node concept="3Tm1VV" id="4WLweXm3SW6" role="1B3o_S" />
+      <node concept="3Tqbb2" id="4WLweXm3SYD" role="3clF45">
+        <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+      </node>
+      <node concept="3clFbS" id="4WLweXm3SW8" role="3clF47">
+        <node concept="3cpWs6" id="4WLweXm4tFB" role="3cqZAp">
+          <node concept="10Nm6u" id="4WLweXm4tFI" role="3cqZAk" />
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="4WLweXm3SVV" role="13h7CW">
+      <node concept="3clFbS" id="4WLweXm3SVW" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/structure.mps
@@ -34,6 +34,9 @@
       <concept id="1224240836180" name="jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation" flags="ig" index="asaX9">
         <property id="1225118933224" name="comment" index="YLQ7P" />
       </concept>
+      <concept id="7862711839422615209" name="jetbrains.mps.lang.structure.structure.DocumentedNodeAnnotation" flags="ng" index="t5JxF">
+        <property id="7862711839422615217" name="text" index="t5JxN" />
+      </concept>
       <concept id="6054523464627964745" name="jetbrains.mps.lang.structure.structure.AttributeInfo_AttributedConcept" flags="ng" index="trNpa">
         <reference id="6054523464627965081" name="concept" index="trN6q" />
       </concept>
@@ -1460,6 +1463,12 @@
       <property role="20lbJX" value="0..1" />
       <property role="IQ2ns" value="8811147530085329321" />
       <ref role="20lvS9" node="6sdnDbSlaok" resolve="Type" />
+      <node concept="t5JxF" id="4WLweXm3TQV" role="lGtFl">
+        <property role="t5JxN" value="type is actually required, but is 0..1 here to improve editor usability" />
+      </node>
+    </node>
+    <node concept="PrWs8" id="4WLweXm3TWP" role="PrDN$">
+      <ref role="PrY4T" node="4WLweXm3SVw" resolve="ITypeable" />
     </node>
   </node>
   <node concept="PlHQZ" id="3pe7Y2RWByP">
@@ -2119,6 +2128,13 @@
       <property role="20lbJX" value="0..1" />
       <ref role="20lvS9" node="6sdnDbSla17" resolve="Expression" />
       <node concept="asaX9" id="5Iz9nTHIdkh" role="lGtFl" />
+    </node>
+  </node>
+  <node concept="PlHQZ" id="4WLweXm3SVw">
+    <property role="EcuMT" value="5706483968284528352" />
+    <property role="TrG5h" value="ITypeable" />
+    <node concept="t5JxF" id="57In_Tx2eIg" role="lGtFl">
+      <property role="t5JxN" value="Nodes that have a defined type but not necessarily specified explicitly in a child" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
@@ -5433,51 +5433,6 @@
       <ref role="1YaFvo" to="hm2y:68xoVn7qAL8" resolve="ITyped" />
     </node>
   </node>
-  <node concept="1YbPZF" id="54pTGl8k9Ob">
-    <property role="TrG5h" value="typeof_ITyped" />
-    <node concept="3clFbS" id="54pTGl8k9Oc" role="18ibNy">
-      <node concept="3clFbJ" id="54pTGl8k9Ol" role="3cqZAp">
-        <node concept="3clFbS" id="54pTGl8k9Om" role="3clFbx">
-          <node concept="1Z5TYs" id="54pTGl8k9On" role="3cqZAp">
-            <node concept="mw_s8" id="54pTGl8k9Oo" role="1ZfhKB">
-              <node concept="1Z2H0r" id="54pTGl8k9Op" role="mwGJk">
-                <node concept="2OqwBi" id="54pTGl8k9Oq" role="1Z2MuG">
-                  <node concept="1YBJjd" id="54pTGl8kaHH" role="2Oq$k0">
-                    <ref role="1YBMHb" node="54pTGl8k9Oe" resolve="it" />
-                  </node>
-                  <node concept="3TrEf2" id="54pTGl8k9Os" role="2OqNvi">
-                    <ref role="3Tt5mk" to="hm2y:7D7uZV2iYAD" resolve="type" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="mw_s8" id="54pTGl8k9Ot" role="1ZfhK$">
-              <node concept="1Z2H0r" id="54pTGl8k9Ou" role="mwGJk">
-                <node concept="1YBJjd" id="54pTGl8kaAp" role="1Z2MuG">
-                  <ref role="1YBMHb" node="54pTGl8k9Oe" resolve="it" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2OqwBi" id="54pTGl8kahb" role="3clFbw">
-          <node concept="2OqwBi" id="54pTGl8k9Oy" role="2Oq$k0">
-            <node concept="1YBJjd" id="54pTGl8k9Te" role="2Oq$k0">
-              <ref role="1YBMHb" node="54pTGl8k9Oe" resolve="it" />
-            </node>
-            <node concept="3TrEf2" id="54pTGl8k9O$" role="2OqNvi">
-              <ref role="3Tt5mk" to="hm2y:7D7uZV2iYAD" resolve="type" />
-            </node>
-          </node>
-          <node concept="3x8VRR" id="54pTGl8ka$n" role="2OqNvi" />
-        </node>
-      </node>
-    </node>
-    <node concept="1YaCAy" id="54pTGl8k9Oe" role="1YuTPh">
-      <property role="TrG5h" value="it" />
-      <ref role="1YaFvo" to="hm2y:68xoVn7qAL8" resolve="ITyped" />
-    </node>
-  </node>
   <node concept="35pCF_" id="6iJ_gQBcrDt">
     <property role="3GE5qa" value="error" />
     <property role="TrG5h" value="replaceAttemptErrorTypes" />
@@ -8003,6 +7958,57 @@
     <node concept="1YaCAy" id="24Fec4177Mc" role="1YuTPh">
       <property role="TrG5h" value="bang" />
       <ref role="1YaFvo" to="hm2y:24Fec4173Us" resolve="BangOp" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="54pTGl8k9Ob">
+    <property role="TrG5h" value="typeof_ITypeable" />
+    <node concept="3clFbS" id="54pTGl8k9Oc" role="18ibNy">
+      <node concept="3cpWs8" id="57In_Tx2ee7" role="3cqZAp">
+        <node concept="3cpWsn" id="57In_Tx2ee8" role="3cpWs9">
+          <property role="TrG5h" value="type" />
+          <node concept="3Tqbb2" id="57In_Tx2ee3" role="1tU5fm">
+            <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+          </node>
+          <node concept="2OqwBi" id="57In_Tx2ee9" role="33vP2m">
+            <node concept="1YBJjd" id="57In_Tx2eea" role="2Oq$k0">
+              <ref role="1YBMHb" node="54pTGl8k9Oe" resolve="it" />
+            </node>
+            <node concept="2qgKlT" id="57In_Tx2eeb" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:4WLweXm3SW5" resolve="type" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbJ" id="54pTGl8k9Ol" role="3cqZAp">
+        <node concept="3clFbS" id="54pTGl8k9Om" role="3clFbx">
+          <node concept="1Z5TYs" id="54pTGl8k9On" role="3cqZAp">
+            <node concept="mw_s8" id="54pTGl8k9Oo" role="1ZfhKB">
+              <node concept="1Z2H0r" id="54pTGl8k9Op" role="mwGJk">
+                <node concept="37vLTw" id="57In_Tx2eBG" role="1Z2MuG">
+                  <ref role="3cqZAo" node="57In_Tx2ee8" resolve="type" />
+                </node>
+              </node>
+            </node>
+            <node concept="mw_s8" id="54pTGl8k9Ot" role="1ZfhK$">
+              <node concept="1Z2H0r" id="54pTGl8k9Ou" role="mwGJk">
+                <node concept="1YBJjd" id="54pTGl8kaAp" role="1Z2MuG">
+                  <ref role="1YBMHb" node="54pTGl8k9Oe" resolve="it" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2OqwBi" id="54pTGl8kahb" role="3clFbw">
+          <node concept="37vLTw" id="57In_Tx2eec" role="2Oq$k0">
+            <ref role="3cqZAo" node="57In_Tx2ee8" resolve="type" />
+          </node>
+          <node concept="3x8VRR" id="54pTGl8ka$n" role="2OqNvi" />
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="54pTGl8k9Oe" role="1YuTPh">
+      <property role="TrG5h" value="it" />
+      <ref role="1YaFvo" to="hm2y:4WLweXm3SVw" resolve="ITypeable" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/generator/template/org.iets3.core.expr.genjava.toplevel.main@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/generator/template/org.iets3.core.expr.genjava.toplevel.main@generator.mps
@@ -8870,7 +8870,7 @@
                   <node concept="3clFbF" id="6XE8Bc$gDWf" role="3cqZAp">
                     <node concept="2OqwBi" id="6XE8Bc$gDWg" role="3clFbG">
                       <node concept="30H73N" id="6XE8Bc$gDWh" role="2Oq$k0" />
-                      <node concept="3JvlWi" id="6XE8Bc$gDWi" role="2OqNvi" />
+                      <node concept="3JvlWi" id="57In_Tx49$R" role="2OqNvi" />
                     </node>
                   </node>
                 </node>
@@ -8899,8 +8899,8 @@
               <node concept="3clFbS" id="6XE8Bc$gDWt" role="2VODD2">
                 <node concept="3clFbF" id="6XE8Bc$gDWu" role="3cqZAp">
                   <node concept="2OqwBi" id="6XE8Bc$gDWv" role="3clFbG">
-                    <node concept="3Tsc0h" id="6XE8Bc$gDWw" role="2OqNvi">
-                      <ref role="3TtcxE" to="yv47:xu7xcKioz5" resolve="members" />
+                    <node concept="2qgKlT" id="57In_Tx3gip" role="2OqNvi">
+                      <ref role="37wK5l" to="nu60:58eyHuUgYVm" resolve="nonEmptyMembers" />
                     </node>
                     <node concept="30H73N" id="6XE8Bc$gDWx" role="2Oq$k0" />
                   </node>
@@ -8955,9 +8955,7 @@
                   <node concept="3clFbS" id="6XE8Bc$gDWU" role="2VODD2">
                     <node concept="3clFbF" id="6XE8Bc$gDWV" role="3cqZAp">
                       <node concept="2OqwBi" id="6XE8Bc$gDWW" role="3clFbG">
-                        <node concept="3TrEf2" id="6XE8Bc$gDWX" role="2OqNvi">
-                          <ref role="3Tt5mk" to="hm2y:7D7uZV2iYAD" resolve="type" />
-                        </node>
+                        <node concept="3JvlWi" id="57In_Tx3QY8" role="2OqNvi" />
                         <node concept="30H73N" id="6XE8Bc$gDWY" role="2Oq$k0" />
                       </node>
                     </node>
@@ -8971,8 +8969,8 @@
                   <node concept="3clFbF" id="6XE8Bc$gDX2" role="3cqZAp">
                     <node concept="2OqwBi" id="6XE8Bc$gDX3" role="3clFbG">
                       <node concept="30H73N" id="6XE8Bc$gDX4" role="2Oq$k0" />
-                      <node concept="3Tsc0h" id="6XE8Bc$gDX5" role="2OqNvi">
-                        <ref role="3TtcxE" to="yv47:xu7xcKioz5" resolve="members" />
+                      <node concept="2qgKlT" id="57In_Tx3d4W" role="2OqNvi">
+                        <ref role="37wK5l" to="nu60:58eyHuUgYVm" resolve="nonEmptyMembers" />
                       </node>
                     </node>
                   </node>
@@ -9025,8 +9023,8 @@
                   <node concept="2OqwBi" id="6XE8Bc$gDXA" role="3clFbG">
                     <node concept="2OqwBi" id="6XE8Bc$gDXB" role="2Oq$k0">
                       <node concept="30H73N" id="6XE8Bc$gDXC" role="2Oq$k0" />
-                      <node concept="3Tsc0h" id="6XE8Bc$gDXD" role="2OqNvi">
-                        <ref role="3TtcxE" to="yv47:xu7xcKioz5" resolve="members" />
+                      <node concept="2qgKlT" id="57In_Tx3DU6" role="2OqNvi">
+                        <ref role="37wK5l" to="nu60:58eyHuUgYVm" resolve="nonEmptyMembers" />
                       </node>
                     </node>
                     <node concept="3GX2aA" id="6XE8Bc$gDXE" role="2OqNvi" />
@@ -9057,8 +9055,8 @@
               <node concept="3clFbS" id="6XE8Bc$gDXN" role="2VODD2">
                 <node concept="3clFbF" id="6XE8Bc$gDXO" role="3cqZAp">
                   <node concept="2OqwBi" id="6XE8Bc$gDXP" role="3clFbG">
-                    <node concept="3Tsc0h" id="6XE8Bc$gDXQ" role="2OqNvi">
-                      <ref role="3TtcxE" to="yv47:xu7xcKioz5" resolve="members" />
+                    <node concept="2qgKlT" id="57In_Tx3yMc" role="2OqNvi">
+                      <ref role="37wK5l" to="nu60:58eyHuUgYVm" resolve="nonEmptyMembers" />
                     </node>
                     <node concept="30H73N" id="6XE8Bc$gDXR" role="2Oq$k0" />
                   </node>
@@ -9470,8 +9468,8 @@
               <node concept="3clFbS" id="6XE8Bc$gE0H" role="2VODD2">
                 <node concept="3clFbF" id="6XE8Bc$gE0I" role="3cqZAp">
                   <node concept="2OqwBi" id="6XE8Bc$gE0J" role="3clFbG">
-                    <node concept="3Tsc0h" id="6XE8Bc$gE0K" role="2OqNvi">
-                      <ref role="3TtcxE" to="yv47:xu7xcKioz5" resolve="members" />
+                    <node concept="2qgKlT" id="57In_Tx4hoj" role="2OqNvi">
+                      <ref role="37wK5l" to="nu60:58eyHuUgYVm" resolve="nonEmptyMembers" />
                     </node>
                     <node concept="30H73N" id="6XE8Bc$gE0L" role="2Oq$k0" />
                   </node>
@@ -9574,6 +9572,53 @@
               </node>
               <node concept="Xjq3P" id="lH$Puj3F2a" role="2nBT83">
                 <ref role="1HBi2w" node="5LerK4sm_WN" resolve="OuterClass.MapRecordDeclaration" />
+              </node>
+            </node>
+            <node concept="2nBT84" id="57In_TxokLU" role="3cqZAp">
+              <node concept="2nBT81" id="57In_TxolyU" role="2nBTao">
+                <node concept="3y3z36" id="57In_Txon4q" role="2nBT80">
+                  <node concept="10Nm6u" id="57In_Txon4Q" role="3uHU7w" />
+                  <node concept="2kixu8" id="57In_TxolAd" role="3uHU7B" />
+                </node>
+                <node concept="Xl_RD" id="57In_Txomih" role="2nBT8e">
+                  <property role="Xl_RC" value="err" />
+                </node>
+                <node concept="2b32R4" id="57In_TxozYa" role="lGtFl">
+                  <node concept="3JmXsc" id="57In_TxozYd" role="2P8S$">
+                    <node concept="3clFbS" id="57In_TxozYe" role="2VODD2">
+                      <node concept="3clFbF" id="57In_TxozYk" role="3cqZAp">
+                        <node concept="2OqwBi" id="57In_TxoUm3" role="3clFbG">
+                          <node concept="2OqwBi" id="57In_TxozYf" role="2Oq$k0">
+                            <node concept="3TrEf2" id="57In_TxoJ$x" role="2OqNvi">
+                              <ref role="3Tt5mk" to="hm2y:KaZMgy4Ily" resolve="contract" />
+                            </node>
+                            <node concept="30H73N" id="57In_TxozYj" role="2Oq$k0" />
+                          </node>
+                          <node concept="3Tsc0h" id="57In_Txp54b" role="2OqNvi">
+                            <ref role="3TtcxE" to="hm2y:KaZMgy4Il_" resolve="items" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="57In_TxolsA" role="2nBT83">
+                <ref role="3cqZAo" node="6XE8Bc$gDWa" resolve="i" />
+              </node>
+              <node concept="1WS0z7" id="57In_Txy37x" role="lGtFl">
+                <node concept="3JmXsc" id="57In_Txy37y" role="3Jn$fo">
+                  <node concept="3clFbS" id="57In_Txy37z" role="2VODD2">
+                    <node concept="3clFbF" id="57In_Txy3qq" role="3cqZAp">
+                      <node concept="2OqwBi" id="57In_Txy3Yk" role="3clFbG">
+                        <node concept="30H73N" id="57In_Txy3qp" role="2Oq$k0" />
+                        <node concept="2qgKlT" id="57In_Txy5Vi" role="2OqNvi">
+                          <ref role="37wK5l" to="nu60:58eyHuUgYVm" resolve="nonEmptyMembers" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -9749,8 +9794,8 @@
                     <node concept="3clFbF" id="6XE8Bc$gE3v" role="3cqZAp">
                       <node concept="2OqwBi" id="6XE8Bc$gE3w" role="3clFbG">
                         <node concept="2OqwBi" id="6XE8Bc$gE3x" role="2Oq$k0">
-                          <node concept="3Tsc0h" id="6XE8Bc$gE3y" role="2OqNvi">
-                            <ref role="3TtcxE" to="yv47:xu7xcKioz5" resolve="members" />
+                          <node concept="2qgKlT" id="57In_Tx4xCV" role="2OqNvi">
+                            <ref role="37wK5l" to="nu60:58eyHuUgYVm" resolve="nonEmptyMembers" />
                           </node>
                           <node concept="30H73N" id="6XE8Bc$gE3z" role="2Oq$k0" />
                         </node>
@@ -9898,8 +9943,8 @@
                     <node concept="3clFbF" id="6XE8Bc$gE4$" role="3cqZAp">
                       <node concept="2OqwBi" id="6XE8Bc$gE4_" role="3clFbG">
                         <node concept="2OqwBi" id="6XE8Bc$gE4A" role="2Oq$k0">
-                          <node concept="3Tsc0h" id="6XE8Bc$gE4B" role="2OqNvi">
-                            <ref role="3TtcxE" to="yv47:xu7xcKioz5" resolve="members" />
+                          <node concept="2qgKlT" id="57In_Tx4$Kg" role="2OqNvi">
+                            <ref role="37wK5l" to="nu60:58eyHuUgYVm" resolve="nonEmptyMembers" />
                           </node>
                           <node concept="30H73N" id="6XE8Bc$gE4C" role="2Oq$k0" />
                         </node>
@@ -10045,8 +10090,8 @@
                   <node concept="3clFbS" id="6XE8Bc$gE5E" role="2VODD2">
                     <node concept="3clFbF" id="6XE8Bc$gE5F" role="3cqZAp">
                       <node concept="2OqwBi" id="6XE8Bc$gE5G" role="3clFbG">
-                        <node concept="3Tsc0h" id="6XE8Bc$gE5H" role="2OqNvi">
-                          <ref role="3TtcxE" to="yv47:xu7xcKioz5" resolve="members" />
+                        <node concept="2qgKlT" id="57In_Tx4BpG" role="2OqNvi">
+                          <ref role="37wK5l" to="nu60:58eyHuUgYVm" resolve="nonEmptyMembers" />
                         </node>
                         <node concept="30H73N" id="6XE8Bc$gE5I" role="2Oq$k0" />
                       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -6518,8 +6518,8 @@
                           <node concept="37vLTw" id="6JZACDWH6b9" role="2Oq$k0">
                             <ref role="3cqZAo" node="6JZACDWH5Xo" resolve="it" />
                           </node>
-                          <node concept="3TrEf2" id="6JZACDWH6SP" role="2OqNvi">
-                            <ref role="3Tt5mk" to="hm2y:7D7uZV2iYAD" resolve="type" />
+                          <node concept="2qgKlT" id="4WLweXm4piJ" role="2OqNvi">
+                            <ref role="37wK5l" to="pbu6:4WLweXm3SW5" resolve="type" />
                           </node>
                         </node>
                         <node concept="1mIQ4w" id="6JZACDWH8ku" role="2OqNvi">
@@ -6550,8 +6550,8 @@
                           <node concept="37vLTw" id="6JZACDWGX$F" role="2Oq$k0">
                             <ref role="3cqZAo" node="6JZACDWGX$G" resolve="it" />
                           </node>
-                          <node concept="3TrEf2" id="6JZACDWHady" role="2OqNvi">
-                            <ref role="3Tt5mk" to="hm2y:7D7uZV2iYAD" resolve="type" />
+                          <node concept="2qgKlT" id="4WLweXm4qig" role="2OqNvi">
+                            <ref role="37wK5l" to="pbu6:4WLweXm3SW5" resolve="type" />
                           </node>
                         </node>
                       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/structure.mps
@@ -347,6 +347,9 @@
     <node concept="PrWs8" id="xu7xcKdQCE" role="PzmwI">
       <ref role="PrY4T" node="xu7xcKdQCB" resolve="IRecordMember" />
     </node>
+    <node concept="PrWs8" id="4WLweXm3Vmv" role="PzmwI">
+      <ref role="PrY4T" to="hm2y:68xoVn7qAL8" resolve="ITyped" />
+    </node>
     <node concept="PrWs8" id="46cplYy1Svf" role="PzmwI">
       <ref role="PrY4T" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
     </node>
@@ -685,8 +688,8 @@
     <node concept="PrWs8" id="5YygIlbfTYR" role="PrDN$">
       <ref role="PrY4T" to="4kwy:cJpacq5T0O" resolve="IValidNamedConcept" />
     </node>
-    <node concept="PrWs8" id="54pTGl8og01" role="PrDN$">
-      <ref role="PrY4T" to="hm2y:68xoVn7qAL8" resolve="ITyped" />
+    <node concept="PrWs8" id="4WLweXm3V3Q" role="PrDN$">
+      <ref role="PrY4T" to="hm2y:4WLweXm3SVw" resolve="ITypeable" />
     </node>
     <node concept="PrWs8" id="3z0ZJXm0MfZ" role="PrDN$">
       <ref role="PrY4T" to="vs0r:65XyadYMMYC" resolve="ICommentable" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/typesystem.mps
@@ -804,37 +804,6 @@
       <ref role="1YaFvo" to="yv47:ub9nkyG$WT" resolve="ConstantRef" />
     </node>
   </node>
-  <node concept="1YbPZF" id="7D7uZV2e2LI">
-    <property role="TrG5h" value="typeof_IRecordMember" />
-    <property role="3GE5qa" value="record" />
-    <node concept="3clFbS" id="7D7uZV2e2LJ" role="18ibNy">
-      <node concept="1Z5TYs" id="7D7uZV2e2O0" role="3cqZAp">
-        <node concept="mw_s8" id="7D7uZV2e2Oh" role="1ZfhKB">
-          <node concept="1Z2H0r" id="7D7uZV2e2Od" role="mwGJk">
-            <node concept="2OqwBi" id="7D7uZV2e3QP" role="1Z2MuG">
-              <node concept="1YBJjd" id="7D7uZV2e3O6" role="2Oq$k0">
-                <ref role="1YBMHb" node="7D7uZV2e2LL" resolve="rm" />
-              </node>
-              <node concept="3TrEf2" id="54pTGl8ohmo" role="2OqNvi">
-                <ref role="3Tt5mk" to="hm2y:7D7uZV2iYAD" resolve="type" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="mw_s8" id="7D7uZV2e2O3" role="1ZfhK$">
-          <node concept="1Z2H0r" id="7D7uZV2e2LY" role="mwGJk">
-            <node concept="1YBJjd" id="7D7uZV2e2Me" role="1Z2MuG">
-              <ref role="1YBMHb" node="7D7uZV2e2LL" resolve="rm" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="1YaCAy" id="7D7uZV2e2LL" role="1YuTPh">
-      <property role="TrG5h" value="rm" />
-      <ref role="1YaFvo" to="yv47:xu7xcKdQCB" resolve="IRecordMember" />
-    </node>
-  </node>
   <node concept="1YbPZF" id="7D7uZV2e3Y$">
     <property role="TrG5h" value="typeof_IRecordDeclaration" />
     <property role="3GE5qa" value="record" />
@@ -1060,8 +1029,8 @@
                                     <node concept="37vLTw" id="4$QBvTqUuAy" role="2Oq$k0">
                                       <ref role="3cqZAo" node="7D7uZV2p7hm" resolve="m" />
                                     </node>
-                                    <node concept="3TrEf2" id="4$QBvTqUv56" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="hm2y:7D7uZV2iYAD" resolve="type" />
+                                    <node concept="2qgKlT" id="4WLweXm4zOB" role="2OqNvi">
+                                      <ref role="37wK5l" to="pbu6:4WLweXm3SW5" resolve="type" />
                                     </node>
                                   </node>
                                 </node>
@@ -3192,16 +3161,16 @@
                     <node concept="2GrUjf" id="7cphKbLm7L6" role="2Oq$k0">
                       <ref role="2Gs0qQ" node="7cphKbLlQGG" resolve="m1" />
                     </node>
-                    <node concept="3TrEf2" id="7cphKbLm7L7" role="2OqNvi">
-                      <ref role="3Tt5mk" to="hm2y:7D7uZV2iYAD" resolve="type" />
+                    <node concept="2qgKlT" id="4WLweXm4w9D" role="2OqNvi">
+                      <ref role="37wK5l" to="pbu6:4WLweXm3SW5" resolve="type" />
                     </node>
                   </node>
                   <node concept="2OqwBi" id="7cphKbLm7L8" role="3JuZjQ">
                     <node concept="37vLTw" id="7cphKbLm7L9" role="2Oq$k0">
                       <ref role="3cqZAo" node="7cphKbLlYvk" resolve="m2" />
                     </node>
-                    <node concept="3TrEf2" id="7cphKbLm7La" role="2OqNvi">
-                      <ref role="3Tt5mk" to="hm2y:7D7uZV2iYAD" resolve="type" />
+                    <node concept="2qgKlT" id="4WLweXm4wU5" role="2OqNvi">
+                      <ref role="37wK5l" to="pbu6:4WLweXm3SW5" resolve="type" />
                     </node>
                   </node>
                 </node>
@@ -3279,16 +3248,13 @@
                 <node concept="3clFbS" id="7cphKbLtZjL" role="3clFbx">
                   <node concept="1Z5TYs" id="7cphKbLtZWe" role="3cqZAp">
                     <node concept="mw_s8" id="7cphKbLu06s" role="1ZfhKB">
-                      <node concept="2OqwBi" id="7cphKbLu1f7" role="mwGJk">
-                        <node concept="2OqwBi" id="7cphKbLu0iG" role="2Oq$k0">
-                          <node concept="37vLTw" id="7cphKbLu06q" role="2Oq$k0">
-                            <ref role="3cqZAo" node="7cphKbLtYG_" resolve="m" />
-                          </node>
-                          <node concept="3TrEf2" id="7cphKbLu0Qa" role="2OqNvi">
-                            <ref role="3Tt5mk" to="hm2y:7D7uZV2iYAD" resolve="type" />
-                          </node>
+                      <node concept="2OqwBi" id="7cphKbLu0iG" role="mwGJk">
+                        <node concept="37vLTw" id="7cphKbLu06q" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7cphKbLtYG_" resolve="m" />
                         </node>
-                        <node concept="1$rogu" id="7cphKbLu1uW" role="2OqNvi" />
+                        <node concept="2qgKlT" id="4WLweXm4y6Y" role="2OqNvi">
+                          <ref role="37wK5l" to="pbu6:4WLweXm3SW5" resolve="type" />
+                        </node>
                       </node>
                     </node>
                     <node concept="mw_s8" id="7cphKbLtZWh" role="1ZfhK$">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.toplevel.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.toplevel.interpreter/models/plugin.mps
@@ -1245,8 +1245,8 @@
                       <node concept="37vLTw" id="4ptnK4jiz0C" role="2Oq$k0">
                         <ref role="3cqZAo" node="4ptnK4jiz09" resolve="member" />
                       </node>
-                      <node concept="3TrEf2" id="4ptnK4jiz0D" role="2OqNvi">
-                        <ref role="3Tt5mk" to="hm2y:7D7uZV2iYAD" resolve="type" />
+                      <node concept="2qgKlT" id="4WLweXm4DoK" role="2OqNvi">
+                        <ref role="37wK5l" to="pbu6:4WLweXm3SW5" resolve="type" />
                       </node>
                     </node>
                     <node concept="2OqwBi" id="4ptnK4jiz0E" role="37wK5m">
@@ -1524,8 +1524,8 @@
                       <node concept="37vLTw" id="15mJ3JeE64g" role="2Oq$k0">
                         <ref role="3cqZAo" node="15mJ3JeE5UJ" resolve="member" />
                       </node>
-                      <node concept="3TrEf2" id="54pTGl8oh3_" role="2OqNvi">
-                        <ref role="3Tt5mk" to="hm2y:7D7uZV2iYAD" resolve="type" />
+                      <node concept="2qgKlT" id="4WLweXm4E6B" role="2OqNvi">
+                        <ref role="37wK5l" to="pbu6:4WLweXm3SW5" resolve="type" />
                       </node>
                     </node>
                     <node concept="2OqwBi" id="4nChbdg6YcT" role="37wK5m">


### PR DESCRIPTION
This PR introduces ITypeable interface concept. ITypeable doesn't have any children, only `type()` behavior method. ITyped implements `type()` by returning `this.type`.

IRecordMember now implements ITypeable instead of ITyped. RecordMember continues to implement ITyped.

It's motivated by the need to have custom record members whose base type and multiplicity is specified separately, so the actual member type is then either the base type or collection of base type.

Although simple, this is potentially breaking change if you have defined custom IRecordMembers or are working with the IRecordMember interface so I'd like to have it reviewed before merging.