### PR TITLE
Fix BracketOP for IOrderedCollection

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/structure.mps
@@ -2,8 +2,8 @@
 <model ref="r:61b1de80-490d-4fee-8e95-b956503290e9(org.iets3.core.expr.collections.structure)">
   <persistence version="9" />
   <languages>
-    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="7" />
-    <use id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources" version="2" />
+    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="-1" />
+    <use id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources" version="-1" />
     <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
   <imports>
@@ -174,6 +174,9 @@
     <property role="TrG5h" value="IOrderedCollection" />
     <property role="3GE5qa" value="ordered" />
     <property role="EcuMT" value="7554398283339848519" />
+    <node concept="PrWs8" id="1SHQl3yge92" role="PrDN$">
+      <ref role="PrY4T" to="hm2y:5WNmJ7DoRmx" resolve="ICollectionType" />
+    </node>
   </node>
   <node concept="PlHQZ" id="6zmBjqUiHHJ">
     <property role="TrG5h" value="IOrderedCollectionOp" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/typesystem.mps
@@ -2210,15 +2210,15 @@
                 <node concept="mw_s8" id="7kYh9Ws$4ah" role="1ZfhKB">
                   <node concept="2OqwBi" id="7kYh9Ws$4ai" role="mwGJk">
                     <node concept="1PxgMI" id="7kYh9Ws$4aj" role="2Oq$k0">
-                      <node concept="chp4Y" id="2uo6UInBSUx" role="3oSUPX">
-                        <ref role="cht4Q" to="700h:6zmBjqUinsw" resolve="ListType" />
+                      <node concept="chp4Y" id="1SHQl3ygg3H" role="3oSUPX">
+                        <ref role="cht4Q" to="700h:6zmBjqUiHH7" resolve="IOrderedCollection" />
                       </node>
                       <node concept="2X3wrD" id="7kYh9Ws$4ak" role="1m5AlR">
                         <ref role="2X3Bk0" node="54HsVvNVcz_" resolve="contextType" />
                       </node>
                     </node>
-                    <node concept="3TrEf2" id="7kYh9Ws$4al" role="2OqNvi">
-                      <ref role="3Tt5mk" to="700h:6zmBjqUily6" resolve="baseType" />
+                    <node concept="2qgKlT" id="1SHQl3yggm5" role="2OqNvi">
+                      <ref role="37wK5l" to="pbu6:3oWFox95OZf" resolve="getBaseType" />
                     </node>
                   </node>
                 </node>
@@ -2258,8 +2258,8 @@
                 <ref role="2X3Bk0" node="54HsVvNVcz_" resolve="contextType" />
               </node>
               <node concept="1mIQ4w" id="54HsVvNVczz" role="2OqNvi">
-                <node concept="chp4Y" id="2uo6UInBSPy" role="cj9EA">
-                  <ref role="cht4Q" to="700h:6zmBjqUinsw" resolve="ListType" />
+                <node concept="chp4Y" id="1SHQl3ygfZQ" role="cj9EA">
+                  <ref role="cht4Q" to="700h:6zmBjqUiHH7" resolve="IOrderedCollection" />
                 </node>
               </node>
             </node>


### PR DESCRIPTION
The BracketOP editor works with any IOrderedCollection, but the typesystem fails with a runtime error if it isn't a list. To fix the typesystem rule IOrderedCollection is now inheriting from ICollectionType. Since ICollectionType extends IHasBaseType, we can use getBaseType() to fix the typesystem rule.