### PR TITLE
Fix interpreter for FailExpr, add test

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -4511,15 +4511,58 @@
                 <node concept="3clFbS" id="78hTg1_hS2t" role="TDEfX">
                   <node concept="3clFbF" id="78hTg1_hSrp" role="3cqZAp">
                     <node concept="37vLTI" id="78hTg1_hSrq" role="3clFbG">
-                      <node concept="3clFbT" id="78hTg1_hSrr" role="37vLTx">
-                        <property role="3clFbU" value="true" />
-                      </node>
+                      <node concept="3clFbT" id="78hTg1_hSrr" role="37vLTx" />
                       <node concept="2OqwBi" id="78hTg1_hSrs" role="37vLTJ">
                         <node concept="37vLTw" id="78hTg1_hSrt" role="2Oq$k0">
                           <ref role="3cqZAo" node="78hTg1$TLoy" resolve="result" />
                         </node>
                         <node concept="2OwXpG" id="78hTg1_hSru" role="2OqNvi">
                           <ref role="2Oxat5" node="ub9nkyOIfW" resolve="ok" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="6UrZmTWnTSh" role="3cqZAp">
+                    <node concept="37vLTI" id="6UrZmTWnTSi" role="3clFbG">
+                      <node concept="2OqwBi" id="6UrZmTWnTSj" role="37vLTJ">
+                        <node concept="37vLTw" id="6UrZmTWnTSk" role="2Oq$k0">
+                          <ref role="3cqZAo" node="78hTg1$TLoy" resolve="result" />
+                        </node>
+                        <node concept="2OwXpG" id="6UrZmTWnTSl" role="2OqNvi">
+                          <ref role="2Oxat5" node="ub9nkyQiZj" resolve="errorMessage" />
+                        </node>
+                      </node>
+                      <node concept="2ShNRf" id="6UrZmTWnTSm" role="37vLTx">
+                        <node concept="1pGfFk" id="6UrZmTWnTSn" role="2ShVmc">
+                          <ref role="37wK5l" to="oq0c:4AahbtULK5l" resolve="MessageValue" />
+                          <node concept="3cpWs3" id="6UrZmTWnUME" role="37wK5m">
+                            <node concept="2OqwBi" id="6UrZmTWoFdN" role="3uHU7w">
+                              <node concept="37vLTw" id="6UrZmTWoEPG" role="2Oq$k0">
+                                <ref role="3cqZAo" node="78hTg1_hS2r" resolve="ire" />
+                              </node>
+                              <node concept="liA8E" id="6UrZmTWoFF$" role="2OqNvi">
+                                <ref role="37wK5l" to="2ahs:9nJ_zCAH8C" resolve="getMessage" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="6UrZmTWnTSo" role="3uHU7B">
+                              <property role="Xl_RC" value="failed with InterpreterRuntimeException: " />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="6UrZmTWoDrv" role="3cqZAp">
+                    <node concept="37vLTI" id="6UrZmTWoEBq" role="3clFbG">
+                      <node concept="37vLTw" id="6UrZmTWoEC$" role="37vLTx">
+                        <ref role="3cqZAo" node="78hTg1_hS2r" resolve="ire" />
+                      </node>
+                      <node concept="2OqwBi" id="6UrZmTWoDFU" role="37vLTJ">
+                        <node concept="37vLTw" id="6UrZmTWoDrt" role="2Oq$k0">
+                          <ref role="3cqZAo" node="78hTg1$TLoy" resolve="result" />
+                        </node>
+                        <node concept="2OwXpG" id="6UrZmTWoDUO" role="2OqNvi">
+                          <ref role="2Oxat5" node="7vHKcHd4kI1" resolve="exception" />
                         </node>
                       </node>
                     </node>
@@ -4625,15 +4668,15 @@
                   <node concept="1bVj0M" id="78hTg1_ehmW" role="23t8la">
                     <node concept="3clFbS" id="78hTg1_ehmX" role="1bW5cS">
                       <node concept="3clFbF" id="78hTg1_ehmY" role="3cqZAp">
-                        <node concept="3clFbC" id="78hTg1_ehmZ" role="3clFbG">
-                          <node concept="35c_gC" id="78hTg1_ehn0" role="3uHU7w">
-                            <ref role="35c_gD" to="hm2y:6sdnDbSla17" resolve="Expression" />
-                          </node>
-                          <node concept="2OqwBi" id="78hTg1_ehn1" role="3uHU7B">
-                            <node concept="37vLTw" id="78hTg1_ehn2" role="2Oq$k0">
+                        <node concept="2OqwBi" id="6UrZmTWpfp4" role="3clFbG">
+                          <node concept="2OqwBi" id="6UrZmTWpdBF" role="2Oq$k0">
+                            <node concept="37vLTw" id="6UrZmTWpdBG" role="2Oq$k0">
                               <ref role="3cqZAo" node="78hTg1_ehn4" resolve="it" />
                             </node>
-                            <node concept="2yIwOk" id="78hTg1_ehn3" role="2OqNvi" />
+                            <node concept="2yIwOk" id="6UrZmTWpdBH" role="2OqNvi" />
+                          </node>
+                          <node concept="liA8E" id="6UrZmTWpjj2" role="2OqNvi">
+                            <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
                           </node>
                         </node>
                       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
@@ -1801,6 +1801,9 @@
         </node>
       </node>
     </node>
+    <node concept="PMmxH" id="6UrZmTWpShN" role="6VMZX">
+      <ref role="PMmxG" node="5Pgo_ASgPrj" resolve="StackTrace_EditorComponent" />
+    </node>
   </node>
   <node concept="24kQdi" id="4_qY3E4CWiZ">
     <ref role="1XX52x" to="av4b:4_qY3E4CWhU" resolve="EmptyTestItem" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.interpreter/models/plugin.mps
@@ -810,11 +810,8 @@
                 <node concept="3uibUv" id="UwUtc3njGy" role="1tU5fm">
                   <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
                 </node>
-                <node concept="10QFUN" id="mQGcCvQ2J9" role="33vP2m">
-                  <node concept="rqRoa" id="mQGcCvQ2J8" role="10QFUP">
-                    <ref role="rqRob" to="hm2y:mQGcCvPueY" resolve="message" />
-                  </node>
-                  <node concept="17QB3L" id="mQGcCvQ2Tq" role="10QFUM" />
+                <node concept="rqRoa" id="mQGcCvQ2J8" role="33vP2m">
+                  <ref role="rqRob" to="hm2y:mQGcCvPueY" resolve="message" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/solutions/test.ex.core.expr.genjava/models/messages@tests.mps
+++ b/code/languages/org.iets3.opensource/solutions/test.ex.core.expr.genjava/models/messages@tests.mps
@@ -76,6 +76,7 @@
     </language>
     <language id="d441fba0-f46b-43cd-b723-dad7b65da615" name="org.iets3.core.expr.tests">
       <concept id="8219602584783477663" name="org.iets3.core.expr.tests.structure.ConstraintFailedTestItem" flags="ng" index="mXNUv">
+        <property id="5974682372640371252" name="errmsg" index="xVyv2" />
         <child id="8219602584783494093" name="actual" index="mXJVd" />
       </concept>
       <concept id="543569365052056273" name="org.iets3.core.expr.tests.structure.EqualsTestOp" flags="ng" index="_fku$" />
@@ -772,10 +773,11 @@
     <node concept="_fkuM" id="5GmVcyjQtQQ" role="_iOnB">
       <property role="TrG5h" value="failWithAMessage" />
       <node concept="mXNUv" id="5GmVcyjQtZA" role="_fkp5">
+        <property role="xVyv2" value="failure number 42" />
         <node concept="qoPdK" id="5GmVcyjQtZN" role="mXJVd">
           <node concept="1QScDb" id="5GmVcyjQuqS" role="qoPdO">
-            <node concept="1WPo9w" id="3HIl9G7kxYY" role="1QScD9">
-              <ref role="1WPo9$" node="3vxfdxbrKAj" resolve="m1" />
+            <node concept="1WPo9w" id="6UrZmTWroOc" role="1QScD9">
+              <ref role="1WPo9$" node="6UrZmTWnBVH" resolve="failure42" />
             </node>
             <node concept="1WPpZc" id="5GmVcyjQuqF" role="30czhm">
               <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
@@ -853,6 +855,12 @@
             <property role="19SUeA" value="m3" />
           </node>
         </node>
+      </node>
+    </node>
+    <node concept="1WOOD3" id="6UrZmTWnBVH" role="1WOfUI">
+      <property role="TrG5h" value="failure42" />
+      <node concept="30bdrP" id="6UrZmTWnC1k" role="1WPxOI">
+        <property role="30bdrQ" value="failure number 42" />
       </node>
     </node>
     <node concept="1WOfU3" id="3vxfdxbthIg" role="1WOfUI">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/todo@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/todo@tests.mps
@@ -890,7 +890,7 @@
     </node>
     <node concept="2zPypq" id="5ipapt3Eqiq" role="_iOnB">
       <property role="TrG5h" value="p2" />
-      <property role="0Rz4W" value="899765441" />
+      <property role="0Rz4W" value="132159520" />
       <node concept="2S399m" id="5ipapt3Eqir" role="2zPyp_">
         <node concept="2Ss9cW" id="5ipapt3Eqis" role="2S399n">
           <ref role="2Ss9cX" node="5ipapt3EfEW" resolve="Person" />
@@ -917,7 +917,7 @@
     </node>
     <node concept="2zPypq" id="5ipapt3Erxk" role="_iOnB">
       <property role="TrG5h" value="p3" />
-      <property role="0Rz4W" value="-1040570628" />
+      <property role="0Rz4W" value="1719184826" />
       <node concept="2S399m" id="5ipapt3Erxl" role="2zPyp_">
         <node concept="2Ss9cW" id="5ipapt3Erxm" role="2S399n">
           <ref role="2Ss9cX" node="5ipapt3EfEW" resolve="Person" />
@@ -1246,6 +1246,7 @@
               <node concept="1QScDb" id="6H5IFDj1G$h" role="30czhm">
                 <node concept="2TEanv" id="6H5IFDj2nwl" role="1QScD9" />
                 <node concept="1af_rf" id="6H5IFDj1z9W" role="30czhm">
+                  <property role="0Rz4W" value="329581607" />
                   <ref role="1afhQb" node="5ipapt3EfHe" resolve="brotherAges4" />
                   <node concept="_emDc" id="6H5IFDj1BR6" role="1afhQ5">
                     <ref role="_emDf" node="5ipapt3Ejin" resolve="p1" />


### PR DESCRIPTION
Fix a small issue in the interpreter for FailExpr, making it possible to use with message values.

Make sure this is caught by tests: adjust `confail` to report any exception that's not a constraint failure as an error.