### PR TITLE
BuilderAdapter: avoid exceptions in the editor

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -7864,26 +7864,44 @@
     <node concept="13i0hz" id="4ptnK4jbrao" role="13h7CS">
       <property role="TrG5h" value="getMandatoryFields" />
       <property role="13i0it" value="true" />
-      <property role="13i0iv" value="true" />
       <node concept="3Tm1VV" id="4ptnK4jbrap" role="1B3o_S" />
       <node concept="A3Dl8" id="4ptnK4jbvzo" role="3clF45">
         <node concept="3Tqbb2" id="4ptnK4jbvzp" role="A3Ik2">
           <ref role="ehGHo" to="tpck:h0TrEE$" resolve="INamedConcept" />
         </node>
       </node>
-      <node concept="3clFbS" id="4ptnK4jbrar" role="3clF47" />
+      <node concept="3clFbS" id="4ptnK4jbrar" role="3clF47">
+        <node concept="3cpWs6" id="7aPbRR484W8" role="3cqZAp">
+          <node concept="2ShNRf" id="7aPbRR484WS" role="3cqZAk">
+            <node concept="kMnCb" id="7aPbRR487om" role="2ShVmc">
+              <node concept="3Tqbb2" id="7aPbRR4881e" role="kMuH3">
+                <ref role="ehGHo" to="tpck:h0TrEE$" resolve="INamedConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="13i0hz" id="4ptnK4jbrbr" role="13h7CS">
       <property role="TrG5h" value="getAllFields" />
       <property role="13i0it" value="true" />
-      <property role="13i0iv" value="true" />
       <node concept="3Tm1VV" id="4ptnK4jbrbs" role="1B3o_S" />
       <node concept="A3Dl8" id="4ptnK4jbvzR" role="3clF45">
         <node concept="3Tqbb2" id="4ptnK4jbv$e" role="A3Ik2">
           <ref role="ehGHo" to="tpck:h0TrEE$" resolve="INamedConcept" />
         </node>
       </node>
-      <node concept="3clFbS" id="4ptnK4jbrbu" role="3clF47" />
+      <node concept="3clFbS" id="4ptnK4jbrbu" role="3clF47">
+        <node concept="3cpWs6" id="7aPbRR489n5" role="3cqZAp">
+          <node concept="2ShNRf" id="7aPbRR489n6" role="3cqZAk">
+            <node concept="kMnCb" id="7aPbRR489n7" role="2ShVmc">
+              <node concept="3Tqbb2" id="7aPbRR489n8" role="kMuH3">
+                <ref role="ehGHo" to="tpck:h0TrEE$" resolve="INamedConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="13i0hz" id="4ptnK4jbJRO" role="13h7CS">
       <property role="TrG5h" value="missingSetters" />


### PR DESCRIPTION
Implement abstract methods that get invoked when an instance of
BuilderAdapter gets created by the editor even though it is abstract.