### PR TITLE
 make EnumLiteralRef editable

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -2204,6 +2204,9 @@
           <node concept="VechU" id="67Y8mp$MWs7" role="3F10Kt">
             <property role="Vb096" value="darkGray" />
           </node>
+          <node concept="VPxyj" id="14te8iJyb8p" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
         </node>
       </node>
       <node concept="OXEIz" id="7cBI1LfPKUe" role="P5bDN">


### PR DESCRIPTION
The problem reported by Lodas (Issue 574) was, that within `Slices` (in `TemporalLiterals`) values can not be deleted without deleting the whole `Slice`. Infact it works for e.g. `NumberLiterals`. Their example was using EnumLiteralRefs. I tried different ways but the only one that worked was making the `EnumLiteralRef` editable, which is not so nice. 

Better approaches are welcome. 