### PR TITLE
take RuntimeErrorType into account when inferring type of BinaryExpression

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
@@ -725,11 +725,26 @@
                                     </node>
                                   </node>
                                 </node>
+                                <node concept="3clFbH" id="5aYM8it7Cjz" role="3cqZAp" />
                                 <node concept="3clFbF" id="7KDVkAF4P69" role="3cqZAp">
-                                  <node concept="3y3z36" id="7KDVkAF4S2Z" role="3clFbG">
-                                    <node concept="10Nm6u" id="7KDVkAF4SDv" role="3uHU7w" />
-                                    <node concept="37vLTw" id="7KDVkAF5dKD" role="3uHU7B">
-                                      <ref role="3cqZAo" node="7KDVkAF5dK$" resolve="opType" />
+                                  <node concept="1Wc70l" id="5aYM8it7667" role="3clFbG">
+                                    <node concept="3y3z36" id="7KDVkAF4S2Z" role="3uHU7B">
+                                      <node concept="37vLTw" id="7KDVkAF5dKD" role="3uHU7B">
+                                        <ref role="3cqZAo" node="7KDVkAF5dK$" resolve="opType" />
+                                      </node>
+                                      <node concept="10Nm6u" id="7KDVkAF4SDv" role="3uHU7w" />
+                                    </node>
+                                    <node concept="3fqX7Q" id="5aYM8it76HU" role="3uHU7w">
+                                      <node concept="3JuTUA" id="5aYM8it76HV" role="3fr31v">
+                                        <node concept="37vLTw" id="5aYM8it76HW" role="3JuY14">
+                                          <ref role="3cqZAo" node="6Mx2TmozGCe" resolve="operationType" />
+                                        </node>
+                                        <node concept="2pJPEk" id="5aYM8it76HX" role="3JuZjQ">
+                                          <node concept="2pJPED" id="5aYM8it76HY" role="2pJPEn">
+                                            <ref role="2pJxaS" to="tpd4:hfSilrT" resolve="RuntimeErrorType" />
+                                          </node>
+                                        </node>
+                                      </node>
                                     </node>
                                   </node>
                                 </node>
@@ -944,10 +959,24 @@
                     </node>
                   </node>
                 </node>
-                <node concept="3y3z36" id="6Mx2TmozGII" role="3clFbw">
-                  <node concept="10Nm6u" id="6Mx2TmozGJ7" role="3uHU7w" />
-                  <node concept="37vLTw" id="6Mx2TmozGH$" role="3uHU7B">
-                    <ref role="3cqZAo" node="6Mx2TmozGCe" resolve="operationType" />
+                <node concept="1Wc70l" id="5aYM8it3yXW" role="3clFbw">
+                  <node concept="3fqX7Q" id="5aYM8it3ztr" role="3uHU7w">
+                    <node concept="3JuTUA" id="5aYM8it3ztY" role="3fr31v">
+                      <node concept="37vLTw" id="5aYM8it3zuG" role="3JuY14">
+                        <ref role="3cqZAo" node="6Mx2TmozGCe" resolve="operationType" />
+                      </node>
+                      <node concept="2pJPEk" id="5aYM8it3zvm" role="3JuZjQ">
+                        <node concept="2pJPED" id="5aYM8it3zw6" role="2pJPEn">
+                          <ref role="2pJxaS" to="tpd4:hfSilrT" resolve="RuntimeErrorType" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3y3z36" id="6Mx2TmozGII" role="3uHU7B">
+                    <node concept="37vLTw" id="6Mx2TmozGH$" role="3uHU7B">
+                      <ref role="3cqZAo" node="6Mx2TmozGCe" resolve="operationType" />
+                    </node>
+                    <node concept="10Nm6u" id="6Mx2TmozGJ7" role="3uHU7w" />
                   </node>
                 </node>
               </node>
@@ -4324,6 +4353,7 @@
                   </node>
                 </node>
               </node>
+              <node concept="3clFbH" id="5aYM8it6aCg" role="3cqZAp" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
@@ -85,6 +85,7 @@
       <concept id="5115872837156802409" name="org.iets3.core.expr.base.structure.UnaryExpression" flags="ng" index="30czhk">
         <child id="5115872837156802411" name="expr" index="30czhm" />
       </concept>
+      <concept id="5115872837156761033" name="org.iets3.core.expr.base.structure.EqualsExpression" flags="ng" index="30cPrO" />
       <concept id="5115872837156687890" name="org.iets3.core.expr.base.structure.LessExpression" flags="ng" index="30d6GJ" />
       <concept id="5115872837156652603" name="org.iets3.core.expr.base.structure.DivExpression" flags="ng" index="30dvO6" />
       <concept id="5115872837156652453" name="org.iets3.core.expr.base.structure.MinusExpression" flags="ng" index="30dvUo" />
@@ -110,6 +111,7 @@
       <concept id="8219602584782245544" name="org.iets3.core.expr.simpleTypes.structure.NumberType" flags="ng" index="mLuIC">
         <child id="1330041117646892937" name="prec" index="2gteVg" />
       </concept>
+      <concept id="7425695345928358745" name="org.iets3.core.expr.simpleTypes.structure.TrueLiteral" flags="ng" index="2vmpnb" />
       <concept id="7425695345928349207" name="org.iets3.core.expr.simpleTypes.structure.BooleanType" flags="ng" index="2vmvy5" />
       <concept id="5115872837157054284" name="org.iets3.core.expr.simpleTypes.structure.RealType" flags="ng" index="30bXLL" />
       <concept id="5115872837157054169" name="org.iets3.core.expr.simpleTypes.structure.IntegerType" flags="ng" index="30bXR$" />
@@ -689,6 +691,44 @@
             </node>
           </node>
           <node concept="2vmvy5" id="1fzaMYHrwaK" role="2zM23F" />
+        </node>
+        <node concept="2zPypq" id="5aYM8it48mb" role="_iOnB">
+          <property role="TrG5h" value="h" />
+          <node concept="30dDZf" id="5aYM8it4aHB" role="2zPyp_">
+            <node concept="1YnStw" id="5aYM8it4aM5" role="30dEs_">
+              <node concept="CIsGf" id="5aYM8it4aLX" role="2c7tTI">
+                <node concept="CIsvn" id="5aYM8it4aLY" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS4" resolve="m" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="5aYM8it4aHU" role="1YnStB">
+                <property role="30bXRw" value="2" />
+              </node>
+            </node>
+            <node concept="2vmpnb" id="5aYM8it4awK" role="30dEsF" />
+          </node>
+          <node concept="7CXmI" id="5aYM8it7yju" role="lGtFl">
+            <node concept="1TM$A" id="5aYM8it7yjv" role="7EUXB" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="5aYM8it4c7q" role="_iOnB">
+          <property role="TrG5h" value="i" />
+          <node concept="30cPrO" id="5aYM8it4cJF" role="2zPyp_">
+            <node concept="1YnStw" id="5aYM8it4cO1" role="30dEs_">
+              <node concept="CIsGf" id="5aYM8it4cNT" role="2c7tTI">
+                <node concept="CIsvn" id="5aYM8it4cNU" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS4" resolve="m" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="5aYM8it4cJY" role="1YnStB">
+                <property role="30bXRw" value="2" />
+              </node>
+            </node>
+            <node concept="2vmpnb" id="5aYM8it4cGP" role="30dEsF" />
+          </node>
+          <node concept="7CXmI" id="5aYM8it7xCT" role="lGtFl">
+            <node concept="1TM$A" id="5aYM8it7xCU" role="7EUXB" />
+          </node>
         </node>
         <node concept="7CXmI" id="2S3ZC$oC8QF" role="lGtFl">
           <node concept="7OXhh" id="2S3ZC$oC8QG" role="7EUXB" />


### PR DESCRIPTION
ErrorType was not taken into account during the inference of the Binary Expression Type, which lead to errors when BinaryExpressions were used together with units.

Fix: Test operationType not only for null but also for Runtime ErrorType to get the right error messages.