### PR TITLE
Proper support of collections in test asserts

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/models/structure.mps
@@ -474,6 +474,9 @@
     <property role="TrG5h" value="Copy" />
     <property role="34LRSv" value="copy" />
     <ref role="1TJDcQ" node="7aipPVpLOlr" resolve="AlgebraicDotTarget" />
+    <node concept="PrWs8" id="6z5WYdPcNAn" role="PzmwI">
+      <ref role="PrY4T" to="hm2y:6z5WYdPcLnz" resolve="IContextTypedOp" />
+    </node>
   </node>
   <node concept="1TIwiD" id="28$LOSAMCgX">
     <property role="EcuMT" value="2460310434923316285" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/models/typesystem.mps
@@ -19,7 +19,6 @@
     <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" />
     <import index="tpd4" ref="r:00000000-0000-4000-0000-011c895902b4(jetbrains.mps.lang.typesystem.structure)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
-    <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -1957,48 +1956,6 @@
     <node concept="1YaCAy" id="28$LOSAMCi0" role="1YuTPh">
       <property role="TrG5h" value="size" />
       <ref role="1YaFvo" to="v0r8:28$LOSAMCgX" resolve="Size" />
-    </node>
-  </node>
-  <node concept="1YbPZF" id="28$LOSANXqe">
-    <property role="TrG5h" value="typeof_Copy" />
-    <property role="3GE5qa" value="dot" />
-    <node concept="3clFbS" id="28$LOSANXqf" role="18ibNy">
-      <node concept="nvevp" id="28$LOSALaBc" role="3cqZAp">
-        <node concept="3clFbS" id="28$LOSALaBd" role="nvhr_">
-          <node concept="1Z5TYs" id="28$LOSALbtf" role="3cqZAp">
-            <node concept="mw_s8" id="28$LOSALbtD" role="1ZfhKB">
-              <node concept="2X3wrD" id="28$LOSALbtB" role="mwGJk">
-                <ref role="2X3Bk0" node="28$LOSALaBf" resolve="contextType" />
-              </node>
-            </node>
-            <node concept="mw_s8" id="28$LOSALbti" role="1ZfhK$">
-              <node concept="1Z2H0r" id="28$LOSALbc$" role="mwGJk">
-                <node concept="1YBJjd" id="28$LOSANXy5" role="1Z2MuG">
-                  <ref role="1YBMHb" node="28$LOSANXqh" resolve="copy" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1Z2H0r" id="28$LOSALaC3" role="nvjzm">
-          <node concept="2OqwBi" id="28$LOSALaMD" role="1Z2MuG">
-            <node concept="1YBJjd" id="28$LOSANXss" role="2Oq$k0">
-              <ref role="1YBMHb" node="28$LOSANXqh" resolve="copy" />
-            </node>
-            <node concept="2qgKlT" id="28$LOSALb6T" role="2OqNvi">
-              <ref role="37wK5l" to="pbu6:6zmBjqUivyF" resolve="contextExpression" />
-            </node>
-          </node>
-        </node>
-        <node concept="2X1qdy" id="28$LOSALaBf" role="2X0Ygz">
-          <property role="TrG5h" value="contextType" />
-          <node concept="2jxLKc" id="28$LOSALaBg" role="1tU5fm" />
-        </node>
-      </node>
-    </node>
-    <node concept="1YaCAy" id="28$LOSANXqh" role="1YuTPh">
-      <property role="TrG5h" value="copy" />
-      <ref role="1YaFvo" to="v0r8:28$LOSALaA2" resolve="Copy" />
     </node>
   </node>
   <node concept="1YbPZF" id="28$LOSBq9c_">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/structure.mps
@@ -2195,5 +2195,12 @@
     <property role="EcuMT" value="8946943035394495000" />
     <property role="TrG5h" value="IParameterizedTypeSupportsEquals" />
   </node>
+  <node concept="PlHQZ" id="6z5WYdPcLnz">
+    <property role="EcuMT" value="7549708508605912547" />
+    <property role="TrG5h" value="IContextTypedOp" />
+    <node concept="PrWs8" id="6z5WYdPcLtB" role="PrDN$">
+      <ref role="PrY4T" node="7NJy08a3O9a" resolve="IDotTarget" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
@@ -9100,5 +9100,46 @@
       <ref role="1YaFvo" to="hm2y:7khFtBHnQPW" resolve="ConvenientValueCond" />
     </node>
   </node>
+  <node concept="1YbPZF" id="6z5WYdPcLuD">
+    <property role="TrG5h" value="typeof_IContextTypedOp" />
+    <node concept="3clFbS" id="6z5WYdPcLuE" role="18ibNy">
+      <node concept="nvevp" id="28$LOSALaBc" role="3cqZAp">
+        <node concept="3clFbS" id="28$LOSALaBd" role="nvhr_">
+          <node concept="1Z5TYs" id="28$LOSALbtf" role="3cqZAp">
+            <node concept="mw_s8" id="28$LOSALbtD" role="1ZfhKB">
+              <node concept="2X3wrD" id="28$LOSALbtB" role="mwGJk">
+                <ref role="2X3Bk0" node="28$LOSALaBf" resolve="contextType" />
+              </node>
+            </node>
+            <node concept="mw_s8" id="28$LOSALbti" role="1ZfhK$">
+              <node concept="1Z2H0r" id="28$LOSALbc$" role="mwGJk">
+                <node concept="1YBJjd" id="6z5WYdPcN9R" role="1Z2MuG">
+                  <ref role="1YBMHb" node="6z5WYdPcLuG" resolve="contextTypedOp" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1Z2H0r" id="28$LOSALaC3" role="nvjzm">
+          <node concept="2OqwBi" id="28$LOSALaMD" role="1Z2MuG">
+            <node concept="1YBJjd" id="6z5WYdPcMHF" role="2Oq$k0">
+              <ref role="1YBMHb" node="6z5WYdPcLuG" resolve="contextTypedOp" />
+            </node>
+            <node concept="2qgKlT" id="28$LOSALb6T" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:6zmBjqUivyF" resolve="contextExpression" />
+            </node>
+          </node>
+        </node>
+        <node concept="2X1qdy" id="28$LOSALaBf" role="2X0Ygz">
+          <property role="TrG5h" value="contextType" />
+          <node concept="2jxLKc" id="28$LOSALaBg" role="1tU5fm" />
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="6z5WYdPcLuG" role="1YuTPh">
+      <property role="TrG5h" value="contextTypedOp" />
+      <ref role="1YaFvo" to="hm2y:6z5WYdPcLnz" resolve="IContextTypedOp" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -50,6 +50,7 @@
     <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
     <import index="w474" ref="r:06b241ed-1779-4f34-8d6f-e61e9dd94387(org.iets3.core.expr.testExecution.plugin)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
+    <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -264,6 +265,7 @@
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -273,6 +275,9 @@
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1144226303539" name="jetbrains.mps.baseLanguage.structure.ForeachStatement" flags="nn" index="1DcWWT">
+        <child id="1144226360166" name="iterable" index="1DdaDG" />
       </concept>
       <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
         <child id="1144230900587" name="variable" index="1Duv9x" />
@@ -12132,18 +12137,12 @@
               </node>
             </node>
           </node>
-          <node concept="1Wc70l" id="1EZBwZ4mnQf" role="3clFbw">
-            <node concept="3clFbC" id="1EZBwZ4mnQg" role="3uHU7w">
-              <node concept="10Nm6u" id="1EZBwZ4mnQh" role="3uHU7w" />
-              <node concept="37vLTw" id="1EZBwZ4mnQi" role="3uHU7B">
-                <ref role="3cqZAo" node="1EZBwZ4mpvz" resolve="exp" />
-              </node>
+          <node concept="3clFbC" id="1EZBwZ4mnQj" role="3clFbw">
+            <node concept="37vLTw" id="1EZBwZ4mnQk" role="3uHU7B">
+              <ref role="3cqZAo" node="1EZBwZ4moPT" resolve="act" />
             </node>
-            <node concept="3clFbC" id="1EZBwZ4mnQj" role="3uHU7B">
-              <node concept="37vLTw" id="1EZBwZ4mnQk" role="3uHU7B">
-                <ref role="3cqZAo" node="1EZBwZ4moPT" resolve="act" />
-              </node>
-              <node concept="10Nm6u" id="1EZBwZ4mnQl" role="3uHU7w" />
+            <node concept="37vLTw" id="7DJqxi4CheD" role="3uHU7w">
+              <ref role="3cqZAo" node="1EZBwZ4mpvz" resolve="exp" />
             </node>
           </node>
           <node concept="3eNFk2" id="1EZBwZ4mnQm" role="3eNLev">
@@ -12154,41 +12153,18 @@
                 </node>
               </node>
             </node>
-            <node concept="1Wc70l" id="1EZBwZ4mnQq" role="3eO9$A">
-              <node concept="3y3z36" id="1EZBwZ4mnQr" role="3uHU7w">
-                <node concept="10Nm6u" id="1EZBwZ4mnQs" role="3uHU7w" />
-                <node concept="37vLTw" id="1EZBwZ4mnQt" role="3uHU7B">
-                  <ref role="3cqZAo" node="1EZBwZ4mpvz" resolve="exp" />
-                </node>
-              </node>
+            <node concept="22lmx$" id="7DJqxi4ChBC" role="3eO9$A">
               <node concept="3clFbC" id="1EZBwZ4mnQu" role="3uHU7B">
                 <node concept="37vLTw" id="1EZBwZ4mnQv" role="3uHU7B">
                   <ref role="3cqZAo" node="1EZBwZ4moPT" resolve="act" />
                 </node>
                 <node concept="10Nm6u" id="1EZBwZ4mnQw" role="3uHU7w" />
               </node>
-            </node>
-          </node>
-          <node concept="3eNFk2" id="1EZBwZ4mnQx" role="3eNLev">
-            <node concept="3clFbS" id="1EZBwZ4mnQy" role="3eOfB_">
-              <node concept="3cpWs6" id="1EZBwZ4mnQz" role="3cqZAp">
-                <node concept="3clFbT" id="1EZBwZ4mnQ$" role="3cqZAk">
-                  <property role="3clFbU" value="false" />
-                </node>
-              </node>
-            </node>
-            <node concept="1Wc70l" id="1EZBwZ4mnQ_" role="3eO9$A">
-              <node concept="3clFbC" id="1EZBwZ4mnQA" role="3uHU7w">
-                <node concept="37vLTw" id="1EZBwZ4mnQB" role="3uHU7B">
+              <node concept="3clFbC" id="7DJqxi4ChXM" role="3uHU7w">
+                <node concept="37vLTw" id="1EZBwZ4mnQt" role="3uHU7B">
                   <ref role="3cqZAo" node="1EZBwZ4mpvz" resolve="exp" />
                 </node>
-                <node concept="10Nm6u" id="1EZBwZ4mnQC" role="3uHU7w" />
-              </node>
-              <node concept="3y3z36" id="1EZBwZ4mnQD" role="3uHU7B">
-                <node concept="37vLTw" id="1EZBwZ4mnQE" role="3uHU7B">
-                  <ref role="3cqZAo" node="1EZBwZ4moPT" resolve="act" />
-                </node>
-                <node concept="10Nm6u" id="1EZBwZ4mnQF" role="3uHU7w" />
+                <node concept="10Nm6u" id="1EZBwZ4mnQs" role="3uHU7w" />
               </node>
             </node>
           </node>
@@ -12503,6 +12479,319 @@
                       <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
                     </node>
                     <node concept="37vLTw" id="1EZBwZ4mnSD" role="2ZW6bz">
+                      <ref role="3cqZAo" node="1EZBwZ4moPT" resolve="act" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="6z5WYdP5THT" role="3cqZAp">
+                <node concept="3clFbS" id="6z5WYdP5THU" role="3clFbx">
+                  <node concept="3cpWs8" id="6z5WYdPaiSY" role="3cqZAp">
+                    <node concept="3cpWsn" id="6z5WYdPaiSZ" role="3cpWs9">
+                      <property role="TrG5h" value="iter1" />
+                      <node concept="3uibUv" id="6z5WYdPaiSN" role="1tU5fm">
+                        <ref role="3uigEE" to="33ny:~Iterator" resolve="Iterator" />
+                        <node concept="3uibUv" id="6z5WYdPaiSQ" role="11_B2D">
+                          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="6z5WYdPaiT0" role="33vP2m">
+                        <node concept="1eOMI4" id="6z5WYdPajYl" role="2Oq$k0">
+                          <node concept="10QFUN" id="6z5WYdPajYi" role="1eOMHV">
+                            <node concept="37vLTw" id="6z5WYdPajYj" role="10QFUP">
+                              <ref role="3cqZAo" node="1EZBwZ4moPT" resolve="act" />
+                            </node>
+                            <node concept="3uibUv" id="6z5WYdPajYk" role="10QFUM">
+                              <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="6z5WYdPaiT2" role="2OqNvi">
+                          <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="6z5WYdPamAp" role="3cqZAp">
+                    <node concept="3cpWsn" id="6z5WYdPamAq" role="3cpWs9">
+                      <property role="TrG5h" value="iter2" />
+                      <node concept="3uibUv" id="6z5WYdPamAh" role="1tU5fm">
+                        <ref role="3uigEE" to="33ny:~Iterator" resolve="Iterator" />
+                        <node concept="3uibUv" id="6z5WYdPamAk" role="11_B2D">
+                          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="6z5WYdPamAr" role="33vP2m">
+                        <node concept="1eOMI4" id="6z5WYdPanWm" role="2Oq$k0">
+                          <node concept="10QFUN" id="6z5WYdPanWj" role="1eOMHV">
+                            <node concept="37vLTw" id="6z5WYdPanWk" role="10QFUP">
+                              <ref role="3cqZAo" node="1EZBwZ4mpvz" resolve="exp" />
+                            </node>
+                            <node concept="3uibUv" id="6z5WYdPanWl" role="10QFUM">
+                              <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="6z5WYdPamAt" role="2OqNvi">
+                          <ref role="37wK5l" to="33ny:~List.iterator()" resolve="iterator" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="6z5WYdPb4xW" role="3cqZAp" />
+                  <node concept="2$JKZl" id="6z5WYdPaoXx" role="3cqZAp">
+                    <node concept="3clFbS" id="6z5WYdPaoXz" role="2LFqv$">
+                      <node concept="3cpWs8" id="6z5WYdPav$t" role="3cqZAp">
+                        <node concept="3cpWsn" id="6z5WYdPav$u" role="3cpWs9">
+                          <property role="TrG5h" value="obj1" />
+                          <node concept="3uibUv" id="6z5WYdPav$j" role="1tU5fm">
+                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                          </node>
+                          <node concept="2OqwBi" id="6z5WYdPav$v" role="33vP2m">
+                            <node concept="37vLTw" id="6z5WYdPav$w" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6z5WYdPaiSZ" resolve="iter1" />
+                            </node>
+                            <node concept="liA8E" id="6z5WYdPav$x" role="2OqNvi">
+                              <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="6z5WYdPavLe" role="3cqZAp">
+                        <node concept="3cpWsn" id="6z5WYdPavLf" role="3cpWs9">
+                          <property role="TrG5h" value="obj2" />
+                          <node concept="3uibUv" id="6z5WYdPavLg" role="1tU5fm">
+                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                          </node>
+                          <node concept="2OqwBi" id="6z5WYdPavLh" role="33vP2m">
+                            <node concept="37vLTw" id="6z5WYdPavUP" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6z5WYdPamAq" resolve="iter2" />
+                            </node>
+                            <node concept="liA8E" id="6z5WYdPavLj" role="2OqNvi">
+                              <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbJ" id="6z5WYdPawm4" role="3cqZAp">
+                        <node concept="3clFbS" id="6z5WYdPawm6" role="3clFbx">
+                          <node concept="3cpWs6" id="6z5WYdPawE7" role="3cqZAp">
+                            <node concept="3clFbT" id="6z5WYdPawFa" role="3cqZAk" />
+                          </node>
+                        </node>
+                        <node concept="3fqX7Q" id="6z5WYdPaw_m" role="3clFbw">
+                          <node concept="1rXfSq" id="6z5WYdPaw_o" role="3fr31v">
+                            <ref role="37wK5l" node="1EZBwZ4muLD" resolve="equals" />
+                            <node concept="37vLTw" id="6z5WYdPaw_p" role="37wK5m">
+                              <ref role="3cqZAo" node="6z5WYdPav$u" resolve="obj1" />
+                            </node>
+                            <node concept="37vLTw" id="6z5WYdPaw_q" role="37wK5m">
+                              <ref role="3cqZAo" node="6z5WYdPavLf" resolve="obj2" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1Wc70l" id="6z5WYdPassD" role="2$JKZa">
+                      <node concept="2OqwBi" id="6z5WYdPasH5" role="3uHU7w">
+                        <node concept="37vLTw" id="6z5WYdPaswj" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6z5WYdPamAq" resolve="iter2" />
+                        </node>
+                        <node concept="liA8E" id="6z5WYdPav8j" role="2OqNvi">
+                          <ref role="37wK5l" to="33ny:~Iterator.hasNext()" resolve="hasNext" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="6z5WYdPapF4" role="3uHU7B">
+                        <node concept="37vLTw" id="6z5WYdPapuB" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6z5WYdPaiSZ" resolve="iter1" />
+                        </node>
+                        <node concept="liA8E" id="6z5WYdPas9i" role="2OqNvi">
+                          <ref role="37wK5l" to="33ny:~Iterator.hasNext()" resolve="hasNext" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs6" id="6z5WYdPaxMv" role="3cqZAp">
+                    <node concept="1Wc70l" id="6z5WYdPaC1y" role="3cqZAk">
+                      <node concept="3fqX7Q" id="6z5WYdPaGTN" role="3uHU7w">
+                        <node concept="2OqwBi" id="6z5WYdPaGTP" role="3fr31v">
+                          <node concept="37vLTw" id="6z5WYdPaGTQ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6z5WYdPamAq" resolve="iter2" />
+                          </node>
+                          <node concept="liA8E" id="6z5WYdPaGTR" role="2OqNvi">
+                            <ref role="37wK5l" to="33ny:~Iterator.hasNext()" resolve="hasNext" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3fqX7Q" id="6z5WYdPaBbb" role="3uHU7B">
+                        <node concept="2OqwBi" id="6z5WYdPaBbd" role="3fr31v">
+                          <node concept="37vLTw" id="6z5WYdPaBbe" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6z5WYdPaiSZ" resolve="iter1" />
+                          </node>
+                          <node concept="liA8E" id="6z5WYdPaBbf" role="2OqNvi">
+                            <ref role="37wK5l" to="33ny:~Iterator.hasNext()" resolve="hasNext" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1Wc70l" id="6z5WYdP5TIF" role="3clFbw">
+                  <node concept="2ZW3vV" id="6z5WYdP5TIG" role="3uHU7w">
+                    <node concept="3uibUv" id="6z5WYdPabg2" role="2ZW6by">
+                      <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                    </node>
+                    <node concept="37vLTw" id="6z5WYdP5TII" role="2ZW6bz">
+                      <ref role="3cqZAo" node="1EZBwZ4mpvz" resolve="exp" />
+                    </node>
+                  </node>
+                  <node concept="2ZW3vV" id="6z5WYdP5TIJ" role="3uHU7B">
+                    <node concept="3uibUv" id="6z5WYdPabd5" role="2ZW6by">
+                      <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                    </node>
+                    <node concept="37vLTw" id="6z5WYdP5TIL" role="2ZW6bz">
+                      <ref role="3cqZAo" node="1EZBwZ4moPT" resolve="act" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="6z5WYdPaH_X" role="3cqZAp">
+                <node concept="3clFbS" id="6z5WYdPaH_Y" role="3clFbx">
+                  <node concept="3cpWs8" id="6z5WYdPaNv2" role="3cqZAp">
+                    <node concept="3cpWsn" id="6z5WYdPaNv3" role="3cpWs9">
+                      <property role="TrG5h" value="set1" />
+                      <node concept="3uibUv" id="6z5WYdPaNv0" role="1tU5fm">
+                        <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+                      </node>
+                      <node concept="10QFUN" id="6z5WYdPaNv5" role="33vP2m">
+                        <node concept="3uibUv" id="6z5WYdPaNv6" role="10QFUM">
+                          <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+                        </node>
+                        <node concept="37vLTw" id="6z5WYdPaNv7" role="10QFUP">
+                          <ref role="3cqZAo" node="1EZBwZ4moPT" resolve="act" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="6z5WYdPaOi6" role="3cqZAp">
+                    <node concept="3cpWsn" id="6z5WYdPaOi7" role="3cpWs9">
+                      <property role="TrG5h" value="set2" />
+                      <node concept="3uibUv" id="6z5WYdPaOi8" role="1tU5fm">
+                        <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+                      </node>
+                      <node concept="10QFUN" id="6z5WYdPaOi9" role="33vP2m">
+                        <node concept="3uibUv" id="6z5WYdPaOia" role="10QFUM">
+                          <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+                        </node>
+                        <node concept="37vLTw" id="6z5WYdPaP1z" role="10QFUP">
+                          <ref role="3cqZAo" node="1EZBwZ4mpvz" resolve="exp" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="6z5WYdPb5eZ" role="3cqZAp" />
+                  <node concept="3clFbJ" id="6z5WYdPaQyY" role="3cqZAp">
+                    <node concept="3clFbS" id="6z5WYdPaQz0" role="3clFbx">
+                      <node concept="3cpWs6" id="6z5WYdPaUHQ" role="3cqZAp">
+                        <node concept="3clFbT" id="6z5WYdPaUJ1" role="3cqZAk" />
+                      </node>
+                    </node>
+                    <node concept="3y3z36" id="6z5WYdPaTiv" role="3clFbw">
+                      <node concept="2OqwBi" id="6z5WYdPaTH_" role="3uHU7w">
+                        <node concept="37vLTw" id="6z5WYdPaTlv" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6z5WYdPaOi7" resolve="set2" />
+                        </node>
+                        <node concept="liA8E" id="6z5WYdPaUEg" role="2OqNvi">
+                          <ref role="37wK5l" to="33ny:~Set.size()" resolve="size" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="6z5WYdPaRvS" role="3uHU7B">
+                        <node concept="37vLTw" id="6z5WYdPaRgV" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6z5WYdPaNv3" resolve="set1" />
+                        </node>
+                        <node concept="liA8E" id="6z5WYdPaSs8" role="2OqNvi">
+                          <ref role="37wK5l" to="33ny:~Set.size()" resolve="size" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1DcWWT" id="6z5WYdPb2g5" role="3cqZAp">
+                    <node concept="3clFbS" id="6z5WYdPb2g7" role="2LFqv$">
+                      <node concept="3clFbJ" id="6z5WYdPbcnV" role="3cqZAp">
+                        <node concept="3clFbS" id="6z5WYdPbcnX" role="3clFbx">
+                          <node concept="3cpWs6" id="6z5WYdPbdyN" role="3cqZAp">
+                            <node concept="3clFbT" id="6z5WYdPbd$1" role="3cqZAk" />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="6z5WYdPb9cg" role="3clFbw">
+                          <node concept="2OqwBi" id="6z5WYdPb762" role="2Oq$k0">
+                            <node concept="37vLTw" id="6z5WYdPb6Qp" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6z5WYdPaNv3" resolve="set1" />
+                            </node>
+                            <node concept="liA8E" id="6z5WYdPb7nJ" role="2OqNvi">
+                              <ref role="37wK5l" to="33ny:~Collection.stream()" resolve="stream" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="6z5WYdPb9JN" role="2OqNvi">
+                            <ref role="37wK5l" to="1ctc:~Stream.allMatch(java.util.function.Predicate)" resolve="allMatch" />
+                            <node concept="1bVj0M" id="6z5WYdPba2U" role="37wK5m">
+                              <node concept="3clFbS" id="6z5WYdPba2V" role="1bW5cS">
+                                <node concept="3clFbF" id="6z5WYdPbbqt" role="3cqZAp">
+                                  <node concept="3fqX7Q" id="6z5WYdPbdj_" role="3clFbG">
+                                    <node concept="2YIFZM" id="6z5WYdPbS6K" role="3fr31v">
+                                      <ref role="37wK5l" node="1EZBwZ4muLD" resolve="equals" />
+                                      <ref role="1Pybhc" node="1EZBwZ4mn8E" resolve="EqualsHelper" />
+                                      <node concept="37vLTw" id="6z5WYdPbdjC" role="37wK5m">
+                                        <ref role="3cqZAo" node="6z5WYdPbafe" resolve="elem1" />
+                                      </node>
+                                      <node concept="37vLTw" id="6z5WYdPbdjD" role="37wK5m">
+                                        <ref role="3cqZAo" node="6z5WYdPb2g8" resolve="elem2" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="37vLTG" id="6z5WYdPbafe" role="1bW2Oz">
+                                <property role="TrG5h" value="elem1" />
+                                <node concept="3uibUv" id="6z5WYdPbafd" role="1tU5fm">
+                                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWsn" id="6z5WYdPb2g8" role="1Duv9x">
+                      <property role="TrG5h" value="elem2" />
+                      <node concept="3uibUv" id="6z5WYdPb36l" role="1tU5fm">
+                        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="6z5WYdPb3CI" role="1DdaDG">
+                      <ref role="3cqZAo" node="6z5WYdPaOi7" resolve="set2" />
+                    </node>
+                  </node>
+                  <node concept="3cpWs6" id="6z5WYdPaHAK" role="3cqZAp">
+                    <node concept="3clFbT" id="6z5WYdPbf95" role="3cqZAk">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="1Wc70l" id="6z5WYdPaHAU" role="3clFbw">
+                  <node concept="2ZW3vV" id="6z5WYdPaHAV" role="3uHU7w">
+                    <node concept="3uibUv" id="6z5WYdPaI_G" role="2ZW6by">
+                      <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+                    </node>
+                    <node concept="37vLTw" id="6z5WYdPaHAX" role="2ZW6bz">
+                      <ref role="3cqZAo" node="1EZBwZ4mpvz" resolve="exp" />
+                    </node>
+                  </node>
+                  <node concept="2ZW3vV" id="6z5WYdPaHAY" role="3uHU7B">
+                    <node concept="3uibUv" id="6z5WYdPaIyO" role="2ZW6by">
+                      <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+                    </node>
+                    <node concept="37vLTw" id="6z5WYdPaHB0" role="2ZW6bz">
                       <ref role="3cqZAo" node="1EZBwZ4moPT" resolve="act" />
                     </node>
                   </node>
@@ -13360,18 +13649,12 @@
               </node>
             </node>
           </node>
-          <node concept="1Wc70l" id="4kV9Ob9XpTh" role="3clFbw">
-            <node concept="3clFbC" id="4kV9Ob9XpTi" role="3uHU7w">
-              <node concept="10Nm6u" id="4kV9Ob9XpTj" role="3uHU7w" />
-              <node concept="37vLTw" id="4kV9Ob9XpTk" role="3uHU7B">
-                <ref role="3cqZAo" node="7bZFIimi31K" resolve="exp" />
-              </node>
+          <node concept="3clFbC" id="4kV9Ob9XpTl" role="3clFbw">
+            <node concept="37vLTw" id="4kV9Ob9XpTm" role="3uHU7B">
+              <ref role="3cqZAo" node="7bZFIimi31I" resolve="act" />
             </node>
-            <node concept="3clFbC" id="4kV9Ob9XpTl" role="3uHU7B">
-              <node concept="37vLTw" id="4kV9Ob9XpTm" role="3uHU7B">
-                <ref role="3cqZAo" node="7bZFIimi31I" resolve="act" />
-              </node>
-              <node concept="10Nm6u" id="4kV9Ob9XpTn" role="3uHU7w" />
+            <node concept="37vLTw" id="6z5WYdP6pJx" role="3uHU7w">
+              <ref role="3cqZAo" node="7bZFIimi31K" resolve="exp" />
             </node>
           </node>
           <node concept="3eNFk2" id="4kV9Ob9XpTo" role="3eNLev">
@@ -13382,41 +13665,18 @@
                 </node>
               </node>
             </node>
-            <node concept="1Wc70l" id="4kV9Ob9XpTs" role="3eO9$A">
-              <node concept="3y3z36" id="4kV9Ob9XpTt" role="3uHU7w">
-                <node concept="10Nm6u" id="4kV9Ob9XpTu" role="3uHU7w" />
-                <node concept="37vLTw" id="4kV9Ob9XpTv" role="3uHU7B">
-                  <ref role="3cqZAo" node="7bZFIimi31K" resolve="exp" />
-                </node>
-              </node>
+            <node concept="22lmx$" id="6z5WYdP6q9t" role="3eO9$A">
               <node concept="3clFbC" id="4kV9Ob9XpTw" role="3uHU7B">
                 <node concept="37vLTw" id="4kV9Ob9XpTx" role="3uHU7B">
                   <ref role="3cqZAo" node="7bZFIimi31I" resolve="act" />
                 </node>
                 <node concept="10Nm6u" id="4kV9Ob9XpTy" role="3uHU7w" />
               </node>
-            </node>
-          </node>
-          <node concept="3eNFk2" id="4kV9Ob9XpTz" role="3eNLev">
-            <node concept="3clFbS" id="4kV9Ob9XpT$" role="3eOfB_">
-              <node concept="3cpWs6" id="4kV9Ob9XpT_" role="3cqZAp">
-                <node concept="3clFbT" id="4kV9Ob9XpTA" role="3cqZAk">
-                  <property role="3clFbU" value="false" />
-                </node>
-              </node>
-            </node>
-            <node concept="1Wc70l" id="4kV9Ob9XpTB" role="3eO9$A">
-              <node concept="3clFbC" id="4kV9Ob9XpTC" role="3uHU7w">
-                <node concept="37vLTw" id="4kV9Ob9XpTD" role="3uHU7B">
+              <node concept="3clFbC" id="6z5WYdP6qw3" role="3uHU7w">
+                <node concept="37vLTw" id="4kV9Ob9XpTv" role="3uHU7B">
                   <ref role="3cqZAo" node="7bZFIimi31K" resolve="exp" />
                 </node>
-                <node concept="10Nm6u" id="4kV9Ob9XpTE" role="3uHU7w" />
-              </node>
-              <node concept="3y3z36" id="4kV9Ob9XpTF" role="3uHU7B">
-                <node concept="37vLTw" id="4kV9Ob9XpTG" role="3uHU7B">
-                  <ref role="3cqZAo" node="7bZFIimi31I" resolve="act" />
-                </node>
-                <node concept="10Nm6u" id="4kV9Ob9XpTH" role="3uHU7w" />
+                <node concept="10Nm6u" id="4kV9Ob9XpTu" role="3uHU7w" />
               </node>
             </node>
           </node>


### PR DESCRIPTION
This PR includes support of handling collections with numbers when executing asserts in test suites. Before EqualsTestOp in the assert only took care of comparing BigInteger and BigDecimal objects by wrapping BigInteger into BigDecimal and using corresponding `compareTo()` method in BigDecimal (instead of `equals()` method which could not handle BigInteger/BigDecimal). However in case of collections it simply delegated to the `equals()` method and therefore never correctly handled numbers in the collections, which could be semantically equal, but not according to the strict equals() implementation. For example:

```
val fraction = list(1 / 4)                                                                               
test case divide [fail] {                                                                                
  assert fraction equals list(0.25) [1 ms] [error] Test Failed. Expected: [0.25], but was: [0.2500000000]
}                                                                                                        
```                                                                                               
This fails because number precision after division doesn't equal precision of the number literal, even if the number is the same. Comparing these two parts w/o a list would work, because we would then apply custom equals logic from above, which ignores different precisions.

To handle this correctly EqualsHelper has been extended to compare collections (Lists and Sets) and apply custom equals logic to its elements.

This PR also includes another small extension: `IContextTypedOp` interface, which is an extension of `IDotTarget` that automatically derives its type from the context expression in `DotExpression`