### PR TITLE
Rename KernelF Generators

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:4243557f-1c7a-4d6b-953a-807576e4bee7(main@generator)">
+<model ref="r:4243557f-1c7a-4d6b-953a-807576e4bee7(org.iets3.core.expr.genjava.base@generator)">
   <persistence version="9" />
   <languages>
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="-1" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.contracts/generator/template/org.iets3.core.expr.genjava.contracts@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.contracts/generator/template/org.iets3.core.expr.genjava.contracts@generator.mps
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:d262ac25-cee7-4097-ba94-1f4ad5204b8c(main@generator)">
+<model ref="r:d262ac25-cee7-4097-ba94-1f4ad5204b8c(org.iets3.core.expr.genjava.contracts@generator)">
   <persistence version="9" />
   <languages>
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="1" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.datetime/generator/template/org.iets3.core.expr.genjava.datetime@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.datetime/generator/template/org.iets3.core.expr.genjava.datetime@generator.mps
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:b8c087fd-3b95-4bc9-873f-612d5c8e00f9(main@generator)">
+<model ref="r:b8c087fd-3b95-4bc9-873f-612d5c8e00f9(org.iets3.core.expr.genjava.datetime@generator)">
   <persistence version="9" />
   <languages>
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="1" />
@@ -7,7 +7,7 @@
   </languages>
   <imports>
     <import index="dyw1" ref="r:1bfba2ec-5951-40d1-b23d-5e10b3fd8ecc(org.iets3.core.expr.genjava.datetime.structure)" />
-    <import index="rw5i" ref="r:4243557f-1c7a-4d6b-953a-807576e4bee7(main@generator)" />
+    <import index="rw5i" ref="r:4243557f-1c7a-4d6b-953a-807576e4bee7(org.iets3.core.expr.genjava.base@generator)" />
     <import index="28m1" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time(JDK/)" />
     <import index="xlxw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.math(JDK/)" />
     <import index="mi3w" ref="r:9ec53fca-e669-4a18-ba8b-6c9f4f1cb361(org.iets3.core.expr.datetime.structure)" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.messages/generator/template/org.iets3.core.expr.genjava.messages@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.messages/generator/template/org.iets3.core.expr.genjava.messages@generator.mps
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:0f46ac0f-8ffe-4980-b3f0-4c60a1f0312c(main@generator)">
+<model ref="r:0f46ac0f-8ffe-4980-b3f0-4c60a1f0312c(org.iets3.core.expr.genjava.messages@generator)">
   <persistence version="9" />
   <languages>
     <use id="817e4e70-961e-4a95-98a1-15e9f32231f1" name="jetbrains.mps.ide.httpsupport" version="0" />
@@ -10,7 +10,7 @@
     <import index="kelk" ref="r:1a11ce0d-cf54-4682-9b8a-ab4ee15fc129(org.iets3.core.expr.messages.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="aafr" ref="r:fc2b8fcf-559d-4f16-ae65-376838b59be6(org.iets3.core.expr.messages.behavior)" />
-    <import index="rw5i" ref="r:4243557f-1c7a-4d6b-953a-807576e4bee7(main@generator)" />
+    <import index="rw5i" ref="r:4243557f-1c7a-4d6b-953a-807576e4bee7(org.iets3.core.expr.genjava.base@generator)" />
     <import index="vj64" ref="r:bc28ef12-2b45-4cb1-adef-885617bf3e39(org.iets3.core.expr.genjava.messages.rt.rt)" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
     <import index="ip43" ref="r:49940317-a737-440f-8676-add9b899b862(org.iets3.core.expr.genjava.base.structure)" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.simpleTypes/generator/template/org.iets3.core.expr.genjava.simpleTypes@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.simpleTypes/generator/template/org.iets3.core.expr.genjava.simpleTypes@generator.mps
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:3490917a-a35f-43d7-9a1f-1311fda2da92(main@generator)">
+<model ref="r:3490917a-a35f-43d7-9a1f-1311fda2da92(org.iets3.core.expr.genjava.simpleTypes@generator)">
   <persistence version="9" />
   <languages>
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="1" />
@@ -10,7 +10,7 @@
     <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" />
     <import index="xlxw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.math(JDK/)" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
-    <import index="rw5i" ref="r:4243557f-1c7a-4d6b-953a-807576e4bee7(main@generator)" />
+    <import index="rw5i" ref="r:4243557f-1c7a-4d6b-953a-807576e4bee7(org.iets3.core.expr.genjava.base@generator)" />
     <import index="wfax" ref="r:5d67e954-7960-4214-97d1-8f5d3823a964(org.iets3.core.expr.genjava.simpleTypes.rt.rt)" />
     <import index="700h" ref="r:61b1de80-490d-4fee-8e95-b956503290e9(org.iets3.core.expr.collections.structure)" />
     <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.stateMachineExample/generator/template/main@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.stateMachineExample/generator/template/main@generator.mps
@@ -7,7 +7,7 @@
   <imports>
     <import index="44fz" ref="r:93558715-ee8d-4b41-af94-bc16c022d73d(org.iets3.core.expr.genjava.stateMachineExample.structure)" />
     <import index="3xse" ref="r:df8c8cfe-6ded-4712-b12b-d009ae7da92b(org.iets3.core.expr.genjava.stateMachineExample.runtime)" />
-    <import index="rw5i" ref="r:4243557f-1c7a-4d6b-953a-807576e4bee7(main@generator)" />
+    <import index="rw5i" ref="r:4243557f-1c7a-4d6b-953a-807576e4bee7(org.iets3.core.expr.genjava.base@generator)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.temporal/generator/template/org.iets3.core.expr.genjava.temporal@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.temporal/generator/template/org.iets3.core.expr.genjava.temporal@generator.mps
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:68ac91a8-ab55-4011-ba7a-b67f487e2bf8(main@generator)">
+<model ref="r:68ac91a8-ab55-4011-ba7a-b67f487e2bf8(org.iets3.core.expr.genjava.temporal@generator)">
   <persistence version="9" />
   <languages>
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="1" />
     <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
   </languages>
   <imports>
-    <import index="rw5i" ref="r:4243557f-1c7a-4d6b-953a-807576e4bee7(main@generator)" />
+    <import index="rw5i" ref="r:4243557f-1c7a-4d6b-953a-807576e4bee7(org.iets3.core.expr.genjava.base@generator)" />
     <import index="t677" ref="r:e44c17a0-d569-437a-a7a1-7c26f734db5f(org.iets3.core.expr.temporal.plugin)" />
     <import index="28m1" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time(JDK/)" />
     <import index="xlxw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.math(JDK/)" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.tests/generator/template/org.iets3.core.expr.genjava.tests@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.tests/generator/template/org.iets3.core.expr.genjava.tests@generator.mps
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:2b78f57a-6f72-4761-a6db-5c650deac424(main@generator)">
+<model ref="r:2b78f57a-6f72-4761-a6db-5c650deac424(org.iets3.core.expr.genjava.tests@generator)">
   <persistence version="9" />
   <languages>
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
@@ -10,7 +10,7 @@
   <imports>
     <import index="av4b" ref="r:ba7faab6-2b80-43d5-8b95-0c440665312c(org.iets3.core.expr.tests.structure)" />
     <import index="u132" ref="49808fad-9d41-4b96-83fa-9231640f6b2b/java:junit.framework(JUnit/)" />
-    <import index="rw5i" ref="r:4243557f-1c7a-4d6b-953a-807576e4bee7(main@generator)" />
+    <import index="rw5i" ref="r:4243557f-1c7a-4d6b-953a-807576e4bee7(org.iets3.core.expr.genjava.base@generator)" />
     <import index="vsv5" ref="r:7df3c033-0c27-4a50-97c3-f940e7dd27c2(org.iets3.core.expr.genjava.base.rt.rt)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/generator/template/org.iets3.core.expr.genjava.toplevel@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/generator/template/org.iets3.core.expr.genjava.toplevel@generator.mps
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:77acc36f-5eb1-43af-9f80-e6d4d70bca5f(org.iets3.core.expr.genjava.toplevel.main@generator)">
+<model ref="r:77acc36f-5eb1-43af-9f80-e6d4d70bca5f(org.iets3.core.expr.genjava.toplevel@generator)">
   <persistence version="9" />
   <languages>
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="-1" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.util/generator/template/org.iets3.core.expr.genjava.util@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.util/generator/template/org.iets3.core.expr.genjava.util@generator.mps
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:1dfe8d4f-ee6a-48e4-a00f-b8497efb0e5c(main@generator)">
+<model ref="r:1dfe8d4f-ee6a-48e4-a00f-b8497efb0e5c(org.iets3.core.expr.genjava.util@generator)">
   <persistence version="9" />
   <languages>
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="-1" />
@@ -12,12 +12,12 @@
   </languages>
   <imports>
     <import index="5pht" ref="r:2963f1d9-ee74-48d9-8a07-471e05081e4f(org.iets3.core.expr.genjava.util.structure)" />
-    <import index="rw5i" ref="r:4243557f-1c7a-4d6b-953a-807576e4bee7(main@generator)" />
+    <import index="rw5i" ref="r:4243557f-1c7a-4d6b-953a-807576e4bee7(org.iets3.core.expr.genjava.base@generator)" />
     <import index="kfo3" ref="r:6bb59b1e-6116-48ad-b11d-2641d4f6b6a1(org.iets3.core.expr.util.structure)" />
-    <import index="j10v" ref="cfaa4966-b7d5-4b69-b66a-309a6e1a7290/java:org.pcollections(org.iets3.core.expr.base/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
     <import index="wthy" ref="r:a4614e23-a6b5-4dbe-9bc5-9ff1ecfd0a3a(org.iets3.core.expr.util.behavior)" />
+    <import index="j10v" ref="b76a0f63-5959-456b-993a-c796cc0d0c13/java:org.pcollections(org.iets3.core.expr.base.collections.stubs/)" />
     <import index="zzzn" ref="r:af0af2e7-f7e1-4536-83b5-6bf010d4afd2(org.iets3.core.expr.lambda.structure)" implicit="true" />
   </imports>
   <registry>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.util/org.iets3.core.expr.genjava.util.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.util/org.iets3.core.expr.genjava.util.mpl
@@ -18,6 +18,7 @@
         <dependency reexport="false">4517af98-2eaa-4f19-a962-92df60010094(org.iets3.core.expr.genjava.base#8286534136181746510)</dependency>
         <dependency reexport="false">8bb1251e-eae5-47ab-9843-33adfae8edaa(org.iets3.core.expr.util)</dependency>
         <dependency reexport="false">cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</dependency>
+        <dependency reexport="false">b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)</dependency>
       </dependencies>
       <languageVersions>
         <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="5" />
@@ -87,6 +88,7 @@
         <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="0" />
         <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
         <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="3" />
+        <module reference="b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)" version="0" />
         <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="5" />
         <module reference="4517af98-2eaa-4f19-a962-92df60010094(org.iets3.core.expr.genjava.base#8286534136181746510)" version="0" />
         <module reference="15d858db-2d21-4ae9-90c4-f595086d0bdf(org.iets3.core.expr.genjava.util)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -5169,11 +5169,6 @@
             <ref role="3bR37D" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
           </node>
         </node>
-        <node concept="1SiIV0" id="3vxfdxbuGqG" role="3bR37C">
-          <node concept="3bR9La" id="3vxfdxbuGqH" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6Lc2" resolve="jetbrains.mps.lang.typesystem" />
-          </node>
-        </node>
         <node concept="1SiIV0" id="3vxfdxbuGqI" role="3bR37C">
           <node concept="3bR9La" id="3vxfdxbuGqJ" role="1SiIV1">
             <ref role="3bR37D" node="3vxfdxbuEmk" resolve="org.iets3.core.expr.messages" />
@@ -6800,6 +6795,11 @@
           <node concept="1SiIV0" id="6hYPZtwrXq$" role="3bR37C">
             <node concept="3bR9La" id="6hYPZtwrXq_" role="1SiIV1">
               <ref role="3bR37D" node="26tZ$Z4rnV1" resolve="org.iets3.core.expr.genjava.base#8286534136181746510" />
+            </node>
+          </node>
+          <node concept="1SiIV0" id="32Mgz$buMoE" role="3bR37C">
+            <node concept="3bR9La" id="32Mgz$buMoF" role="1SiIV1">
+              <ref role="3bR37D" node="5khwDRKS378" resolve="org.iets3.core.expr.base.collections.stubs" />
             </node>
           </node>
         </node>


### PR DESCRIPTION
Since it is annoying to find the right KernelF generators to import in the model properties when they are all named `main@generator`, I renamed all KernelF java generators.