### PR TITLE
Updates to messages

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
@@ -7728,7 +7728,7 @@
     <property role="TrG5h" value="typeof_FailExpr" />
     <node concept="3clFbS" id="mQGcCvPugI" role="18ibNy">
       <node concept="1ZobV4" id="mQGcCvPvmA" role="3cqZAp">
-        <property role="3wDh2S" value="false" />
+        <property role="3wDh2S" value="true" />
         <node concept="mw_s8" id="mQGcCvPvmC" role="1ZfhK$">
           <node concept="1Z2H0r" id="mQGcCvPvmD" role="mwGJk">
             <node concept="2OqwBi" id="mQGcCvPvmE" role="1Z2MuG">
@@ -7741,13 +7741,29 @@
             </node>
           </node>
         </node>
-        <node concept="mw_s8" id="mQGcCvPvpo" role="1ZfhKB">
-          <node concept="2YIFZM" id="5wDe8wA6zrS" role="mwGJk">
-            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
-            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+        <node concept="mw_s8" id="5GmVcyjQw4f" role="1ZfhKB">
+          <node concept="2pJPEk" id="5GmVcyjQw49" role="mwGJk">
+            <node concept="2pJPED" id="5GmVcyjQw4q" role="2pJPEn">
+              <ref role="2pJxaS" to="tpd4:hausRW2" resolve="JoinType" />
+              <node concept="2pIpSj" id="5GmVcyjQw4r" role="2pJxcM">
+                <ref role="2pIpSl" to="tpd4:hausUtE" resolve="argument" />
+                <node concept="36be1Y" id="5GmVcyjQw4s" role="2pJxcZ">
+                  <node concept="36biLy" id="5GmVcyjQw4t" role="36be1Z">
+                    <node concept="2YIFZM" id="5GmVcyjQw4u" role="36biLW">
+                      <ref role="1Pybhc" to="oq0c:2Qbt$1tTQaH" resolve="PTF" />
+                      <ref role="37wK5l" to="oq0c:2Qbt$1tTQdA" resolve="createStringType" />
+                    </node>
+                  </node>
+                  <node concept="2pJPED" id="5GmVcyjQw4v" role="36be1Z">
+                    <ref role="2pJxaS" to="hm2y:4AahbtULQzU" resolve="MessageValueType" />
+                  </node>
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
+      <node concept="3clFbH" id="5GmVcyjQw71" role="3cqZAp" />
       <node concept="3clFbJ" id="6jT4GDwgBEs" role="3cqZAp">
         <node concept="3clFbS" id="6jT4GDwgBEt" role="3clFbx">
           <node concept="1Z5TYs" id="6jT4GDwgBEu" role="3cqZAp">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/main@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/main@generator.mps
@@ -373,7 +373,11 @@
       <concept id="1138661924179" name="jetbrains.mps.lang.smodel.structure.Property_SetOperation" flags="nn" index="tyxLq">
         <child id="1138662048170" name="value" index="tz02z" />
       </concept>
+      <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
+        <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
+      </concept>
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
+      <concept id="8758390115028452779" name="jetbrains.mps.lang.smodel.structure.Node_GetReferencesOperation" flags="nn" index="2z74zc" />
       <concept id="1173122760281" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorsOperation" flags="nn" index="z$bX8" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
@@ -393,6 +397,7 @@
         <child id="1145567471833" name="createdType" index="2T96Bj" />
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="4124388153790980106" name="jetbrains.mps.lang.smodel.structure.Reference_GetTargetOperation" flags="nn" index="2ZHEkA" />
       <concept id="3562215692195599741" name="jetbrains.mps.lang.smodel.structure.SLinkImplicitSelect" flags="nn" index="13MTOL">
         <reference id="3562215692195600259" name="link" index="13MTZf" />
       </concept>
@@ -402,6 +407,7 @@
       </concept>
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
@@ -477,10 +483,12 @@
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
+      <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
@@ -18851,266 +18859,268 @@
   <node concept="13MO4I" id="lH$Puhb0bi">
     <property role="TrG5h" value="reduce_ContractItemError2MessageValue" />
     <ref role="3gUMe" to="hm2y:KaZMgy4Ils" resolve="ContractItem" />
-    <node concept="2OqwBi" id="kKmKqg6uBE" role="13RCb5">
-      <node concept="2YIFZM" id="lH$Puhb5$6" role="2Oq$k0">
-        <ref role="1Pybhc" to="vj64:4NeJNX_xLh$" resolve="Message" />
-        <ref role="37wK5l" to="vj64:1aR2a4nX_QO" resolve="fromText" />
-        <node concept="Xl_RD" id="lH$Puhb5$j" role="37wK5m">
-          <property role="Xl_RC" value="xyz" />
-        </node>
-        <node concept="1W57fq" id="lH$Puhb5_c" role="lGtFl">
-          <node concept="3IZrLx" id="lH$Puhb5_d" role="3IZSJc">
-            <node concept="3clFbS" id="lH$Puhb5_e" role="2VODD2">
-              <node concept="3clFbF" id="lH$Puhb5GP" role="3cqZAp">
-                <node concept="2OqwBi" id="lH$Puhb7YP" role="3clFbG">
-                  <node concept="2OqwBi" id="lH$Puhb6Vd" role="2Oq$k0">
-                    <node concept="2OqwBi" id="lH$Puhb5UW" role="2Oq$k0">
-                      <node concept="30H73N" id="lH$Puhb5GO" role="2Oq$k0" />
-                      <node concept="3TrEf2" id="lH$Puhb6kW" role="2OqNvi">
-                        <ref role="3Tt5mk" to="hm2y:5F8uib8hsjE" resolve="err" />
+    <node concept="2OqwBi" id="TA$XW2lGxO" role="13RCb5">
+      <node concept="2OqwBi" id="kKmKqg6uBE" role="2Oq$k0">
+        <node concept="2YIFZM" id="lH$Puhb5$6" role="2Oq$k0">
+          <ref role="1Pybhc" to="vj64:4NeJNX_xLh$" resolve="Message" />
+          <ref role="37wK5l" to="vj64:1aR2a4nX_QO" resolve="fromText" />
+          <node concept="Xl_RD" id="lH$Puhb5$j" role="37wK5m">
+            <property role="Xl_RC" value="xyz" />
+          </node>
+          <node concept="1W57fq" id="lH$Puhb5_c" role="lGtFl">
+            <node concept="3IZrLx" id="lH$Puhb5_d" role="3IZSJc">
+              <node concept="3clFbS" id="lH$Puhb5_e" role="2VODD2">
+                <node concept="3clFbF" id="lH$Puhb5GP" role="3cqZAp">
+                  <node concept="2OqwBi" id="lH$Puhb7YP" role="3clFbG">
+                    <node concept="2OqwBi" id="lH$Puhb6Vd" role="2Oq$k0">
+                      <node concept="2OqwBi" id="lH$Puhb5UW" role="2Oq$k0">
+                        <node concept="30H73N" id="lH$Puhb5GO" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="lH$Puhb6kW" role="2OqNvi">
+                          <ref role="3Tt5mk" to="hm2y:5F8uib8hsjE" resolve="err" />
+                        </node>
                       </node>
+                      <node concept="3JvlWi" id="lH$Puhb7qZ" role="2OqNvi" />
                     </node>
-                    <node concept="3JvlWi" id="lH$Puhb7qZ" role="2OqNvi" />
-                  </node>
-                  <node concept="1mIQ4w" id="lH$Puhb8pO" role="2OqNvi">
-                    <node concept="chp4Y" id="lH$Puhb8_A" role="cj9EA">
-                      <ref role="cht4Q" to="hm2y:4AahbtULQzU" resolve="MessageValueType" />
+                    <node concept="1mIQ4w" id="lH$Puhb8pO" role="2OqNvi">
+                      <node concept="chp4Y" id="lH$Puhb8_A" role="cj9EA">
+                        <ref role="cht4Q" to="hm2y:4AahbtULQzU" resolve="MessageValueType" />
+                      </node>
                     </node>
                   </node>
                 </node>
               </node>
             </node>
-          </node>
-          <node concept="gft3U" id="lH$PuhbaUz" role="UU_$l">
-            <node concept="2ShNRf" id="lH$Puhbbdx" role="gfFT$">
-              <node concept="1pGfFk" id="lH$Puhbbzh" role="2ShVmc">
-                <ref role="37wK5l" to="vj64:lH$PuhbfPv" resolve="Message" />
-                <node concept="2YIFZM" id="lH$PuhbcOZ" role="37wK5m">
-                  <ref role="37wK5l" to="vj64:55imU6w9XVW" resolve="warning" />
-                  <ref role="1Pybhc" to="vj64:55imU6w9XcV" resolve="BuiltinMessageKinds" />
-                  <node concept="1W57fq" id="lH$PuhbcP0" role="lGtFl">
-                    <node concept="3IZrLx" id="lH$PuhbcP1" role="3IZSJc">
-                      <node concept="3clFbS" id="lH$PuhbcP2" role="2VODD2">
-                        <node concept="3clFbF" id="lH$PuhbcP3" role="3cqZAp">
-                          <node concept="2OqwBi" id="lH$PuhbcP4" role="3clFbG">
-                            <node concept="30H73N" id="lH$PuhbcP5" role="2Oq$k0" />
-                            <node concept="3TrcHB" id="lH$PuhbcP6" role="2OqNvi">
-                              <ref role="3TsBF5" to="hm2y:3xthw2gJs74" resolve="warning" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="gft3U" id="lH$Puhbd9g" role="UU_$l">
-                      <node concept="2YIFZM" id="lH$PuhbdjS" role="gfFT$">
-                        <ref role="1Pybhc" to="vj64:55imU6w9XcV" resolve="BuiltinMessageKinds" />
-                        <ref role="37wK5l" to="vj64:5LerK4rfeKq" resolve="error" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="Xl_RD" id="lH$Puhbdkc" role="37wK5m">
-                  <property role="Xl_RC" value="text" />
-                  <node concept="1W57fq" id="lH$PuhcIeF" role="lGtFl">
-                    <node concept="3IZrLx" id="lH$PuhcIeG" role="3IZSJc">
-                      <node concept="3clFbS" id="lH$PuhcIeH" role="2VODD2">
-                        <node concept="3clFbF" id="lH$PuhcItv" role="3cqZAp">
-                          <node concept="3y3z36" id="lH$PuhcJoZ" role="3clFbG">
-                            <node concept="10Nm6u" id="lH$PuhcJpd" role="3uHU7w" />
-                            <node concept="2OqwBi" id="lH$PuhcIFA" role="3uHU7B">
-                              <node concept="30H73N" id="lH$PuhcItu" role="2Oq$k0" />
-                              <node concept="3TrEf2" id="lH$PuhcIX6" role="2OqNvi">
-                                <ref role="3Tt5mk" to="hm2y:5F8uib8hsjE" resolve="err" />
+            <node concept="gft3U" id="lH$PuhbaUz" role="UU_$l">
+              <node concept="2ShNRf" id="lH$Puhbbdx" role="gfFT$">
+                <node concept="1pGfFk" id="lH$Puhbbzh" role="2ShVmc">
+                  <ref role="37wK5l" to="vj64:lH$PuhbfPv" resolve="Message" />
+                  <node concept="2YIFZM" id="lH$PuhbcOZ" role="37wK5m">
+                    <ref role="37wK5l" to="vj64:55imU6w9XVW" resolve="warning" />
+                    <ref role="1Pybhc" to="vj64:55imU6w9XcV" resolve="BuiltinMessageKinds" />
+                    <node concept="1W57fq" id="lH$PuhbcP0" role="lGtFl">
+                      <node concept="3IZrLx" id="lH$PuhbcP1" role="3IZSJc">
+                        <node concept="3clFbS" id="lH$PuhbcP2" role="2VODD2">
+                          <node concept="3clFbF" id="lH$PuhbcP3" role="3cqZAp">
+                            <node concept="2OqwBi" id="lH$PuhbcP4" role="3clFbG">
+                              <node concept="30H73N" id="lH$PuhbcP5" role="2Oq$k0" />
+                              <node concept="3TrcHB" id="lH$PuhbcP6" role="2OqNvi">
+                                <ref role="3TsBF5" to="hm2y:3xthw2gJs74" resolve="warning" />
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
+                      <node concept="gft3U" id="lH$Puhbd9g" role="UU_$l">
+                        <node concept="2YIFZM" id="lH$PuhbdjS" role="gfFT$">
+                          <ref role="1Pybhc" to="vj64:55imU6w9XcV" resolve="BuiltinMessageKinds" />
+                          <ref role="37wK5l" to="vj64:5LerK4rfeKq" resolve="error" />
+                        </node>
+                      </node>
                     </node>
-                    <node concept="gft3U" id="lH$PuhcK4$" role="UU_$l">
-                      <node concept="3cpWs3" id="lH$PuiKhI5" role="gfFT$">
-                        <node concept="Xl_RD" id="lH$PuiKhI8" role="3uHU7w">
-                          <property role="Xl_RC" value="presentation" />
-                          <node concept="17Uvod" id="lH$PuiKhRj" role="lGtFl">
-                            <property role="2qtEX9" value="value" />
-                            <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                            <node concept="3zFVjK" id="lH$PuiKhRk" role="3zH0cK">
-                              <node concept="3clFbS" id="lH$PuiKhRl" role="2VODD2">
-                                <node concept="3clFbF" id="lH$PuiKi4p" role="3cqZAp">
-                                  <node concept="2OqwBi" id="6XE8Bc_9qj2" role="3clFbG">
-                                    <node concept="2OqwBi" id="6XE8Bc_2PWB" role="2Oq$k0">
-                                      <node concept="1iwH7S" id="6XE8Bc_2Psn" role="2Oq$k0" />
-                                      <node concept="12$id9" id="6XE8Bc_2Qz8" role="2OqNvi">
-                                        <node concept="2OqwBi" id="6imM90AyGJ1" role="12$y8L">
-                                          <node concept="30H73N" id="6XE8Bc_2QXl" role="2Oq$k0" />
-                                          <node concept="3TrEf2" id="6imM90AyHmT" role="2OqNvi">
-                                            <ref role="3Tt5mk" to="hm2y:KaZMgy4Ilu" resolve="expr" />
+                  </node>
+                  <node concept="Xl_RD" id="lH$Puhbdkc" role="37wK5m">
+                    <property role="Xl_RC" value="text" />
+                    <node concept="1W57fq" id="lH$PuhcIeF" role="lGtFl">
+                      <node concept="3IZrLx" id="lH$PuhcIeG" role="3IZSJc">
+                        <node concept="3clFbS" id="lH$PuhcIeH" role="2VODD2">
+                          <node concept="3clFbF" id="lH$PuhcItv" role="3cqZAp">
+                            <node concept="3y3z36" id="lH$PuhcJoZ" role="3clFbG">
+                              <node concept="10Nm6u" id="lH$PuhcJpd" role="3uHU7w" />
+                              <node concept="2OqwBi" id="lH$PuhcIFA" role="3uHU7B">
+                                <node concept="30H73N" id="lH$PuhcItu" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="lH$PuhcIX6" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="hm2y:5F8uib8hsjE" resolve="err" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gft3U" id="lH$PuhcK4$" role="UU_$l">
+                        <node concept="3cpWs3" id="lH$PuiKhI5" role="gfFT$">
+                          <node concept="Xl_RD" id="lH$PuiKhI8" role="3uHU7w">
+                            <property role="Xl_RC" value="presentation" />
+                            <node concept="17Uvod" id="lH$PuiKhRj" role="lGtFl">
+                              <property role="2qtEX9" value="value" />
+                              <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                              <node concept="3zFVjK" id="lH$PuiKhRk" role="3zH0cK">
+                                <node concept="3clFbS" id="lH$PuiKhRl" role="2VODD2">
+                                  <node concept="3clFbF" id="lH$PuiKi4p" role="3cqZAp">
+                                    <node concept="2OqwBi" id="6XE8Bc_9qj2" role="3clFbG">
+                                      <node concept="2OqwBi" id="6XE8Bc_2PWB" role="2Oq$k0">
+                                        <node concept="1iwH7S" id="6XE8Bc_2Psn" role="2Oq$k0" />
+                                        <node concept="12$id9" id="6XE8Bc_2Qz8" role="2OqNvi">
+                                          <node concept="2OqwBi" id="6imM90AyGJ1" role="12$y8L">
+                                            <node concept="30H73N" id="6XE8Bc_2QXl" role="2Oq$k0" />
+                                            <node concept="3TrEf2" id="6imM90AyHmT" role="2OqNvi">
+                                              <ref role="3Tt5mk" to="hm2y:KaZMgy4Ilu" resolve="expr" />
+                                            </node>
                                           </node>
                                         </node>
                                       </node>
-                                    </node>
-                                    <node concept="2qgKlT" id="6XE8Bc_9r0s" role="2OqNvi">
-                                      <ref role="37wK5l" to="tpcu:22G2W3WJ92t" resolve="getDetailedPresentation" />
+                                      <node concept="2qgKlT" id="6XE8Bc_9r0s" role="2OqNvi">
+                                        <ref role="37wK5l" to="tpcu:22G2W3WJ92t" resolve="getDetailedPresentation" />
+                                      </node>
                                     </node>
                                   </node>
                                 </node>
                               </node>
                             </node>
                           </node>
-                        </node>
-                        <node concept="3cpWs3" id="lH$PuiKhfM" role="3uHU7B">
-                          <node concept="10M0yZ" id="lH$PuhcKzB" role="3uHU7B">
-                            <ref role="1PxDUh" to="vsv5:10wUh3OyTwB" resolve="ContractViolatedException" />
-                            <ref role="3cqZAo" to="vsv5:1QYs15esRbY" resolve="CONSTRAINT_FAILED" />
-                            <node concept="1sPUBX" id="lH$PuiVULP" role="lGtFl">
-                              <ref role="v9R2y" node="lH$PuiVUun" resolve="switch_ContractItem_DefaultErrorMessage" />
+                          <node concept="3cpWs3" id="lH$PuiKhfM" role="3uHU7B">
+                            <node concept="10M0yZ" id="lH$PuhcKzB" role="3uHU7B">
+                              <ref role="1PxDUh" to="vsv5:10wUh3OyTwB" resolve="ContractViolatedException" />
+                              <ref role="3cqZAo" to="vsv5:1QYs15esRbY" resolve="CONSTRAINT_FAILED" />
+                              <node concept="1sPUBX" id="lH$PuiVULP" role="lGtFl">
+                                <ref role="v9R2y" node="lH$PuiVUun" resolve="switch_ContractItem_DefaultErrorMessage" />
+                              </node>
                             </node>
-                          </node>
-                          <node concept="Xl_RD" id="lH$PuiKhfP" role="3uHU7w">
-                            <property role="Xl_RC" value=": " />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="29HgVG" id="lH$PuhcGWq" role="lGtFl">
-                    <node concept="3NFfHV" id="lH$PuhcH6w" role="3NFExx">
-                      <node concept="3clFbS" id="lH$PuhcH6x" role="2VODD2">
-                        <node concept="3clFbF" id="lH$PuhcH6C" role="3cqZAp">
-                          <node concept="2OqwBi" id="lH$PuhcHlt" role="3clFbG">
-                            <node concept="30H73N" id="lH$PuhcH6B" role="2Oq$k0" />
-                            <node concept="3TrEf2" id="lH$PuhcHAX" role="2OqNvi">
-                              <ref role="3Tt5mk" to="hm2y:5F8uib8hsjE" resolve="err" />
+                            <node concept="Xl_RD" id="lH$PuiKhfP" role="3uHU7w">
+                              <property role="Xl_RC" value=": " />
                             </node>
                           </node>
                         </node>
                       </node>
                     </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="29HgVG" id="lH$Puhb9kI" role="lGtFl">
-          <node concept="3NFfHV" id="lH$Puhb9zz" role="3NFExx">
-            <node concept="3clFbS" id="lH$Puhb9z$" role="2VODD2">
-              <node concept="3clFbF" id="lH$Puhb9zF" role="3cqZAp">
-                <node concept="2OqwBi" id="lH$Puhb9Pd" role="3clFbG">
-                  <node concept="30H73N" id="lH$Puhb9zE" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="lH$Puhba6H" role="2OqNvi">
-                    <ref role="3Tt5mk" to="hm2y:5F8uib8hsjE" resolve="err" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="liA8E" id="kKmKqg6vnA" role="2OqNvi">
-        <ref role="37wK5l" to="vj64:1aR2a4nXyQP" resolve="withLocation" />
-        <node concept="2ShNRf" id="kKmKqg6wbq" role="37wK5m">
-          <node concept="1pGfFk" id="kKmKqg6yBA" role="2ShVmc">
-            <ref role="37wK5l" to="vj64:65vXeyMqhNf" resolve="ProgramLocation" />
-            <node concept="Xl_RD" id="kKmKqg6yCd" role="37wK5m">
-              <property role="Xl_RC" value="ref" />
-              <node concept="17Uvod" id="kKmKqg6Y_H" role="lGtFl">
-                <property role="2qtEX9" value="value" />
-                <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                <node concept="3zFVjK" id="kKmKqg6Y_I" role="3zH0cK">
-                  <node concept="3clFbS" id="kKmKqg6Y_J" role="2VODD2">
-                    <node concept="3clFbF" id="kKmKqg6Zir" role="3cqZAp">
-                      <node concept="2OqwBi" id="kKmKqg72VN" role="3clFbG">
-                        <node concept="2JrnkZ" id="kKmKqg727k" role="2Oq$k0">
-                          <node concept="2OqwBi" id="kKmKqg6ZKb" role="2JrQYb">
-                            <node concept="1iwH7S" id="kKmKqg6Ziq" role="2Oq$k0" />
-                            <node concept="1psM6Z" id="3pRoIUFZe67" role="2OqNvi">
-                              <ref role="1psM6Y" node="3pRoIUFZe65" resolve="loc" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="liA8E" id="kKmKqg7uAu" role="2OqNvi">
-                          <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="Xl_RD" id="kKmKqg6$7I" role="37wK5m">
-              <property role="Xl_RC" value="url" />
-              <node concept="17Uvod" id="kKmKqg7v1O" role="lGtFl">
-                <property role="2qtEX9" value="value" />
-                <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                <node concept="3zFVjK" id="kKmKqg7v1P" role="3zH0cK">
-                  <node concept="3clFbS" id="kKmKqg7v1Q" role="2VODD2">
-                    <node concept="3clFbF" id="kKmKqg7wjO" role="3cqZAp">
-                      <node concept="2YIFZM" id="kKmKqg7xn5" role="3clFbG">
-                        <ref role="37wK5l" to="ciba:1_yOWEXeo7V" resolve="getURL" />
-                        <ref role="1Pybhc" to="ciba:3OrGkZCn9ZQ" resolve="HttpSupportUtil" />
-                        <node concept="2OqwBi" id="kKmKqg7xEJ" role="37wK5m">
-                          <node concept="1iwH7S" id="kKmKqg7xna" role="2Oq$k0" />
-                          <node concept="1psM6Z" id="3pRoIUFZe68" role="2OqNvi">
-                            <ref role="1psM6Y" node="3pRoIUFZe65" resolve="loc" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="1ps_y7" id="3pRoIUFZe66" role="lGtFl">
-            <node concept="1ps_xZ" id="3pRoIUFZe65" role="1ps_xO">
-              <property role="TrG5h" value="loc" />
-              <node concept="2sp9CU" id="kKmKqg6ADq" role="1ps_xK" />
-              <node concept="2jfdEK" id="kKmKqg6A8S" role="1ps_xN">
-                <node concept="3clFbS" id="kKmKqg6A8T" role="2VODD2">
-                  <node concept="3cpWs8" id="kKmKqg6DOT" role="3cqZAp">
-                    <node concept="3cpWsn" id="kKmKqg6DOU" role="3cpWs9">
-                      <property role="TrG5h" value="messageTarget" />
-                      <node concept="3Tqbb2" id="kKmKqg6DOR" role="1tU5fm" />
-                      <node concept="1PxgMI" id="kKmKqg6RSm" role="33vP2m">
-                        <property role="1BlNFB" value="true" />
-                        <node concept="chp4Y" id="kKmKqg6SBI" role="3oSUPX">
-                          <ref role="cht4Q" to="kelk:3vxfdxbdbUS" resolve="MessageTarget" />
-                        </node>
-                        <node concept="2OqwBi" id="kKmKqg6Fe7" role="1m5AlR">
-                          <node concept="1PxgMI" id="kKmKqg6EHq" role="2Oq$k0">
-                            <property role="1BlNFB" value="true" />
-                            <node concept="chp4Y" id="kKmKqg6EPj" role="3oSUPX">
-                              <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
-                            </node>
-                            <node concept="2OqwBi" id="kKmKqg6DOV" role="1m5AlR">
-                              <node concept="30H73N" id="kKmKqg6DOW" role="2Oq$k0" />
-                              <node concept="3TrEf2" id="kKmKqg6DOX" role="2OqNvi">
+                    <node concept="29HgVG" id="lH$PuhcGWq" role="lGtFl">
+                      <node concept="3NFfHV" id="lH$PuhcH6w" role="3NFExx">
+                        <node concept="3clFbS" id="lH$PuhcH6x" role="2VODD2">
+                          <node concept="3clFbF" id="lH$PuhcH6C" role="3cqZAp">
+                            <node concept="2OqwBi" id="lH$PuhcHlt" role="3clFbG">
+                              <node concept="30H73N" id="lH$PuhcH6B" role="2Oq$k0" />
+                              <node concept="3TrEf2" id="lH$PuhcHAX" role="2OqNvi">
                                 <ref role="3Tt5mk" to="hm2y:5F8uib8hsjE" resolve="err" />
                               </node>
                             </node>
                           </node>
-                          <node concept="3TrEf2" id="kKmKqg6Lgo" role="2OqNvi">
-                            <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="29HgVG" id="lH$Puhb9kI" role="lGtFl">
+            <node concept="3NFfHV" id="lH$Puhb9zz" role="3NFExx">
+              <node concept="3clFbS" id="lH$Puhb9z$" role="2VODD2">
+                <node concept="3clFbF" id="lH$Puhb9zF" role="3cqZAp">
+                  <node concept="2OqwBi" id="lH$Puhb9Pd" role="3clFbG">
+                    <node concept="30H73N" id="lH$Puhb9zE" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="lH$Puhba6H" role="2OqNvi">
+                      <ref role="3Tt5mk" to="hm2y:5F8uib8hsjE" resolve="err" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="liA8E" id="kKmKqg6vnA" role="2OqNvi">
+          <ref role="37wK5l" to="vj64:1aR2a4nXyQP" resolve="withLocation" />
+          <node concept="2ShNRf" id="kKmKqg6wbq" role="37wK5m">
+            <node concept="1pGfFk" id="kKmKqg6yBA" role="2ShVmc">
+              <ref role="37wK5l" to="vj64:65vXeyMqhNf" resolve="ProgramLocation" />
+              <node concept="Xl_RD" id="kKmKqg6yCd" role="37wK5m">
+                <property role="Xl_RC" value="ref" />
+                <node concept="17Uvod" id="kKmKqg6Y_H" role="lGtFl">
+                  <property role="2qtEX9" value="value" />
+                  <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                  <node concept="3zFVjK" id="kKmKqg6Y_I" role="3zH0cK">
+                    <node concept="3clFbS" id="kKmKqg6Y_J" role="2VODD2">
+                      <node concept="3clFbF" id="kKmKqg6Zir" role="3cqZAp">
+                        <node concept="2OqwBi" id="kKmKqg72VN" role="3clFbG">
+                          <node concept="2JrnkZ" id="kKmKqg727k" role="2Oq$k0">
+                            <node concept="2OqwBi" id="kKmKqg6ZKb" role="2JrQYb">
+                              <node concept="1iwH7S" id="kKmKqg6Ziq" role="2Oq$k0" />
+                              <node concept="1psM6Z" id="3pRoIUFZe67" role="2OqNvi">
+                                <ref role="1psM6Y" node="3pRoIUFZe65" resolve="loc" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="kKmKqg7uAu" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
                           </node>
                         </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbF" id="kKmKqg6BL0" role="3cqZAp">
-                    <node concept="2YIFZM" id="kKmKqg6Cdd" role="3clFbG">
-                      <ref role="37wK5l" to="fwk:~TracingUtil.getInput(org.jetbrains.mps.openapi.model.SNode)" resolve="getInput" />
-                      <ref role="1Pybhc" to="fwk:~TracingUtil" resolve="TracingUtil" />
-                      <node concept="3K4zz7" id="kKmKqg6Vof" role="37wK5m">
-                        <node concept="37vLTw" id="kKmKqg6W3u" role="3K4E3e">
-                          <ref role="3cqZAo" node="kKmKqg6DOU" resolve="messageTarget" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="kKmKqg6$7I" role="37wK5m">
+                <property role="Xl_RC" value="url" />
+                <node concept="17Uvod" id="kKmKqg7v1O" role="lGtFl">
+                  <property role="2qtEX9" value="value" />
+                  <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                  <node concept="3zFVjK" id="kKmKqg7v1P" role="3zH0cK">
+                    <node concept="3clFbS" id="kKmKqg7v1Q" role="2VODD2">
+                      <node concept="3clFbF" id="kKmKqg7wjO" role="3cqZAp">
+                        <node concept="2YIFZM" id="kKmKqg7xn5" role="3clFbG">
+                          <ref role="37wK5l" to="ciba:1_yOWEXeo7V" resolve="getURL" />
+                          <ref role="1Pybhc" to="ciba:3OrGkZCn9ZQ" resolve="HttpSupportUtil" />
+                          <node concept="2OqwBi" id="kKmKqg7xEJ" role="37wK5m">
+                            <node concept="1iwH7S" id="kKmKqg7xna" role="2Oq$k0" />
+                            <node concept="1psM6Z" id="3pRoIUFZe68" role="2OqNvi">
+                              <ref role="1psM6Y" node="3pRoIUFZe65" resolve="loc" />
+                            </node>
+                          </node>
                         </node>
-                        <node concept="30H73N" id="kKmKqg6WhO" role="3K4GZi" />
-                        <node concept="3y3z36" id="kKmKqg6VP3" role="3K4Cdx">
-                          <node concept="37vLTw" id="kKmKqg6V01" role="3uHU7B">
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1ps_y7" id="3pRoIUFZe66" role="lGtFl">
+              <node concept="1ps_xZ" id="3pRoIUFZe65" role="1ps_xO">
+                <property role="TrG5h" value="loc" />
+                <node concept="2sp9CU" id="kKmKqg6ADq" role="1ps_xK" />
+                <node concept="2jfdEK" id="kKmKqg6A8S" role="1ps_xN">
+                  <node concept="3clFbS" id="kKmKqg6A8T" role="2VODD2">
+                    <node concept="3cpWs8" id="kKmKqg6DOT" role="3cqZAp">
+                      <node concept="3cpWsn" id="kKmKqg6DOU" role="3cpWs9">
+                        <property role="TrG5h" value="messageTarget" />
+                        <node concept="3Tqbb2" id="kKmKqg6DOR" role="1tU5fm" />
+                        <node concept="1PxgMI" id="kKmKqg6RSm" role="33vP2m">
+                          <property role="1BlNFB" value="true" />
+                          <node concept="chp4Y" id="kKmKqg6SBI" role="3oSUPX">
+                            <ref role="cht4Q" to="kelk:3vxfdxbdbUS" resolve="MessageTarget" />
+                          </node>
+                          <node concept="2OqwBi" id="kKmKqg6Fe7" role="1m5AlR">
+                            <node concept="1PxgMI" id="kKmKqg6EHq" role="2Oq$k0">
+                              <property role="1BlNFB" value="true" />
+                              <node concept="chp4Y" id="kKmKqg6EPj" role="3oSUPX">
+                                <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+                              </node>
+                              <node concept="2OqwBi" id="kKmKqg6DOV" role="1m5AlR">
+                                <node concept="30H73N" id="kKmKqg6DOW" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="kKmKqg6DOX" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="hm2y:5F8uib8hsjE" resolve="err" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3TrEf2" id="kKmKqg6Lgo" role="2OqNvi">
+                              <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="kKmKqg6BL0" role="3cqZAp">
+                      <node concept="2YIFZM" id="kKmKqg6Cdd" role="3clFbG">
+                        <ref role="37wK5l" to="fwk:~TracingUtil.getInput(org.jetbrains.mps.openapi.model.SNode)" resolve="getInput" />
+                        <ref role="1Pybhc" to="fwk:~TracingUtil" resolve="TracingUtil" />
+                        <node concept="3K4zz7" id="kKmKqg6Vof" role="37wK5m">
+                          <node concept="37vLTw" id="kKmKqg6W3u" role="3K4E3e">
                             <ref role="3cqZAo" node="kKmKqg6DOU" resolve="messageTarget" />
                           </node>
-                          <node concept="10Nm6u" id="kKmKqg6VdK" role="3uHU7w" />
+                          <node concept="30H73N" id="kKmKqg6WhO" role="3K4GZi" />
+                          <node concept="3y3z36" id="kKmKqg6VP3" role="3K4Cdx">
+                            <node concept="37vLTw" id="kKmKqg6V01" role="3uHU7B">
+                              <ref role="3cqZAo" node="kKmKqg6DOU" resolve="messageTarget" />
+                            </node>
+                            <node concept="10Nm6u" id="kKmKqg6VdK" role="3uHU7w" />
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -19121,7 +19131,110 @@
           </node>
         </node>
       </node>
-      <node concept="raruj" id="kKmKqg6_BD" role="lGtFl" />
+      <node concept="liA8E" id="TA$XW2mI_G" role="2OqNvi">
+        <ref role="37wK5l" to="vj64:TA$XW2lgNg" resolve="withAffectedMemberNames" />
+        <node concept="2ShNRf" id="TA$XW2mKt_" role="37wK5m">
+          <node concept="1pGfFk" id="TA$XW2mNsr" role="2ShVmc">
+            <ref role="37wK5l" to="33ny:~HashSet.&lt;init&gt;(java.util.Collection)" resolve="HashSet" />
+            <node concept="3uibUv" id="TA$XW2mOs7" role="1pMfVU">
+              <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+            </node>
+            <node concept="2YIFZM" id="TA$XW2mQ9T" role="37wK5m">
+              <ref role="37wK5l" to="33ny:~Arrays.asList(java.lang.Object...)" resolve="asList" />
+              <ref role="1Pybhc" to="33ny:~Arrays" resolve="Arrays" />
+              <node concept="Xl_RD" id="TA$XW2mQYz" role="37wK5m">
+                <property role="Xl_RC" value="MemberFqName" />
+                <node concept="1WS0z7" id="TA$XW2mXS2" role="lGtFl">
+                  <node concept="3JmXsc" id="TA$XW2mXS3" role="3Jn$fo">
+                    <node concept="3clFbS" id="TA$XW2mXS4" role="2VODD2">
+                      <node concept="3clFbF" id="TA$XW2mZ5g" role="3cqZAp">
+                        <node concept="2OqwBi" id="TA$XW2qiLO" role="3clFbG">
+                          <node concept="2OqwBi" id="TA$XW2n0IJ" role="2Oq$k0">
+                            <node concept="2OqwBi" id="TA$XW2mZii" role="2Oq$k0">
+                              <node concept="30H73N" id="TA$XW2mZ5f" role="2Oq$k0" />
+                              <node concept="3TrEf2" id="TA$XW2n0fp" role="2OqNvi">
+                                <ref role="3Tt5mk" to="hm2y:KaZMgy4Ilu" resolve="expr" />
+                              </node>
+                            </node>
+                            <node concept="2Rf3mk" id="TA$XW2n1AJ" role="2OqNvi">
+                              <node concept="1xIGOp" id="TA$XW2$_hP" role="1xVPHs" />
+                            </node>
+                          </node>
+                          <node concept="3goQfb" id="TA$XW2qlZv" role="2OqNvi">
+                            <node concept="1bVj0M" id="TA$XW2qlZx" role="23t8la">
+                              <node concept="3clFbS" id="TA$XW2qlZy" role="1bW5cS">
+                                <node concept="3clFbF" id="TA$XW2qmNk" role="3cqZAp">
+                                  <node concept="2OqwBi" id="TA$XW2riSM" role="3clFbG">
+                                    <node concept="2OqwBi" id="TA$XW2qqzk" role="2Oq$k0">
+                                      <node concept="2OqwBi" id="TA$XW2qn8N" role="2Oq$k0">
+                                        <node concept="37vLTw" id="TA$XW2qmNj" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="TA$XW2qlZz" resolve="it" />
+                                        </node>
+                                        <node concept="2z74zc" id="TA$XW2qp0y" role="2OqNvi" />
+                                      </node>
+                                      <node concept="3$u5V9" id="TA$XW2rJOf" role="2OqNvi">
+                                        <node concept="1bVj0M" id="TA$XW2rJOh" role="23t8la">
+                                          <node concept="3clFbS" id="TA$XW2rJOi" role="1bW5cS">
+                                            <node concept="3clFbF" id="TA$XW2rJOj" role="3cqZAp">
+                                              <node concept="2OqwBi" id="TA$XW2rJOk" role="3clFbG">
+                                                <node concept="37vLTw" id="TA$XW2rJOl" role="2Oq$k0">
+                                                  <ref role="3cqZAo" node="TA$XW2rJOn" resolve="n" />
+                                                </node>
+                                                <node concept="2ZHEkA" id="TA$XW2rJOm" role="2OqNvi" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="Rh6nW" id="TA$XW2rJOn" role="1bW2Oz">
+                                            <property role="TrG5h" value="n" />
+                                            <node concept="2jxLKc" id="TA$XW2rJOo" role="1tU5fm" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="v3k3i" id="TA$XW2rGNV" role="2OqNvi">
+                                      <node concept="chp4Y" id="TA$XW2rHjc" role="v3oSu">
+                                        <ref role="cht4Q" to="yv47:xu7xcKdQCB" resolve="IRecordMember" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="Rh6nW" id="TA$XW2qlZz" role="1bW2Oz">
+                                <property role="TrG5h" value="it" />
+                                <node concept="2jxLKc" id="TA$XW2qlZ$" role="1tU5fm" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="17Uvod" id="TA$XW2n2oQ" role="lGtFl">
+                  <property role="2qtEX9" value="value" />
+                  <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                  <node concept="3zFVjK" id="TA$XW2n2oR" role="3zH0cK">
+                    <node concept="3clFbS" id="TA$XW2n2oS" role="2VODD2">
+                      <node concept="3clFbF" id="TA$XW2n3Cq" role="3cqZAp">
+                        <node concept="2OqwBi" id="TA$XW2n3ZJ" role="3clFbG">
+                          <node concept="30H73N" id="TA$XW2n3Cp" role="2Oq$k0" />
+                          <node concept="2qgKlT" id="TA$XW2n5pa" role="2OqNvi">
+                            <ref role="37wK5l" to="tpcu:hEwIO9y" resolve="getFqName" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3uibUv" id="TA$XW2rUyW" role="3PaCim">
+                <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="raruj" id="TA$XW2mJiL" role="lGtFl" />
     </node>
   </node>
   <node concept="1pmfR0" id="119IXVQKQyh">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.messages/generator/template/main@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.messages/generator/template/main@generator.mps
@@ -34,9 +34,6 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
-      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
-        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
-      </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
@@ -99,9 +96,6 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
-      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
-        <child id="1081516765348" name="expression" index="3fr31v" />
-      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -128,7 +122,6 @@
         <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
-      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
       <concept id="1114706874351" name="jetbrains.mps.lang.generator.structure.CopySrcNodeMacro" flags="ln" index="29HgVG">
@@ -1379,358 +1372,16 @@
       <node concept="30G5F_" id="5LerK4sDF68" role="30HLyM">
         <node concept="3clFbS" id="5LerK4sDF69" role="2VODD2">
           <node concept="3clFbF" id="5LerK4sDFdw" role="3cqZAp">
-            <node concept="1Wc70l" id="5LerK4sSErd" role="3clFbG">
-              <node concept="2OqwBi" id="5LerK4sSHud" role="3uHU7w">
-                <node concept="1PxgMI" id="5LerK4sSGKq" role="2Oq$k0">
-                  <node concept="chp4Y" id="5LerK4sSH4t" role="3oSUPX">
-                    <ref role="cht4Q" to="kelk:3vxfdxbdbUS" resolve="MessageTarget" />
-                  </node>
-                  <node concept="2OqwBi" id="5LerK4sSEZf" role="1m5AlR">
-                    <node concept="30H73N" id="5LerK4sSEDs" role="2Oq$k0" />
-                    <node concept="3TrEf2" id="5LerK4sSFL2" role="2OqNvi">
-                      <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3TrcHB" id="5LerK4sSHXf" role="2OqNvi">
-                  <ref role="3TsBF5" to="kelk:4AahbtV9FsC" resolve="messageValue" />
+            <node concept="2OqwBi" id="5LerK4sDGUN" role="3clFbG">
+              <node concept="2OqwBi" id="5LerK4sDFyI" role="2Oq$k0">
+                <node concept="30H73N" id="5LerK4sDFdv" role="2Oq$k0" />
+                <node concept="3TrEf2" id="5LerK4sDG4H" role="2OqNvi">
+                  <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
                 </node>
               </node>
-              <node concept="2OqwBi" id="5LerK4sDGUN" role="3uHU7B">
-                <node concept="2OqwBi" id="5LerK4sDFyI" role="2Oq$k0">
-                  <node concept="30H73N" id="5LerK4sDFdv" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="5LerK4sDG4H" role="2OqNvi">
-                    <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
-                  </node>
-                </node>
-                <node concept="1mIQ4w" id="5LerK4sDHJ9" role="2OqNvi">
-                  <node concept="chp4Y" id="5LerK4sDHW$" role="cj9EA">
-                    <ref role="cht4Q" to="kelk:3vxfdxbdbUS" resolve="MessageTarget" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="3aamgX" id="5LerK4sSIl8" role="3aUrZf">
-      <ref role="30HIoZ" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
-      <node concept="1Koe21" id="5LerK4sSIl9" role="1lVwrX">
-        <node concept="312cEu" id="5LerK4sSIla" role="1Koe22">
-          <property role="TrG5h" value="SomeClass" />
-          <node concept="2YIFZL" id="5LerK4sSIlb" role="jymVt">
-            <property role="TrG5h" value="someMethod" />
-            <node concept="3clFbS" id="5LerK4sSIlc" role="3clF47">
-              <node concept="3cpWs8" id="5LerK4sSSop" role="3cqZAp">
-                <node concept="3cpWsn" id="5LerK4sSSos" role="3cpWs9">
-                  <property role="TrG5h" value="s" />
-                  <node concept="17QB3L" id="5LerK4sSSon" role="1tU5fm" />
-                  <node concept="2OqwBi" id="5LerK4sSNw$" role="33vP2m">
-                    <node concept="2YIFZM" id="5LerK4sSIle" role="2Oq$k0">
-                      <ref role="1Pybhc" node="5LerK4sSIla" resolve="SomeClass" />
-                      <ref role="37wK5l" node="5LerK4sSIlb" resolve="someMethod" />
-                      <node concept="Xl_RD" id="7TQUV1FEvap" role="37wK5m">
-                        <property role="Xl_RC" value="nodeRef" />
-                        <node concept="17Uvod" id="7TQUV1FEvaq" role="lGtFl">
-                          <property role="2qtEX9" value="value" />
-                          <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                          <node concept="3zFVjK" id="7TQUV1FEvar" role="3zH0cK">
-                            <node concept="3clFbS" id="7TQUV1FEvas" role="2VODD2">
-                              <node concept="3clFbF" id="7TQUV1FEvat" role="3cqZAp">
-                                <node concept="2OqwBi" id="7TQUV1FEvau" role="3clFbG">
-                                  <node concept="2JrnkZ" id="7TQUV1FEvav" role="2Oq$k0">
-                                    <node concept="2OqwBi" id="7TQUV1FEvaw" role="2JrQYb">
-                                      <node concept="1iwH7S" id="7TQUV1FEvax" role="2Oq$k0" />
-                                      <node concept="1psM6Z" id="3pRoIUFZe9a" role="2OqNvi">
-                                        <ref role="1psM6Y" node="3pRoIUFZe98" resolve="programLocation" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="liA8E" id="7TQUV1FEvaz" role="2OqNvi">
-                                    <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="Xl_RD" id="7TQUV1FEva$" role="37wK5m">
-                        <property role="Xl_RC" value="nodeUrl" />
-                        <node concept="17Uvod" id="7TQUV1FEva_" role="lGtFl">
-                          <property role="2qtEX9" value="value" />
-                          <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                          <node concept="3zFVjK" id="7TQUV1FEvaA" role="3zH0cK">
-                            <node concept="3clFbS" id="7TQUV1FEvaB" role="2VODD2">
-                              <node concept="3clFbF" id="7TQUV1FEvaC" role="3cqZAp">
-                                <node concept="2YIFZM" id="7TQUV1FEvaD" role="3clFbG">
-                                  <ref role="37wK5l" to="ciba:1_yOWEXeo7V" resolve="getURL" />
-                                  <ref role="1Pybhc" to="ciba:3OrGkZCn9ZQ" resolve="HttpSupportUtil" />
-                                  <node concept="2OqwBi" id="7TQUV1FEvaE" role="37wK5m">
-                                    <node concept="1iwH7S" id="7TQUV1FEvaF" role="2Oq$k0" />
-                                    <node concept="1psM6Z" id="3pRoIUFZe9b" role="2OqNvi">
-                                      <ref role="1psM6Y" node="3pRoIUFZe98" resolve="programLocation" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3cmrfG" id="5LerK4sSIlA" role="37wK5m">
-                        <property role="3cmrfH" value="10" />
-                        <node concept="2b32R4" id="5LerK4sSIlB" role="lGtFl">
-                          <node concept="3JmXsc" id="5LerK4sSIlC" role="2P8S$">
-                            <node concept="3clFbS" id="5LerK4sSIlD" role="2VODD2">
-                              <node concept="3clFbF" id="5LerK4sSIlE" role="3cqZAp">
-                                <node concept="2OqwBi" id="5LerK4sSIlF" role="3clFbG">
-                                  <node concept="1PxgMI" id="5LerK4sSIlG" role="2Oq$k0">
-                                    <node concept="chp4Y" id="5LerK4sSIlH" role="3oSUPX">
-                                      <ref role="cht4Q" to="kelk:3vxfdxbdbUS" resolve="MessageTarget" />
-                                    </node>
-                                    <node concept="2OqwBi" id="5LerK4sSIlI" role="1m5AlR">
-                                      <node concept="3TrEf2" id="5LerK4sSIlJ" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
-                                      </node>
-                                      <node concept="30H73N" id="5LerK4sSIlK" role="2Oq$k0" />
-                                    </node>
-                                  </node>
-                                  <node concept="3Tsc0h" id="5LerK4sSIlL" role="2OqNvi">
-                                    <ref role="3TtcxE" to="kelk:3vxfdxbjb$U" resolve="args" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="1ZhdrF" id="5LerK4sSIlN" role="lGtFl">
-                        <property role="2qtEX8" value="classConcept" />
-                        <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1081236700937/1144433194310" />
-                        <node concept="3$xsQk" id="5LerK4sSIlO" role="3$ytzL">
-                          <node concept="3clFbS" id="5LerK4sSIlP" role="2VODD2">
-                            <node concept="3clFbF" id="5LerK4sSIlQ" role="3cqZAp">
-                              <node concept="2OqwBi" id="5LerK4sSIlR" role="3clFbG">
-                                <node concept="1iwH7S" id="5LerK4sSIlS" role="2Oq$k0" />
-                                <node concept="1iwH70" id="5LerK4sSIlT" role="2OqNvi">
-                                  <ref role="1iwH77" node="5LerK4rhfZW" resolve="IMessageNamespaceClass" />
-                                  <node concept="1PxgMI" id="5LerK4sSIlU" role="1iwH7V">
-                                    <property role="1BlNFB" value="true" />
-                                    <node concept="chp4Y" id="5LerK4sSIlV" role="3oSUPX">
-                                      <ref role="cht4Q" to="kelk:3vxfdxbcs9j" resolve="IMessageNamespace" />
-                                    </node>
-                                    <node concept="2OqwBi" id="5LerK4sSIlW" role="1m5AlR">
-                                      <node concept="2OqwBi" id="5LerK4sSIlX" role="2Oq$k0">
-                                        <node concept="1PxgMI" id="5LerK4sSIlY" role="2Oq$k0">
-                                          <node concept="chp4Y" id="5LerK4sSIlZ" role="3oSUPX">
-                                            <ref role="cht4Q" to="kelk:3vxfdxbdbUS" resolve="MessageTarget" />
-                                          </node>
-                                          <node concept="2OqwBi" id="5LerK4sSIm0" role="1m5AlR">
-                                            <node concept="30H73N" id="5LerK4sSIm1" role="2Oq$k0" />
-                                            <node concept="3TrEf2" id="5LerK4sSIm2" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                        <node concept="3TrEf2" id="5LerK4sSIm3" role="2OqNvi">
-                                          <ref role="3Tt5mk" to="kelk:3vxfdxbdbUW" resolve="message" />
-                                        </node>
-                                      </node>
-                                      <node concept="1mfA1w" id="5LerK4sSIm4" role="2OqNvi" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="1ZhdrF" id="5LerK4sSIm5" role="lGtFl">
-                        <property role="2qtEX8" value="baseMethodDeclaration" />
-                        <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
-                        <node concept="3$xsQk" id="5LerK4sSIm6" role="3$ytzL">
-                          <node concept="3clFbS" id="5LerK4sSIm7" role="2VODD2">
-                            <node concept="3clFbF" id="5LerK4sSIm8" role="3cqZAp">
-                              <node concept="2OqwBi" id="5LerK4sSIm9" role="3clFbG">
-                                <node concept="1iwH7S" id="5LerK4sSIma" role="2Oq$k0" />
-                                <node concept="1iwH70" id="5LerK4sSImb" role="2OqNvi">
-                                  <ref role="1iwH77" node="5LerK4rhFWP" resolve="IMessageNamespaceContentMethod" />
-                                  <node concept="2OqwBi" id="5LerK4sSImc" role="1iwH7V">
-                                    <node concept="1PxgMI" id="5LerK4sSImd" role="2Oq$k0">
-                                      <node concept="chp4Y" id="5LerK4sSIme" role="3oSUPX">
-                                        <ref role="cht4Q" to="kelk:3vxfdxbdbUS" resolve="MessageTarget" />
-                                      </node>
-                                      <node concept="2OqwBi" id="5LerK4sSImf" role="1m5AlR">
-                                        <node concept="30H73N" id="5LerK4sSImg" role="2Oq$k0" />
-                                        <node concept="3TrEf2" id="5LerK4sSImh" role="2OqNvi">
-                                          <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="5LerK4sSImi" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="kelk:3vxfdxbdbUW" resolve="message" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="4ZjVa_SVnvx" role="2OqNvi">
-                      <ref role="37wK5l" to="vj64:4ZjVa_SLF9Y" resolve="textWithKind" />
-                    </node>
-                    <node concept="raruj" id="5LerK4sSRA7" role="lGtFl" />
-                    <node concept="1ps_y7" id="3pRoIUFZe99" role="lGtFl">
-                      <node concept="1ps_xZ" id="3pRoIUFZe98" role="1ps_xO">
-                        <property role="TrG5h" value="programLocation" />
-                        <node concept="2sp9CU" id="7TQUV1FEux_" role="1ps_xK" />
-                        <node concept="2jfdEK" id="7TQUV1FEtNF" role="1ps_xN">
-                          <node concept="3clFbS" id="7TQUV1FEtNG" role="2VODD2">
-                            <node concept="3cpWs8" id="7TQUV1FEuVl" role="3cqZAp">
-                              <node concept="3cpWsn" id="7TQUV1FEuVm" role="3cpWs9">
-                                <property role="TrG5h" value="plp" />
-                                <node concept="3Tqbb2" id="7TQUV1FEuVn" role="1tU5fm">
-                                  <ref role="ehGHo" to="hm2y:4AahbtUNHrQ" resolve="IProgramLocationProvider" />
-                                </node>
-                                <node concept="2OqwBi" id="7TQUV1FEuVo" role="33vP2m">
-                                  <node concept="30H73N" id="7TQUV1FEuVp" role="2Oq$k0" />
-                                  <node concept="2Xjw5R" id="7TQUV1FEuVq" role="2OqNvi">
-                                    <node concept="1xMEDy" id="7TQUV1FEuVr" role="1xVPHs">
-                                      <node concept="chp4Y" id="7TQUV1FEuVs" role="ri$Ld">
-                                        <ref role="cht4Q" to="hm2y:4AahbtUNHrQ" resolve="IProgramLocationProvider" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3cpWs8" id="7TQUV1FEuVt" role="3cqZAp">
-                              <node concept="3cpWsn" id="7TQUV1FEuVu" role="3cpWs9">
-                                <property role="TrG5h" value="loc" />
-                                <node concept="3Tqbb2" id="7TQUV1FEuVv" role="1tU5fm" />
-                                <node concept="3K4zz7" id="7TQUV1FEuVw" role="33vP2m">
-                                  <node concept="30H73N" id="7TQUV1FEuVx" role="3K4GZi" />
-                                  <node concept="3y3z36" id="7TQUV1FEuVy" role="3K4Cdx">
-                                    <node concept="10Nm6u" id="7TQUV1FEuVz" role="3uHU7w" />
-                                    <node concept="37vLTw" id="7TQUV1FEuV$" role="3uHU7B">
-                                      <ref role="3cqZAo" node="7TQUV1FEuVm" resolve="plp" />
-                                    </node>
-                                  </node>
-                                  <node concept="2OqwBi" id="7TQUV1FEuV_" role="3K4E3e">
-                                    <node concept="2OqwBi" id="7TQUV1FEuVA" role="2Oq$k0">
-                                      <node concept="37vLTw" id="7TQUV1FEuVB" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="7TQUV1FEuVm" resolve="plp" />
-                                      </node>
-                                      <node concept="2qgKlT" id="7TQUV1FEuVC" role="2OqNvi">
-                                        <ref role="37wK5l" to="pbu6:4AahbtUNHsr" resolve="getProgramLocation" />
-                                      </node>
-                                    </node>
-                                    <node concept="liA8E" id="7TQUV1FEuVD" role="2OqNvi">
-                                      <ref role="37wK5l" to="oq0c:4AahbtUR_Y1" resolve="node" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3clFbJ" id="7TQUV1FEuVE" role="3cqZAp">
-                              <node concept="3clFbS" id="7TQUV1FEuVF" role="3clFbx">
-                                <node concept="3clFbF" id="7TQUV1FEuVG" role="3cqZAp">
-                                  <node concept="2OqwBi" id="7TQUV1FEuVH" role="3clFbG">
-                                    <node concept="1iwH7S" id="7TQUV1FEuVI" role="2Oq$k0" />
-                                    <node concept="2k5nB$" id="7TQUV1FEuVJ" role="2OqNvi">
-                                      <node concept="Xl_RD" id="7TQUV1FEuVK" role="2k5Stb">
-                                        <property role="Xl_RC" value="Program location is null for node" />
-                                      </node>
-                                      <node concept="30H73N" id="7TQUV1FEuVL" role="2k6f33" />
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="3clFbF" id="7TQUV1FEuVM" role="3cqZAp">
-                                  <node concept="37vLTI" id="7TQUV1FEuVN" role="3clFbG">
-                                    <node concept="30H73N" id="7TQUV1FEuVO" role="37vLTx" />
-                                    <node concept="37vLTw" id="7TQUV1FEuVP" role="37vLTJ">
-                                      <ref role="3cqZAo" node="7TQUV1FEuVu" resolve="loc" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3clFbC" id="7TQUV1FEuVQ" role="3clFbw">
-                                <node concept="10Nm6u" id="7TQUV1FEuVR" role="3uHU7w" />
-                                <node concept="37vLTw" id="7TQUV1FEuVS" role="3uHU7B">
-                                  <ref role="3cqZAo" node="7TQUV1FEuVu" resolve="loc" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3clFbH" id="7TQUV1FEuVT" role="3cqZAp" />
-                            <node concept="3cpWs6" id="7TQUV1FEuVU" role="3cqZAp">
-                              <node concept="2YIFZM" id="7TQUV1FEuVV" role="3cqZAk">
-                                <ref role="37wK5l" to="fwk:~TracingUtil.getInput(org.jetbrains.mps.openapi.model.SNode)" resolve="getInput" />
-                                <ref role="1Pybhc" to="fwk:~TracingUtil" resolve="TracingUtil" />
-                                <node concept="37vLTw" id="7TQUV1FEuVW" role="37wK5m">
-                                  <ref role="3cqZAo" node="7TQUV1FEuVu" resolve="loc" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3cpWs6" id="5LerK4sSSna" role="3cqZAp">
-                <node concept="10Nm6u" id="5LerK4sSSnI" role="3cqZAk" />
-              </node>
-            </node>
-            <node concept="3Tm1VV" id="5LerK4sSImI" role="1B3o_S" />
-            <node concept="3uibUv" id="5LerK4sSM9F" role="3clF45">
-              <ref role="3uigEE" to="vj64:4NeJNX_xLh$" resolve="Message" />
-            </node>
-            <node concept="37vLTG" id="5LerK4sSImK" role="3clF46">
-              <property role="TrG5h" value="arg" />
-              <node concept="10Oyi0" id="5LerK4sSImL" role="1tU5fm" />
-            </node>
-          </node>
-          <node concept="3Tm1VV" id="5LerK4sSImM" role="1B3o_S" />
-        </node>
-      </node>
-      <node concept="30G5F_" id="5LerK4sSImN" role="30HLyM">
-        <node concept="3clFbS" id="5LerK4sSImO" role="2VODD2">
-          <node concept="3clFbF" id="5LerK4sSImP" role="3cqZAp">
-            <node concept="1Wc70l" id="5LerK4sSImQ" role="3clFbG">
-              <node concept="3fqX7Q" id="5LerK4sSJL4" role="3uHU7w">
-                <node concept="2OqwBi" id="5LerK4sSJL6" role="3fr31v">
-                  <node concept="1PxgMI" id="5LerK4sSJL7" role="2Oq$k0">
-                    <node concept="chp4Y" id="5LerK4sSJL8" role="3oSUPX">
-                      <ref role="cht4Q" to="kelk:3vxfdxbdbUS" resolve="MessageTarget" />
-                    </node>
-                    <node concept="2OqwBi" id="5LerK4sSJL9" role="1m5AlR">
-                      <node concept="30H73N" id="5LerK4sSJLa" role="2Oq$k0" />
-                      <node concept="3TrEf2" id="5LerK4sSJLb" role="2OqNvi">
-                        <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3TrcHB" id="5LerK4sSJLc" role="2OqNvi">
-                    <ref role="3TsBF5" to="kelk:4AahbtV9FsC" resolve="messageValue" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="5LerK4sSImY" role="3uHU7B">
-                <node concept="2OqwBi" id="5LerK4sSImZ" role="2Oq$k0">
-                  <node concept="30H73N" id="5LerK4sSIn0" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="5LerK4sSIn1" role="2OqNvi">
-                    <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
-                  </node>
-                </node>
-                <node concept="1mIQ4w" id="5LerK4sSIn2" role="2OqNvi">
-                  <node concept="chp4Y" id="5LerK4sSIn3" role="cj9EA">
-                    <ref role="cht4Q" to="kelk:3vxfdxbdbUS" resolve="MessageTarget" />
-                  </node>
+              <node concept="1mIQ4w" id="5LerK4sDHJ9" role="2OqNvi">
+                <node concept="chp4Y" id="5LerK4sDHW$" role="cj9EA">
+                  <ref role="cht4Q" to="kelk:3vxfdxbdbUS" resolve="MessageTarget" />
                 </node>
               </node>
             </node>
@@ -1763,8 +1414,8 @@
                     </node>
                   </node>
                 </node>
-                <node concept="2OwXpG" id="23q4Crn$x3t" role="2OqNvi">
-                  <ref role="2Oxat5" to="vj64:4NeJNX_xLp2" resolve="text" />
+                <node concept="liA8E" id="2rZI03v8Zk8" role="2OqNvi">
+                  <ref role="37wK5l" to="vj64:4ZjVa_SLF9Y" resolve="textWithKind" />
                 </node>
                 <node concept="raruj" id="23q4Crn$_dg" role="lGtFl" />
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.messages/generator/template/main@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.messages/generator/template/main@generator.mps
@@ -434,7 +434,46 @@
       <node concept="gft3U" id="23q4CrnA1rr" role="1lVwrX">
         <node concept="2YIFZM" id="23q4CrnA1rs" role="gfFT$">
           <ref role="1Pybhc" to="vj64:55imU6w9XcV" resolve="BuiltinMessageKinds" />
-          <ref role="37wK5l" to="vj64:55imU6w9XVW" resolve="warning" />
+          <ref role="37wK5l" to="vj64:7fFM7QP5ifn" resolve="warning" />
+          <node concept="Xl_RD" id="7fFM7QP5me0" role="37wK5m">
+            <property role="Xl_RC" value="warningID" />
+            <node concept="17Uvod" id="7fFM7QP5me1" role="lGtFl">
+              <property role="2qtEX9" value="value" />
+              <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+              <node concept="3zFVjK" id="7fFM7QP5me2" role="3zH0cK">
+                <node concept="3clFbS" id="7fFM7QP5me3" role="2VODD2">
+                  <node concept="3clFbF" id="7fFM7QP5me4" role="3cqZAp">
+                    <node concept="2OqwBi" id="7fFM7QP5me5" role="3clFbG">
+                      <node concept="30H73N" id="7fFM7QP5me6" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="7fFM7QP5o$R" role="2OqNvi">
+                        <ref role="3TsBF5" to="kelk:7OtDX6qjWPO" resolve="warningID" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1W57fq" id="7fFM7QP5me8" role="lGtFl">
+              <node concept="3IZrLx" id="7fFM7QP5me9" role="3IZSJc">
+                <node concept="3clFbS" id="7fFM7QP5mea" role="2VODD2">
+                  <node concept="3clFbF" id="7fFM7QP5meb" role="3cqZAp">
+                    <node concept="2OqwBi" id="7fFM7QP5mec" role="3clFbG">
+                      <node concept="2OqwBi" id="7fFM7QP5med" role="2Oq$k0">
+                        <node concept="30H73N" id="7fFM7QP5mee" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="7fFM7QP5o6V" role="2OqNvi">
+                          <ref role="3TsBF5" to="kelk:7OtDX6qjWPO" resolve="warningID" />
+                        </node>
+                      </node>
+                      <node concept="17RvpY" id="7fFM7QP5meg" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="gft3U" id="7fFM7QP5meh" role="UU_$l">
+                <node concept="10Nm6u" id="7fFM7QP5mei" role="gfFT$" />
+              </node>
+            </node>
+          </node>
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
@@ -685,10 +685,13 @@
       </node>
       <node concept="1kHk_G" id="4AahbtV9GlW" role="3EZMnx">
         <property role="ZjSer" value="!" />
-        <ref role="1NtTu8" to="kelk:4AahbtV9FsC" resolve="messageValue" />
+        <ref role="1NtTu8" to="kelk:4AahbtV9FsC" resolve="messageValue_DEPRECATED" />
         <ref role="1k5W1q" node="3vxfdxbhnuU" resolve="message" />
         <node concept="11L4FC" id="4AahbtVaxPr" role="3F10Kt">
           <property role="VOm3f" value="true" />
+        </node>
+        <node concept="VechU" id="7OtDX6qkaOM" role="3F10Kt">
+          <property role="Vb096" value="red" />
         </node>
       </node>
       <node concept="2iRfu4" id="3vxfdxbjbRV" role="2iSdaV" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
@@ -928,6 +928,9 @@
             <property role="1iTho6" value="FD7D01" />
           </node>
         </node>
+        <node concept="11LMrY" id="1_tUShijhel" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
       </node>
       <node concept="3F0A7n" id="7OtDX6qjWQd" role="3EZMnx">
         <ref role="1NtTu8" to="kelk:7OtDX6qjWPO" resolve="warningID" />
@@ -940,6 +943,14 @@
       </node>
       <node concept="3F0ifn" id="7OtDX6qjWQr" role="3EZMnx">
         <property role="3F0ifm" value="]" />
+        <node concept="VechU" id="1_tUShijhdT" role="3F10Kt">
+          <node concept="1iSF2X" id="1_tUShijhdU" role="VblUZ">
+            <property role="1iTho6" value="FD7D01" />
+          </node>
+        </node>
+        <node concept="11L4FC" id="1_tUShijhe6" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
@@ -685,8 +685,8 @@
       </node>
       <node concept="1kHk_G" id="4AahbtV9GlW" role="3EZMnx">
         <property role="ZjSer" value="!" />
-        <ref role="1NtTu8" to="kelk:4AahbtV9FsC" resolve="messageValue_DEPRECATED" />
         <ref role="1k5W1q" node="3vxfdxbhnuU" resolve="message" />
+        <ref role="1NtTu8" to="kelk:4AahbtV9FsC" resolve="messageValue_DEPRECATED" />
         <node concept="11L4FC" id="4AahbtVaxPr" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
@@ -919,12 +919,27 @@
   <node concept="24kQdi" id="3vxfdxbkQjz">
     <property role="3GE5qa" value="kind" />
     <ref role="1XX52x" to="kelk:3vxfdxbkQj9" resolve="WarningKind" />
-    <node concept="3F0ifn" id="3vxfdxbkQj_" role="2wV5jI">
-      <property role="3F0ifm" value="warning" />
-      <node concept="VechU" id="3vxfdxbkQjD" role="3F10Kt">
-        <node concept="1iSF2X" id="3vxfdxbkQjG" role="VblUZ">
-          <property role="1iTho6" value="FD7D01" />
+    <node concept="3EZMnI" id="7OtDX6qjWPQ" role="2wV5jI">
+      <node concept="2iRfu4" id="7OtDX6qjWPR" role="2iSdaV" />
+      <node concept="3F0ifn" id="3vxfdxbkQj_" role="3EZMnx">
+        <property role="3F0ifm" value="warning[" />
+        <node concept="VechU" id="3vxfdxbkQjD" role="3F10Kt">
+          <node concept="1iSF2X" id="3vxfdxbkQjG" role="VblUZ">
+            <property role="1iTho6" value="FD7D01" />
+          </node>
         </node>
+      </node>
+      <node concept="3F0A7n" id="7OtDX6qjWQd" role="3EZMnx">
+        <ref role="1NtTu8" to="kelk:7OtDX6qjWPO" resolve="warningID" />
+        <node concept="VechU" id="7OtDX6qjWQe" role="3F10Kt">
+          <property role="Vb096" value="red" />
+          <node concept="1iSF2X" id="7OtDX6qjWQz" role="VblUZ">
+            <property role="1iTho6" value="FD7D01" />
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="7OtDX6qjWQr" role="3EZMnx">
+        <property role="3F0ifm" value="]" />
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/structure.mps
@@ -16,6 +16,9 @@
   </imports>
   <registry>
     <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="1224240836180" name="jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation" flags="ig" index="asaX9">
+        <property id="1225118933224" name="comment" index="YLQ7P" />
+      </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
         <property id="4628067390765907488" name="conceptShortDescription" index="R4oN_" />
@@ -51,6 +54,7 @@
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
@@ -195,8 +199,11 @@
     </node>
     <node concept="1TJgyi" id="4AahbtV9FsC" role="1TKVEl">
       <property role="IQ2nx" value="5299123466390648616" />
-      <property role="TrG5h" value="messageValue" />
+      <property role="TrG5h" value="messageValue_DEPRECATED" />
       <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+      <node concept="asaX9" id="7OtDX6qk7uV" role="lGtFl">
+        <property role="YLQ7P" value="treated as always true" />
+      </node>
     </node>
   </node>
   <node concept="1TIwiD" id="3vxfdxbdUeD">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/structure.mps
@@ -293,6 +293,11 @@
     <property role="34LRSv" value="warning" />
     <property role="R4oN_" value="a message representing a warning" />
     <ref role="1TJDcQ" node="3vxfdxbksat" resolve="MessageKind" />
+    <node concept="1TJgyi" id="7OtDX6qjWPO" role="1TKVEl">
+      <property role="IQ2nx" value="9015546547744525684" />
+      <property role="TrG5h" value="warningID" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+    </node>
   </node>
   <node concept="1TIwiD" id="3vxfdxblP3W">
     <property role="EcuMT" value="4026566441520550140" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/typesystem.mps
@@ -6,10 +6,8 @@
     <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
   </languages>
   <imports>
-    <import index="oq0c" ref="r:6c6155f0-4bbe-4af5-8c26-244d570e21e4(org.iets3.core.expr.base.plugin)" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
     <import index="kelk" ref="r:1a11ce0d-cf54-4682-9b8a-ab4ee15fc129(org.iets3.core.expr.messages.structure)" />
-    <import index="tpd4" ref="r:00000000-0000-4000-0000-011c895902b4(jetbrains.mps.lang.typesystem.structure)" />
     <import index="700h" ref="r:61b1de80-490d-4fee-8e95-b956503290e9(org.iets3.core.expr.collections.structure)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" implicit="true" />
@@ -45,6 +43,7 @@
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
@@ -132,6 +131,7 @@
       </concept>
       <concept id="1174658326157" name="jetbrains.mps.lang.typesystem.structure.CreateEquationStatement" flags="nn" index="1Z5TYs" />
       <concept id="1174660718586" name="jetbrains.mps.lang.typesystem.structure.AbstractEquationStatement" flags="nn" index="1Zf1VF">
+        <property id="1206359757216" name="checkOnly" index="3wDh2S" />
         <child id="1174660783413" name="leftExpression" index="1ZfhK$" />
         <child id="1174660783414" name="rightExpression" index="1ZfhKB" />
       </concept>
@@ -156,9 +156,6 @@
       <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
-      </concept>
-      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
-        <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
@@ -191,53 +188,23 @@
   <node concept="1YbPZF" id="3vxfdxbdzYm">
     <property role="TrG5h" value="typeof_MessageTarget" />
     <node concept="3clFbS" id="3vxfdxbdzYn" role="18ibNy">
-      <node concept="3clFbJ" id="4AahbtV9HAh" role="3cqZAp">
-        <node concept="3clFbS" id="4AahbtV9HAj" role="3clFbx">
-          <node concept="1Z5TYs" id="4AahbtV9ILu" role="3cqZAp">
-            <node concept="mw_s8" id="4AahbtV9ILv" role="1ZfhKB">
-              <node concept="2pJPEk" id="4AahbtV9ILw" role="mwGJk">
-                <node concept="2pJPED" id="4AahbtV9ILx" role="2pJPEn">
-                  <ref role="2pJxaS" to="hm2y:4AahbtULQzU" resolve="MessageValueType" />
-                </node>
-              </node>
-            </node>
-            <node concept="mw_s8" id="4AahbtV9ILy" role="1ZfhK$">
-              <node concept="1Z2H0r" id="4AahbtV9ILz" role="mwGJk">
-                <node concept="1YBJjd" id="4AahbtV9IL$" role="1Z2MuG">
-                  <ref role="1YBMHb" node="3vxfdxbdzYp" resolve="mt" />
-                </node>
-              </node>
+      <node concept="1Z5TYs" id="4AahbtV9ILu" role="3cqZAp">
+        <node concept="mw_s8" id="4AahbtV9ILv" role="1ZfhKB">
+          <node concept="2pJPEk" id="4AahbtV9ILw" role="mwGJk">
+            <node concept="2pJPED" id="4AahbtV9ILx" role="2pJPEn">
+              <ref role="2pJxaS" to="hm2y:4AahbtULQzU" resolve="MessageValueType" />
             </node>
           </node>
         </node>
-        <node concept="2OqwBi" id="4AahbtV9HMs" role="3clFbw">
-          <node concept="1YBJjd" id="4AahbtV9HBn" role="2Oq$k0">
-            <ref role="1YBMHb" node="3vxfdxbdzYp" resolve="mt" />
-          </node>
-          <node concept="3TrcHB" id="4AahbtV9IcD" role="2OqNvi">
-            <ref role="3TsBF5" to="kelk:4AahbtV9FsC" resolve="messageValue" />
-          </node>
-        </node>
-        <node concept="9aQIb" id="4AahbtV9If3" role="9aQIa">
-          <node concept="3clFbS" id="4AahbtV9If4" role="9aQI4">
-            <node concept="1Z5TYs" id="3vxfdxbd$9k" role="3cqZAp">
-              <node concept="mw_s8" id="4AahbtV9Jnd" role="1ZfhKB">
-                <node concept="2YIFZM" id="5wDe8wA6zrF" role="mwGJk">
-                  <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
-                  <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-                </node>
-              </node>
-              <node concept="mw_s8" id="3vxfdxbd$9n" role="1ZfhK$">
-                <node concept="1Z2H0r" id="3vxfdxbdzYw" role="mwGJk">
-                  <node concept="1YBJjd" id="3vxfdxbdzYN" role="1Z2MuG">
-                    <ref role="1YBMHb" node="3vxfdxbdzYp" resolve="mt" />
-                  </node>
-                </node>
-              </node>
+        <node concept="mw_s8" id="4AahbtV9ILy" role="1ZfhK$">
+          <node concept="1Z2H0r" id="4AahbtV9ILz" role="mwGJk">
+            <node concept="1YBJjd" id="4AahbtV9IL$" role="1Z2MuG">
+              <ref role="1YBMHb" node="3vxfdxbdzYp" resolve="mt" />
             </node>
           </node>
         </node>
       </node>
+      <node concept="3clFbH" id="7OtDX6qkbKi" role="3cqZAp" />
       <node concept="3clFbJ" id="3vxfdxbk3_O" role="3cqZAp">
         <node concept="3clFbS" id="3vxfdxbk3_Q" role="3clFbx">
           <node concept="2MkqsV" id="3vxfdxbkcc5" role="3cqZAp">
@@ -309,6 +276,7 @@
               </node>
               <node concept="3clFbS" id="3vxfdxbkiTp" role="2LFqv$">
                 <node concept="1ZobV4" id="3vxfdxbkjQ2" role="3cqZAp">
+                  <property role="3wDh2S" value="true" />
                   <node concept="mw_s8" id="3vxfdxbkjQu" role="1ZfhKB">
                     <node concept="1Z2H0r" id="3vxfdxbkjQq" role="mwGJk">
                       <node concept="2OqwBi" id="3vxfdxbkns2" role="1Z2MuG">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/org.iets3.core.expr.messages.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/org.iets3.core.expr.messages.mpl
@@ -81,7 +81,6 @@
     <dependency reexport="false">6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)</dependency>
     <dependency reexport="false">553a35c5-ccd6-40ba-9923-5e3b354d0c76(org.iets3.core.expr.messages)</dependency>
     <dependency reexport="false">d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)</dependency>
-    <dependency reexport="false">7a5dda62-9140-4668-ab76-d5ed1746f2b2(jetbrains.mps.lang.typesystem)</dependency>
     <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
     <dependency reexport="false">71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)</dependency>
     <dependency reexport="false">2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)</dependency>
@@ -146,14 +145,9 @@
     <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="63650c59-16c8-498a-99c8-005c7ee9515d(jetbrains.mps.lang.access)" version="0" />
-    <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
-    <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
-    <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
-    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
-    <module reference="7a5dda62-9140-4668-ab76-d5ed1746f2b2(jetbrains.mps.lang.typesystem)" version="0" />
     <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="0" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
     <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="3" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -166,6 +166,9 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
       <concept id="1082113931046" name="jetbrains.mps.baseLanguage.structure.ContinueStatement" flags="nn" index="3N13vt" />
       <concept id="6329021646629104957" name="jetbrains.mps.baseLanguage.structure.TextCommentPart" flags="nn" index="3SKdUq">
         <property id="6329021646629104958" name="text" index="3SKdUp" />
@@ -242,6 +245,14 @@
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
@@ -7640,6 +7651,60 @@
         </node>
       </node>
       <node concept="10P_77" id="5YygIlbmK__" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="TA$XW2_xOF" role="13h7CS">
+      <property role="TrG5h" value="getFqName" />
+      <ref role="13i0hy" to="tpcu:hEwIO9y" resolve="getFqName" />
+      <node concept="3Tm1VV" id="TA$XW2_xPq" role="1B3o_S" />
+      <node concept="3clFbS" id="TA$XW2_xPr" role="3clF47">
+        <node concept="Jncv_" id="TA$XW2_$Va" role="3cqZAp">
+          <ref role="JncvD" to="tpck:h0TrEE$" resolve="INamedConcept" />
+          <node concept="2OqwBi" id="TA$XW2__mW" role="JncvB">
+            <node concept="13iPFW" id="TA$XW2__4C" role="2Oq$k0" />
+            <node concept="1mfA1w" id="TA$XW2__TJ" role="2OqNvi" />
+          </node>
+          <node concept="3clFbS" id="TA$XW2_$Ve" role="Jncv$">
+            <node concept="3cpWs6" id="TA$XW2_AfP" role="3cqZAp">
+              <node concept="3cpWs3" id="TA$XW2_J9n" role="3cqZAk">
+                <node concept="2OqwBi" id="TA$XW2_JwN" role="3uHU7w">
+                  <node concept="13iPFW" id="TA$XW2_J9O" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="TA$XW2_Khi" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+                <node concept="3cpWs3" id="TA$XW2_IE8" role="3uHU7B">
+                  <node concept="2OqwBi" id="TA$XW2_AqN" role="3uHU7B">
+                    <node concept="Jnkvi" id="TA$XW2_AfW" role="2Oq$k0">
+                      <ref role="1M0zk5" node="TA$XW2_$Vg" resolve="nc" />
+                    </node>
+                    <node concept="2qgKlT" id="TA$XW2_Ifs" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIO9y" resolve="getFqName" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="TA$XW2_IEb" role="3uHU7w">
+                    <property role="Xl_RC" value="." />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="TA$XW2_$Vg" role="JncvA">
+            <property role="TrG5h" value="nc" />
+            <node concept="2jxLKc" id="TA$XW2_$Vh" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="TA$XW2_KNp" role="3cqZAp">
+          <node concept="2OqwBi" id="TA$XW2_KNq" role="3cqZAk">
+            <node concept="13iAh5" id="TA$XW2_KNr" role="2Oq$k0">
+              <ref role="3eA5LN" to="4kwy:cJpacq5T0O" resolve="IValidNamedConcept" />
+            </node>
+            <node concept="2qgKlT" id="TA$XW2_KNs" role="2OqNvi">
+              <ref role="37wK5l" to="tpcu:hEwIO9y" resolve="getFqName" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="TA$XW2_xPs" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="4ptnK4jbra4">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.genjava.base.rt/models/rt.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.genjava.base.rt/models/rt.mps
@@ -1155,6 +1155,40 @@
         <property role="TrG5h" value="T" />
       </node>
     </node>
+    <node concept="2tJIrI" id="5GmVcyjRJ43" role="jymVt" />
+    <node concept="2YIFZL" id="5GmVcyjRIQz" role="jymVt">
+      <property role="TrG5h" value="fail" />
+      <node concept="3clFbS" id="5GmVcyjRIQ$" role="3clF47">
+        <node concept="YS8fn" id="5GmVcyjRIQ_" role="3cqZAp">
+          <node concept="2ShNRf" id="5GmVcyjRIQA" role="YScLw">
+            <node concept="1pGfFk" id="5GmVcyjRIQB" role="2ShVmc">
+              <ref role="37wK5l" node="6jT4GDw1g9U" resolve="FailException" />
+              <node concept="2OqwBi" id="5GmVcyjRNal" role="37wK5m">
+                <node concept="37vLTw" id="5GmVcyjRIQC" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5GmVcyjRIQE" resolve="message" />
+                </node>
+                <node concept="liA8E" id="5GmVcyjRNj6" role="2OqNvi">
+                  <ref role="37wK5l" to="vj64:4ZjVa_SLF9Y" resolve="textWithKind" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5GmVcyjRIQD" role="1B3o_S" />
+      <node concept="37vLTG" id="5GmVcyjRIQE" role="3clF46">
+        <property role="TrG5h" value="message" />
+        <node concept="3uibUv" id="5GmVcyjRIY4" role="1tU5fm">
+          <ref role="3uigEE" to="vj64:4NeJNX_xLh$" resolve="Message" />
+        </node>
+      </node>
+      <node concept="16syzq" id="5GmVcyjRIQG" role="3clF45">
+        <ref role="16sUi3" node="5GmVcyjRIQH" resolve="T" />
+      </node>
+      <node concept="16euLQ" id="5GmVcyjRIQH" role="16eVyc">
+        <property role="TrG5h" value="T" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="6jT4GDw1g9J" role="jymVt" />
     <node concept="3Tm1VV" id="6jT4GDw1g67" role="1B3o_S" />
     <node concept="3uibUv" id="6jT4GDw1g79" role="1zkMxy">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.genjava.messages.rt/models/rt.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.genjava.messages.rt/models/rt.mps
@@ -275,14 +275,64 @@
     <node concept="2tJIrI" id="55imU6wacrY" role="jymVt" />
     <node concept="312cEu" id="55imU6wacHt" role="jymVt">
       <property role="TrG5h" value="Warning" />
+      <node concept="312cEg" id="7OtDX6qk3xd" role="jymVt">
+        <property role="TrG5h" value="warningId" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3Tm1VV" id="7OtDX6qk3xe" role="1B3o_S" />
+        <node concept="17QB3L" id="7OtDX6qk3xf" role="1tU5fm" />
+        <node concept="2AHcQZ" id="7OtDX6qk3xg" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="7OtDX6qk3LH" role="jymVt" />
+      <node concept="3clFbW" id="7OtDX6qk3Zc" role="jymVt">
+        <node concept="3cqZAl" id="7OtDX6qk3Zd" role="3clF45" />
+        <node concept="3clFbS" id="7OtDX6qk3Ze" role="3clF47">
+          <node concept="3clFbF" id="7OtDX6qk3Zf" role="3cqZAp">
+            <node concept="37vLTI" id="7OtDX6qk3Zg" role="3clFbG">
+              <node concept="37vLTw" id="7OtDX6qk4wJ" role="37vLTx">
+                <ref role="3cqZAo" node="7OtDX6qk3Zm" resolve="warningId" />
+              </node>
+              <node concept="2OqwBi" id="7OtDX6qk3Zi" role="37vLTJ">
+                <node concept="Xjq3P" id="7OtDX6qk3Zj" role="2Oq$k0" />
+                <node concept="2OwXpG" id="7OtDX6qk4nY" role="2OqNvi">
+                  <ref role="2Oxat5" node="7OtDX6qk3xd" resolve="warningId" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3Tm1VV" id="7OtDX6qk3Zl" role="1B3o_S" />
+        <node concept="37vLTG" id="7OtDX6qk3Zm" role="3clF46">
+          <property role="TrG5h" value="warningId" />
+          <node concept="17QB3L" id="7OtDX6qk3Zn" role="1tU5fm" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="7OtDX6qk3YL" role="jymVt" />
       <node concept="3clFb_" id="55imU6wa8eY" role="jymVt">
         <property role="TrG5h" value="toString" />
         <node concept="3Tm1VV" id="55imU6wa8eZ" role="1B3o_S" />
         <node concept="17QB3L" id="55imU6wac2p" role="3clF45" />
         <node concept="3clFbS" id="55imU6wa8f3" role="3clF47">
           <node concept="3cpWs6" id="55imU6wa8k$" role="3cqZAp">
-            <node concept="Xl_RD" id="55imU6wa8QO" role="3cqZAk">
-              <property role="Xl_RC" value="WARNING" />
+            <node concept="3K4zz7" id="7OtDX6qk62D" role="3cqZAk">
+              <node concept="3cpWs3" id="7OtDX6qk71d" role="3K4GZi">
+                <node concept="37vLTw" id="7OtDX6qk7g6" role="3uHU7w">
+                  <ref role="3cqZAo" node="7OtDX6qk3xd" resolve="warningId" />
+                </node>
+                <node concept="Xl_RD" id="7OtDX6qk6vU" role="3uHU7B">
+                  <property role="Xl_RC" value="WARNING " />
+                </node>
+              </node>
+              <node concept="3clFbC" id="7OtDX6qk5u8" role="3K4Cdx">
+                <node concept="10Nm6u" id="7OtDX6qk5Ks" role="3uHU7w" />
+                <node concept="37vLTw" id="7OtDX6qk5eV" role="3uHU7B">
+                  <ref role="3cqZAo" node="7OtDX6qk3xd" resolve="warningId" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="55imU6wa8QO" role="3K4E3e">
+                <property role="Xl_RC" value="WARNING" />
+              </node>
             </node>
           </node>
         </node>
@@ -385,15 +435,41 @@
       <property role="TrG5h" value="warning" />
       <node concept="3clFbS" id="55imU6w9XVZ" role="3clF47">
         <node concept="3cpWs6" id="55imU6w9Ymx" role="3cqZAp">
-          <node concept="2ShNRf" id="55imU6wadA4" role="3cqZAk">
-            <node concept="HV5vD" id="55imU6wadLm" role="2ShVmc">
-              <ref role="HV5vE" node="55imU6wacHt" resolve="BuiltinMessageKinds.Warning" />
-            </node>
+          <node concept="1rXfSq" id="7fFM7QP5jcG" role="3cqZAk">
+            <ref role="37wK5l" node="7fFM7QP5ifn" resolve="warning" />
+            <node concept="10Nm6u" id="7fFM7QP5jje" role="37wK5m" />
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="55imU6w9XTh" role="1B3o_S" />
       <node concept="3uibUv" id="55imU6w9XVG" role="3clF45">
+        <ref role="3uigEE" node="55imU6w9RYW" resolve="MessageKind" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7fFM7QP5hTH" role="jymVt" />
+    <node concept="2YIFZL" id="7fFM7QP5ifn" role="jymVt">
+      <property role="TrG5h" value="warning" />
+      <node concept="37vLTG" id="7fFM7QP5ifo" role="3clF46">
+        <property role="TrG5h" value="warningId" />
+        <node concept="17QB3L" id="7fFM7QP5ifp" role="1tU5fm" />
+        <node concept="2AHcQZ" id="7fFM7QP5ifq" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7fFM7QP5ifr" role="3clF47">
+        <node concept="3cpWs6" id="7fFM7QP5ifs" role="3cqZAp">
+          <node concept="2ShNRf" id="7fFM7QP5ift" role="3cqZAk">
+            <node concept="1pGfFk" id="7fFM7QP5ifu" role="2ShVmc">
+              <ref role="37wK5l" node="7OtDX6qk3Zc" resolve="BuiltinMessageKinds.Warning" />
+              <node concept="37vLTw" id="7fFM7QP5ktt" role="37wK5m">
+                <ref role="3cqZAo" node="7fFM7QP5ifo" resolve="warningId" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7fFM7QP5ifw" role="1B3o_S" />
+      <node concept="3uibUv" id="7fFM7QP5ifx" role="3clF45">
         <ref role="3uigEE" node="55imU6w9RYW" resolve="MessageKind" />
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.genjava.messages.rt/models/rt.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.genjava.messages.rt/models/rt.mps
@@ -6,6 +6,7 @@
   </languages>
   <imports>
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -87,6 +88,7 @@
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
+        <child id="4972241301747169160" name="typeArgument" index="3PaCim" />
       </concept>
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
@@ -96,6 +98,7 @@
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -512,7 +515,61 @@
         <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
       </node>
     </node>
+    <node concept="2tJIrI" id="TA$XW2l2Hw" role="jymVt" />
+    <node concept="312cEg" id="TA$XW2l3mv" role="jymVt">
+      <property role="TrG5h" value="affectedMemberNames" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm1VV" id="TA$XW2l34u" role="1B3o_S" />
+      <node concept="3uibUv" id="TA$XW2lbDg" role="1tU5fm">
+        <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+        <node concept="3uibUv" id="TA$XW2lbFr" role="11_B2D">
+          <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="TA$XW2nazG" role="jymVt" />
+    <node concept="312cEg" id="TA$XW2ncJu" role="jymVt">
+      <property role="TrG5h" value="userData" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm1VV" id="TA$XW2nbtQ" role="1B3o_S" />
+      <node concept="3uibUv" id="TA$XW2ncoR" role="1tU5fm">
+        <ref role="3uigEE" to="33ny:~Map" resolve="Map" />
+        <node concept="3uibUv" id="TA$XW2nc$W" role="11_B2D">
+          <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+        </node>
+        <node concept="3uibUv" id="TA$XW2ncEd" role="11_B2D">
+          <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="65vXeyMqjEF" role="jymVt" />
+    <node concept="3clFbW" id="lH$PuhbfPv" role="jymVt">
+      <node concept="3cqZAl" id="lH$PuhbfPw" role="3clF45" />
+      <node concept="3Tm1VV" id="lH$PuhbfPx" role="1B3o_S" />
+      <node concept="3clFbS" id="lH$PuhbfPy" role="3clF47">
+        <node concept="1VxSAg" id="TA$XW2nvi1" role="3cqZAp">
+          <ref role="37wK5l" node="65vXeyMqtif" resolve="Message" />
+          <node concept="37vLTw" id="TA$XW2nvrT" role="37wK5m">
+            <ref role="3cqZAo" node="lH$PuhbfPP" resolve="kind" />
+          </node>
+          <node concept="37vLTw" id="TA$XW2nvsn" role="37wK5m">
+            <ref role="3cqZAo" node="lH$PuhbfPR" resolve="text" />
+          </node>
+          <node concept="10Nm6u" id="TA$XW2nvsJ" role="37wK5m" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="lH$PuhbfPP" role="3clF46">
+        <property role="TrG5h" value="kind" />
+        <node concept="3uibUv" id="lH$PuhbfPQ" role="1tU5fm">
+          <ref role="3uigEE" node="55imU6w9RYW" resolve="MessageKind" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="lH$PuhbfPR" role="3clF46">
+        <property role="TrG5h" value="text" />
+        <node concept="17QB3L" id="lH$PuhbfPS" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4ZjVa_SLELp" role="jymVt" />
     <node concept="3clFbW" id="4NeJNX_xLql" role="jymVt">
       <node concept="37vLTG" id="4NeJNX_xLqP" role="3clF46">
         <property role="TrG5h" value="kind" />
@@ -551,7 +608,7 @@
       <node concept="3cqZAl" id="4NeJNX_xLqm" role="3clF45" />
       <node concept="3clFbS" id="4NeJNX_xLqo" role="3clF47">
         <node concept="1VxSAg" id="65vXeyMquCe" role="3cqZAp">
-          <ref role="37wK5l" node="65vXeyMqtif" resolve="Message" />
+          <ref role="37wK5l" node="TA$XW2lbJb" resolve="Message" />
           <node concept="37vLTw" id="65vXeyMquIj" role="37wK5m">
             <ref role="3cqZAo" node="4NeJNX_xLqP" resolve="kind" />
           </node>
@@ -586,105 +643,58 @@
               </node>
             </node>
           </node>
+          <node concept="2YIFZM" id="TA$XW2n9WN" role="37wK5m">
+            <ref role="37wK5l" to="33ny:~Collections.emptySet()" resolve="emptySet" />
+            <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+            <node concept="3uibUv" id="TA$XW2nakD" role="3PaCim">
+              <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="TA$XW2ntVb" role="37wK5m">
+            <ref role="37wK5l" to="33ny:~Collections.emptyMap()" resolve="emptyMap" />
+            <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+            <node concept="3uibUv" id="TA$XW2nujP" role="3PaCim">
+              <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+            </node>
+            <node concept="3uibUv" id="TA$XW2nuA1" role="3PaCim">
+              <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+            </node>
+          </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="4NeJNX_xLpY" role="1B3o_S" />
-    </node>
-    <node concept="2tJIrI" id="4ZjVa_SLELp" role="jymVt" />
-    <node concept="3clFbW" id="lH$PuhbfPv" role="jymVt">
-      <node concept="3cqZAl" id="lH$PuhbfPw" role="3clF45" />
-      <node concept="3Tm1VV" id="lH$PuhbfPx" role="1B3o_S" />
-      <node concept="3clFbS" id="lH$PuhbfPy" role="3clF47">
-        <node concept="3clFbF" id="lH$PuhbfPz" role="3cqZAp">
-          <node concept="37vLTI" id="lH$PuhbfP$" role="3clFbG">
-            <node concept="2OqwBi" id="lH$PuhbfP_" role="37vLTJ">
-              <node concept="Xjq3P" id="lH$PuhbfPA" role="2Oq$k0" />
-              <node concept="2OwXpG" id="lH$PuhbfPB" role="2OqNvi">
-                <ref role="2Oxat5" node="4NeJNX_xLnL" resolve="kind" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="lH$PuhbfPC" role="37vLTx">
-              <ref role="3cqZAo" node="lH$PuhbfPP" resolve="kind" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="lH$PuhbfPD" role="3cqZAp">
-          <node concept="37vLTI" id="lH$PuhbfPE" role="3clFbG">
-            <node concept="2OqwBi" id="lH$PuhbfPF" role="37vLTJ">
-              <node concept="Xjq3P" id="lH$PuhbfPG" role="2Oq$k0" />
-              <node concept="2OwXpG" id="lH$PuhbfPH" role="2OqNvi">
-                <ref role="2Oxat5" node="4NeJNX_xLp2" resolve="text" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="lH$PuhbfPI" role="37vLTx">
-              <ref role="3cqZAo" node="lH$PuhbfPR" resolve="text" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="lH$PuhbfPJ" role="3cqZAp">
-          <node concept="37vLTI" id="lH$PuhbfPK" role="3clFbG">
-            <node concept="2OqwBi" id="lH$PuhbfPL" role="37vLTJ">
-              <node concept="Xjq3P" id="lH$PuhbfPM" role="2Oq$k0" />
-              <node concept="2OwXpG" id="lH$PuhbfPN" role="2OqNvi">
-                <ref role="2Oxat5" node="65vXeyMqnfI" resolve="programLocation" />
-              </node>
-            </node>
-            <node concept="10Nm6u" id="lH$PuhbgM4" role="37vLTx" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="lH$PuhbfPP" role="3clF46">
-        <property role="TrG5h" value="kind" />
-        <node concept="3uibUv" id="lH$PuhbfPQ" role="1tU5fm">
-          <ref role="3uigEE" node="55imU6w9RYW" resolve="MessageKind" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="lH$PuhbfPR" role="3clF46">
-        <property role="TrG5h" value="text" />
-        <node concept="17QB3L" id="lH$PuhbfPS" role="1tU5fm" />
-      </node>
     </node>
     <node concept="2tJIrI" id="lH$PuhbgqF" role="jymVt" />
     <node concept="3clFbW" id="65vXeyMqtif" role="jymVt">
       <node concept="3cqZAl" id="65vXeyMqtig" role="3clF45" />
       <node concept="3Tm1VV" id="65vXeyMqtih" role="1B3o_S" />
       <node concept="3clFbS" id="65vXeyMqtij" role="3clF47">
-        <node concept="3clFbF" id="65vXeyMqtin" role="3cqZAp">
-          <node concept="37vLTI" id="65vXeyMqtip" role="3clFbG">
-            <node concept="2OqwBi" id="65vXeyMqtit" role="37vLTJ">
-              <node concept="Xjq3P" id="65vXeyMqtiu" role="2Oq$k0" />
-              <node concept="2OwXpG" id="65vXeyMqtiv" role="2OqNvi">
-                <ref role="2Oxat5" node="4NeJNX_xLnL" resolve="kind" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="65vXeyMqtiw" role="37vLTx">
-              <ref role="3cqZAo" node="65vXeyMqtim" resolve="kind" />
+        <node concept="1VxSAg" id="TA$XW2leur" role="3cqZAp">
+          <ref role="37wK5l" node="TA$XW2lbJb" resolve="Message" />
+          <node concept="37vLTw" id="TA$XW2le$q" role="37wK5m">
+            <ref role="3cqZAo" node="65vXeyMqtim" resolve="kind" />
+          </node>
+          <node concept="37vLTw" id="TA$XW2le$S" role="37wK5m">
+            <ref role="3cqZAo" node="65vXeyMqtiy" resolve="text" />
+          </node>
+          <node concept="37vLTw" id="TA$XW2leGc" role="37wK5m">
+            <ref role="3cqZAo" node="65vXeyMqtiI" resolve="programLocation" />
+          </node>
+          <node concept="2YIFZM" id="TA$XW2leQP" role="37wK5m">
+            <ref role="37wK5l" to="33ny:~Collections.emptySet()" resolve="emptySet" />
+            <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+            <node concept="3uibUv" id="TA$XW2leZu" role="3PaCim">
+              <ref role="3uigEE" to="wyt6:~String" resolve="String" />
             </node>
           </node>
-        </node>
-        <node concept="3clFbF" id="65vXeyMqtiz" role="3cqZAp">
-          <node concept="37vLTI" id="65vXeyMqti_" role="3clFbG">
-            <node concept="2OqwBi" id="65vXeyMqtiD" role="37vLTJ">
-              <node concept="Xjq3P" id="65vXeyMqtiE" role="2Oq$k0" />
-              <node concept="2OwXpG" id="65vXeyMqtiF" role="2OqNvi">
-                <ref role="2Oxat5" node="4NeJNX_xLp2" resolve="text" />
-              </node>
+          <node concept="2YIFZM" id="TA$XW2nuZn" role="37wK5m">
+            <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+            <ref role="37wK5l" to="33ny:~Collections.emptyMap()" resolve="emptyMap" />
+            <node concept="3uibUv" id="TA$XW2nuZo" role="3PaCim">
+              <ref role="3uigEE" to="wyt6:~String" resolve="String" />
             </node>
-            <node concept="37vLTw" id="65vXeyMqtiG" role="37vLTx">
-              <ref role="3cqZAo" node="65vXeyMqtiy" resolve="text" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="65vXeyMqtiJ" role="3cqZAp">
-          <node concept="37vLTI" id="65vXeyMqtiL" role="3clFbG">
-            <node concept="2OqwBi" id="65vXeyMqtiP" role="37vLTJ">
-              <node concept="Xjq3P" id="65vXeyMqtiQ" role="2Oq$k0" />
-              <node concept="2OwXpG" id="65vXeyMqtiR" role="2OqNvi">
-                <ref role="2Oxat5" node="65vXeyMqnfI" resolve="programLocation" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="65vXeyMqtiS" role="37vLTx">
-              <ref role="3cqZAo" node="65vXeyMqtiI" resolve="programLocation" />
+            <node concept="3uibUv" id="TA$XW2nuZp" role="3PaCim">
+              <ref role="3uigEE" to="wyt6:~String" resolve="String" />
             </node>
           </node>
         </node>
@@ -703,6 +713,115 @@
         <property role="TrG5h" value="programLocation" />
         <node concept="3uibUv" id="65vXeyMqtiH" role="1tU5fm">
           <ref role="3uigEE" node="65vXeyMqhK2" resolve="ProgramLocation" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="TA$XW2lc6u" role="jymVt" />
+    <node concept="3clFbW" id="TA$XW2lbJb" role="jymVt">
+      <node concept="3cqZAl" id="TA$XW2lbJc" role="3clF45" />
+      <node concept="3Tm1VV" id="TA$XW2lbJd" role="1B3o_S" />
+      <node concept="3clFbS" id="TA$XW2lbJe" role="3clF47">
+        <node concept="3clFbF" id="TA$XW2lbJf" role="3cqZAp">
+          <node concept="37vLTI" id="TA$XW2lbJg" role="3clFbG">
+            <node concept="2OqwBi" id="TA$XW2lbJh" role="37vLTJ">
+              <node concept="Xjq3P" id="TA$XW2lbJi" role="2Oq$k0" />
+              <node concept="2OwXpG" id="TA$XW2lbJj" role="2OqNvi">
+                <ref role="2Oxat5" node="4NeJNX_xLnL" resolve="kind" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="TA$XW2lbJk" role="37vLTx">
+              <ref role="3cqZAo" node="TA$XW2lbJx" resolve="kind" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="TA$XW2lbJl" role="3cqZAp">
+          <node concept="37vLTI" id="TA$XW2lbJm" role="3clFbG">
+            <node concept="2OqwBi" id="TA$XW2lbJn" role="37vLTJ">
+              <node concept="Xjq3P" id="TA$XW2lbJo" role="2Oq$k0" />
+              <node concept="2OwXpG" id="TA$XW2lbJp" role="2OqNvi">
+                <ref role="2Oxat5" node="4NeJNX_xLp2" resolve="text" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="TA$XW2lbJq" role="37vLTx">
+              <ref role="3cqZAo" node="TA$XW2lbJz" resolve="text" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="TA$XW2lbJr" role="3cqZAp">
+          <node concept="37vLTI" id="TA$XW2lbJs" role="3clFbG">
+            <node concept="2OqwBi" id="TA$XW2lbJt" role="37vLTJ">
+              <node concept="Xjq3P" id="TA$XW2lbJu" role="2Oq$k0" />
+              <node concept="2OwXpG" id="TA$XW2lbJv" role="2OqNvi">
+                <ref role="2Oxat5" node="65vXeyMqnfI" resolve="programLocation" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="TA$XW2lbJw" role="37vLTx">
+              <ref role="3cqZAo" node="TA$XW2lbJ_" resolve="programLocation" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="TA$XW2lc_z" role="3cqZAp">
+          <node concept="37vLTI" id="TA$XW2lcZ8" role="3clFbG">
+            <node concept="37vLTw" id="TA$XW2ld9p" role="37vLTx">
+              <ref role="3cqZAo" node="TA$XW2lcsF" resolve="affectedMemberNames" />
+            </node>
+            <node concept="2OqwBi" id="TA$XW2lcE2" role="37vLTJ">
+              <node concept="Xjq3P" id="TA$XW2lc_x" role="2Oq$k0" />
+              <node concept="2OwXpG" id="TA$XW2lcJ6" role="2OqNvi">
+                <ref role="2Oxat5" node="TA$XW2l3mv" resolve="affectedMemberNames" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="TA$XW2ns7Y" role="3cqZAp">
+          <node concept="37vLTI" id="TA$XW2nsCd" role="3clFbG">
+            <node concept="37vLTw" id="TA$XW2nsEj" role="37vLTx">
+              <ref role="3cqZAo" node="TA$XW2nkjV" resolve="userData" />
+            </node>
+            <node concept="2OqwBi" id="TA$XW2nshX" role="37vLTJ">
+              <node concept="Xjq3P" id="TA$XW2ns7W" role="2Oq$k0" />
+              <node concept="2OwXpG" id="TA$XW2nsuj" role="2OqNvi">
+                <ref role="2Oxat5" node="TA$XW2ncJu" resolve="userData" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="TA$XW2lbJx" role="3clF46">
+        <property role="TrG5h" value="kind" />
+        <node concept="3uibUv" id="TA$XW2lbJy" role="1tU5fm">
+          <ref role="3uigEE" node="55imU6w9RYW" resolve="MessageKind" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="TA$XW2lbJz" role="3clF46">
+        <property role="TrG5h" value="text" />
+        <node concept="17QB3L" id="TA$XW2lbJ$" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="TA$XW2lbJ_" role="3clF46">
+        <property role="TrG5h" value="programLocation" />
+        <node concept="3uibUv" id="TA$XW2lbJA" role="1tU5fm">
+          <ref role="3uigEE" node="65vXeyMqhK2" resolve="ProgramLocation" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="TA$XW2lcsF" role="3clF46">
+        <property role="TrG5h" value="affectedMemberNames" />
+        <node concept="3uibUv" id="TA$XW2lcxi" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+          <node concept="3uibUv" id="TA$XW2lcyb" role="11_B2D">
+            <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="TA$XW2nkjV" role="3clF46">
+        <property role="TrG5h" value="userData" />
+        <node concept="3uibUv" id="TA$XW2nl46" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~Map" resolve="Map" />
+          <node concept="3uibUv" id="TA$XW2nmej" role="11_B2D">
+            <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+          </node>
+          <node concept="3uibUv" id="TA$XW2nnmD" role="11_B2D">
+            <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+          </node>
         </node>
       </node>
     </node>
@@ -763,7 +882,7 @@
         <node concept="3cpWs6" id="1aR2a4nXzf2" role="3cqZAp">
           <node concept="2ShNRf" id="1aR2a4nXzfg" role="3cqZAk">
             <node concept="1pGfFk" id="1aR2a4nXzkw" role="2ShVmc">
-              <ref role="37wK5l" node="65vXeyMqtif" resolve="Message" />
+              <ref role="37wK5l" node="TA$XW2lbJb" resolve="Message" />
               <node concept="37vLTw" id="1aR2a4nXzvE" role="37wK5m">
                 <ref role="3cqZAo" node="4NeJNX_xLnL" resolve="kind" />
               </node>
@@ -772,6 +891,12 @@
               </node>
               <node concept="37vLTw" id="1aR2a4nXzFQ" role="37wK5m">
                 <ref role="3cqZAo" node="1aR2a4nXz3w" resolve="programLocation" />
+              </node>
+              <node concept="37vLTw" id="TA$XW2ldD5" role="37wK5m">
+                <ref role="3cqZAo" node="TA$XW2l3mv" resolve="affectedMemberNames" />
+              </node>
+              <node concept="37vLTw" id="TA$XW2n_Cs" role="37wK5m">
+                <ref role="3cqZAo" node="TA$XW2ncJu" resolve="userData" />
               </node>
             </node>
           </node>
@@ -788,6 +913,91 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="TA$XW2lh_R" role="jymVt" />
+    <node concept="3clFb_" id="TA$XW2lgNg" role="jymVt">
+      <property role="TrG5h" value="withAffectedMemberNames" />
+      <node concept="3clFbS" id="TA$XW2lgNh" role="3clF47">
+        <node concept="3cpWs6" id="TA$XW2lgNi" role="3cqZAp">
+          <node concept="2ShNRf" id="TA$XW2lgNj" role="3cqZAk">
+            <node concept="1pGfFk" id="TA$XW2lgNk" role="2ShVmc">
+              <ref role="37wK5l" node="TA$XW2lbJb" resolve="Message" />
+              <node concept="37vLTw" id="TA$XW2lgNl" role="37wK5m">
+                <ref role="3cqZAo" node="4NeJNX_xLnL" resolve="kind" />
+              </node>
+              <node concept="37vLTw" id="TA$XW2lgNm" role="37wK5m">
+                <ref role="3cqZAo" node="4NeJNX_xLp2" resolve="text" />
+              </node>
+              <node concept="37vLTw" id="TA$XW2lnGN" role="37wK5m">
+                <ref role="3cqZAo" node="65vXeyMqnfI" resolve="programLocation" />
+              </node>
+              <node concept="37vLTw" id="TA$XW2loqw" role="37wK5m">
+                <ref role="3cqZAo" node="TA$XW2lgNr" resolve="affectedMemberNames" />
+              </node>
+              <node concept="37vLTw" id="TA$XW2nAKg" role="37wK5m">
+                <ref role="3cqZAo" node="TA$XW2ncJu" resolve="userData" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="TA$XW2lgNp" role="1B3o_S" />
+      <node concept="3uibUv" id="TA$XW2lgNq" role="3clF45">
+        <ref role="3uigEE" node="4NeJNX_xLh$" resolve="Message" />
+      </node>
+      <node concept="37vLTG" id="TA$XW2lgNr" role="3clF46">
+        <property role="TrG5h" value="affectedMemberNames" />
+        <node concept="3uibUv" id="TA$XW2lj09" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+          <node concept="3uibUv" id="TA$XW2lkTB" role="11_B2D">
+            <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="TA$XW2neAk" role="jymVt" />
+    <node concept="3clFb_" id="TA$XW2ndGA" role="jymVt">
+      <property role="TrG5h" value="withUserData" />
+      <node concept="3clFbS" id="TA$XW2ndGB" role="3clF47">
+        <node concept="3cpWs6" id="TA$XW2ndGC" role="3cqZAp">
+          <node concept="2ShNRf" id="TA$XW2ndGD" role="3cqZAk">
+            <node concept="1pGfFk" id="TA$XW2ndGE" role="2ShVmc">
+              <ref role="37wK5l" node="TA$XW2lbJb" resolve="Message" />
+              <node concept="37vLTw" id="TA$XW2ndGF" role="37wK5m">
+                <ref role="3cqZAo" node="4NeJNX_xLnL" resolve="kind" />
+              </node>
+              <node concept="37vLTw" id="TA$XW2ndGG" role="37wK5m">
+                <ref role="3cqZAo" node="4NeJNX_xLp2" resolve="text" />
+              </node>
+              <node concept="37vLTw" id="TA$XW2ndGH" role="37wK5m">
+                <ref role="3cqZAo" node="65vXeyMqnfI" resolve="programLocation" />
+              </node>
+              <node concept="37vLTw" id="TA$XW2nE11" role="37wK5m">
+                <ref role="3cqZAo" node="TA$XW2l3mv" resolve="affectedMemberNames" />
+              </node>
+              <node concept="37vLTw" id="TA$XW2ndGI" role="37wK5m">
+                <ref role="3cqZAo" node="TA$XW2ndGL" resolve="userData" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="TA$XW2ndGJ" role="1B3o_S" />
+      <node concept="3uibUv" id="TA$XW2ndGK" role="3clF45">
+        <ref role="3uigEE" node="4NeJNX_xLh$" resolve="Message" />
+      </node>
+      <node concept="37vLTG" id="TA$XW2ndGL" role="3clF46">
+        <property role="TrG5h" value="userData" />
+        <node concept="3uibUv" id="TA$XW2ndGM" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~Map" resolve="Map" />
+          <node concept="3uibUv" id="TA$XW2ndGN" role="11_B2D">
+            <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+          </node>
+          <node concept="3uibUv" id="TA$XW2niG6" role="11_B2D">
+            <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="4NeJNX_xLX3" role="jymVt" />
     <node concept="3Tm1VV" id="4NeJNX_xLh_" role="1B3o_S" />
     <node concept="3clFb_" id="55imU6waFOR" role="jymVt">
@@ -800,34 +1010,24 @@
             <node concept="Xl_RD" id="55imU6waFOQ" role="3uHU7w">
               <property role="Xl_RC" value="}" />
             </node>
-            <node concept="3cpWs3" id="55imU6waFOK" role="3uHU7B">
-              <node concept="37vLTw" id="65vXeyMqrm1" role="3uHU7w">
-                <ref role="3cqZAo" node="65vXeyMqnfI" resolve="programLocation" />
+            <node concept="3cpWs3" id="55imU6waFOG" role="3uHU7B">
+              <node concept="37vLTw" id="55imU6waFOD" role="3uHU7w">
+                <ref role="3cqZAo" node="4NeJNX_xLp2" resolve="text" />
               </node>
-              <node concept="3cpWs3" id="55imU6waFOJ" role="3uHU7B">
-                <node concept="Xl_RD" id="55imU6waFOI" role="3uHU7w">
-                  <property role="Xl_RC" value=", programLocation=" />
+              <node concept="3cpWs3" id="55imU6waFOF" role="3uHU7B">
+                <node concept="Xl_RD" id="55imU6waFOE" role="3uHU7w">
+                  <property role="Xl_RC" value=", text=" />
                 </node>
-                <node concept="3cpWs3" id="55imU6waFOG" role="3uHU7B">
-                  <node concept="37vLTw" id="55imU6waFOD" role="3uHU7w">
-                    <ref role="3cqZAo" node="4NeJNX_xLp2" resolve="text" />
+                <node concept="3cpWs3" id="55imU6waFOC" role="3uHU7B">
+                  <node concept="37vLTw" id="55imU6waFO$" role="3uHU7w">
+                    <ref role="3cqZAo" node="4NeJNX_xLnL" resolve="kind" />
                   </node>
-                  <node concept="3cpWs3" id="55imU6waFOF" role="3uHU7B">
-                    <node concept="Xl_RD" id="55imU6waFOE" role="3uHU7w">
-                      <property role="Xl_RC" value=", text=" />
+                  <node concept="3cpWs3" id="55imU6waFOA" role="3uHU7B">
+                    <node concept="Xl_RD" id="55imU6waFOB" role="3uHU7B">
+                      <property role="Xl_RC" value="Message{" />
                     </node>
-                    <node concept="3cpWs3" id="55imU6waFOC" role="3uHU7B">
-                      <node concept="37vLTw" id="55imU6waFO$" role="3uHU7w">
-                        <ref role="3cqZAo" node="4NeJNX_xLnL" resolve="kind" />
-                      </node>
-                      <node concept="3cpWs3" id="55imU6waFOA" role="3uHU7B">
-                        <node concept="Xl_RD" id="55imU6waFOB" role="3uHU7B">
-                          <property role="Xl_RC" value="Message{" />
-                        </node>
-                        <node concept="Xl_RD" id="55imU6waFO_" role="3uHU7w">
-                          <property role="Xl_RC" value="kind=" />
-                        </node>
-                      </node>
+                    <node concept="Xl_RD" id="55imU6waFO_" role="3uHU7w">
+                      <property role="Xl_RC" value="kind=" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.messages.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.messages.interpreter/models/plugin.mps
@@ -64,7 +64,6 @@
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
-        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
@@ -759,114 +758,95 @@
                 </node>
               </node>
             </node>
-            <node concept="3clFbJ" id="4AahbtV9L1n" role="3cqZAp">
-              <node concept="3clFbS" id="4AahbtV9L1p" role="3clFbx">
-                <node concept="3cpWs8" id="4AahbtV2ABN" role="3cqZAp">
-                  <node concept="3cpWsn" id="4AahbtV2ABO" role="3cpWs9">
-                    <property role="TrG5h" value="v" />
-                    <node concept="3uibUv" id="4AahbtV2ABP" role="1tU5fm">
-                      <ref role="3uigEE" to="oq0c:4AahbtULJtR" resolve="MessageValue" />
-                    </node>
-                    <node concept="2ShNRf" id="4AahbtV2DXE" role="33vP2m">
-                      <node concept="1pGfFk" id="4AahbtV2DXF" role="2ShVmc">
-                        <ref role="37wK5l" to="oq0c:4AahbtULJ$q" resolve="MessageValue" />
-                        <node concept="37vLTw" id="4AahbtV2DXG" role="37wK5m">
-                          <ref role="3cqZAo" node="5ZJ96SJBjoN" resolve="messageText" />
-                        </node>
-                        <node concept="2ShNRf" id="4AahbtVpkmn" role="37wK5m">
-                          <node concept="1pGfFk" id="4AahbtVpkmm" role="2ShVmc">
-                            <ref role="37wK5l" to="oq0c:4AahbtUR_FK" resolve="ProgramLocationValue" />
-                            <node concept="oxGPV" id="4AahbtVpknH" role="37wK5m" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
+            <node concept="3cpWs8" id="4AahbtV2ABN" role="3cqZAp">
+              <node concept="3cpWsn" id="4AahbtV2ABO" role="3cpWs9">
+                <property role="TrG5h" value="v" />
+                <node concept="3uibUv" id="4AahbtV2ABP" role="1tU5fm">
+                  <ref role="3uigEE" to="oq0c:4AahbtULJtR" resolve="MessageValue" />
                 </node>
-                <node concept="3cpWs8" id="4AahbtVpkyE" role="3cqZAp">
-                  <node concept="3cpWsn" id="4AahbtVpkyF" role="3cpWs9">
-                    <property role="TrG5h" value="plp" />
-                    <node concept="3Tqbb2" id="4AahbtVpkyD" role="1tU5fm">
-                      <ref role="ehGHo" to="hm2y:4AahbtUNHrQ" resolve="IProgramLocationProvider" />
-                    </node>
-                    <node concept="2OqwBi" id="4AahbtVpkyG" role="33vP2m">
-                      <node concept="oxGPV" id="4AahbtVpkyH" role="2Oq$k0" />
-                      <node concept="2Xjw5R" id="4AahbtVpkyI" role="2OqNvi">
-                        <node concept="1xMEDy" id="4AahbtVpkyJ" role="1xVPHs">
-                          <node concept="chp4Y" id="4AahbtVpkyK" role="ri$Ld">
-                            <ref role="cht4Q" to="hm2y:4AahbtUNHrQ" resolve="IProgramLocationProvider" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="4AahbtVpjhb" role="3cqZAp">
-                  <node concept="3clFbS" id="4AahbtVpjhd" role="3clFbx">
-                    <node concept="3clFbF" id="4AahbtVpkpV" role="3cqZAp">
-                      <node concept="37vLTI" id="4AahbtVpkwj" role="3clFbG">
-                        <node concept="37vLTw" id="4AahbtVpkpT" role="37vLTJ">
-                          <ref role="3cqZAo" node="4AahbtV2ABO" resolve="v" />
-                        </node>
-                        <node concept="2ShNRf" id="4AahbtVpkwC" role="37vLTx">
-                          <node concept="1pGfFk" id="4AahbtVpkwD" role="2ShVmc">
-                            <ref role="37wK5l" to="oq0c:4AahbtULJ$q" resolve="MessageValue" />
-                            <node concept="37vLTw" id="4AahbtVpkwE" role="37wK5m">
-                              <ref role="3cqZAo" node="5ZJ96SJBjoN" resolve="messageText" />
-                            </node>
-                            <node concept="2OqwBi" id="4AahbtVpkPs" role="37wK5m">
-                              <node concept="37vLTw" id="4AahbtVpkI2" role="2Oq$k0">
-                                <ref role="3cqZAo" node="4AahbtVpkyF" resolve="plp" />
-                              </node>
-                              <node concept="2qgKlT" id="4AahbtVpl3P" role="2OqNvi">
-                                <ref role="37wK5l" to="pbu6:4AahbtUNHsr" resolve="getProgramLocation" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="4AahbtVpjMI" role="3clFbw">
-                    <node concept="37vLTw" id="4AahbtVpkyL" role="2Oq$k0">
-                      <ref role="3cqZAo" node="4AahbtVpkyF" resolve="plp" />
-                    </node>
-                    <node concept="3x8VRR" id="4AahbtVpk04" role="2OqNvi" />
-                  </node>
-                </node>
-                <node concept="3clFbF" id="4AahbtV2HrD" role="3cqZAp">
-                  <node concept="2OqwBi" id="4AahbtV2YCb" role="3clFbG">
-                    <node concept="37vLTw" id="4AahbtV2Y$2" role="2Oq$k0">
-                      <ref role="3cqZAo" node="4AahbtV2ABO" resolve="v" />
-                    </node>
-                    <node concept="liA8E" id="4AahbtV2YIc" role="2OqNvi">
-                      <ref role="37wK5l" to="oq0c:4AahbtV2Iy1" resolve="setData" />
-                      <node concept="37vLTw" id="4AahbtV2YM_" role="37wK5m">
-                        <ref role="3cqZAo" node="4AahbtV2F8C" resolve="data" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs6" id="4AahbtV2GEG" role="3cqZAp">
-                  <node concept="37vLTw" id="4AahbtV2H36" role="3cqZAk">
-                    <ref role="3cqZAo" node="4AahbtV2ABO" resolve="v" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="4AahbtV9LA5" role="3clFbw">
-                <node concept="oxGPV" id="4AahbtV9Lt0" role="2Oq$k0" />
-                <node concept="3TrcHB" id="4AahbtV9LL4" role="2OqNvi">
-                  <ref role="3TsBF5" to="kelk:4AahbtV9FsC" resolve="messageValue" />
-                </node>
-              </node>
-              <node concept="9aQIb" id="4AahbtV9MOH" role="9aQIa">
-                <node concept="3clFbS" id="4AahbtV9MOI" role="9aQI4">
-                  <node concept="3cpWs6" id="4AahbtV9MUl" role="3cqZAp">
-                    <node concept="37vLTw" id="4AahbtV9MUt" role="3cqZAk">
+                <node concept="2ShNRf" id="4AahbtV2DXE" role="33vP2m">
+                  <node concept="1pGfFk" id="4AahbtV2DXF" role="2ShVmc">
+                    <ref role="37wK5l" to="oq0c:4AahbtULJ$q" resolve="MessageValue" />
+                    <node concept="37vLTw" id="4AahbtV2DXG" role="37wK5m">
                       <ref role="3cqZAo" node="5ZJ96SJBjoN" resolve="messageText" />
                     </node>
+                    <node concept="2ShNRf" id="4AahbtVpkmn" role="37wK5m">
+                      <node concept="1pGfFk" id="4AahbtVpkmm" role="2ShVmc">
+                        <ref role="37wK5l" to="oq0c:4AahbtUR_FK" resolve="ProgramLocationValue" />
+                        <node concept="oxGPV" id="4AahbtVpknH" role="37wK5m" />
+                      </node>
+                    </node>
                   </node>
                 </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="4AahbtVpkyE" role="3cqZAp">
+              <node concept="3cpWsn" id="4AahbtVpkyF" role="3cpWs9">
+                <property role="TrG5h" value="plp" />
+                <node concept="3Tqbb2" id="4AahbtVpkyD" role="1tU5fm">
+                  <ref role="ehGHo" to="hm2y:4AahbtUNHrQ" resolve="IProgramLocationProvider" />
+                </node>
+                <node concept="2OqwBi" id="4AahbtVpkyG" role="33vP2m">
+                  <node concept="oxGPV" id="4AahbtVpkyH" role="2Oq$k0" />
+                  <node concept="2Xjw5R" id="4AahbtVpkyI" role="2OqNvi">
+                    <node concept="1xMEDy" id="4AahbtVpkyJ" role="1xVPHs">
+                      <node concept="chp4Y" id="4AahbtVpkyK" role="ri$Ld">
+                        <ref role="cht4Q" to="hm2y:4AahbtUNHrQ" resolve="IProgramLocationProvider" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="4AahbtVpjhb" role="3cqZAp">
+              <node concept="3clFbS" id="4AahbtVpjhd" role="3clFbx">
+                <node concept="3clFbF" id="4AahbtVpkpV" role="3cqZAp">
+                  <node concept="37vLTI" id="4AahbtVpkwj" role="3clFbG">
+                    <node concept="37vLTw" id="4AahbtVpkpT" role="37vLTJ">
+                      <ref role="3cqZAo" node="4AahbtV2ABO" resolve="v" />
+                    </node>
+                    <node concept="2ShNRf" id="4AahbtVpkwC" role="37vLTx">
+                      <node concept="1pGfFk" id="4AahbtVpkwD" role="2ShVmc">
+                        <ref role="37wK5l" to="oq0c:4AahbtULJ$q" resolve="MessageValue" />
+                        <node concept="37vLTw" id="4AahbtVpkwE" role="37wK5m">
+                          <ref role="3cqZAo" node="5ZJ96SJBjoN" resolve="messageText" />
+                        </node>
+                        <node concept="2OqwBi" id="4AahbtVpkPs" role="37wK5m">
+                          <node concept="37vLTw" id="4AahbtVpkI2" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4AahbtVpkyF" resolve="plp" />
+                          </node>
+                          <node concept="2qgKlT" id="4AahbtVpl3P" role="2OqNvi">
+                            <ref role="37wK5l" to="pbu6:4AahbtUNHsr" resolve="getProgramLocation" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4AahbtVpjMI" role="3clFbw">
+                <node concept="37vLTw" id="4AahbtVpkyL" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4AahbtVpkyF" resolve="plp" />
+                </node>
+                <node concept="3x8VRR" id="4AahbtVpk04" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="3clFbF" id="4AahbtV2HrD" role="3cqZAp">
+              <node concept="2OqwBi" id="4AahbtV2YCb" role="3clFbG">
+                <node concept="37vLTw" id="4AahbtV2Y$2" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4AahbtV2ABO" resolve="v" />
+                </node>
+                <node concept="liA8E" id="4AahbtV2YIc" role="2OqNvi">
+                  <ref role="37wK5l" to="oq0c:4AahbtV2Iy1" resolve="setData" />
+                  <node concept="37vLTw" id="4AahbtV2YM_" role="37wK5m">
+                    <ref role="3cqZAo" node="4AahbtV2F8C" resolve="data" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="4AahbtV2GEG" role="3cqZAp">
+              <node concept="37vLTw" id="4AahbtV2H36" role="3cqZAk">
+                <ref role="3cqZAo" node="4AahbtV2ABO" resolve="v" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/solutions/test.ex.core.expr.genjava/models/messages@tests.mps
+++ b/code/languages/org.iets3.opensource/solutions/test.ex.core.expr.genjava/models/messages@tests.mps
@@ -30,6 +30,9 @@
       <concept id="7971844778466793028" name="org.iets3.core.expr.base.structure.AlternativesExpression" flags="ng" index="2fGnzi">
         <child id="7971844778466793162" name="alternatives" index="2fGnxs" />
       </concept>
+      <concept id="411710798114972602" name="org.iets3.core.expr.base.structure.FailExpr" flags="ng" index="qoPdK">
+        <child id="411710798114972606" name="message" index="qoPdO" />
+      </concept>
       <concept id="7071042522334260296" name="org.iets3.core.expr.base.structure.ITyped" flags="ng" index="2_iKZX">
         <child id="8811147530085329321" name="type" index="2S399n" />
       </concept>
@@ -766,6 +769,21 @@
       </node>
     </node>
     <node concept="_ixoA" id="4AahbtVkefb" role="_iOnB" />
+    <node concept="_fkuM" id="5GmVcyjQtQQ" role="_iOnB">
+      <property role="TrG5h" value="failWithAMessage" />
+      <node concept="mXNUv" id="5GmVcyjQtZA" role="_fkp5">
+        <node concept="qoPdK" id="5GmVcyjQtZN" role="mXJVd">
+          <node concept="1QScDb" id="5GmVcyjQuqS" role="qoPdO">
+            <node concept="1WPo9w" id="3HIl9G7kxYY" role="1QScD9">
+              <ref role="1WPo9$" node="3vxfdxbrKAj" resolve="m1" />
+            </node>
+            <node concept="1WPpZc" id="5GmVcyjQuqF" role="30czhm">
+              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="_ixoA" id="4AahbtVbkzw" role="_iOnB" />
   </node>
   <node concept="1WOfUn" id="3vxfdxbret3">

--- a/code/languages/org.iets3.opensource/solutions/test.ex.core.expr.genjava/models/messages@tests.mps
+++ b/code/languages/org.iets3.opensource/solutions/test.ex.core.expr.genjava/models/messages@tests.mps
@@ -173,7 +173,7 @@
         <child id="4026566441518474145" name="args" index="1WPDXT" />
       </concept>
       <concept id="4026566441518284472" name="org.iets3.core.expr.messages.structure.MessageTarget" flags="ng" index="1WPo9w">
-        <property id="5299123466390648616" name="messageValue" index="MFfev" />
+        <property id="5299123466390648616" name="messageValue_DEPRECATED" index="MFfev" />
         <reference id="4026566441518284476" name="message" index="1WPo9$" />
         <child id="4026566441519855930" name="args" index="1WFony" />
       </concept>
@@ -226,11 +226,11 @@
     <ref role="2HwdWd" node="1CNpG_h50DB" resolve="Data" />
     <node concept="1aga60" id="4AahbtV2zVo" role="_iOnB">
       <property role="TrG5h" value="funWithMsg" />
-      <property role="0Rz4W" value="-524441368" />
+      <property role="0Rz4W" value="1957565637" />
       <node concept="1aduha" id="4AahbtV2zZB" role="1ahQXP">
         <node concept="1QScDb" id="4AahbtV2$0Y" role="1aduh9">
           <node concept="1WPo9w" id="4AahbtV2$be" role="1QScD9">
-            <property role="MFfev" value="true" />
+            <property role="MFfev" value="false" />
             <ref role="1WPo9$" node="3vxfdxbrKAj" resolve="m1" />
           </node>
           <node concept="1WPpZc" id="4AahbtV2$0v" role="30czhm">
@@ -248,7 +248,7 @@
         <node concept="_fku$" id="3vxfdxbrKID" role="_fkur" />
         <node concept="1QScDb" id="4AahbtUNAep" role="_fkuY">
           <node concept="1af_rf" id="4AahbtV2$eI" role="30czhm">
-            <property role="0Rz4W" value="-630332183" />
+            <property role="0Rz4W" value="-2109004502" />
             <ref role="1afhQb" node="4AahbtV2zVo" resolve="funWithMsg" />
           </node>
           <node concept="NjiR8" id="23q4Crn$i8e" role="1QScD9" />
@@ -267,7 +267,7 @@
               <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
             </node>
             <node concept="1WPo9w" id="4AahbtV2$bB" role="1QScD9">
-              <property role="MFfev" value="true" />
+              <property role="MFfev" value="false" />
               <ref role="1WPo9$" node="3vxfdxbrKAj" resolve="m1" />
             </node>
           </node>
@@ -276,32 +276,19 @@
           <property role="30bdrQ" value="m1" />
         </node>
       </node>
-      <node concept="_fkuZ" id="4AahbtVb9a5" role="_fkp5">
-        <property role="3sVy9A" value="true" />
-        <node concept="_fku$" id="4AahbtVb9a6" role="_fkur" />
-        <node concept="1QScDb" id="4AahbtVb9a9" role="_fkuY">
-          <node concept="1WPpZc" id="4AahbtVb9aa" role="30czhm">
-            <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
-          </node>
-          <node concept="1WPo9w" id="4AahbtVb9ab" role="1QScD9">
-            <property role="MFfev" value="false" />
-            <ref role="1WPo9$" node="3vxfdxbrKAj" resolve="m1" />
-          </node>
-        </node>
-        <node concept="30bdrP" id="4AahbtVb9ac" role="_fkuS">
-          <property role="30bdrQ" value="m1" />
-        </node>
-      </node>
       <node concept="_fkuZ" id="3vxfdxbs7e_" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="3vxfdxbs7eA" role="_fkur" />
-        <node concept="1QScDb" id="3vxfdxbs7eB" role="_fkuY">
-          <node concept="1WPo9w" id="3vxfdxbs7iJ" role="1QScD9">
-            <property role="MFfev" value="false" />
-            <ref role="1WPo9$" node="3vxfdxbrKAQ" resolve="m2" />
-          </node>
-          <node concept="1WPpZc" id="3vxfdxbs7eD" role="30czhm">
-            <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+        <node concept="1QScDb" id="7OtDX6qlg_j" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlgNi" role="1QScD9" />
+          <node concept="1QScDb" id="3vxfdxbs7eB" role="30czhm">
+            <node concept="1WPo9w" id="3vxfdxbs7iJ" role="1QScD9">
+              <property role="MFfev" value="false" />
+              <ref role="1WPo9$" node="3vxfdxbrKAQ" resolve="m2" />
+            </node>
+            <node concept="1WPpZc" id="3vxfdxbs7eD" role="30czhm">
+              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            </node>
           </node>
         </node>
         <node concept="30bdrP" id="3vxfdxbs7eE" role="_fkuS">
@@ -311,13 +298,16 @@
       <node concept="_fkuZ" id="3vxfdxbs7f4" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="3vxfdxbs7f5" role="_fkur" />
-        <node concept="1QScDb" id="3vxfdxbs7f6" role="_fkuY">
-          <node concept="1WPo9w" id="3vxfdxbs7jj" role="1QScD9">
-            <property role="MFfev" value="false" />
-            <ref role="1WPo9$" node="3vxfdxbrKCL" resolve="m3" />
-          </node>
-          <node concept="1WPpZc" id="3vxfdxbs7f8" role="30czhm">
-            <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+        <node concept="1QScDb" id="7OtDX6qlgRL" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlh5K" role="1QScD9" />
+          <node concept="1QScDb" id="3vxfdxbs7f6" role="30czhm">
+            <node concept="1WPo9w" id="3vxfdxbs7jj" role="1QScD9">
+              <property role="MFfev" value="false" />
+              <ref role="1WPo9$" node="3vxfdxbrKCL" resolve="m3" />
+            </node>
+            <node concept="1WPpZc" id="3vxfdxbs7f8" role="30czhm">
+              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            </node>
           </node>
         </node>
         <node concept="30bdrP" id="3vxfdxbs7f9" role="_fkuS">
@@ -327,19 +317,22 @@
       <node concept="_fkuZ" id="3vxfdxbs7fJ" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="3vxfdxbs7fK" role="_fkur" />
-        <node concept="1QScDb" id="3vxfdxbs7fL" role="_fkuY">
-          <node concept="1WPo9w" id="3vxfdxbs7jL" role="1QScD9">
-            <ref role="1WPo9$" node="3vxfdxbrKDC" resolve="m4" />
-            <node concept="30bdrP" id="3vxfdxbthCm" role="1WFony">
-              <property role="30bdrQ" value="42" />
+        <node concept="1QScDb" id="7OtDX6qlh6e" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlhDi" role="1QScD9" />
+          <node concept="1QScDb" id="3vxfdxbs7fL" role="30czhm">
+            <node concept="1WPo9w" id="3vxfdxbs7jL" role="1QScD9">
+              <ref role="1WPo9$" node="3vxfdxbrKDC" resolve="m4" />
+              <node concept="30bdrP" id="3vxfdxbthCm" role="1WFony">
+                <property role="30bdrQ" value="42" />
+              </node>
             </node>
-          </node>
-          <node concept="1QScDb" id="3vxfdxbthN0" role="30czhm">
-            <node concept="1WETeO" id="3vxfdxbthP4" role="1QScD9">
-              <ref role="1WETeC" node="3vxfdxbthIg" resolve="withStringArgs" />
-            </node>
-            <node concept="1WPpZc" id="3vxfdxbs7fN" role="30czhm">
-              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            <node concept="1QScDb" id="3vxfdxbthN0" role="30czhm">
+              <node concept="1WETeO" id="3vxfdxbthP4" role="1QScD9">
+                <ref role="1WETeC" node="3vxfdxbthIg" resolve="withStringArgs" />
+              </node>
+              <node concept="1WPpZc" id="3vxfdxbs7fN" role="30czhm">
+                <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+              </node>
             </node>
           </node>
         </node>
@@ -350,19 +343,22 @@
       <node concept="_fkuZ" id="3vxfdxbs7gA" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="3vxfdxbs7gB" role="_fkur" />
-        <node concept="1QScDb" id="3vxfdxbs7gC" role="_fkuY">
-          <node concept="1WPo9w" id="3vxfdxbs7kf" role="1QScD9">
-            <ref role="1WPo9$" node="3vxfdxbrKFr" resolve="m5" />
-            <node concept="30bdrP" id="3vxfdxbthD7" role="1WFony">
-              <property role="30bdrQ" value="33" />
+        <node concept="1QScDb" id="7OtDX6qlhE1" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlid5" role="1QScD9" />
+          <node concept="1QScDb" id="3vxfdxbs7gC" role="30czhm">
+            <node concept="1WPo9w" id="3vxfdxbs7kf" role="1QScD9">
+              <ref role="1WPo9$" node="3vxfdxbrKFr" resolve="m5" />
+              <node concept="30bdrP" id="3vxfdxbthD7" role="1WFony">
+                <property role="30bdrQ" value="33" />
+              </node>
             </node>
-          </node>
-          <node concept="1QScDb" id="3vxfdxbthPC" role="30czhm">
-            <node concept="1WETeO" id="3vxfdxbthQl" role="1QScD9">
-              <ref role="1WETeC" node="3vxfdxbthIg" resolve="withStringArgs" />
-            </node>
-            <node concept="1WPpZc" id="3vxfdxbs7gE" role="30czhm">
-              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            <node concept="1QScDb" id="3vxfdxbthPC" role="30czhm">
+              <node concept="1WETeO" id="3vxfdxbthQl" role="1QScD9">
+                <ref role="1WETeC" node="3vxfdxbthIg" resolve="withStringArgs" />
+              </node>
+              <node concept="1WPpZc" id="3vxfdxbs7gE" role="30czhm">
+                <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+              </node>
             </node>
           </node>
         </node>
@@ -373,19 +369,22 @@
       <node concept="_fkuZ" id="3vxfdxbtTgB" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="3vxfdxbtTgC" role="_fkur" />
-        <node concept="1QScDb" id="3vxfdxbtTgD" role="_fkuY">
-          <node concept="1WPo9w" id="3vxfdxbtTgE" role="1QScD9">
-            <ref role="1WPo9$" node="3vxfdxbthSx" resolve="m4" />
-            <node concept="30bXRB" id="3vxfdxbtTo3" role="1WFony">
-              <property role="30bXRw" value="42" />
+        <node concept="1QScDb" id="7OtDX6qlidO" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlj2a" role="1QScD9" />
+          <node concept="1QScDb" id="3vxfdxbtTgD" role="30czhm">
+            <node concept="1WPo9w" id="3vxfdxbtTgE" role="1QScD9">
+              <ref role="1WPo9$" node="3vxfdxbthSx" resolve="m4" />
+              <node concept="30bXRB" id="3vxfdxbtTo3" role="1WFony">
+                <property role="30bXRw" value="42" />
+              </node>
             </node>
-          </node>
-          <node concept="1QScDb" id="3vxfdxbtTgG" role="30czhm">
-            <node concept="1WETeO" id="3vxfdxbtTjx" role="1QScD9">
-              <ref role="1WETeC" node="3vxfdxbthSw" resolve="withIntArgs" />
-            </node>
-            <node concept="1WPpZc" id="3vxfdxbtTgI" role="30czhm">
-              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            <node concept="1QScDb" id="3vxfdxbtTgG" role="30czhm">
+              <node concept="1WETeO" id="3vxfdxbtTjx" role="1QScD9">
+                <ref role="1WETeC" node="3vxfdxbthSw" resolve="withIntArgs" />
+              </node>
+              <node concept="1WPpZc" id="3vxfdxbtTgI" role="30czhm">
+                <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+              </node>
             </node>
           </node>
         </node>
@@ -400,7 +399,7 @@
           <node concept="NjiR8" id="4AahbtUNAHD" role="1QScD9" />
           <node concept="1QScDb" id="3vxfdxbtTgw" role="30czhm">
             <node concept="1WPo9w" id="3vxfdxbtTgx" role="1QScD9">
-              <property role="MFfev" value="true" />
+              <property role="MFfev" value="false" />
               <ref role="1WPo9$" node="3vxfdxbthSE" resolve="m5" />
               <node concept="30bXRB" id="3vxfdxbtTqq" role="1WFony">
                 <property role="30bXRw" value="33" />
@@ -423,24 +422,27 @@
       <node concept="_fkuZ" id="3vxfdxburJ8" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="3vxfdxburJ9" role="_fkur" />
-        <node concept="1QScDb" id="3vxfdxburJa" role="_fkuY">
-          <node concept="1WPo9w" id="3vxfdxburJb" role="1QScD9">
-            <ref role="1WPo9$" node="3vxfdxburCP" resolve="m6" />
-            <node concept="30bXRB" id="3vxfdxburJc" role="1WFony">
-              <property role="30bXRw" value="33" />
-            </node>
-            <node concept="2vmpnb" id="3vxfdxburWO" role="1WFony" />
-          </node>
-          <node concept="1QScDb" id="3vxfdxburMv" role="30czhm">
-            <node concept="1WETeO" id="3vxfdxburS0" role="1QScD9">
-              <ref role="1WETeC" node="3vxfdxburAI" resolve="sub" />
-            </node>
-            <node concept="1QScDb" id="3vxfdxburJd" role="30czhm">
-              <node concept="1WETeO" id="3vxfdxburJe" role="1QScD9">
-                <ref role="1WETeC" node="3vxfdxbthSw" resolve="withIntArgs" />
+        <node concept="1QScDb" id="7OtDX6qlj3W" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlkes" role="1QScD9" />
+          <node concept="1QScDb" id="3vxfdxburJa" role="30czhm">
+            <node concept="1WPo9w" id="3vxfdxburJb" role="1QScD9">
+              <ref role="1WPo9$" node="3vxfdxburCP" resolve="m6" />
+              <node concept="30bXRB" id="3vxfdxburJc" role="1WFony">
+                <property role="30bXRw" value="33" />
               </node>
-              <node concept="1WPpZc" id="3vxfdxburJf" role="30czhm">
-                <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+              <node concept="2vmpnb" id="3vxfdxburWO" role="1WFony" />
+            </node>
+            <node concept="1QScDb" id="3vxfdxburMv" role="30czhm">
+              <node concept="1WETeO" id="3vxfdxburS0" role="1QScD9">
+                <ref role="1WETeC" node="3vxfdxburAI" resolve="sub" />
+              </node>
+              <node concept="1QScDb" id="3vxfdxburJd" role="30czhm">
+                <node concept="1WETeO" id="3vxfdxburJe" role="1QScD9">
+                  <ref role="1WETeC" node="3vxfdxbthSw" resolve="withIntArgs" />
+                </node>
+                <node concept="1WPpZc" id="3vxfdxburJf" role="30czhm">
+                  <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+                </node>
               </node>
             </node>
           </node>
@@ -452,16 +454,19 @@
       <node concept="_fkuZ" id="5ZJ96SJBsQF" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="5ZJ96SJBsQG" role="_fkur" />
-        <node concept="1QScDb" id="5ZJ96SJBsQL" role="_fkuY">
-          <node concept="1WPo9w" id="5ZJ96SJBt7f" role="1QScD9">
-            <ref role="1WPo9$" node="5ZJ96SJBr43" resolve="w" />
-          </node>
-          <node concept="1QScDb" id="5ZJ96SJBsQN" role="30czhm">
-            <node concept="1WETeO" id="5ZJ96SJBsUr" role="1QScD9">
-              <ref role="1WETeC" node="5ZJ96SJBr0f" resolve="withKinds" />
+        <node concept="1QScDb" id="7OtDX6qlktK" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlkPF" role="1QScD9" />
+          <node concept="1QScDb" id="5ZJ96SJBsQL" role="30czhm">
+            <node concept="1WPo9w" id="5ZJ96SJBt7f" role="1QScD9">
+              <ref role="1WPo9$" node="5ZJ96SJBr43" resolve="w" />
             </node>
-            <node concept="1WPpZc" id="5ZJ96SJBsQP" role="30czhm">
-              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            <node concept="1QScDb" id="5ZJ96SJBsQN" role="30czhm">
+              <node concept="1WETeO" id="5ZJ96SJBsUr" role="1QScD9">
+                <ref role="1WETeC" node="5ZJ96SJBr0f" resolve="withKinds" />
+              </node>
+              <node concept="1WPpZc" id="5ZJ96SJBsQP" role="30czhm">
+                <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+              </node>
             </node>
           </node>
         </node>
@@ -472,17 +477,20 @@
       <node concept="_fkuZ" id="5ZJ96SJBtgw" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="5ZJ96SJBtgx" role="_fkur" />
-        <node concept="1QScDb" id="5ZJ96SJBtgy" role="_fkuY">
-          <node concept="1QScDb" id="5ZJ96SJBtg$" role="30czhm">
-            <node concept="1WETeO" id="5ZJ96SJBtg_" role="1QScD9">
-              <ref role="1WETeC" node="5ZJ96SJBr0f" resolve="withKinds" />
+        <node concept="1QScDb" id="7OtDX6qll4q" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qllsl" role="1QScD9" />
+          <node concept="1QScDb" id="5ZJ96SJBtgy" role="30czhm">
+            <node concept="1QScDb" id="5ZJ96SJBtg$" role="30czhm">
+              <node concept="1WETeO" id="5ZJ96SJBtg_" role="1QScD9">
+                <ref role="1WETeC" node="5ZJ96SJBr0f" resolve="withKinds" />
+              </node>
+              <node concept="1WPpZc" id="5ZJ96SJBtgA" role="30czhm">
+                <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+              </node>
             </node>
-            <node concept="1WPpZc" id="5ZJ96SJBtgA" role="30czhm">
-              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            <node concept="1WPo9w" id="5ZJ96SJBtkk" role="1QScD9">
+              <ref role="1WPo9$" node="5ZJ96SJBr6$" resolve="e" />
             </node>
-          </node>
-          <node concept="1WPo9w" id="5ZJ96SJBtkk" role="1QScD9">
-            <ref role="1WPo9$" node="5ZJ96SJBr6$" resolve="e" />
           </node>
         </node>
         <node concept="30bdrP" id="5ZJ96SJBtgB" role="_fkuS">
@@ -496,23 +504,26 @@
       <node concept="_fkuZ" id="1CNpG_h8fN8" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="1CNpG_h8fN9" role="_fkur" />
-        <node concept="1QScDb" id="1CNpG_h8gCO" role="_fkuY">
-          <node concept="1WPo9w" id="1CNpG_h8gDA" role="1QScD9">
-            <ref role="1WPo9$" node="1CNpG_h8fSR" resolve="mPoint" />
-            <node concept="2S399m" id="1CNpG_h8gDS" role="1WFony">
-              <node concept="2Ss9cW" id="1CNpG_h8gEm" role="2S399n">
-                <ref role="2Ss9cX" node="1CNpG_h50DD" resolve="Point" />
-              </node>
-              <node concept="30bXRB" id="1CNpG_h8gFR" role="2S399l">
-                <property role="30bXRw" value="1" />
-              </node>
-              <node concept="30bXRB" id="1CNpG_h8gG5" role="2S399l">
-                <property role="30bXRw" value="2" />
+        <node concept="1QScDb" id="7OtDX6ql$CE" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlAly" role="1QScD9" />
+          <node concept="1QScDb" id="1CNpG_h8gCO" role="30czhm">
+            <node concept="1WPo9w" id="1CNpG_h8gDA" role="1QScD9">
+              <ref role="1WPo9$" node="1CNpG_h8fSR" resolve="mPoint" />
+              <node concept="2S399m" id="1CNpG_h8gDS" role="1WFony">
+                <node concept="2Ss9cW" id="1CNpG_h8gEm" role="2S399n">
+                  <ref role="2Ss9cX" node="1CNpG_h50DD" resolve="Point" />
+                </node>
+                <node concept="30bXRB" id="1CNpG_h8gFR" role="2S399l">
+                  <property role="30bXRw" value="1" />
+                </node>
+                <node concept="30bXRB" id="1CNpG_h8gG5" role="2S399l">
+                  <property role="30bXRw" value="2" />
+                </node>
               </node>
             </node>
-          </node>
-          <node concept="1WPpZc" id="1CNpG_h8gC$" role="30czhm">
-            <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            <node concept="1WPpZc" id="1CNpG_h8gC$" role="30czhm">
+              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            </node>
           </node>
         </node>
         <node concept="30bdrP" id="1CNpG_h8gHy" role="_fkuS">
@@ -522,15 +533,18 @@
       <node concept="_fkuZ" id="1CNpG_h8Ft_" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="1CNpG_h8FtA" role="_fkur" />
-        <node concept="1QScDb" id="1CNpG_h8FtB" role="_fkuY">
-          <node concept="1WPo9w" id="1CNpG_h8FtC" role="1QScD9">
-            <ref role="1WPo9$" node="1CNpG_h8F6P" resolve="mMoney" />
-            <node concept="30bXRB" id="1CNpG_h8F_K" role="1WFony">
-              <property role="30bXRw" value="100" />
+        <node concept="1QScDb" id="7OtDX6qlAmX" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlB3P" role="1QScD9" />
+          <node concept="1QScDb" id="1CNpG_h8FtB" role="30czhm">
+            <node concept="1WPo9w" id="1CNpG_h8FtC" role="1QScD9">
+              <ref role="1WPo9$" node="1CNpG_h8F6P" resolve="mMoney" />
+              <node concept="30bXRB" id="1CNpG_h8F_K" role="1WFony">
+                <property role="30bXRw" value="100" />
+              </node>
             </node>
-          </node>
-          <node concept="1WPpZc" id="1CNpG_h8FtH" role="30czhm">
-            <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            <node concept="1WPpZc" id="1CNpG_h8FtH" role="30czhm">
+              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            </node>
           </node>
         </node>
         <node concept="30bdrP" id="1CNpG_h8FtI" role="_fkuS">
@@ -633,7 +647,7 @@
         <node concept="InuEK" id="4AahbtVbbGs" role="I61D1">
           <node concept="1QScDb" id="4AahbtVRMRz" role="2izrR8">
             <node concept="1WPo9w" id="4AahbtVRNhJ" role="1QScD9">
-              <property role="MFfev" value="true" />
+              <property role="MFfev" value="false" />
               <ref role="1WPo9$" node="4AahbtVRLW6" resolve="xeey" />
               <node concept="XrbUJ" id="4AahbtVRNmn" role="1WFony">
                 <ref role="XrbUP" node="4AahbtVbbGn" resolve="x" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/messages@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/messages@tests.mps
@@ -38,6 +38,9 @@
       <concept id="7971844778466793028" name="org.iets3.core.expr.base.structure.AlternativesExpression" flags="ng" index="2fGnzi">
         <child id="7971844778466793162" name="alternatives" index="2fGnxs" />
       </concept>
+      <concept id="411710798114972602" name="org.iets3.core.expr.base.structure.FailExpr" flags="ng" index="qoPdK">
+        <child id="411710798114972606" name="message" index="qoPdO" />
+      </concept>
       <concept id="7071042522334260296" name="org.iets3.core.expr.base.structure.ITyped" flags="ng" index="2_iKZX">
         <child id="8811147530085329321" name="type" index="2S399n" />
       </concept>
@@ -895,6 +898,22 @@
           </node>
           <node concept="30bXRB" id="4AahbtVmxsq" role="_fkuS">
             <property role="30bXRw" value="1" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="_ixoA" id="5GmVcyjQtDK" role="_iOnB" />
+    <node concept="_fkuM" id="5GmVcyjQtQQ" role="_iOnB">
+      <property role="TrG5h" value="failWithAMessage" />
+      <node concept="mXNUv" id="5GmVcyjQtZA" role="_fkp5">
+        <node concept="qoPdK" id="5GmVcyjQtZN" role="mXJVd">
+          <node concept="1QScDb" id="5GmVcyjQuqS" role="qoPdO">
+            <node concept="1WPo9w" id="5GmVcyjQuI$" role="1QScD9">
+              <ref role="1WPo9$" node="3vxfdxbrKAj" resolve="m1" />
+            </node>
+            <node concept="1WPpZc" id="5GmVcyjQuqF" role="30czhm">
+              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/messages@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/messages@tests.mps
@@ -190,7 +190,7 @@
         <child id="4026566441518474145" name="args" index="1WPDXT" />
       </concept>
       <concept id="4026566441518284472" name="org.iets3.core.expr.messages.structure.MessageTarget" flags="ng" index="1WPo9w">
-        <property id="5299123466390648616" name="messageValue" index="MFfev" />
+        <property id="5299123466390648616" name="messageValue_DEPRECATED" index="MFfev" />
         <reference id="4026566441518284476" name="message" index="1WPo9$" />
         <child id="4026566441519855930" name="args" index="1WFony" />
       </concept>
@@ -243,11 +243,11 @@
     <ref role="2HwdWd" node="1CNpG_h50DB" resolve="Data" />
     <node concept="1aga60" id="4AahbtV2zVo" role="_iOnB">
       <property role="TrG5h" value="funWithMsg" />
-      <property role="0Rz4W" value="-524441368" />
+      <property role="0Rz4W" value="-1090313021" />
       <node concept="1aduha" id="4AahbtV2zZB" role="1ahQXP">
         <node concept="1QScDb" id="4AahbtV2$0Y" role="1aduh9">
           <node concept="1WPo9w" id="4AahbtV2$be" role="1QScD9">
-            <property role="MFfev" value="true" />
+            <property role="MFfev" value="false" />
             <ref role="1WPo9$" node="3vxfdxbrKAj" resolve="m1" />
           </node>
           <node concept="1WPpZc" id="4AahbtV2$0v" role="30czhm">
@@ -308,28 +308,12 @@
               <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
             </node>
             <node concept="1WPo9w" id="4AahbtV2$bB" role="1QScD9">
-              <property role="MFfev" value="true" />
+              <property role="MFfev" value="false" />
               <ref role="1WPo9$" node="3vxfdxbrKAj" resolve="m1" />
             </node>
           </node>
         </node>
         <node concept="30bdrP" id="4AahbtV2$bD" role="_fkuS">
-          <property role="30bdrQ" value="m1" />
-        </node>
-      </node>
-      <node concept="_fkuZ" id="4AahbtVb9a5" role="_fkp5">
-        <property role="3sVy9A" value="true" />
-        <node concept="_fku$" id="4AahbtVb9a6" role="_fkur" />
-        <node concept="1QScDb" id="4AahbtVb9a9" role="_fkuY">
-          <node concept="1WPpZc" id="4AahbtVb9aa" role="30czhm">
-            <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
-          </node>
-          <node concept="1WPo9w" id="4AahbtVb9ab" role="1QScD9">
-            <property role="MFfev" value="false" />
-            <ref role="1WPo9$" node="3vxfdxbrKAj" resolve="m1" />
-          </node>
-        </node>
-        <node concept="30bdrP" id="4AahbtVb9ac" role="_fkuS">
           <property role="30bdrQ" value="m1" />
         </node>
       </node>
@@ -348,7 +332,7 @@
               <node concept="NlJPO" id="4AahbtURxg3" role="1QScD9" />
               <node concept="1QScDb" id="4AahbtURx4f" role="30czhm">
                 <node concept="1WPo9w" id="4AahbtURx4g" role="1QScD9">
-                  <property role="MFfev" value="true" />
+                  <property role="MFfev" value="false" />
                   <ref role="1WPo9$" node="3vxfdxbrKAj" resolve="m1" />
                 </node>
                 <node concept="1WPpZc" id="4AahbtURx4h" role="30czhm">
@@ -363,13 +347,16 @@
       <node concept="_fkuZ" id="3vxfdxbs7e_" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="3vxfdxbs7eA" role="_fkur" />
-        <node concept="1QScDb" id="3vxfdxbs7eB" role="_fkuY">
-          <node concept="1WPo9w" id="3vxfdxbs7iJ" role="1QScD9">
-            <property role="MFfev" value="false" />
-            <ref role="1WPo9$" node="3vxfdxbrKAQ" resolve="m2" />
-          </node>
-          <node concept="1WPpZc" id="3vxfdxbs7eD" role="30czhm">
-            <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+        <node concept="1QScDb" id="7OtDX6qlCxe" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlCJ2" role="1QScD9" />
+          <node concept="1QScDb" id="3vxfdxbs7eB" role="30czhm">
+            <node concept="1WPo9w" id="3vxfdxbs7iJ" role="1QScD9">
+              <property role="MFfev" value="false" />
+              <ref role="1WPo9$" node="3vxfdxbrKAQ" resolve="m2" />
+            </node>
+            <node concept="1WPpZc" id="3vxfdxbs7eD" role="30czhm">
+              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            </node>
           </node>
         </node>
         <node concept="30bdrP" id="3vxfdxbs7eE" role="_fkuS">
@@ -379,13 +366,16 @@
       <node concept="_fkuZ" id="3vxfdxbs7f4" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="3vxfdxbs7f5" role="_fkur" />
-        <node concept="1QScDb" id="3vxfdxbs7f6" role="_fkuY">
-          <node concept="1WPo9w" id="3vxfdxbs7jj" role="1QScD9">
-            <property role="MFfev" value="false" />
-            <ref role="1WPo9$" node="3vxfdxbrKCL" resolve="m3" />
-          </node>
-          <node concept="1WPpZc" id="3vxfdxbs7f8" role="30czhm">
-            <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+        <node concept="1QScDb" id="7OtDX6qlCNu" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlD1i" role="1QScD9" />
+          <node concept="1QScDb" id="3vxfdxbs7f6" role="30czhm">
+            <node concept="1WPo9w" id="3vxfdxbs7jj" role="1QScD9">
+              <property role="MFfev" value="false" />
+              <ref role="1WPo9$" node="3vxfdxbrKCL" resolve="m3" />
+            </node>
+            <node concept="1WPpZc" id="3vxfdxbs7f8" role="30czhm">
+              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            </node>
           </node>
         </node>
         <node concept="30bdrP" id="3vxfdxbs7f9" role="_fkuS">
@@ -395,19 +385,22 @@
       <node concept="_fkuZ" id="3vxfdxbs7fJ" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="3vxfdxbs7fK" role="_fkur" />
-        <node concept="1QScDb" id="3vxfdxbs7fL" role="_fkuY">
-          <node concept="1WPo9w" id="3vxfdxbs7jL" role="1QScD9">
-            <ref role="1WPo9$" node="3vxfdxbrKDC" resolve="m4" />
-            <node concept="30bdrP" id="3vxfdxbthCm" role="1WFony">
-              <property role="30bdrQ" value="42" />
+        <node concept="1QScDb" id="7OtDX6qlDC1" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlEbf" role="1QScD9" />
+          <node concept="1QScDb" id="3vxfdxbs7fL" role="30czhm">
+            <node concept="1WPo9w" id="3vxfdxbs7jL" role="1QScD9">
+              <ref role="1WPo9$" node="3vxfdxbrKDC" resolve="m4" />
+              <node concept="30bdrP" id="3vxfdxbthCm" role="1WFony">
+                <property role="30bdrQ" value="42" />
+              </node>
             </node>
-          </node>
-          <node concept="1QScDb" id="3vxfdxbthN0" role="30czhm">
-            <node concept="1WETeO" id="3vxfdxbthP4" role="1QScD9">
-              <ref role="1WETeC" node="3vxfdxbthIg" resolve="withStringArgs" />
-            </node>
-            <node concept="1WPpZc" id="3vxfdxbs7fN" role="30czhm">
-              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            <node concept="1QScDb" id="3vxfdxbthN0" role="30czhm">
+              <node concept="1WETeO" id="3vxfdxbthP4" role="1QScD9">
+                <ref role="1WETeC" node="3vxfdxbthIg" resolve="withStringArgs" />
+              </node>
+              <node concept="1WPpZc" id="3vxfdxbs7fN" role="30czhm">
+                <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+              </node>
             </node>
           </node>
         </node>
@@ -418,19 +411,22 @@
       <node concept="_fkuZ" id="3vxfdxbs7gA" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="3vxfdxbs7gB" role="_fkur" />
-        <node concept="1QScDb" id="3vxfdxbs7gC" role="_fkuY">
-          <node concept="1WPo9w" id="3vxfdxbs7kf" role="1QScD9">
-            <ref role="1WPo9$" node="3vxfdxbrKFr" resolve="m5" />
-            <node concept="30bdrP" id="3vxfdxbthD7" role="1WFony">
-              <property role="30bdrQ" value="33" />
+        <node concept="1QScDb" id="7OtDX6qlEbV" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlEIz" role="1QScD9" />
+          <node concept="1QScDb" id="3vxfdxbs7gC" role="30czhm">
+            <node concept="1WPo9w" id="3vxfdxbs7kf" role="1QScD9">
+              <ref role="1WPo9$" node="3vxfdxbrKFr" resolve="m5" />
+              <node concept="30bdrP" id="3vxfdxbthD7" role="1WFony">
+                <property role="30bdrQ" value="33" />
+              </node>
             </node>
-          </node>
-          <node concept="1QScDb" id="3vxfdxbthPC" role="30czhm">
-            <node concept="1WETeO" id="3vxfdxbthQl" role="1QScD9">
-              <ref role="1WETeC" node="3vxfdxbthIg" resolve="withStringArgs" />
-            </node>
-            <node concept="1WPpZc" id="3vxfdxbs7gE" role="30czhm">
-              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            <node concept="1QScDb" id="3vxfdxbthPC" role="30czhm">
+              <node concept="1WETeO" id="3vxfdxbthQl" role="1QScD9">
+                <ref role="1WETeC" node="3vxfdxbthIg" resolve="withStringArgs" />
+              </node>
+              <node concept="1WPpZc" id="3vxfdxbs7gE" role="30czhm">
+                <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+              </node>
             </node>
           </node>
         </node>
@@ -441,19 +437,22 @@
       <node concept="_fkuZ" id="3vxfdxbtTgB" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="3vxfdxbtTgC" role="_fkur" />
-        <node concept="1QScDb" id="3vxfdxbtTgD" role="_fkuY">
-          <node concept="1WPo9w" id="3vxfdxbtTgE" role="1QScD9">
-            <ref role="1WPo9$" node="3vxfdxbthSx" resolve="m4" />
-            <node concept="30bXRB" id="3vxfdxbtTo3" role="1WFony">
-              <property role="30bXRw" value="42" />
+        <node concept="1QScDb" id="7OtDX6qlEJi" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlFyY" role="1QScD9" />
+          <node concept="1QScDb" id="3vxfdxbtTgD" role="30czhm">
+            <node concept="1WPo9w" id="3vxfdxbtTgE" role="1QScD9">
+              <ref role="1WPo9$" node="3vxfdxbthSx" resolve="m4" />
+              <node concept="30bXRB" id="3vxfdxbtTo3" role="1WFony">
+                <property role="30bXRw" value="42" />
+              </node>
             </node>
-          </node>
-          <node concept="1QScDb" id="3vxfdxbtTgG" role="30czhm">
-            <node concept="1WETeO" id="3vxfdxbtTjx" role="1QScD9">
-              <ref role="1WETeC" node="3vxfdxbthSw" resolve="withIntArgs" />
-            </node>
-            <node concept="1WPpZc" id="3vxfdxbtTgI" role="30czhm">
-              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            <node concept="1QScDb" id="3vxfdxbtTgG" role="30czhm">
+              <node concept="1WETeO" id="3vxfdxbtTjx" role="1QScD9">
+                <ref role="1WETeC" node="3vxfdxbthSw" resolve="withIntArgs" />
+              </node>
+              <node concept="1WPpZc" id="3vxfdxbtTgI" role="30czhm">
+                <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+              </node>
             </node>
           </node>
         </node>
@@ -468,7 +467,7 @@
           <node concept="MxAYs" id="4AahbtV3fgs" role="1QScD9" />
           <node concept="1QScDb" id="4AahbtV3f1_" role="30czhm">
             <node concept="1WPo9w" id="4AahbtV3f1A" role="1QScD9">
-              <property role="MFfev" value="true" />
+              <property role="MFfev" value="false" />
               <ref role="1WPo9$" node="3vxfdxbthSx" resolve="m4" />
               <node concept="30bXRB" id="4AahbtV3f1B" role="1WFony">
                 <property role="30bXRw" value="42" />
@@ -506,7 +505,7 @@
             <node concept="MxAYs" id="4AahbtV85bD" role="1QScD9" />
             <node concept="1QScDb" id="4AahbtV85bE" role="30czhm">
               <node concept="1WPo9w" id="4AahbtV85bF" role="1QScD9">
-                <property role="MFfev" value="true" />
+                <property role="MFfev" value="false" />
                 <ref role="1WPo9$" node="3vxfdxbthSx" resolve="m4" />
                 <node concept="30bXRB" id="4AahbtV85bG" role="1WFony">
                   <property role="30bXRw" value="42" />
@@ -534,7 +533,7 @@
           <node concept="NjiR8" id="4AahbtUNAHD" role="1QScD9" />
           <node concept="1QScDb" id="3vxfdxbtTgw" role="30czhm">
             <node concept="1WPo9w" id="3vxfdxbtTgx" role="1QScD9">
-              <property role="MFfev" value="true" />
+              <property role="MFfev" value="false" />
               <ref role="1WPo9$" node="3vxfdxbthSE" resolve="m5" />
               <node concept="30bXRB" id="3vxfdxbtTqq" role="1WFony">
                 <property role="30bXRw" value="33" />
@@ -557,24 +556,27 @@
       <node concept="_fkuZ" id="3vxfdxburJ8" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="3vxfdxburJ9" role="_fkur" />
-        <node concept="1QScDb" id="3vxfdxburJa" role="_fkuY">
-          <node concept="1WPo9w" id="3vxfdxburJb" role="1QScD9">
-            <ref role="1WPo9$" node="3vxfdxburCP" resolve="m6" />
-            <node concept="30bXRB" id="3vxfdxburJc" role="1WFony">
-              <property role="30bXRw" value="33" />
-            </node>
-            <node concept="2vmpnb" id="3vxfdxburWO" role="1WFony" />
-          </node>
-          <node concept="1QScDb" id="3vxfdxburMv" role="30czhm">
-            <node concept="1WETeO" id="3vxfdxburS0" role="1QScD9">
-              <ref role="1WETeC" node="3vxfdxburAI" resolve="sub" />
-            </node>
-            <node concept="1QScDb" id="3vxfdxburJd" role="30czhm">
-              <node concept="1WETeO" id="3vxfdxburJe" role="1QScD9">
-                <ref role="1WETeC" node="3vxfdxbthSw" resolve="withIntArgs" />
+        <node concept="1QScDb" id="7OtDX6qlFIZ" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlGRv" role="1QScD9" />
+          <node concept="1QScDb" id="3vxfdxburJa" role="30czhm">
+            <node concept="1WPo9w" id="3vxfdxburJb" role="1QScD9">
+              <ref role="1WPo9$" node="3vxfdxburCP" resolve="m6" />
+              <node concept="30bXRB" id="3vxfdxburJc" role="1WFony">
+                <property role="30bXRw" value="33" />
               </node>
-              <node concept="1WPpZc" id="3vxfdxburJf" role="30czhm">
-                <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+              <node concept="2vmpnb" id="3vxfdxburWO" role="1WFony" />
+            </node>
+            <node concept="1QScDb" id="3vxfdxburMv" role="30czhm">
+              <node concept="1WETeO" id="3vxfdxburS0" role="1QScD9">
+                <ref role="1WETeC" node="3vxfdxburAI" resolve="sub" />
+              </node>
+              <node concept="1QScDb" id="3vxfdxburJd" role="30czhm">
+                <node concept="1WETeO" id="3vxfdxburJe" role="1QScD9">
+                  <ref role="1WETeC" node="3vxfdxbthSw" resolve="withIntArgs" />
+                </node>
+                <node concept="1WPpZc" id="3vxfdxburJf" role="30czhm">
+                  <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+                </node>
               </node>
             </node>
           </node>
@@ -586,16 +588,19 @@
       <node concept="_fkuZ" id="5ZJ96SJBsQF" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="5ZJ96SJBsQG" role="_fkur" />
-        <node concept="1QScDb" id="5ZJ96SJBsQL" role="_fkuY">
-          <node concept="1WPo9w" id="5ZJ96SJBt7f" role="1QScD9">
-            <ref role="1WPo9$" node="5ZJ96SJBr43" resolve="w" />
-          </node>
-          <node concept="1QScDb" id="5ZJ96SJBsQN" role="30czhm">
-            <node concept="1WETeO" id="5ZJ96SJBsUr" role="1QScD9">
-              <ref role="1WETeC" node="5ZJ96SJBr0f" resolve="withKinds" />
+        <node concept="1QScDb" id="7OtDX6qlI0O" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlIos" role="1QScD9" />
+          <node concept="1QScDb" id="5ZJ96SJBsQL" role="30czhm">
+            <node concept="1WPo9w" id="5ZJ96SJBt7f" role="1QScD9">
+              <ref role="1WPo9$" node="5ZJ96SJBr43" resolve="w" />
             </node>
-            <node concept="1WPpZc" id="5ZJ96SJBsQP" role="30czhm">
-              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            <node concept="1QScDb" id="5ZJ96SJBsQN" role="30czhm">
+              <node concept="1WETeO" id="5ZJ96SJBsUr" role="1QScD9">
+                <ref role="1WETeC" node="5ZJ96SJBr0f" resolve="withKinds" />
+              </node>
+              <node concept="1WPpZc" id="5ZJ96SJBsQP" role="30czhm">
+                <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+              </node>
             </node>
           </node>
         </node>
@@ -606,17 +611,20 @@
       <node concept="_fkuZ" id="5ZJ96SJBtgw" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="5ZJ96SJBtgx" role="_fkur" />
-        <node concept="1QScDb" id="5ZJ96SJBtgy" role="_fkuY">
-          <node concept="1QScDb" id="5ZJ96SJBtg$" role="30czhm">
-            <node concept="1WETeO" id="5ZJ96SJBtg_" role="1QScD9">
-              <ref role="1WETeC" node="5ZJ96SJBr0f" resolve="withKinds" />
+        <node concept="1QScDb" id="7OtDX6qlIB0" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlIYC" role="1QScD9" />
+          <node concept="1QScDb" id="5ZJ96SJBtgy" role="30czhm">
+            <node concept="1QScDb" id="5ZJ96SJBtg$" role="30czhm">
+              <node concept="1WETeO" id="5ZJ96SJBtg_" role="1QScD9">
+                <ref role="1WETeC" node="5ZJ96SJBr0f" resolve="withKinds" />
+              </node>
+              <node concept="1WPpZc" id="5ZJ96SJBtgA" role="30czhm">
+                <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+              </node>
             </node>
-            <node concept="1WPpZc" id="5ZJ96SJBtgA" role="30czhm">
-              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            <node concept="1WPo9w" id="5ZJ96SJBtkk" role="1QScD9">
+              <ref role="1WPo9$" node="5ZJ96SJBr6$" resolve="e" />
             </node>
-          </node>
-          <node concept="1WPo9w" id="5ZJ96SJBtkk" role="1QScD9">
-            <ref role="1WPo9$" node="5ZJ96SJBr6$" resolve="e" />
           </node>
         </node>
         <node concept="30bdrP" id="5ZJ96SJBtgB" role="_fkuS">
@@ -630,23 +638,26 @@
       <node concept="_fkuZ" id="1CNpG_h8fN8" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="1CNpG_h8fN9" role="_fkur" />
-        <node concept="1QScDb" id="1CNpG_h8gCO" role="_fkuY">
-          <node concept="1WPo9w" id="1CNpG_h8gDA" role="1QScD9">
-            <ref role="1WPo9$" node="1CNpG_h8fSR" resolve="mPoint" />
-            <node concept="2S399m" id="1CNpG_h8gDS" role="1WFony">
-              <node concept="2Ss9cW" id="1CNpG_h8gEm" role="2S399n">
-                <ref role="2Ss9cX" node="1CNpG_h50DD" resolve="Point" />
-              </node>
-              <node concept="30bXRB" id="1CNpG_h8gFR" role="2S399l">
-                <property role="30bXRw" value="1" />
-              </node>
-              <node concept="30bXRB" id="1CNpG_h8gG5" role="2S399l">
-                <property role="30bXRw" value="2" />
+        <node concept="1QScDb" id="7OtDX6qlJi5" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlKUd" role="1QScD9" />
+          <node concept="1QScDb" id="1CNpG_h8gCO" role="30czhm">
+            <node concept="1WPo9w" id="1CNpG_h8gDA" role="1QScD9">
+              <ref role="1WPo9$" node="1CNpG_h8fSR" resolve="mPoint" />
+              <node concept="2S399m" id="1CNpG_h8gDS" role="1WFony">
+                <node concept="2Ss9cW" id="1CNpG_h8gEm" role="2S399n">
+                  <ref role="2Ss9cX" node="1CNpG_h50DD" resolve="Point" />
+                </node>
+                <node concept="30bXRB" id="1CNpG_h8gFR" role="2S399l">
+                  <property role="30bXRw" value="1" />
+                </node>
+                <node concept="30bXRB" id="1CNpG_h8gG5" role="2S399l">
+                  <property role="30bXRw" value="2" />
+                </node>
               </node>
             </node>
-          </node>
-          <node concept="1WPpZc" id="1CNpG_h8gC$" role="30czhm">
-            <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            <node concept="1WPpZc" id="1CNpG_h8gC$" role="30czhm">
+              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            </node>
           </node>
         </node>
         <node concept="30bdrP" id="1CNpG_h8gHy" role="_fkuS">
@@ -656,15 +667,18 @@
       <node concept="_fkuZ" id="1CNpG_h8Ft_" role="_fkp5">
         <property role="3sVy9A" value="true" />
         <node concept="_fku$" id="1CNpG_h8FtA" role="_fkur" />
-        <node concept="1QScDb" id="1CNpG_h8FtB" role="_fkuY">
-          <node concept="1WPo9w" id="1CNpG_h8FtC" role="1QScD9">
-            <ref role="1WPo9$" node="1CNpG_h8F6P" resolve="mMoney" />
-            <node concept="30bXRB" id="1CNpG_h8F_K" role="1WFony">
-              <property role="30bXRw" value="100" />
+        <node concept="1QScDb" id="7OtDX6qlKVP" role="_fkuY">
+          <node concept="NjiR8" id="7OtDX6qlLC9" role="1QScD9" />
+          <node concept="1QScDb" id="1CNpG_h8FtB" role="30czhm">
+            <node concept="1WPo9w" id="1CNpG_h8FtC" role="1QScD9">
+              <ref role="1WPo9$" node="1CNpG_h8F6P" resolve="mMoney" />
+              <node concept="30bXRB" id="1CNpG_h8F_K" role="1WFony">
+                <property role="30bXRw" value="100" />
+              </node>
             </node>
-          </node>
-          <node concept="1WPpZc" id="1CNpG_h8FtH" role="30czhm">
-            <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            <node concept="1WPpZc" id="1CNpG_h8FtH" role="30czhm">
+              <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
+            </node>
           </node>
         </node>
         <node concept="30bdrP" id="1CNpG_h8FtI" role="_fkuS">
@@ -767,7 +781,7 @@
         <node concept="InuEK" id="4AahbtVbbGs" role="I61D1">
           <node concept="1QScDb" id="4AahbtVRMRz" role="2izrR8">
             <node concept="1WPo9w" id="4AahbtVRNhJ" role="1QScD9">
-              <property role="MFfev" value="true" />
+              <property role="MFfev" value="false" />
               <ref role="1WPo9$" node="4AahbtVRLW6" resolve="xeey" />
               <node concept="XrbUJ" id="4AahbtVRNmn" role="1WFony">
                 <ref role="XrbUP" node="4AahbtVbbGn" resolve="x" />


### PR DESCRIPTION
* Deprecate MessageTarget.messagValue. All calls to messages now return the full message object. If only text is desired, `.text` can be used. This encourages using the full message object in constraints so that error kind is not lost.

* Add warningID to WarningKind.

* Message: collect fqnames of members that were mentioned in the constraint in affectedMemberNames.

* Message: add userData to allow customer-specific data to be attached to the message (in the generator).