### PR TITLE
enable switching between generator/interpreter test execution in depending projects

### DIFF
--- a/code/languages/org.iets3.opensource/_spreferences/TestExecutionPreferences/models/org.iets3.opensource.__spreferences.TestExecutionPreferences.mps
+++ b/code/languages/org.iets3.opensource/_spreferences/TestExecutionPreferences/models/org.iets3.opensource.__spreferences.TestExecutionPreferences.mps
@@ -20,7 +20,7 @@
   </registry>
   <node concept="3ZOQsN" id="6pNCASbHXH8">
     <property role="TrG5h" value="KernelFTestExecution" />
-    <node concept="3ZOXxk" id="6BwCX4pd7QU" role="3ZOXzE" />
+    <node concept="3ZOXxk" id="AG_FWssSSC" role="3ZOXzE" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/_spreferences/TestExecutionPreferences/models/org.iets3.opensource.__spreferences.TestExecutionPreferences.mps
+++ b/code/languages/org.iets3.opensource/_spreferences/TestExecutionPreferences/models/org.iets3.opensource.__spreferences.TestExecutionPreferences.mps
@@ -15,12 +15,12 @@
       <concept id="4473287864570292399" name="org.iets3.core.expr.testExecution.structure.TestExecutionConfig" flags="ng" index="3ZOQsN">
         <child id="4473287864570320758" name="executionMode" index="3ZOXzE" />
       </concept>
-      <concept id="4473287864570320810" name="org.iets3.core.expr.testExecution.structure.GeneratorExecutionMode" flags="ng" index="3ZOXwQ" />
+      <concept id="4473287864570320840" name="org.iets3.core.expr.testExecution.structure.InterpreterExecutionMode" flags="ng" index="3ZOXxk" />
     </language>
   </registry>
   <node concept="3ZOQsN" id="6pNCASbHXH8">
     <property role="TrG5h" value="KernelFTestExecution" />
-    <node concept="3ZOXwQ" id="6N3Rwqvd0TC" role="3ZOXzE" />
+    <node concept="3ZOXxk" id="6BwCX4pd7QU" role="3ZOXzE" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -2523,33 +2523,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="57VdFqPkLxS" role="3cqZAp" />
-        <node concept="3clFbH" id="57VdFqPikSS" role="3cqZAp" />
-        <node concept="3clFbF" id="3GEHGglRraj" role="3cqZAp">
-          <node concept="2OqwBi" id="3GEHGglRrWn" role="3clFbG">
-            <node concept="10M0yZ" id="3GEHGglRrmL" role="2Oq$k0">
-              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
-              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-            </node>
-            <node concept="liA8E" id="3GEHGglRsEq" role="2OqNvi">
-              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
-              <node concept="3cpWs3" id="3GEHGglRtvm" role="37wK5m">
-                <node concept="Xl_RD" id="3GEHGglRsEW" role="3uHU7B">
-                  <property role="Xl_RC" value="!!!!! module " />
-                </node>
-                <node concept="2OqwBi" id="57VdFqPlreT" role="3uHU7w">
-                  <node concept="liA8E" id="57VdFqPltIx" role="2OqNvi">
-                    <ref role="37wK5l" to="mhbf:~SModel.getModule()" resolve="getModule" />
-                  </node>
-                  <node concept="2JrnkZ" id="57VdFqPlreY" role="2Oq$k0">
-                    <node concept="37vLTw" id="57VdFqPkMTw" role="2JrQYb">
-                      <ref role="3cqZAo" node="57VdFqPfgDL" resolve="m" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3cpWs8" id="ljKHDcIbRS" role="3cqZAp">
           <node concept="3cpWsn" id="ljKHDcIbRT" role="3cpWs9">
             <property role="TrG5h" value="tec" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -6,6 +6,7 @@
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="-1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="-1" />
     <use id="c3bfea76-7bba-4f0e-b5a2-ff4e7a8d7cf1" name="com.mbeddr.mpsutil.spreferences" version="-1" />
+    <use id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -50,6 +51,7 @@
     <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
     <import index="tmud" ref="c3bfea76-7bba-4f0e-b5a2-ff4e7a8d7cf1/r:8d0fa52a-32d1-4359-892e-669a9b66600c(com.mbeddr.mpsutil.spreferences/com.mbeddr.mpsutil.spreferences.structure)" />
     <import index="w474" ref="r:06b241ed-1779-4f34-8d6f-e61e9dd94387(org.iets3.core.expr.testExecution.plugin)" />
+    <import index="dvox" ref="r:9dfd3567-3b1f-4edb-85a0-3981ca2bfd8c(jetbrains.mps.lang.modelapi.structure)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -2489,6 +2491,25 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbF" id="3GEHGglRraj" role="3cqZAp">
+          <node concept="2OqwBi" id="3GEHGglRrWn" role="3clFbG">
+            <node concept="10M0yZ" id="3GEHGglRrmL" role="2Oq$k0">
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+            </node>
+            <node concept="liA8E" id="3GEHGglRsEq" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="3cpWs3" id="3GEHGglRtvm" role="37wK5m">
+                <node concept="Xl_RD" id="3GEHGglRsEW" role="3uHU7B">
+                  <property role="Xl_RC" value="!!!!! module " />
+                </node>
+                <node concept="3rM5sP" id="3GEHGglRty6" role="3uHU7w">
+                  <property role="3rM5sR" value="~_PreferencesModule#org.iets3.opensource.__spreferences.TestExecutionPreferences" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="ljKHDcIbRS" role="3cqZAp">
           <node concept="3cpWsn" id="ljKHDcIbRT" role="3cpWs9">
             <property role="TrG5h" value="tec" />
@@ -2497,7 +2518,7 @@
             </node>
             <node concept="9H$SH" id="ljKHDcIbRV" role="33vP2m">
               <ref role="9Hxhg" to="w474:3SkjTN1M1kS" resolve="TestExecutionPreferences" />
-              <node concept="3rM5sP" id="ljKHDcIbRW" role="9HWM5">
+              <node concept="3rM5sP" id="3GEHGglTZmf" role="9HWM5">
                 <property role="3rM5sR" value="~_PreferencesModule#org.iets3.opensource.__spreferences.TestExecutionPreferences" />
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -46,13 +46,9 @@
     <import index="tpe3" ref="r:00000000-0000-4000-0000-011c895902d7(jetbrains.mps.baseLanguage.unitTest.structure)" />
     <import index="tp6m" ref="r:00000000-0000-4000-0000-011c895903a2(jetbrains.mps.lang.test.runtime)" />
     <import index="4k19" ref="1fd846c3-c5f9-4b9e-9ecc-e716f7149f86/java:org.hamcrest(Hamcrest/)" />
-    <import index="xk6s" ref="r:7961970e-5737-42e2-b144-9bef3ad8d077(org.iets3.core.expr.tests.behavior)" />
     <import index="6yn5" ref="r:2bfc35a4-8334-4342-8e2a-a54b7cda4a4c(org.iets3.core.expr.testExecution.structure)" />
     <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
-    <import index="tmud" ref="c3bfea76-7bba-4f0e-b5a2-ff4e7a8d7cf1/r:8d0fa52a-32d1-4359-892e-669a9b66600c(com.mbeddr.mpsutil.spreferences/com.mbeddr.mpsutil.spreferences.structure)" />
     <import index="w474" ref="r:06b241ed-1779-4f34-8d6f-e61e9dd94387(org.iets3.core.expr.testExecution.plugin)" />
-    <import index="dvox" ref="r:9dfd3567-3b1f-4edb-85a0-3981ca2bfd8c(jetbrains.mps.lang.modelapi.structure)" />
-    <import index="hypd" ref="r:aa31e43e-9240-4f4d-b6db-5c1c9a86c59e(jetbrains.mps.lang.project.structure)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
   </imports>
   <registry>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -52,6 +52,7 @@
     <import index="tmud" ref="c3bfea76-7bba-4f0e-b5a2-ff4e7a8d7cf1/r:8d0fa52a-32d1-4359-892e-669a9b66600c(com.mbeddr.mpsutil.spreferences/com.mbeddr.mpsutil.spreferences.structure)" />
     <import index="w474" ref="r:06b241ed-1779-4f34-8d6f-e61e9dd94387(org.iets3.core.expr.testExecution.plugin)" />
     <import index="dvox" ref="r:9dfd3567-3b1f-4edb-85a0-3981ca2bfd8c(jetbrains.mps.lang.modelapi.structure)" />
+    <import index="hypd" ref="r:aa31e43e-9240-4f4d-b6db-5c1c9a86c59e(jetbrains.mps.lang.project.structure)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -390,9 +391,6 @@
       </concept>
       <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="334628810661441841" name="jetbrains.mps.lang.smodel.structure.AsSConcept" flags="nn" index="1rGIog" />
-      <concept id="4040588429969021681" name="jetbrains.mps.lang.smodel.structure.ModuleReferenceExpression" flags="nn" index="3rM5sP">
-        <property id="4040588429969021683" name="moduleId" index="3rM5sR" />
-      </concept>
       <concept id="1146171026731" name="jetbrains.mps.lang.smodel.structure.Property_HasValue_Enum" flags="nn" index="3t7uKx">
         <child id="1146171026732" name="value" index="3t7uKA" />
       </concept>
@@ -2346,6 +2344,22 @@
       <ref role="13i0hy" to="tpe5:hSQIE8p" resolve="getSimpleClassName" />
       <node concept="3Tm1VV" id="6VjyfUYe1Ga" role="1B3o_S" />
       <node concept="3clFbS" id="6VjyfUYe2XB" role="3clF47">
+        <node concept="3cpWs8" id="57VdFqPiDia" role="3cqZAp">
+          <node concept="3cpWsn" id="57VdFqPiDib" role="3cpWs9">
+            <property role="TrG5h" value="m" />
+            <node concept="H_c77" id="57VdFqPiDic" role="1tU5fm" />
+            <node concept="2OqwBi" id="57VdFqPiDid" role="33vP2m">
+              <node concept="liA8E" id="57VdFqPiDie" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
+              </node>
+              <node concept="2JrnkZ" id="57VdFqPiDif" role="2Oq$k0">
+                <node concept="13iPFW" id="57VdFqPiDig" role="2JrQYb" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="57VdFqPiDih" role="3cqZAp" />
+        <node concept="3clFbH" id="57VdFqPiDhq" role="3cqZAp" />
         <node concept="3cpWs8" id="6VjyfUYekA1" role="3cqZAp">
           <node concept="3cpWsn" id="6VjyfUYekA2" role="3cpWs9">
             <property role="TrG5h" value="tec" />
@@ -2354,8 +2368,15 @@
             </node>
             <node concept="9H$SH" id="6VjyfUYekA3" role="33vP2m">
               <ref role="9Hxhg" to="w474:3SkjTN1M1kS" resolve="TestExecutionPreferences" />
-              <node concept="3rM5sP" id="6VjyfUYekA4" role="9HWM5">
-                <property role="3rM5sR" value="~_PreferencesModule#org.iets3.opensource.__spreferences.TestExecutionPreferences" />
+              <node concept="2OqwBi" id="57VdFqPlqll" role="9HWM5">
+                <node concept="liA8E" id="57VdFqPlqzy" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SModel.getModule()" resolve="getModule" />
+                </node>
+                <node concept="2JrnkZ" id="57VdFqPlqlq" role="2Oq$k0">
+                  <node concept="37vLTw" id="57VdFqPkSll" role="2JrQYb">
+                    <ref role="3cqZAo" node="57VdFqPiDib" resolve="m" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -2491,6 +2512,22 @@
             </node>
           </node>
         </node>
+        <node concept="3cpWs8" id="57VdFqPfgDI" role="3cqZAp">
+          <node concept="3cpWsn" id="57VdFqPfgDL" role="3cpWs9">
+            <property role="TrG5h" value="m" />
+            <node concept="H_c77" id="57VdFqPfgDG" role="1tU5fm" />
+            <node concept="2OqwBi" id="57VdFqPfhOt" role="33vP2m">
+              <node concept="2JrnkZ" id="57VdFqPfhOy" role="2Oq$k0">
+                <node concept="13iPFW" id="57VdFqPfh09" role="2JrQYb" />
+              </node>
+              <node concept="liA8E" id="57VdFqPkJwF" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SNode.getModel()" resolve="getModel" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="57VdFqPkLxS" role="3cqZAp" />
+        <node concept="3clFbH" id="57VdFqPikSS" role="3cqZAp" />
         <node concept="3clFbF" id="3GEHGglRraj" role="3cqZAp">
           <node concept="2OqwBi" id="3GEHGglRrWn" role="3clFbG">
             <node concept="10M0yZ" id="3GEHGglRrmL" role="2Oq$k0">
@@ -2503,8 +2540,15 @@
                 <node concept="Xl_RD" id="3GEHGglRsEW" role="3uHU7B">
                   <property role="Xl_RC" value="!!!!! module " />
                 </node>
-                <node concept="3rM5sP" id="3GEHGglRty6" role="3uHU7w">
-                  <property role="3rM5sR" value="~_PreferencesModule#org.iets3.opensource.__spreferences.TestExecutionPreferences" />
+                <node concept="2OqwBi" id="57VdFqPlreT" role="3uHU7w">
+                  <node concept="liA8E" id="57VdFqPltIx" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModel.getModule()" resolve="getModule" />
+                  </node>
+                  <node concept="2JrnkZ" id="57VdFqPlreY" role="2Oq$k0">
+                    <node concept="37vLTw" id="57VdFqPkMTw" role="2JrQYb">
+                      <ref role="3cqZAo" node="57VdFqPfgDL" resolve="m" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -2518,8 +2562,15 @@
             </node>
             <node concept="9H$SH" id="ljKHDcIbRV" role="33vP2m">
               <ref role="9Hxhg" to="w474:3SkjTN1M1kS" resolve="TestExecutionPreferences" />
-              <node concept="3rM5sP" id="3GEHGglTZmf" role="9HWM5">
-                <property role="3rM5sR" value="~_PreferencesModule#org.iets3.opensource.__spreferences.TestExecutionPreferences" />
+              <node concept="2OqwBi" id="57VdFqPlujP" role="9HWM5">
+                <node concept="liA8E" id="57VdFqPlx1b" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SModel.getModule()" resolve="getModule" />
+                </node>
+                <node concept="2JrnkZ" id="57VdFqPlujU" role="2Oq$k0">
+                  <node concept="37vLTw" id="57VdFqPkPAU" role="2JrQYb">
+                    <ref role="3cqZAo" node="57VdFqPfgDL" resolve="m" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/org.iets3.core.expr.tests.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/org.iets3.core.expr.tests.mpl
@@ -134,10 +134,8 @@
     <dependency reexport="false">8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)</dependency>
     <dependency reexport="false">707c4fde-f79a-44b5-b3d7-b5cef8844ccf(jetbrains.mps.lang.test.runtime)</dependency>
     <dependency reexport="false">28583149-5b6e-4663-9c02-b9a8fa3cb099(com.mbeddr.mpsutil.contextactions.runtime)</dependency>
-    <dependency reexport="false">c3bfea76-7bba-4f0e-b5a2-ff4e7a8d7cf1(com.mbeddr.mpsutil.spreferences)</dependency>
     <dependency reexport="false">2022a471-10ba-4431-ba5d-622df898f3c6(org.iets3.core.expr.testExecution)</dependency>
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
-    <dependency reexport="false">86ef8290-12bb-4ca7-947f-093788f263a9(jetbrains.mps.lang.project)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3b3dc28-fee3-49e1-a46e-685e96389094:com.mbeddr.mpsutil.bldoc" version="0" />
@@ -219,7 +217,6 @@
     <module reference="1c897ba5-9d43-4035-ac7f-0306495743ac(com.mbeddr.mpsutil.interpreter.test)" version="0" />
     <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />
     <module reference="b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)" version="0" />
-    <module reference="c3bfea76-7bba-4f0e-b5a2-ff4e7a8d7cf1(com.mbeddr.mpsutil.spreferences)" version="0" />
     <module reference="726886d1-ef90-4249-a08f-1e3ec23a7113(com.mbeddr.mpsutil.traceExplorer)" version="0" />
     <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
     <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
@@ -241,7 +238,6 @@
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
     <module reference="18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)" version="0" />
     <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
-    <module reference="86ef8290-12bb-4ca7-947f-093788f263a9(jetbrains.mps.lang.project)" version="0" />
     <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/org.iets3.core.expr.tests.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/org.iets3.core.expr.tests.mpl
@@ -137,6 +137,7 @@
     <dependency reexport="false">c3bfea76-7bba-4f0e-b5a2-ff4e7a8d7cf1(com.mbeddr.mpsutil.spreferences)</dependency>
     <dependency reexport="false">2022a471-10ba-4431-ba5d-622df898f3c6(org.iets3.core.expr.testExecution)</dependency>
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
+    <dependency reexport="false">86ef8290-12bb-4ca7-947f-093788f263a9(jetbrains.mps.lang.project)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3b3dc28-fee3-49e1-a46e-685e96389094:com.mbeddr.mpsutil.bldoc" version="0" />
@@ -240,6 +241,7 @@
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
     <module reference="18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)" version="0" />
     <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
+    <module reference="86ef8290-12bb-4ca7-947f-093788f263a9(jetbrains.mps.lang.project)" version="0" />
     <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/models/plugin.mps
@@ -7685,15 +7685,15 @@
         </node>
         <node concept="fuyK3" id="4BZFyk0pEV2" role="3cqZAp">
           <node concept="2ShNRf" id="4BZFyk0pEV3" role="fuByb">
-            <node concept="HV5vD" id="4ye5wdhZKI7" role="2ShVmc">
-              <ref role="HV5vE" node="4ye5wdhZeLz" resolve="Generator" />
+            <node concept="1pGfFk" id="57VdFqPm5c3" role="2ShVmc">
+              <ref role="37wK5l" node="4ye5wdi0zah" resolve="Generator" />
             </node>
           </node>
         </node>
         <node concept="fuyK3" id="4ye5wdhZKJf" role="3cqZAp">
           <node concept="2ShNRf" id="4ye5wdhZKJg" role="fuByb">
-            <node concept="HV5vD" id="4ye5wdhZKJh" role="2ShVmc">
-              <ref role="HV5vE" node="4ye5wdhZm8Q" resolve="Interpreter" />
+            <node concept="1pGfFk" id="57VdFqPm5c8" role="2ShVmc">
+              <ref role="37wK5l" node="4ye5wdi0$xe" resolve="Interpreter" />
             </node>
           </node>
         </node>
@@ -7748,21 +7748,32 @@
             </node>
           </node>
         </node>
+        <node concept="3cpWs8" id="57VdFqPmBm$" role="3cqZAp">
+          <node concept="3cpWsn" id="57VdFqPmBm_" role="3cpWs9">
+            <property role="TrG5h" value="mpsproj" />
+            <node concept="3uibUv" id="57VdFqPmBmz" role="1tU5fm">
+              <ref role="3uigEE" to="z1c3:~MPSProject" resolve="MPSProject" />
+            </node>
+            <node concept="2YIFZM" id="57VdFqPmBmA" role="33vP2m">
+              <ref role="37wK5l" to="alof:~ProjectHelper.fromIdeaProject(com.intellij.openapi.project.Project)" resolve="fromIdeaProject" />
+              <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+              <node concept="2OqwBi" id="57VdFqPmBmB" role="37wK5m">
+                <node concept="37vLTw" id="57VdFqPmBmC" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4ye5wdhZeRb" resolve="event" />
+                </node>
+                <node concept="liA8E" id="57VdFqPmBmD" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~AnActionEvent.getProject()" resolve="getProject" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="6pNCASbIzik" role="3cqZAp">
           <node concept="2OqwBi" id="6pNCASbI_ic" role="3clFbG">
             <node concept="2OqwBi" id="6pNCASbI$Ic" role="2Oq$k0">
               <node concept="2OqwBi" id="6pNCASbIzOc" role="2Oq$k0">
-                <node concept="2YIFZM" id="6pNCASbIzim" role="2Oq$k0">
-                  <ref role="37wK5l" to="alof:~ProjectHelper.fromIdeaProject(com.intellij.openapi.project.Project)" resolve="fromIdeaProject" />
-                  <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
-                  <node concept="2OqwBi" id="6pNCASbIzin" role="37wK5m">
-                    <node concept="37vLTw" id="6pNCASbIzio" role="2Oq$k0">
-                      <ref role="3cqZAo" node="4ye5wdhZeRb" resolve="event" />
-                    </node>
-                    <node concept="liA8E" id="6pNCASbIzip" role="2OqNvi">
-                      <ref role="37wK5l" to="qkt:~AnActionEvent.getProject()" resolve="getProject" />
-                    </node>
-                  </node>
+                <node concept="37vLTw" id="57VdFqPmBmE" role="2Oq$k0">
+                  <ref role="3cqZAo" node="57VdFqPmBm_" resolve="mpsproj" />
                 </node>
                 <node concept="liA8E" id="6pNCASbI$_M" role="2OqNvi">
                   <ref role="37wK5l" to="z1c4:~Project.getRepository()" resolve="getRepository" />
@@ -7776,6 +7787,25 @@
               <ref role="37wK5l" to="lui2:~ModelAccess.executeCommand(java.lang.Runnable)" resolve="executeCommand" />
               <node concept="1bVj0M" id="6pNCASbIAtp" role="37wK5m">
                 <node concept="3clFbS" id="6pNCASbIAtq" role="1bW5cS">
+                  <node concept="3cpWs8" id="57VdFqPmOku" role="3cqZAp">
+                    <node concept="3cpWsn" id="57VdFqPmOkv" role="3cpWs9">
+                      <property role="TrG5h" value="projectModules" />
+                      <node concept="3uibUv" id="57VdFqPmOkp" role="1tU5fm">
+                        <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                        <node concept="3uibUv" id="57VdFqPmOks" role="11_B2D">
+                          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="57VdFqPmOkw" role="33vP2m">
+                        <node concept="37vLTw" id="57VdFqPmOkx" role="2Oq$k0">
+                          <ref role="3cqZAo" node="57VdFqPmBm_" resolve="mpsproj" />
+                        </node>
+                        <node concept="liA8E" id="57VdFqPmOky" role="2OqNvi">
+                          <ref role="37wK5l" to="z1c4:~ProjectBase.getProjectModules()" resolve="getProjectModules" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
                   <node concept="3cpWs8" id="6pNCASbIAyC" role="3cqZAp">
                     <node concept="3cpWsn" id="6pNCASbIAyD" role="3cpWs9">
                       <property role="TrG5h" value="tec" />
@@ -7784,8 +7814,16 @@
                       </node>
                       <node concept="9H$SH" id="6pNCASbIAyF" role="33vP2m">
                         <ref role="9Hxhg" to="w474:3SkjTN1M1kS" resolve="TestExecutionPreferences" />
-                        <node concept="3rM5sP" id="6pNCASbIAyG" role="9HWM5">
-                          <property role="3rM5sR" value="~_PreferencesModule#org.iets3.opensource.__spreferences.TestExecutionPreferences" />
+                        <node concept="2OqwBi" id="57VdFqPmPwR" role="9HWM5">
+                          <node concept="37vLTw" id="57VdFqPmOkz" role="2Oq$k0">
+                            <ref role="3cqZAo" node="57VdFqPmOkv" resolve="projectModules" />
+                          </node>
+                          <node concept="liA8E" id="57VdFqPmQwq" role="2OqNvi">
+                            <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
+                            <node concept="3cmrfG" id="57VdFqPmR6P" role="37wK5m">
+                              <property role="3cmrfH" value="0" />
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -7845,21 +7883,32 @@
         <node concept="10P_77" id="4ye5wdhZeRo" role="1tU5fm" />
       </node>
       <node concept="3clFbS" id="4ye5wdhZeRp" role="3clF47">
+        <node concept="3cpWs8" id="57VdFqPmRnA" role="3cqZAp">
+          <node concept="3cpWsn" id="57VdFqPmRnB" role="3cpWs9">
+            <property role="TrG5h" value="mpsproj" />
+            <node concept="3uibUv" id="57VdFqPmRnz" role="1tU5fm">
+              <ref role="3uigEE" to="z1c3:~MPSProject" resolve="MPSProject" />
+            </node>
+            <node concept="2YIFZM" id="57VdFqPmRnC" role="33vP2m">
+              <ref role="37wK5l" to="alof:~ProjectHelper.fromIdeaProject(com.intellij.openapi.project.Project)" resolve="fromIdeaProject" />
+              <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+              <node concept="2OqwBi" id="57VdFqPmRnD" role="37wK5m">
+                <node concept="37vLTw" id="57VdFqPmRnE" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4ye5wdhZeRl" resolve="event" />
+                </node>
+                <node concept="liA8E" id="57VdFqPmRnF" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~AnActionEvent.getProject()" resolve="getProject" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="6pNCASbIHtm" role="3cqZAp">
           <node concept="2OqwBi" id="6pNCASbIHtn" role="3clFbG">
             <node concept="2OqwBi" id="6pNCASbIHto" role="2Oq$k0">
               <node concept="2OqwBi" id="6pNCASbIHtp" role="2Oq$k0">
-                <node concept="2YIFZM" id="6pNCASbIHtq" role="2Oq$k0">
-                  <ref role="37wK5l" to="alof:~ProjectHelper.fromIdeaProject(com.intellij.openapi.project.Project)" resolve="fromIdeaProject" />
-                  <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
-                  <node concept="2OqwBi" id="6pNCASbIHtr" role="37wK5m">
-                    <node concept="37vLTw" id="6pNCASbIHts" role="2Oq$k0">
-                      <ref role="3cqZAo" node="4ye5wdhZeRl" resolve="event" />
-                    </node>
-                    <node concept="liA8E" id="6pNCASbIHtt" role="2OqNvi">
-                      <ref role="37wK5l" to="qkt:~AnActionEvent.getProject()" resolve="getProject" />
-                    </node>
-                  </node>
+                <node concept="37vLTw" id="57VdFqPmRnG" role="2Oq$k0">
+                  <ref role="3cqZAo" node="57VdFqPmRnB" resolve="mpsproj" />
                 </node>
                 <node concept="liA8E" id="6pNCASbIHtu" role="2OqNvi">
                   <ref role="37wK5l" to="z1c4:~Project.getRepository()" resolve="getRepository" />
@@ -7873,6 +7922,25 @@
               <ref role="37wK5l" to="lui2:~ModelAccess.executeCommand(java.lang.Runnable)" resolve="executeCommand" />
               <node concept="1bVj0M" id="6pNCASbIHtx" role="37wK5m">
                 <node concept="3clFbS" id="6pNCASbIHty" role="1bW5cS">
+                  <node concept="3cpWs8" id="57VdFqPmRIK" role="3cqZAp">
+                    <node concept="3cpWsn" id="57VdFqPmRIL" role="3cpWs9">
+                      <property role="TrG5h" value="projectModules" />
+                      <node concept="3uibUv" id="57VdFqPmRIM" role="1tU5fm">
+                        <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                        <node concept="3uibUv" id="57VdFqPmRIN" role="11_B2D">
+                          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="57VdFqPmRIO" role="33vP2m">
+                        <node concept="37vLTw" id="57VdFqPmRIP" role="2Oq$k0">
+                          <ref role="3cqZAo" node="57VdFqPmRnB" resolve="mpsproj" />
+                        </node>
+                        <node concept="liA8E" id="57VdFqPmRIQ" role="2OqNvi">
+                          <ref role="37wK5l" to="z1c4:~ProjectBase.getProjectModules()" resolve="getProjectModules" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
                   <node concept="3cpWs8" id="6pNCASbIHtz" role="3cqZAp">
                     <node concept="3cpWsn" id="6pNCASbIHt$" role="3cpWs9">
                       <property role="TrG5h" value="tec" />
@@ -7881,8 +7949,16 @@
                       </node>
                       <node concept="9H$SH" id="6pNCASbIHtA" role="33vP2m">
                         <ref role="9Hxhg" to="w474:3SkjTN1M1kS" resolve="TestExecutionPreferences" />
-                        <node concept="3rM5sP" id="6pNCASbIHtB" role="9HWM5">
-                          <property role="3rM5sR" value="~_PreferencesModule#org.iets3.opensource.__spreferences.TestExecutionPreferences" />
+                        <node concept="2OqwBi" id="57VdFqPmRTE" role="9HWM5">
+                          <node concept="37vLTw" id="57VdFqPmRTF" role="2Oq$k0">
+                            <ref role="3cqZAo" node="57VdFqPmRIL" resolve="projectModules" />
+                          </node>
+                          <node concept="liA8E" id="57VdFqPmRTG" role="2OqNvi">
+                            <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
+                            <node concept="3cmrfG" id="57VdFqPmRTH" role="37wK5m">
+                              <property role="3cmrfH" value="0" />
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/models/plugin.mps
@@ -75,7 +75,6 @@
     <import index="kqnq" ref="r:7628c3bd-6988-4d33-9682-86b8cef4b8c0(com.mbeddr.mpsutil.interpreter.behavior)" implicit="true" />
     <import index="71xd" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.tools(MPS.Platform/)" implicit="true" />
     <import index="tprs" ref="r:00000000-0000-4000-0000-011c895904a4(jetbrains.mps.ide.actions)" implicit="true" />
-    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -469,9 +468,6 @@
       </concept>
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
-      </concept>
-      <concept id="4040588429969021681" name="jetbrains.mps.lang.smodel.structure.ModuleReferenceExpression" flags="nn" index="3rM5sP">
-        <property id="4040588429969021683" name="moduleId" index="3rM5sR" />
       </concept>
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
@@ -7807,35 +7803,6 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbF" id="AG_FWsrTgJ" role="3cqZAp">
-                    <node concept="2OqwBi" id="AG_FWsrTVC" role="3clFbG">
-                      <node concept="10M0yZ" id="AG_FWsrToU" role="2Oq$k0">
-                        <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
-                        <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-                      </node>
-                      <node concept="liA8E" id="AG_FWsrVam" role="2OqNvi">
-                        <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
-                        <node concept="3cpWs3" id="AG_FWsrYxk" role="37wK5m">
-                          <node concept="37vLTw" id="AG_FWsrZhu" role="3uHU7w">
-                            <ref role="3cqZAo" node="57VdFqPmOkv" resolve="projectModules" />
-                          </node>
-                          <node concept="3cpWs3" id="AG_FWssx2L" role="3uHU7B">
-                            <node concept="Xl_RD" id="AG_FWsswch" role="3uHU7w">
-                              <property role="Xl_RC" value=" " />
-                            </node>
-                            <node concept="3cpWs3" id="AG_FWssvKe" role="3uHU7B">
-                              <node concept="Xl_RD" id="AG_FWsrVAT" role="3uHU7B">
-                                <property role="Xl_RC" value="!!!!! plugin: " />
-                              </node>
-                              <node concept="37vLTw" id="AG_FWssxGu" role="3uHU7w">
-                                <ref role="3cqZAo" node="57VdFqPmBm_" resolve="mpsproj" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
                   <node concept="3cpWs8" id="6pNCASbIAyC" role="3cqZAp">
                     <node concept="3cpWsn" id="6pNCASbIAyD" role="3cpWs9">
                       <property role="TrG5h" value="tec" />
@@ -7971,35 +7938,6 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbF" id="AG_FWss05v" role="3cqZAp">
-                    <node concept="2OqwBi" id="AG_FWss0D1" role="3clFbG">
-                      <node concept="10M0yZ" id="AG_FWss0cv" role="2Oq$k0">
-                        <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
-                        <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-                      </node>
-                      <node concept="liA8E" id="AG_FWss1se" role="2OqNvi">
-                        <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
-                        <node concept="3cpWs3" id="AG_FWss48x" role="37wK5m">
-                          <node concept="37vLTw" id="AG_FWss4xf" role="3uHU7w">
-                            <ref role="3cqZAo" node="57VdFqPmRIL" resolve="projectModules" />
-                          </node>
-                          <node concept="3cpWs3" id="AG_FWsszFs" role="3uHU7B">
-                            <node concept="Xl_RD" id="AG_FWssyK$" role="3uHU7w">
-                              <property role="Xl_RC" value=" " />
-                            </node>
-                            <node concept="3cpWs3" id="AG_FWssyqW" role="3uHU7B">
-                              <node concept="Xl_RD" id="AG_FWss1T8" role="3uHU7B">
-                                <property role="Xl_RC" value="!!!!!! plugin: " />
-                              </node>
-                              <node concept="37vLTw" id="AG_FWss$eI" role="3uHU7w">
-                                <ref role="3cqZAo" node="57VdFqPmRnB" resolve="mpsproj" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
                   <node concept="3cpWs8" id="6pNCASbIHtz" role="3cqZAp">
                     <node concept="3cpWsn" id="6pNCASbIHt$" role="3cpWs9">
                       <property role="TrG5h" value="tec" />
@@ -8042,7 +7980,6 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="6$CIdY$$awB" role="3cqZAp" />
       </node>
       <node concept="2AHcQZ" id="4ye5wdhZeRq" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
@@ -8091,21 +8028,32 @@
             </node>
           </node>
         </node>
+        <node concept="3cpWs8" id="5MbB62qyUuz" role="3cqZAp">
+          <node concept="3cpWsn" id="5MbB62qyUu$" role="3cpWs9">
+            <property role="TrG5h" value="mpsproj" />
+            <node concept="3uibUv" id="5MbB62qyUu_" role="1tU5fm">
+              <ref role="3uigEE" to="z1c3:~MPSProject" resolve="MPSProject" />
+            </node>
+            <node concept="2YIFZM" id="5MbB62qyUuA" role="33vP2m">
+              <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+              <ref role="37wK5l" to="alof:~ProjectHelper.fromIdeaProject(com.intellij.openapi.project.Project)" resolve="fromIdeaProject" />
+              <node concept="2OqwBi" id="5MbB62qyUuB" role="37wK5m">
+                <node concept="37vLTw" id="5MbB62qyUuC" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4ye5wdhZm8W" resolve="event" />
+                </node>
+                <node concept="liA8E" id="5MbB62qyUuD" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~AnActionEvent.getProject()" resolve="getProject" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="6pNCASbIIig" role="3cqZAp">
           <node concept="2OqwBi" id="6pNCASbIIih" role="3clFbG">
             <node concept="2OqwBi" id="6pNCASbIIii" role="2Oq$k0">
               <node concept="2OqwBi" id="6pNCASbIIij" role="2Oq$k0">
-                <node concept="2YIFZM" id="6pNCASbIIik" role="2Oq$k0">
-                  <ref role="37wK5l" to="alof:~ProjectHelper.fromIdeaProject(com.intellij.openapi.project.Project)" resolve="fromIdeaProject" />
-                  <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
-                  <node concept="2OqwBi" id="6pNCASbIIil" role="37wK5m">
-                    <node concept="37vLTw" id="6pNCASbIIim" role="2Oq$k0">
-                      <ref role="3cqZAo" node="4ye5wdhZm8W" resolve="event" />
-                    </node>
-                    <node concept="liA8E" id="6pNCASbIIin" role="2OqNvi">
-                      <ref role="37wK5l" to="qkt:~AnActionEvent.getProject()" resolve="getProject" />
-                    </node>
-                  </node>
+                <node concept="37vLTw" id="5MbB62qz1PQ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5MbB62qyUu$" resolve="mpsproj" />
                 </node>
                 <node concept="liA8E" id="6pNCASbIIio" role="2OqNvi">
                   <ref role="37wK5l" to="z1c4:~Project.getRepository()" resolve="getRepository" />
@@ -8119,6 +8067,25 @@
               <ref role="37wK5l" to="lui2:~ModelAccess.executeCommand(java.lang.Runnable)" resolve="executeCommand" />
               <node concept="1bVj0M" id="6pNCASbIIir" role="37wK5m">
                 <node concept="3clFbS" id="6pNCASbIIis" role="1bW5cS">
+                  <node concept="3cpWs8" id="5MbB62qyTgi" role="3cqZAp">
+                    <node concept="3cpWsn" id="5MbB62qyTgj" role="3cpWs9">
+                      <property role="TrG5h" value="projectModules" />
+                      <node concept="3uibUv" id="5MbB62qyTgk" role="1tU5fm">
+                        <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                        <node concept="3uibUv" id="5MbB62qyTgl" role="11_B2D">
+                          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="5MbB62qyTgm" role="33vP2m">
+                        <node concept="37vLTw" id="5MbB62qyTgn" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5MbB62qyUu$" resolve="mpsproj" />
+                        </node>
+                        <node concept="liA8E" id="5MbB62qyTgo" role="2OqNvi">
+                          <ref role="37wK5l" to="z1c4:~ProjectBase.getProjectModules()" resolve="getProjectModules" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
                   <node concept="3cpWs8" id="6pNCASbIIit" role="3cqZAp">
                     <node concept="3cpWsn" id="6pNCASbIIiu" role="3cpWs9">
                       <property role="TrG5h" value="tec" />
@@ -8127,8 +8094,16 @@
                       </node>
                       <node concept="9H$SH" id="6pNCASbIIiw" role="33vP2m">
                         <ref role="9Hxhg" to="w474:3SkjTN1M1kS" resolve="TestExecutionPreferences" />
-                        <node concept="3rM5sP" id="6pNCASbIIix" role="9HWM5">
-                          <property role="3rM5sR" value="~_PreferencesModule#org.iets3.opensource.__spreferences.TestExecutionPreferences" />
+                        <node concept="2OqwBi" id="5MbB62qz2PO" role="9HWM5">
+                          <node concept="37vLTw" id="5MbB62qz2PP" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5MbB62qyTgj" resolve="projectModules" />
+                          </node>
+                          <node concept="liA8E" id="5MbB62qz2PQ" role="2OqNvi">
+                            <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
+                            <node concept="3cmrfG" id="5MbB62qz2PR" role="37wK5m">
+                              <property role="3cmrfH" value="0" />
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -8188,6 +8163,26 @@
         <node concept="10P_77" id="4ye5wdhZm9h" role="1tU5fm" />
       </node>
       <node concept="3clFbS" id="4ye5wdhZm9i" role="3clF47">
+        <node concept="3cpWs8" id="5MbB62qz47X" role="3cqZAp">
+          <node concept="3cpWsn" id="5MbB62qz47Y" role="3cpWs9">
+            <property role="TrG5h" value="mpsproj" />
+            <node concept="3uibUv" id="5MbB62qz47Z" role="1tU5fm">
+              <ref role="3uigEE" to="z1c3:~MPSProject" resolve="MPSProject" />
+            </node>
+            <node concept="2YIFZM" id="5MbB62qz480" role="33vP2m">
+              <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+              <ref role="37wK5l" to="alof:~ProjectHelper.fromIdeaProject(com.intellij.openapi.project.Project)" resolve="fromIdeaProject" />
+              <node concept="2OqwBi" id="5MbB62qz481" role="37wK5m">
+                <node concept="37vLTw" id="5MbB62qz482" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4ye5wdhZm9e" resolve="event" />
+                </node>
+                <node concept="liA8E" id="5MbB62qz483" role="2OqNvi">
+                  <ref role="37wK5l" to="qkt:~AnActionEvent.getProject()" resolve="getProject" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="6pNCASbIIOu" role="3cqZAp">
           <node concept="2OqwBi" id="6pNCASbIIOv" role="3clFbG">
             <node concept="2OqwBi" id="6pNCASbIIOw" role="2Oq$k0">
@@ -8216,6 +8211,25 @@
               <ref role="37wK5l" to="lui2:~ModelAccess.executeCommand(java.lang.Runnable)" resolve="executeCommand" />
               <node concept="1bVj0M" id="6pNCASbIIOD" role="37wK5m">
                 <node concept="3clFbS" id="6pNCASbIIOE" role="1bW5cS">
+                  <node concept="3cpWs8" id="5MbB62qz5EH" role="3cqZAp">
+                    <node concept="3cpWsn" id="5MbB62qz5EI" role="3cpWs9">
+                      <property role="TrG5h" value="projectModules" />
+                      <node concept="3uibUv" id="5MbB62qz5EJ" role="1tU5fm">
+                        <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                        <node concept="3uibUv" id="5MbB62qz5EK" role="11_B2D">
+                          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="5MbB62qz5EL" role="33vP2m">
+                        <node concept="37vLTw" id="5MbB62qz5EM" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5MbB62qz47Y" resolve="mpsproj" />
+                        </node>
+                        <node concept="liA8E" id="5MbB62qz5EN" role="2OqNvi">
+                          <ref role="37wK5l" to="z1c4:~ProjectBase.getProjectModules()" resolve="getProjectModules" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
                   <node concept="3cpWs8" id="6pNCASbIIOF" role="3cqZAp">
                     <node concept="3cpWsn" id="6pNCASbIIOG" role="3cpWs9">
                       <property role="TrG5h" value="tec" />
@@ -8224,8 +8238,16 @@
                       </node>
                       <node concept="9H$SH" id="6pNCASbIIOI" role="33vP2m">
                         <ref role="9Hxhg" to="w474:3SkjTN1M1kS" resolve="TestExecutionPreferences" />
-                        <node concept="3rM5sP" id="6pNCASbIIOJ" role="9HWM5">
-                          <property role="3rM5sR" value="~_PreferencesModule#org.iets3.opensource.__spreferences.TestExecutionPreferences" />
+                        <node concept="2OqwBi" id="5MbB62qz3iV" role="9HWM5">
+                          <node concept="37vLTw" id="5MbB62qz3iW" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5MbB62qz5EI" resolve="projectModules" />
+                          </node>
+                          <node concept="liA8E" id="5MbB62qz3iX" role="2OqNvi">
+                            <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
+                            <node concept="3cmrfG" id="5MbB62qz3iY" role="37wK5m">
+                              <property role="3cmrfH" value="0" />
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/models/plugin.mps
@@ -75,6 +75,7 @@
     <import index="kqnq" ref="r:7628c3bd-6988-4d33-9682-86b8cef4b8c0(com.mbeddr.mpsutil.interpreter.behavior)" implicit="true" />
     <import index="71xd" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.tools(MPS.Platform/)" implicit="true" />
     <import index="tprs" ref="r:00000000-0000-4000-0000-011c895904a4(jetbrains.mps.ide.actions)" implicit="true" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -7806,6 +7807,35 @@
                       </node>
                     </node>
                   </node>
+                  <node concept="3clFbF" id="AG_FWsrTgJ" role="3cqZAp">
+                    <node concept="2OqwBi" id="AG_FWsrTVC" role="3clFbG">
+                      <node concept="10M0yZ" id="AG_FWsrToU" role="2Oq$k0">
+                        <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+                        <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                      </node>
+                      <node concept="liA8E" id="AG_FWsrVam" role="2OqNvi">
+                        <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                        <node concept="3cpWs3" id="AG_FWsrYxk" role="37wK5m">
+                          <node concept="37vLTw" id="AG_FWsrZhu" role="3uHU7w">
+                            <ref role="3cqZAo" node="57VdFqPmOkv" resolve="projectModules" />
+                          </node>
+                          <node concept="3cpWs3" id="AG_FWssx2L" role="3uHU7B">
+                            <node concept="Xl_RD" id="AG_FWsswch" role="3uHU7w">
+                              <property role="Xl_RC" value=" " />
+                            </node>
+                            <node concept="3cpWs3" id="AG_FWssvKe" role="3uHU7B">
+                              <node concept="Xl_RD" id="AG_FWsrVAT" role="3uHU7B">
+                                <property role="Xl_RC" value="!!!!! plugin: " />
+                              </node>
+                              <node concept="37vLTw" id="AG_FWssxGu" role="3uHU7w">
+                                <ref role="3cqZAo" node="57VdFqPmBm_" resolve="mpsproj" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
                   <node concept="3cpWs8" id="6pNCASbIAyC" role="3cqZAp">
                     <node concept="3cpWsn" id="6pNCASbIAyD" role="3cpWs9">
                       <property role="TrG5h" value="tec" />
@@ -7937,6 +7967,35 @@
                         </node>
                         <node concept="liA8E" id="57VdFqPmRIQ" role="2OqNvi">
                           <ref role="37wK5l" to="z1c4:~ProjectBase.getProjectModules()" resolve="getProjectModules" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="AG_FWss05v" role="3cqZAp">
+                    <node concept="2OqwBi" id="AG_FWss0D1" role="3clFbG">
+                      <node concept="10M0yZ" id="AG_FWss0cv" role="2Oq$k0">
+                        <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+                        <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                      </node>
+                      <node concept="liA8E" id="AG_FWss1se" role="2OqNvi">
+                        <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                        <node concept="3cpWs3" id="AG_FWss48x" role="37wK5m">
+                          <node concept="37vLTw" id="AG_FWss4xf" role="3uHU7w">
+                            <ref role="3cqZAo" node="57VdFqPmRIL" resolve="projectModules" />
+                          </node>
+                          <node concept="3cpWs3" id="AG_FWsszFs" role="3uHU7B">
+                            <node concept="Xl_RD" id="AG_FWssyK$" role="3uHU7w">
+                              <property role="Xl_RC" value=" " />
+                            </node>
+                            <node concept="3cpWs3" id="AG_FWssyqW" role="3uHU7B">
+                              <node concept="Xl_RD" id="AG_FWss1T8" role="3uHU7B">
+                                <property role="Xl_RC" value="!!!!!! plugin: " />
+                              </node>
+                              <node concept="37vLTw" id="AG_FWss$eI" role="3uHU7w">
+                                <ref role="3cqZAo" node="57VdFqPmRnB" resolve="mpsproj" />
+                              </node>
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>


### PR DESCRIPTION
Switching between test execution with generator and interpreter already worked within iets3.opensource. It worked as well for depending projects, when iets3.opensource was opened in mps together with the depending project.

Changing the Module access from hardcoded to calculated makes it now also work for depending projects when iets3.opensource is only available through artifacts.