### PR TITLE
Bugfix/unit types for math expressions

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/structure.mps
@@ -8,7 +8,7 @@
   <imports>
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
     <import index="4kwy" ref="r:657c9fde-2f36-4e61-ae17-20f02b8630ad(org.iets3.core.base.structure)" />
-    <import index="3673" ref="r:78633c85-d020-485e-aaa3-59e2daa3b826(com.mbeddr.mpsutil.interpreter.structure)" implicit="true" />
+    <import index="3673" ref="r:78633c85-d020-485e-aaa3-59e2daa3b826(com.mbeddr.mpsutil.interpreter.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/typesystem.mps
@@ -205,49 +205,103 @@
   <node concept="1YbPZF" id="4iu6t1eAWx_">
     <property role="TrG5h" value="typeof_AbsExpression" />
     <node concept="3clFbS" id="4iu6t1eAWxA" role="18ibNy">
-      <node concept="1Z5TYs" id="4r1mNB_uhX6" role="3cqZAp">
-        <node concept="mw_s8" id="4r1mNB_uhYd" role="1ZfhKB">
-          <node concept="1Z2H0r" id="4r1mNB_uhY9" role="mwGJk">
-            <node concept="2OqwBi" id="4r1mNB_ui4i" role="1Z2MuG">
-              <node concept="1YBJjd" id="4iu6t1eAWAx" role="2Oq$k0">
-                <ref role="1YBMHb" node="4iu6t1eAWxC" resolve="abs" />
+      <node concept="nvevp" id="6q$NxWeFCRg" role="3cqZAp">
+        <node concept="3clFbS" id="6q$NxWeFCRi" role="nvhr_">
+          <node concept="3cpWs8" id="1JTgXSYRD$1" role="3cqZAp">
+            <node concept="3cpWsn" id="1JTgXSYRD$2" role="3cpWs9">
+              <property role="TrG5h" value="operationType" />
+              <node concept="3Tqbb2" id="1JTgXSYRDzT" role="1tU5fm" />
+              <node concept="3h4ouC" id="1JTgXSYRD$3" role="33vP2m">
+                <node concept="1YBJjd" id="1JTgXSYRD$4" role="3h4sjZ">
+                  <ref role="1YBMHb" node="4iu6t1eAWxC" resolve="abs" />
+                </node>
+                <node concept="2X3wrD" id="6q$NxWeHvzm" role="3h4u4a">
+                  <ref role="2X3Bk0" node="6q$NxWeFCRm" resolve="absExpressionType" />
+                </node>
+                <node concept="10Nm6u" id="1JTgXSYRD$8" role="3h4u2h" />
               </node>
-              <node concept="3TrEf2" id="4iu6t1eB9uF" role="2OqNvi">
-                <ref role="3Tt5mk" to="1qv1:4iu6t1eB97r" resolve="expr" />
+            </node>
+          </node>
+          <node concept="3clFbJ" id="1JTgXSYRCN$" role="3cqZAp">
+            <node concept="3clFbS" id="1JTgXSYRCNA" role="3clFbx">
+              <node concept="1Z5TYs" id="1JTgXSYRTob" role="3cqZAp">
+                <node concept="mw_s8" id="1JTgXSYRTot" role="1ZfhKB">
+                  <node concept="37vLTw" id="1JTgXSYRTor" role="mwGJk">
+                    <ref role="3cqZAo" node="1JTgXSYRD$2" resolve="operationType" />
+                  </node>
+                </node>
+                <node concept="mw_s8" id="1JTgXSYRToe" role="1ZfhK$">
+                  <node concept="1Z2H0r" id="1JTgXSYRTby" role="mwGJk">
+                    <node concept="1YBJjd" id="1JTgXSYRTds" role="1Z2MuG">
+                      <ref role="1YBMHb" node="4iu6t1eAWxC" resolve="abs" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1JTgXSYRDJk" role="3clFbw">
+              <node concept="37vLTw" id="1JTgXSYRDAL" role="2Oq$k0">
+                <ref role="3cqZAo" node="1JTgXSYRD$2" resolve="operationType" />
+              </node>
+              <node concept="3x8VRR" id="1JTgXSYRDQ1" role="2OqNvi" />
+            </node>
+            <node concept="9aQIb" id="1JTgXSYRDTt" role="9aQIa">
+              <node concept="3clFbS" id="1JTgXSYRDTu" role="9aQI4">
+                <node concept="1Z5TYs" id="4r1mNB_uhX6" role="3cqZAp">
+                  <node concept="mw_s8" id="6q$NxWeFDZr" role="1ZfhKB">
+                    <node concept="2X3wrD" id="6q$NxWeFDZl" role="mwGJk">
+                      <ref role="2X3Bk0" node="6q$NxWeFCRm" resolve="absExpressionType" />
+                    </node>
+                  </node>
+                  <node concept="mw_s8" id="4r1mNB_uhX9" role="1ZfhK$">
+                    <node concept="1Z2H0r" id="4r1mNB_uhTu" role="mwGJk">
+                      <node concept="1YBJjd" id="4iu6t1eAW$_" role="1Z2MuG">
+                        <ref role="1YBMHb" node="4iu6t1eAWxC" resolve="abs" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1ZobV4" id="4r1mNB_ujsr" role="3cqZAp">
+                  <property role="3wDh2S" value="true" />
+                  <node concept="mw_s8" id="4r1mNB_ujuG" role="1ZfhKB">
+                    <node concept="2ShNRf" id="4r1mNB_ujuC" role="mwGJk">
+                      <node concept="3zrR0B" id="4r1mNB_uj_7" role="2ShVmc">
+                        <node concept="3Tqbb2" id="4r1mNB_uj_9" role="3zrR0E">
+                          <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="mw_s8" id="4r1mNB_ujsu" role="1ZfhK$">
+                    <node concept="1Z2H0r" id="4r1mNB_uiQ$" role="mwGJk">
+                      <node concept="2OqwBi" id="4r1mNB_uiXE" role="1Z2MuG">
+                        <node concept="1YBJjd" id="4iu6t1eAWIc" role="2Oq$k0">
+                          <ref role="1YBMHb" node="4iu6t1eAWxC" resolve="abs" />
+                        </node>
+                        <node concept="3TrEf2" id="4iu6t1eB9lC" role="2OqNvi">
+                          <ref role="3Tt5mk" to="1qv1:4iu6t1eB97r" resolve="expr" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="mw_s8" id="4r1mNB_uhX9" role="1ZfhK$">
-          <node concept="1Z2H0r" id="4r1mNB_uhTu" role="mwGJk">
-            <node concept="1YBJjd" id="4iu6t1eAW$_" role="1Z2MuG">
+        <node concept="1Z2H0r" id="6q$NxWeFCSJ" role="nvjzm">
+          <node concept="2OqwBi" id="6q$NxWeFDeQ" role="1Z2MuG">
+            <node concept="1YBJjd" id="6q$NxWeFCUP" role="2Oq$k0">
               <ref role="1YBMHb" node="4iu6t1eAWxC" resolve="abs" />
             </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1ZobV4" id="4r1mNB_ujsr" role="3cqZAp">
-        <property role="3wDh2S" value="true" />
-        <node concept="mw_s8" id="4r1mNB_ujuG" role="1ZfhKB">
-          <node concept="2ShNRf" id="4r1mNB_ujuC" role="mwGJk">
-            <node concept="3zrR0B" id="4r1mNB_uj_7" role="2ShVmc">
-              <node concept="3Tqbb2" id="4r1mNB_uj_9" role="3zrR0E">
-                <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
-              </node>
+            <node concept="3TrEf2" id="6q$NxWeFDwQ" role="2OqNvi">
+              <ref role="3Tt5mk" to="1qv1:4iu6t1eB97r" resolve="expr" />
             </node>
           </node>
         </node>
-        <node concept="mw_s8" id="4r1mNB_ujsu" role="1ZfhK$">
-          <node concept="1Z2H0r" id="4r1mNB_uiQ$" role="mwGJk">
-            <node concept="2OqwBi" id="4r1mNB_uiXE" role="1Z2MuG">
-              <node concept="1YBJjd" id="4iu6t1eAWIc" role="2Oq$k0">
-                <ref role="1YBMHb" node="4iu6t1eAWxC" resolve="abs" />
-              </node>
-              <node concept="3TrEf2" id="4iu6t1eB9lC" role="2OqNvi">
-                <ref role="3Tt5mk" to="1qv1:4iu6t1eB97r" resolve="expr" />
-              </node>
-            </node>
-          </node>
+        <node concept="2X1qdy" id="6q$NxWeFCRm" role="2X0Ygz">
+          <property role="TrG5h" value="absExpressionType" />
+          <node concept="2jxLKc" id="6q$NxWeFCRn" role="1tU5fm" />
         </node>
       </node>
     </node>
@@ -264,125 +318,170 @@
         <node concept="3clFbS" id="7BZzIqkloOQ" role="nvhr_">
           <node concept="nvevp" id="7BZzIqkloWC" role="3cqZAp">
             <node concept="3clFbS" id="7BZzIqkloWD" role="nvhr_">
-              <node concept="1ZobV4" id="5mz5Tt_hl4X" role="3cqZAp">
-                <property role="3wDh2S" value="true" />
-                <node concept="mw_s8" id="5mz5Tt_hl5w" role="1ZfhKB">
-                  <node concept="2YIFZM" id="7BZzIqkljhU" role="mwGJk">
-                    <ref role="37wK5l" to="xfg9:2Qbt$1tTQdc" resolve="createRealType" />
-                    <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-                    <node concept="10Nm6u" id="7BZzIqkljhV" role="37wK5m" />
-                  </node>
-                </node>
-                <node concept="mw_s8" id="7BZzIqklpP6" role="1ZfhK$">
-                  <node concept="2X3wrD" id="7BZzIqklpP0" role="mwGJk">
-                    <ref role="2X3Bk0" node="7BZzIqkloOU" resolve="numType" />
-                  </node>
-                </node>
-              </node>
-              <node concept="1ZobV4" id="5mz5Tt_hl95" role="3cqZAp">
-                <property role="3wDh2S" value="true" />
-                <node concept="mw_s8" id="5mz5Tt_hl96" role="1ZfhKB">
-                  <node concept="2YIFZM" id="7BZzIqkloKD" role="mwGJk">
-                    <ref role="37wK5l" to="xfg9:2Qbt$1tTQdc" resolve="createRealType" />
-                    <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-                    <node concept="10Nm6u" id="7BZzIqkloKE" role="37wK5m" />
-                  </node>
-                </node>
-                <node concept="mw_s8" id="7BZzIqklpWD" role="1ZfhK$">
-                  <node concept="2X3wrD" id="7BZzIqklpWz" role="mwGJk">
-                    <ref role="2X3Bk0" node="7BZzIqkloWI" resolve="denType" />
+              <node concept="3cpWs8" id="1JTgXSYTQCw" role="3cqZAp">
+                <node concept="3cpWsn" id="1JTgXSYTQCx" role="3cpWs9">
+                  <property role="TrG5h" value="operationType" />
+                  <node concept="3Tqbb2" id="1JTgXSYTQz$" role="1tU5fm" />
+                  <node concept="3h4ouC" id="1JTgXSYTQCy" role="33vP2m">
+                    <node concept="1YBJjd" id="1JTgXSYTQCz" role="3h4sjZ">
+                      <ref role="1YBMHb" node="4iu6t1eAX1B" resolve="frac" />
+                    </node>
+                    <node concept="2X3wrD" id="1JTgXSYTQC$" role="3h4u4a">
+                      <ref role="2X3Bk0" node="7BZzIqkloOU" resolve="numType" />
+                    </node>
+                    <node concept="2X3wrD" id="1JTgXSYTQC_" role="3h4u2h">
+                      <ref role="2X3Bk0" node="7BZzIqkloWI" resolve="denType" />
+                    </node>
                   </node>
                 </node>
               </node>
-              <node concept="3clFbJ" id="7BZzIqklpZV" role="3cqZAp">
-                <node concept="3clFbS" id="7BZzIqklpZX" role="3clFbx">
-                  <node concept="1Z5TYs" id="2X81bnKeKSe" role="3cqZAp">
-                    <node concept="mw_s8" id="2X81bnKeKSi" role="1ZfhKB">
-                      <node concept="2pJPEk" id="5mz5Tt_hmCA" role="mwGJk">
-                        <node concept="2pJPED" id="5mz5Tt_hmCM" role="2pJPEn">
-                          <ref role="2pJxaS" to="1qv1:5mz5Tt_h1dJ" resolve="RationalType" />
-                        </node>
+              <node concept="3clFbJ" id="1JTgXSYTQR3" role="3cqZAp">
+                <node concept="3clFbS" id="1JTgXSYTQR5" role="3clFbx">
+                  <node concept="1Z5TYs" id="1JTgXSYTXAU" role="3cqZAp">
+                    <node concept="mw_s8" id="1JTgXSYTXBc" role="1ZfhKB">
+                      <node concept="37vLTw" id="1JTgXSYTXBa" role="mwGJk">
+                        <ref role="3cqZAo" node="1JTgXSYTQCx" resolve="operationType" />
                       </node>
                     </node>
-                    <node concept="mw_s8" id="2X81bnKeKSh" role="1ZfhK$">
-                      <node concept="1Z2H0r" id="2X81bnKeKSb" role="mwGJk">
-                        <node concept="1YBJjd" id="4iu6t1eAXPx" role="1Z2MuG">
+                    <node concept="mw_s8" id="1JTgXSYTXAX" role="1ZfhK$">
+                      <node concept="1Z2H0r" id="1JTgXSYTWMS" role="mwGJk">
+                        <node concept="1YBJjd" id="1JTgXSYTWOQ" role="1Z2MuG">
                           <ref role="1YBMHb" node="4iu6t1eAX1B" resolve="frac" />
                         </node>
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="1Wc70l" id="7BZzIqklqqO" role="3clFbw">
-                  <node concept="2YIFZM" id="4kor_v$0ywt" role="3uHU7B">
-                    <ref role="37wK5l" to="xfg9:2Qbt$1tU33e" resolve="isIntegerType" />
-                    <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-                    <node concept="2X3wrD" id="4kor_v$0ywu" role="37wK5m">
-                      <ref role="2X3Bk0" node="7BZzIqkloOU" resolve="numType" />
-                    </node>
+                <node concept="2OqwBi" id="1JTgXSYTR3c" role="3clFbw">
+                  <node concept="37vLTw" id="1JTgXSYTQUD" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1JTgXSYTQCx" resolve="operationType" />
                   </node>
-                  <node concept="2YIFZM" id="4kor_v$0ySo" role="3uHU7w">
-                    <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-                    <ref role="37wK5l" to="xfg9:2Qbt$1tU33e" resolve="isIntegerType" />
-                    <node concept="2X3wrD" id="4kor_v$0ySp" role="37wK5m">
-                      <ref role="2X3Bk0" node="7BZzIqkloWI" resolve="denType" />
-                    </node>
-                  </node>
+                  <node concept="3x8VRR" id="1JTgXSYTR9T" role="2OqNvi" />
                 </node>
-                <node concept="9aQIb" id="7BZzIqklqPQ" role="9aQIa">
-                  <node concept="3clFbS" id="7BZzIqklqPR" role="9aQI4">
-                    <node concept="1Z5TYs" id="7BZzIqklqPU" role="3cqZAp">
-                      <node concept="mw_s8" id="7BZzIqklubB" role="1ZfhKB">
-                        <node concept="3h4ouC" id="7BZzIqklubn" role="mwGJk">
-                          <node concept="2pJPEk" id="7BZzIqkluc6" role="3h4sjZ">
-                            <node concept="2pJPED" id="7BZzIqkluc$" role="2pJPEn">
-                              <ref role="2pJxaS" to="hm2y:4rZeNQ6MGoV" resolve="DivExpression" />
-                              <node concept="2pIpSj" id="7BZzIqkluej" role="2pJxcM">
-                                <ref role="2pIpSl" to="hm2y:4rZeNQ6MpKm" resolve="left" />
-                                <node concept="36biLy" id="7BZzIqklufi" role="28nt2d">
-                                  <node concept="2OqwBi" id="7BZzIqklw1N" role="36biLW">
-                                    <node concept="2OqwBi" id="7BZzIqkluvi" role="2Oq$k0">
-                                      <node concept="1YBJjd" id="7BZzIqklufN" role="2Oq$k0">
-                                        <ref role="1YBMHb" node="4iu6t1eAX1B" resolve="frac" />
-                                      </node>
-                                      <node concept="3TrEf2" id="7BZzIqkluVE" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="1qv1:4iu6t1eAWP7" resolve="numerator" />
-                                      </node>
-                                    </node>
-                                    <node concept="1$rogu" id="7BZzIqklwA6" role="2OqNvi" />
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="2pIpSj" id="7BZzIqklwHo" role="2pJxcM">
-                                <ref role="2pIpSl" to="hm2y:4rZeNQ6MpKo" resolve="right" />
-                                <node concept="36biLy" id="7BZzIqklwHp" role="28nt2d">
-                                  <node concept="2OqwBi" id="7BZzIqklwHq" role="36biLW">
-                                    <node concept="2OqwBi" id="7BZzIqklwHr" role="2Oq$k0">
-                                      <node concept="1YBJjd" id="7BZzIqklwHs" role="2Oq$k0">
-                                        <ref role="1YBMHb" node="4iu6t1eAX1B" resolve="frac" />
-                                      </node>
-                                      <node concept="3TrEf2" id="7BZzIqklxbV" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="1qv1:4iu6t1eAWPa" resolve="denominator" />
-                                      </node>
-                                    </node>
-                                    <node concept="1$rogu" id="7BZzIqklwHu" role="2OqNvi" />
-                                  </node>
-                                </node>
+                <node concept="9aQIb" id="1JTgXSYTRdl" role="9aQIa">
+                  <node concept="3clFbS" id="1JTgXSYTRdm" role="9aQI4">
+                    <node concept="1ZobV4" id="5mz5Tt_hl4X" role="3cqZAp">
+                      <property role="3wDh2S" value="true" />
+                      <node concept="mw_s8" id="5mz5Tt_hl5w" role="1ZfhKB">
+                        <node concept="2YIFZM" id="7BZzIqkljhU" role="mwGJk">
+                          <ref role="37wK5l" to="xfg9:2Qbt$1tTQdc" resolve="createRealType" />
+                          <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+                          <node concept="10Nm6u" id="7BZzIqkljhV" role="37wK5m" />
+                        </node>
+                      </node>
+                      <node concept="mw_s8" id="7BZzIqklpP6" role="1ZfhK$">
+                        <node concept="2X3wrD" id="7BZzIqklpP0" role="mwGJk">
+                          <ref role="2X3Bk0" node="7BZzIqkloOU" resolve="numType" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1ZobV4" id="5mz5Tt_hl95" role="3cqZAp">
+                      <property role="3wDh2S" value="true" />
+                      <node concept="mw_s8" id="5mz5Tt_hl96" role="1ZfhKB">
+                        <node concept="2YIFZM" id="7BZzIqkloKD" role="mwGJk">
+                          <ref role="37wK5l" to="xfg9:2Qbt$1tTQdc" resolve="createRealType" />
+                          <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+                          <node concept="10Nm6u" id="7BZzIqkloKE" role="37wK5m" />
+                        </node>
+                      </node>
+                      <node concept="mw_s8" id="7BZzIqklpWD" role="1ZfhK$">
+                        <node concept="2X3wrD" id="7BZzIqklpWz" role="mwGJk">
+                          <ref role="2X3Bk0" node="7BZzIqkloWI" resolve="denType" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="7BZzIqklpZV" role="3cqZAp">
+                      <node concept="3clFbS" id="7BZzIqklpZX" role="3clFbx">
+                        <node concept="1Z5TYs" id="2X81bnKeKSe" role="3cqZAp">
+                          <node concept="mw_s8" id="2X81bnKeKSi" role="1ZfhKB">
+                            <node concept="2pJPEk" id="5mz5Tt_hmCA" role="mwGJk">
+                              <node concept="2pJPED" id="5mz5Tt_hmCM" role="2pJPEn">
+                                <ref role="2pJxaS" to="1qv1:5mz5Tt_h1dJ" resolve="RationalType" />
                               </node>
                             </node>
                           </node>
-                          <node concept="2X3wrD" id="7BZzIqklxfv" role="3h4u4a">
+                          <node concept="mw_s8" id="2X81bnKeKSh" role="1ZfhK$">
+                            <node concept="1Z2H0r" id="2X81bnKeKSb" role="mwGJk">
+                              <node concept="1YBJjd" id="4iu6t1eAXPx" role="1Z2MuG">
+                                <ref role="1YBMHb" node="4iu6t1eAX1B" resolve="frac" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="1Wc70l" id="7BZzIqklqqO" role="3clFbw">
+                        <node concept="2YIFZM" id="4kor_v$0ywt" role="3uHU7B">
+                          <ref role="37wK5l" to="xfg9:2Qbt$1tU33e" resolve="isIntegerType" />
+                          <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+                          <node concept="2X3wrD" id="4kor_v$0ywu" role="37wK5m">
                             <ref role="2X3Bk0" node="7BZzIqkloOU" resolve="numType" />
                           </node>
-                          <node concept="2X3wrD" id="7BZzIqklxgl" role="3h4u2h">
+                        </node>
+                        <node concept="2YIFZM" id="4kor_v$0ySo" role="3uHU7w">
+                          <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+                          <ref role="37wK5l" to="xfg9:2Qbt$1tU33e" resolve="isIntegerType" />
+                          <node concept="2X3wrD" id="4kor_v$0ySp" role="37wK5m">
                             <ref role="2X3Bk0" node="7BZzIqkloWI" resolve="denType" />
                           </node>
                         </node>
                       </node>
-                      <node concept="mw_s8" id="7BZzIqklqPY" role="1ZfhK$">
-                        <node concept="1Z2H0r" id="7BZzIqklqPZ" role="mwGJk">
-                          <node concept="1YBJjd" id="7BZzIqklqQ0" role="1Z2MuG">
-                            <ref role="1YBMHb" node="4iu6t1eAX1B" resolve="frac" />
+                      <node concept="9aQIb" id="7BZzIqklqPQ" role="9aQIa">
+                        <node concept="3clFbS" id="7BZzIqklqPR" role="9aQI4">
+                          <node concept="1Z5TYs" id="7BZzIqklqPU" role="3cqZAp">
+                            <node concept="mw_s8" id="7BZzIqklubB" role="1ZfhKB">
+                              <node concept="3h4ouC" id="7BZzIqklubn" role="mwGJk">
+                                <node concept="2pJPEk" id="7BZzIqkluc6" role="3h4sjZ">
+                                  <node concept="2pJPED" id="7BZzIqkluc$" role="2pJPEn">
+                                    <ref role="2pJxaS" to="hm2y:4rZeNQ6MGoV" resolve="DivExpression" />
+                                    <node concept="2pIpSj" id="7BZzIqkluej" role="2pJxcM">
+                                      <ref role="2pIpSl" to="hm2y:4rZeNQ6MpKm" resolve="left" />
+                                      <node concept="36biLy" id="7BZzIqklufi" role="28nt2d">
+                                        <node concept="2OqwBi" id="7BZzIqklw1N" role="36biLW">
+                                          <node concept="2OqwBi" id="7BZzIqkluvi" role="2Oq$k0">
+                                            <node concept="1YBJjd" id="7BZzIqklufN" role="2Oq$k0">
+                                              <ref role="1YBMHb" node="4iu6t1eAX1B" resolve="frac" />
+                                            </node>
+                                            <node concept="3TrEf2" id="7BZzIqkluVE" role="2OqNvi">
+                                              <ref role="3Tt5mk" to="1qv1:4iu6t1eAWP7" resolve="numerator" />
+                                            </node>
+                                          </node>
+                                          <node concept="1$rogu" id="7BZzIqklwA6" role="2OqNvi" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="2pIpSj" id="7BZzIqklwHo" role="2pJxcM">
+                                      <ref role="2pIpSl" to="hm2y:4rZeNQ6MpKo" resolve="right" />
+                                      <node concept="36biLy" id="7BZzIqklwHp" role="28nt2d">
+                                        <node concept="2OqwBi" id="7BZzIqklwHq" role="36biLW">
+                                          <node concept="2OqwBi" id="7BZzIqklwHr" role="2Oq$k0">
+                                            <node concept="1YBJjd" id="7BZzIqklwHs" role="2Oq$k0">
+                                              <ref role="1YBMHb" node="4iu6t1eAX1B" resolve="frac" />
+                                            </node>
+                                            <node concept="3TrEf2" id="7BZzIqklxbV" role="2OqNvi">
+                                              <ref role="3Tt5mk" to="1qv1:4iu6t1eAWPa" resolve="denominator" />
+                                            </node>
+                                          </node>
+                                          <node concept="1$rogu" id="7BZzIqklwHu" role="2OqNvi" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="2X3wrD" id="7BZzIqklxfv" role="3h4u4a">
+                                  <ref role="2X3Bk0" node="7BZzIqkloOU" resolve="numType" />
+                                </node>
+                                <node concept="2X3wrD" id="7BZzIqklxgl" role="3h4u2h">
+                                  <ref role="2X3Bk0" node="7BZzIqkloWI" resolve="denType" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="mw_s8" id="7BZzIqklqPY" role="1ZfhK$">
+                              <node concept="1Z2H0r" id="7BZzIqklqPZ" role="mwGJk">
+                                <node concept="1YBJjd" id="7BZzIqklqQ0" role="1Z2MuG">
+                                  <ref role="1YBMHb" node="4iu6t1eAX1B" resolve="frac" />
+                                </node>
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -578,66 +677,66 @@
   <node concept="1YbPZF" id="4iu6t1eB68j">
     <property role="TrG5h" value="typeof_PowerExpression" />
     <node concept="3clFbS" id="4iu6t1eB68k" role="18ibNy">
-      <node concept="1Z5TYs" id="4r1mNB_oeov" role="3cqZAp">
-        <node concept="mw_s8" id="4r1mNB_oepA" role="1ZfhKB">
-          <node concept="2ShNRf" id="4r1mNB_oepy" role="mwGJk">
-            <node concept="3zrR0B" id="4r1mNB_oew1" role="2ShVmc">
-              <node concept="3Tqbb2" id="4r1mNB_oew3" role="3zrR0E">
+      <node concept="1Z5TYs" id="6q$NxWeJqFX" role="3cqZAp">
+        <node concept="mw_s8" id="6q$NxWeJqFY" role="1ZfhKB">
+          <node concept="2ShNRf" id="6q$NxWeJqFZ" role="mwGJk">
+            <node concept="3zrR0B" id="6q$NxWeJqG0" role="2ShVmc">
+              <node concept="3Tqbb2" id="6q$NxWeJqG1" role="3zrR0E">
                 <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="mw_s8" id="4r1mNB_oeoy" role="1ZfhK$">
-          <node concept="1Z2H0r" id="4r1mNB_oee5" role="mwGJk">
-            <node concept="1YBJjd" id="4iu6t1eB6bD" role="1Z2MuG">
+        <node concept="mw_s8" id="6q$NxWeJqG2" role="1ZfhK$">
+          <node concept="1Z2H0r" id="6q$NxWeJqG3" role="mwGJk">
+            <node concept="1YBJjd" id="6q$NxWeJqIz" role="1Z2MuG">
               <ref role="1YBMHb" node="4iu6t1eB68m" resolve="pe" />
             </node>
           </node>
         </node>
       </node>
-      <node concept="1ZobV4" id="4r1mNB_ogst" role="3cqZAp">
+      <node concept="1ZobV4" id="6q$NxWeJqG5" role="3cqZAp">
         <property role="3wDh2S" value="true" />
-        <node concept="mw_s8" id="4r1mNB_ogsz" role="1ZfhK$">
-          <node concept="1Z2H0r" id="4r1mNB_ogs$" role="mwGJk">
-            <node concept="2OqwBi" id="4r1mNB_ogs_" role="1Z2MuG">
-              <node concept="1YBJjd" id="4iu6t1eB6dF" role="2Oq$k0">
+        <node concept="mw_s8" id="6q$NxWeJqG6" role="1ZfhK$">
+          <node concept="1Z2H0r" id="6q$NxWeJqG7" role="mwGJk">
+            <node concept="2OqwBi" id="6q$NxWeJqG8" role="1Z2MuG">
+              <node concept="1YBJjd" id="6q$NxWeJqIO" role="2Oq$k0">
                 <ref role="1YBMHb" node="4iu6t1eB68m" resolve="pe" />
               </node>
-              <node concept="3TrEf2" id="4iu6t1eB6ko" role="2OqNvi">
+              <node concept="3TrEf2" id="6q$NxWeJqGa" role="2OqNvi">
                 <ref role="3Tt5mk" to="1qv1:4r1mNB_o5WJ" resolve="exponent" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="mw_s8" id="4r1mNB_ogsv" role="1ZfhKB">
-          <node concept="2ShNRf" id="4r1mNB_ogsw" role="mwGJk">
-            <node concept="3zrR0B" id="4r1mNB_ogsx" role="2ShVmc">
-              <node concept="3Tqbb2" id="4r1mNB_ogsy" role="3zrR0E">
+        <node concept="mw_s8" id="6q$NxWeJqGb" role="1ZfhKB">
+          <node concept="2ShNRf" id="6q$NxWeJqGc" role="mwGJk">
+            <node concept="3zrR0B" id="6q$NxWeJqGd" role="2ShVmc">
+              <node concept="3Tqbb2" id="6q$NxWeJqGe" role="3zrR0E">
                 <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
               </node>
             </node>
           </node>
         </node>
       </node>
-      <node concept="1ZobV4" id="4r1mNB_og_V" role="3cqZAp">
+      <node concept="1ZobV4" id="6q$NxWeJqGf" role="3cqZAp">
         <property role="3wDh2S" value="true" />
-        <node concept="mw_s8" id="4r1mNB_ogA1" role="1ZfhK$">
-          <node concept="1Z2H0r" id="4r1mNB_ogA2" role="mwGJk">
-            <node concept="2OqwBi" id="4r1mNB_ogA3" role="1Z2MuG">
-              <node concept="1YBJjd" id="4iu6t1eB6ls" role="2Oq$k0">
+        <node concept="mw_s8" id="6q$NxWeJqGg" role="1ZfhK$">
+          <node concept="1Z2H0r" id="6q$NxWeJqGh" role="mwGJk">
+            <node concept="2OqwBi" id="6q$NxWeJqGi" role="1Z2MuG">
+              <node concept="1YBJjd" id="6q$NxWeJqL_" role="2Oq$k0">
                 <ref role="1YBMHb" node="4iu6t1eB68m" resolve="pe" />
               </node>
-              <node concept="3TrEf2" id="60ih66HBR7k" role="2OqNvi">
+              <node concept="3TrEf2" id="6q$NxWeJqGk" role="2OqNvi">
                 <ref role="3Tt5mk" to="1qv1:4iu6t1eBdVy" resolve="expr" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="mw_s8" id="4r1mNB_og_X" role="1ZfhKB">
-          <node concept="2ShNRf" id="4r1mNB_og_Y" role="mwGJk">
-            <node concept="3zrR0B" id="4r1mNB_og_Z" role="2ShVmc">
-              <node concept="3Tqbb2" id="4r1mNB_ogA0" role="3zrR0E">
+        <node concept="mw_s8" id="6q$NxWeJqGl" role="1ZfhKB">
+          <node concept="2ShNRf" id="6q$NxWeJqGm" role="mwGJk">
+            <node concept="3zrR0B" id="6q$NxWeJqGn" role="2ShVmc">
+              <node concept="3Tqbb2" id="6q$NxWeJqGo" role="3zrR0E">
                 <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/typesystem.mps
@@ -8,18 +8,31 @@
     <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="1qv1" ref="r:c53b8bbc-6142-4787-a6e4-66310b772b37(org.iets3.core.expr.math.structure)" />
-    <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
+    <import index="tpd5" ref="r:00000000-0000-4000-0000-011c895902b5(jetbrains.mps.lang.typesystem.dependencies)" />
+    <import index="u78q" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.typesystem.inference(MPS.Core/)" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
-    <import index="u78q" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.typesystem.inference(MPS.Core/)" implicit="true" />
+    <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
+    <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1219920932475" name="jetbrains.mps.baseLanguage.structure.VariableArityType" flags="in" index="8X2XB">
+        <child id="1219921048460" name="componentType" index="8Xvag" />
+      </concept>
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="ng" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -33,6 +46,7 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
@@ -40,18 +54,27 @@
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
       </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
@@ -63,11 +86,16 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
@@ -75,14 +103,30 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
-      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
-        <child id="1350122676458893092" name="text" index="3ndbpf" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
@@ -114,6 +158,9 @@
         <child id="1185805056450" name="argument" index="nvjzm" />
         <child id="1205761991995" name="argumentRepresentator" index="2X0Ygz" />
       </concept>
+      <concept id="1175517767210" name="jetbrains.mps.lang.typesystem.structure.ReportErrorStatement" flags="nn" index="2MkqsV">
+        <child id="1175517851849" name="errorString" index="2MkJ7o" />
+      </concept>
       <concept id="1175594888091" name="jetbrains.mps.lang.typesystem.structure.TypeCheckerAccessExpression" flags="nn" index="2QUAEa" />
       <concept id="1205762105978" name="jetbrains.mps.lang.typesystem.structure.WhenConcreteVariableDeclaration" flags="ng" index="2X1qdy" />
       <concept id="1205762656241" name="jetbrains.mps.lang.typesystem.structure.WhenConcreteVariableReference" flags="nn" index="2X3wrD">
@@ -124,15 +171,21 @@
         <child id="8124453027370845341" name="operationConcept" index="32tDTA" />
         <child id="6136676636349909553" name="isApplicable" index="1QeD3i" />
       </concept>
+      <concept id="8124453027370766044" name="jetbrains.mps.lang.typesystem.structure.OverloadedOpTypeRule_OneTypeSpecified" flags="ng" index="32tXgB">
+        <child id="8124453027370845366" name="operandType" index="32tDTd" />
+      </concept>
       <concept id="1195213580585" name="jetbrains.mps.lang.typesystem.structure.AbstractCheckingRule" flags="ig" index="18hYwZ">
         <child id="1195213635060" name="body" index="18ibNy" />
       </concept>
+      <concept id="1195214364922" name="jetbrains.mps.lang.typesystem.structure.NonTypesystemRule" flags="ig" index="18kY7G" />
       <concept id="1236083041311" name="jetbrains.mps.lang.typesystem.structure.OverloadedOperatorTypeRule" flags="ng" index="3ciAk0">
+        <property id="1236771585835" name="rightIsExact" index="3PlbSO" />
         <child id="1236083115043" name="leftOperandType" index="3ciSkW" />
         <child id="1236083115200" name="rightOperandType" index="3ciSnv" />
       </concept>
       <concept id="1236083146670" name="jetbrains.mps.lang.typesystem.structure.OverloadedOperatorTypeFunction" flags="in" index="3ciZUL" />
       <concept id="1236083209648" name="jetbrains.mps.lang.typesystem.structure.LeftOperandType_parameter" flags="nn" index="3cjfiJ" />
+      <concept id="1236083245720" name="jetbrains.mps.lang.typesystem.structure.Operation_parameter" flags="nn" index="3cjoe7" />
       <concept id="1236083248858" name="jetbrains.mps.lang.typesystem.structure.RightOperandType_parameter" flags="nn" index="3cjoZ5" />
       <concept id="1236163200695" name="jetbrains.mps.lang.typesystem.structure.GetOperationType" flags="nn" index="3h4ouC">
         <child id="1236163216864" name="operation" index="3h4sjZ" />
@@ -142,6 +195,10 @@
       <concept id="1236165709895" name="jetbrains.mps.lang.typesystem.structure.OverloadedOpRulesContainer" flags="ng" index="3hdX5o">
         <child id="1236165725858" name="rule" index="3he0YX" />
       </concept>
+      <concept id="3937244445246642777" name="jetbrains.mps.lang.typesystem.structure.AbstractReportStatement" flags="ng" index="1urrMJ">
+        <child id="3937244445246642781" name="nodeToReport" index="1urrMF" />
+      </concept>
+      <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
       <concept id="6136676636349908958" name="jetbrains.mps.lang.typesystem.structure.OverloadedOpIsApplicableFunction" flags="in" index="1QeDOX" />
       <concept id="1174642788531" name="jetbrains.mps.lang.typesystem.structure.ConceptReference" flags="ig" index="1YaCAy">
         <reference id="1174642800329" name="concept" index="1YaFvo" />
@@ -167,14 +224,25 @@
       <concept id="1174663118805" name="jetbrains.mps.lang.typesystem.structure.CreateLessThanInequationStatement" flags="nn" index="1ZobV4" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
       <concept id="1154546950173" name="jetbrains.mps.lang.smodel.structure.ConceptReference" flags="ng" index="3gn64h">
         <reference id="1154546997487" name="concept" index="3gnhBz" />
       </concept>
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
       <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -193,13 +261,16 @@
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
-    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
-      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="ng" index="3oM_SD">
-        <property id="155656958578482949" name="value" index="3oM_SC" />
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
-      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="ng" index="1PaTwC">
-        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
+        <child id="1240687658305" name="delimiter" index="3uJOhx" />
       </concept>
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
     </language>
   </registry>
   <node concept="1YbPZF" id="4iu6t1eAWx_">
@@ -207,83 +278,22 @@
     <node concept="3clFbS" id="4iu6t1eAWxA" role="18ibNy">
       <node concept="nvevp" id="6q$NxWeFCRg" role="3cqZAp">
         <node concept="3clFbS" id="6q$NxWeFCRi" role="nvhr_">
-          <node concept="3cpWs8" id="1JTgXSYRD$1" role="3cqZAp">
-            <node concept="3cpWsn" id="1JTgXSYRD$2" role="3cpWs9">
-              <property role="TrG5h" value="operationType" />
-              <node concept="3Tqbb2" id="1JTgXSYRDzT" role="1tU5fm" />
-              <node concept="3h4ouC" id="1JTgXSYRD$3" role="33vP2m">
-                <node concept="1YBJjd" id="1JTgXSYRD$4" role="3h4sjZ">
+          <node concept="1Z5TYs" id="6q$NxWgdp5I" role="3cqZAp">
+            <node concept="mw_s8" id="6q$NxWgdp6d" role="1ZfhKB">
+              <node concept="3h4ouC" id="6q$NxWgdp65" role="mwGJk">
+                <node concept="1YBJjd" id="6q$NxWgdp6G" role="3h4sjZ">
                   <ref role="1YBMHb" node="4iu6t1eAWxC" resolve="abs" />
                 </node>
-                <node concept="2X3wrD" id="6q$NxWeHvzm" role="3h4u4a">
+                <node concept="2X3wrD" id="6q$NxWgdp7g" role="3h4u4a">
                   <ref role="2X3Bk0" node="6q$NxWeFCRm" resolve="absExpressionType" />
                 </node>
-                <node concept="10Nm6u" id="1JTgXSYRD$8" role="3h4u2h" />
+                <node concept="10Nm6u" id="6q$NxWgdpbj" role="3h4u2h" />
               </node>
             </node>
-          </node>
-          <node concept="3clFbJ" id="1JTgXSYRCN$" role="3cqZAp">
-            <node concept="3clFbS" id="1JTgXSYRCNA" role="3clFbx">
-              <node concept="1Z5TYs" id="1JTgXSYRTob" role="3cqZAp">
-                <node concept="mw_s8" id="1JTgXSYRTot" role="1ZfhKB">
-                  <node concept="37vLTw" id="1JTgXSYRTor" role="mwGJk">
-                    <ref role="3cqZAo" node="1JTgXSYRD$2" resolve="operationType" />
-                  </node>
-                </node>
-                <node concept="mw_s8" id="1JTgXSYRToe" role="1ZfhK$">
-                  <node concept="1Z2H0r" id="1JTgXSYRTby" role="mwGJk">
-                    <node concept="1YBJjd" id="1JTgXSYRTds" role="1Z2MuG">
-                      <ref role="1YBMHb" node="4iu6t1eAWxC" resolve="abs" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="2OqwBi" id="1JTgXSYRDJk" role="3clFbw">
-              <node concept="37vLTw" id="1JTgXSYRDAL" role="2Oq$k0">
-                <ref role="3cqZAo" node="1JTgXSYRD$2" resolve="operationType" />
-              </node>
-              <node concept="3x8VRR" id="1JTgXSYRDQ1" role="2OqNvi" />
-            </node>
-            <node concept="9aQIb" id="1JTgXSYRDTt" role="9aQIa">
-              <node concept="3clFbS" id="1JTgXSYRDTu" role="9aQI4">
-                <node concept="1Z5TYs" id="4r1mNB_uhX6" role="3cqZAp">
-                  <node concept="mw_s8" id="6q$NxWeFDZr" role="1ZfhKB">
-                    <node concept="2X3wrD" id="6q$NxWeFDZl" role="mwGJk">
-                      <ref role="2X3Bk0" node="6q$NxWeFCRm" resolve="absExpressionType" />
-                    </node>
-                  </node>
-                  <node concept="mw_s8" id="4r1mNB_uhX9" role="1ZfhK$">
-                    <node concept="1Z2H0r" id="4r1mNB_uhTu" role="mwGJk">
-                      <node concept="1YBJjd" id="4iu6t1eAW$_" role="1Z2MuG">
-                        <ref role="1YBMHb" node="4iu6t1eAWxC" resolve="abs" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="1ZobV4" id="4r1mNB_ujsr" role="3cqZAp">
-                  <property role="3wDh2S" value="true" />
-                  <node concept="mw_s8" id="4r1mNB_ujuG" role="1ZfhKB">
-                    <node concept="2ShNRf" id="4r1mNB_ujuC" role="mwGJk">
-                      <node concept="3zrR0B" id="4r1mNB_uj_7" role="2ShVmc">
-                        <node concept="3Tqbb2" id="4r1mNB_uj_9" role="3zrR0E">
-                          <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="mw_s8" id="4r1mNB_ujsu" role="1ZfhK$">
-                    <node concept="1Z2H0r" id="4r1mNB_uiQ$" role="mwGJk">
-                      <node concept="2OqwBi" id="4r1mNB_uiXE" role="1Z2MuG">
-                        <node concept="1YBJjd" id="4iu6t1eAWIc" role="2Oq$k0">
-                          <ref role="1YBMHb" node="4iu6t1eAWxC" resolve="abs" />
-                        </node>
-                        <node concept="3TrEf2" id="4iu6t1eB9lC" role="2OqNvi">
-                          <ref role="3Tt5mk" to="1qv1:4iu6t1eB97r" resolve="expr" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
+            <node concept="mw_s8" id="6q$NxWgdp5L" role="1ZfhK$">
+              <node concept="1Z2H0r" id="6q$NxWgdoRI" role="mwGJk">
+                <node concept="1YBJjd" id="6q$NxWgdp1n" role="1Z2MuG">
+                  <ref role="1YBMHb" node="4iu6t1eAWxC" resolve="abs" />
                 </node>
               </node>
             </node>
@@ -318,173 +328,24 @@
         <node concept="3clFbS" id="7BZzIqkloOQ" role="nvhr_">
           <node concept="nvevp" id="7BZzIqkloWC" role="3cqZAp">
             <node concept="3clFbS" id="7BZzIqkloWD" role="nvhr_">
-              <node concept="3cpWs8" id="1JTgXSYTQCw" role="3cqZAp">
-                <node concept="3cpWsn" id="1JTgXSYTQCx" role="3cpWs9">
-                  <property role="TrG5h" value="operationType" />
-                  <node concept="3Tqbb2" id="1JTgXSYTQz$" role="1tU5fm" />
-                  <node concept="3h4ouC" id="1JTgXSYTQCy" role="33vP2m">
-                    <node concept="1YBJjd" id="1JTgXSYTQCz" role="3h4sjZ">
+              <node concept="1Z5TYs" id="6q$NxWgdqf$" role="3cqZAp">
+                <node concept="mw_s8" id="6q$NxWgdqnG" role="1ZfhKB">
+                  <node concept="3h4ouC" id="6q$NxWgdqn$" role="mwGJk">
+                    <node concept="1YBJjd" id="6q$NxWgdqob" role="3h4sjZ">
                       <ref role="1YBMHb" node="4iu6t1eAX1B" resolve="frac" />
                     </node>
-                    <node concept="2X3wrD" id="1JTgXSYTQC$" role="3h4u4a">
+                    <node concept="2X3wrD" id="6q$NxWgdqoL" role="3h4u4a">
                       <ref role="2X3Bk0" node="7BZzIqkloOU" resolve="numType" />
                     </node>
-                    <node concept="2X3wrD" id="1JTgXSYTQC_" role="3h4u2h">
+                    <node concept="2X3wrD" id="6q$NxWgdqwY" role="3h4u2h">
                       <ref role="2X3Bk0" node="7BZzIqkloWI" resolve="denType" />
                     </node>
                   </node>
                 </node>
-              </node>
-              <node concept="3clFbJ" id="1JTgXSYTQR3" role="3cqZAp">
-                <node concept="3clFbS" id="1JTgXSYTQR5" role="3clFbx">
-                  <node concept="1Z5TYs" id="1JTgXSYTXAU" role="3cqZAp">
-                    <node concept="mw_s8" id="1JTgXSYTXBc" role="1ZfhKB">
-                      <node concept="37vLTw" id="1JTgXSYTXBa" role="mwGJk">
-                        <ref role="3cqZAo" node="1JTgXSYTQCx" resolve="operationType" />
-                      </node>
-                    </node>
-                    <node concept="mw_s8" id="1JTgXSYTXAX" role="1ZfhK$">
-                      <node concept="1Z2H0r" id="1JTgXSYTWMS" role="mwGJk">
-                        <node concept="1YBJjd" id="1JTgXSYTWOQ" role="1Z2MuG">
-                          <ref role="1YBMHb" node="4iu6t1eAX1B" resolve="frac" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="1JTgXSYTR3c" role="3clFbw">
-                  <node concept="37vLTw" id="1JTgXSYTQUD" role="2Oq$k0">
-                    <ref role="3cqZAo" node="1JTgXSYTQCx" resolve="operationType" />
-                  </node>
-                  <node concept="3x8VRR" id="1JTgXSYTR9T" role="2OqNvi" />
-                </node>
-                <node concept="9aQIb" id="1JTgXSYTRdl" role="9aQIa">
-                  <node concept="3clFbS" id="1JTgXSYTRdm" role="9aQI4">
-                    <node concept="1ZobV4" id="5mz5Tt_hl4X" role="3cqZAp">
-                      <property role="3wDh2S" value="true" />
-                      <node concept="mw_s8" id="5mz5Tt_hl5w" role="1ZfhKB">
-                        <node concept="2YIFZM" id="7BZzIqkljhU" role="mwGJk">
-                          <ref role="37wK5l" to="xfg9:2Qbt$1tTQdc" resolve="createRealType" />
-                          <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-                          <node concept="10Nm6u" id="7BZzIqkljhV" role="37wK5m" />
-                        </node>
-                      </node>
-                      <node concept="mw_s8" id="7BZzIqklpP6" role="1ZfhK$">
-                        <node concept="2X3wrD" id="7BZzIqklpP0" role="mwGJk">
-                          <ref role="2X3Bk0" node="7BZzIqkloOU" resolve="numType" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="1ZobV4" id="5mz5Tt_hl95" role="3cqZAp">
-                      <property role="3wDh2S" value="true" />
-                      <node concept="mw_s8" id="5mz5Tt_hl96" role="1ZfhKB">
-                        <node concept="2YIFZM" id="7BZzIqkloKD" role="mwGJk">
-                          <ref role="37wK5l" to="xfg9:2Qbt$1tTQdc" resolve="createRealType" />
-                          <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-                          <node concept="10Nm6u" id="7BZzIqkloKE" role="37wK5m" />
-                        </node>
-                      </node>
-                      <node concept="mw_s8" id="7BZzIqklpWD" role="1ZfhK$">
-                        <node concept="2X3wrD" id="7BZzIqklpWz" role="mwGJk">
-                          <ref role="2X3Bk0" node="7BZzIqkloWI" resolve="denType" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbJ" id="7BZzIqklpZV" role="3cqZAp">
-                      <node concept="3clFbS" id="7BZzIqklpZX" role="3clFbx">
-                        <node concept="1Z5TYs" id="2X81bnKeKSe" role="3cqZAp">
-                          <node concept="mw_s8" id="2X81bnKeKSi" role="1ZfhKB">
-                            <node concept="2pJPEk" id="5mz5Tt_hmCA" role="mwGJk">
-                              <node concept="2pJPED" id="5mz5Tt_hmCM" role="2pJPEn">
-                                <ref role="2pJxaS" to="1qv1:5mz5Tt_h1dJ" resolve="RationalType" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="mw_s8" id="2X81bnKeKSh" role="1ZfhK$">
-                            <node concept="1Z2H0r" id="2X81bnKeKSb" role="mwGJk">
-                              <node concept="1YBJjd" id="4iu6t1eAXPx" role="1Z2MuG">
-                                <ref role="1YBMHb" node="4iu6t1eAX1B" resolve="frac" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="1Wc70l" id="7BZzIqklqqO" role="3clFbw">
-                        <node concept="2YIFZM" id="4kor_v$0ywt" role="3uHU7B">
-                          <ref role="37wK5l" to="xfg9:2Qbt$1tU33e" resolve="isIntegerType" />
-                          <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-                          <node concept="2X3wrD" id="4kor_v$0ywu" role="37wK5m">
-                            <ref role="2X3Bk0" node="7BZzIqkloOU" resolve="numType" />
-                          </node>
-                        </node>
-                        <node concept="2YIFZM" id="4kor_v$0ySo" role="3uHU7w">
-                          <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-                          <ref role="37wK5l" to="xfg9:2Qbt$1tU33e" resolve="isIntegerType" />
-                          <node concept="2X3wrD" id="4kor_v$0ySp" role="37wK5m">
-                            <ref role="2X3Bk0" node="7BZzIqkloWI" resolve="denType" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="9aQIb" id="7BZzIqklqPQ" role="9aQIa">
-                        <node concept="3clFbS" id="7BZzIqklqPR" role="9aQI4">
-                          <node concept="1Z5TYs" id="7BZzIqklqPU" role="3cqZAp">
-                            <node concept="mw_s8" id="7BZzIqklubB" role="1ZfhKB">
-                              <node concept="3h4ouC" id="7BZzIqklubn" role="mwGJk">
-                                <node concept="2pJPEk" id="7BZzIqkluc6" role="3h4sjZ">
-                                  <node concept="2pJPED" id="7BZzIqkluc$" role="2pJPEn">
-                                    <ref role="2pJxaS" to="hm2y:4rZeNQ6MGoV" resolve="DivExpression" />
-                                    <node concept="2pIpSj" id="7BZzIqkluej" role="2pJxcM">
-                                      <ref role="2pIpSl" to="hm2y:4rZeNQ6MpKm" resolve="left" />
-                                      <node concept="36biLy" id="7BZzIqklufi" role="28nt2d">
-                                        <node concept="2OqwBi" id="7BZzIqklw1N" role="36biLW">
-                                          <node concept="2OqwBi" id="7BZzIqkluvi" role="2Oq$k0">
-                                            <node concept="1YBJjd" id="7BZzIqklufN" role="2Oq$k0">
-                                              <ref role="1YBMHb" node="4iu6t1eAX1B" resolve="frac" />
-                                            </node>
-                                            <node concept="3TrEf2" id="7BZzIqkluVE" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="1qv1:4iu6t1eAWP7" resolve="numerator" />
-                                            </node>
-                                          </node>
-                                          <node concept="1$rogu" id="7BZzIqklwA6" role="2OqNvi" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="2pIpSj" id="7BZzIqklwHo" role="2pJxcM">
-                                      <ref role="2pIpSl" to="hm2y:4rZeNQ6MpKo" resolve="right" />
-                                      <node concept="36biLy" id="7BZzIqklwHp" role="28nt2d">
-                                        <node concept="2OqwBi" id="7BZzIqklwHq" role="36biLW">
-                                          <node concept="2OqwBi" id="7BZzIqklwHr" role="2Oq$k0">
-                                            <node concept="1YBJjd" id="7BZzIqklwHs" role="2Oq$k0">
-                                              <ref role="1YBMHb" node="4iu6t1eAX1B" resolve="frac" />
-                                            </node>
-                                            <node concept="3TrEf2" id="7BZzIqklxbV" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="1qv1:4iu6t1eAWPa" resolve="denominator" />
-                                            </node>
-                                          </node>
-                                          <node concept="1$rogu" id="7BZzIqklwHu" role="2OqNvi" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="2X3wrD" id="7BZzIqklxfv" role="3h4u4a">
-                                  <ref role="2X3Bk0" node="7BZzIqkloOU" resolve="numType" />
-                                </node>
-                                <node concept="2X3wrD" id="7BZzIqklxgl" role="3h4u2h">
-                                  <ref role="2X3Bk0" node="7BZzIqkloWI" resolve="denType" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="mw_s8" id="7BZzIqklqPY" role="1ZfhK$">
-                              <node concept="1Z2H0r" id="7BZzIqklqPZ" role="mwGJk">
-                                <node concept="1YBJjd" id="7BZzIqklqQ0" role="1Z2MuG">
-                                  <ref role="1YBMHb" node="4iu6t1eAX1B" resolve="frac" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
+                <node concept="mw_s8" id="6q$NxWgdqfB" role="1ZfhK$">
+                  <node concept="1Z2H0r" id="6q$NxWgdq4H" role="mwGJk">
+                    <node concept="1YBJjd" id="6q$NxWgdqag" role="1Z2MuG">
+                      <ref role="1YBMHb" node="4iu6t1eAX1B" resolve="frac" />
                     </node>
                   </node>
                 </node>
@@ -681,113 +542,24 @@
         <node concept="3clFbS" id="6q$NxWeVY1D" role="nvhr_">
           <node concept="nvevp" id="6q$NxWeVYAi" role="3cqZAp">
             <node concept="3clFbS" id="6q$NxWeVYAk" role="nvhr_">
-              <node concept="3cpWs8" id="6q$NxWeVZo8" role="3cqZAp">
-                <node concept="3cpWsn" id="6q$NxWeVZo9" role="3cpWs9">
-                  <property role="TrG5h" value="operationType" />
-                  <node concept="3Tqbb2" id="6q$NxWeVZly" role="1tU5fm" />
-                  <node concept="3h4ouC" id="6q$NxWeVZoa" role="33vP2m">
-                    <node concept="1YBJjd" id="6q$NxWeVZob" role="3h4sjZ">
+              <node concept="1Z5TYs" id="6q$NxWgdcOB" role="3cqZAp">
+                <node concept="mw_s8" id="6q$NxWgdcSt" role="1ZfhKB">
+                  <node concept="3h4ouC" id="6q$NxWgdcSl" role="mwGJk">
+                    <node concept="1YBJjd" id="6q$NxWgdcSW" role="3h4sjZ">
                       <ref role="1YBMHb" node="4iu6t1eB68m" resolve="pe" />
                     </node>
-                    <node concept="2X3wrD" id="6q$NxWf2ALD" role="3h4u4a">
+                    <node concept="2X3wrD" id="6q$NxWgdcTw" role="3h4u4a">
                       <ref role="2X3Bk0" node="6q$NxWeVY1H" resolve="innerPowerExpressionType" />
                     </node>
-                    <node concept="2X3wrD" id="6q$NxWf2AWd" role="3h4u2h">
+                    <node concept="2X3wrD" id="6q$NxWgdd2a" role="3h4u2h">
                       <ref role="2X3Bk0" node="6q$NxWeVYAo" resolve="exponentType" />
                     </node>
                   </node>
                 </node>
-              </node>
-              <node concept="3clFbJ" id="6q$NxWeVZs1" role="3cqZAp">
-                <node concept="3clFbS" id="6q$NxWeVZs3" role="3clFbx">
-                  <node concept="1Z5TYs" id="6q$NxWeW0ya" role="3cqZAp">
-                    <node concept="mw_s8" id="6q$NxWeW0ys" role="1ZfhKB">
-                      <node concept="37vLTw" id="6q$NxWeW0yq" role="mwGJk">
-                        <ref role="3cqZAo" node="6q$NxWeVZo9" resolve="operationType" />
-                      </node>
-                    </node>
-                    <node concept="mw_s8" id="6q$NxWeW0yd" role="1ZfhK$">
-                      <node concept="1Z2H0r" id="6q$NxWeW0np" role="mwGJk">
-                        <node concept="1YBJjd" id="6q$NxWeW0nD" role="1Z2MuG">
-                          <ref role="1YBMHb" node="4iu6t1eB68m" resolve="pe" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="6q$NxWeVZ_z" role="3clFbw">
-                  <node concept="37vLTw" id="6q$NxWeVZt0" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6q$NxWeVZo9" resolve="operationType" />
-                  </node>
-                  <node concept="3x8VRR" id="6q$NxWeVZGg" role="2OqNvi" />
-                </node>
-                <node concept="9aQIb" id="6q$NxWeVZJG" role="9aQIa">
-                  <node concept="3clFbS" id="6q$NxWeVZJH" role="9aQI4">
-                    <node concept="1Z5TYs" id="6q$NxWeJqFX" role="3cqZAp">
-                      <node concept="mw_s8" id="6q$NxWeJqFY" role="1ZfhKB">
-                        <node concept="2ShNRf" id="6q$NxWeJqFZ" role="mwGJk">
-                          <node concept="3zrR0B" id="6q$NxWeJqG0" role="2ShVmc">
-                            <node concept="3Tqbb2" id="6q$NxWeJqG1" role="3zrR0E">
-                              <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="mw_s8" id="6q$NxWeJqG2" role="1ZfhK$">
-                        <node concept="1Z2H0r" id="6q$NxWeJqG3" role="mwGJk">
-                          <node concept="1YBJjd" id="6q$NxWeJqIz" role="1Z2MuG">
-                            <ref role="1YBMHb" node="4iu6t1eB68m" resolve="pe" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="1ZobV4" id="6q$NxWeJqG5" role="3cqZAp">
-                      <property role="3wDh2S" value="true" />
-                      <node concept="mw_s8" id="6q$NxWeJqG6" role="1ZfhK$">
-                        <node concept="1Z2H0r" id="6q$NxWeJqG7" role="mwGJk">
-                          <node concept="2OqwBi" id="6q$NxWeJqG8" role="1Z2MuG">
-                            <node concept="1YBJjd" id="6q$NxWeJqIO" role="2Oq$k0">
-                              <ref role="1YBMHb" node="4iu6t1eB68m" resolve="pe" />
-                            </node>
-                            <node concept="3TrEf2" id="6q$NxWeJqGa" role="2OqNvi">
-                              <ref role="3Tt5mk" to="1qv1:4r1mNB_o5WJ" resolve="exponent" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="mw_s8" id="6q$NxWeJqGb" role="1ZfhKB">
-                        <node concept="2ShNRf" id="6q$NxWeJqGc" role="mwGJk">
-                          <node concept="3zrR0B" id="6q$NxWeJqGd" role="2ShVmc">
-                            <node concept="3Tqbb2" id="6q$NxWeJqGe" role="3zrR0E">
-                              <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="1ZobV4" id="6q$NxWeJqGf" role="3cqZAp">
-                      <property role="3wDh2S" value="true" />
-                      <node concept="mw_s8" id="6q$NxWeJqGg" role="1ZfhK$">
-                        <node concept="1Z2H0r" id="6q$NxWeJqGh" role="mwGJk">
-                          <node concept="2OqwBi" id="6q$NxWeJqGi" role="1Z2MuG">
-                            <node concept="1YBJjd" id="6q$NxWeJqL_" role="2Oq$k0">
-                              <ref role="1YBMHb" node="4iu6t1eB68m" resolve="pe" />
-                            </node>
-                            <node concept="3TrEf2" id="6q$NxWeJqGk" role="2OqNvi">
-                              <ref role="3Tt5mk" to="1qv1:4iu6t1eBdVy" resolve="expr" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="mw_s8" id="6q$NxWeJqGl" role="1ZfhKB">
-                        <node concept="2ShNRf" id="6q$NxWeJqGm" role="mwGJk">
-                          <node concept="3zrR0B" id="6q$NxWeJqGn" role="2ShVmc">
-                            <node concept="3Tqbb2" id="6q$NxWeJqGo" role="3zrR0E">
-                              <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
+                <node concept="mw_s8" id="6q$NxWgdcOE" role="1ZfhK$">
+                  <node concept="1Z2H0r" id="6q$NxWgdcJX" role="mwGJk">
+                    <node concept="1YBJjd" id="6q$NxWgdcMz" role="1Z2MuG">
+                      <ref role="1YBMHb" node="4iu6t1eB68m" resolve="pe" />
                     </node>
                   </node>
                 </node>
@@ -835,142 +607,22 @@
     <node concept="3clFbS" id="4iu6t1eB8V0" role="18ibNy">
       <node concept="nvevp" id="3htFKtcd8wN" role="3cqZAp">
         <node concept="3clFbS" id="3htFKtcd8wP" role="nvhr_">
-          <node concept="3cpWs8" id="2OGPkCTl61h" role="3cqZAp">
-            <node concept="3cpWsn" id="2OGPkCTl61i" role="3cpWs9">
-              <property role="TrG5h" value="operationType" />
-              <node concept="3Tqbb2" id="2OGPkCTl5Zh" role="1tU5fm" />
-              <node concept="3h4ouC" id="2OGPkCTl61j" role="33vP2m">
-                <node concept="1YBJjd" id="2OGPkCTl61k" role="3h4sjZ">
+          <node concept="1Z5TYs" id="6q$NxWgcBYv" role="3cqZAp">
+            <node concept="mw_s8" id="6q$NxWgcBZK" role="1ZfhKB">
+              <node concept="3h4ouC" id="6q$NxWgcBZC" role="mwGJk">
+                <node concept="1YBJjd" id="6q$NxWgcC0f" role="3h4sjZ">
                   <ref role="1YBMHb" node="4iu6t1eB8V2" resolve="sqrt" />
                 </node>
-                <node concept="2X3wrD" id="3htFKtcd9lI" role="3h4u4a">
+                <node concept="2X3wrD" id="6q$NxWgcC0N" role="3h4u4a">
                   <ref role="2X3Bk0" node="3htFKtcd8wT" resolve="sqrtExpressionInnerType" />
                 </node>
-                <node concept="10Nm6u" id="2OGPkCTl61p" role="3h4u2h" />
+                <node concept="10Nm6u" id="6q$NxWgcC8H" role="3h4u2h" />
               </node>
             </node>
-          </node>
-          <node concept="3clFbJ" id="2OGPkCTl6ai" role="3cqZAp">
-            <node concept="3clFbS" id="2OGPkCTl6ak" role="3clFbx">
-              <node concept="1Z5TYs" id="2OGPkCTl56U" role="3cqZAp">
-                <node concept="mw_s8" id="2OGPkCTl74w" role="1ZfhKB">
-                  <node concept="37vLTw" id="2OGPkCTl74n" role="mwGJk">
-                    <ref role="3cqZAo" node="2OGPkCTl61i" resolve="operationType" />
-                  </node>
-                </node>
-                <node concept="mw_s8" id="2OGPkCTl56W" role="1ZfhK$">
-                  <node concept="1Z2H0r" id="2OGPkCTl56X" role="mwGJk">
-                    <node concept="1YBJjd" id="2OGPkCTl56Y" role="1Z2MuG">
-                      <ref role="1YBMHb" node="4iu6t1eB8V2" resolve="sqrt" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="2OqwBi" id="2OGPkCTl6jG" role="3clFbw">
-              <node concept="37vLTw" id="2OGPkCTl6b9" role="2Oq$k0">
-                <ref role="3cqZAo" node="2OGPkCTl61i" resolve="operationType" />
-              </node>
-              <node concept="3x8VRR" id="2OGPkCTl6qp" role="2OqNvi" />
-            </node>
-            <node concept="9aQIb" id="2OGPkCTl6MJ" role="9aQIa">
-              <node concept="3clFbS" id="2OGPkCTl6MK" role="9aQI4">
-                <node concept="3SKdUt" id="2OGPkCTl6Rt" role="3cqZAp">
-                  <node concept="1PaTwC" id="2OGPkCTl6Ru" role="3ndbpf">
-                    <node concept="3oM_SD" id="2OGPkCTl6Rw" role="1PaTwD">
-                      <property role="3oM_SC" value="in" />
-                    </node>
-                    <node concept="3oM_SD" id="2OGPkCTl6RS" role="1PaTwD">
-                      <property role="3oM_SC" value="case" />
-                    </node>
-                    <node concept="3oM_SD" id="2OGPkCTl6RV" role="1PaTwD">
-                      <property role="3oM_SC" value="the" />
-                    </node>
-                    <node concept="3oM_SD" id="2OGPkCTl6RZ" role="1PaTwD">
-                      <property role="3oM_SC" value="operation" />
-                    </node>
-                    <node concept="3oM_SD" id="2OGPkCTl6S4" role="1PaTwD">
-                      <property role="3oM_SC" value="type" />
-                    </node>
-                    <node concept="3oM_SD" id="2OGPkCTl6Sa" role="1PaTwD">
-                      <property role="3oM_SC" value="returned" />
-                    </node>
-                    <node concept="3oM_SD" id="2OGPkCTl6Sh" role="1PaTwD">
-                      <property role="3oM_SC" value="null," />
-                    </node>
-                    <node concept="3oM_SD" id="2OGPkCTl6Sp" role="1PaTwD">
-                      <property role="3oM_SC" value="i.e.," />
-                    </node>
-                    <node concept="3oM_SD" id="2OGPkCTl6Sy" role="1PaTwD">
-                      <property role="3oM_SC" value="no" />
-                    </node>
-                    <node concept="3oM_SD" id="2OGPkCTl6SG" role="1PaTwD">
-                      <property role="3oM_SC" value="special" />
-                    </node>
-                    <node concept="3oM_SD" id="2OGPkCTl6SR" role="1PaTwD">
-                      <property role="3oM_SC" value="type" />
-                    </node>
-                    <node concept="3oM_SD" id="2OGPkCTl6T3" role="1PaTwD">
-                      <property role="3oM_SC" value="needs" />
-                    </node>
-                    <node concept="3oM_SD" id="2OGPkCTl6Tg" role="1PaTwD">
-                      <property role="3oM_SC" value="to" />
-                    </node>
-                    <node concept="3oM_SD" id="2OGPkCTl6Tu" role="1PaTwD">
-                      <property role="3oM_SC" value="be" />
-                    </node>
-                    <node concept="3oM_SD" id="2OGPkCTl6TH" role="1PaTwD">
-                      <property role="3oM_SC" value="used" />
-                    </node>
-                    <node concept="3oM_SD" id="2OGPkCTl6UN" role="1PaTwD">
-                      <property role="3oM_SC" value="use" />
-                    </node>
-                    <node concept="3oM_SD" id="2OGPkCTl6Uw" role="1PaTwD">
-                      <property role="3oM_SC" value="real" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="1Z5TYs" id="4r1mNB_n4_e" role="3cqZAp">
-                  <node concept="mw_s8" id="4r1mNB_n4Al" role="1ZfhKB">
-                    <node concept="2ShNRf" id="4r1mNB_n4Ah" role="mwGJk">
-                      <node concept="3zrR0B" id="4r1mNB_n9be" role="2ShVmc">
-                        <node concept="3Tqbb2" id="4r1mNB_n9bg" role="3zrR0E">
-                          <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="mw_s8" id="4r1mNB_n4_h" role="1ZfhK$">
-                    <node concept="1Z2H0r" id="4r1mNB_n4ya" role="mwGJk">
-                      <node concept="1YBJjd" id="4iu6t1eB8Y1" role="1Z2MuG">
-                        <ref role="1YBMHb" node="4iu6t1eB8V2" resolve="sqrt" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="1ZobV4" id="4r1mNB_na5P" role="3cqZAp">
-                  <property role="3wDh2S" value="true" />
-                  <node concept="mw_s8" id="4r1mNB_na85" role="1ZfhKB">
-                    <node concept="2ShNRf" id="4r1mNB_na81" role="mwGJk">
-                      <node concept="3zrR0B" id="4r1mNB_naew" role="2ShVmc">
-                        <node concept="3Tqbb2" id="4r1mNB_naey" role="3zrR0E">
-                          <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="mw_s8" id="4r1mNB_na5S" role="1ZfhK$">
-                    <node concept="1Z2H0r" id="4r1mNB_n9di" role="mwGJk">
-                      <node concept="2OqwBi" id="4r1mNB_n9k1" role="1Z2MuG">
-                        <node concept="1YBJjd" id="4iu6t1eB8ZU" role="2Oq$k0">
-                          <ref role="1YBMHb" node="4iu6t1eB8V2" resolve="sqrt" />
-                        </node>
-                        <node concept="3TrEf2" id="4iu6t1eBa72" role="2OqNvi">
-                          <ref role="3Tt5mk" to="1qv1:4iu6t1eB9SW" resolve="expr" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
+            <node concept="mw_s8" id="6q$NxWgcBYy" role="1ZfhK$">
+              <node concept="1Z2H0r" id="6q$NxWgcB9_" role="mwGJk">
+                <node concept="1YBJjd" id="6q$NxWgcBy8" role="1Z2MuG">
+                  <ref role="1YBMHb" node="4iu6t1eB8V2" resolve="sqrt" />
                 </node>
               </node>
             </node>
@@ -1587,6 +1239,571 @@
     <node concept="1YaCAy" id="5mz5Tt_jQxQ" role="1YuTPh">
       <property role="TrG5h" value="toInteger" />
       <ref role="1YaFvo" to="1qv1:5mz5Tt_jQwU" resolve="ToInteger" />
+    </node>
+  </node>
+  <node concept="3hdX5o" id="6q$NxWgbHC$">
+    <property role="TrG5h" value="MathExpressionsOpRules" />
+    <node concept="3ciAk0" id="6q$NxWgbHE_" role="3he0YX">
+      <property role="3PlbSO" value="true" />
+      <node concept="10Nm6u" id="6q$NxWgbIzW" role="3ciSnv" />
+      <node concept="3gn64h" id="6q$NxWgbHHg" role="32tDTA">
+        <ref role="3gnhBz" to="1qv1:4iu6t1eB8RC" resolve="SqrtExpression" />
+      </node>
+      <node concept="3ciZUL" id="6q$NxWgbHET" role="32tDT$">
+        <node concept="3clFbS" id="6q$NxWgbHEY" role="2VODD2">
+          <node concept="3cpWs6" id="6q$NxWgbLAL" role="3cqZAp">
+            <node concept="2ShNRf" id="6q$NxWgbLAX" role="3cqZAk">
+              <node concept="3zrR0B" id="6q$NxWgbLQO" role="2ShVmc">
+                <node concept="3Tqbb2" id="6q$NxWgbLQQ" role="3zrR0E">
+                  <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2pJPEk" id="6q$NxWgcK91" role="3ciSkW">
+        <node concept="2pJPED" id="6q$NxWgcK9Y" role="2pJPEn">
+          <ref role="2pJxaS" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+        </node>
+      </node>
+      <node concept="1QeDOX" id="6q$NxWgeeOY" role="1QeD3i">
+        <node concept="3clFbS" id="6q$NxWgeeOZ" role="2VODD2">
+          <node concept="3cpWs6" id="6q$NxWgeePH" role="3cqZAp">
+            <node concept="2OqwBi" id="6q$NxWgeePO" role="3cqZAk">
+              <node concept="1PxgMI" id="6q$NxWgeePP" role="2Oq$k0">
+                <node concept="chp4Y" id="6q$NxWgeePQ" role="3oSUPX">
+                  <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                </node>
+                <node concept="3cjfiJ" id="6q$NxWgeePR" role="1m5AlR" />
+              </node>
+              <node concept="2qgKlT" id="6q$NxWgeePS" role="2OqNvi">
+                <ref role="37wK5l" to="pbu6:7McqtXG$h_u" resolve="notRequiresSpecialCapability" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3ciAk0" id="6q$NxWgdrf1" role="3he0YX">
+      <property role="3PlbSO" value="true" />
+      <node concept="2pJPEk" id="6q$NxWgdrlQ" role="3ciSkW">
+        <node concept="2pJPED" id="6q$NxWgdrma" role="2pJPEn">
+          <ref role="2pJxaS" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+        </node>
+      </node>
+      <node concept="10Nm6u" id="6q$NxWgdrln" role="3ciSnv" />
+      <node concept="3gn64h" id="6q$NxWgdrkP" role="32tDTA">
+        <ref role="3gnhBz" to="1qv1:4iu6t1eAWup" resolve="AbsExpression" />
+      </node>
+      <node concept="3ciZUL" id="6q$NxWgdrfl" role="32tDT$">
+        <node concept="3clFbS" id="6q$NxWgdrfq" role="2VODD2">
+          <node concept="3cpWs6" id="6q$NxWgdrs1" role="3cqZAp">
+            <node concept="2ShNRf" id="6q$NxWgdrsf" role="3cqZAk">
+              <node concept="3zrR0B" id="6q$NxWgdr_W" role="2ShVmc">
+                <node concept="3Tqbb2" id="6q$NxWgdr_Y" role="3zrR0E">
+                  <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1QeDOX" id="6q$NxWgefDP" role="1QeD3i">
+        <node concept="3clFbS" id="6q$NxWgefDQ" role="2VODD2">
+          <node concept="3cpWs6" id="6q$NxWgefTf" role="3cqZAp">
+            <node concept="2OqwBi" id="6q$NxWgefTg" role="3cqZAk">
+              <node concept="1PxgMI" id="6q$NxWgefTh" role="2Oq$k0">
+                <node concept="chp4Y" id="6q$NxWgefTi" role="3oSUPX">
+                  <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                </node>
+                <node concept="3cjfiJ" id="6q$NxWgefTj" role="1m5AlR" />
+              </node>
+              <node concept="2qgKlT" id="6q$NxWgefTk" role="2OqNvi">
+                <ref role="37wK5l" to="pbu6:7McqtXG$h_u" resolve="notRequiresSpecialCapability" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="32tXgB" id="6q$NxWgdcif" role="3he0YX">
+      <node concept="2pJPEk" id="6q$NxWgdcju" role="32tDTd">
+        <node concept="2pJPED" id="6q$NxWgdcjG" role="2pJPEn">
+          <ref role="2pJxaS" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+        </node>
+      </node>
+      <node concept="3gn64h" id="6q$NxWgdcjj" role="32tDTA">
+        <ref role="3gnhBz" to="1qv1:4iu6t1eAWP6" resolve="FractionExpression" />
+      </node>
+      <node concept="3ciZUL" id="6q$NxWgdciu" role="32tDT$">
+        <node concept="3clFbS" id="6q$NxWgdciz" role="2VODD2">
+          <node concept="3cpWs8" id="6q$NxWgdjvH" role="3cqZAp">
+            <node concept="3cpWsn" id="6q$NxWgdjvI" role="3cpWs9">
+              <property role="TrG5h" value="numType" />
+              <node concept="3Tqbb2" id="6q$NxWgdjuH" role="1tU5fm" />
+              <node concept="3cjfiJ" id="6q$NxWgdjvJ" role="33vP2m" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="6q$NxWgdjQB" role="3cqZAp">
+            <node concept="3cpWsn" id="6q$NxWgdjQC" role="3cpWs9">
+              <property role="TrG5h" value="denType" />
+              <node concept="3Tqbb2" id="6q$NxWgdjPu" role="1tU5fm" />
+              <node concept="3cjoZ5" id="6q$NxWgdjQD" role="33vP2m" />
+            </node>
+          </node>
+          <node concept="3clFbJ" id="6q$NxWgdivd" role="3cqZAp">
+            <node concept="3clFbS" id="6q$NxWgdive" role="3clFbx">
+              <node concept="3cpWs6" id="6q$NxWgdiLa" role="3cqZAp">
+                <node concept="2pJPEk" id="6q$NxWgdiNa" role="3cqZAk">
+                  <node concept="2pJPED" id="6q$NxWgdiP1" role="2pJPEn">
+                    <ref role="2pJxaS" to="1qv1:5mz5Tt_h1dJ" resolve="RationalType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1Wc70l" id="6q$NxWgdivm" role="3clFbw">
+              <node concept="2YIFZM" id="6q$NxWgdivn" role="3uHU7B">
+                <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+                <ref role="37wK5l" to="xfg9:2Qbt$1tU33e" resolve="isIntegerType" />
+                <node concept="37vLTw" id="6q$NxWgdk5s" role="37wK5m">
+                  <ref role="3cqZAo" node="6q$NxWgdjvI" resolve="numType" />
+                </node>
+              </node>
+              <node concept="2YIFZM" id="6q$NxWgdivp" role="3uHU7w">
+                <ref role="37wK5l" to="xfg9:2Qbt$1tU33e" resolve="isIntegerType" />
+                <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+                <node concept="37vLTw" id="6q$NxWgdkmh" role="37wK5m">
+                  <ref role="3cqZAo" node="6q$NxWgdjQC" resolve="denType" />
+                </node>
+              </node>
+            </node>
+            <node concept="9aQIb" id="6q$NxWgdivr" role="9aQIa">
+              <node concept="3clFbS" id="6q$NxWgdivs" role="9aQI4">
+                <node concept="3cpWs6" id="6q$NxWgdj1F" role="3cqZAp">
+                  <node concept="3h4ouC" id="6q$NxWgdlxK" role="3cqZAk">
+                    <node concept="2pJPEk" id="6q$NxWgdl$H" role="3h4sjZ">
+                      <node concept="2pJPED" id="6q$NxWgdlDv" role="2pJPEn">
+                        <ref role="2pJxaS" to="hm2y:4rZeNQ6MGoV" resolve="DivExpression" />
+                        <node concept="2pIpSj" id="6q$NxWgdlGj" role="2pJxcM">
+                          <ref role="2pIpSl" to="hm2y:4rZeNQ6MpKm" resolve="left" />
+                          <node concept="36biLy" id="6q$NxWgdlL6" role="28nt2d">
+                            <node concept="2OqwBi" id="6q$NxWgdmNB" role="36biLW">
+                              <node concept="2OqwBi" id="6q$NxWgdlZf" role="2Oq$k0">
+                                <node concept="3cjoe7" id="6q$NxWgdlLu" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="6q$NxWgdmik" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="1qv1:4iu6t1eAWP7" resolve="numerator" />
+                                </node>
+                              </node>
+                              <node concept="1$rogu" id="6q$NxWgdn11" role="2OqNvi" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2pIpSj" id="6q$NxWgdn9R" role="2pJxcM">
+                          <ref role="2pIpSl" to="hm2y:4rZeNQ6MpKo" resolve="right" />
+                          <node concept="36biLy" id="6q$NxWgdndi" role="28nt2d">
+                            <node concept="2OqwBi" id="6q$NxWgdnS7" role="36biLW">
+                              <node concept="2OqwBi" id="6q$NxWgdnrr" role="2Oq$k0">
+                                <node concept="3cjoe7" id="6q$NxWgdndE" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="6q$NxWgdnIw" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="1qv1:4iu6t1eAWPa" resolve="denominator" />
+                                </node>
+                              </node>
+                              <node concept="1$rogu" id="6q$NxWgdoly" role="2OqNvi" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="6q$NxWgdoml" role="3h4u4a">
+                      <ref role="3cqZAo" node="6q$NxWgdjvI" resolve="numType" />
+                    </node>
+                    <node concept="37vLTw" id="6q$NxWgdouO" role="3h4u2h">
+                      <ref role="3cqZAo" node="6q$NxWgdjQC" resolve="denType" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="6q$NxWgdcjZ" role="3cqZAp" />
+        </node>
+      </node>
+      <node concept="1QeDOX" id="6q$NxWgecwF" role="1QeD3i">
+        <node concept="3clFbS" id="6q$NxWgecwG" role="2VODD2">
+          <node concept="3cpWs6" id="6q$NxWgecGW" role="3cqZAp">
+            <node concept="1Wc70l" id="6q$NxWgedJr" role="3cqZAk">
+              <node concept="2OqwBi" id="6q$NxWgeer_" role="3uHU7w">
+                <node concept="1PxgMI" id="6q$NxWgee2$" role="2Oq$k0">
+                  <node concept="chp4Y" id="6q$NxWgeefB" role="3oSUPX">
+                    <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                  </node>
+                  <node concept="3cjoZ5" id="6q$NxWgedSS" role="1m5AlR" />
+                </node>
+                <node concept="2qgKlT" id="6q$NxWgeeFn" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:7McqtXG$h_u" resolve="notRequiresSpecialCapability" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="6q$NxWgedb0" role="3uHU7B">
+                <node concept="1PxgMI" id="6q$NxWgecUc" role="2Oq$k0">
+                  <node concept="chp4Y" id="6q$NxWgecV0" role="3oSUPX">
+                    <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                  </node>
+                  <node concept="3cjfiJ" id="6q$NxWgecHw" role="1m5AlR" />
+                </node>
+                <node concept="2qgKlT" id="6q$NxWgedok" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:7McqtXG$h_u" resolve="notRequiresSpecialCapability" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3ciAk0" id="6q$NxWgdcmE" role="3he0YX">
+      <node concept="2pJPEk" id="6q$NxWgdcpU" role="3ciSkW">
+        <node concept="2pJPED" id="6q$NxWgdcqe" role="2pJPEn">
+          <ref role="2pJxaS" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+        </node>
+      </node>
+      <node concept="3gn64h" id="6q$NxWgdcpD" role="32tDTA">
+        <ref role="3gnhBz" to="1qv1:4iu6t1eB654" resolve="PowerExpression" />
+      </node>
+      <node concept="3ciZUL" id="6q$NxWgdcmY" role="32tDT$">
+        <node concept="3clFbS" id="6q$NxWgdcn3" role="2VODD2">
+          <node concept="3cpWs6" id="6q$NxWgdhMf" role="3cqZAp">
+            <node concept="2ShNRf" id="6q$NxWgdhMt" role="3cqZAk">
+              <node concept="3zrR0B" id="6q$NxWgdhWa" role="2ShVmc">
+                <node concept="3Tqbb2" id="6q$NxWgdhWc" role="3zrR0E">
+                  <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1QeDOX" id="6q$NxWgeeVw" role="1QeD3i">
+        <node concept="3clFbS" id="6q$NxWgeeVx" role="2VODD2">
+          <node concept="3cpWs6" id="6q$NxWgeeZM" role="3cqZAp">
+            <node concept="1Wc70l" id="50kkvMT08vO" role="3cqZAk">
+              <node concept="2OqwBi" id="50kkvMT09So" role="3uHU7w">
+                <node concept="1PxgMI" id="50kkvMT09lo" role="2Oq$k0">
+                  <node concept="chp4Y" id="50kkvMT09z0" role="3oSUPX">
+                    <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                  </node>
+                  <node concept="3cjoZ5" id="50kkvMT08Ee" role="1m5AlR" />
+                </node>
+                <node concept="2qgKlT" id="50kkvMT0afD" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:7McqtXG$h_u" resolve="notRequiresSpecialCapability" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="6q$NxWgeeZT" role="3uHU7B">
+                <node concept="1PxgMI" id="6q$NxWgeeZU" role="2Oq$k0">
+                  <node concept="chp4Y" id="6q$NxWgeeZV" role="3oSUPX">
+                    <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                  </node>
+                  <node concept="3cjfiJ" id="6q$NxWgeeZW" role="1m5AlR" />
+                </node>
+                <node concept="2qgKlT" id="6q$NxWgeeZX" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:7McqtXG$h_u" resolve="notRequiresSpecialCapability" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2pJPEk" id="50kkvMT07D2" role="3ciSnv">
+        <node concept="2pJPED" id="50kkvMT07To" role="2pJPEn">
+          <ref role="2pJxaS" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="18kY7G" id="6q$NxWgcCaU">
+    <property role="TrG5h" value="check_SqrtExpression" />
+    <node concept="3clFbS" id="6q$NxWgcCaV" role="18ibNy">
+      <node concept="3clFbF" id="6q$NxWgd7qE" role="3cqZAp">
+        <node concept="2YIFZM" id="6q$NxWgd8y6" role="3clFbG">
+          <ref role="37wK5l" node="6q$NxWgd7rp" resolve="ensureTypeIsNotNull" />
+          <ref role="1Pybhc" node="6q$NxWgd429" resolve="MathTypesystemHelper" />
+          <node concept="2OqwBi" id="6q$NxWgd8FU" role="37wK5m">
+            <node concept="1YBJjd" id="6q$NxWgd8yl" role="2Oq$k0">
+              <ref role="1YBMHb" node="6q$NxWgcCbn" resolve="sqrtExpression" />
+            </node>
+            <node concept="3JvlWi" id="6q$NxWgd8Lr" role="2OqNvi" />
+          </node>
+          <node concept="1YBJjd" id="6q$NxWgd8Ni" role="37wK5m">
+            <ref role="1YBMHb" node="6q$NxWgcCbn" resolve="sqrtExpression" />
+          </node>
+          <node concept="2OqwBi" id="6q$NxWge_Gf" role="37wK5m">
+            <node concept="2OqwBi" id="6q$NxWgeytZ" role="2Oq$k0">
+              <node concept="1YBJjd" id="6q$NxWgeyjD" role="2Oq$k0">
+                <ref role="1YBMHb" node="6q$NxWgcCbn" resolve="sqrtExpression" />
+              </node>
+              <node concept="3TrEf2" id="6q$NxWgeyFB" role="2OqNvi">
+                <ref role="3Tt5mk" to="1qv1:4iu6t1eB9SW" resolve="expr" />
+              </node>
+            </node>
+            <node concept="3JvlWi" id="6q$NxWge_KU" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="6q$NxWgcCbn" role="1YuTPh">
+      <property role="TrG5h" value="sqrtExpression" />
+      <ref role="1YaFvo" to="1qv1:4iu6t1eB8RC" resolve="SqrtExpression" />
+    </node>
+  </node>
+  <node concept="312cEu" id="6q$NxWgd429">
+    <property role="TrG5h" value="MathTypesystemHelper" />
+    <node concept="3clFbW" id="6q$NxWgd43V" role="jymVt">
+      <node concept="3cqZAl" id="6q$NxWgd43X" role="3clF45" />
+      <node concept="3Tm6S6" id="6q$NxWgd44l" role="1B3o_S" />
+      <node concept="3clFbS" id="6q$NxWgd43Z" role="3clF47" />
+    </node>
+    <node concept="2tJIrI" id="6q$NxWgd44B" role="jymVt" />
+    <node concept="2YIFZL" id="6q$NxWgd7rp" role="jymVt">
+      <property role="TrG5h" value="ensureTypeIsNotNull" />
+      <node concept="3clFbS" id="6q$NxWgd7rt" role="3clF47">
+        <node concept="3clFbJ" id="6q$NxWgeACm" role="3cqZAp">
+          <node concept="3clFbS" id="6q$NxWgeACo" role="3clFbx">
+            <node concept="3cpWs8" id="6q$NxWgeFBy" role="3cqZAp">
+              <node concept="3cpWsn" id="6q$NxWgeFBz" role="3cpWs9">
+                <property role="TrG5h" value="innerTypesString" />
+                <node concept="17QB3L" id="6q$NxWgeFAt" role="1tU5fm" />
+                <node concept="2OqwBi" id="6q$NxWgeFB$" role="33vP2m">
+                  <node concept="2OqwBi" id="6q$NxWgeFB_" role="2Oq$k0">
+                    <node concept="2OqwBi" id="6q$NxWgeFBA" role="2Oq$k0">
+                      <node concept="37vLTw" id="6q$NxWgeFBB" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6q$NxWgeoNC" resolve="innerTypes" />
+                      </node>
+                      <node concept="39bAoz" id="6q$NxWgeFBC" role="2OqNvi" />
+                    </node>
+                    <node concept="3$u5V9" id="6q$NxWgeFBD" role="2OqNvi">
+                      <node concept="1bVj0M" id="6q$NxWgeFBE" role="23t8la">
+                        <node concept="3clFbS" id="6q$NxWgeFBF" role="1bW5cS">
+                          <node concept="3clFbF" id="6q$NxWgeFBG" role="3cqZAp">
+                            <node concept="3K4zz7" id="6q$NxWgeFBH" role="3clFbG">
+                              <node concept="2OqwBi" id="6q$NxWgeFBI" role="3K4E3e">
+                                <node concept="2OqwBi" id="6q$NxWgeFBJ" role="2Oq$k0">
+                                  <node concept="37vLTw" id="6q$NxWgeFBK" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="6q$NxWgeFBR" resolve="it" />
+                                  </node>
+                                  <node concept="2yIwOk" id="6q$NxWgeFBL" role="2OqNvi" />
+                                </node>
+                                <node concept="liA8E" id="6q$NxWgeFBM" role="2OqNvi">
+                                  <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
+                                </node>
+                              </node>
+                              <node concept="Xl_RD" id="6q$NxWgeFBN" role="3K4GZi">
+                                <property role="Xl_RC" value="&lt;no type&gt;" />
+                              </node>
+                              <node concept="2OqwBi" id="6q$NxWgeFBO" role="3K4Cdx">
+                                <node concept="37vLTw" id="6q$NxWgeFBP" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="6q$NxWgeFBR" resolve="it" />
+                                </node>
+                                <node concept="3x8VRR" id="6q$NxWgeFBQ" role="2OqNvi" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="6q$NxWgeFBR" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="6q$NxWgeFBS" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3uJxvA" id="6q$NxWgeFBT" role="2OqNvi">
+                    <node concept="Xl_RD" id="6q$NxWgeJCF" role="3uJOhx">
+                      <property role="Xl_RC" value=", " />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2MkqsV" id="6q$NxWgeBa4" role="3cqZAp">
+              <node concept="37vLTw" id="6q$NxWgeTU5" role="1urrMF">
+                <ref role="3cqZAo" node="6q$NxWgd7r$" resolve="nodeWithType" />
+              </node>
+              <node concept="2YIFZM" id="6q$NxWgep0D" role="2MkJ7o">
+                <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
+                <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                <node concept="Xl_RD" id="6q$NxWgd7y4" role="37wK5m">
+                  <property role="Xl_RC" value="Cannot infer type for %s. Reason: The inner type %s is not supported." />
+                </node>
+                <node concept="2OqwBi" id="6q$NxWgeLb4" role="37wK5m">
+                  <node concept="2OqwBi" id="6q$NxWgeKJz" role="2Oq$k0">
+                    <node concept="37vLTw" id="50kkvMSZM5Z" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6q$NxWgd7r$" resolve="nodeWithType" />
+                    </node>
+                    <node concept="2yIwOk" id="6q$NxWgeKTz" role="2OqNvi" />
+                  </node>
+                  <node concept="liA8E" id="6q$NxWgeLsW" role="2OqNvi">
+                    <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="6q$NxWgeLPp" role="37wK5m">
+                  <ref role="3cqZAo" node="6q$NxWgeFBz" resolve="innerTypesString" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="6q$NxWgeANu" role="3clFbw">
+            <node concept="37vLTw" id="6q$NxWgeTO8" role="2Oq$k0">
+              <ref role="3cqZAo" node="6q$NxWgd7Cv" resolve="type" />
+            </node>
+            <node concept="3w_OXm" id="6q$NxWgeB60" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="6q$NxWgd7rr" role="3clF45" />
+      <node concept="2AHcQZ" id="6q$NxWgd8kB" role="2AJF6D">
+        <ref role="2AI5Lk" to="tpd5:hNAUp6x" resolve="CheckingMethod" />
+      </node>
+      <node concept="37vLTG" id="6q$NxWgd7Cv" role="3clF46">
+        <property role="TrG5h" value="type" />
+        <node concept="3Tqbb2" id="6q$NxWgd7CR" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6q$NxWgd7r$" role="3clF46">
+        <property role="TrG5h" value="nodeWithType" />
+        <node concept="3Tqbb2" id="6q$NxWgd7r_" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6q$NxWgeoNC" role="3clF46">
+        <property role="TrG5h" value="innerTypes" />
+        <node concept="8X2XB" id="6q$NxWgeA5t" role="1tU5fm">
+          <node concept="3Tqbb2" id="6q$NxWgeoT5" role="8Xvag" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6q$NxWgd7rs" role="1B3o_S" />
+    </node>
+    <node concept="3Tm1VV" id="6q$NxWgd42a" role="1B3o_S" />
+  </node>
+  <node concept="18kY7G" id="6q$NxWgdd9S">
+    <property role="TrG5h" value="check_PowerExpression" />
+    <node concept="3clFbS" id="6q$NxWgdd9T" role="18ibNy">
+      <node concept="3clFbF" id="6q$NxWgdda5" role="3cqZAp">
+        <node concept="2YIFZM" id="6q$NxWgddas" role="3clFbG">
+          <ref role="37wK5l" node="6q$NxWgd7rp" resolve="ensureTypeIsNotNull" />
+          <ref role="1Pybhc" node="6q$NxWgd429" resolve="MathTypesystemHelper" />
+          <node concept="2OqwBi" id="6q$NxWgddkM" role="37wK5m">
+            <node concept="1YBJjd" id="6q$NxWgddaF" role="2Oq$k0">
+              <ref role="1YBMHb" node="6q$NxWgdd9V" resolve="powerExpression" />
+            </node>
+            <node concept="3JvlWi" id="6q$NxWgdd$b" role="2OqNvi" />
+          </node>
+          <node concept="1YBJjd" id="6q$NxWgddAE" role="37wK5m">
+            <ref role="1YBMHb" node="6q$NxWgdd9V" resolve="powerExpression" />
+          </node>
+          <node concept="2OqwBi" id="6q$NxWgexLo" role="37wK5m">
+            <node concept="2OqwBi" id="6q$NxWgexnA" role="2Oq$k0">
+              <node concept="1YBJjd" id="6q$NxWgexdg" role="2Oq$k0">
+                <ref role="1YBMHb" node="6q$NxWgdd9V" resolve="powerExpression" />
+              </node>
+              <node concept="3TrEf2" id="6q$NxWgex_e" role="2OqNvi">
+                <ref role="3Tt5mk" to="1qv1:4iu6t1eBdVy" resolve="expr" />
+              </node>
+            </node>
+            <node concept="3JvlWi" id="6q$NxWgeydy" role="2OqNvi" />
+          </node>
+          <node concept="2OqwBi" id="50kkvMT05WO" role="37wK5m">
+            <node concept="2OqwBi" id="50kkvMT05eR" role="2Oq$k0">
+              <node concept="1YBJjd" id="50kkvMT050I" role="2Oq$k0">
+                <ref role="1YBMHb" node="6q$NxWgdd9V" resolve="powerExpression" />
+              </node>
+              <node concept="3TrEf2" id="50kkvMT05yf" role="2OqNvi">
+                <ref role="3Tt5mk" to="1qv1:4r1mNB_o5WJ" resolve="exponent" />
+              </node>
+            </node>
+            <node concept="3JvlWi" id="50kkvMT06sz" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="6q$NxWgdd9V" role="1YuTPh">
+      <property role="TrG5h" value="powerExpression" />
+      <ref role="1YaFvo" to="1qv1:4iu6t1eB654" resolve="PowerExpression" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="6q$NxWgdpdO">
+    <property role="TrG5h" value="check_AbsExpression" />
+    <node concept="3clFbS" id="6q$NxWgdpdP" role="18ibNy">
+      <node concept="3clFbF" id="6q$NxWgdpe1" role="3cqZAp">
+        <node concept="2YIFZM" id="6q$NxWgdpeq" role="3clFbG">
+          <ref role="37wK5l" node="6q$NxWgd7rp" resolve="ensureTypeIsNotNull" />
+          <ref role="1Pybhc" node="6q$NxWgd429" resolve="MathTypesystemHelper" />
+          <node concept="2OqwBi" id="6q$NxWgdpoK" role="37wK5m">
+            <node concept="1YBJjd" id="6q$NxWgdpeD" role="2Oq$k0">
+              <ref role="1YBMHb" node="6q$NxWgdpdR" resolve="absExpression" />
+            </node>
+            <node concept="3JvlWi" id="6q$NxWgdpBy" role="2OqNvi" />
+          </node>
+          <node concept="1YBJjd" id="6q$NxWgdpCE" role="37wK5m">
+            <ref role="1YBMHb" node="6q$NxWgdpdR" resolve="absExpression" />
+          </node>
+          <node concept="2OqwBi" id="6q$NxWge_9O" role="37wK5m">
+            <node concept="2OqwBi" id="6q$NxWgeyW2" role="2Oq$k0">
+              <node concept="1YBJjd" id="6q$NxWgeyLG" role="2Oq$k0">
+                <ref role="1YBMHb" node="6q$NxWgdpdR" resolve="absExpression" />
+              </node>
+              <node concept="3TrEf2" id="6q$NxWgez9z" role="2OqNvi">
+                <ref role="3Tt5mk" to="1qv1:4iu6t1eB97r" resolve="expr" />
+              </node>
+            </node>
+            <node concept="3JvlWi" id="6q$NxWge_pU" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="6q$NxWgdpdR" role="1YuTPh">
+      <property role="TrG5h" value="absExpression" />
+      <ref role="1YaFvo" to="1qv1:4iu6t1eAWup" resolve="AbsExpression" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="6q$NxWgduJF">
+    <property role="TrG5h" value="check_FractionExpression" />
+    <node concept="3clFbS" id="6q$NxWgduJG" role="18ibNy">
+      <node concept="3clFbF" id="6q$NxWgdvfg" role="3cqZAp">
+        <node concept="2YIFZM" id="6q$NxWgdvfB" role="3clFbG">
+          <ref role="37wK5l" node="6q$NxWgd7rp" resolve="ensureTypeIsNotNull" />
+          <ref role="1Pybhc" node="6q$NxWgd429" resolve="MathTypesystemHelper" />
+          <node concept="2OqwBi" id="6q$NxWgdvvd" role="37wK5m">
+            <node concept="1YBJjd" id="6q$NxWgdvfQ" role="2Oq$k0">
+              <ref role="1YBMHb" node="6q$NxWgdvf6" resolve="fractionExpression" />
+            </node>
+            <node concept="3JvlWi" id="6q$NxWgdvMv" role="2OqNvi" />
+          </node>
+          <node concept="1YBJjd" id="6q$NxWgdvND" role="37wK5m">
+            <ref role="1YBMHb" node="6q$NxWgdvf6" resolve="fractionExpression" />
+          </node>
+          <node concept="2OqwBi" id="6q$NxWge$$3" role="37wK5m">
+            <node concept="2OqwBi" id="6q$NxWgewRa" role="2Oq$k0">
+              <node concept="1YBJjd" id="6q$NxWgewDX" role="2Oq$k0">
+                <ref role="1YBMHb" node="6q$NxWgdvf6" resolve="fractionExpression" />
+              </node>
+              <node concept="3TrEf2" id="6q$NxWgezz4" role="2OqNvi">
+                <ref role="3Tt5mk" to="1qv1:4iu6t1eAWPa" resolve="denominator" />
+              </node>
+            </node>
+            <node concept="3JvlWi" id="6q$NxWge$P2" role="2OqNvi" />
+          </node>
+          <node concept="2OqwBi" id="6q$NxWge$9W" role="37wK5m">
+            <node concept="2OqwBi" id="6q$NxWgezSn" role="2Oq$k0">
+              <node concept="1YBJjd" id="6q$NxWgezGg" role="2Oq$k0">
+                <ref role="1YBMHb" node="6q$NxWgdvf6" resolve="fractionExpression" />
+              </node>
+              <node concept="3TrEf2" id="6q$NxWgezVX" role="2OqNvi">
+                <ref role="3Tt5mk" to="1qv1:4iu6t1eAWP7" resolve="numerator" />
+              </node>
+            </node>
+            <node concept="3JvlWi" id="6q$NxWge$nI" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="6q$NxWgdvf6" role="1YuTPh">
+      <property role="TrG5h" value="fractionExpression" />
+      <ref role="1YaFvo" to="1qv1:4iu6t1eAWP6" resolve="FractionExpression" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/typesystem.mps
@@ -677,70 +677,151 @@
   <node concept="1YbPZF" id="4iu6t1eB68j">
     <property role="TrG5h" value="typeof_PowerExpression" />
     <node concept="3clFbS" id="4iu6t1eB68k" role="18ibNy">
-      <node concept="1Z5TYs" id="6q$NxWeJqFX" role="3cqZAp">
-        <node concept="mw_s8" id="6q$NxWeJqFY" role="1ZfhKB">
-          <node concept="2ShNRf" id="6q$NxWeJqFZ" role="mwGJk">
-            <node concept="3zrR0B" id="6q$NxWeJqG0" role="2ShVmc">
-              <node concept="3Tqbb2" id="6q$NxWeJqG1" role="3zrR0E">
-                <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+      <node concept="nvevp" id="6q$NxWeVY1B" role="3cqZAp">
+        <node concept="3clFbS" id="6q$NxWeVY1D" role="nvhr_">
+          <node concept="nvevp" id="6q$NxWeVYAi" role="3cqZAp">
+            <node concept="3clFbS" id="6q$NxWeVYAk" role="nvhr_">
+              <node concept="3cpWs8" id="6q$NxWeVZo8" role="3cqZAp">
+                <node concept="3cpWsn" id="6q$NxWeVZo9" role="3cpWs9">
+                  <property role="TrG5h" value="operationType" />
+                  <node concept="3Tqbb2" id="6q$NxWeVZly" role="1tU5fm" />
+                  <node concept="3h4ouC" id="6q$NxWeVZoa" role="33vP2m">
+                    <node concept="1YBJjd" id="6q$NxWeVZob" role="3h4sjZ">
+                      <ref role="1YBMHb" node="4iu6t1eB68m" resolve="pe" />
+                    </node>
+                    <node concept="2X3wrD" id="6q$NxWf2ALD" role="3h4u4a">
+                      <ref role="2X3Bk0" node="6q$NxWeVY1H" resolve="innerPowerExpressionType" />
+                    </node>
+                    <node concept="2X3wrD" id="6q$NxWf2AWd" role="3h4u2h">
+                      <ref role="2X3Bk0" node="6q$NxWeVYAo" resolve="exponentType" />
+                    </node>
+                  </node>
+                </node>
               </node>
+              <node concept="3clFbJ" id="6q$NxWeVZs1" role="3cqZAp">
+                <node concept="3clFbS" id="6q$NxWeVZs3" role="3clFbx">
+                  <node concept="1Z5TYs" id="6q$NxWeW0ya" role="3cqZAp">
+                    <node concept="mw_s8" id="6q$NxWeW0ys" role="1ZfhKB">
+                      <node concept="37vLTw" id="6q$NxWeW0yq" role="mwGJk">
+                        <ref role="3cqZAo" node="6q$NxWeVZo9" resolve="operationType" />
+                      </node>
+                    </node>
+                    <node concept="mw_s8" id="6q$NxWeW0yd" role="1ZfhK$">
+                      <node concept="1Z2H0r" id="6q$NxWeW0np" role="mwGJk">
+                        <node concept="1YBJjd" id="6q$NxWeW0nD" role="1Z2MuG">
+                          <ref role="1YBMHb" node="4iu6t1eB68m" resolve="pe" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="6q$NxWeVZ_z" role="3clFbw">
+                  <node concept="37vLTw" id="6q$NxWeVZt0" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6q$NxWeVZo9" resolve="operationType" />
+                  </node>
+                  <node concept="3x8VRR" id="6q$NxWeVZGg" role="2OqNvi" />
+                </node>
+                <node concept="9aQIb" id="6q$NxWeVZJG" role="9aQIa">
+                  <node concept="3clFbS" id="6q$NxWeVZJH" role="9aQI4">
+                    <node concept="1Z5TYs" id="6q$NxWeJqFX" role="3cqZAp">
+                      <node concept="mw_s8" id="6q$NxWeJqFY" role="1ZfhKB">
+                        <node concept="2ShNRf" id="6q$NxWeJqFZ" role="mwGJk">
+                          <node concept="3zrR0B" id="6q$NxWeJqG0" role="2ShVmc">
+                            <node concept="3Tqbb2" id="6q$NxWeJqG1" role="3zrR0E">
+                              <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="mw_s8" id="6q$NxWeJqG2" role="1ZfhK$">
+                        <node concept="1Z2H0r" id="6q$NxWeJqG3" role="mwGJk">
+                          <node concept="1YBJjd" id="6q$NxWeJqIz" role="1Z2MuG">
+                            <ref role="1YBMHb" node="4iu6t1eB68m" resolve="pe" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1ZobV4" id="6q$NxWeJqG5" role="3cqZAp">
+                      <property role="3wDh2S" value="true" />
+                      <node concept="mw_s8" id="6q$NxWeJqG6" role="1ZfhK$">
+                        <node concept="1Z2H0r" id="6q$NxWeJqG7" role="mwGJk">
+                          <node concept="2OqwBi" id="6q$NxWeJqG8" role="1Z2MuG">
+                            <node concept="1YBJjd" id="6q$NxWeJqIO" role="2Oq$k0">
+                              <ref role="1YBMHb" node="4iu6t1eB68m" resolve="pe" />
+                            </node>
+                            <node concept="3TrEf2" id="6q$NxWeJqGa" role="2OqNvi">
+                              <ref role="3Tt5mk" to="1qv1:4r1mNB_o5WJ" resolve="exponent" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="mw_s8" id="6q$NxWeJqGb" role="1ZfhKB">
+                        <node concept="2ShNRf" id="6q$NxWeJqGc" role="mwGJk">
+                          <node concept="3zrR0B" id="6q$NxWeJqGd" role="2ShVmc">
+                            <node concept="3Tqbb2" id="6q$NxWeJqGe" role="3zrR0E">
+                              <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1ZobV4" id="6q$NxWeJqGf" role="3cqZAp">
+                      <property role="3wDh2S" value="true" />
+                      <node concept="mw_s8" id="6q$NxWeJqGg" role="1ZfhK$">
+                        <node concept="1Z2H0r" id="6q$NxWeJqGh" role="mwGJk">
+                          <node concept="2OqwBi" id="6q$NxWeJqGi" role="1Z2MuG">
+                            <node concept="1YBJjd" id="6q$NxWeJqL_" role="2Oq$k0">
+                              <ref role="1YBMHb" node="4iu6t1eB68m" resolve="pe" />
+                            </node>
+                            <node concept="3TrEf2" id="6q$NxWeJqGk" role="2OqNvi">
+                              <ref role="3Tt5mk" to="1qv1:4iu6t1eBdVy" resolve="expr" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="mw_s8" id="6q$NxWeJqGl" role="1ZfhKB">
+                        <node concept="2ShNRf" id="6q$NxWeJqGm" role="mwGJk">
+                          <node concept="3zrR0B" id="6q$NxWeJqGn" role="2ShVmc">
+                            <node concept="3Tqbb2" id="6q$NxWeJqGo" role="3zrR0E">
+                              <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1Z2H0r" id="6q$NxWeVYB8" role="nvjzm">
+              <node concept="2OqwBi" id="6q$NxWeVYVh" role="1Z2MuG">
+                <node concept="1YBJjd" id="6q$NxWeVYB$" role="2Oq$k0">
+                  <ref role="1YBMHb" node="4iu6t1eB68m" resolve="pe" />
+                </node>
+                <node concept="3TrEf2" id="6q$NxWeVZbk" role="2OqNvi">
+                  <ref role="3Tt5mk" to="1qv1:4r1mNB_o5WJ" resolve="exponent" />
+                </node>
+              </node>
+            </node>
+            <node concept="2X1qdy" id="6q$NxWeVYAo" role="2X0Ygz">
+              <property role="TrG5h" value="exponentType" />
+              <node concept="2jxLKc" id="6q$NxWeVYAp" role="1tU5fm" />
             </node>
           </node>
         </node>
-        <node concept="mw_s8" id="6q$NxWeJqG2" role="1ZfhK$">
-          <node concept="1Z2H0r" id="6q$NxWeJqG3" role="mwGJk">
-            <node concept="1YBJjd" id="6q$NxWeJqIz" role="1Z2MuG">
+        <node concept="1Z2H0r" id="6q$NxWeVY32" role="nvjzm">
+          <node concept="2OqwBi" id="6q$NxWeVYee" role="1Z2MuG">
+            <node concept="1YBJjd" id="6q$NxWeVY3u" role="2Oq$k0">
               <ref role="1YBMHb" node="4iu6t1eB68m" resolve="pe" />
             </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1ZobV4" id="6q$NxWeJqG5" role="3cqZAp">
-        <property role="3wDh2S" value="true" />
-        <node concept="mw_s8" id="6q$NxWeJqG6" role="1ZfhK$">
-          <node concept="1Z2H0r" id="6q$NxWeJqG7" role="mwGJk">
-            <node concept="2OqwBi" id="6q$NxWeJqG8" role="1Z2MuG">
-              <node concept="1YBJjd" id="6q$NxWeJqIO" role="2Oq$k0">
-                <ref role="1YBMHb" node="4iu6t1eB68m" resolve="pe" />
-              </node>
-              <node concept="3TrEf2" id="6q$NxWeJqGa" role="2OqNvi">
-                <ref role="3Tt5mk" to="1qv1:4r1mNB_o5WJ" resolve="exponent" />
-              </node>
+            <node concept="3TrEf2" id="6q$NxWeVYwN" role="2OqNvi">
+              <ref role="3Tt5mk" to="1qv1:4iu6t1eBdVy" resolve="expr" />
             </node>
           </node>
         </node>
-        <node concept="mw_s8" id="6q$NxWeJqGb" role="1ZfhKB">
-          <node concept="2ShNRf" id="6q$NxWeJqGc" role="mwGJk">
-            <node concept="3zrR0B" id="6q$NxWeJqGd" role="2ShVmc">
-              <node concept="3Tqbb2" id="6q$NxWeJqGe" role="3zrR0E">
-                <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1ZobV4" id="6q$NxWeJqGf" role="3cqZAp">
-        <property role="3wDh2S" value="true" />
-        <node concept="mw_s8" id="6q$NxWeJqGg" role="1ZfhK$">
-          <node concept="1Z2H0r" id="6q$NxWeJqGh" role="mwGJk">
-            <node concept="2OqwBi" id="6q$NxWeJqGi" role="1Z2MuG">
-              <node concept="1YBJjd" id="6q$NxWeJqL_" role="2Oq$k0">
-                <ref role="1YBMHb" node="4iu6t1eB68m" resolve="pe" />
-              </node>
-              <node concept="3TrEf2" id="6q$NxWeJqGk" role="2OqNvi">
-                <ref role="3Tt5mk" to="1qv1:4iu6t1eBdVy" resolve="expr" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="mw_s8" id="6q$NxWeJqGl" role="1ZfhKB">
-          <node concept="2ShNRf" id="6q$NxWeJqGm" role="mwGJk">
-            <node concept="3zrR0B" id="6q$NxWeJqGn" role="2ShVmc">
-              <node concept="3Tqbb2" id="6q$NxWeJqGo" role="3zrR0E">
-                <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
-              </node>
-            </node>
-          </node>
+        <node concept="2X1qdy" id="6q$NxWeVY1H" role="2X0Ygz">
+          <property role="TrG5h" value="innerPowerExpressionType" />
+          <node concept="2jxLKc" id="6q$NxWeVY1I" role="1tU5fm" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/typesystem.mps
@@ -7,7 +7,7 @@
   <imports>
     <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
-    <import index="1qv1" ref="r:c53b8bbc-6142-4787-a6e4-66310b772b37(org.iets3.core.expr.math.structure)" implicit="true" />
+    <import index="1qv1" ref="r:c53b8bbc-6142-4787-a6e4-66310b772b37(org.iets3.core.expr.math.structure)" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
@@ -40,6 +40,9 @@
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -61,6 +64,10 @@
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
@@ -71,6 +78,9 @@
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="1350122676458893092" name="text" index="3ndbpf" />
       </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
@@ -160,6 +170,7 @@
       <concept id="1154546950173" name="jetbrains.mps.lang.smodel.structure.ConceptReference" flags="ng" index="3gn64h">
         <reference id="1154546997487" name="concept" index="3gnhBz" />
       </concept>
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
@@ -180,6 +191,14 @@
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="ng" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="ng" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
   </registry>
@@ -634,46 +653,162 @@
   <node concept="1YbPZF" id="4iu6t1eB8UZ">
     <property role="TrG5h" value="typeof_SqrtExpression" />
     <node concept="3clFbS" id="4iu6t1eB8V0" role="18ibNy">
-      <node concept="1Z5TYs" id="4r1mNB_n4_e" role="3cqZAp">
-        <node concept="mw_s8" id="4r1mNB_n4Al" role="1ZfhKB">
-          <node concept="2ShNRf" id="4r1mNB_n4Ah" role="mwGJk">
-            <node concept="3zrR0B" id="4r1mNB_n9be" role="2ShVmc">
-              <node concept="3Tqbb2" id="4r1mNB_n9bg" role="3zrR0E">
-                <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+      <node concept="nvevp" id="3htFKtcd8wN" role="3cqZAp">
+        <node concept="3clFbS" id="3htFKtcd8wP" role="nvhr_">
+          <node concept="3cpWs8" id="2OGPkCTl61h" role="3cqZAp">
+            <node concept="3cpWsn" id="2OGPkCTl61i" role="3cpWs9">
+              <property role="TrG5h" value="operationType" />
+              <node concept="3Tqbb2" id="2OGPkCTl5Zh" role="1tU5fm" />
+              <node concept="3h4ouC" id="2OGPkCTl61j" role="33vP2m">
+                <node concept="1YBJjd" id="2OGPkCTl61k" role="3h4sjZ">
+                  <ref role="1YBMHb" node="4iu6t1eB8V2" resolve="sqrt" />
+                </node>
+                <node concept="2X3wrD" id="3htFKtcd9lI" role="3h4u4a">
+                  <ref role="2X3Bk0" node="3htFKtcd8wT" resolve="sqrtExpressionInnerType" />
+                </node>
+                <node concept="10Nm6u" id="2OGPkCTl61p" role="3h4u2h" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="2OGPkCTl6ai" role="3cqZAp">
+            <node concept="3clFbS" id="2OGPkCTl6ak" role="3clFbx">
+              <node concept="1Z5TYs" id="2OGPkCTl56U" role="3cqZAp">
+                <node concept="mw_s8" id="2OGPkCTl74w" role="1ZfhKB">
+                  <node concept="37vLTw" id="2OGPkCTl74n" role="mwGJk">
+                    <ref role="3cqZAo" node="2OGPkCTl61i" resolve="operationType" />
+                  </node>
+                </node>
+                <node concept="mw_s8" id="2OGPkCTl56W" role="1ZfhK$">
+                  <node concept="1Z2H0r" id="2OGPkCTl56X" role="mwGJk">
+                    <node concept="1YBJjd" id="2OGPkCTl56Y" role="1Z2MuG">
+                      <ref role="1YBMHb" node="4iu6t1eB8V2" resolve="sqrt" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="2OGPkCTl6jG" role="3clFbw">
+              <node concept="37vLTw" id="2OGPkCTl6b9" role="2Oq$k0">
+                <ref role="3cqZAo" node="2OGPkCTl61i" resolve="operationType" />
+              </node>
+              <node concept="3x8VRR" id="2OGPkCTl6qp" role="2OqNvi" />
+            </node>
+            <node concept="9aQIb" id="2OGPkCTl6MJ" role="9aQIa">
+              <node concept="3clFbS" id="2OGPkCTl6MK" role="9aQI4">
+                <node concept="3SKdUt" id="2OGPkCTl6Rt" role="3cqZAp">
+                  <node concept="1PaTwC" id="2OGPkCTl6Ru" role="3ndbpf">
+                    <node concept="3oM_SD" id="2OGPkCTl6Rw" role="1PaTwD">
+                      <property role="3oM_SC" value="in" />
+                    </node>
+                    <node concept="3oM_SD" id="2OGPkCTl6RS" role="1PaTwD">
+                      <property role="3oM_SC" value="case" />
+                    </node>
+                    <node concept="3oM_SD" id="2OGPkCTl6RV" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="2OGPkCTl6RZ" role="1PaTwD">
+                      <property role="3oM_SC" value="operation" />
+                    </node>
+                    <node concept="3oM_SD" id="2OGPkCTl6S4" role="1PaTwD">
+                      <property role="3oM_SC" value="type" />
+                    </node>
+                    <node concept="3oM_SD" id="2OGPkCTl6Sa" role="1PaTwD">
+                      <property role="3oM_SC" value="returned" />
+                    </node>
+                    <node concept="3oM_SD" id="2OGPkCTl6Sh" role="1PaTwD">
+                      <property role="3oM_SC" value="null," />
+                    </node>
+                    <node concept="3oM_SD" id="2OGPkCTl6Sp" role="1PaTwD">
+                      <property role="3oM_SC" value="i.e.," />
+                    </node>
+                    <node concept="3oM_SD" id="2OGPkCTl6Sy" role="1PaTwD">
+                      <property role="3oM_SC" value="no" />
+                    </node>
+                    <node concept="3oM_SD" id="2OGPkCTl6SG" role="1PaTwD">
+                      <property role="3oM_SC" value="special" />
+                    </node>
+                    <node concept="3oM_SD" id="2OGPkCTl6SR" role="1PaTwD">
+                      <property role="3oM_SC" value="type" />
+                    </node>
+                    <node concept="3oM_SD" id="2OGPkCTl6T3" role="1PaTwD">
+                      <property role="3oM_SC" value="needs" />
+                    </node>
+                    <node concept="3oM_SD" id="2OGPkCTl6Tg" role="1PaTwD">
+                      <property role="3oM_SC" value="to" />
+                    </node>
+                    <node concept="3oM_SD" id="2OGPkCTl6Tu" role="1PaTwD">
+                      <property role="3oM_SC" value="be" />
+                    </node>
+                    <node concept="3oM_SD" id="2OGPkCTl6TH" role="1PaTwD">
+                      <property role="3oM_SC" value="used" />
+                    </node>
+                    <node concept="3oM_SD" id="2OGPkCTl6UN" role="1PaTwD">
+                      <property role="3oM_SC" value="use" />
+                    </node>
+                    <node concept="3oM_SD" id="2OGPkCTl6Uw" role="1PaTwD">
+                      <property role="3oM_SC" value="real" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="1Z5TYs" id="4r1mNB_n4_e" role="3cqZAp">
+                  <node concept="mw_s8" id="4r1mNB_n4Al" role="1ZfhKB">
+                    <node concept="2ShNRf" id="4r1mNB_n4Ah" role="mwGJk">
+                      <node concept="3zrR0B" id="4r1mNB_n9be" role="2ShVmc">
+                        <node concept="3Tqbb2" id="4r1mNB_n9bg" role="3zrR0E">
+                          <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="mw_s8" id="4r1mNB_n4_h" role="1ZfhK$">
+                    <node concept="1Z2H0r" id="4r1mNB_n4ya" role="mwGJk">
+                      <node concept="1YBJjd" id="4iu6t1eB8Y1" role="1Z2MuG">
+                        <ref role="1YBMHb" node="4iu6t1eB8V2" resolve="sqrt" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1ZobV4" id="4r1mNB_na5P" role="3cqZAp">
+                  <property role="3wDh2S" value="true" />
+                  <node concept="mw_s8" id="4r1mNB_na85" role="1ZfhKB">
+                    <node concept="2ShNRf" id="4r1mNB_na81" role="mwGJk">
+                      <node concept="3zrR0B" id="4r1mNB_naew" role="2ShVmc">
+                        <node concept="3Tqbb2" id="4r1mNB_naey" role="3zrR0E">
+                          <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="mw_s8" id="4r1mNB_na5S" role="1ZfhK$">
+                    <node concept="1Z2H0r" id="4r1mNB_n9di" role="mwGJk">
+                      <node concept="2OqwBi" id="4r1mNB_n9k1" role="1Z2MuG">
+                        <node concept="1YBJjd" id="4iu6t1eB8ZU" role="2Oq$k0">
+                          <ref role="1YBMHb" node="4iu6t1eB8V2" resolve="sqrt" />
+                        </node>
+                        <node concept="3TrEf2" id="4iu6t1eBa72" role="2OqNvi">
+                          <ref role="3Tt5mk" to="1qv1:4iu6t1eB9SW" resolve="expr" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="mw_s8" id="4r1mNB_n4_h" role="1ZfhK$">
-          <node concept="1Z2H0r" id="4r1mNB_n4ya" role="mwGJk">
-            <node concept="1YBJjd" id="4iu6t1eB8Y1" role="1Z2MuG">
+        <node concept="1Z2H0r" id="3htFKtcd8y_" role="nvjzm">
+          <node concept="2OqwBi" id="3htFKtcd8Kb" role="1Z2MuG">
+            <node concept="1YBJjd" id="3htFKtcd8z1" role="2Oq$k0">
               <ref role="1YBMHb" node="4iu6t1eB8V2" resolve="sqrt" />
             </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1ZobV4" id="4r1mNB_na5P" role="3cqZAp">
-        <property role="3wDh2S" value="true" />
-        <node concept="mw_s8" id="4r1mNB_na85" role="1ZfhKB">
-          <node concept="2ShNRf" id="4r1mNB_na81" role="mwGJk">
-            <node concept="3zrR0B" id="4r1mNB_naew" role="2ShVmc">
-              <node concept="3Tqbb2" id="4r1mNB_naey" role="3zrR0E">
-                <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
-              </node>
+            <node concept="3TrEf2" id="3htFKtcd96v" role="2OqNvi">
+              <ref role="3Tt5mk" to="1qv1:4iu6t1eB9SW" resolve="expr" />
             </node>
           </node>
         </node>
-        <node concept="mw_s8" id="4r1mNB_na5S" role="1ZfhK$">
-          <node concept="1Z2H0r" id="4r1mNB_n9di" role="mwGJk">
-            <node concept="2OqwBi" id="4r1mNB_n9k1" role="1Z2MuG">
-              <node concept="1YBJjd" id="4iu6t1eB8ZU" role="2Oq$k0">
-                <ref role="1YBMHb" node="4iu6t1eB8V2" resolve="sqrt" />
-              </node>
-              <node concept="3TrEf2" id="4iu6t1eBa72" role="2OqNvi">
-                <ref role="3Tt5mk" to="1qv1:4iu6t1eB9SW" resolve="expr" />
-              </node>
-            </node>
-          </node>
+        <node concept="2X1qdy" id="3htFKtcd8wT" role="2X0Ygz">
+          <property role="TrG5h" value="sqrtExpressionInnerType" />
+          <node concept="2jxLKc" id="3htFKtcd8wU" role="1tU5fm" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/org.iets3.core.expr.math.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/org.iets3.core.expr.math.mpl
@@ -82,6 +82,8 @@
     <dependency reexport="false">cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</dependency>
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
     <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
+    <dependency reexport="false">20c6e580-bdc5-4067-8049-d7e3265a86de(jetbrains.mps.typesystemEngine)</dependency>
+    <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:677f00fb-4488-405e-9885-abb75d472fd1:com.mbeddr.mpsutil.contextactions" version="0" />
@@ -175,6 +177,7 @@
     <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
     <module reference="8fe4c62a-2020-4ff4-8eda-f322a55bdc9f(jetbrains.mps.refactoring.runtime)" version="0" />
+    <module reference="20c6e580-bdc5-4067-8049-d7e3265a86de(jetbrains.mps.typesystemEngine)" version="0" />
     <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="0" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
     <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="3" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/behavior.mps
@@ -10519,7 +10519,7 @@
       </node>
       <node concept="3Tm1VV" id="3htFKtciTSh" role="1B3o_S" />
     </node>
-    <node concept="2tJIrI" id="3htFKtceGgQ" role="jymVt" />
+    <node concept="2tJIrI" id="6q$NxWeDzq_" role="jymVt" />
     <node concept="3Tm1VV" id="4jkbLB5RJZM" role="1B3o_S" />
   </node>
   <node concept="312cEu" id="5dSoB2LOIkf">
@@ -10534,7 +10534,7 @@
         <ref role="ehGHo" to="b0gq:7eOyx9r3k3e" resolve="IUnit" />
       </node>
     </node>
-    <node concept="2tJIrI" id="5dSoB2LOIpM" role="jymVt" />
+    <node concept="2tJIrI" id="1JTgXSYTEud" role="jymVt" />
     <node concept="3clFbW" id="5dSoB2LOIpN" role="jymVt">
       <node concept="3cqZAl" id="5dSoB2LOIpO" role="3clF45" />
       <node concept="3clFbS" id="5dSoB2LOIpP" role="3clF47">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/behavior.mps
@@ -32,6 +32,7 @@
     <import index="tpd4" ref="r:00000000-0000-4000-0000-011c895902b4(jetbrains.mps.lang.typesystem.structure)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
     <import index="gdgh" ref="r:e4d9478b-ae0e-416e-be60-73d136571015(org.iets3.core.base.behavior)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="b1h1" ref="r:ac5f749f-6179-4d4f-ad24-ad9edbd8077b(org.iets3.core.expr.simpleTypes.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -332,10 +333,6 @@
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
-      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
-        <property id="559557797393021807" name="stereotype" index="BaGAP" />
-        <property id="559557797393017702" name="name" index="BaHAW" />
-      </concept>
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
@@ -343,9 +340,6 @@
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
-      <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7">
-        <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
-      </concept>
       <concept id="1145567426890" name="jetbrains.mps.lang.smodel.structure.SNodeListCreator" flags="nn" index="2T8Vx0">
         <child id="1145567471833" name="createdType" index="2T96Bj" />
       </concept>
@@ -5581,28 +5575,6 @@
               </node>
             </node>
           </node>
-        </node>
-        <node concept="3clFbH" id="26hWC1II3PL" role="3cqZAp" />
-        <node concept="3clFbF" id="2Ux6GHgYcbD" role="3cqZAp">
-          <node concept="2OqwBi" id="2Ux6GHgYdI3" role="3clFbG">
-            <node concept="37vLTw" id="2Ux6GHgYcbB" role="2Oq$k0">
-              <ref role="3cqZAo" node="AeX2Dl1jqU" resolve="units" />
-            </node>
-            <node concept="X8dFx" id="2Ux6GHgYfUi" role="2OqNvi">
-              <node concept="2OqwBi" id="2Ux6GHgYhih" role="25WWJ7">
-                <node concept="BaHAS" id="2Ux6GHgYhii" role="2Oq$k0">
-                  <property role="BaHAW" value="org.iets3.core.expr.typetags.units.si" />
-                  <property role="BaGAP" value="" />
-                </node>
-                <node concept="2SmgA7" id="2Ux6GHgYhij" role="2OqNvi">
-                  <node concept="chp4Y" id="2Ux6GHgYi5i" role="1dBWTz">
-                    <ref role="cht4Q" to="b0gq:7eOyx9r3jsZ" resolve="Unit" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="15s5l7" id="2Ux6GHgYjwA" role="lGtFl" />
         </node>
         <node concept="3clFbH" id="2Ux6GHgYavD" role="3cqZAp" />
         <node concept="3SKdUt" id="4DRdDUoCYK0" role="3cqZAp">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/behavior.mps
@@ -5124,6 +5124,49 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="6q$NxWeZjOs" role="jymVt" />
+    <node concept="3clFb_" id="6q$NxWeZmu8" role="jymVt">
+      <property role="TrG5h" value="pow" />
+      <node concept="3clFbS" id="6q$NxWeZmub" role="3clF47">
+        <node concept="3cpWs6" id="6q$NxWf09Z$" role="3cqZAp">
+          <node concept="2OqwBi" id="6q$NxWf0mnv" role="3cqZAk">
+            <node concept="2ShNRf" id="6q$NxWf09ZX" role="2Oq$k0">
+              <node concept="1pGfFk" id="6q$NxWf0bzi" role="2ShVmc">
+                <ref role="37wK5l" node="5dSoB2LN6CU" resolve="Fraction" />
+                <node concept="17qRlL" id="6q$NxWf0gbi" role="37wK5m">
+                  <node concept="37vLTw" id="6q$NxWf0hv$" role="3uHU7w">
+                    <ref role="3cqZAo" node="6q$NxWeZnZa" resolve="power" />
+                  </node>
+                  <node concept="2OqwBi" id="6q$NxWf0cVt" role="3uHU7B">
+                    <node concept="Xjq3P" id="6q$NxWf0bZv" role="2Oq$k0" />
+                    <node concept="2OwXpG" id="6q$NxWf0e__" role="2OqNvi">
+                      <ref role="2Oxat5" node="5dSoB2LN5wd" resolve="numerator" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="6q$NxWf0jBC" role="37wK5m">
+                  <node concept="Xjq3P" id="6q$NxWf0iQN" role="2Oq$k0" />
+                  <node concept="2OwXpG" id="6q$NxWf0kXu" role="2OqNvi">
+                    <ref role="2Oxat5" node="5dSoB2LN6B2" resolve="denumerator" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="6q$NxWf0n1M" role="2OqNvi">
+              <ref role="37wK5l" node="5dSoB2LO87p" resolve="simplify" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6q$NxWeZkKa" role="1B3o_S" />
+      <node concept="3uibUv" id="6q$NxWeZmgw" role="3clF45">
+        <ref role="3uigEE" node="5dSoB2LMRlC" resolve="Fraction" />
+      </node>
+      <node concept="37vLTG" id="6q$NxWeZnZa" role="3clF46">
+        <property role="TrG5h" value="power" />
+        <node concept="10Oyi0" id="6q$NxWf0omW" role="1tU5fm" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="5dSoB2LNedn" role="jymVt" />
     <node concept="3clFb_" id="5dSoB2LNgCx" role="jymVt">
       <property role="1EzhhJ" value="false" />
@@ -10447,57 +10490,12 @@
           </node>
         </node>
         <node concept="3clFbH" id="3htFKtciTSH" role="3cqZAp" />
-        <node concept="3cpWs8" id="3htFKtciTSI" role="3cqZAp">
-          <node concept="3cpWsn" id="3htFKtciTSJ" role="3cpWs9">
-            <property role="TrG5h" value="sqrtUnitRefs" />
-            <node concept="_YKpA" id="3htFKtciTSK" role="1tU5fm">
-              <node concept="3Tqbb2" id="3htFKtciTSL" role="_ZDj9">
-                <ref role="ehGHo" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
-              </node>
+        <node concept="3cpWs6" id="6q$NxWeYC7W" role="3cqZAp">
+          <node concept="1rXfSq" id="6q$NxWeYGoI" role="3cqZAk">
+            <ref role="37wK5l" node="6q$NxWeXJxq" resolve="createUnitSpecification" />
+            <node concept="37vLTw" id="6q$NxWeYLnY" role="37wK5m">
+              <ref role="3cqZAo" node="3htFKtciTSr" resolve="sqrtUnitMap" />
             </node>
-            <node concept="1rXfSq" id="3htFKtciTSM" role="33vP2m">
-              <ref role="37wK5l" node="4jkbLB618gR" resolve="createUnitReferences" />
-              <node concept="37vLTw" id="3htFKtciTSN" role="37wK5m">
-                <ref role="3cqZAo" node="3htFKtciTSr" resolve="sqrtUnitMap" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="1JTgXSYLkUu" role="3cqZAp">
-          <node concept="3cpWsn" id="1JTgXSYLkUv" role="3cpWs9">
-            <property role="TrG5h" value="sqrtUnitSpecifciation" />
-            <node concept="3Tqbb2" id="1JTgXSYLkUj" role="1tU5fm">
-              <ref role="ehGHo" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
-            </node>
-            <node concept="2ShNRf" id="1JTgXSYLkUw" role="33vP2m">
-              <node concept="3zrR0B" id="1JTgXSYLkUx" role="2ShVmc">
-                <node concept="3Tqbb2" id="1JTgXSYLkUy" role="3zrR0E">
-                  <ref role="ehGHo" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="1JTgXSYLtlO" role="3cqZAp">
-          <node concept="2OqwBi" id="1JTgXSYLvAs" role="3clFbG">
-            <node concept="2OqwBi" id="1JTgXSYLtKu" role="2Oq$k0">
-              <node concept="37vLTw" id="1JTgXSYLtlM" role="2Oq$k0">
-                <ref role="3cqZAo" node="1JTgXSYLkUv" resolve="sqrtUnitSpecifciation" />
-              </node>
-              <node concept="3Tsc0h" id="1JTgXSYLu1R" role="2OqNvi">
-                <ref role="3TtcxE" to="b0gq:7eOyx9r3qG3" resolve="components" />
-              </node>
-            </node>
-            <node concept="X8dFx" id="1JTgXSYL$kL" role="2OqNvi">
-              <node concept="37vLTw" id="1JTgXSYLAGE" role="25WWJ7">
-                <ref role="3cqZAo" node="3htFKtciTSJ" resolve="sqrtUnitRefs" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs6" id="3htFKtciTSO" role="3cqZAp">
-          <node concept="37vLTw" id="1JTgXSYLEhm" role="3cqZAk">
-            <ref role="3cqZAo" node="1JTgXSYLkUv" resolve="sqrtUnitSpecifciation" />
           </node>
         </node>
       </node>
@@ -10520,6 +10518,198 @@
       <node concept="3Tm1VV" id="3htFKtciTSh" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="6q$NxWeDzq_" role="jymVt" />
+    <node concept="2tJIrI" id="6q$NxWeWFID" role="jymVt" />
+    <node concept="2YIFZL" id="6q$NxWeWUdj" role="jymVt">
+      <property role="TrG5h" value="pow" />
+      <node concept="3clFbS" id="6q$NxWeWUdn" role="3clF47">
+        <node concept="3cpWs8" id="6q$NxWeXkLh" role="3cqZAp">
+          <node concept="3cpWsn" id="6q$NxWeXkLi" role="3cpWs9">
+            <property role="TrG5h" value="originalUnitMap" />
+            <node concept="3rvAFt" id="6q$NxWeXkLj" role="1tU5fm">
+              <node concept="3Tqbb2" id="6q$NxWeXkLk" role="3rvQeY">
+                <ref role="ehGHo" to="b0gq:7eOyx9r3k3e" resolve="IUnit" />
+              </node>
+              <node concept="3uibUv" id="6q$NxWeXkLl" role="3rvSg0">
+                <ref role="3uigEE" node="5dSoB2LMRlC" resolve="Fraction" />
+              </node>
+            </node>
+            <node concept="1rXfSq" id="6q$NxWeXkLm" role="33vP2m">
+              <ref role="37wK5l" node="1GIWTDBlWlh" resolve="getUnitMap_UnitSpecification" />
+              <node concept="37vLTw" id="6q$NxWeXppq" role="37wK5m">
+                <ref role="3cqZAo" node="6q$NxWeX50H" resolve="unitSpecification" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6q$NxWeXkLo" role="3cqZAp">
+          <node concept="3cpWsn" id="6q$NxWeXkLp" role="3cpWs9">
+            <property role="TrG5h" value="powUnitMap" />
+            <node concept="3rvAFt" id="6q$NxWeXkLq" role="1tU5fm">
+              <node concept="3Tqbb2" id="6q$NxWeXkLr" role="3rvQeY">
+                <ref role="ehGHo" to="b0gq:7eOyx9r3k3e" resolve="IUnit" />
+              </node>
+              <node concept="3uibUv" id="6q$NxWeXkLs" role="3rvSg0">
+                <ref role="3uigEE" node="5dSoB2LMRlC" resolve="Fraction" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="6q$NxWeXkLt" role="33vP2m">
+              <node concept="3rGOSV" id="6q$NxWeXkLu" role="2ShVmc">
+                <node concept="3Tqbb2" id="6q$NxWeXkLv" role="3rHrn6">
+                  <ref role="ehGHo" to="b0gq:7eOyx9r3k3e" resolve="IUnit" />
+                </node>
+                <node concept="3uibUv" id="6q$NxWeXkLw" role="3rHtpV">
+                  <ref role="3uigEE" node="5dSoB2LMRlC" resolve="Fraction" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6q$NxWeXsak" role="3cqZAp" />
+        <node concept="3clFbF" id="6q$NxWeXsBL" role="3cqZAp">
+          <node concept="2OqwBi" id="6q$NxWeXtew" role="3clFbG">
+            <node concept="37vLTw" id="6q$NxWeXsBJ" role="2Oq$k0">
+              <ref role="3cqZAo" node="6q$NxWeXkLi" resolve="originalUnitMap" />
+            </node>
+            <node concept="2es0OD" id="6q$NxWeXtS6" role="2OqNvi">
+              <node concept="1bVj0M" id="6q$NxWeXtS8" role="23t8la">
+                <node concept="3clFbS" id="6q$NxWeXtS9" role="1bW5cS">
+                  <node concept="3clFbF" id="6q$NxWeXuaY" role="3cqZAp">
+                    <node concept="37vLTI" id="6q$NxWeXvZK" role="3clFbG">
+                      <node concept="2OqwBi" id="6q$NxWeXxCB" role="37vLTx">
+                        <node concept="2OqwBi" id="6q$NxWeXwHl" role="2Oq$k0">
+                          <node concept="37vLTw" id="6q$NxWeXwbz" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6q$NxWeXtSa" resolve="it" />
+                          </node>
+                          <node concept="3AV6Ez" id="6q$NxWeXx6R" role="2OqNvi" />
+                        </node>
+                        <node concept="liA8E" id="6q$NxWf06ed" role="2OqNvi">
+                          <ref role="37wK5l" node="6q$NxWeZmu8" resolve="pow" />
+                          <node concept="37vLTw" id="6q$NxWf06sY" role="37wK5m">
+                            <ref role="3cqZAo" node="6q$NxWeXcKq" resolve="power" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3EllGN" id="6q$NxWeXutC" role="37vLTJ">
+                        <node concept="2OqwBi" id="6q$NxWeXvj4" role="3ElVtu">
+                          <node concept="37vLTw" id="6q$NxWeXuIe" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6q$NxWeXtSa" resolve="it" />
+                          </node>
+                          <node concept="3AY5_j" id="6q$NxWeXvG3" role="2OqNvi" />
+                        </node>
+                        <node concept="37vLTw" id="6q$NxWeXuaX" role="3ElQJh">
+                          <ref role="3cqZAo" node="6q$NxWeXkLp" resolve="powUnitMap" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="6q$NxWeXtSa" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="6q$NxWeXtSb" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6q$NxWeXy7q" role="3cqZAp" />
+        <node concept="3cpWs6" id="6q$NxWeYZtZ" role="3cqZAp">
+          <node concept="1rXfSq" id="6q$NxWeZ32I" role="3cqZAk">
+            <ref role="37wK5l" node="6q$NxWeXJxq" resolve="createUnitSpecification" />
+            <node concept="37vLTw" id="6q$NxWeZ6Hi" role="37wK5m">
+              <ref role="3cqZAo" node="6q$NxWeXkLp" resolve="powUnitMap" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="6q$NxWeWXnn" role="3clF45">
+        <ref role="ehGHo" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+      </node>
+      <node concept="3Tm1VV" id="6q$NxWeWUdm" role="1B3o_S" />
+      <node concept="37vLTG" id="6q$NxWeX50H" role="3clF46">
+        <property role="TrG5h" value="unitSpecification" />
+        <node concept="3Tqbb2" id="6q$NxWeX50G" role="1tU5fm">
+          <ref role="ehGHo" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6q$NxWeXcKq" role="3clF46">
+        <property role="TrG5h" value="power" />
+        <node concept="10Oyi0" id="6q$NxWeZ_8e" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6q$NxWeXCnL" role="jymVt" />
+    <node concept="2YIFZL" id="6q$NxWeXJxq" role="jymVt">
+      <property role="TrG5h" value="createUnitSpecification" />
+      <node concept="37vLTG" id="6q$NxWeY6ul" role="3clF46">
+        <property role="TrG5h" value="unitMap" />
+        <node concept="3rvAFt" id="6q$NxWeY6up" role="1tU5fm">
+          <node concept="3Tqbb2" id="6q$NxWeY6uq" role="3rvQeY">
+            <ref role="ehGHo" to="b0gq:7eOyx9r3k3e" resolve="IUnit" />
+          </node>
+          <node concept="3uibUv" id="6q$NxWeY6ur" role="3rvSg0">
+            <ref role="3uigEE" node="5dSoB2LMRlC" resolve="Fraction" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbS" id="6q$NxWeXJxu" role="3clF47">
+        <node concept="3cpWs8" id="6q$NxWeYcv2" role="3cqZAp">
+          <node concept="3cpWsn" id="6q$NxWeYcv3" role="3cpWs9">
+            <property role="TrG5h" value="unitRefs" />
+            <node concept="_YKpA" id="6q$NxWeYcv4" role="1tU5fm">
+              <node concept="3Tqbb2" id="6q$NxWeYcv5" role="_ZDj9">
+                <ref role="ehGHo" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+              </node>
+            </node>
+            <node concept="1rXfSq" id="6q$NxWeYcv6" role="33vP2m">
+              <ref role="37wK5l" node="4jkbLB618gR" resolve="createUnitReferences" />
+              <node concept="37vLTw" id="6q$NxWeYgU5" role="37wK5m">
+                <ref role="3cqZAo" node="6q$NxWeY6ul" resolve="unitMap" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6q$NxWeYcv8" role="3cqZAp">
+          <node concept="3cpWsn" id="6q$NxWeYcv9" role="3cpWs9">
+            <property role="TrG5h" value="newUnitSpecifciation" />
+            <node concept="3Tqbb2" id="6q$NxWeYcva" role="1tU5fm">
+              <ref role="ehGHo" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+            </node>
+            <node concept="2ShNRf" id="6q$NxWeYcvb" role="33vP2m">
+              <node concept="3zrR0B" id="6q$NxWeYcvc" role="2ShVmc">
+                <node concept="3Tqbb2" id="6q$NxWeYcvd" role="3zrR0E">
+                  <ref role="ehGHo" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6q$NxWeYcve" role="3cqZAp">
+          <node concept="2OqwBi" id="6q$NxWeYcvf" role="3clFbG">
+            <node concept="2OqwBi" id="6q$NxWeYcvg" role="2Oq$k0">
+              <node concept="37vLTw" id="6q$NxWeYcvh" role="2Oq$k0">
+                <ref role="3cqZAo" node="6q$NxWeYcv9" resolve="newUnitSpecifciation" />
+              </node>
+              <node concept="3Tsc0h" id="6q$NxWeYcvi" role="2OqNvi">
+                <ref role="3TtcxE" to="b0gq:7eOyx9r3qG3" resolve="components" />
+              </node>
+            </node>
+            <node concept="X8dFx" id="6q$NxWeYcvj" role="2OqNvi">
+              <node concept="37vLTw" id="6q$NxWeYcvk" role="25WWJ7">
+                <ref role="3cqZAo" node="6q$NxWeYcv3" resolve="unitRefs" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6q$NxWeYcvl" role="3cqZAp">
+          <node concept="37vLTw" id="6q$NxWeYcvm" role="3cqZAk">
+            <ref role="3cqZAo" node="6q$NxWeYcv9" resolve="newUnitSpecifciation" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="6q$NxWeXMVk" role="3clF45">
+        <ref role="ehGHo" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+      </node>
+      <node concept="3Tm6S6" id="6q$NxWeXJxt" role="1B3o_S" />
+    </node>
     <node concept="3Tm1VV" id="4jkbLB5RJZM" role="1B3o_S" />
   </node>
   <node concept="312cEu" id="5dSoB2LOIkf">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/behavior.mps
@@ -5085,6 +5085,45 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="3htFKtci2Ac" role="jymVt" />
+    <node concept="3clFb_" id="3htFKtci6tU" role="jymVt">
+      <property role="TrG5h" value="sqrt" />
+      <node concept="3uibUv" id="3htFKtci7RA" role="3clF45">
+        <ref role="3uigEE" node="5dSoB2LMRlC" resolve="Fraction" />
+      </node>
+      <node concept="3Tm1VV" id="3htFKtci6tW" role="1B3o_S" />
+      <node concept="3clFbS" id="3htFKtci6tZ" role="3clF47">
+        <node concept="3cpWs6" id="3htFKtcigIw" role="3cqZAp">
+          <node concept="2OqwBi" id="3htFKtciwhU" role="3cqZAk">
+            <node concept="2ShNRf" id="3htFKtcigIX" role="2Oq$k0">
+              <node concept="1pGfFk" id="3htFKtciinp" role="2ShVmc">
+                <ref role="37wK5l" node="5dSoB2LN6CU" resolve="Fraction" />
+                <node concept="2OqwBi" id="3htFKtcik_C" role="37wK5m">
+                  <node concept="Xjq3P" id="3htFKtcijCz" role="2Oq$k0" />
+                  <node concept="2OwXpG" id="3htFKtcim9V" role="2OqNvi">
+                    <ref role="2Oxat5" node="5dSoB2LN5wd" resolve="numerator" />
+                  </node>
+                </node>
+                <node concept="17qRlL" id="3htFKtcng69" role="37wK5m">
+                  <node concept="3cmrfG" id="3htFKtcng6l" role="3uHU7w">
+                    <property role="3cmrfH" value="2" />
+                  </node>
+                  <node concept="2OqwBi" id="3htFKtcipK6" role="3uHU7B">
+                    <node concept="Xjq3P" id="3htFKtcioGQ" role="2Oq$k0" />
+                    <node concept="2OwXpG" id="3htFKtcirfr" role="2OqNvi">
+                      <ref role="2Oxat5" node="5dSoB2LN6B2" resolve="denumerator" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="3htFKtcixhg" role="2OqNvi">
+              <ref role="37wK5l" node="5dSoB2LO87p" resolve="simplify" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="5dSoB2LNedn" role="jymVt" />
     <node concept="3clFb_" id="5dSoB2LNgCx" role="jymVt">
       <property role="1EzhhJ" value="false" />
@@ -10317,6 +10356,170 @@
       </node>
     </node>
     <node concept="2tJIrI" id="26hWC1Il5Nk" role="jymVt" />
+    <node concept="2tJIrI" id="3htFKtch6EF" role="jymVt" />
+    <node concept="2YIFZL" id="3htFKtciTSe" role="jymVt">
+      <property role="TrG5h" value="sqrt" />
+      <node concept="3clFbS" id="3htFKtciTSi" role="3clF47">
+        <node concept="3cpWs8" id="3htFKtciTSj" role="3cqZAp">
+          <node concept="3cpWsn" id="3htFKtciTSk" role="3cpWs9">
+            <property role="TrG5h" value="originalUnitMap" />
+            <node concept="3rvAFt" id="3htFKtciTSl" role="1tU5fm">
+              <node concept="3Tqbb2" id="3htFKtciTSm" role="3rvQeY">
+                <ref role="ehGHo" to="b0gq:7eOyx9r3k3e" resolve="IUnit" />
+              </node>
+              <node concept="3uibUv" id="3htFKtciTSn" role="3rvSg0">
+                <ref role="3uigEE" node="5dSoB2LMRlC" resolve="Fraction" />
+              </node>
+            </node>
+            <node concept="1rXfSq" id="3htFKtciTSo" role="33vP2m">
+              <ref role="37wK5l" node="1GIWTDBlWlh" resolve="getUnitMap_UnitSpecification" />
+              <node concept="37vLTw" id="3htFKtciTSp" role="37wK5m">
+                <ref role="3cqZAo" node="3htFKtciTSU" resolve="unitSpecificaion" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3htFKtciTSq" role="3cqZAp">
+          <node concept="3cpWsn" id="3htFKtciTSr" role="3cpWs9">
+            <property role="TrG5h" value="sqrtUnitMap" />
+            <node concept="3rvAFt" id="3htFKtciTSs" role="1tU5fm">
+              <node concept="3Tqbb2" id="3htFKtciTSt" role="3rvQeY">
+                <ref role="ehGHo" to="b0gq:7eOyx9r3k3e" resolve="IUnit" />
+              </node>
+              <node concept="3uibUv" id="3htFKtciTSu" role="3rvSg0">
+                <ref role="3uigEE" node="5dSoB2LMRlC" resolve="Fraction" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="3htFKtciTSv" role="33vP2m">
+              <node concept="3rGOSV" id="3htFKtciTSw" role="2ShVmc">
+                <node concept="3Tqbb2" id="3htFKtciTSx" role="3rHrn6">
+                  <ref role="ehGHo" to="b0gq:7eOyx9r3k3e" resolve="IUnit" />
+                </node>
+                <node concept="3uibUv" id="3htFKtciTSy" role="3rHtpV">
+                  <ref role="3uigEE" node="5dSoB2LMRlC" resolve="Fraction" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3htFKtciTSz" role="3cqZAp" />
+        <node concept="3clFbF" id="3htFKtciTS$" role="3cqZAp">
+          <node concept="2OqwBi" id="3htFKtciTS_" role="3clFbG">
+            <node concept="37vLTw" id="3htFKtciTSA" role="2Oq$k0">
+              <ref role="3cqZAo" node="3htFKtciTSk" resolve="originalUnitMap" />
+            </node>
+            <node concept="2es0OD" id="3htFKtciTSB" role="2OqNvi">
+              <node concept="1bVj0M" id="3htFKtciTSC" role="23t8la">
+                <node concept="3clFbS" id="3htFKtciTSD" role="1bW5cS">
+                  <node concept="3clFbF" id="3htFKtcjdgG" role="3cqZAp">
+                    <node concept="37vLTI" id="3htFKtcjglK" role="3clFbG">
+                      <node concept="2OqwBi" id="3htFKtcjhWD" role="37vLTx">
+                        <node concept="2OqwBi" id="3htFKtcjhqW" role="2Oq$k0">
+                          <node concept="37vLTw" id="3htFKtcjh8W" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3htFKtciTSF" resolve="it" />
+                          </node>
+                          <node concept="3AV6Ez" id="3htFKtcjhEi" role="2OqNvi" />
+                        </node>
+                        <node concept="liA8E" id="3htFKtcjinC" role="2OqNvi">
+                          <ref role="37wK5l" node="3htFKtci6tU" resolve="sqrt" />
+                        </node>
+                      </node>
+                      <node concept="3EllGN" id="3htFKtcjeJQ" role="37vLTJ">
+                        <node concept="2OqwBi" id="3htFKtcjffF" role="3ElVtu">
+                          <node concept="37vLTw" id="3htFKtcjeYq" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3htFKtciTSF" resolve="it" />
+                          </node>
+                          <node concept="3AY5_j" id="3htFKtcjfp7" role="2OqNvi" />
+                        </node>
+                        <node concept="37vLTw" id="3htFKtcjdRf" role="3ElQJh">
+                          <ref role="3cqZAo" node="3htFKtciTSr" resolve="sqrtUnitMap" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="3htFKtciTSF" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="3htFKtciTSG" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3htFKtciTSH" role="3cqZAp" />
+        <node concept="3cpWs8" id="3htFKtciTSI" role="3cqZAp">
+          <node concept="3cpWsn" id="3htFKtciTSJ" role="3cpWs9">
+            <property role="TrG5h" value="sqrtUnitRefs" />
+            <node concept="_YKpA" id="3htFKtciTSK" role="1tU5fm">
+              <node concept="3Tqbb2" id="3htFKtciTSL" role="_ZDj9">
+                <ref role="ehGHo" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+              </node>
+            </node>
+            <node concept="1rXfSq" id="3htFKtciTSM" role="33vP2m">
+              <ref role="37wK5l" node="4jkbLB618gR" resolve="createUnitReferences" />
+              <node concept="37vLTw" id="3htFKtciTSN" role="37wK5m">
+                <ref role="3cqZAo" node="3htFKtciTSr" resolve="sqrtUnitMap" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1JTgXSYLkUu" role="3cqZAp">
+          <node concept="3cpWsn" id="1JTgXSYLkUv" role="3cpWs9">
+            <property role="TrG5h" value="sqrtUnitSpecifciation" />
+            <node concept="3Tqbb2" id="1JTgXSYLkUj" role="1tU5fm">
+              <ref role="ehGHo" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+            </node>
+            <node concept="2ShNRf" id="1JTgXSYLkUw" role="33vP2m">
+              <node concept="3zrR0B" id="1JTgXSYLkUx" role="2ShVmc">
+                <node concept="3Tqbb2" id="1JTgXSYLkUy" role="3zrR0E">
+                  <ref role="ehGHo" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1JTgXSYLtlO" role="3cqZAp">
+          <node concept="2OqwBi" id="1JTgXSYLvAs" role="3clFbG">
+            <node concept="2OqwBi" id="1JTgXSYLtKu" role="2Oq$k0">
+              <node concept="37vLTw" id="1JTgXSYLtlM" role="2Oq$k0">
+                <ref role="3cqZAo" node="1JTgXSYLkUv" resolve="sqrtUnitSpecifciation" />
+              </node>
+              <node concept="3Tsc0h" id="1JTgXSYLu1R" role="2OqNvi">
+                <ref role="3TtcxE" to="b0gq:7eOyx9r3qG3" resolve="components" />
+              </node>
+            </node>
+            <node concept="X8dFx" id="1JTgXSYL$kL" role="2OqNvi">
+              <node concept="37vLTw" id="1JTgXSYLAGE" role="25WWJ7">
+                <ref role="3cqZAo" node="3htFKtciTSJ" resolve="sqrtUnitRefs" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="3htFKtciTSO" role="3cqZAp">
+          <node concept="37vLTw" id="1JTgXSYLEhm" role="3cqZAk">
+            <ref role="3cqZAo" node="1JTgXSYLkUv" resolve="sqrtUnitSpecifciation" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="3htFKtciTSg" role="3clF45">
+        <ref role="ehGHo" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+      </node>
+      <node concept="37vLTG" id="3htFKtciTSU" role="3clF46">
+        <property role="TrG5h" value="unitSpecificaion" />
+        <node concept="3Tqbb2" id="3htFKtciTSV" role="1tU5fm">
+          <ref role="ehGHo" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="3htFKtciTSW" role="lGtFl">
+        <node concept="TZ5HA" id="3htFKtciTSX" role="TZ5H$">
+          <node concept="1dT_AC" id="3htFKtciTSY" role="1dT_Ay">
+            <property role="1dT_AB" value="Calculates the sqrt of the units within the provided UnitSpecification and returns a new UnitSpecification." />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3htFKtciTSh" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="3htFKtceGgQ" role="jymVt" />
     <node concept="3Tm1VV" id="4jkbLB5RJZM" role="1B3o_S" />
   </node>
   <node concept="312cEu" id="5dSoB2LOIkf">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/typesystem.mps
@@ -45,6 +45,7 @@
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="ng" index="2tJIrI" />
       <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
         <child id="1239714902950" name="expression" index="2$L3a6" />
       </concept>
@@ -64,6 +65,7 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
@@ -74,6 +76,7 @@
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
@@ -81,10 +84,16 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
       </concept>
       <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
@@ -103,6 +112,7 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
@@ -114,6 +124,7 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
         <child id="1206060619838" name="condition" index="3eO9$A" />
         <child id="1206060644605" name="statementList" index="3eOfB_" />
@@ -131,6 +142,9 @@
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
@@ -141,6 +155,9 @@
       </concept>
       <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
       <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
         <child id="1144230900587" name="variable" index="1Duv9x" />
       </concept>
@@ -156,6 +173,8 @@
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="1350122676458893092" name="text" index="3ndbpf" />
       </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
@@ -197,6 +216,9 @@
         <child id="1205761991995" name="argumentRepresentator" index="2X0Ygz" />
       </concept>
       <concept id="1177406296561" name="jetbrains.mps.lang.typesystem.structure.IsStrongSubtypeExpression" flags="nn" index="yS_3z" />
+      <concept id="1175517400280" name="jetbrains.mps.lang.typesystem.structure.AssertStatement" flags="nn" index="2Mj0R9">
+        <child id="1175517761460" name="condition" index="2MkoU_" />
+      </concept>
       <concept id="1175517767210" name="jetbrains.mps.lang.typesystem.structure.ReportErrorStatement" flags="nn" index="2MkqsV">
         <child id="1175517851849" name="errorString" index="2MkJ7o" />
       </concept>
@@ -220,6 +242,9 @@
         <child id="8124453027370845341" name="operationConcept" index="32tDTA" />
         <child id="6136676636349909553" name="isApplicable" index="1QeD3i" />
       </concept>
+      <concept id="8124453027370766044" name="jetbrains.mps.lang.typesystem.structure.OverloadedOpTypeRule_OneTypeSpecified" flags="ng" index="32tXgB">
+        <child id="8124453027370845366" name="operandType" index="32tDTd" />
+      </concept>
       <concept id="1195213580585" name="jetbrains.mps.lang.typesystem.structure.AbstractCheckingRule" flags="ig" index="18hYwZ">
         <child id="1195213635060" name="body" index="18ibNy" />
       </concept>
@@ -231,7 +256,13 @@
       </concept>
       <concept id="1236083146670" name="jetbrains.mps.lang.typesystem.structure.OverloadedOperatorTypeFunction" flags="in" index="3ciZUL" />
       <concept id="1236083209648" name="jetbrains.mps.lang.typesystem.structure.LeftOperandType_parameter" flags="nn" index="3cjfiJ" />
+      <concept id="1236083245720" name="jetbrains.mps.lang.typesystem.structure.Operation_parameter" flags="nn" index="3cjoe7" />
       <concept id="1236083248858" name="jetbrains.mps.lang.typesystem.structure.RightOperandType_parameter" flags="nn" index="3cjoZ5" />
+      <concept id="1236163200695" name="jetbrains.mps.lang.typesystem.structure.GetOperationType" flags="nn" index="3h4ouC">
+        <child id="1236163216864" name="operation" index="3h4sjZ" />
+        <child id="1236163223950" name="rightOperandType" index="3h4u2h" />
+        <child id="1236163223573" name="leftOperandType" index="3h4u4a" />
+      </concept>
       <concept id="1236165709895" name="jetbrains.mps.lang.typesystem.structure.OverloadedOpRulesContainer" flags="ng" index="3hdX5o">
         <child id="1236165725858" name="rule" index="3he0YX" />
       </concept>
@@ -312,6 +343,7 @@
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
+      <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
         <property id="1238684351431" name="asCast" index="1BlNFB" />
       </concept>
@@ -337,6 +369,9 @@
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
       <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7" />
+      <concept id="779128492853369165" name="jetbrains.mps.lang.core.structure.SideTransformInfo" flags="ng" index="1KehLL">
+        <property id="779128492853934523" name="cellId" index="1K8rM7" />
+      </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
       <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="ng" index="3oM_SD">
@@ -2690,110 +2725,286 @@
       </node>
       <node concept="1QeDOX" id="3htFKtcdXFZ" role="1QeD3i">
         <node concept="3clFbS" id="3htFKtcdXG0" role="2VODD2">
-          <node concept="3clFbJ" id="3htFKtcdYmg" role="3cqZAp">
-            <node concept="1Wc70l" id="3htFKtcdZ6$" role="3clFbw">
-              <node concept="3clFbC" id="3htFKtcdZi$" role="3uHU7w">
-                <node concept="10Nm6u" id="3htFKtcdZvN" role="3uHU7w" />
-                <node concept="3cjoZ5" id="3htFKtcdZ7C" role="3uHU7B" />
-              </node>
-              <node concept="1Wc70l" id="3htFKtcekD6" role="3uHU7B">
-                <node concept="2OqwBi" id="3htFKtcdYzg" role="3uHU7B">
-                  <node concept="3cjfiJ" id="3htFKtcdYmL" role="2Oq$k0" />
-                  <node concept="1mIQ4w" id="3htFKtcdYEj" role="2OqNvi">
-                    <node concept="chp4Y" id="3htFKtcdYGA" role="cj9EA">
-                      <ref role="cht4Q" to="w1hl:1xEzHAktP2Q" resolve="TaggedType" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2ZW3vV" id="7McqtXGDfX2" role="3uHU7w">
-                  <node concept="3uibUv" id="7McqtXGDgjR" role="2ZW6by">
-                    <ref role="3uigEE" to="qlm2:7McqtXGCExM" resolve="TagHandlingCapability" />
-                  </node>
-                  <node concept="2OqwBi" id="7McqtXGDeE2" role="2ZW6bz">
-                    <node concept="1PxgMI" id="7McqtXGDe4z" role="2Oq$k0">
-                      <property role="1BlNFB" value="true" />
-                      <node concept="3cjfiJ" id="7McqtXGDdvZ" role="1m5AlR" />
-                      <node concept="chp4Y" id="72_xmu9gQ2L" role="3oSUPX">
-                        <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
-                      </node>
-                    </node>
-                    <node concept="2qgKlT" id="7McqtXGDf6_" role="2OqNvi">
-                      <ref role="37wK5l" to="pbu6:7McqtXGyz8c" resolve="getCapabilityRequirement" />
-                    </node>
-                  </node>
-                </node>
-              </node>
+          <node concept="3cpWs6" id="1JTgXSYRJ0I" role="3cqZAp">
+            <node concept="2YIFZM" id="1JTgXSYRKOa" role="3cqZAk">
+              <ref role="37wK5l" node="1JTgXSYRK0d" resolve="hasSingleUnitSpecificationTag" />
+              <ref role="1Pybhc" node="1JTgXSYRFrf" resolve="MathExpressionsOpRulesHelper" />
+              <node concept="3cjfiJ" id="1JTgXSYRKUZ" role="37wK5m" />
             </node>
-            <node concept="3clFbS" id="3htFKtcdYmi" role="3clFbx">
-              <node concept="3cpWs8" id="3htFKtce06V" role="3cqZAp">
-                <node concept="3cpWsn" id="3htFKtce06W" role="3cpWs9">
-                  <property role="TrG5h" value="taggedType" />
-                  <node concept="3Tqbb2" id="3htFKtce06A" role="1tU5fm">
-                    <ref role="ehGHo" to="w1hl:1xEzHAktP2Q" resolve="TaggedType" />
-                  </node>
-                  <node concept="1PxgMI" id="3htFKtce06X" role="33vP2m">
-                    <node concept="chp4Y" id="3htFKtce06Y" role="3oSUPX">
-                      <ref role="cht4Q" to="w1hl:1xEzHAktP2Q" resolve="TaggedType" />
-                    </node>
-                    <node concept="3cjfiJ" id="3htFKtce06Z" role="1m5AlR" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3cpWs8" id="3htFKtcedxR" role="3cqZAp">
-                <node concept="3cpWsn" id="3htFKtcedxS" role="3cpWs9">
-                  <property role="TrG5h" value="hasSingleUnitSpecificationTag" />
-                  <node concept="10P_77" id="3htFKtcedsN" role="1tU5fm" />
-                  <node concept="1Wc70l" id="3htFKtcedxT" role="33vP2m">
-                    <node concept="2OqwBi" id="3htFKtcedxU" role="3uHU7w">
-                      <node concept="2OqwBi" id="3htFKtcedxV" role="2Oq$k0">
-                        <node concept="2OqwBi" id="3htFKtcedxW" role="2Oq$k0">
-                          <node concept="37vLTw" id="3htFKtcedxX" role="2Oq$k0">
-                            <ref role="3cqZAo" node="3htFKtce06W" resolve="taggedType" />
-                          </node>
-                          <node concept="3Tsc0h" id="3htFKtcedxY" role="2OqNvi">
-                            <ref role="3TtcxE" to="w1hl:1xEzHAktP2R" resolve="tags" />
-                          </node>
-                        </node>
-                        <node concept="1uHKPH" id="3htFKtcedxZ" role="2OqNvi" />
-                      </node>
-                      <node concept="1mIQ4w" id="3htFKtcedy0" role="2OqNvi">
-                        <node concept="chp4Y" id="3htFKtcedy1" role="cj9EA">
-                          <ref role="cht4Q" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbC" id="3htFKtcedy2" role="3uHU7B">
-                      <node concept="2OqwBi" id="3htFKtcedy3" role="3uHU7B">
-                        <node concept="2OqwBi" id="3htFKtcedy4" role="2Oq$k0">
-                          <node concept="37vLTw" id="3htFKtcedy5" role="2Oq$k0">
-                            <ref role="3cqZAo" node="3htFKtce06W" resolve="taggedType" />
-                          </node>
-                          <node concept="3Tsc0h" id="3htFKtcedy6" role="2OqNvi">
-                            <ref role="3TtcxE" to="w1hl:1xEzHAktP2R" resolve="tags" />
-                          </node>
-                        </node>
-                        <node concept="34oBXx" id="3htFKtcedy7" role="2OqNvi" />
-                      </node>
-                      <node concept="3cmrfG" id="3htFKtcedy8" role="3uHU7w">
-                        <property role="3cmrfH" value="1" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3cpWs6" id="3htFKtcehu2" role="3cqZAp">
-                <node concept="37vLTw" id="3htFKtcehu4" role="3cqZAk">
-                  <ref role="3cqZAo" node="3htFKtcedxS" resolve="hasSingleUnitSpecificationTag" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs6" id="3htFKtcdZy0" role="3cqZAp">
-            <node concept="3clFbT" id="3htFKtcdZyn" role="3cqZAk" />
           </node>
         </node>
       </node>
     </node>
+    <node concept="3ciAk0" id="1JTgXSYRFe0" role="3he0YX">
+      <property role="3PlbSO" value="true" />
+      <node concept="10Nm6u" id="1JTgXSYRFmi" role="3ciSnv" />
+      <node concept="3gn64h" id="1JTgXSYRFky" role="32tDTA">
+        <ref role="3gnhBz" to="1qv1:4iu6t1eAWup" resolve="AbsExpression" />
+      </node>
+      <node concept="3ciZUL" id="1JTgXSYRFek" role="32tDT$">
+        <node concept="3clFbS" id="1JTgXSYRFep" role="2VODD2">
+          <node concept="3cpWs6" id="1JTgXSYRLRy" role="3cqZAp">
+            <node concept="2OqwBi" id="1JTgXSYRM1y" role="3cqZAk">
+              <node concept="3cjfiJ" id="1JTgXSYRLSs" role="2Oq$k0" />
+              <node concept="1$rogu" id="1JTgXSYRM8g" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2pJPEk" id="6q$NxWeHvSf" role="3ciSkW">
+        <node concept="2pJPED" id="6q$NxWeHvU_" role="2pJPEn">
+          <ref role="2pJxaS" to="w1hl:4HxogODTnzM" resolve="AbstractTaggedType" />
+        </node>
+      </node>
+      <node concept="1QeDOX" id="1JTgXSYRFmL" role="1QeD3i">
+        <node concept="3clFbS" id="1JTgXSYRFmM" role="2VODD2">
+          <node concept="3cpWs6" id="1JTgXSYRT6Z" role="3cqZAp">
+            <node concept="2YIFZM" id="1JTgXSYRT71" role="3cqZAk">
+              <ref role="37wK5l" node="1JTgXSYRK0d" resolve="hasSingleUnitSpecificationTag" />
+              <ref role="1Pybhc" node="1JTgXSYRFrf" resolve="MathExpressionsOpRulesHelper" />
+              <node concept="3cjfiJ" id="1JTgXSYRT72" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="32tXgB" id="6q$NxWeCz0Y" role="3he0YX">
+      <node concept="3gn64h" id="6q$NxWeCz7X" role="32tDTA">
+        <ref role="3gnhBz" to="1qv1:4iu6t1eAWP6" resolve="FractionExpression" />
+      </node>
+      <node concept="3ciZUL" id="6q$NxWeCz1d" role="32tDT$">
+        <node concept="3clFbS" id="6q$NxWeCz1i" role="2VODD2">
+          <node concept="3cpWs6" id="6q$NxWeCz9m" role="3cqZAp">
+            <node concept="3h4ouC" id="6q$NxWeCz9n" role="3cqZAk">
+              <node concept="2pJPEk" id="6q$NxWeCz9o" role="3h4sjZ">
+                <node concept="2pJPED" id="6q$NxWeCz9p" role="2pJPEn">
+                  <ref role="2pJxaS" to="hm2y:4rZeNQ6MGoV" resolve="DivExpression" />
+                  <node concept="2pIpSj" id="6q$NxWeCz9q" role="2pJxcM">
+                    <ref role="2pIpSl" to="hm2y:4rZeNQ6MpKm" resolve="left" />
+                    <node concept="36biLy" id="6q$NxWeCz9r" role="28nt2d">
+                      <node concept="2OqwBi" id="6q$NxWeCz9s" role="36biLW">
+                        <node concept="2OqwBi" id="6q$NxWeCz9t" role="2Oq$k0">
+                          <node concept="3cjoe7" id="6q$NxWeCz9u" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="6q$NxWeCz9v" role="2OqNvi">
+                            <ref role="3Tt5mk" to="1qv1:4iu6t1eAWP7" resolve="numerator" />
+                          </node>
+                        </node>
+                        <node concept="1$rogu" id="6q$NxWeCz9w" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="6q$NxWeCz9x" role="2pJxcM">
+                    <ref role="2pIpSl" to="hm2y:4rZeNQ6MpKo" resolve="right" />
+                    <node concept="36biLy" id="6q$NxWeCz9y" role="28nt2d">
+                      <node concept="2OqwBi" id="6q$NxWeCz9z" role="36biLW">
+                        <node concept="2OqwBi" id="6q$NxWeCz9$" role="2Oq$k0">
+                          <node concept="3cjoe7" id="6q$NxWeCz9_" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="6q$NxWeCz9A" role="2OqNvi">
+                            <ref role="3Tt5mk" to="1qv1:4iu6t1eAWPa" resolve="denominator" />
+                          </node>
+                        </node>
+                        <node concept="1$rogu" id="6q$NxWeCz9B" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cjfiJ" id="6q$NxWeCz9C" role="3h4u4a" />
+              <node concept="3cjoZ5" id="6q$NxWeCz9D" role="3h4u2h" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2pJPEk" id="6q$NxWeCz6o" role="32tDTd">
+        <node concept="2pJPED" id="6q$NxWeCEQG" role="2pJPEn">
+          <ref role="2pJxaS" to="w1hl:4HxogODTnzM" resolve="AbstractTaggedType" />
+        </node>
+      </node>
+      <node concept="1QeDOX" id="6q$NxWeCzn8" role="1QeD3i">
+        <node concept="3clFbS" id="6q$NxWeCzn9" role="2VODD2">
+          <node concept="3cpWs6" id="6q$NxWeCztW" role="3cqZAp">
+            <node concept="22lmx$" id="6q$NxWeCztX" role="3cqZAk">
+              <node concept="2YIFZM" id="6q$NxWeCztY" role="3uHU7w">
+                <ref role="37wK5l" node="1JTgXSYRK0d" resolve="hasSingleUnitSpecificationTag" />
+                <ref role="1Pybhc" node="1JTgXSYRFrf" resolve="MathExpressionsOpRulesHelper" />
+                <node concept="3cjoZ5" id="6q$NxWeCztZ" role="37wK5m" />
+              </node>
+              <node concept="2YIFZM" id="6q$NxWeCzu0" role="3uHU7B">
+                <ref role="37wK5l" node="1JTgXSYRK0d" resolve="hasSingleUnitSpecificationTag" />
+                <ref role="1Pybhc" node="1JTgXSYRFrf" resolve="MathExpressionsOpRulesHelper" />
+                <node concept="3cjfiJ" id="6q$NxWeCzu1" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="18kY7G" id="1JTgXSYQXiX">
+    <property role="3GE5qa" value="conversion" />
+    <property role="TrG5h" value="CheckLogExpressionHasNoUnits" />
+    <node concept="3clFbS" id="1JTgXSYQXiY" role="18ibNy">
+      <node concept="2Mj0R9" id="1JTgXSYQXKZ" role="3cqZAp">
+        <node concept="3fqX7Q" id="1JTgXSYRxtG" role="2MkoU_">
+          <node concept="2YIFZM" id="1JTgXSYRxtI" role="3fr31v">
+            <ref role="37wK5l" to="dntf:5pSqQr$Qyek" resolve="hasUnitSpecification" />
+            <ref role="1Pybhc" to="dntf:4jkbLB5RJZL" resolve="UnitConversionUtil" />
+            <node concept="2OqwBi" id="1JTgXSYRxtJ" role="37wK5m">
+              <node concept="2OqwBi" id="1JTgXSYRxtK" role="2Oq$k0">
+                <node concept="1YBJjd" id="1JTgXSYRxtL" role="2Oq$k0">
+                  <ref role="1YBMHb" node="1JTgXSYQXj0" resolve="logExpression" />
+                </node>
+                <node concept="3TrEf2" id="1JTgXSYRxtM" role="2OqNvi">
+                  <ref role="3Tt5mk" to="1qv1:4iu6t1eB9_$" resolve="expr" />
+                </node>
+              </node>
+              <node concept="3JvlWi" id="1JTgXSYRxtN" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="Xl_RD" id="1JTgXSYRpdE" role="2MkJ7o">
+          <property role="Xl_RC" value="A log expression is not allowed to have units!" />
+        </node>
+        <node concept="2OqwBi" id="1JTgXSYRpBf" role="1urrMF">
+          <node concept="1YBJjd" id="1JTgXSYRpl5" role="2Oq$k0">
+            <ref role="1YBMHb" node="1JTgXSYQXj0" resolve="logExpression" />
+          </node>
+          <node concept="3TrEf2" id="1JTgXSYRpUB" role="2OqNvi">
+            <ref role="3Tt5mk" to="1qv1:4iu6t1eB9_$" resolve="expr" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="1JTgXSYQXj0" role="1YuTPh">
+      <property role="TrG5h" value="logExpression" />
+      <ref role="1YaFvo" to="1qv1:4iu6t1eAXZR" resolve="LogExpression" />
+    </node>
+  </node>
+  <node concept="312cEu" id="1JTgXSYRFrf">
+    <property role="3GE5qa" value="conversion" />
+    <property role="TrG5h" value="MathExpressionsOpRulesHelper" />
+    <node concept="3clFbW" id="1JTgXSYRFt1" role="jymVt">
+      <node concept="3cqZAl" id="1JTgXSYRFt3" role="3clF45" />
+      <node concept="3Tm6S6" id="1JTgXSYRFtr" role="1B3o_S" />
+      <node concept="3clFbS" id="1JTgXSYRFt5" role="3clF47" />
+    </node>
+    <node concept="2tJIrI" id="1JTgXSYRFwb" role="jymVt" />
+    <node concept="2YIFZL" id="1JTgXSYRK0d" role="jymVt">
+      <property role="TrG5h" value="hasSingleUnitSpecificationTag" />
+      <node concept="3clFbS" id="1JTgXSYRK0h" role="3clF47">
+        <node concept="3clFbJ" id="1JTgXSYRK0i" role="3cqZAp">
+          <node concept="1Wc70l" id="1JTgXSYRK0j" role="3clFbw">
+            <node concept="2OqwBi" id="1JTgXSYRK0k" role="3uHU7B">
+              <node concept="37vLTw" id="1JTgXSYRK0l" role="2Oq$k0">
+                <ref role="3cqZAo" node="1JTgXSYRK0X" resolve="node" />
+              </node>
+              <node concept="1mIQ4w" id="1JTgXSYRK0m" role="2OqNvi">
+                <node concept="chp4Y" id="1JTgXSYRK0n" role="cj9EA">
+                  <ref role="cht4Q" to="w1hl:1xEzHAktP2Q" resolve="TaggedType" />
+                </node>
+              </node>
+            </node>
+            <node concept="2ZW3vV" id="1JTgXSYRK0o" role="3uHU7w">
+              <node concept="3uibUv" id="1JTgXSYRK0p" role="2ZW6by">
+                <ref role="3uigEE" to="qlm2:7McqtXGCExM" resolve="TagHandlingCapability" />
+              </node>
+              <node concept="2OqwBi" id="1JTgXSYRK0q" role="2ZW6bz">
+                <node concept="1PxgMI" id="1JTgXSYRK0r" role="2Oq$k0">
+                  <property role="1BlNFB" value="true" />
+                  <node concept="37vLTw" id="1JTgXSYRK0s" role="1m5AlR">
+                    <ref role="3cqZAo" node="1JTgXSYRK0X" resolve="node" />
+                  </node>
+                  <node concept="chp4Y" id="1JTgXSYRK0t" role="3oSUPX">
+                    <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="1JTgXSYRK0u" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:7McqtXGyz8c" resolve="getCapabilityRequirement" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="1JTgXSYRK0v" role="3clFbx">
+            <node concept="3cpWs8" id="1JTgXSYRK0w" role="3cqZAp">
+              <node concept="3cpWsn" id="1JTgXSYRK0x" role="3cpWs9">
+                <property role="TrG5h" value="taggedType" />
+                <node concept="3Tqbb2" id="1JTgXSYRK0y" role="1tU5fm">
+                  <ref role="ehGHo" to="w1hl:1xEzHAktP2Q" resolve="TaggedType" />
+                </node>
+                <node concept="1PxgMI" id="1JTgXSYRK0z" role="33vP2m">
+                  <node concept="chp4Y" id="1JTgXSYRK0$" role="3oSUPX">
+                    <ref role="cht4Q" to="w1hl:1xEzHAktP2Q" resolve="TaggedType" />
+                  </node>
+                  <node concept="37vLTw" id="1JTgXSYRK0_" role="1m5AlR">
+                    <ref role="3cqZAo" node="1JTgXSYRK0X" resolve="node" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="1JTgXSYRK0A" role="3cqZAp">
+              <node concept="3cpWsn" id="1JTgXSYRK0B" role="3cpWs9">
+                <property role="TrG5h" value="hasSingleUnitSpecificationTag" />
+                <node concept="10P_77" id="1JTgXSYRK0C" role="1tU5fm" />
+                <node concept="1Wc70l" id="1JTgXSYRK0D" role="33vP2m">
+                  <node concept="2OqwBi" id="1JTgXSYRK0E" role="3uHU7w">
+                    <node concept="2OqwBi" id="1JTgXSYRK0F" role="2Oq$k0">
+                      <node concept="2OqwBi" id="1JTgXSYRK0G" role="2Oq$k0">
+                        <node concept="37vLTw" id="1JTgXSYRK0H" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1JTgXSYRK0x" resolve="taggedType" />
+                        </node>
+                        <node concept="3Tsc0h" id="1JTgXSYRK0I" role="2OqNvi">
+                          <ref role="3TtcxE" to="w1hl:1xEzHAktP2R" resolve="tags" />
+                        </node>
+                      </node>
+                      <node concept="1uHKPH" id="1JTgXSYRK0J" role="2OqNvi" />
+                    </node>
+                    <node concept="1mIQ4w" id="1JTgXSYRK0K" role="2OqNvi">
+                      <node concept="chp4Y" id="1JTgXSYRK0L" role="cj9EA">
+                        <ref role="cht4Q" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbC" id="1JTgXSYRK0M" role="3uHU7B">
+                    <node concept="2OqwBi" id="1JTgXSYRK0N" role="3uHU7B">
+                      <node concept="2OqwBi" id="1JTgXSYRK0O" role="2Oq$k0">
+                        <node concept="37vLTw" id="1JTgXSYRK0P" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1JTgXSYRK0x" resolve="taggedType" />
+                        </node>
+                        <node concept="3Tsc0h" id="1JTgXSYRK0Q" role="2OqNvi">
+                          <ref role="3TtcxE" to="w1hl:1xEzHAktP2R" resolve="tags" />
+                        </node>
+                      </node>
+                      <node concept="34oBXx" id="1JTgXSYRK0R" role="2OqNvi" />
+                    </node>
+                    <node concept="3cmrfG" id="1JTgXSYRK0S" role="3uHU7w">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="1JTgXSYRK0T" role="3cqZAp">
+              <node concept="37vLTw" id="1JTgXSYRK0U" role="3cqZAk">
+                <ref role="3cqZAo" node="1JTgXSYRK0B" resolve="hasSingleUnitSpecificationTag" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="1JTgXSYRK0V" role="3cqZAp">
+          <node concept="3clFbT" id="1JTgXSYRK0W" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="10P_77" id="1JTgXSYRK0f" role="3clF45" />
+      <node concept="37vLTG" id="1JTgXSYRK0X" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="1JTgXSYRK0Y" role="1tU5fm" />
+      </node>
+      <node concept="3Tm1VV" id="1JTgXSYRK0g" role="1B3o_S" />
+      <node concept="1KehLL" id="1JTgXSYRK1T" role="lGtFl">
+        <property role="1K8rM7" value="staticModifier" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="1JTgXSYRFrg" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/typesystem.mps
@@ -21,6 +21,8 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" />
     <import index="qlm2" ref="r:c0482758-b46b-48c3-8482-fa4a3115b53b(org.iets3.core.expr.typetags.behavior)" />
+    <import index="1qv1" ref="r:c53b8bbc-6142-4787-a6e4-66310b772b37(org.iets3.core.expr.math.structure)" implicit="true" />
+    <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -64,6 +66,10 @@
       </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
@@ -209,10 +215,26 @@
       <concept id="1205762656241" name="jetbrains.mps.lang.typesystem.structure.WhenConcreteVariableReference" flags="nn" index="2X3wrD">
         <reference id="1205762683928" name="whenConcreteVar" index="2X3Bk0" />
       </concept>
+      <concept id="8124453027370845339" name="jetbrains.mps.lang.typesystem.structure.AbstractOverloadedOpsTypeRule" flags="ng" index="32tDTw">
+        <child id="8124453027370845343" name="function" index="32tDT$" />
+        <child id="8124453027370845341" name="operationConcept" index="32tDTA" />
+        <child id="6136676636349909553" name="isApplicable" index="1QeD3i" />
+      </concept>
       <concept id="1195213580585" name="jetbrains.mps.lang.typesystem.structure.AbstractCheckingRule" flags="ig" index="18hYwZ">
         <child id="1195213635060" name="body" index="18ibNy" />
       </concept>
       <concept id="1195214364922" name="jetbrains.mps.lang.typesystem.structure.NonTypesystemRule" flags="ig" index="18kY7G" />
+      <concept id="1236083041311" name="jetbrains.mps.lang.typesystem.structure.OverloadedOperatorTypeRule" flags="ng" index="3ciAk0">
+        <property id="1236771585835" name="rightIsExact" index="3PlbSO" />
+        <child id="1236083115043" name="leftOperandType" index="3ciSkW" />
+        <child id="1236083115200" name="rightOperandType" index="3ciSnv" />
+      </concept>
+      <concept id="1236083146670" name="jetbrains.mps.lang.typesystem.structure.OverloadedOperatorTypeFunction" flags="in" index="3ciZUL" />
+      <concept id="1236083209648" name="jetbrains.mps.lang.typesystem.structure.LeftOperandType_parameter" flags="nn" index="3cjfiJ" />
+      <concept id="1236083248858" name="jetbrains.mps.lang.typesystem.structure.RightOperandType_parameter" flags="nn" index="3cjoZ5" />
+      <concept id="1236165709895" name="jetbrains.mps.lang.typesystem.structure.OverloadedOpRulesContainer" flags="ng" index="3hdX5o">
+        <child id="1236165725858" name="rule" index="3he0YX" />
+      </concept>
       <concept id="3937244445246642777" name="jetbrains.mps.lang.typesystem.structure.AbstractReportStatement" flags="ng" index="1urrMJ">
         <child id="3937244445246643221" name="helginsIntention" index="1urrFz" />
         <child id="3937244445246642781" name="nodeToReport" index="1urrMF" />
@@ -231,6 +253,7 @@
         <child id="1176543950311" name="supertypeExpression" index="3JuZjQ" />
       </concept>
       <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
+      <concept id="6136676636349908958" name="jetbrains.mps.lang.typesystem.structure.OverloadedOpIsApplicableFunction" flags="in" index="1QeDOX" />
       <concept id="1174642788531" name="jetbrains.mps.lang.typesystem.structure.ConceptReference" flags="ig" index="1YaCAy">
         <reference id="1174642800329" name="concept" index="1YaFvo" />
       </concept>
@@ -276,6 +299,9 @@
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz">
         <reference id="6677504323281689839" name="conceptDeclaraton" index="3bZ5Sy" />
       </concept>
+      <concept id="1154546950173" name="jetbrains.mps.lang.smodel.structure.ConceptReference" flags="ng" index="3gn64h">
+        <reference id="1154546997487" name="concept" index="3gnhBz" />
+      </concept>
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
@@ -283,7 +309,12 @@
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
-      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
+      <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
+        <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -2536,6 +2567,229 @@
                 <ref role="3Tt5mk" to="b0gq:yGiRIEUFLN" resolve="conversionSpecifier" />
               </node>
             </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="3hdX5o" id="3htFKtcdWPm">
+    <property role="3GE5qa" value="conversion" />
+    <property role="TrG5h" value="MathExpressionsOpRules" />
+    <node concept="3ciAk0" id="3htFKtcdXBh" role="3he0YX">
+      <property role="3PlbSO" value="true" />
+      <node concept="2pJPEk" id="3htFKtcdXDP" role="3ciSkW">
+        <node concept="2pJPED" id="3htFKtcdXFu" role="2pJPEn">
+          <ref role="2pJxaS" to="w1hl:4HxogODTnzM" resolve="AbstractTaggedType" />
+        </node>
+      </node>
+      <node concept="10Nm6u" id="3htFKtcdXEL" role="3ciSnv" />
+      <node concept="3gn64h" id="3htFKtcdXD$" role="32tDTA">
+        <ref role="3gnhBz" to="1qv1:4iu6t1eB8RC" resolve="SqrtExpression" />
+      </node>
+      <node concept="3ciZUL" id="3htFKtcdXBl" role="32tDT$">
+        <node concept="3clFbS" id="3htFKtcdXBm" role="2VODD2">
+          <node concept="3cpWs8" id="3htFKtcfAsh" role="3cqZAp">
+            <node concept="3cpWsn" id="3htFKtcfAsi" role="3cpWs9">
+              <property role="TrG5h" value="unitSpecification" />
+              <node concept="3Tqbb2" id="3htFKtcfArA" role="1tU5fm">
+                <ref role="ehGHo" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+              </node>
+              <node concept="1PxgMI" id="3htFKtcfAsj" role="33vP2m">
+                <node concept="chp4Y" id="3htFKtcfAsk" role="3oSUPX">
+                  <ref role="cht4Q" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+                </node>
+                <node concept="2OqwBi" id="3htFKtcfAsl" role="1m5AlR">
+                  <node concept="2OqwBi" id="3htFKtcfAsm" role="2Oq$k0">
+                    <node concept="1PxgMI" id="3htFKtcfAsn" role="2Oq$k0">
+                      <node concept="chp4Y" id="3htFKtcfAso" role="3oSUPX">
+                        <ref role="cht4Q" to="w1hl:1xEzHAktP2Q" resolve="TaggedType" />
+                      </node>
+                      <node concept="3cjfiJ" id="3htFKtcfAsp" role="1m5AlR" />
+                    </node>
+                    <node concept="3Tsc0h" id="3htFKtcfAsq" role="2OqNvi">
+                      <ref role="3TtcxE" to="w1hl:1xEzHAktP2R" resolve="tags" />
+                    </node>
+                  </node>
+                  <node concept="1uHKPH" id="3htFKtcfAsr" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="3htFKtcj0pv" role="3cqZAp">
+            <node concept="3cpWsn" id="3htFKtcj0pw" role="3cpWs9">
+              <property role="TrG5h" value="sqrtUnitSpecification" />
+              <node concept="3Tqbb2" id="3htFKtcj0fp" role="1tU5fm">
+                <ref role="ehGHo" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+              </node>
+              <node concept="2YIFZM" id="3htFKtcj0px" role="33vP2m">
+                <ref role="37wK5l" to="dntf:3htFKtciTSe" resolve="sqrt" />
+                <ref role="1Pybhc" to="dntf:4jkbLB5RJZL" resolve="UnitConversionUtil" />
+                <node concept="37vLTw" id="3htFKtcj0py" role="37wK5m">
+                  <ref role="3cqZAo" node="3htFKtcfAsi" resolve="unitSpecification" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="3htFKtcj2we" role="3cqZAp">
+            <node concept="3cpWsn" id="3htFKtcj2wf" role="3cpWs9">
+              <property role="TrG5h" value="sqrtExpressionType" />
+              <node concept="3Tqbb2" id="3htFKtcj2tm" role="1tU5fm">
+                <ref role="ehGHo" to="w1hl:1xEzHAktP2Q" resolve="TaggedType" />
+              </node>
+              <node concept="2ShNRf" id="3htFKtcj2wg" role="33vP2m">
+                <node concept="3zrR0B" id="3htFKtcj2wh" role="2ShVmc">
+                  <node concept="3Tqbb2" id="3htFKtcj2wi" role="3zrR0E">
+                    <ref role="ehGHo" to="w1hl:1xEzHAktP2Q" resolve="TaggedType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="3htFKtcj22Y" role="3cqZAp">
+            <node concept="37vLTI" id="3htFKtcj41i" role="3clFbG">
+              <node concept="2ShNRf" id="3htFKtcj47T" role="37vLTx">
+                <node concept="3zrR0B" id="3htFKtcj47R" role="2ShVmc">
+                  <node concept="3Tqbb2" id="3htFKtcj47S" role="3zrR0E">
+                    <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="3htFKtcj3pn" role="37vLTJ">
+                <node concept="37vLTw" id="3htFKtcj2wj" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3htFKtcj2wf" resolve="sqrtExpressionType" />
+                </node>
+                <node concept="3TrEf2" id="3htFKtcj3Qi" role="2OqNvi">
+                  <ref role="3Tt5mk" to="w1hl:1xEzHAktP2T" resolve="baseType" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="3htFKtcj4sw" role="3cqZAp">
+            <node concept="2OqwBi" id="3htFKtcj6G_" role="3clFbG">
+              <node concept="2OqwBi" id="3htFKtcj4Mi" role="2Oq$k0">
+                <node concept="37vLTw" id="3htFKtcj4su" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3htFKtcj2wf" resolve="sqrtExpressionType" />
+                </node>
+                <node concept="3Tsc0h" id="3htFKtcj58p" role="2OqNvi">
+                  <ref role="3TtcxE" to="w1hl:1xEzHAktP2R" resolve="tags" />
+                </node>
+              </node>
+              <node concept="TSZUe" id="3htFKtcj87M" role="2OqNvi">
+                <node concept="37vLTw" id="3htFKtcj8Hc" role="25WWJ7">
+                  <ref role="3cqZAo" node="3htFKtcj0pw" resolve="sqrtUnitSpecification" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="3htFKtceqDp" role="3cqZAp">
+            <node concept="37vLTw" id="3htFKtceqlR" role="3cqZAk">
+              <ref role="3cqZAo" node="3htFKtcj2wf" resolve="sqrtExpressionType" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1QeDOX" id="3htFKtcdXFZ" role="1QeD3i">
+        <node concept="3clFbS" id="3htFKtcdXG0" role="2VODD2">
+          <node concept="3clFbJ" id="3htFKtcdYmg" role="3cqZAp">
+            <node concept="1Wc70l" id="3htFKtcdZ6$" role="3clFbw">
+              <node concept="3clFbC" id="3htFKtcdZi$" role="3uHU7w">
+                <node concept="10Nm6u" id="3htFKtcdZvN" role="3uHU7w" />
+                <node concept="3cjoZ5" id="3htFKtcdZ7C" role="3uHU7B" />
+              </node>
+              <node concept="1Wc70l" id="3htFKtcekD6" role="3uHU7B">
+                <node concept="2OqwBi" id="3htFKtcdYzg" role="3uHU7B">
+                  <node concept="3cjfiJ" id="3htFKtcdYmL" role="2Oq$k0" />
+                  <node concept="1mIQ4w" id="3htFKtcdYEj" role="2OqNvi">
+                    <node concept="chp4Y" id="3htFKtcdYGA" role="cj9EA">
+                      <ref role="cht4Q" to="w1hl:1xEzHAktP2Q" resolve="TaggedType" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2ZW3vV" id="7McqtXGDfX2" role="3uHU7w">
+                  <node concept="3uibUv" id="7McqtXGDgjR" role="2ZW6by">
+                    <ref role="3uigEE" to="qlm2:7McqtXGCExM" resolve="TagHandlingCapability" />
+                  </node>
+                  <node concept="2OqwBi" id="7McqtXGDeE2" role="2ZW6bz">
+                    <node concept="1PxgMI" id="7McqtXGDe4z" role="2Oq$k0">
+                      <property role="1BlNFB" value="true" />
+                      <node concept="3cjfiJ" id="7McqtXGDdvZ" role="1m5AlR" />
+                      <node concept="chp4Y" id="72_xmu9gQ2L" role="3oSUPX">
+                        <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="7McqtXGDf6_" role="2OqNvi">
+                      <ref role="37wK5l" to="pbu6:7McqtXGyz8c" resolve="getCapabilityRequirement" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="3htFKtcdYmi" role="3clFbx">
+              <node concept="3cpWs8" id="3htFKtce06V" role="3cqZAp">
+                <node concept="3cpWsn" id="3htFKtce06W" role="3cpWs9">
+                  <property role="TrG5h" value="taggedType" />
+                  <node concept="3Tqbb2" id="3htFKtce06A" role="1tU5fm">
+                    <ref role="ehGHo" to="w1hl:1xEzHAktP2Q" resolve="TaggedType" />
+                  </node>
+                  <node concept="1PxgMI" id="3htFKtce06X" role="33vP2m">
+                    <node concept="chp4Y" id="3htFKtce06Y" role="3oSUPX">
+                      <ref role="cht4Q" to="w1hl:1xEzHAktP2Q" resolve="TaggedType" />
+                    </node>
+                    <node concept="3cjfiJ" id="3htFKtce06Z" role="1m5AlR" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="3htFKtcedxR" role="3cqZAp">
+                <node concept="3cpWsn" id="3htFKtcedxS" role="3cpWs9">
+                  <property role="TrG5h" value="hasSingleUnitSpecificationTag" />
+                  <node concept="10P_77" id="3htFKtcedsN" role="1tU5fm" />
+                  <node concept="1Wc70l" id="3htFKtcedxT" role="33vP2m">
+                    <node concept="2OqwBi" id="3htFKtcedxU" role="3uHU7w">
+                      <node concept="2OqwBi" id="3htFKtcedxV" role="2Oq$k0">
+                        <node concept="2OqwBi" id="3htFKtcedxW" role="2Oq$k0">
+                          <node concept="37vLTw" id="3htFKtcedxX" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3htFKtce06W" resolve="taggedType" />
+                          </node>
+                          <node concept="3Tsc0h" id="3htFKtcedxY" role="2OqNvi">
+                            <ref role="3TtcxE" to="w1hl:1xEzHAktP2R" resolve="tags" />
+                          </node>
+                        </node>
+                        <node concept="1uHKPH" id="3htFKtcedxZ" role="2OqNvi" />
+                      </node>
+                      <node concept="1mIQ4w" id="3htFKtcedy0" role="2OqNvi">
+                        <node concept="chp4Y" id="3htFKtcedy1" role="cj9EA">
+                          <ref role="cht4Q" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbC" id="3htFKtcedy2" role="3uHU7B">
+                      <node concept="2OqwBi" id="3htFKtcedy3" role="3uHU7B">
+                        <node concept="2OqwBi" id="3htFKtcedy4" role="2Oq$k0">
+                          <node concept="37vLTw" id="3htFKtcedy5" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3htFKtce06W" resolve="taggedType" />
+                          </node>
+                          <node concept="3Tsc0h" id="3htFKtcedy6" role="2OqNvi">
+                            <ref role="3TtcxE" to="w1hl:1xEzHAktP2R" resolve="tags" />
+                          </node>
+                        </node>
+                        <node concept="34oBXx" id="3htFKtcedy7" role="2OqNvi" />
+                      </node>
+                      <node concept="3cmrfG" id="3htFKtcedy8" role="3uHU7w">
+                        <property role="3cmrfH" value="1" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs6" id="3htFKtcehu2" role="3cqZAp">
+                <node concept="37vLTw" id="3htFKtcehu4" role="3cqZAk">
+                  <ref role="3cqZAo" node="3htFKtcedxS" resolve="hasSingleUnitSpecificationTag" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="3htFKtcdZy0" role="3cqZAp">
+            <node concept="3clFbT" id="3htFKtcdZyn" role="3cqZAk" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/typesystem.mps
@@ -21,7 +21,8 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" />
     <import index="qlm2" ref="r:c0482758-b46b-48c3-8482-fa4a3115b53b(org.iets3.core.expr.typetags.behavior)" />
-    <import index="1qv1" ref="r:c53b8bbc-6142-4787-a6e4-66310b772b37(org.iets3.core.expr.math.structure)" implicit="true" />
+    <import index="b1h1" ref="r:ac5f749f-6179-4d4f-ad24-ad9edbd8077b(org.iets3.core.expr.simpleTypes.behavior)" />
+    <import index="1qv1" ref="r:c53b8bbc-6142-4787-a6e4-66310b772b37(org.iets3.core.expr.math.structure)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -56,8 +57,16 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1164879751025" name="jetbrains.mps.baseLanguage.structure.TryCatchStatement" flags="nn" index="SfApY">
+        <child id="1164879758292" name="body" index="SfCbr" />
+        <child id="1164903496223" name="catchClause" index="TEbGg" />
+      </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1164903280175" name="jetbrains.mps.baseLanguage.structure.CatchClause" flags="nn" index="TDmWw">
+        <child id="1164903359218" name="catchBody" index="TDEfX" />
+        <child id="1164903359217" name="throwable" index="TDEfY" />
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
@@ -123,6 +132,7 @@
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
+      <concept id="1068581242867" name="jetbrains.mps.baseLanguage.structure.LongType" flags="in" index="3cpWsb" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
@@ -369,9 +379,6 @@
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
       <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7" />
-      <concept id="779128492853369165" name="jetbrains.mps.lang.core.structure.SideTransformInfo" flags="ng" index="1KehLL">
-        <property id="779128492853934523" name="cellId" index="1K8rM7" />
-      </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
       <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="ng" index="3oM_SD">
@@ -2839,6 +2846,244 @@
         </node>
       </node>
     </node>
+    <node concept="3ciAk0" id="6q$NxWeW1Pa" role="3he0YX">
+      <node concept="2pJPEk" id="6q$NxWeW1Zb" role="3ciSnv">
+        <node concept="2pJPED" id="6q$NxWeW2ug" role="2pJPEn">
+          <ref role="2pJxaS" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+        </node>
+      </node>
+      <node concept="3gn64h" id="6q$NxWeW1WM" role="32tDTA">
+        <ref role="3gnhBz" to="1qv1:4iu6t1eB654" resolve="PowerExpression" />
+      </node>
+      <node concept="3ciZUL" id="6q$NxWeW1Pu" role="32tDT$">
+        <node concept="3clFbS" id="6q$NxWeW1Pz" role="2VODD2">
+          <node concept="3cpWs8" id="6q$NxWeWrXN" role="3cqZAp">
+            <node concept="3cpWsn" id="6q$NxWeWrXQ" role="3cpWs9">
+              <property role="TrG5h" value="unitSpecification" />
+              <node concept="3Tqbb2" id="6q$NxWeWrXR" role="1tU5fm">
+                <ref role="ehGHo" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+              </node>
+              <node concept="1PxgMI" id="6q$NxWeWrXS" role="33vP2m">
+                <node concept="chp4Y" id="6q$NxWeWrXT" role="3oSUPX">
+                  <ref role="cht4Q" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+                </node>
+                <node concept="2OqwBi" id="6q$NxWeWrXU" role="1m5AlR">
+                  <node concept="2OqwBi" id="6q$NxWeWrXV" role="2Oq$k0">
+                    <node concept="1PxgMI" id="6q$NxWeWrXW" role="2Oq$k0">
+                      <node concept="chp4Y" id="6q$NxWeWrXX" role="3oSUPX">
+                        <ref role="cht4Q" to="w1hl:1xEzHAktP2Q" resolve="TaggedType" />
+                      </node>
+                      <node concept="3cjfiJ" id="6q$NxWeWrXY" role="1m5AlR" />
+                    </node>
+                    <node concept="3Tsc0h" id="6q$NxWeWrXZ" role="2OqNvi">
+                      <ref role="3TtcxE" to="w1hl:1xEzHAktP2R" resolve="tags" />
+                    </node>
+                  </node>
+                  <node concept="1uHKPH" id="6q$NxWeWrY0" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="6q$NxWeWrqe" role="3cqZAp">
+            <node concept="3cpWsn" id="6q$NxWeWrqf" role="3cpWs9">
+              <property role="TrG5h" value="power" />
+              <node concept="10Oyi0" id="6q$NxWf03TW" role="1tU5fm" />
+              <node concept="2YIFZM" id="6q$NxWf03iX" role="33vP2m">
+                <ref role="37wK5l" to="wyt6:~Math.toIntExact(long)" resolve="toIntExact" />
+                <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                <node concept="1LFfDK" id="6q$NxWeWrqg" role="37wK5m">
+                  <node concept="3cmrfG" id="6q$NxWeWrqh" role="1LF_Uc">
+                    <property role="3cmrfH" value="1" />
+                  </node>
+                  <node concept="2OqwBi" id="6q$NxWeWrqi" role="1LFl5Q">
+                    <node concept="1PxgMI" id="6q$NxWeWrqj" role="2Oq$k0">
+                      <node concept="chp4Y" id="6q$NxWeWrqk" role="3oSUPX">
+                        <ref role="cht4Q" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                      </node>
+                      <node concept="3cjoZ5" id="6q$NxWeWrql" role="1m5AlR" />
+                    </node>
+                    <node concept="2qgKlT" id="6q$NxWeWrqm" role="2OqNvi">
+                      <ref role="37wK5l" to="b1h1:3p6$WoEzHkL" resolve="intRange" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="6q$NxWeWvSx" role="3cqZAp" />
+          <node concept="3cpWs8" id="6q$NxWeWsv6" role="3cqZAp">
+            <node concept="3cpWsn" id="6q$NxWeWsv9" role="3cpWs9">
+              <property role="TrG5h" value="powUnitSpecification" />
+              <node concept="3Tqbb2" id="6q$NxWeWsva" role="1tU5fm">
+                <ref role="ehGHo" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+              </node>
+              <node concept="2YIFZM" id="6q$NxWeZpMV" role="33vP2m">
+                <ref role="37wK5l" to="dntf:6q$NxWeWUdj" resolve="pow" />
+                <ref role="1Pybhc" to="dntf:4jkbLB5RJZL" resolve="UnitConversionUtil" />
+                <node concept="37vLTw" id="6q$NxWeZpMW" role="37wK5m">
+                  <ref role="3cqZAo" node="6q$NxWeWrXQ" resolve="unitSpecification" />
+                </node>
+                <node concept="37vLTw" id="6q$NxWeZrtU" role="37wK5m">
+                  <ref role="3cqZAo" node="6q$NxWeWrqf" resolve="power" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="6q$NxWeWw6j" role="3cqZAp" />
+          <node concept="3cpWs8" id="6q$NxWeWtdo" role="3cqZAp">
+            <node concept="3cpWsn" id="6q$NxWeWtdp" role="3cpWs9">
+              <property role="TrG5h" value="powExpressionType" />
+              <node concept="3Tqbb2" id="6q$NxWeWtdq" role="1tU5fm">
+                <ref role="ehGHo" to="w1hl:1xEzHAktP2Q" resolve="TaggedType" />
+              </node>
+              <node concept="2ShNRf" id="6q$NxWeWtdr" role="33vP2m">
+                <node concept="3zrR0B" id="6q$NxWeWtds" role="2ShVmc">
+                  <node concept="3Tqbb2" id="6q$NxWeWtdt" role="3zrR0E">
+                    <ref role="ehGHo" to="w1hl:1xEzHAktP2Q" resolve="TaggedType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="6q$NxWeWtdu" role="3cqZAp">
+            <node concept="37vLTI" id="6q$NxWeWtdv" role="3clFbG">
+              <node concept="2ShNRf" id="6q$NxWeWtdw" role="37vLTx">
+                <node concept="3zrR0B" id="6q$NxWeWtdx" role="2ShVmc">
+                  <node concept="3Tqbb2" id="6q$NxWeWtdy" role="3zrR0E">
+                    <ref role="ehGHo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="6q$NxWeWtdz" role="37vLTJ">
+                <node concept="37vLTw" id="6q$NxWeWtd$" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6q$NxWeWtdp" resolve="powExpressionType" />
+                </node>
+                <node concept="3TrEf2" id="6q$NxWeWtd_" role="2OqNvi">
+                  <ref role="3Tt5mk" to="w1hl:1xEzHAktP2T" resolve="baseType" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="6q$NxWeWtdA" role="3cqZAp">
+            <node concept="2OqwBi" id="6q$NxWeWtdB" role="3clFbG">
+              <node concept="2OqwBi" id="6q$NxWeWtdC" role="2Oq$k0">
+                <node concept="37vLTw" id="6q$NxWeWtdD" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6q$NxWeWtdp" resolve="powExpressionType" />
+                </node>
+                <node concept="3Tsc0h" id="6q$NxWeWtdE" role="2OqNvi">
+                  <ref role="3TtcxE" to="w1hl:1xEzHAktP2R" resolve="tags" />
+                </node>
+              </node>
+              <node concept="TSZUe" id="6q$NxWeWtdF" role="2OqNvi">
+                <node concept="37vLTw" id="6q$NxWeWtLf" role="25WWJ7">
+                  <ref role="3cqZAo" node="6q$NxWeWsv9" resolve="powUnitSpecification" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="6q$NxWeWucM" role="3cqZAp">
+            <node concept="37vLTw" id="6q$NxWeWuBC" role="3cqZAk">
+              <ref role="3cqZAo" node="6q$NxWeWtdp" resolve="powExpressionType" />
+            </node>
+          </node>
+          <node concept="3clFbH" id="6q$NxWeWsi8" role="3cqZAp" />
+        </node>
+      </node>
+      <node concept="2pJPEk" id="6q$NxWeW1Yy" role="3ciSkW">
+        <node concept="2pJPED" id="6q$NxWeW1YQ" role="2pJPEn">
+          <ref role="2pJxaS" to="w1hl:4HxogODTnzM" resolve="AbstractTaggedType" />
+        </node>
+      </node>
+      <node concept="1QeDOX" id="6q$NxWeW3MU" role="1QeD3i">
+        <node concept="3clFbS" id="6q$NxWeW3MV" role="2VODD2">
+          <node concept="3cpWs8" id="6q$NxWeW4m7" role="3cqZAp">
+            <node concept="3cpWsn" id="6q$NxWeW4m8" role="3cpWs9">
+              <property role="TrG5h" value="intRange" />
+              <node concept="1LlUBW" id="6q$NxWeW4iO" role="1tU5fm">
+                <node concept="3cpWsb" id="6q$NxWeW4iT" role="1Lm7xW" />
+                <node concept="3cpWsb" id="6q$NxWeW4iU" role="1Lm7xW" />
+              </node>
+              <node concept="2OqwBi" id="6q$NxWeW4m9" role="33vP2m">
+                <node concept="1PxgMI" id="6q$NxWeW4ma" role="2Oq$k0">
+                  <node concept="chp4Y" id="6q$NxWeW4mb" role="3oSUPX">
+                    <ref role="cht4Q" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                  </node>
+                  <node concept="3cjoZ5" id="6q$NxWeW4mc" role="1m5AlR" />
+                </node>
+                <node concept="2qgKlT" id="6q$NxWeW4md" role="2OqNvi">
+                  <ref role="37wK5l" to="b1h1:3p6$WoEzHkL" resolve="intRange" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="6q$NxWeWaZt" role="3cqZAp">
+            <node concept="3cpWsn" id="6q$NxWeWaZu" role="3cpWs9">
+              <property role="TrG5h" value="rangeIsValue" />
+              <node concept="10P_77" id="6q$NxWeWazW" role="1tU5fm" />
+              <node concept="2YIFZM" id="6q$NxWf20D1" role="33vP2m">
+                <ref role="37wK5l" node="6q$NxWf0F0Z" resolve="rangeIsValue" />
+                <ref role="1Pybhc" node="1JTgXSYRFrf" resolve="MathExpressionsOpRulesHelper" />
+                <node concept="1PxgMI" id="6q$NxWf22rf" role="37wK5m">
+                  <node concept="chp4Y" id="6q$NxWf22BR" role="3oSUPX">
+                    <ref role="cht4Q" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                  </node>
+                  <node concept="3cjoZ5" id="6q$NxWf220O" role="1m5AlR" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="6q$NxWeZMJe" role="3cqZAp">
+            <node concept="3clFbS" id="6q$NxWeZMJg" role="3clFbx">
+              <node concept="3cpWs8" id="6q$NxWf0$Ek" role="3cqZAp">
+                <node concept="3cpWsn" id="6q$NxWf0$El" role="3cpWs9">
+                  <property role="TrG5h" value="isIntValue" />
+                  <node concept="10P_77" id="6q$NxWf0v8C" role="1tU5fm" />
+                  <node concept="2YIFZM" id="6q$NxWf0$Em" role="33vP2m">
+                    <ref role="37wK5l" node="6q$NxWf0rZK" resolve="isIntValue" />
+                    <ref role="1Pybhc" node="1JTgXSYRFrf" resolve="MathExpressionsOpRulesHelper" />
+                    <node concept="1LFfDK" id="6q$NxWf0$En" role="37wK5m">
+                      <node concept="3cmrfG" id="6q$NxWf0$Eo" role="1LF_Uc">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                      <node concept="37vLTw" id="6q$NxWf0$Ep" role="1LFl5Q">
+                        <ref role="3cqZAo" node="6q$NxWeW4m8" resolve="intRange" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="6q$NxWeWgIT" role="3cqZAp">
+                <node concept="3cpWsn" id="6q$NxWeWgIU" role="3cpWs9">
+                  <property role="TrG5h" value="hasSingleUnitSpecificationTag" />
+                  <node concept="10P_77" id="6q$NxWeWgjk" role="1tU5fm" />
+                  <node concept="2YIFZM" id="6q$NxWeWgIV" role="33vP2m">
+                    <ref role="37wK5l" node="1JTgXSYRK0d" resolve="hasSingleUnitSpecificationTag" />
+                    <ref role="1Pybhc" node="1JTgXSYRFrf" resolve="MathExpressionsOpRulesHelper" />
+                    <node concept="3cjfiJ" id="6q$NxWeWgIW" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs6" id="6q$NxWeWhlz" role="3cqZAp">
+                <node concept="1Wc70l" id="6q$NxWeWivh" role="3cqZAk">
+                  <node concept="37vLTw" id="6q$NxWf0_Uw" role="3uHU7B">
+                    <ref role="3cqZAo" node="6q$NxWf0$El" resolve="isIntValue" />
+                  </node>
+                  <node concept="37vLTw" id="6q$NxWeWhl_" role="3uHU7w">
+                    <ref role="3cqZAo" node="6q$NxWeWgIU" resolve="hasSingleUnitSpecificationTag" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="6q$NxWeZNij" role="3clFbw">
+              <ref role="3cqZAo" node="6q$NxWeWaZu" resolve="rangeIsValue" />
+            </node>
+          </node>
+          <node concept="3cpWs6" id="6q$NxWeZOHm" role="3cqZAp">
+            <node concept="3clFbT" id="6q$NxWeZOLJ" role="3cqZAk" />
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="18kY7G" id="1JTgXSYQXiX">
     <property role="3GE5qa" value="conversion" />
@@ -3000,43 +3245,215 @@
         <node concept="3Tqbb2" id="1JTgXSYRK0Y" role="1tU5fm" />
       </node>
       <node concept="3Tm1VV" id="1JTgXSYRK0g" role="1B3o_S" />
-      <node concept="1KehLL" id="1JTgXSYRK1T" role="lGtFl">
-        <property role="1K8rM7" value="staticModifier" />
+    </node>
+    <node concept="2tJIrI" id="6q$NxWf0rVy" role="jymVt" />
+    <node concept="2YIFZL" id="6q$NxWf0F0Z" role="jymVt">
+      <property role="TrG5h" value="rangeIsValue" />
+      <node concept="3clFbS" id="6q$NxWf0F12" role="3clF47">
+        <node concept="3cpWs8" id="6q$NxWf0USk" role="3cqZAp">
+          <node concept="3cpWsn" id="6q$NxWf0USl" role="3cpWs9">
+            <property role="TrG5h" value="intRange" />
+            <node concept="1LlUBW" id="6q$NxWf0US2" role="1tU5fm">
+              <node concept="3cpWsb" id="6q$NxWf0US8" role="1Lm7xW" />
+              <node concept="3cpWsb" id="6q$NxWf0US7" role="1Lm7xW" />
+            </node>
+            <node concept="2OqwBi" id="6q$NxWf0USm" role="33vP2m">
+              <node concept="37vLTw" id="6q$NxWf0USn" role="2Oq$k0">
+                <ref role="3cqZAo" node="6q$NxWf0QNx" resolve="numberType" />
+              </node>
+              <node concept="2qgKlT" id="6q$NxWf0USo" role="2OqNvi">
+                <ref role="37wK5l" to="b1h1:3p6$WoEzHkL" resolve="intRange" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6q$NxWf0RE1" role="3cqZAp">
+          <node concept="3y3z36" id="6q$NxWf0Unp" role="3clFbw">
+            <node concept="10Nm6u" id="6q$NxWf0URd" role="3uHU7w" />
+            <node concept="37vLTw" id="6q$NxWf0USp" role="3uHU7B">
+              <ref role="3cqZAo" node="6q$NxWf0USl" resolve="intRange" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="6q$NxWf0RE3" role="3clFbx">
+            <node concept="3cpWs6" id="6q$NxWf0X0R" role="3cqZAp">
+              <node concept="3clFbC" id="6q$NxWf0Ym1" role="3cqZAk">
+                <node concept="1LFfDK" id="6q$NxWf1015" role="3uHU7w">
+                  <node concept="3cmrfG" id="6q$NxWf10v7" role="1LF_Uc">
+                    <property role="3cmrfH" value="1" />
+                  </node>
+                  <node concept="37vLTw" id="6q$NxWf0YO7" role="1LFl5Q">
+                    <ref role="3cqZAo" node="6q$NxWf0USl" resolve="intRange" />
+                  </node>
+                </node>
+                <node concept="1LFfDK" id="6q$NxWf0X0T" role="3uHU7B">
+                  <node concept="3cmrfG" id="6q$NxWf0X0U" role="1LF_Uc">
+                    <property role="3cmrfH" value="0" />
+                  </node>
+                  <node concept="37vLTw" id="6q$NxWf0X0V" role="1LFl5Q">
+                    <ref role="3cqZAo" node="6q$NxWf0USl" resolve="intRange" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6q$NxWf0WLv" role="3cqZAp">
+          <node concept="3clFbT" id="6q$NxWf0WM4" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6q$NxWf0EYF" role="1B3o_S" />
+      <node concept="10P_77" id="6q$NxWf0F0G" role="3clF45" />
+      <node concept="37vLTG" id="6q$NxWf0QNx" role="3clF46">
+        <property role="TrG5h" value="numberType" />
+        <node concept="3Tqbb2" id="6q$NxWf0QNw" role="1tU5fm">
+          <ref role="ehGHo" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6q$NxWf0EWk" role="jymVt" />
+    <node concept="2YIFZL" id="6q$NxWf0rZK" role="jymVt">
+      <property role="TrG5h" value="isIntValue" />
+      <node concept="3clFbS" id="6q$NxWf0rZN" role="3clF47">
+        <node concept="SfApY" id="6q$NxWf0s2F" role="3cqZAp">
+          <node concept="3clFbS" id="6q$NxWf0s2G" role="SfCbr">
+            <node concept="3clFbF" id="6q$NxWf0s3v" role="3cqZAp">
+              <node concept="2YIFZM" id="6q$NxWf0s6J" role="3clFbG">
+                <ref role="37wK5l" to="wyt6:~Math.toIntExact(long)" resolve="toIntExact" />
+                <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                <node concept="37vLTw" id="6q$NxWf0s7m" role="37wK5m">
+                  <ref role="3cqZAo" node="6q$NxWf0s1j" resolve="longValue" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="6q$NxWf0sbg" role="3cqZAp">
+              <node concept="3clFbT" id="6q$NxWf0seG" role="3cqZAk">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="TDmWw" id="6q$NxWf0s2H" role="TEbGg">
+            <node concept="3cpWsn" id="6q$NxWf0s2I" role="TDEfY">
+              <property role="TrG5h" value="e" />
+              <node concept="3uibUv" id="6q$NxWf0sj0" role="1tU5fm">
+                <ref role="3uigEE" to="wyt6:~ArithmeticException" resolve="ArithmeticException" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="6q$NxWf0s2K" role="TDEfX">
+              <node concept="3cpWs6" id="6q$NxWf0sfF" role="3cqZAp">
+                <node concept="3clFbT" id="6q$NxWf0sfV" role="3cqZAk" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6q$NxWf0rY9" role="1B3o_S" />
+      <node concept="10P_77" id="6q$NxWf0rZw" role="3clF45" />
+      <node concept="37vLTG" id="6q$NxWf0s1j" role="3clF46">
+        <property role="TrG5h" value="longValue" />
+        <node concept="3cpWsb" id="6q$NxWf0s1i" role="1tU5fm" />
       </node>
     </node>
     <node concept="3Tm1VV" id="1JTgXSYRFrg" role="1B3o_S" />
   </node>
   <node concept="18kY7G" id="6q$NxWeKeoO">
     <property role="3GE5qa" value="conversion" />
-    <property role="TrG5h" value="check_PowExpressionHasNoUnits" />
+    <property role="TrG5h" value="check_PowExpressionUnits" />
     <node concept="3clFbS" id="6q$NxWeKeoP" role="18ibNy">
-      <node concept="2Mj0R9" id="6q$NxWeKeoQ" role="3cqZAp">
-        <node concept="3fqX7Q" id="6q$NxWeKeoR" role="2MkoU_">
-          <node concept="2YIFZM" id="6q$NxWeKeoS" role="3fr31v">
-            <ref role="1Pybhc" to="dntf:4jkbLB5RJZL" resolve="UnitConversionUtil" />
-            <ref role="37wK5l" to="dntf:5pSqQr$Qyek" resolve="hasUnitSpecification" />
-            <node concept="2OqwBi" id="6q$NxWeKeoT" role="37wK5m">
-              <node concept="2OqwBi" id="6q$NxWeKeoU" role="2Oq$k0">
-                <node concept="1YBJjd" id="6q$NxWeKeoV" role="2Oq$k0">
-                  <ref role="1YBMHb" node="6q$NxWeKep2" resolve="powerExpression" />
+      <node concept="3clFbJ" id="6q$NxWf0CL$" role="3cqZAp">
+        <node concept="3clFbS" id="6q$NxWf0CLA" role="3clFbx">
+          <node concept="3cpWs8" id="6q$NxWf12zo" role="3cqZAp">
+            <node concept="3cpWsn" id="6q$NxWf12zp" role="3cpWs9">
+              <property role="TrG5h" value="exponentType" />
+              <node concept="3Tqbb2" id="6q$NxWf12zl" role="1tU5fm" />
+              <node concept="2OqwBi" id="6q$NxWf12zq" role="33vP2m">
+                <node concept="2OqwBi" id="6q$NxWf12zr" role="2Oq$k0">
+                  <node concept="1YBJjd" id="6q$NxWf12zs" role="2Oq$k0">
+                    <ref role="1YBMHb" node="6q$NxWeKep2" resolve="powerExpression" />
+                  </node>
+                  <node concept="3TrEf2" id="6q$NxWf12zt" role="2OqNvi">
+                    <ref role="3Tt5mk" to="1qv1:4r1mNB_o5WJ" resolve="exponent" />
+                  </node>
                 </node>
-                <node concept="3TrEf2" id="6q$NxWeKfGH" role="2OqNvi">
-                  <ref role="3Tt5mk" to="1qv1:4iu6t1eBdVy" resolve="expr" />
-                </node>
+                <node concept="3JvlWi" id="6q$NxWf12zu" role="2OqNvi" />
               </node>
-              <node concept="3JvlWi" id="6q$NxWeKeoX" role="2OqNvi" />
             </node>
           </node>
-        </node>
-        <node concept="Xl_RD" id="6q$NxWeKeoY" role="2MkJ7o">
-          <property role="Xl_RC" value="A log power expression is not allowed to have units!" />
-        </node>
-        <node concept="2OqwBi" id="6q$NxWeKeoZ" role="1urrMF">
-          <node concept="1YBJjd" id="6q$NxWeKep0" role="2Oq$k0">
-            <ref role="1YBMHb" node="6q$NxWeKep2" resolve="powerExpression" />
+          <node concept="2Mj0R9" id="6q$NxWf138i" role="3cqZAp">
+            <node concept="1Wc70l" id="6q$NxWf13Dk" role="2MkoU_">
+              <node concept="2YIFZM" id="6q$NxWf13GF" role="3uHU7w">
+                <ref role="37wK5l" node="6q$NxWf0rZK" resolve="isIntValue" />
+                <ref role="1Pybhc" node="1JTgXSYRFrf" resolve="MathExpressionsOpRulesHelper" />
+                <node concept="1LFfDK" id="6q$NxWf15M6" role="37wK5m">
+                  <node concept="3cmrfG" id="6q$NxWf15TE" role="1LF_Uc">
+                    <property role="3cmrfH" value="0" />
+                  </node>
+                  <node concept="2OqwBi" id="6q$NxWf14ds" role="1LFl5Q">
+                    <node concept="1PxgMI" id="6q$NxWf13Rl" role="2Oq$k0">
+                      <node concept="chp4Y" id="6q$NxWf13SJ" role="3oSUPX">
+                        <ref role="cht4Q" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                      </node>
+                      <node concept="37vLTw" id="6q$NxWf13H_" role="1m5AlR">
+                        <ref role="3cqZAo" node="6q$NxWf12zp" resolve="exponentType" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="6q$NxWf153L" role="2OqNvi">
+                      <ref role="37wK5l" to="b1h1:3p6$WoEzHkL" resolve="intRange" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1Wc70l" id="6q$NxWf16fy" role="3uHU7B">
+                <node concept="2YIFZM" id="6q$NxWf1398" role="3uHU7w">
+                  <ref role="37wK5l" node="6q$NxWf0F0Z" resolve="rangeIsValue" />
+                  <ref role="1Pybhc" node="1JTgXSYRFrf" resolve="MathExpressionsOpRulesHelper" />
+                  <node concept="1PxgMI" id="6q$NxWf13ir" role="37wK5m">
+                    <node concept="chp4Y" id="6q$NxWf13WD" role="3oSUPX">
+                      <ref role="cht4Q" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                    </node>
+                    <node concept="37vLTw" id="6q$NxWf139w" role="1m5AlR">
+                      <ref role="3cqZAo" node="6q$NxWf12zp" resolve="exponentType" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="6q$NxWf16nv" role="3uHU7B">
+                  <node concept="37vLTw" id="6q$NxWf16nw" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6q$NxWf12zp" resolve="exponentType" />
+                  </node>
+                  <node concept="1mIQ4w" id="6q$NxWf16nx" role="2OqNvi">
+                    <node concept="chp4Y" id="6q$NxWf16ny" role="cj9EA">
+                      <ref role="cht4Q" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="Xl_RD" id="6q$NxWf15Xj" role="2MkJ7o">
+              <property role="Xl_RC" value="A power expression is only allowed to have units if the exponent is a number type in the range of int" />
+            </node>
+            <node concept="2OqwBi" id="6q$NxWf66U6" role="1urrMF">
+              <node concept="1YBJjd" id="6q$NxWf16Dx" role="2Oq$k0">
+                <ref role="1YBMHb" node="6q$NxWeKep2" resolve="powerExpression" />
+              </node>
+              <node concept="3TrEf2" id="6q$NxWf67qD" role="2OqNvi">
+                <ref role="3Tt5mk" to="1qv1:4r1mNB_o5WJ" resolve="exponent" />
+              </node>
+            </node>
           </node>
-          <node concept="3TrEf2" id="6q$NxWeKfMP" role="2OqNvi">
-            <ref role="3Tt5mk" to="1qv1:4iu6t1eBdVy" resolve="expr" />
+          <node concept="3clFbH" id="6q$NxWf6iJA" role="3cqZAp" />
+        </node>
+        <node concept="2YIFZM" id="6q$NxWf0Dda" role="3clFbw">
+          <ref role="37wK5l" to="dntf:5pSqQr$Qyek" resolve="hasUnitSpecification" />
+          <ref role="1Pybhc" to="dntf:4jkbLB5RJZL" resolve="UnitConversionUtil" />
+          <node concept="2OqwBi" id="6q$NxWf0Elr" role="37wK5m">
+            <node concept="2OqwBi" id="6q$NxWf0DBR" role="2Oq$k0">
+              <node concept="1YBJjd" id="6q$NxWf0Dks" role="2Oq$k0">
+                <ref role="1YBMHb" node="6q$NxWeKep2" resolve="powerExpression" />
+              </node>
+              <node concept="3TrEf2" id="6q$NxWf0E64" role="2OqNvi">
+                <ref role="3Tt5mk" to="1qv1:4iu6t1eBdVy" resolve="expr" />
+              </node>
+            </node>
+            <node concept="3JvlWi" id="6q$NxWf0ENz" role="2OqNvi" />
           </node>
         </node>
       </node>
@@ -3060,8 +3477,8 @@
                 <node concept="1YBJjd" id="6q$NxWeKf00" role="2Oq$k0">
                   <ref role="1YBMHb" node="6q$NxWeKf07" resolve="productLoopExpression" />
                 </node>
-                <node concept="3TrEf2" id="6q$NxWeKf01" role="2OqNvi">
-                  <ref role="3Tt5mk" to="1qv1:4iu6t1eBdVy" resolve="expr" />
+                <node concept="3TrEf2" id="6q$NxWeVPlK" role="2OqNvi">
+                  <ref role="3Tt5mk" to="1qv1:PWcNB4VG_6" resolve="body" />
                 </node>
               </node>
               <node concept="3JvlWi" id="6q$NxWeKf02" role="2OqNvi" />
@@ -3069,14 +3486,14 @@
           </node>
         </node>
         <node concept="Xl_RD" id="6q$NxWeKf03" role="2MkJ7o">
-          <property role="Xl_RC" value="A log product loop expression is not allowed to have units!" />
+          <property role="Xl_RC" value="A product loop expression is not allowed to have units!" />
         </node>
         <node concept="2OqwBi" id="6q$NxWeKf04" role="1urrMF">
           <node concept="1YBJjd" id="6q$NxWeKf05" role="2Oq$k0">
             <ref role="1YBMHb" node="6q$NxWeKf07" resolve="productLoopExpression" />
           </node>
-          <node concept="3TrEf2" id="6q$NxWeKf06" role="2OqNvi">
-            <ref role="3Tt5mk" to="1qv1:4iu6t1eBdVy" resolve="expr" />
+          <node concept="3TrEf2" id="6q$NxWeVPtY" role="2OqNvi">
+            <ref role="3Tt5mk" to="1qv1:PWcNB4VG_6" resolve="body" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/typesystem.mps
@@ -2842,7 +2842,7 @@
   </node>
   <node concept="18kY7G" id="1JTgXSYQXiX">
     <property role="3GE5qa" value="conversion" />
-    <property role="TrG5h" value="CheckLogExpressionHasNoUnits" />
+    <property role="TrG5h" value="check_LogExpressionHasNoUnits" />
     <node concept="3clFbS" id="1JTgXSYQXiY" role="18ibNy">
       <node concept="2Mj0R9" id="1JTgXSYQXKZ" role="3cqZAp">
         <node concept="3fqX7Q" id="1JTgXSYRxtG" role="2MkoU_">
@@ -3005,6 +3005,86 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="1JTgXSYRFrg" role="1B3o_S" />
+  </node>
+  <node concept="18kY7G" id="6q$NxWeKeoO">
+    <property role="3GE5qa" value="conversion" />
+    <property role="TrG5h" value="check_PowExpressionHasNoUnits" />
+    <node concept="3clFbS" id="6q$NxWeKeoP" role="18ibNy">
+      <node concept="2Mj0R9" id="6q$NxWeKeoQ" role="3cqZAp">
+        <node concept="3fqX7Q" id="6q$NxWeKeoR" role="2MkoU_">
+          <node concept="2YIFZM" id="6q$NxWeKeoS" role="3fr31v">
+            <ref role="1Pybhc" to="dntf:4jkbLB5RJZL" resolve="UnitConversionUtil" />
+            <ref role="37wK5l" to="dntf:5pSqQr$Qyek" resolve="hasUnitSpecification" />
+            <node concept="2OqwBi" id="6q$NxWeKeoT" role="37wK5m">
+              <node concept="2OqwBi" id="6q$NxWeKeoU" role="2Oq$k0">
+                <node concept="1YBJjd" id="6q$NxWeKeoV" role="2Oq$k0">
+                  <ref role="1YBMHb" node="6q$NxWeKep2" resolve="powerExpression" />
+                </node>
+                <node concept="3TrEf2" id="6q$NxWeKfGH" role="2OqNvi">
+                  <ref role="3Tt5mk" to="1qv1:4iu6t1eBdVy" resolve="expr" />
+                </node>
+              </node>
+              <node concept="3JvlWi" id="6q$NxWeKeoX" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="Xl_RD" id="6q$NxWeKeoY" role="2MkJ7o">
+          <property role="Xl_RC" value="A log power expression is not allowed to have units!" />
+        </node>
+        <node concept="2OqwBi" id="6q$NxWeKeoZ" role="1urrMF">
+          <node concept="1YBJjd" id="6q$NxWeKep0" role="2Oq$k0">
+            <ref role="1YBMHb" node="6q$NxWeKep2" resolve="powerExpression" />
+          </node>
+          <node concept="3TrEf2" id="6q$NxWeKfMP" role="2OqNvi">
+            <ref role="3Tt5mk" to="1qv1:4iu6t1eBdVy" resolve="expr" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="6q$NxWeKep2" role="1YuTPh">
+      <property role="TrG5h" value="powerExpression" />
+      <ref role="1YaFvo" to="1qv1:4iu6t1eB654" resolve="PowerExpression" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="6q$NxWeKeZT">
+    <property role="3GE5qa" value="conversion" />
+    <property role="TrG5h" value="check_ProductLoopExpressionHasNoUnits" />
+    <node concept="3clFbS" id="6q$NxWeKeZU" role="18ibNy">
+      <node concept="2Mj0R9" id="6q$NxWeKeZV" role="3cqZAp">
+        <node concept="3fqX7Q" id="6q$NxWeKeZW" role="2MkoU_">
+          <node concept="2YIFZM" id="6q$NxWeKeZX" role="3fr31v">
+            <ref role="1Pybhc" to="dntf:4jkbLB5RJZL" resolve="UnitConversionUtil" />
+            <ref role="37wK5l" to="dntf:5pSqQr$Qyek" resolve="hasUnitSpecification" />
+            <node concept="2OqwBi" id="6q$NxWeKeZY" role="37wK5m">
+              <node concept="2OqwBi" id="6q$NxWeKeZZ" role="2Oq$k0">
+                <node concept="1YBJjd" id="6q$NxWeKf00" role="2Oq$k0">
+                  <ref role="1YBMHb" node="6q$NxWeKf07" resolve="productLoopExpression" />
+                </node>
+                <node concept="3TrEf2" id="6q$NxWeKf01" role="2OqNvi">
+                  <ref role="3Tt5mk" to="1qv1:4iu6t1eBdVy" resolve="expr" />
+                </node>
+              </node>
+              <node concept="3JvlWi" id="6q$NxWeKf02" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="Xl_RD" id="6q$NxWeKf03" role="2MkJ7o">
+          <property role="Xl_RC" value="A log product loop expression is not allowed to have units!" />
+        </node>
+        <node concept="2OqwBi" id="6q$NxWeKf04" role="1urrMF">
+          <node concept="1YBJjd" id="6q$NxWeKf05" role="2Oq$k0">
+            <ref role="1YBMHb" node="6q$NxWeKf07" resolve="productLoopExpression" />
+          </node>
+          <node concept="3TrEf2" id="6q$NxWeKf06" role="2OqNvi">
+            <ref role="3Tt5mk" to="1qv1:4iu6t1eBdVy" resolve="expr" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="6q$NxWeKf07" role="1YuTPh">
+      <property role="TrG5h" value="productLoopExpression" />
+      <ref role="1YaFvo" to="1qv1:4iu6t1eB6zV" resolve="ProductLoopExpression" />
+    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/typesystem.mps
@@ -2616,7 +2616,7 @@
   </node>
   <node concept="3hdX5o" id="3htFKtcdWPm">
     <property role="3GE5qa" value="conversion" />
-    <property role="TrG5h" value="MathExpressionsOpRules" />
+    <property role="TrG5h" value="MathExpressionsWithUnitsOpRules" />
     <node concept="3ciAk0" id="3htFKtcdXBh" role="3he0YX">
       <property role="3PlbSO" value="true" />
       <node concept="2pJPEk" id="3htFKtcdXDP" role="3ciSkW">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags/models/org/iets3/core/expr/typetags/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags/models/org/iets3/core/expr/typetags/behavior.mps
@@ -21,6 +21,7 @@
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="u78q" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.typesystem.inference(MPS.Core/)" />
     <import index="tpd4" ref="r:00000000-0000-4000-0000-011c895902b4(jetbrains.mps.lang.typesystem.structure)" />
+    <import index="kqnq" ref="r:7628c3bd-6988-4d33-9682-86b8cef4b8c0(com.mbeddr.mpsutil.interpreter.behavior)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -745,6 +746,22 @@
         </node>
       </node>
       <node concept="17QB3L" id="4HxogODR6FF" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="6q$NxWg8fA4" role="13h7CS">
+      <property role="TrG5h" value="wrappedType" />
+      <ref role="13i0hy" to="kqnq:6bG6MAFRDvi" resolve="wrappedType" />
+      <node concept="3Tm1VV" id="6q$NxWg8fA5" role="1B3o_S" />
+      <node concept="3clFbS" id="6q$NxWg8fA8" role="3clF47">
+        <node concept="3cpWs6" id="6q$NxWg8igP" role="3cqZAp">
+          <node concept="2OqwBi" id="6q$NxWg8iur" role="3cqZAk">
+            <node concept="13iPFW" id="6q$NxWg8iha" role="2Oq$k0" />
+            <node concept="3TrEf2" id="6q$NxWg8iMW" role="2OqNvi">
+              <ref role="3Tt5mk" to="w1hl:1xEzHAktP2T" resolve="baseType" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="6q$NxWg8fA9" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="4HxogODTmV$">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags/models/org/iets3/core/expr/typetags/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags/models/org/iets3/core/expr/typetags/structure.mps
@@ -7,6 +7,7 @@
   </languages>
   <imports>
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
+    <import index="3673" ref="r:78633c85-d020-485e-aaa3-59e2daa3b826(com.mbeddr.mpsutil.interpreter.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
@@ -62,6 +63,9 @@
     </node>
     <node concept="PrWs8" id="76ZhK6XXupN" role="PzmwI">
       <ref role="PrY4T" node="76ZhK6XX6GY" resolve="IWithTags" />
+    </node>
+    <node concept="PrWs8" id="6q$NxWg8dO4" role="PzmwI">
+      <ref role="PrY4T" to="3673:6bG6MAFRAaG" resolve="IInterpreterWrapperType" />
     </node>
   </node>
   <node concept="PlHQZ" id="4HxogODR$_x">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags/org.iets3.core.expr.typetags.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags/org.iets3.core.expr.typetags.mpl
@@ -97,6 +97,7 @@
     <dependency reexport="false">20c6e580-bdc5-4067-8049-d7e3265a86de(jetbrains.mps.typesystemEngine)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">7a5dda62-9140-4668-ab76-d5ed1746f2b2(jetbrains.mps.lang.typesystem)</dependency>
+    <dependency reexport="false">47f075a6-558e-4640-a606-7ce0236c8023(com.mbeddr.mpsutil.interpreter)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -12449,6 +12449,11 @@
           </node>
         </node>
       </node>
+      <node concept="1SiIV0" id="6q$NxWg9UyJ" role="3bR37C">
+        <node concept="3bR9La" id="6q$NxWg9UyK" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+        </node>
+      </node>
     </node>
     <node concept="1E1JtA" id="OJuIQp$d7j" role="3989C9">
       <property role="BnDLt" value="true" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -2240,6 +2240,31 @@
         <node concept="1yeLz9" id="cPLa7FuN0e" role="1TViLv">
           <property role="TrG5h" value="org.iets3.core.expr.data#01" />
           <property role="3LESm3" value="99d416a5-b471-4948-913f-38b04b465846" />
+          <node concept="1BupzO" id="6q$NxWeKRhc" role="3bR31x">
+            <property role="3ZfqAx" value="generator/template" />
+            <property role="1Hdu6h" value="true" />
+            <property role="1HemKv" value="true" />
+            <node concept="3LXTmp" id="6q$NxWeKRhd" role="1HemKq">
+              <node concept="398BVA" id="6q$NxWeKRgZ" role="3LXTmr">
+                <ref role="398BVh" node="5wLtKNeTaqD" resolve="iets3.lang.opensource" />
+                <node concept="2Ry0Ak" id="6q$NxWeKRh0" role="iGT6I">
+                  <property role="2Ry0Am" value="languages" />
+                  <node concept="2Ry0Ak" id="6q$NxWeKRh1" role="2Ry0An">
+                    <property role="2Ry0Am" value="org.iets3.core.expr.data" />
+                    <node concept="2Ry0Ak" id="6q$NxWeKRh2" role="2Ry0An">
+                      <property role="2Ry0Am" value="generator" />
+                      <node concept="2Ry0Ak" id="6q$NxWeKRh3" role="2Ry0An">
+                        <property role="2Ry0Am" value="template" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3qWCbU" id="6q$NxWeKRhe" role="3LXTna">
+                <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+              </node>
+            </node>
+          </node>
         </node>
         <node concept="1SiIV0" id="cPLa7FuNL_" role="3bR37C">
           <node concept="3bR9La" id="cPLa7FuNLA" role="1SiIV1">
@@ -2254,6 +2279,28 @@
         <node concept="1SiIV0" id="cPLa7FuNQe" role="3bR37C">
           <node concept="3bR9La" id="cPLa7FuNQf" role="1SiIV1">
             <ref role="3bR37D" node="cPLa7FuMZR" resolve="org.iets3.core.expr.data" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="6q$NxWeKRgW" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="6q$NxWeKRgX" role="1HemKq">
+            <node concept="398BVA" id="6q$NxWeKRgL" role="3LXTmr">
+              <ref role="398BVh" node="5wLtKNeTaqD" resolve="iets3.lang.opensource" />
+              <node concept="2Ry0Ak" id="6q$NxWeKRgM" role="iGT6I">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="6q$NxWeKRgN" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.iets3.core.expr.data" />
+                  <node concept="2Ry0Ak" id="6q$NxWeKRgO" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="6q$NxWeKRgY" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
           </node>
         </node>
       </node>
@@ -3425,6 +3472,28 @@
         <node concept="1SiIV0" id="cPLa7FuOKb" role="3bR37C">
           <node concept="3bR9La" id="cPLa7FuOKc" role="1SiIV1">
             <ref role="3bR37D" node="cPLa7FuMZR" resolve="org.iets3.core.expr.data" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="6q$NxWeKRkz" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="6q$NxWeKRk$" role="1HemKq">
+            <node concept="398BVA" id="6q$NxWeKRko" role="3LXTmr">
+              <ref role="398BVh" node="5wLtKNeTaqD" resolve="iets3.lang.opensource" />
+              <node concept="2Ry0Ak" id="6q$NxWeKRkp" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6q$NxWeKRkq" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.iets3.core.expr.data.interpreter" />
+                  <node concept="2Ry0Ak" id="6q$NxWeKRkr" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="6q$NxWeKRk_" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
           </node>
         </node>
       </node>
@@ -8330,6 +8399,105 @@
         <node concept="3LEz8M" id="kEKsc8qBa7" role="3LEz9a">
           <ref role="3LEz8N" node="2zpAVpC$xZc" resolve="org.iets3.core.expr.genjava.core.devkit" />
         </node>
+        <node concept="3LEDTy" id="6q$NxWeKRw1" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRRB" resolve="org.iets3.core.base" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRw2" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRw3" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRw4" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRw5" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRw6" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRw7" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRw8" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRw9" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwa" role="3LEDUa">
+          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwb" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwc" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwd" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwe" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwf" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwg" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwh" role="3LEDUa">
+          <ref role="3LEDTV" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwi" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwj" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwk" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwl" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwm" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwn" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwo" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAaa" resolve="org.iets3.analysis.base" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwp" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwq" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwr" role="3LEDUa">
+          <ref role="3LEDTV" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRws" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwt" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwu" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwv" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRww" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRwx" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC_4Ut" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -8926,6 +9094,11 @@
               <node concept="3qWCbU" id="1RMC8GHEwUe" role="3LXTna">
                 <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
               </node>
+            </node>
+          </node>
+          <node concept="1SiIV0" id="6q$NxWeKRy3" role="3bR37C">
+            <node concept="3bR9La" id="6q$NxWeKRy2" role="1SiIV1">
+              <ref role="3bR37D" node="26tZ$Z4rnV1" resolve="org.iets3.core.expr.genjava.base#8286534136181746510" />
             </node>
           </node>
         </node>
@@ -10504,6 +10677,15 @@
         <node concept="3LEDTM" id="1RMC8GHEwZG" role="3LEDUa">
           <ref role="3LEDTN" node="5khwDRKS378" resolve="org.iets3.core.expr.base.collections.stubs" />
         </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAs" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAt" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAu" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC$OJa" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10548,6 +10730,30 @@
         <node concept="3LEDTM" id="6wnckeEe9TH" role="3LEDUa">
           <ref role="3LEDTN" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
         </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAv" role="3LEDUa">
+          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAw" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAx" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAy" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAz" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRA$" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRA_" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAA" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
       </node>
       <node concept="3LEwk6" id="j5CxBKa9ks" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10573,6 +10779,123 @@
         </node>
         <node concept="3LEDTM" id="1RMC8GHEwZU" role="3LEDUa">
           <ref role="3LEDTN" node="2zpAVpC$IQf" resolve="org.iets3.core.expr.genjava.advanced.genplan" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAB" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRRB" resolve="org.iets3.core.base" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAC" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAD" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAE" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAF" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAG" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAH" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAI" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAJ" role="3LEDUa">
+          <ref role="3LEDTV" node="6hYPZtwrWbD" resolve="org.iets3.core.expr.genjava.util" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAK" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAL" role="3LEDUa">
+          <ref role="3LEDTV" node="5Y0kZK1N637" resolve="org.iets3.core.expr.genjava.datetime" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAM" role="3LEDUa">
+          <ref role="3LEDTV" node="5zQvLw7dx1X" resolve="org.iets3.core.expr.datetime" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAN" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAO" role="3LEDUa">
+          <ref role="3LEDTV" node="7sID8G9sQTG" resolve="org.iets3.core.expr.genjava.temporal" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAP" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAQ" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAR" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAS" role="3LEDUa">
+          <ref role="3LEDTV" node="23q4CrmMjzr" resolve="org.iets3.core.expr.genjava.messages" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAT" role="3LEDUa">
+          <ref role="3LEDTV" node="5zQvLw7dsP5" resolve="org.iets3.core.expr.temporal" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAU" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAV" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAW" role="3LEDUa">
+          <ref role="3LEDTV" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAX" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAY" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRAZ" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRB0" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRB1" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRB2" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRB3" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAaa" resolve="org.iets3.analysis.base" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRB4" role="3LEDUa">
+          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRB5" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRB6" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRB7" role="3LEDUa">
+          <ref role="3LEDTV" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRB8" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRB9" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRBa" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRBb" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRBc" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRBd" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
         </node>
       </node>
       <node concept="3LEwk6" id="26tZ$Z4sNNn" role="2G$12L">
@@ -10605,6 +10928,15 @@
         </node>
         <node concept="3LEDTy" id="3vxfdxbuHow" role="3LEDUa">
           <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRBe" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRBf" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
+        <node concept="3LEDTy" id="6q$NxWeKRBg" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
         </node>
       </node>
     </node>
@@ -12330,6 +12662,43 @@
           </node>
           <node concept="3qWCbU" id="5IOlOc8vvhs" role="3LXTna">
             <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="6q$NxWeKRIj" role="3bR37C">
+        <node concept="3bR9La" id="6q$NxWeKRIk" role="1SiIV1">
+          <ref role="3bR37D" node="5wLtKNeSRQv" resolve="org.iets3.core.expr.math" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="6q$NxWeKRIl" role="3bR37C">
+        <node concept="3bR9La" id="6q$NxWeKRIm" role="1SiIV1">
+          <ref role="3bR37D" to="al5i:776vT$mR9hk" resolve="com.mbeddr.mpsutil.compare" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="6q$NxWeKRIn" role="3bR37C">
+        <node concept="3bR9La" id="6q$NxWeKRIo" role="1SiIV1">
+          <ref role="3bR37D" node="JUiQTzdslj" resolve="org.iets3.core.expr.typetags" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="6q$NxWeKRIF" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="6q$NxWeKRIG" role="1HemKq">
+          <node concept="398BVA" id="6q$NxWeKRIp" role="3LXTmr">
+            <ref role="398BVh" node="OJuIQp$deE" resolve="iets3.lang.core" />
+            <node concept="2Ry0Ak" id="6q$NxWeKRIq" role="iGT6I">
+              <property role="2Ry0Am" value="tests" />
+              <node concept="2Ry0Ak" id="6q$NxWeKRIr" role="2Ry0An">
+                <property role="2Ry0Am" value="test.ts.expr.os" />
+                <node concept="2Ry0Ak" id="6q$NxWeKRIs" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="6q$NxWeKRIH" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -1123,6 +1123,16 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="50kkvMT0J4i" role="3bR37C">
+          <node concept="3bR9La" id="50kkvMT0J4j" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="50kkvMT0J4k" role="3bR37C">
+          <node concept="3bR9La" id="50kkvMT0J4l" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6Lh7" resolve="jetbrains.mps.typesystemEngine" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="44TucI3cjtV" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -8404,6 +8414,105 @@
         <node concept="3LEz8M" id="kEKsc8qBa7" role="3LEz9a">
           <ref role="3LEz8N" node="2zpAVpC$xZc" resolve="org.iets3.core.expr.genjava.core.devkit" />
         </node>
+        <node concept="3LEDTy" id="50kkvMT0JmJ" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JmK" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JmL" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JmM" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JmN" role="3LEDUa">
+          <ref role="3LEDTV" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JmO" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JmP" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JmQ" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAaa" resolve="org.iets3.analysis.base" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JmR" role="3LEDUa">
+          <ref role="3LEDTV" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JmS" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JmT" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JmU" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JmV" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JmW" role="3LEDUa">
+          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JmX" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JmY" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JmZ" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jn0" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jn1" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jn2" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jn3" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jn4" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jn5" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jn6" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jn7" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jn8" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jn9" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRRB" resolve="org.iets3.core.base" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jna" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jnb" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jnc" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jnd" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jne" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jnf" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC_4Ut" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10583,6 +10692,15 @@
         <node concept="3LEDTM" id="1RMC8GHEwZG" role="3LEDUa">
           <ref role="3LEDTN" node="5khwDRKS378" resolve="org.iets3.core.expr.base.collections.stubs" />
         </node>
+        <node concept="3LEDTy" id="50kkvMT0Jt8" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jt9" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jta" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC$OJa" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10627,6 +10745,30 @@
         <node concept="3LEDTM" id="6wnckeEe9TH" role="3LEDUa">
           <ref role="3LEDTN" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
         </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtb" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtc" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtd" role="3LEDUa">
+          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jte" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtf" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtg" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jth" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jti" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
       </node>
       <node concept="3LEwk6" id="j5CxBKa9ks" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10652,6 +10794,123 @@
         </node>
         <node concept="3LEDTM" id="1RMC8GHEwZU" role="3LEDUa">
           <ref role="3LEDTN" node="2zpAVpC$IQf" resolve="org.iets3.core.expr.genjava.advanced.genplan" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtj" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtk" role="3LEDUa">
+          <ref role="3LEDTV" node="5zQvLw7dsP5" resolve="org.iets3.core.expr.temporal" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtl" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtm" role="3LEDUa">
+          <ref role="3LEDTV" node="6hYPZtwrWbD" resolve="org.iets3.core.expr.genjava.util" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtn" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jto" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtp" role="3LEDUa">
+          <ref role="3LEDTV" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtq" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtr" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jts" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtt" role="3LEDUa">
+          <ref role="3LEDTV" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtu" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtv" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtw" role="3LEDUa">
+          <ref role="3LEDTV" node="5Y0kZK1N637" resolve="org.iets3.core.expr.genjava.datetime" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtx" role="3LEDUa">
+          <ref role="3LEDTV" node="5zQvLw7dx1X" resolve="org.iets3.core.expr.datetime" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jty" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jtz" role="3LEDUa">
+          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jt$" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0Jt_" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtA" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtB" role="3LEDUa">
+          <ref role="3LEDTV" node="7sID8G9sQTG" resolve="org.iets3.core.expr.genjava.temporal" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtC" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtD" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtE" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtF" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtG" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtH" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtI" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtJ" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtK" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtL" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtM" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRRB" resolve="org.iets3.core.base" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtN" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtO" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtP" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtQ" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtR" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAaa" resolve="org.iets3.analysis.base" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtS" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtT" role="3LEDUa">
+          <ref role="3LEDTV" node="23q4CrmMjzr" resolve="org.iets3.core.expr.genjava.messages" />
         </node>
       </node>
       <node concept="3LEwk6" id="26tZ$Z4sNNn" role="2G$12L">
@@ -10684,6 +10943,15 @@
         </node>
         <node concept="3LEDTy" id="3vxfdxbuHow" role="3LEDUa">
           <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtU" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtV" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="50kkvMT0JtW" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -1711,6 +1711,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="6q$NxWg9bO1" role="3bR37C">
+          <node concept="3bR9La" id="6q$NxWg9bO2" role="1SiIV1">
+            <ref role="3bR37D" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="JUiQTzdtrz" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -8399,105 +8404,6 @@
         <node concept="3LEz8M" id="kEKsc8qBa7" role="3LEz9a">
           <ref role="3LEz8N" node="2zpAVpC$xZc" resolve="org.iets3.core.expr.genjava.core.devkit" />
         </node>
-        <node concept="3LEDTy" id="6q$NxWeKRw1" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRRB" resolve="org.iets3.core.base" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRw2" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRw3" role="3LEDUa">
-          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRw4" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRw5" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRw6" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRw7" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRw8" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRw9" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwa" role="3LEDUa">
-          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwb" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwc" role="3LEDUa">
-          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwd" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwe" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwf" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwg" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwh" role="3LEDUa">
-          <ref role="3LEDTV" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwi" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwj" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwk" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwl" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwm" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwn" role="3LEDUa">
-          <ref role="3LEDTV" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwo" role="3LEDUa">
-          <ref role="3LEDTV" node="49WTic8jAaa" resolve="org.iets3.analysis.base" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwp" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwq" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwr" role="3LEDUa">
-          <ref role="3LEDTV" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRws" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwt" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwu" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwv" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRww" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRwx" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
-        </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC_4Ut" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10677,15 +10583,6 @@
         <node concept="3LEDTM" id="1RMC8GHEwZG" role="3LEDUa">
           <ref role="3LEDTN" node="5khwDRKS378" resolve="org.iets3.core.expr.base.collections.stubs" />
         </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAs" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAt" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAu" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
-        </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC$OJa" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10730,30 +10627,6 @@
         <node concept="3LEDTM" id="6wnckeEe9TH" role="3LEDUa">
           <ref role="3LEDTN" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
         </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAv" role="3LEDUa">
-          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAw" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAx" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAy" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAz" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRA$" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRA_" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAA" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
-        </node>
       </node>
       <node concept="3LEwk6" id="j5CxBKa9ks" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10779,123 +10652,6 @@
         </node>
         <node concept="3LEDTM" id="1RMC8GHEwZU" role="3LEDUa">
           <ref role="3LEDTN" node="2zpAVpC$IQf" resolve="org.iets3.core.expr.genjava.advanced.genplan" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAB" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRRB" resolve="org.iets3.core.base" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAC" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAD" role="3LEDUa">
-          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAE" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAF" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAG" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAH" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAI" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAJ" role="3LEDUa">
-          <ref role="3LEDTV" node="6hYPZtwrWbD" resolve="org.iets3.core.expr.genjava.util" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAK" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAL" role="3LEDUa">
-          <ref role="3LEDTV" node="5Y0kZK1N637" resolve="org.iets3.core.expr.genjava.datetime" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAM" role="3LEDUa">
-          <ref role="3LEDTV" node="5zQvLw7dx1X" resolve="org.iets3.core.expr.datetime" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAN" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAO" role="3LEDUa">
-          <ref role="3LEDTV" node="7sID8G9sQTG" resolve="org.iets3.core.expr.genjava.temporal" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAP" role="3LEDUa">
-          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAQ" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAR" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAS" role="3LEDUa">
-          <ref role="3LEDTV" node="23q4CrmMjzr" resolve="org.iets3.core.expr.genjava.messages" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAT" role="3LEDUa">
-          <ref role="3LEDTV" node="5zQvLw7dsP5" resolve="org.iets3.core.expr.temporal" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAU" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAV" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAW" role="3LEDUa">
-          <ref role="3LEDTV" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAX" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAY" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRAZ" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRB0" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRB1" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRB2" role="3LEDUa">
-          <ref role="3LEDTV" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRB3" role="3LEDUa">
-          <ref role="3LEDTV" node="49WTic8jAaa" resolve="org.iets3.analysis.base" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRB4" role="3LEDUa">
-          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRB5" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRB6" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRB7" role="3LEDUa">
-          <ref role="3LEDTV" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRB8" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRB9" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRBa" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRBb" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRBc" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRBd" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
         </node>
       </node>
       <node concept="3LEwk6" id="26tZ$Z4sNNn" role="2G$12L">
@@ -10928,15 +10684,6 @@
         </node>
         <node concept="3LEDTy" id="3vxfdxbuHow" role="3LEDUa">
           <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRBe" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRBf" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
-        </node>
-        <node concept="3LEDTy" id="6q$NxWeKRBg" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
@@ -238,6 +238,9 @@
       </concept>
       <concept id="7425695345928358745" name="org.iets3.core.expr.simpleTypes.structure.TrueLiteral" flags="ng" index="2vmpnb" />
       <concept id="7425695345928349207" name="org.iets3.core.expr.simpleTypes.structure.BooleanType" flags="ng" index="2vmvy5" />
+      <concept id="5115872837157252552" name="org.iets3.core.expr.simpleTypes.structure.StringLiteral" flags="ng" index="30bdrP">
+        <property id="5115872837157252555" name="value" index="30bdrQ" />
+      </concept>
       <concept id="5115872837157054284" name="org.iets3.core.expr.simpleTypes.structure.RealType" flags="ng" index="30bXLL" />
       <concept id="5115872837157054169" name="org.iets3.core.expr.simpleTypes.structure.IntegerType" flags="ng" index="30bXR$" />
       <concept id="5115872837157054170" name="org.iets3.core.expr.simpleTypes.structure.NumberLiteral" flags="ng" index="30bXRB">
@@ -2353,12 +2356,12 @@
         <node concept="2zPypq" id="1JTgXSYMNAl" role="_iOnC">
           <property role="TrG5h" value="sqrtWithoutUnit" />
           <node concept="a0DgS" id="1JTgXSYMNCP" role="2zPyp_">
-            <node concept="30dDZf" id="1JTgXSYMNFE" role="a0CvG">
-              <node concept="30bXRB" id="1JTgXSYMNGd" role="30dEs_">
-                <property role="30bXRw" value="15" />
-              </node>
-              <node concept="30bXRB" id="1JTgXSYMND4" role="30dEsF">
+            <node concept="30dDZf" id="50kkvMT04DN" role="a0CvG">
+              <node concept="30bXRB" id="50kkvMT04DO" role="30dEsF">
                 <property role="30bXRw" value="1" />
+              </node>
+              <node concept="30bXRB" id="50kkvMT04DP" role="30dEs_">
+                <property role="30bXRw" value="15" />
               </node>
             </node>
             <node concept="3xLA65" id="1JTgXSYMNUM" role="lGtFl">
@@ -2703,14 +2706,14 @@
             </node>
           </node>
         </node>
-        <node concept="_ixoA" id="6q$NxWeU1Jc" role="_iOnC" />
+        <node concept="_ixoA" id="6q$NxWgcXXU" role="_iOnC" />
         <node concept="2zPypq" id="6q$NxWeU1Yu" role="_iOnC">
           <property role="TrG5h" value="powWithoutUnit" />
           <node concept="a0Byk" id="6q$NxWeU26u" role="2zPyp_">
             <node concept="30bXRB" id="6q$NxWeU26V" role="a0GsM">
               <property role="30bXRw" value="5" />
             </node>
-            <node concept="30bXRB" id="6q$NxWeU27A" role="2zCggm">
+            <node concept="30bXRB" id="6q$NxWgf04a" role="2zCggm">
               <property role="30bXRw" value="10" />
             </node>
             <node concept="3xLA65" id="6q$NxWf2GI7" role="lGtFl">
@@ -2851,7 +2854,6 @@
             </node>
           </node>
         </node>
-        <node concept="_ixoA" id="6q$NxWeHFA4" role="_iOnC" />
         <node concept="7CXmI" id="1fzaMYHrHph" role="lGtFl">
           <node concept="7OXhh" id="1fzaMYHrHpi" role="7EUXB" />
         </node>
@@ -3199,9 +3201,6 @@
               <node concept="30bXRB" id="6q$NxWf65WW" role="1YnStB">
                 <property role="30bXRw" value="10" />
               </node>
-              <node concept="7CXmI" id="6q$NxWf8W6T" role="lGtFl">
-                <node concept="1TM$A" id="6q$NxWf8W6U" role="7EUXB" />
-              </node>
             </node>
             <node concept="30dDTi" id="6q$NxWf664x" role="2zCggm">
               <node concept="_emDc" id="6q$NxWf66tJ" role="30dEs_">
@@ -3213,6 +3212,9 @@
               <node concept="7CXmI" id="6q$NxWf7_VG" role="lGtFl">
                 <node concept="1TM$A" id="6q$NxWf7_VH" role="7EUXB" />
               </node>
+            </node>
+            <node concept="7CXmI" id="58FgifhGu5u" role="lGtFl">
+              <node concept="1TM$A" id="58FgifhGu5v" role="7EUXB" />
             </node>
           </node>
         </node>
@@ -3228,15 +3230,68 @@
               <node concept="30bXRB" id="6q$NxWf6i0p" role="1YnStB">
                 <property role="30bXRw" value="10" />
               </node>
-              <node concept="7CXmI" id="6q$NxWf8WdR" role="lGtFl">
-                <node concept="1TM$A" id="6q$NxWf8WdS" role="7EUXB" />
-              </node>
             </node>
             <node concept="30bXRB" id="6q$NxWf6i3x" role="2zCggm">
               <property role="30bXRw" value="10000000000" />
               <node concept="7CXmI" id="6q$NxWf7_T4" role="lGtFl">
                 <node concept="1TM$A" id="6q$NxWf7_T5" role="7EUXB" />
               </node>
+            </node>
+            <node concept="7CXmI" id="58FgifhGu9d" role="lGtFl">
+              <node concept="1TM$A" id="58FgifhGu9e" role="7EUXB" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="6q$NxWgcY$H" role="_iOnC">
+          <property role="TrG5h" value="sqrtError" />
+          <node concept="a0DgS" id="6q$NxWgcYBA" role="2zPyp_">
+            <node concept="30bdrP" id="6q$NxWgcYBT" role="a0CvG">
+              <property role="30bdrQ" value="asdf" />
+            </node>
+            <node concept="7CXmI" id="6q$NxWgcYCi" role="lGtFl">
+              <node concept="1TM$A" id="6q$NxWgcYCj" role="7EUXB" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="6q$NxWgdWN8" role="_iOnC">
+          <property role="TrG5h" value="powError" />
+          <node concept="a0Byk" id="6q$NxWgdWQ8" role="2zPyp_">
+            <node concept="30bXRB" id="6q$NxWgdWQt" role="a0GsM">
+              <property role="30bXRw" value="5" />
+            </node>
+            <node concept="30bdrP" id="6q$NxWgdWQW" role="2zCggm">
+              <property role="30bdrQ" value="asdf" />
+            </node>
+            <node concept="7CXmI" id="6q$NxWgeSJw" role="lGtFl">
+              <node concept="1TM$A" id="6q$NxWgeSJx" role="7EUXB" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="6q$NxWgeSFb" role="_iOnC">
+          <property role="TrG5h" value="absError" />
+          <node concept="a1tT9" id="6q$NxWgeSId" role="2zPyp_">
+            <node concept="30dDZf" id="50kkvMSZSDB" role="a0Cwb">
+              <node concept="30bdrP" id="50kkvMSZSEb" role="30dEs_" />
+              <node concept="30bXRB" id="6q$NxWgeSIM" role="30dEsF">
+                <property role="30bXRw" value="3.4" />
+              </node>
+            </node>
+            <node concept="7CXmI" id="6q$NxWgeSKi" role="lGtFl">
+              <node concept="1TM$A" id="6q$NxWgeSKj" role="7EUXB" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="6q$NxWgeSNT" role="_iOnC">
+          <property role="TrG5h" value="fracError" />
+          <node concept="a1tim" id="6q$NxWgeSR2" role="2zPyp_">
+            <node concept="30bdrP" id="6q$NxWgeT6B" role="a1tin">
+              <property role="30bdrQ" value="asdf" />
+            </node>
+            <node concept="30bdrP" id="6q$NxWgeSUm" role="a1tiq">
+              <property role="30bdrQ" value="5" />
+            </node>
+            <node concept="7CXmI" id="50kkvMT04Mj" role="lGtFl">
+              <node concept="1TM$A" id="50kkvMT04Mk" role="7EUXB" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
@@ -25,6 +25,7 @@
     <import index="8do3" ref="r:cea04c4b-adba-417e-a192-34c7a8799ac1(com.mbeddr.mpsutil.compare.structure)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" implicit="true" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -63,6 +64,7 @@
       <concept id="1219920932475" name="jetbrains.mps.baseLanguage.structure.VariableArityType" flags="in" index="8X2XB">
         <child id="1219921048460" name="componentType" index="8Xvag" />
       </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
         <child id="1239714902950" name="expression" index="2$L3a6" />
       </concept>
@@ -185,6 +187,7 @@
       <concept id="5115872837156802409" name="org.iets3.core.expr.base.structure.UnaryExpression" flags="ng" index="30czhk">
         <child id="5115872837156802411" name="expr" index="30czhm" />
       </concept>
+      <concept id="5115872837156855227" name="org.iets3.core.expr.base.structure.UnaryMinusExpression" flags="ng" index="30cIq6" />
       <concept id="5115872837156761033" name="org.iets3.core.expr.base.structure.EqualsExpression" flags="ng" index="30cPrO" />
       <concept id="5115872837156687890" name="org.iets3.core.expr.base.structure.LessExpression" flags="ng" index="30d6GJ" />
       <concept id="5115872837156652603" name="org.iets3.core.expr.base.structure.DivExpression" flags="ng" index="30dvO6" />
@@ -277,9 +280,23 @@
       <concept id="4944417823362158056" name="org.iets3.core.expr.math.structure.SqrtExpression" flags="ng" index="a0DgS">
         <child id="4944417823362162236" name="expr" index="a0CvG" />
       </concept>
+      <concept id="4944417823362156001" name="org.iets3.core.expr.math.structure.SumExpression" flags="ng" index="a0DKL" />
+      <concept id="4944417823362113527" name="org.iets3.core.expr.math.structure.LogExpression" flags="ng" index="a1soB">
+        <child id="4944417823362160996" name="expr" index="a0C2O" />
+        <child id="4944417823362113528" name="logOf" index="a1soC" />
+      </concept>
       <concept id="4944417823362108742" name="org.iets3.core.expr.math.structure.FractionExpression" flags="ng" index="a1tim">
         <child id="4944417823362108743" name="numerator" index="a1tin" />
         <child id="4944417823362108746" name="denominator" index="a1tiq" />
+      </concept>
+      <concept id="4944417823362107289" name="org.iets3.core.expr.math.structure.AbsExpression" flags="ng" index="a1tT9">
+        <child id="4944417823362159067" name="expr" index="a0Cwb" />
+      </concept>
+      <concept id="4944417823362115312" name="org.iets3.core.expr.math.structure.MathLoopExpr" flags="ng" index="a1vWw">
+        <child id="971707942815410149" name="lower" index="39z1js" />
+        <child id="971707942815429390" name="varType" index="39z40R" />
+        <child id="971707942815320383" name="upper" index="39$JC6" />
+        <child id="971707942815320390" name="body" index="39$JDZ" />
       </concept>
     </language>
     <language id="f47b95d4-5e73-4c04-9204-18076950153b" name="com.mbeddr.mpsutil.compare">
@@ -319,6 +336,7 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
@@ -1275,15 +1293,15 @@
         <node concept="17QB3L" id="1JTgXSYOKN$" role="1tU5fm" />
       </node>
     </node>
-    <node concept="1LZb2c" id="1JTgXSYMM_w" role="1SL9yI">
-      <property role="TrG5h" value="testSqrtExpressionType" />
-      <node concept="3cqZAl" id="1JTgXSYMM_x" role="3clF45" />
-      <node concept="3clFbS" id="1JTgXSYMM__" role="3clF47">
+    <node concept="2XrIbr" id="1JTgXSYTIgr" role="1qtyYc">
+      <property role="TrG5h" value="assertRealType" />
+      <node concept="3cqZAl" id="1JTgXSYTIjF" role="3clF45" />
+      <node concept="3clFbS" id="1JTgXSYTIgt" role="3clF47">
         <node concept="3vwNmj" id="1JTgXSYN8hk" role="3cqZAp">
           <node concept="2OqwBi" id="1JTgXSYN9k3" role="3vwVQn">
             <node concept="2OqwBi" id="1JTgXSYN8pt" role="2Oq$k0">
-              <node concept="3xONca" id="1JTgXSYN8ho" role="2Oq$k0">
-                <ref role="3xOPvv" node="1JTgXSYMNUM" resolve="withoutUnit" />
+              <node concept="37vLTw" id="1JTgXSYTIL8" role="2Oq$k0">
+                <ref role="3cqZAo" node="1JTgXSYTIjP" resolve="node" />
               </node>
               <node concept="3JvlWi" id="1JTgXSYN8I4" role="2OqNvi" />
             </node>
@@ -1294,27 +1312,62 @@
             </node>
           </node>
           <node concept="3_1$Yv" id="1JTgXSYN9$o" role="3_9lra">
-            <node concept="3cpWs3" id="1JTgXSYN9V$" role="3_1BAH">
-              <node concept="2OqwBi" id="1JTgXSYNa8l" role="3uHU7w">
-                <node concept="3xONca" id="1JTgXSYN9VQ" role="2Oq$k0">
-                  <ref role="3xOPvv" node="1JTgXSYMNUM" resolve="withoutUnit" />
+            <node concept="2YIFZM" id="1JTgXSYTIVf" role="3_1BAH">
+              <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+              <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
+              <node concept="Xl_RD" id="1JTgXSYN9$s" role="37wK5m">
+                <property role="Xl_RC" value="The type of node %s without units must have real type, but was %s" />
+              </node>
+              <node concept="2OqwBi" id="1JTgXSYTKZ9" role="37wK5m">
+                <node concept="2OqwBi" id="1JTgXSYTKrC" role="2Oq$k0">
+                  <node concept="37vLTw" id="1JTgXSYTKeC" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1JTgXSYTIjP" resolve="node" />
+                  </node>
+                  <node concept="2yIwOk" id="1JTgXSYTKBc" role="2OqNvi" />
+                </node>
+                <node concept="liA8E" id="1JTgXSYTLjP" role="2OqNvi">
+                  <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="1JTgXSYNa8l" role="37wK5m">
+                <node concept="37vLTw" id="1JTgXSYTLFQ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1JTgXSYTIjP" resolve="node" />
                 </node>
                 <node concept="3JvlWi" id="1JTgXSYNat5" role="2OqNvi" />
-              </node>
-              <node concept="Xl_RD" id="1JTgXSYN9$s" role="3uHU7B">
-                <property role="Xl_RC" value="Sqrt without units must have real type, but was " />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="1JTgXSYOpOK" role="3cqZAp" />
+      </node>
+      <node concept="3Tm6S6" id="1JTgXSYTIjA" role="1B3o_S" />
+      <node concept="37vLTG" id="1JTgXSYTIjP" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="1JTgXSYTIjO" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1JTgXSYMM_w" role="1SL9yI">
+      <property role="TrG5h" value="testSqrtExpressionType" />
+      <node concept="3cqZAl" id="1JTgXSYMM_x" role="3clF45" />
+      <node concept="3clFbS" id="1JTgXSYMM__" role="3clF47">
+        <node concept="3clFbF" id="1JTgXSYTICn" role="3cqZAp">
+          <node concept="2OqwBi" id="1JTgXSYTICh" role="3clFbG">
+            <node concept="2WthIp" id="1JTgXSYTICk" role="2Oq$k0" />
+            <node concept="2XshWL" id="1JTgXSYTICm" role="2OqNvi">
+              <ref role="2WH_rO" node="1JTgXSYTIgr" resolve="assertRealType" />
+              <node concept="3xONca" id="1JTgXSYTIEe" role="2XxRq1">
+                <ref role="3xOPvv" node="1JTgXSYMNUM" resolve="sqrtWithoutUnit" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1JTgXSYTIAy" role="3cqZAp" />
         <node concept="3clFbF" id="1JTgXSYNbwq" role="3cqZAp">
           <node concept="2OqwBi" id="1JTgXSYNbwk" role="3clFbG">
             <node concept="2WthIp" id="1JTgXSYNbwn" role="2Oq$k0" />
             <node concept="2XshWL" id="1JTgXSYNbwp" role="2OqNvi">
               <ref role="2WH_rO" node="1JTgXSYMRE7" resolve="assertNodeUnitType" />
               <node concept="3xONca" id="1JTgXSYNWvg" role="2XxRq1">
-                <ref role="3xOPvv" node="1JTgXSYMNZa" resolve="simpleUnit" />
+                <ref role="3xOPvv" node="1JTgXSYMNZa" resolve="sqrtSimpleUnit" />
               </node>
               <node concept="2pJPEk" id="1JTgXSYNYwP" role="2XxRq1">
                 <node concept="2pJPED" id="1JTgXSYNYNl" role="2pJPEn">
@@ -1343,7 +1396,7 @@
             <node concept="2XshWL" id="1JTgXSYOeOI" role="2OqNvi">
               <ref role="2WH_rO" node="1JTgXSYMRE7" resolve="assertNodeUnitType" />
               <node concept="3xONca" id="1JTgXSYOeOS" role="2XxRq1">
-                <ref role="3xOPvv" node="1JTgXSYMP5j" resolve="combinedUnit" />
+                <ref role="3xOPvv" node="1JTgXSYMP5j" resolve="sqrtCombinedUnit" />
               </node>
               <node concept="2pJPEk" id="1JTgXSYOnrH" role="2XxRq1">
                 <node concept="2pJPED" id="1JTgXSYOntZ" role="2pJPEn">
@@ -1406,7 +1459,7 @@
             <node concept="2XshWL" id="1JTgXSYOK_p" role="2OqNvi">
               <ref role="2WH_rO" node="1JTgXSYMRE7" resolve="assertNodeUnitType" />
               <node concept="3xONca" id="1JTgXSYOKBf" role="2XxRq1">
-                <ref role="3xOPvv" node="1JTgXSYMRgF" resolve="complexUnit" />
+                <ref role="3xOPvv" node="1JTgXSYMRgF" resolve="sqrtComplexUnit" />
               </node>
               <node concept="2pJPEk" id="1JTgXSYOMLT" role="2XxRq1">
                 <node concept="2pJPED" id="1JTgXSYOMMh" role="2pJPEn">
@@ -1447,6 +1500,259 @@
                           <node concept="Xl_RD" id="1JTgXSYONBY" role="2XxRq1">
                             <property role="Xl_RC" value="-2" />
                           </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1JTgXSYQEOF" role="1SL9yI">
+      <property role="TrG5h" value="testSumExpressionType" />
+      <node concept="3cqZAl" id="1JTgXSYQEOG" role="3clF45" />
+      <node concept="3clFbS" id="1JTgXSYQEOK" role="3clF47">
+        <node concept="3vwNmj" id="1JTgXSYQEQV" role="3cqZAp">
+          <node concept="2OqwBi" id="1JTgXSYQGh1" role="3vwVQn">
+            <node concept="2OqwBi" id="1JTgXSYQF3i" role="2Oq$k0">
+              <node concept="3xONca" id="1JTgXSYQER5" role="2Oq$k0">
+                <ref role="3xOPvv" node="1JTgXSYQEe5" resolve="sumWithoutUnit" />
+              </node>
+              <node concept="3JvlWi" id="1JTgXSYQF_L" role="2OqNvi" />
+            </node>
+            <node concept="1mIQ4w" id="1JTgXSYQGsE" role="2OqNvi">
+              <node concept="chp4Y" id="1JTgXSYQGuy" role="cj9EA">
+                <ref role="cht4Q" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+              </node>
+            </node>
+          </node>
+          <node concept="3_1$Yv" id="1JTgXSYQGy_" role="3_9lra">
+            <node concept="3cpWs3" id="1JTgXSYQGLy" role="3_1BAH">
+              <node concept="2OqwBi" id="1JTgXSYQH2r" role="3uHU7w">
+                <node concept="3xONca" id="1JTgXSYQGLO" role="2Oq$k0">
+                  <ref role="3xOPvv" node="1JTgXSYQEe5" resolve="sumWithoutUnit" />
+                </node>
+                <node concept="3JvlWi" id="1JTgXSYQH_3" role="2OqNvi" />
+              </node>
+              <node concept="Xl_RD" id="1JTgXSYQGyD" role="3uHU7B">
+                <property role="Xl_RC" value="The type of the sum needs to be a number type, but was " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1JTgXSYQH_F" role="3cqZAp" />
+        <node concept="3clFbF" id="1JTgXSYQHAf" role="3cqZAp">
+          <node concept="2OqwBi" id="1JTgXSYQHDn" role="3clFbG">
+            <node concept="2WthIp" id="1JTgXSYQHAd" role="2Oq$k0" />
+            <node concept="2XshWL" id="1JTgXSYQHHn" role="2OqNvi">
+              <ref role="2WH_rO" node="1JTgXSYMRE7" resolve="assertNodeUnitType" />
+              <node concept="3xONca" id="1JTgXSYQHHx" role="2XxRq1">
+                <ref role="3xOPvv" node="1JTgXSYQEiZ" resolve="sumSimpleUnit" />
+              </node>
+              <node concept="2pJPEk" id="1JTgXSYQHRQ" role="2XxRq1">
+                <node concept="2pJPED" id="1JTgXSYQHTO" role="2pJPEn">
+                  <ref role="2pJxaS" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+                  <node concept="2pIpSj" id="1JTgXSYQHUt" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFY" resolve="exponent" />
+                    <node concept="2pJPED" id="1JTgXSYQU3M" role="28nt2d">
+                      <ref role="2pJxaS" to="b0gq:7eOyx9r3kR6" resolve="IntegerExponent" />
+                      <node concept="2pJxcG" id="1JTgXSYQU3T" role="2pJxcM">
+                        <ref role="2pJxcJ" to="b0gq:7eOyx9r3kR7" resolve="value" />
+                        <node concept="3cmrfG" id="1JTgXSYQU43" role="28ntcv">
+                          <property role="3cmrfH" value="2" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="1JTgXSYQHVx" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                    <node concept="36bGnv" id="1JTgXSYQHWp" role="28nt2d">
+                      <ref role="36bGnp" to="ku0a:5XaocLWHSS5" resolve="s" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1JTgXSYQHI4" role="3cqZAp" />
+        <node concept="3clFbF" id="1JTgXSYQHIT" role="3cqZAp">
+          <node concept="2OqwBi" id="1JTgXSYQHMc" role="3clFbG">
+            <node concept="2WthIp" id="1JTgXSYQHIR" role="2Oq$k0" />
+            <node concept="2XshWL" id="1JTgXSYQHQc" role="2OqNvi">
+              <ref role="2WH_rO" node="1JTgXSYMRE7" resolve="assertNodeUnitType" />
+              <node concept="3xONca" id="1JTgXSYQHQm" role="2XxRq1">
+                <ref role="3xOPvv" node="1JTgXSYQEwE" resolve="sumComplexUnit" />
+              </node>
+              <node concept="2pJPEk" id="1JTgXSYQHWv" role="2XxRq1">
+                <node concept="2pJPED" id="1JTgXSYQHYM" role="2pJPEn">
+                  <ref role="2pJxaS" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+                  <node concept="2pIpSj" id="1JTgXSYQI08" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                    <node concept="36bGnv" id="1JTgXSYQI0R" role="28nt2d">
+                      <ref role="36bGnp" node="5XaocLWJ9Gy" resolve="acc" />
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="1JTgXSYQI1i" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFY" resolve="exponent" />
+                    <node concept="36biLy" id="1JTgXSYQRMD" role="28nt2d">
+                      <node concept="10Nm6u" id="1JTgXSYQRM_" role="36biLW" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1JTgXSYTIdm" role="1SL9yI">
+      <property role="TrG5h" value="testFracExpression" />
+      <node concept="3cqZAl" id="1JTgXSYTIdn" role="3clF45" />
+      <node concept="3clFbS" id="1JTgXSYTIdr" role="3clF47">
+        <node concept="3vwNmj" id="6q$NxWeD1t8" role="3cqZAp">
+          <node concept="2OqwBi" id="6q$NxWeD1t9" role="3vwVQn">
+            <node concept="2OqwBi" id="6q$NxWeD1ta" role="2Oq$k0">
+              <node concept="3xONca" id="6q$NxWeD1K0" role="2Oq$k0">
+                <ref role="3xOPvv" node="1JTgXSYTGiL" resolve="fracWithoutUnit" />
+              </node>
+              <node concept="3JvlWi" id="6q$NxWeD1tc" role="2OqNvi" />
+            </node>
+            <node concept="1mIQ4w" id="6q$NxWeD1td" role="2OqNvi">
+              <node concept="chp4Y" id="6q$NxWeD211" role="cj9EA">
+                <ref role="cht4Q" to="1qv1:5mz5Tt_h1dJ" resolve="RationalType" />
+              </node>
+            </node>
+          </node>
+          <node concept="3_1$Yv" id="6q$NxWeD1tf" role="3_9lra">
+            <node concept="3cpWs3" id="6q$NxWeD376" role="3_1BAH">
+              <node concept="3cpWs3" id="6q$NxWeD2C3" role="3uHU7B">
+                <node concept="3cpWs3" id="6q$NxWeD2pd" role="3uHU7B">
+                  <node concept="Xl_RD" id="6q$NxWeD2bi" role="3uHU7B">
+                    <property role="Xl_RC" value="The type of " />
+                  </node>
+                  <node concept="3xONca" id="6q$NxWeD2pv" role="3uHU7w">
+                    <ref role="3xOPvv" node="1JTgXSYTGiL" resolve="fracWithoutUnit" />
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="6q$NxWeD2C$" role="3uHU7w">
+                  <property role="Xl_RC" value=" was expected to be a rational type, but was " />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="6q$NxWeD3vW" role="3uHU7w">
+                <node concept="3xONca" id="6q$NxWeD3cD" role="2Oq$k0">
+                  <ref role="3xOPvv" node="1JTgXSYTGiL" resolve="fracWithoutUnit" />
+                </node>
+                <node concept="3JvlWi" id="6q$NxWeD3VA" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1JTgXSYTLIh" role="3cqZAp" />
+        <node concept="3clFbF" id="1JTgXSYTLIJ" role="3cqZAp">
+          <node concept="2OqwBi" id="1JTgXSYTLLO" role="3clFbG">
+            <node concept="2WthIp" id="1JTgXSYTLIH" role="2Oq$k0" />
+            <node concept="2XshWL" id="1JTgXSYTLPO" role="2OqNvi">
+              <ref role="2WH_rO" node="1JTgXSYMRE7" resolve="assertNodeUnitType" />
+              <node concept="3xONca" id="1JTgXSYTLPY" role="2XxRq1">
+                <ref role="3xOPvv" node="1JTgXSYTGoH" resolve="fracSimpleUnit" />
+              </node>
+              <node concept="2pJPEk" id="1JTgXSYTNgT" role="2XxRq1">
+                <node concept="2pJPED" id="1JTgXSYTNju" role="2pJPEn">
+                  <ref role="2pJxaS" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+                  <node concept="2pIpSj" id="1JTgXSYTNk5" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFY" resolve="exponent" />
+                    <node concept="36biLy" id="1JTgXSYTNl8" role="28nt2d">
+                      <node concept="10Nm6u" id="1JTgXSYTNl6" role="36biLW" />
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="1JTgXSYTNlD" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                    <node concept="36bGnv" id="1JTgXSYTNm6" role="28nt2d">
+                      <ref role="36bGnp" to="ku0a:5XaocLWHSS5" resolve="s" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1JTgXSYTN6u" role="3cqZAp" />
+        <node concept="3clFbF" id="1JTgXSYTN7K" role="3cqZAp">
+          <node concept="2OqwBi" id="1JTgXSYTNbp" role="3clFbG">
+            <node concept="2WthIp" id="1JTgXSYTN7I" role="2Oq$k0" />
+            <node concept="2XshWL" id="1JTgXSYTNfp" role="2OqNvi">
+              <ref role="2WH_rO" node="1JTgXSYMRE7" resolve="assertNodeUnitType" />
+              <node concept="3xONca" id="1JTgXSYTNfz" role="2XxRq1">
+                <ref role="3xOPvv" node="1JTgXSYTMF_" resolve="fracWithoutUnitRef" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1JTgXSYTLR7" role="3cqZAp" />
+        <node concept="3clFbF" id="1JTgXSYTLRX" role="3cqZAp">
+          <node concept="2OqwBi" id="1JTgXSYTLVe" role="3clFbG">
+            <node concept="2WthIp" id="1JTgXSYTLRV" role="2Oq$k0" />
+            <node concept="2XshWL" id="1JTgXSYTLZe" role="2OqNvi">
+              <ref role="2WH_rO" node="1JTgXSYMRE7" resolve="assertNodeUnitType" />
+              <node concept="3xONca" id="1JTgXSYTMab" role="2XxRq1">
+                <ref role="3xOPvv" node="1JTgXSYTGIB" resolve="fracCombineUnit" />
+              </node>
+              <node concept="2pJPEk" id="1JTgXSYTOCc" role="2XxRq1">
+                <node concept="2pJPED" id="1JTgXSYTOEa" role="2pJPEn">
+                  <ref role="2pJxaS" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+                  <node concept="2pIpSj" id="1JTgXSYTOI1" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                    <node concept="36bGnv" id="1JTgXSYTOIv" role="28nt2d">
+                      <ref role="36bGnp" to="ku0a:5XaocLWHSS4" resolve="m" />
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="1JTgXSYTOFo" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFY" resolve="exponent" />
+                    <node concept="2pJPED" id="1JTgXSYTOFM" role="28nt2d">
+                      <ref role="2pJxaS" to="b0gq:7eOyx9r3kR6" resolve="IntegerExponent" />
+                      <node concept="2pJxcG" id="1JTgXSYTOFU" role="2pJxcM">
+                        <ref role="2pJxcJ" to="b0gq:7eOyx9r3kR7" resolve="value" />
+                        <node concept="3cmrfG" id="1JTgXSYTOG4" role="28ntcv">
+                          <property role="3cmrfH" value="-1" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1JTgXSYTM0x" role="3cqZAp" />
+        <node concept="3clFbF" id="1JTgXSYTM1J" role="3cqZAp">
+          <node concept="2OqwBi" id="1JTgXSYTM5c" role="3clFbG">
+            <node concept="2WthIp" id="1JTgXSYTM1H" role="2Oq$k0" />
+            <node concept="2XshWL" id="1JTgXSYTM9c" role="2OqNvi">
+              <ref role="2WH_rO" node="1JTgXSYMRE7" resolve="assertNodeUnitType" />
+              <node concept="3xONca" id="1JTgXSYTM9m" role="2XxRq1">
+                <ref role="3xOPvv" node="1JTgXSYTHkK" resolve="fracComplexUnit" />
+              </node>
+              <node concept="2pJPEk" id="1JTgXSYTOV3" role="2XxRq1">
+                <node concept="2pJPED" id="1JTgXSYTOXC" role="2pJPEn">
+                  <ref role="2pJxaS" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+                  <node concept="2pIpSj" id="1JTgXSYTP18" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                    <node concept="36bGnv" id="1JTgXSYTP1G" role="28nt2d">
+                      <ref role="36bGnp" to="ku0a:5XaocLWHSS5" resolve="s" />
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="1JTgXSYTOXW" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFY" resolve="exponent" />
+                    <node concept="2pJPED" id="1JTgXSYTOYk" role="28nt2d">
+                      <ref role="2pJxaS" to="b0gq:7eOyx9r3kR6" resolve="IntegerExponent" />
+                      <node concept="2pJxcG" id="1JTgXSYTOYq" role="2pJxcM">
+                        <ref role="2pJxcJ" to="b0gq:7eOyx9r3kR7" resolve="value" />
+                        <node concept="3cmrfG" id="1JTgXSYTOY$" role="28ntcv">
+                          <property role="3cmrfH" value="-1" />
                         </node>
                       </node>
                     </node>
@@ -1723,7 +2029,7 @@
               </node>
             </node>
             <node concept="3xLA65" id="1JTgXSYMNUM" role="lGtFl">
-              <property role="TrG5h" value="withoutUnit" />
+              <property role="TrG5h" value="sqrtWithoutUnit" />
             </node>
           </node>
         </node>
@@ -1753,7 +2059,7 @@
               </node>
             </node>
             <node concept="3xLA65" id="1JTgXSYMNZa" role="lGtFl">
-              <property role="TrG5h" value="simpleUnit" />
+              <property role="TrG5h" value="sqrtSimpleUnit" />
             </node>
           </node>
         </node>
@@ -1798,7 +2104,7 @@
               </node>
             </node>
             <node concept="3xLA65" id="1JTgXSYMP5j" role="lGtFl">
-              <property role="TrG5h" value="combinedUnit" />
+              <property role="TrG5h" value="sqrtCombinedUnit" />
             </node>
           </node>
         </node>
@@ -1828,11 +2134,282 @@
               </node>
             </node>
             <node concept="3xLA65" id="1JTgXSYMRgF" role="lGtFl">
-              <property role="TrG5h" value="complexUnit" />
+              <property role="TrG5h" value="sqrtComplexUnit" />
             </node>
           </node>
         </node>
-        <node concept="_ixoA" id="2OGPkCTiNPx" role="_iOnB" />
+        <node concept="2zPypq" id="1JTgXSYQBB_" role="_iOnB">
+          <property role="TrG5h" value="sumWithoutUnit" />
+          <node concept="a0DKL" id="1JTgXSYQBHq" role="2zPyp_">
+            <property role="TrG5h" value="a" />
+            <node concept="30bXRB" id="1JTgXSYQBHS" role="39z1js">
+              <property role="30bXRw" value="5" />
+            </node>
+            <node concept="30bXRB" id="1JTgXSYQBIo" role="39$JC6">
+              <property role="30bXRw" value="10" />
+            </node>
+            <node concept="30dDZf" id="1JTgXSYQBMa" role="39$JDZ">
+              <node concept="30bXRB" id="1JTgXSYQBMs" role="30dEs_">
+                <property role="30bXRw" value="3" />
+              </node>
+              <node concept="30bXRB" id="1JTgXSYQBII" role="30dEsF">
+                <property role="30bXRw" value="5" />
+              </node>
+            </node>
+            <node concept="30bXR$" id="1JTgXSYQBIa" role="39z40R" />
+            <node concept="3xLA65" id="1JTgXSYQEe5" role="lGtFl">
+              <property role="TrG5h" value="sumWithoutUnit" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="1JTgXSYQBOI" role="_iOnB">
+          <property role="TrG5h" value="sumSimpleUnit" />
+          <node concept="a0DKL" id="1JTgXSYQBOJ" role="2zPyp_">
+            <property role="TrG5h" value="a" />
+            <node concept="30bXRB" id="1JTgXSYQBOK" role="39z1js">
+              <property role="30bXRw" value="5" />
+            </node>
+            <node concept="30bXRB" id="1JTgXSYQBOL" role="39$JC6">
+              <property role="30bXRw" value="10" />
+            </node>
+            <node concept="30dDZf" id="1JTgXSYQBOM" role="39$JDZ">
+              <node concept="1YnStw" id="1JTgXSYQC47" role="30dEs_">
+                <node concept="CIsGf" id="1JTgXSYQC3O" role="2c7tTI">
+                  <node concept="CIsvn" id="1JTgXSYQC3P" role="CIi4h">
+                    <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                    <node concept="CIsvk" id="1JTgXSYQUie" role="CIi3G">
+                      <property role="CIsvl" value="2" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="30bXRB" id="1JTgXSYQBON" role="1YnStB">
+                  <property role="30bXRw" value="3" />
+                </node>
+              </node>
+              <node concept="1YnStw" id="1JTgXSYQBZb" role="30dEsF">
+                <node concept="CIsGf" id="1JTgXSYQBYS" role="2c7tTI">
+                  <node concept="CIsvn" id="1JTgXSYQBYT" role="CIi4h">
+                    <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                    <node concept="CIsvk" id="1JTgXSYQU4j" role="CIi3G">
+                      <property role="CIsvl" value="2" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="30bXRB" id="1JTgXSYQBOO" role="1YnStB">
+                  <property role="30bXRw" value="5" />
+                </node>
+              </node>
+            </node>
+            <node concept="30bXR$" id="1JTgXSYQBOP" role="39z40R" />
+            <node concept="3xLA65" id="1JTgXSYQEiZ" role="lGtFl">
+              <property role="TrG5h" value="sumSimpleUnit" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="1JTgXSYQCEt" role="_iOnB">
+          <property role="TrG5h" value="sumUnitRef" />
+          <node concept="a0DKL" id="1JTgXSYQCEu" role="2zPyp_">
+            <property role="TrG5h" value="a" />
+            <node concept="30bXRB" id="1JTgXSYQCEv" role="39z1js">
+              <property role="30bXRw" value="5" />
+            </node>
+            <node concept="30bXRB" id="1JTgXSYQCEw" role="39$JC6">
+              <property role="30bXRw" value="10" />
+            </node>
+            <node concept="30dDZf" id="1JTgXSYQCEx" role="39$JDZ">
+              <node concept="1YnStw" id="1JTgXSYQCEy" role="30dEs_">
+                <node concept="CIsGf" id="1JTgXSYQCEz" role="2c7tTI">
+                  <node concept="CIsvn" id="1JTgXSYQCE$" role="CIi4h">
+                    <ref role="CIi3I" node="5XaocLWJ9Gy" resolve="acc" />
+                  </node>
+                </node>
+                <node concept="30bXRB" id="1JTgXSYQCE_" role="1YnStB">
+                  <property role="30bXRw" value="3" />
+                </node>
+              </node>
+              <node concept="1YnStw" id="1JTgXSYQCEA" role="30dEsF">
+                <node concept="CIsGf" id="1JTgXSYQCEB" role="2c7tTI">
+                  <node concept="CIsvn" id="1JTgXSYQCEC" role="CIi4h">
+                    <ref role="CIi3I" node="5XaocLWJ9Gy" resolve="acc" />
+                  </node>
+                </node>
+                <node concept="30bXRB" id="1JTgXSYQCED" role="1YnStB">
+                  <property role="30bXRw" value="5" />
+                </node>
+              </node>
+            </node>
+            <node concept="30bXR$" id="1JTgXSYQCEE" role="39z40R" />
+            <node concept="3xLA65" id="1JTgXSYQEwE" role="lGtFl">
+              <property role="TrG5h" value="sumComplexUnit" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="1JTgXSYRCyL" role="_iOnB">
+          <property role="TrG5h" value="logWithoutUnit" />
+          <node concept="a1soB" id="1JTgXSYRCAs" role="2zPyp_">
+            <node concept="30dDZf" id="1JTgXSYRCFe" role="a0C2O">
+              <node concept="30bXRB" id="1JTgXSYRCGg" role="30dEs_">
+                <property role="30bXRw" value="5" />
+              </node>
+              <node concept="30bXRB" id="1JTgXSYRCBw" role="30dEsF">
+                <property role="30bXRw" value="5" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="1JTgXSYRCAQ" role="a1soC">
+              <property role="30bXRw" value="10" />
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="1JTgXSYS3s7" role="_iOnB" />
+        <node concept="2zPypq" id="1JTgXSYS5os" role="_iOnB">
+          <property role="TrG5h" value="fracWithoutUnit" />
+          <node concept="a1tim" id="1JTgXSYS5rQ" role="2zPyp_">
+            <node concept="30bXRB" id="1JTgXSYS5s8" role="a1tin">
+              <property role="30bXRw" value="10" />
+            </node>
+            <node concept="30bXRB" id="1JTgXSYS5st" role="a1tiq">
+              <property role="30bXRw" value="5" />
+            </node>
+            <node concept="3xLA65" id="1JTgXSYTGiL" role="lGtFl">
+              <property role="TrG5h" value="fracWithoutUnit" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="1JTgXSYS5FR" role="_iOnB">
+          <property role="TrG5h" value="fracSimpleUnit" />
+          <node concept="a1tim" id="1JTgXSYS5Jx" role="2zPyp_">
+            <node concept="1YnStw" id="1JTgXSYS5MV" role="a1tin">
+              <node concept="CIsGf" id="1JTgXSYS5MC" role="2c7tTI">
+                <node concept="CIsvn" id="1JTgXSYS5MD" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="1JTgXSYS5JN" role="1YnStB">
+                <property role="30bXRw" value="10" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="1JTgXSYS5NQ" role="a1tiq">
+              <property role="30bXRw" value="5" />
+            </node>
+            <node concept="3xLA65" id="1JTgXSYTGoH" role="lGtFl">
+              <property role="TrG5h" value="fracSimpleUnit" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="1JTgXSYTMks" role="_iOnB">
+          <property role="TrG5h" value="fracWithoutUnitRef" />
+          <node concept="a1tim" id="1JTgXSYTMp3" role="2zPyp_">
+            <node concept="1YnStw" id="1JTgXSYTMst" role="a1tin">
+              <node concept="CIsGf" id="1JTgXSYTMsa" role="2c7tTI">
+                <node concept="CIsvn" id="6q$NxWeCgEv" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="1JTgXSYTMpl" role="1YnStB">
+                <property role="30bXRw" value="10" />
+              </node>
+            </node>
+            <node concept="1YnStw" id="1JTgXSYTM_d" role="a1tiq">
+              <node concept="CIsGf" id="1JTgXSYTM$U" role="2c7tTI">
+                <node concept="CIsvn" id="1JTgXSYTM$V" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="1JTgXSYTMto" role="1YnStB">
+                <property role="30bXRw" value="5" />
+              </node>
+            </node>
+            <node concept="3xLA65" id="1JTgXSYTMF_" role="lGtFl">
+              <property role="TrG5h" value="fracWithoutUnitRef" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="1JTgXSYS6BE" role="_iOnB">
+          <property role="TrG5h" value="fracCombine" />
+          <node concept="a1tim" id="1JTgXSYS6Fu" role="2zPyp_">
+            <node concept="1YnStw" id="1JTgXSYVKqz" role="a1tin">
+              <node concept="CIsGf" id="1JTgXSYVKqg" role="2c7tTI">
+                <node concept="CIsvn" id="1JTgXSYVKqh" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="1JTgXSYS6FK" role="1YnStB">
+                <property role="30bXRw" value="10" />
+              </node>
+            </node>
+            <node concept="1YnStw" id="1JTgXSYS6RK" role="a1tiq">
+              <node concept="CIsGf" id="1JTgXSYS6Rl" role="2c7tTI">
+                <node concept="CIsvn" id="1JTgXSYS6Rm" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS4" resolve="m" />
+                </node>
+                <node concept="CIsvn" id="1JTgXSYS77m" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="1JTgXSYS6JN" role="1YnStB">
+                <property role="30bXRw" value="5" />
+              </node>
+            </node>
+            <node concept="3xLA65" id="1JTgXSYTGIB" role="lGtFl">
+              <property role="TrG5h" value="fracCombineUnit" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="1JTgXSYS7Ca" role="_iOnB">
+          <property role="TrG5h" value="fracUnitRef" />
+          <node concept="a1tim" id="1JTgXSYS7G3" role="2zPyp_">
+            <node concept="1YnStw" id="1JTgXSYS7Kh" role="a1tin">
+              <node concept="CIsGf" id="1JTgXSYS7Ke" role="2c7tTI">
+                <node concept="CIsvn" id="1JTgXSYS7Kf" role="CIi4h">
+                  <ref role="CIi3I" node="5XaocLWJ9Gy" resolve="acc" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="1JTgXSYS7GE" role="1YnStB">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="1YnStw" id="1JTgXSYS7Zn" role="a1tiq">
+              <node concept="CIsGf" id="1JTgXSYS7Z8" role="2c7tTI">
+                <node concept="CIsvn" id="1JTgXSYS7Z9" role="CIi4h">
+                  <ref role="CIi3I" node="5XaocLWIt6X" resolve="mps" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="1JTgXSYS7QC" role="1YnStB">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="3xLA65" id="1JTgXSYTHkK" role="lGtFl">
+              <property role="TrG5h" value="fracComplexUnit" />
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="6q$NxWeHFcy" role="_iOnB" />
+        <node concept="2zPypq" id="6q$NxWeFCoY" role="_iOnB">
+          <property role="TrG5h" value="absExpr" />
+          <node concept="a1tT9" id="6q$NxWeFCxc" role="2zPyp_">
+            <node concept="30cIq6" id="6q$NxWeICzP" role="a0Cwb">
+              <node concept="30bXRB" id="6q$NxWeIC$0" role="30czhm">
+                <property role="30bXRw" value="5" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="6q$NxWeFCAd" role="_iOnB">
+          <property role="TrG5h" value="absSimpleUnit" />
+          <node concept="a1tT9" id="6q$NxWeFCEu" role="2zPyp_">
+            <node concept="1YnStw" id="6q$NxWeHFwS" role="a0Cwb">
+              <node concept="CIsGf" id="6q$NxWeHFwp" role="2c7tTI">
+                <node concept="CIsvn" id="6q$NxWeHFwq" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="6q$NxWeHcu7" role="1YnStB">
+                <property role="30bXRw" value="5" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="6q$NxWeHFA4" role="_iOnB" />
         <node concept="7CXmI" id="1fzaMYHrHph" role="lGtFl">
           <node concept="7OXhh" id="1fzaMYHrHpi" role="7EUXB" />
         </node>
@@ -2106,6 +2683,28 @@
               </node>
             </node>
             <node concept="mLuIC" id="1fzaMYHvXHg" role="2c7tTw" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="1JTgXSYRxc$" role="_iOnB" />
+        <node concept="2zPypq" id="1JTgXSYRxg7" role="_iOnB">
+          <property role="TrG5h" value="logExpression" />
+          <node concept="a1soB" id="1JTgXSYRxia" role="2zPyp_">
+            <node concept="1YnStw" id="1JTgXSYRCqr" role="a0C2O">
+              <node concept="CIsGf" id="1JTgXSYRCqk" role="2c7tTI">
+                <node concept="CIsvn" id="1JTgXSYRCql" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="1JTgXSYRxje" role="1YnStB">
+                <property role="30bXRw" value="5" />
+              </node>
+              <node concept="7CXmI" id="1JTgXSYRCs6" role="lGtFl">
+                <node concept="1TM$A" id="1JTgXSYRCuc" role="7EUXB" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="1JTgXSYRxi$" role="a1soC">
+              <property role="30bXRw" value="10" />
+            </node>
           </node>
         </node>
         <node concept="7CXmI" id="1fzaMYHvXFD" role="lGtFl">

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
@@ -211,7 +211,12 @@
       <concept id="1330041117646892924" name="org.iets3.core.expr.simpleTypes.structure.NumberPrecSpec" flags="ng" index="2gteS_">
         <property id="1330041117646892934" name="prec" index="2gteVv" />
       </concept>
+      <concept id="1330041117646892901" name="org.iets3.core.expr.simpleTypes.structure.NumberRangeSpec" flags="ng" index="2gteSW">
+        <property id="1330041117646892912" name="max" index="2gteSD" />
+        <property id="1330041117646892911" name="min" index="2gteSQ" />
+      </concept>
       <concept id="8219602584782245544" name="org.iets3.core.expr.simpleTypes.structure.NumberType" flags="ng" index="mLuIC">
+        <child id="1330041117646892920" name="range" index="2gteSx" />
         <child id="1330041117646892937" name="prec" index="2gteVg" />
       </concept>
       <concept id="7425695345928358745" name="org.iets3.core.expr.simpleTypes.structure.TrueLiteral" flags="ng" index="2vmpnb" />
@@ -225,6 +230,9 @@
     <language id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel">
       <concept id="7089558164906249676" name="org.iets3.core.expr.toplevel.structure.Constant" flags="ng" index="2zPypq">
         <child id="7089558164906249715" name="value" index="2zPyp_" />
+      </concept>
+      <concept id="543569365051789113" name="org.iets3.core.expr.toplevel.structure.ConstantRef" flags="ng" index="_emDc">
+        <reference id="543569365051789114" name="constant" index="_emDf" />
       </concept>
       <concept id="543569365052765011" name="org.iets3.core.expr.toplevel.structure.EmptyToplevelContent" flags="ng" index="_ixoA" />
       <concept id="543569365052711055" name="org.iets3.core.expr.toplevel.structure.Library" flags="ng" index="_iOnU">
@@ -277,6 +285,11 @@
       </concept>
     </language>
     <language id="6fadc44e-69c2-4a4a-9d16-7ebf5f8d3ba0" name="org.iets3.core.expr.math">
+      <concept id="4944417823362148603" name="org.iets3.core.expr.math.structure.ProductLoopExpression" flags="ng" index="a0B4F" />
+      <concept id="4944417823362146628" name="org.iets3.core.expr.math.structure.PowerExpression" flags="ng" index="a0Byk">
+        <child id="4944417823362178786" name="expr" index="a0GsM" />
+        <child id="5098456557379673903" name="exponent" index="2zCggm" />
+      </concept>
       <concept id="4944417823362158056" name="org.iets3.core.expr.math.structure.SqrtExpression" flags="ng" index="a0DgS">
         <child id="4944417823362162236" name="expr" index="a0CvG" />
       </concept>
@@ -1579,34 +1592,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="1JTgXSYQHI4" role="3cqZAp" />
-        <node concept="3clFbF" id="1JTgXSYQHIT" role="3cqZAp">
-          <node concept="2OqwBi" id="1JTgXSYQHMc" role="3clFbG">
-            <node concept="2WthIp" id="1JTgXSYQHIR" role="2Oq$k0" />
-            <node concept="2XshWL" id="1JTgXSYQHQc" role="2OqNvi">
-              <ref role="2WH_rO" node="1JTgXSYMRE7" resolve="assertNodeUnitType" />
-              <node concept="3xONca" id="1JTgXSYQHQm" role="2XxRq1">
-                <ref role="3xOPvv" node="1JTgXSYQEwE" resolve="sumComplexUnit" />
-              </node>
-              <node concept="2pJPEk" id="1JTgXSYQHWv" role="2XxRq1">
-                <node concept="2pJPED" id="1JTgXSYQHYM" role="2pJPEn">
-                  <ref role="2pJxaS" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
-                  <node concept="2pIpSj" id="1JTgXSYQI08" role="2pJxcM">
-                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFW" resolve="unit" />
-                    <node concept="36bGnv" id="6q$NxWeOYPo" role="28nt2d">
-                      <ref role="36bGnp" node="5XaocLWJ9Gy" resolve="acc" />
-                    </node>
-                  </node>
-                  <node concept="2pIpSj" id="1JTgXSYQI1i" role="2pJxcM">
-                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFY" resolve="exponent" />
-                    <node concept="36biLy" id="1JTgXSYQRMD" role="28nt2d">
-                      <node concept="10Nm6u" id="1JTgXSYQRM_" role="36biLW" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
       </node>
     </node>
     <node concept="1LZb2c" id="1JTgXSYTIdm" role="1SL9yI">
@@ -1758,6 +1743,215 @@
                     </node>
                   </node>
                 </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="6q$NxWf2GAm" role="1SL9yI">
+      <property role="TrG5h" value="testPowerExpression" />
+      <node concept="3cqZAl" id="6q$NxWf2GAn" role="3clF45" />
+      <node concept="3clFbS" id="6q$NxWf2GAr" role="3clF47">
+        <node concept="3clFbF" id="6q$NxWf2IO2" role="3cqZAp">
+          <node concept="2OqwBi" id="6q$NxWf2IQY" role="3clFbG">
+            <node concept="2WthIp" id="6q$NxWf2IO1" role="2Oq$k0" />
+            <node concept="2XshWL" id="6q$NxWf2IV3" role="2OqNvi">
+              <ref role="2WH_rO" node="1JTgXSYTIgr" resolve="assertRealType" />
+              <node concept="3xONca" id="6q$NxWf2IVh" role="2XxRq1">
+                <ref role="3xOPvv" node="6q$NxWf2GI7" resolve="powWithoutUnit" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6q$NxWf2IVD" role="3cqZAp" />
+        <node concept="3cpWs8" id="6q$NxWf2Kn7" role="3cqZAp">
+          <node concept="3cpWsn" id="6q$NxWf2Kn8" role="3cpWs9">
+            <property role="TrG5h" value="unitRefSToPow20" />
+            <node concept="3Tqbb2" id="6q$NxWf2J90" role="1tU5fm">
+              <ref role="ehGHo" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+            </node>
+            <node concept="2pJPEk" id="6q$NxWf2Kn9" role="33vP2m">
+              <node concept="2pJPED" id="6q$NxWf2Kna" role="2pJPEn">
+                <ref role="2pJxaS" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+                <node concept="2pIpSj" id="6q$NxWf2Knb" role="2pJxcM">
+                  <ref role="2pIpSl" to="b0gq:7eOyx9r3qFY" resolve="exponent" />
+                  <node concept="2pJPED" id="6q$NxWf2Knc" role="28nt2d">
+                    <ref role="2pJxaS" to="b0gq:7eOyx9r3kR6" resolve="IntegerExponent" />
+                    <node concept="2pJxcG" id="6q$NxWf2Knd" role="2pJxcM">
+                      <ref role="2pJxcJ" to="b0gq:7eOyx9r3kR7" resolve="value" />
+                      <node concept="3cmrfG" id="6q$NxWf2Kne" role="28ntcv">
+                        <property role="3cmrfH" value="20" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="6q$NxWf2Knf" role="2pJxcM">
+                  <ref role="2pIpSl" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                  <node concept="36bGnv" id="6q$NxWf2Kng" role="28nt2d">
+                    <ref role="36bGnp" to="ku0a:5XaocLWHSS5" resolve="s" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6q$NxWf6skc" role="3cqZAp" />
+        <node concept="3clFbF" id="6q$NxWf2IWk" role="3cqZAp">
+          <node concept="2OqwBi" id="6q$NxWf2IZx" role="3clFbG">
+            <node concept="2WthIp" id="6q$NxWf2IWi" role="2Oq$k0" />
+            <node concept="2XshWL" id="6q$NxWf2J3W" role="2OqNvi">
+              <ref role="2WH_rO" node="1JTgXSYMRE7" resolve="assertNodeUnitType" />
+              <node concept="3xONca" id="6q$NxWf2J47" role="2XxRq1">
+                <ref role="3xOPvv" node="6q$NxWf2GO8" resolve="powSimpleUnit" />
+              </node>
+              <node concept="37vLTw" id="6q$NxWf2Knh" role="2XxRq1">
+                <ref role="3cqZAo" node="6q$NxWf2Kn8" resolve="unitRefSToPow20" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6q$NxWf6sn3" role="3cqZAp">
+          <node concept="2OqwBi" id="6q$NxWf6ssI" role="3clFbG">
+            <node concept="2WthIp" id="6q$NxWf6sn1" role="2Oq$k0" />
+            <node concept="2XshWL" id="6q$NxWf6swN" role="2OqNvi">
+              <ref role="2WH_rO" node="1JTgXSYMRE7" resolve="assertNodeUnitType" />
+              <node concept="3xONca" id="6q$NxWf6swY" role="2XxRq1">
+                <ref role="3xOPvv" node="6q$NxWf6rPe" resolve="powSimpleUnitNegativeExp" />
+              </node>
+              <node concept="37vLTw" id="6q$NxWf6sxG" role="2XxRq1">
+                <ref role="3cqZAo" node="6q$NxWf2Kn8" resolve="unitRefSToPow20" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6q$NxWf6shs" role="3cqZAp" />
+        <node concept="3clFbF" id="6q$NxWf2Jcy" role="3cqZAp">
+          <node concept="2OqwBi" id="6q$NxWf2Jgg" role="3clFbG">
+            <node concept="2WthIp" id="6q$NxWf2Jcw" role="2Oq$k0" />
+            <node concept="2XshWL" id="6q$NxWf2Jp3" role="2OqNvi">
+              <ref role="2WH_rO" node="1JTgXSYMRE7" resolve="assertNodeUnitType" />
+              <node concept="3xONca" id="6q$NxWf2Jpe" role="2XxRq1">
+                <ref role="3xOPvv" node="6q$NxWf2GYG" resolve="powComplexUnit" />
+              </node>
+              <node concept="2pJPEk" id="6q$NxWf2JpW" role="2XxRq1">
+                <node concept="2pJPED" id="6q$NxWf2JrX" role="2pJPEn">
+                  <ref role="2pJxaS" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+                  <node concept="2pIpSj" id="6q$NxWf2JsJ" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                    <node concept="36bGnv" id="6q$NxWf2Jtk" role="28nt2d">
+                      <ref role="36bGnp" to="ku0a:5XaocLWHSS4" resolve="m" />
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="6q$NxWf2JtN" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFY" resolve="exponent" />
+                    <node concept="2pJPED" id="6q$NxWf2Jus" role="28nt2d">
+                      <ref role="2pJxaS" to="b0gq:7eOyx9r3kR6" resolve="IntegerExponent" />
+                      <node concept="2pJxcG" id="6q$NxWf2JuA" role="2pJxcM">
+                        <ref role="2pJxcJ" to="b0gq:7eOyx9r3kR7" resolve="value" />
+                        <node concept="3cmrfG" id="6q$NxWf2JuM" role="28ntcv">
+                          <property role="3cmrfH" value="-10" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2pJPEk" id="6q$NxWf2Jx9" role="2XxRq1">
+                <node concept="2pJPED" id="6q$NxWf2Jxa" role="2pJPEn">
+                  <ref role="2pJxaS" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+                  <node concept="2pIpSj" id="6q$NxWf2Jxb" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                    <node concept="36bGnv" id="6q$NxWf2Jzw" role="28nt2d">
+                      <ref role="36bGnp" to="ku0a:5XaocLWHSS5" resolve="s" />
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="6q$NxWf2Jxd" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFY" resolve="exponent" />
+                    <node concept="2pJPED" id="6q$NxWf2Jxe" role="28nt2d">
+                      <ref role="2pJxaS" to="b0gq:7eOyx9r3kR6" resolve="IntegerExponent" />
+                      <node concept="2pJxcG" id="6q$NxWf2Jxf" role="2pJxcM">
+                        <ref role="2pJxcJ" to="b0gq:7eOyx9r3kR7" resolve="value" />
+                        <node concept="3cmrfG" id="6q$NxWf2Jxg" role="28ntcv">
+                          <property role="3cmrfH" value="10" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6q$NxWf2Jv1" role="3cqZAp" />
+        <node concept="3clFbF" id="6q$NxWf2J_u" role="3cqZAp">
+          <node concept="2OqwBi" id="6q$NxWf2JDX" role="3clFbG">
+            <node concept="2WthIp" id="6q$NxWf2J_s" role="2Oq$k0" />
+            <node concept="2XshWL" id="6q$NxWf2JIo" role="2OqNvi">
+              <ref role="2WH_rO" node="1JTgXSYMRE7" resolve="assertNodeUnitType" />
+              <node concept="3xONca" id="6q$NxWf2JIz" role="2XxRq1">
+                <ref role="3xOPvv" node="6q$NxWf2Hcw" resolve="powUnitRef" />
+              </node>
+              <node concept="2pJPEk" id="6q$NxWf2K27" role="2XxRq1">
+                <node concept="2pJPED" id="6q$NxWf2K4h" role="2pJPEn">
+                  <ref role="2pJxaS" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+                  <node concept="2pIpSj" id="6q$NxWf2K4A" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                    <node concept="36bGnv" id="6q$NxWf2K50" role="28nt2d">
+                      <ref role="36bGnp" to="ku0a:5XaocLWHSS4" resolve="m" />
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="6q$NxWf2K5C" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFY" resolve="exponent" />
+                    <node concept="2pJPED" id="6q$NxWf2K68" role="28nt2d">
+                      <ref role="2pJxaS" to="b0gq:7eOyx9r3kR6" resolve="IntegerExponent" />
+                      <node concept="2pJxcG" id="6q$NxWf2K6f" role="2pJxcM">
+                        <ref role="2pJxcJ" to="b0gq:7eOyx9r3kR7" resolve="value" />
+                        <node concept="3cmrfG" id="6q$NxWf2K6r" role="28ntcv">
+                          <property role="3cmrfH" value="10" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2pJPEk" id="6q$NxWf2K6$" role="2XxRq1">
+                <node concept="2pJPED" id="6q$NxWf2K6_" role="2pJPEn">
+                  <ref role="2pJxaS" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+                  <node concept="2pIpSj" id="6q$NxWf2K6A" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                    <node concept="36bGnv" id="6q$NxWf2K7T" role="28nt2d">
+                      <ref role="36bGnp" to="ku0a:5XaocLWHSS5" resolve="s" />
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="6q$NxWf2K6C" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFY" resolve="exponent" />
+                    <node concept="2pJPED" id="6q$NxWf2K6D" role="28nt2d">
+                      <ref role="2pJxaS" to="b0gq:7eOyx9r3kR6" resolve="IntegerExponent" />
+                      <node concept="2pJxcG" id="6q$NxWf2K6E" role="2pJxcM">
+                        <ref role="2pJxcJ" to="b0gq:7eOyx9r3kR7" resolve="value" />
+                        <node concept="3cmrfG" id="6q$NxWf2K6F" role="28ntcv">
+                          <property role="3cmrfH" value="-20" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6q$NxWf2K86" role="3cqZAp" />
+        <node concept="3clFbF" id="6q$NxWf2Kcz" role="3cqZAp">
+          <node concept="2OqwBi" id="6q$NxWf2KhN" role="3clFbG">
+            <node concept="2WthIp" id="6q$NxWf2Kcx" role="2Oq$k0" />
+            <node concept="2XshWL" id="6q$NxWf2Kme" role="2OqNvi">
+              <ref role="2WH_rO" node="1JTgXSYMRE7" resolve="assertNodeUnitType" />
+              <node concept="3xONca" id="6q$NxWf2Kmp" role="2XxRq1">
+                <ref role="3xOPvv" node="6q$NxWf2Ig8" resolve="powExponentSum" />
+              </node>
+              <node concept="37vLTw" id="6q$NxWf2Kwe" role="2XxRq1">
+                <ref role="3cqZAo" node="6q$NxWf2Kn8" resolve="unitRefSToPow20" />
               </node>
             </node>
           </node>
@@ -2206,44 +2400,6 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="1JTgXSYQCEt" role="_iOnB">
-          <property role="TrG5h" value="sumUnitRef" />
-          <node concept="a0DKL" id="1JTgXSYQCEu" role="2zPyp_">
-            <property role="TrG5h" value="a" />
-            <node concept="30bXRB" id="1JTgXSYQCEv" role="39z1js">
-              <property role="30bXRw" value="5" />
-            </node>
-            <node concept="30bXRB" id="1JTgXSYQCEw" role="39$JC6">
-              <property role="30bXRw" value="10" />
-            </node>
-            <node concept="30dDZf" id="1JTgXSYQCEx" role="39$JDZ">
-              <node concept="1YnStw" id="1JTgXSYQCEy" role="30dEs_">
-                <node concept="CIsGf" id="1JTgXSYQCEz" role="2c7tTI">
-                  <node concept="CIsvn" id="1JTgXSYQCE$" role="CIi4h">
-                    <ref role="CIi3I" node="5XaocLWJ9Gy" resolve="acc" />
-                  </node>
-                </node>
-                <node concept="30bXRB" id="1JTgXSYQCE_" role="1YnStB">
-                  <property role="30bXRw" value="3" />
-                </node>
-              </node>
-              <node concept="1YnStw" id="1JTgXSYQCEA" role="30dEsF">
-                <node concept="CIsGf" id="1JTgXSYQCEB" role="2c7tTI">
-                  <node concept="CIsvn" id="1JTgXSYQCEC" role="CIi4h">
-                    <ref role="CIi3I" node="5XaocLWJ9Gy" resolve="acc" />
-                  </node>
-                </node>
-                <node concept="30bXRB" id="1JTgXSYQCED" role="1YnStB">
-                  <property role="30bXRw" value="5" />
-                </node>
-              </node>
-            </node>
-            <node concept="30bXR$" id="1JTgXSYQCEE" role="39z40R" />
-            <node concept="3xLA65" id="1JTgXSYQEwE" role="lGtFl">
-              <property role="TrG5h" value="sumComplexUnit" />
-            </node>
-          </node>
-        </node>
         <node concept="2zPypq" id="1JTgXSYRCyL" role="_iOnB">
           <property role="TrG5h" value="logWithoutUnit" />
           <node concept="a1soB" id="1JTgXSYRCAs" role="2zPyp_">
@@ -2383,7 +2539,6 @@
             </node>
           </node>
         </node>
-        <node concept="_ixoA" id="6q$NxWeHFcy" role="_iOnB" />
         <node concept="2zPypq" id="6q$NxWeFCoY" role="_iOnB">
           <property role="TrG5h" value="absExpr" />
           <node concept="a1tT9" id="6q$NxWeFCxc" role="2zPyp_">
@@ -2406,6 +2561,154 @@
               <node concept="30bXRB" id="6q$NxWeHcu7" role="1YnStB">
                 <property role="30bXRw" value="5" />
               </node>
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="6q$NxWeU1Jc" role="_iOnB" />
+        <node concept="2zPypq" id="6q$NxWeU1Yu" role="_iOnB">
+          <property role="TrG5h" value="powWithoutUnit" />
+          <node concept="a0Byk" id="6q$NxWeU26u" role="2zPyp_">
+            <node concept="30bXRB" id="6q$NxWeU26V" role="a0GsM">
+              <property role="30bXRw" value="5" />
+            </node>
+            <node concept="30bXRB" id="6q$NxWeU27A" role="2zCggm">
+              <property role="30bXRw" value="10" />
+            </node>
+            <node concept="3xLA65" id="6q$NxWf2GI7" role="lGtFl">
+              <property role="TrG5h" value="powWithoutUnit" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="6q$NxWeU2gg" role="_iOnB">
+          <property role="TrG5h" value="powSimpleUnit" />
+          <node concept="a0Byk" id="6q$NxWeU2tt" role="2zPyp_">
+            <node concept="1YnStw" id="6q$NxWeVWJw" role="a0GsM">
+              <node concept="CIsGf" id="6q$NxWeVWJt" role="2c7tTI">
+                <node concept="CIsvn" id="6q$NxWeVWJu" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+                <node concept="CIsvn" id="6q$NxWf2Ekk" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="6q$NxWeU2tU" role="1YnStB">
+                <property role="30bXRw" value="5" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="6q$NxWeU2yJ" role="2zCggm">
+              <property role="30bXRw" value="10" />
+            </node>
+            <node concept="3xLA65" id="6q$NxWf2GO8" role="lGtFl">
+              <property role="TrG5h" value="powSimpleUnit" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="6q$NxWf6r12" role="_iOnB">
+          <property role="TrG5h" value="powSimpleUnitNegativeExp" />
+          <node concept="a0Byk" id="6q$NxWf6rau" role="2zPyp_">
+            <node concept="1YnStw" id="6q$NxWf6rdW" role="a0GsM">
+              <node concept="CIsGf" id="6q$NxWf6rdT" role="2c7tTI">
+                <node concept="CIsvn" id="6q$NxWf6rdU" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                  <node concept="CIsvk" id="6q$NxWf6rzg" role="CIi3G">
+                    <property role="CIsvl" value="-2" />
+                  </node>
+                </node>
+              </node>
+              <node concept="30bXRB" id="6q$NxWf6raN" role="1YnStB">
+                <property role="30bXRw" value="5" />
+              </node>
+            </node>
+            <node concept="30cIq6" id="6q$NxWf6reU" role="2zCggm">
+              <node concept="30bXRB" id="6q$NxWf6rfT" role="30czhm">
+                <property role="30bXRw" value="10" />
+              </node>
+            </node>
+            <node concept="3xLA65" id="6q$NxWf6rPe" role="lGtFl">
+              <property role="TrG5h" value="powSimpleUnitNegativeExp" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="6q$NxWeU2Gn" role="_iOnB">
+          <property role="TrG5h" value="powCombineUnit" />
+          <node concept="a0Byk" id="6q$NxWeU31e" role="2zPyp_">
+            <node concept="30bXRB" id="6q$NxWeU33s" role="2zCggm">
+              <property role="30bXRw" value="10" />
+            </node>
+            <node concept="1YnStw" id="6q$NxWeU2RX" role="a0GsM">
+              <node concept="CIsGf" id="6q$NxWeU2RU" role="2c7tTI">
+                <node concept="CIsvn" id="6q$NxWeU2RV" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+                <node concept="CIsvn" id="6q$NxWeU2Ty" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS4" resolve="m" />
+                  <node concept="CIsvk" id="6q$NxWeU2X3" role="CIi3G">
+                    <property role="CIsvl" value="-1" />
+                  </node>
+                </node>
+              </node>
+              <node concept="30bXRB" id="6q$NxWeU2OC" role="1YnStB">
+                <property role="30bXRw" value="5" />
+              </node>
+            </node>
+            <node concept="3xLA65" id="6q$NxWf2GYG" role="lGtFl">
+              <property role="TrG5h" value="powComplexUnit" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="6q$NxWf2Ezl" role="_iOnB">
+          <property role="TrG5h" value="powUnitRef" />
+          <node concept="a0Byk" id="6q$NxWf2EG2" role="2zPyp_">
+            <node concept="1YnStw" id="6q$NxWf2EXf" role="a0GsM">
+              <node concept="CIsGf" id="6q$NxWf2EWQ" role="2c7tTI">
+                <node concept="CIsvn" id="6q$NxWf2EWR" role="CIi4h">
+                  <ref role="CIi3I" node="5XaocLWJ9Gy" resolve="acc" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="6q$NxWf2EHp" role="1YnStB">
+                <property role="30bXRw" value="5" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="6q$NxWf2Fmo" role="2zCggm">
+              <property role="30bXRw" value="10" />
+            </node>
+            <node concept="3xLA65" id="6q$NxWf2Hcw" role="lGtFl">
+              <property role="TrG5h" value="powUnitRef" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="6q$NxWf2GfZ" role="_iOnB">
+          <property role="TrG5h" value="x" />
+          <node concept="30bXRB" id="6q$NxWf2Gp4" role="2zPyp_">
+            <property role="30bXRw" value="5" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="6q$NxWf2FIV" role="_iOnB">
+          <property role="TrG5h" value="powExponentSum" />
+          <node concept="a0Byk" id="6q$NxWf2FSb" role="2zPyp_">
+            <node concept="1YnStw" id="6q$NxWf2FVD" role="a0GsM">
+              <node concept="CIsGf" id="6q$NxWf2FVA" role="2c7tTI">
+                <node concept="CIsvn" id="6q$NxWf2FVB" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+                <node concept="CIsvn" id="6q$NxWf2JJh" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="6q$NxWf2FSw" role="1YnStB">
+                <property role="30bXRw" value="5" />
+              </node>
+            </node>
+            <node concept="30dDZf" id="6q$NxWf2G2l" role="2zCggm">
+              <node concept="30bXRB" id="6q$NxWf2FWD" role="30dEsF">
+                <property role="30bXRw" value="5" />
+              </node>
+              <node concept="_emDc" id="6q$NxWf2GqA" role="30dEs_">
+                <ref role="_emDf" node="6q$NxWf2GfZ" resolve="x" />
+              </node>
+            </node>
+            <node concept="3xLA65" id="6q$NxWf2Ig8" role="lGtFl">
+              <property role="TrG5h" value="powExponentSum" />
             </node>
           </node>
         </node>
@@ -2704,6 +3007,97 @@
             </node>
             <node concept="30bXRB" id="1JTgXSYRxi$" role="a1soC">
               <property role="30bXRw" value="10" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="6q$NxWfbiXh" role="_iOnB">
+          <property role="TrG5h" value="productExpression" />
+          <node concept="a0B4F" id="6q$NxWfbj2i" role="2zPyp_">
+            <property role="TrG5h" value="a" />
+            <node concept="30bXRB" id="6q$NxWfbj32" role="39z1js">
+              <property role="30bXRw" value="5" />
+            </node>
+            <node concept="30bXRB" id="6q$NxWfbj3q" role="39$JC6">
+              <property role="30bXRw" value="10" />
+            </node>
+            <node concept="1YnStw" id="6q$NxWfbj6e" role="39$JDZ">
+              <node concept="CIsGf" id="6q$NxWfbj6b" role="2c7tTI">
+                <node concept="CIsvn" id="6q$NxWfbj6c" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="6q$NxWfbj3M" role="1YnStB">
+                <property role="30bXRw" value="20" />
+              </node>
+              <node concept="7CXmI" id="6q$NxWfbjDu" role="lGtFl">
+                <node concept="1TM$A" id="6q$NxWfbjDv" role="7EUXB" />
+              </node>
+            </node>
+            <node concept="mLuIC" id="6q$NxWfbj2M" role="39z40R" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="6q$NxWf66nu" role="_iOnB">
+          <property role="TrG5h" value="x" />
+          <node concept="30bXRB" id="6q$NxWf66t2" role="2zPyp_">
+            <property role="30bXRw" value="5" />
+          </node>
+          <node concept="mLuIC" id="6q$NxWf66rX" role="2zM23F">
+            <node concept="2gteSW" id="6q$NxWf66sa" role="2gteSx">
+              <property role="2gteSQ" value="1" />
+              <property role="2gteSD" value="10" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="6q$NxWf65Sf" role="_iOnB">
+          <property role="TrG5h" value="powExpressionWithUnknownExponent" />
+          <node concept="a0Byk" id="6q$NxWf65WB" role="2zPyp_">
+            <node concept="1YnStw" id="6q$NxWf65YX" role="a0GsM">
+              <node concept="CIsGf" id="6q$NxWf65YU" role="2c7tTI">
+                <node concept="CIsvn" id="6q$NxWf65YV" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="6q$NxWf65WW" role="1YnStB">
+                <property role="30bXRw" value="10" />
+              </node>
+              <node concept="7CXmI" id="6q$NxWf8W6T" role="lGtFl">
+                <node concept="1TM$A" id="6q$NxWf8W6U" role="7EUXB" />
+              </node>
+            </node>
+            <node concept="30dDTi" id="6q$NxWf664x" role="2zCggm">
+              <node concept="_emDc" id="6q$NxWf66tJ" role="30dEs_">
+                <ref role="_emDf" node="6q$NxWf66nu" resolve="x" />
+              </node>
+              <node concept="30bXRB" id="6q$NxWf65ZX" role="30dEsF">
+                <property role="30bXRw" value="5" />
+              </node>
+              <node concept="7CXmI" id="6q$NxWf7_VG" role="lGtFl">
+                <node concept="1TM$A" id="6q$NxWf7_VH" role="7EUXB" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="6q$NxWf6hVk" role="_iOnB">
+          <property role="TrG5h" value="powExpressionExponentLong" />
+          <node concept="a0Byk" id="6q$NxWf6i04" role="2zPyp_">
+            <node concept="1YnStw" id="6q$NxWf6i2q" role="a0GsM">
+              <node concept="CIsGf" id="6q$NxWf6i2n" role="2c7tTI">
+                <node concept="CIsvn" id="6q$NxWf6i2o" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="6q$NxWf6i0p" role="1YnStB">
+                <property role="30bXRw" value="10" />
+              </node>
+              <node concept="7CXmI" id="6q$NxWf8WdR" role="lGtFl">
+                <node concept="1TM$A" id="6q$NxWf8WdS" role="7EUXB" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="6q$NxWf6i3x" role="2zCggm">
+              <property role="30bXRw" value="10000000000" />
+              <node concept="7CXmI" id="6q$NxWf7_T4" role="lGtFl">
+                <node concept="1TM$A" id="6q$NxWf7_T5" role="7EUXB" />
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
@@ -207,6 +207,22 @@
         <property id="2557074442922438158" name="escapedValue" index="19SUeA" />
       </concept>
     </language>
+    <language id="d441fba0-f46b-43cd-b723-dad7b65da615" name="org.iets3.core.expr.tests">
+      <concept id="543569365052056273" name="org.iets3.core.expr.tests.structure.EqualsTestOp" flags="ng" index="_fku$" />
+      <concept id="543569365052056263" name="org.iets3.core.expr.tests.structure.TestCase" flags="ng" index="_fkuM">
+        <child id="543569365052056368" name="items" index="_fkp5" />
+      </concept>
+      <concept id="543569365052056266" name="org.iets3.core.expr.tests.structure.AssertTestItem" flags="ng" index="_fkuZ">
+        <child id="543569365052056302" name="op" index="_fkur" />
+        <child id="543569365052056269" name="expected" index="_fkuS" />
+        <child id="543569365052056267" name="actual" index="_fkuY" />
+      </concept>
+      <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
+        <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
+        <reference id="2032654994493517823" name="scoper" index="2HwdWd" />
+        <child id="543569365052711058" name="contents" index="_iOnB" />
+      </concept>
+    </language>
     <language id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes">
       <concept id="1330041117646892924" name="org.iets3.core.expr.simpleTypes.structure.NumberPrecSpec" flags="ng" index="2gteS_">
         <property id="1330041117646892934" name="prec" index="2gteVv" />
@@ -235,8 +251,8 @@
         <reference id="543569365051789114" name="constant" index="_emDf" />
       </concept>
       <concept id="543569365052765011" name="org.iets3.core.expr.toplevel.structure.EmptyToplevelContent" flags="ng" index="_ixoA" />
-      <concept id="543569365052711055" name="org.iets3.core.expr.toplevel.structure.Library" flags="ng" index="_iOnU">
-        <child id="543569365052711058" name="contents" index="_iOnB" />
+      <concept id="543569365052711055" name="org.iets3.core.expr.toplevel.structure.Library" flags="ng" index="_iOnV">
+        <child id="543569365052711058" name="contents" index="_iOnC" />
         <child id="6839478809833656927" name="imports" index="3i6evy" />
       </concept>
     </language>
@@ -388,9 +404,9 @@
   <node concept="1lH9Xt" id="2JXkwhJfxJF">
     <property role="TrG5h" value="Conversions" />
     <node concept="1qefOq" id="2JXkwhJfxJG" role="1SKRRt">
-      <node concept="_iOnU" id="7Z_pmaBI0dm" role="1qenE9">
+      <node concept="_iOnV" id="7Z_pmaBI0dm" role="1qenE9">
         <property role="TrG5h" value="Conversions_a" />
-        <node concept="2zPypq" id="2JXkwhJg4g0" role="_iOnB">
+        <node concept="2zPypq" id="2JXkwhJg4g0" role="_iOnC">
           <property role="TrG5h" value="a" />
           <node concept="30dDTi" id="2JXkwhJg4ku" role="2zPyp_">
             <node concept="1PfFCI" id="2JXkwhJg4lN" role="30dEs_">
@@ -446,7 +462,7 @@
             <node concept="mLuIC" id="2JXkwhJg7in" role="2c7tTw" />
           </node>
         </node>
-        <node concept="2zPypq" id="2JXkwhJh8YZ" role="_iOnB">
+        <node concept="2zPypq" id="2JXkwhJh8YZ" role="_iOnC">
           <property role="TrG5h" value="b" />
           <node concept="1PfFCI" id="2JXkwhJh930" role="2zPyp_">
             <ref role="1Pfwd7" node="2JXkwhJfMYw" resolve="mm" />
@@ -479,7 +495,7 @@
             <node concept="mLuIC" id="2JXkwhJh90k" role="2c7tTw" />
           </node>
         </node>
-        <node concept="2zPypq" id="2JXkwhJh9KO" role="_iOnB">
+        <node concept="2zPypq" id="2JXkwhJh9KO" role="_iOnC">
           <property role="TrG5h" value="c" />
           <node concept="1PfFCI" id="2JXkwhJh9Po" role="2zPyp_">
             <ref role="2yhJs8" node="2JXkwhJfX3h" resolve="conversion_nounit_percent (int)" />
@@ -509,9 +525,9 @@
       </node>
     </node>
     <node concept="1qefOq" id="2JXkwhJfxLm" role="1SKRRt">
-      <node concept="_iOnU" id="7Z_pmaBI0dn" role="1qenE9">
+      <node concept="_iOnV" id="7Z_pmaBI0dn" role="1qenE9">
         <property role="TrG5h" value="Conversions_b" />
-        <node concept="2zPypq" id="2JXkwhJhgkJ" role="_iOnB">
+        <node concept="2zPypq" id="2JXkwhJhgkJ" role="_iOnC">
           <property role="TrG5h" value="a" />
           <node concept="1PfFCI" id="2JXkwhJhglJ" role="2zPyp_">
             <ref role="2yhJs8" node="2JXkwhJgCE7" resolve="conversion_m_s (int)" />
@@ -536,7 +552,7 @@
             <node concept="30bXR$" id="2JXkwhJhgUZ" role="2c7tTw" />
           </node>
         </node>
-        <node concept="2zPypq" id="2JXkwhJhhnk" role="_iOnB">
+        <node concept="2zPypq" id="2JXkwhJhhnk" role="_iOnC">
           <property role="TrG5h" value="b" />
           <node concept="1PfFCI" id="2JXkwhJhhpZ" role="2zPyp_">
             <ref role="1Pfwd7" to="ku0a:5XaocLWHSS5" resolve="s" />
@@ -567,7 +583,7 @@
             <node concept="30bXR$" id="2JXkwhJhhp7" role="2c7tTw" />
           </node>
         </node>
-        <node concept="2zPypq" id="2JXkwhJhi0q" role="_iOnB">
+        <node concept="2zPypq" id="2JXkwhJhi0q" role="_iOnC">
           <property role="TrG5h" value="c" />
           <node concept="2c7tTJ" id="2JXkwhJhi2_" role="2zM23F">
             <node concept="CIsGf" id="2JXkwhJhirB" role="2c7tTI">
@@ -603,8 +619,8 @@
             </node>
           </node>
         </node>
-        <node concept="_ixoA" id="2JXkwhJhlRS" role="_iOnB" />
-        <node concept="TRoc0" id="2JXkwhJhlW0" role="_iOnB">
+        <node concept="_ixoA" id="2JXkwhJhlRS" role="_iOnC" />
+        <node concept="TRoc0" id="2JXkwhJhlW0" role="_iOnC">
           <ref role="27Q$ZR" to="ku0a:5XaocLWHSS4" resolve="m" />
           <ref role="27Q$ZQ" to="ku0a:5XaocLWHSS4" resolve="m" />
           <node concept="27LzZq" id="2JXkwhJhlYQ" role="27P04L">
@@ -634,21 +650,21 @@
             <node concept="30bXLL" id="2JXkwhJhVx1" role="2S7B4z" />
           </node>
         </node>
-        <node concept="_ixoA" id="2JXkwhJhlUu" role="_iOnB" />
-        <node concept="CIrOH" id="2JXkwhJhWCi" role="_iOnB">
+        <node concept="_ixoA" id="2JXkwhJhlUu" role="_iOnC" />
+        <node concept="CIrOH" id="2JXkwhJhWCi" role="_iOnC">
           <property role="TrG5h" value="u1" />
           <property role="CIruq" value="u1" />
         </node>
-        <node concept="CIrOH" id="2JXkwhJhWH5" role="_iOnB">
+        <node concept="CIrOH" id="2JXkwhJhWH5" role="_iOnC">
           <property role="TrG5h" value="u2" />
           <property role="CIruq" value="u2" />
         </node>
-        <node concept="CIrOH" id="2JXkwhJhWIP" role="_iOnB">
+        <node concept="CIrOH" id="2JXkwhJhWIP" role="_iOnC">
           <property role="TrG5h" value="u3" />
           <property role="CIruq" value="u3" />
         </node>
-        <node concept="_ixoA" id="2JXkwhJhWEZ" role="_iOnB" />
-        <node concept="TRoc0" id="2JXkwhJhYJZ" role="_iOnB">
+        <node concept="_ixoA" id="2JXkwhJhWEZ" role="_iOnC" />
+        <node concept="TRoc0" id="2JXkwhJhYJZ" role="_iOnC">
           <property role="27Q$Ze" value="true" />
           <ref role="27Q$ZQ" node="2JXkwhJhWCi" resolve="u1" />
           <ref role="27Q$ZR" node="2JXkwhJhWCi" resolve="u1" />
@@ -667,7 +683,7 @@
             </node>
           </node>
         </node>
-        <node concept="_ixoA" id="2JXkwhJhZWF" role="_iOnB" />
+        <node concept="_ixoA" id="2JXkwhJhZWF" role="_iOnC" />
         <node concept="7CXmI" id="2JXkwhJfxLo" role="lGtFl">
           <node concept="7OXhh" id="2JXkwhJfxLp" role="7EUXB">
             <property role="G7GLP" value="true" />
@@ -685,7 +701,7 @@
   <node concept="1lH9Xt" id="2S3ZC$oC8Qf">
     <property role="TrG5h" value="ExpressionsPart1" />
     <node concept="1qefOq" id="2S3ZC$oC8Qg" role="1SKRRt">
-      <node concept="_iOnU" id="7Z_pmaBI0dj" role="1qenE9">
+      <node concept="_iOnV" id="7Z_pmaBI0dj" role="1qenE9">
         <property role="TrG5h" value="ExpressionsPart1" />
         <node concept="3GEVxB" id="7Z_pmaBR45$" role="3i6evy">
           <ref role="3GEb4d" to="ku0a:5XaocLWHGMs" resolve="SIUnits" />
@@ -693,7 +709,7 @@
         <node concept="3GEVxB" id="7Z_pmaBR5R$" role="3i6evy">
           <ref role="3GEb4d" node="2JXkwhJfMDf" resolve="UnitsAndConversions" />
         </node>
-        <node concept="2zPypq" id="76ZhK6XZhug" role="_iOnB">
+        <node concept="2zPypq" id="76ZhK6XZhug" role="_iOnC">
           <property role="TrG5h" value="a" />
           <node concept="30dDZf" id="5XaocLWH3Zw" role="2zPyp_">
             <node concept="1YnStw" id="5XaocLWH43i" role="30dEs_">
@@ -726,7 +742,7 @@
             <node concept="mLuIC" id="1fzaMYHrvTS" role="2c7tTw" />
           </node>
         </node>
-        <node concept="2zPypq" id="5XaocLWH9LL" role="_iOnB">
+        <node concept="2zPypq" id="5XaocLWH9LL" role="_iOnC">
           <property role="TrG5h" value="b" />
           <node concept="30dDTi" id="5XaocLWH9R7" role="2zPyp_">
             <node concept="30bXRB" id="5XaocLWH9Rs" role="30dEs_">
@@ -752,7 +768,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="5XaocLWHG$V" role="_iOnB">
+        <node concept="2zPypq" id="5XaocLWHG$V" role="_iOnC">
           <property role="TrG5h" value="c" />
           <node concept="30dvO6" id="5XaocLWIMSW" role="2zPyp_">
             <node concept="1YnStw" id="5XaocLWJ7LQ" role="30dEs_">
@@ -803,7 +819,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="5XaocLWJ9D1" role="_iOnB">
+        <node concept="2zPypq" id="5XaocLWJ9D1" role="_iOnC">
           <property role="TrG5h" value="d" />
           <node concept="30dvO6" id="5XaocLWJbsF" role="2zPyp_">
             <node concept="1YnStw" id="5XaocLWJbBu" role="30dEs_">
@@ -840,7 +856,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="5XaocLWJc4m" role="_iOnB">
+        <node concept="2zPypq" id="5XaocLWJc4m" role="_iOnC">
           <property role="TrG5h" value="e" />
           <node concept="30bsCy" id="5XaocLWJc92" role="2zPyp_">
             <node concept="30dDZf" id="5XaocLWJccH" role="30bsDf">
@@ -875,7 +891,7 @@
             <node concept="mLuIC" id="1fzaMYHrw2z" role="2c7tTw" />
           </node>
         </node>
-        <node concept="2zPypq" id="5XaocLWJPhm" role="_iOnB">
+        <node concept="2zPypq" id="5XaocLWJPhm" role="_iOnC">
           <property role="TrG5h" value="f" />
           <node concept="30dDZf" id="5XaocLWM2wQ" role="2zPyp_">
             <node concept="30bXRB" id="5XaocLWM2xl" role="30dEs_">
@@ -896,7 +912,7 @@
           </node>
           <node concept="mLuIC" id="1fzaMYHrw7M" role="2zM23F" />
         </node>
-        <node concept="2zPypq" id="5XaocLWM2E1" role="_iOnB">
+        <node concept="2zPypq" id="5XaocLWM2E1" role="_iOnC">
           <property role="TrG5h" value="g" />
           <node concept="30d6GJ" id="5XaocLWM2JA" role="2zPyp_">
             <node concept="1YnStw" id="5XaocLWM2Ri" role="30dEs_">
@@ -922,7 +938,7 @@
           </node>
           <node concept="2vmvy5" id="1fzaMYHrwaK" role="2zM23F" />
         </node>
-        <node concept="2zPypq" id="5aYM8it48mb" role="_iOnB">
+        <node concept="2zPypq" id="5aYM8it48mb" role="_iOnC">
           <property role="TrG5h" value="h" />
           <node concept="30dDZf" id="5aYM8it4aHB" role="2zPyp_">
             <node concept="1YnStw" id="5aYM8it4aM5" role="30dEs_">
@@ -945,7 +961,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="5aYM8it4c7q" role="_iOnB">
+        <node concept="2zPypq" id="5aYM8it4c7q" role="_iOnC">
           <property role="TrG5h" value="i" />
           <node concept="30cPrO" id="5aYM8it4cJF" role="2zPyp_">
             <node concept="1YnStw" id="5aYM8it4cO1" role="30dEs_">
@@ -1959,9 +1975,9 @@
       </node>
     </node>
     <node concept="1qefOq" id="1fzaMYHrHpf" role="1SKRRt">
-      <node concept="_iOnU" id="7Z_pmaBI0dk" role="1qenE9">
+      <node concept="_iOnV" id="7Z_pmaBI0dk" role="1qenE9">
         <property role="TrG5h" value="ExpressionsPart2_a" />
-        <node concept="2zPypq" id="1fzaMYHrIsU" role="_iOnB">
+        <node concept="2zPypq" id="1fzaMYHrIsU" role="_iOnC">
           <property role="TrG5h" value="a" />
           <node concept="30dDZf" id="1fzaMYHtzYj" role="2zPyp_">
             <node concept="1YnStw" id="1fzaMYHt$3J" role="30dEs_">
@@ -2024,7 +2040,7 @@
             <node concept="mLuIC" id="1fzaMYHrItr" role="2c7tTw" />
           </node>
         </node>
-        <node concept="2zPypq" id="1fzaMYHtOXq" role="_iOnB">
+        <node concept="2zPypq" id="1fzaMYHtOXq" role="_iOnC">
           <property role="TrG5h" value="b" />
           <node concept="30dvO6" id="1fzaMYHtPdt" role="2zPyp_">
             <node concept="1YnStw" id="1fzaMYHtPk$" role="30dEs_">
@@ -2084,7 +2100,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="1fzaMYHvS_h" role="_iOnB">
+        <node concept="2zPypq" id="1fzaMYHvS_h" role="_iOnC">
           <property role="TrG5h" value="c" />
           <node concept="30dDTi" id="1fzaMYHvSFp" role="2zPyp_">
             <node concept="1YnStw" id="1fzaMYHvSIR" role="30dEs_">
@@ -2147,7 +2163,7 @@
             <node concept="mLuIC" id="1fzaMYHvSBg" role="2c7tTw" />
           </node>
         </node>
-        <node concept="2zPypq" id="1fzaMYHvUAN" role="_iOnB">
+        <node concept="2zPypq" id="1fzaMYHvUAN" role="_iOnC">
           <property role="TrG5h" value="d" />
           <node concept="30dvUo" id="1fzaMYHvUO9" role="2zPyp_">
             <node concept="1YnStw" id="1fzaMYHvUTN" role="30dEs_">
@@ -2210,8 +2226,8 @@
             <node concept="mLuIC" id="1fzaMYHvUD$" role="2c7tTw" />
           </node>
         </node>
-        <node concept="_ixoA" id="2OGPkCTiMF6" role="_iOnB" />
-        <node concept="2zPypq" id="1JTgXSYMNAl" role="_iOnB">
+        <node concept="_ixoA" id="2OGPkCTiMF6" role="_iOnC" />
+        <node concept="2zPypq" id="1JTgXSYMNAl" role="_iOnC">
           <property role="TrG5h" value="sqrtWithoutUnit" />
           <node concept="a0DgS" id="1JTgXSYMNCP" role="2zPyp_">
             <node concept="30dDZf" id="1JTgXSYMNFE" role="a0CvG">
@@ -2227,7 +2243,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="2OGPkCTlLFT" role="_iOnB">
+        <node concept="2zPypq" id="2OGPkCTlLFT" role="_iOnC">
           <property role="TrG5h" value="sqrtSimple" />
           <node concept="a0DgS" id="2OGPkCTlLIA" role="2zPyp_">
             <node concept="30dDTi" id="2OGPkCTlLKo" role="a0CvG">
@@ -2257,7 +2273,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="2OGPkCTiMK1" role="_iOnB">
+        <node concept="2zPypq" id="2OGPkCTiMK1" role="_iOnC">
           <property role="TrG5h" value="sqrtCombine" />
           <node concept="a0DgS" id="2OGPkCTiMLX" role="2zPyp_">
             <node concept="30dDTi" id="3htFKtcmIFN" role="a0CvG">
@@ -2302,7 +2318,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="1JTgXSYMQpW" role="_iOnB">
+        <node concept="2zPypq" id="1JTgXSYMQpW" role="_iOnC">
           <property role="TrG5h" value="sqrtUnitRef" />
           <node concept="a0DgS" id="1JTgXSYMQss" role="2zPyp_">
             <node concept="30dDTi" id="1JTgXSYMR8y" role="a0CvG">
@@ -2332,7 +2348,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="1JTgXSYQBB_" role="_iOnB">
+        <node concept="2zPypq" id="1JTgXSYQBB_" role="_iOnC">
           <property role="TrG5h" value="sumWithoutUnit" />
           <node concept="a0DKL" id="1JTgXSYQBHq" role="2zPyp_">
             <property role="TrG5h" value="a" />
@@ -2356,7 +2372,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="1JTgXSYQBOI" role="_iOnB">
+        <node concept="2zPypq" id="1JTgXSYQBOI" role="_iOnC">
           <property role="TrG5h" value="sumSimpleUnit" />
           <node concept="a0DKL" id="1JTgXSYQBOJ" role="2zPyp_">
             <property role="TrG5h" value="a" />
@@ -2400,7 +2416,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="1JTgXSYRCyL" role="_iOnB">
+        <node concept="2zPypq" id="1JTgXSYRCyL" role="_iOnC">
           <property role="TrG5h" value="logWithoutUnit" />
           <node concept="a1soB" id="1JTgXSYRCAs" role="2zPyp_">
             <node concept="30dDZf" id="1JTgXSYRCFe" role="a0C2O">
@@ -2416,8 +2432,8 @@
             </node>
           </node>
         </node>
-        <node concept="_ixoA" id="1JTgXSYS3s7" role="_iOnB" />
-        <node concept="2zPypq" id="1JTgXSYS5os" role="_iOnB">
+        <node concept="_ixoA" id="1JTgXSYS3s7" role="_iOnC" />
+        <node concept="2zPypq" id="1JTgXSYS5os" role="_iOnC">
           <property role="TrG5h" value="fracWithoutUnit" />
           <node concept="a1tim" id="1JTgXSYS5rQ" role="2zPyp_">
             <node concept="30bXRB" id="1JTgXSYS5s8" role="a1tin">
@@ -2431,7 +2447,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="1JTgXSYS5FR" role="_iOnB">
+        <node concept="2zPypq" id="1JTgXSYS5FR" role="_iOnC">
           <property role="TrG5h" value="fracSimpleUnit" />
           <node concept="a1tim" id="1JTgXSYS5Jx" role="2zPyp_">
             <node concept="1YnStw" id="1JTgXSYS5MV" role="a1tin">
@@ -2452,7 +2468,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="1JTgXSYTMks" role="_iOnB">
+        <node concept="2zPypq" id="1JTgXSYTMks" role="_iOnC">
           <property role="TrG5h" value="fracWithoutUnitRef" />
           <node concept="a1tim" id="1JTgXSYTMp3" role="2zPyp_">
             <node concept="1YnStw" id="1JTgXSYTMst" role="a1tin">
@@ -2480,7 +2496,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="1JTgXSYS6BE" role="_iOnB">
+        <node concept="2zPypq" id="1JTgXSYS6BE" role="_iOnC">
           <property role="TrG5h" value="fracCombine" />
           <node concept="a1tim" id="1JTgXSYS6Fu" role="2zPyp_">
             <node concept="1YnStw" id="1JTgXSYVKqz" role="a1tin">
@@ -2511,7 +2527,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="1JTgXSYS7Ca" role="_iOnB">
+        <node concept="2zPypq" id="1JTgXSYS7Ca" role="_iOnC">
           <property role="TrG5h" value="fracUnitRef" />
           <node concept="a1tim" id="1JTgXSYS7G3" role="2zPyp_">
             <node concept="1YnStw" id="1JTgXSYS7Kh" role="a1tin">
@@ -2539,7 +2555,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="6q$NxWeFCoY" role="_iOnB">
+        <node concept="2zPypq" id="6q$NxWeFCoY" role="_iOnC">
           <property role="TrG5h" value="absExpr" />
           <node concept="a1tT9" id="6q$NxWeFCxc" role="2zPyp_">
             <node concept="30cIq6" id="6q$NxWeICzP" role="a0Cwb">
@@ -2549,7 +2565,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="6q$NxWeFCAd" role="_iOnB">
+        <node concept="2zPypq" id="6q$NxWeFCAd" role="_iOnC">
           <property role="TrG5h" value="absSimpleUnit" />
           <node concept="a1tT9" id="6q$NxWeFCEu" role="2zPyp_">
             <node concept="1YnStw" id="6q$NxWeHFwS" role="a0Cwb">
@@ -2564,8 +2580,8 @@
             </node>
           </node>
         </node>
-        <node concept="_ixoA" id="6q$NxWeU1Jc" role="_iOnB" />
-        <node concept="2zPypq" id="6q$NxWeU1Yu" role="_iOnB">
+        <node concept="_ixoA" id="6q$NxWeU1Jc" role="_iOnC" />
+        <node concept="2zPypq" id="6q$NxWeU1Yu" role="_iOnC">
           <property role="TrG5h" value="powWithoutUnit" />
           <node concept="a0Byk" id="6q$NxWeU26u" role="2zPyp_">
             <node concept="30bXRB" id="6q$NxWeU26V" role="a0GsM">
@@ -2579,7 +2595,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="6q$NxWeU2gg" role="_iOnB">
+        <node concept="2zPypq" id="6q$NxWeU2gg" role="_iOnC">
           <property role="TrG5h" value="powSimpleUnit" />
           <node concept="a0Byk" id="6q$NxWeU2tt" role="2zPyp_">
             <node concept="1YnStw" id="6q$NxWeVWJw" role="a0GsM">
@@ -2603,7 +2619,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="6q$NxWf6r12" role="_iOnB">
+        <node concept="2zPypq" id="6q$NxWf6r12" role="_iOnC">
           <property role="TrG5h" value="powSimpleUnitNegativeExp" />
           <node concept="a0Byk" id="6q$NxWf6rau" role="2zPyp_">
             <node concept="1YnStw" id="6q$NxWf6rdW" role="a0GsM">
@@ -2629,7 +2645,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="6q$NxWeU2Gn" role="_iOnB">
+        <node concept="2zPypq" id="6q$NxWeU2Gn" role="_iOnC">
           <property role="TrG5h" value="powCombineUnit" />
           <node concept="a0Byk" id="6q$NxWeU31e" role="2zPyp_">
             <node concept="30bXRB" id="6q$NxWeU33s" role="2zCggm">
@@ -2656,7 +2672,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="6q$NxWf2Ezl" role="_iOnB">
+        <node concept="2zPypq" id="6q$NxWf2Ezl" role="_iOnC">
           <property role="TrG5h" value="powUnitRef" />
           <node concept="a0Byk" id="6q$NxWf2EG2" role="2zPyp_">
             <node concept="1YnStw" id="6q$NxWf2EXf" role="a0GsM">
@@ -2677,13 +2693,13 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="6q$NxWf2GfZ" role="_iOnB">
+        <node concept="2zPypq" id="6q$NxWf2GfZ" role="_iOnC">
           <property role="TrG5h" value="x" />
           <node concept="30bXRB" id="6q$NxWf2Gp4" role="2zPyp_">
             <property role="30bXRw" value="5" />
           </node>
         </node>
-        <node concept="2zPypq" id="6q$NxWf2FIV" role="_iOnB">
+        <node concept="2zPypq" id="6q$NxWf2FIV" role="_iOnC">
           <property role="TrG5h" value="powExponentSum" />
           <node concept="a0Byk" id="6q$NxWf2FSb" role="2zPyp_">
             <node concept="1YnStw" id="6q$NxWf2FVD" role="a0GsM">
@@ -2712,7 +2728,7 @@
             </node>
           </node>
         </node>
-        <node concept="_ixoA" id="6q$NxWeHFA4" role="_iOnB" />
+        <node concept="_ixoA" id="6q$NxWeHFA4" role="_iOnC" />
         <node concept="7CXmI" id="1fzaMYHrHph" role="lGtFl">
           <node concept="7OXhh" id="1fzaMYHrHpi" role="7EUXB" />
         </node>
@@ -2725,9 +2741,9 @@
       </node>
     </node>
     <node concept="1qefOq" id="1fzaMYHvXFB" role="1SKRRt">
-      <node concept="_iOnU" id="7Z_pmaBI0dl" role="1qenE9">
+      <node concept="_iOnV" id="7Z_pmaBI0dl" role="1qenE9">
         <property role="TrG5h" value="ExpressionsPart2_b" />
-        <node concept="2zPypq" id="1fzaMYHvXFF" role="_iOnB">
+        <node concept="2zPypq" id="1fzaMYHvXFF" role="_iOnC">
           <property role="TrG5h" value="a" />
           <node concept="30dDZf" id="1fzaMYHvXFG" role="2zPyp_">
             <node concept="1YnStw" id="1fzaMYHvXFH" role="30dEs_">
@@ -2793,7 +2809,7 @@
             <node concept="mLuIC" id="1fzaMYHvXG4" role="2c7tTw" />
           </node>
         </node>
-        <node concept="2zPypq" id="1fzaMYHvXG5" role="_iOnB">
+        <node concept="2zPypq" id="1fzaMYHvXG5" role="_iOnC">
           <property role="TrG5h" value="b" />
           <node concept="30dvO6" id="1fzaMYHvXG6" role="2zPyp_">
             <node concept="1YnStw" id="1fzaMYHvXG7" role="30dEs_">
@@ -2856,7 +2872,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="1fzaMYHvXGt" role="_iOnB">
+        <node concept="2zPypq" id="1fzaMYHvXGt" role="_iOnC">
           <property role="TrG5h" value="c" />
           <node concept="30dDTi" id="1fzaMYHvXGu" role="2zPyp_">
             <node concept="1YnStw" id="1fzaMYHvXGv" role="30dEs_">
@@ -2922,7 +2938,7 @@
             <node concept="mLuIC" id="1fzaMYHvXGQ" role="2c7tTw" />
           </node>
         </node>
-        <node concept="2zPypq" id="1fzaMYHvXGR" role="_iOnB">
+        <node concept="2zPypq" id="1fzaMYHvXGR" role="_iOnC">
           <property role="TrG5h" value="d" />
           <node concept="30dvUo" id="1fzaMYHvXGS" role="2zPyp_">
             <node concept="1YnStw" id="1fzaMYHvXGT" role="30dEs_">
@@ -2988,8 +3004,8 @@
             <node concept="mLuIC" id="1fzaMYHvXHg" role="2c7tTw" />
           </node>
         </node>
-        <node concept="_ixoA" id="1JTgXSYRxc$" role="_iOnB" />
-        <node concept="2zPypq" id="1JTgXSYRxg7" role="_iOnB">
+        <node concept="_ixoA" id="1JTgXSYRxc$" role="_iOnC" />
+        <node concept="2zPypq" id="1JTgXSYRxg7" role="_iOnC">
           <property role="TrG5h" value="logExpression" />
           <node concept="a1soB" id="1JTgXSYRxia" role="2zPyp_">
             <node concept="1YnStw" id="1JTgXSYRCqr" role="a0C2O">
@@ -3010,7 +3026,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="6q$NxWfbiXh" role="_iOnB">
+        <node concept="2zPypq" id="6q$NxWfbiXh" role="_iOnC">
           <property role="TrG5h" value="productExpression" />
           <node concept="a0B4F" id="6q$NxWfbj2i" role="2zPyp_">
             <property role="TrG5h" value="a" />
@@ -3036,7 +3052,7 @@
             <node concept="mLuIC" id="6q$NxWfbj2M" role="39z40R" />
           </node>
         </node>
-        <node concept="2zPypq" id="6q$NxWf66nu" role="_iOnB">
+        <node concept="2zPypq" id="6q$NxWf66nu" role="_iOnC">
           <property role="TrG5h" value="x" />
           <node concept="30bXRB" id="6q$NxWf66t2" role="2zPyp_">
             <property role="30bXRw" value="5" />
@@ -3048,7 +3064,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="6q$NxWf65Sf" role="_iOnB">
+        <node concept="2zPypq" id="6q$NxWf65Sf" role="_iOnC">
           <property role="TrG5h" value="powExpressionWithUnknownExponent" />
           <node concept="a0Byk" id="6q$NxWf65WB" role="2zPyp_">
             <node concept="1YnStw" id="6q$NxWf65YX" role="a0GsM">
@@ -3077,7 +3093,7 @@
             </node>
           </node>
         </node>
-        <node concept="2zPypq" id="6q$NxWf6hVk" role="_iOnB">
+        <node concept="2zPypq" id="6q$NxWf6hVk" role="_iOnC">
           <property role="TrG5h" value="powExpressionExponentLong" />
           <node concept="a0Byk" id="6q$NxWf6i04" role="2zPyp_">
             <node concept="1YnStw" id="6q$NxWf6i2q" role="a0GsM">
@@ -3113,25 +3129,25 @@
   <node concept="2XOHcx" id="4rZeNQ6M9GV">
     <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
-  <node concept="_iOnU" id="2JXkwhJfMDf">
+  <node concept="_iOnV" id="2JXkwhJfMDf">
     <property role="TrG5h" value="UnitsAndConversions" />
-    <node concept="CIrOH" id="2JXkwhJfMYw" role="_iOnB">
+    <node concept="CIrOH" id="2JXkwhJfMYw" role="_iOnC">
       <property role="TrG5h" value="mm" />
       <property role="CIruq" value="millimetre" />
     </node>
-    <node concept="CIrOH" id="2JXkwhJfNt9" role="_iOnB">
+    <node concept="CIrOH" id="2JXkwhJfNt9" role="_iOnC">
       <property role="TrG5h" value="dm" />
       <property role="CIruq" value="decimetre" />
     </node>
-    <node concept="CIrOH" id="2JXkwhJfQ5c" role="_iOnB">
+    <node concept="CIrOH" id="2JXkwhJfQ5c" role="_iOnC">
       <property role="TrG5h" value="cm" />
       <property role="CIruq" value="centimetre" />
     </node>
-    <node concept="CIrOH" id="2JXkwhJfWHv" role="_iOnB">
+    <node concept="CIrOH" id="2JXkwhJfWHv" role="_iOnC">
       <property role="TrG5h" value="percent" />
       <property role="CIruq" value="percent" />
     </node>
-    <node concept="CIrOH" id="5XaocLWIt6X" role="_iOnB">
+    <node concept="CIrOH" id="5XaocLWIt6X" role="_iOnC">
       <property role="TrG5h" value="mps" />
       <property role="CIruq" value="metre per second" />
       <node concept="CIsGf" id="5XaocLWIt7Y" role="CIsG9">
@@ -3146,7 +3162,7 @@
         </node>
       </node>
     </node>
-    <node concept="CIrOH" id="5XaocLWJ9Gy" role="_iOnB">
+    <node concept="CIrOH" id="5XaocLWJ9Gy" role="_iOnC">
       <property role="TrG5h" value="acc" />
       <property role="CIruq" value="acceleration" />
       <node concept="CIsGf" id="5XaocLWJadY" role="CIsG9">
@@ -3161,8 +3177,8 @@
         </node>
       </node>
     </node>
-    <node concept="_ixoA" id="2JXkwhJfMXY" role="_iOnB" />
-    <node concept="TRoc0" id="2JXkwhJfMDh" role="_iOnB">
+    <node concept="_ixoA" id="2JXkwhJfMXY" role="_iOnC" />
+    <node concept="TRoc0" id="2JXkwhJfMDh" role="_iOnC">
       <property role="27Q$Ze" value="true" />
       <ref role="27Q$ZR" node="2JXkwhJfMYw" resolve="mm" />
       <ref role="27Q$ZQ" to="ku0a:5XaocLWHSS4" resolve="m" />
@@ -3194,8 +3210,8 @@
         </node>
       </node>
     </node>
-    <node concept="_ixoA" id="2JXkwhJfMIE" role="_iOnB" />
-    <node concept="TRoc0" id="2JXkwhJfNn1" role="_iOnB">
+    <node concept="_ixoA" id="2JXkwhJfMIE" role="_iOnC" />
+    <node concept="TRoc0" id="2JXkwhJfNn1" role="_iOnC">
       <ref role="27Q$ZR" node="2JXkwhJfNt9" resolve="dm" />
       <ref role="27Q$ZQ" to="ku0a:5XaocLWHSS4" resolve="m" />
       <node concept="27LzZq" id="2JXkwhJfNn3" role="27P04L">
@@ -3207,8 +3223,8 @@
         </node>
       </node>
     </node>
-    <node concept="_ixoA" id="2JXkwhJfPR6" role="_iOnB" />
-    <node concept="TRoc0" id="2JXkwhJfPY0" role="_iOnB">
+    <node concept="_ixoA" id="2JXkwhJfPR6" role="_iOnC" />
+    <node concept="TRoc0" id="2JXkwhJfPY0" role="_iOnC">
       <ref role="27Q$ZQ" node="2JXkwhJfNt9" resolve="dm" />
       <ref role="27Q$ZR" node="2JXkwhJfQ5c" resolve="cm" />
       <node concept="27LzZq" id="2JXkwhJfPY2" role="27P04L">
@@ -3220,8 +3236,8 @@
         </node>
       </node>
     </node>
-    <node concept="_ixoA" id="2JXkwhJfQi9" role="_iOnB" />
-    <node concept="TRoc0" id="2JXkwhJfQpY" role="_iOnB">
+    <node concept="_ixoA" id="2JXkwhJfQi9" role="_iOnC" />
+    <node concept="TRoc0" id="2JXkwhJfQpY" role="_iOnC">
       <ref role="27Q$ZR" node="2JXkwhJfMYw" resolve="mm" />
       <ref role="27Q$ZQ" node="2JXkwhJfQ5c" resolve="cm" />
       <node concept="27LzZq" id="2JXkwhJfQq0" role="27P04L">
@@ -3233,8 +3249,8 @@
         </node>
       </node>
     </node>
-    <node concept="_ixoA" id="2JXkwhJfQ$u" role="_iOnB" />
-    <node concept="TRoc0" id="2JXkwhJfX3f" role="_iOnB">
+    <node concept="_ixoA" id="2JXkwhJfQ$u" role="_iOnC" />
+    <node concept="TRoc0" id="2JXkwhJfX3f" role="_iOnC">
       <ref role="27Q$ZQ" to="ku0a:5XaocLWHSSb" resolve="nounit" />
       <ref role="27Q$ZR" node="2JXkwhJfWHv" resolve="percent" />
       <node concept="27LzZq" id="2JXkwhJfX3h" role="27P04L">
@@ -3247,8 +3263,8 @@
         <node concept="30bXR$" id="2JXkwhJfX7j" role="2S7B4z" />
       </node>
     </node>
-    <node concept="_ixoA" id="2JXkwhJgCvC" role="_iOnB" />
-    <node concept="TRoc0" id="2JXkwhJgCE5" role="_iOnB">
+    <node concept="_ixoA" id="2JXkwhJgCvC" role="_iOnC" />
+    <node concept="TRoc0" id="2JXkwhJgCE5" role="_iOnC">
       <ref role="27Q$ZR" to="ku0a:5XaocLWHSS5" resolve="s" />
       <ref role="27Q$ZQ" to="ku0a:5XaocLWHSS4" resolve="m" />
       <node concept="27LzZq" id="2JXkwhJgCE7" role="27P04L">
@@ -3277,6 +3293,130 @@
     </node>
     <node concept="3GEVxB" id="2uo6UInRQU5" role="3i6evy">
       <ref role="3GEb4d" to="ku0a:5XaocLWHGMs" resolve="SIUnits" />
+    </node>
+  </node>
+  <node concept="_iOnU" id="6q$NxWfbBxq">
+    <property role="1XBH2A" value="true" />
+    <property role="TrG5h" value="TestInterpreterForUnits" />
+    <ref role="2HwdWd" node="7Z_pmaBI0dk" resolve="ExpressionsPart2_a" />
+    <node concept="_fkuM" id="6q$NxWfbBxr" role="_iOnB">
+      <property role="TrG5h" value="testInterpreterForUnit" />
+      <node concept="_fkuZ" id="6q$NxWfbBxx" role="_fkp5">
+        <node concept="_fku$" id="6q$NxWfbBxy" role="_fkur" />
+        <node concept="a0DgS" id="6q$NxWg7Ahe" role="_fkuY">
+          <node concept="1YnStw" id="6q$NxWg7QD7" role="a0CvG">
+            <node concept="CIsGf" id="6q$NxWg7QD4" role="2c7tTI">
+              <node concept="CIsvn" id="6q$NxWg7QD5" role="CIi4h">
+                <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="6q$NxWg7Ahy" role="1YnStB">
+              <property role="30bXRw" value="16" />
+            </node>
+          </node>
+        </node>
+        <node concept="30bXRB" id="6q$NxWfbByX" role="_fkuS">
+          <property role="30bXRw" value="4" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="6q$NxWg8_RL" role="_fkp5">
+        <node concept="_fku$" id="6q$NxWg8_RM" role="_fkur" />
+        <node concept="a0DKL" id="6q$NxWg8_S$" role="_fkuY">
+          <property role="TrG5h" value="a" />
+          <node concept="30bXRB" id="6q$NxWg8_Tf" role="39z1js">
+            <property role="30bXRw" value="5" />
+          </node>
+          <node concept="30bXRB" id="6q$NxWg8_TC" role="39$JC6">
+            <property role="30bXRw" value="10" />
+          </node>
+          <node concept="1YnStw" id="6q$NxWg8_Xh" role="39$JDZ">
+            <node concept="CIsGf" id="6q$NxWg8_Xe" role="2c7tTI">
+              <node concept="CIsvn" id="6q$NxWg8_Xf" role="CIi4h">
+                <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="6q$NxWg8_U1" role="1YnStB">
+              <property role="30bXRw" value="5" />
+            </node>
+          </node>
+          <node concept="mLuIC" id="6q$NxWg8_SY" role="39z40R" />
+        </node>
+        <node concept="30bXRB" id="6q$NxWg8_Yy" role="_fkuS">
+          <property role="30bXRw" value="30" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="6q$NxWg8_Zm" role="_fkp5">
+        <node concept="_fku$" id="6q$NxWg8_Zn" role="_fkur" />
+        <node concept="a1tim" id="6q$NxWg8A0L" role="_fkuY">
+          <node concept="1YnStw" id="6q$NxWg8A4d" role="a1tin">
+            <node concept="CIsGf" id="6q$NxWg8A4a" role="2c7tTI">
+              <node concept="CIsvn" id="6q$NxWg8A4b" role="CIi4h">
+                <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="6q$NxWg8A14" role="1YnStB">
+              <property role="30bXRw" value="10" />
+            </node>
+          </node>
+          <node concept="1YnStw" id="6q$NxWg8Ab4" role="a1tiq">
+            <node concept="CIsGf" id="6q$NxWg8AaO" role="2c7tTI">
+              <node concept="CIsvn" id="6q$NxWg8AaP" role="CIi4h">
+                <ref role="CIi3I" to="ku0a:5XaocLWHSS4" resolve="m" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="6q$NxWg8A59" role="1YnStB">
+              <property role="30bXRw" value="5" />
+            </node>
+          </node>
+        </node>
+        <node concept="a1tim" id="6q$NxWg8J8v" role="_fkuS">
+          <node concept="30bXRB" id="6q$NxWg8J8M" role="a1tin">
+            <property role="30bXRw" value="10" />
+          </node>
+          <node concept="30bXRB" id="6q$NxWg8J98" role="a1tiq">
+            <property role="30bXRw" value="5" />
+          </node>
+        </node>
+      </node>
+      <node concept="_fkuZ" id="6q$NxWg8u_c" role="_fkp5">
+        <node concept="_fku$" id="6q$NxWg8u_d" role="_fkur" />
+        <node concept="a0Byk" id="6q$NxWg8u_J" role="_fkuY">
+          <node concept="30dDZf" id="6q$NxWg8uLt" role="a0GsM">
+            <node concept="1YnStw" id="6q$NxWg8uT1" role="30dEs_">
+              <node concept="CIsGf" id="6q$NxWg8uSY" role="2c7tTI">
+                <node concept="CIsvn" id="6q$NxWg8uSZ" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+                <node concept="CIsvn" id="6q$NxWg8uXs" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="6q$NxWg8uMP" role="1YnStB">
+                <property role="30bXRw" value="2" />
+              </node>
+            </node>
+            <node concept="1YnStw" id="6q$NxWg8uD5" role="30dEsF">
+              <node concept="CIsGf" id="6q$NxWg8uD2" role="2c7tTI">
+                <node concept="CIsvn" id="6q$NxWg8uD3" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+                <node concept="CIsvn" id="6q$NxWg8uGe" role="CIi4h">
+                  <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="6q$NxWg8uA2" role="1YnStB">
+                <property role="30bXRw" value="2" />
+              </node>
+            </node>
+          </node>
+          <node concept="30bXRB" id="6q$NxWg8uE1" role="2zCggm">
+            <property role="30bXRw" value="2" />
+          </node>
+        </node>
+        <node concept="30bXRB" id="6q$NxWg8v72" role="_fkuS">
+          <property role="30bXRw" value="16" />
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
@@ -1569,7 +1569,7 @@
                   </node>
                   <node concept="2pIpSj" id="1JTgXSYQHVx" role="2pJxcM">
                     <ref role="2pIpSl" to="b0gq:7eOyx9r3qFW" resolve="unit" />
-                    <node concept="36bGnv" id="1JTgXSYQHWp" role="28nt2d">
+                    <node concept="36bGnv" id="6q$NxWeOYPi" role="28nt2d">
                       <ref role="36bGnp" to="ku0a:5XaocLWHSS5" resolve="s" />
                     </node>
                   </node>
@@ -1592,7 +1592,7 @@
                   <ref role="2pJxaS" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
                   <node concept="2pIpSj" id="1JTgXSYQI08" role="2pJxcM">
                     <ref role="2pIpSl" to="b0gq:7eOyx9r3qFW" resolve="unit" />
-                    <node concept="36bGnv" id="1JTgXSYQI0R" role="28nt2d">
+                    <node concept="36bGnv" id="6q$NxWeOYPo" role="28nt2d">
                       <ref role="36bGnp" node="5XaocLWJ9Gy" resolve="acc" />
                     </node>
                   </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
@@ -23,6 +23,7 @@
     <import index="b0gq" ref="r:1eb914ff-b91c-4cbc-93c6-3ecde7821894(org.iets3.core.expr.typetags.units.structure)" />
     <import index="1qv1" ref="r:c53b8bbc-6142-4787-a6e4-66310b772b37(org.iets3.core.expr.math.structure)" />
     <import index="8do3" ref="r:cea04c4b-adba-417e-a192-34c7a8799ac1(com.mbeddr.mpsutil.compare.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" implicit="true" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
@@ -64,13 +65,10 @@
       <concept id="1219920932475" name="jetbrains.mps.baseLanguage.structure.VariableArityType" flags="in" index="8X2XB">
         <child id="1219921048460" name="componentType" index="8Xvag" />
       </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
         <child id="1239714902950" name="expression" index="2$L3a6" />
-      </concept>
-      <concept id="1173175405605" name="jetbrains.mps.baseLanguage.structure.ArrayAccessExpression" flags="nn" index="AH0OO">
-        <child id="1173175577737" name="index" index="AHEQo" />
-        <child id="1173175590490" name="array" index="AHHXb" />
       </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
@@ -109,6 +107,9 @@
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
@@ -256,6 +257,12 @@
         <child id="6839478809833656927" name="imports" index="3i6evy" />
       </concept>
     </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
     <language id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base">
       <concept id="8375407818529178006" name="com.mbeddr.core.base.structure.TextBlock" flags="ng" index="OjmMv">
         <child id="8375407818529178007" name="text" index="OjmMu" />
@@ -380,6 +387,12 @@
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
@@ -393,11 +406,24 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1205679737078" name="jetbrains.mps.baseLanguage.collections.structure.SortOperation" flags="nn" index="2S7cBI">
+        <child id="1205679832066" name="ascending" index="2S7zOq" />
+      </concept>
       <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
+      <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
     </language>
   </registry>
@@ -1168,6 +1194,101 @@
             </node>
           </node>
         </node>
+        <node concept="3cpWs8" id="6q$NxWg9sy5" role="3cqZAp">
+          <node concept="3cpWsn" id="6q$NxWg9sy6" role="3cpWs9">
+            <property role="TrG5h" value="sortedExpectedUnitReferences" />
+            <node concept="_YKpA" id="6q$NxWg9_L4" role="1tU5fm">
+              <node concept="3Tqbb2" id="6q$NxWg9_L6" role="_ZDj9">
+                <ref role="ehGHo" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6q$NxWg9Agm" role="33vP2m">
+              <node concept="2OqwBi" id="6q$NxWg9sy7" role="2Oq$k0">
+                <node concept="2OqwBi" id="6q$NxWg9sy8" role="2Oq$k0">
+                  <node concept="37vLTw" id="6q$NxWg9sy9" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1JTgXSYNc2$" resolve="expectedUnitReferences" />
+                  </node>
+                  <node concept="39bAoz" id="6q$NxWg9sya" role="2OqNvi" />
+                </node>
+                <node concept="2S7cBI" id="6q$NxWg9syb" role="2OqNvi">
+                  <node concept="1bVj0M" id="6q$NxWg9syc" role="23t8la">
+                    <node concept="3clFbS" id="6q$NxWg9syd" role="1bW5cS">
+                      <node concept="3clFbF" id="6q$NxWg9sye" role="3cqZAp">
+                        <node concept="2OqwBi" id="6q$NxWg9syf" role="3clFbG">
+                          <node concept="2OqwBi" id="6q$NxWg9syg" role="2Oq$k0">
+                            <node concept="37vLTw" id="6q$NxWg9syh" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6q$NxWg9syk" resolve="it" />
+                            </node>
+                            <node concept="3TrEf2" id="6q$NxWg9syi" role="2OqNvi">
+                              <ref role="3Tt5mk" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                            </node>
+                          </node>
+                          <node concept="3TrcHB" id="6q$NxWg9syj" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="6q$NxWg9syk" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="6q$NxWg9syl" role="1tU5fm" />
+                    </node>
+                  </node>
+                  <node concept="1nlBCl" id="6q$NxWg9sym" role="2S7zOq">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="ANE8D" id="6q$NxWg9B2Q" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6q$NxWg9yyv" role="3cqZAp">
+          <node concept="3cpWsn" id="6q$NxWg9yyw" role="3cpWs9">
+            <property role="TrG5h" value="sortedActualUnitReferences" />
+            <node concept="_YKpA" id="6q$NxWg9_HV" role="1tU5fm">
+              <node concept="3Tqbb2" id="6q$NxWg9_HX" role="_ZDj9">
+                <ref role="ehGHo" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6q$NxWg9$Kg" role="33vP2m">
+              <node concept="2OqwBi" id="6q$NxWg9yyx" role="2Oq$k0">
+                <node concept="37vLTw" id="6q$NxWg9yyy" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1JTgXSYNx9w" resolve="actualUnitReferences" />
+                </node>
+                <node concept="2S7cBI" id="6q$NxWg9yyz" role="2OqNvi">
+                  <node concept="1bVj0M" id="6q$NxWg9yy$" role="23t8la">
+                    <node concept="3clFbS" id="6q$NxWg9yy_" role="1bW5cS">
+                      <node concept="3clFbF" id="6q$NxWg9yyA" role="3cqZAp">
+                        <node concept="2OqwBi" id="6q$NxWg9yyB" role="3clFbG">
+                          <node concept="2OqwBi" id="6q$NxWg9yyC" role="2Oq$k0">
+                            <node concept="37vLTw" id="6q$NxWg9yyD" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6q$NxWg9yyG" resolve="it" />
+                            </node>
+                            <node concept="3TrEf2" id="6q$NxWg9yyE" role="2OqNvi">
+                              <ref role="3Tt5mk" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                            </node>
+                          </node>
+                          <node concept="3TrcHB" id="6q$NxWg9yyF" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="6q$NxWg9yyG" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="6q$NxWg9yyH" role="1tU5fm" />
+                    </node>
+                  </node>
+                  <node concept="1nlBCl" id="6q$NxWg9yyI" role="2S7zOq">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="ANE8D" id="6q$NxWg9_6z" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
         <node concept="1Dw8fO" id="1JTgXSYNMAR" role="3cqZAp">
           <node concept="3clFbS" id="1JTgXSYNMAT" role="2LFqv$">
             <node concept="3clFbF" id="1JTgXSYNOQn" role="3cqZAp">
@@ -1175,22 +1296,24 @@
                 <node concept="2WthIp" id="1JTgXSYNOQk" role="2Oq$k0" />
                 <node concept="2XshWL" id="1JTgXSYNOQm" role="2OqNvi">
                   <ref role="2WH_rO" node="1JTgXSYNDVk" resolve="assertUnitReference" />
-                  <node concept="2OqwBi" id="1JTgXSYNQqT" role="2XxRq1">
-                    <node concept="37vLTw" id="1JTgXSYNOQ$" role="2Oq$k0">
-                      <ref role="3cqZAo" node="1JTgXSYNx9w" resolve="actualUnitReferences" />
+                  <node concept="2OqwBi" id="6q$NxWg9$zo" role="2XxRq1">
+                    <node concept="37vLTw" id="6q$NxWg9z6z" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6q$NxWg9yyw" resolve="sortedActualUnitReferences" />
                     </node>
-                    <node concept="34jXtK" id="1JTgXSYNWeO" role="2OqNvi">
-                      <node concept="37vLTw" id="1JTgXSYNWgh" role="25WWJ7">
+                    <node concept="34jXtK" id="6q$NxWg9DK7" role="2OqNvi">
+                      <node concept="37vLTw" id="6q$NxWg9E5a" role="25WWJ7">
                         <ref role="3cqZAo" node="1JTgXSYNMAU" resolve="i" />
                       </node>
                     </node>
                   </node>
-                  <node concept="AH0OO" id="1JTgXSYNTy3" role="2XxRq1">
-                    <node concept="37vLTw" id="1JTgXSYNT_1" role="AHEQo">
-                      <ref role="3cqZAo" node="1JTgXSYNMAU" resolve="i" />
+                  <node concept="2OqwBi" id="6q$NxWg9GSZ" role="2XxRq1">
+                    <node concept="37vLTw" id="6q$NxWg9z32" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6q$NxWg9sy6" resolve="sortedExpectedUnitReferences" />
                     </node>
-                    <node concept="37vLTw" id="1JTgXSYNTtA" role="AHHXb">
-                      <ref role="3cqZAo" node="1JTgXSYNc2$" resolve="expectedUnitReferences" />
+                    <node concept="34jXtK" id="6q$NxWg9J5S" role="2OqNvi">
+                      <node concept="37vLTw" id="6q$NxWg9J7z" role="25WWJ7">
+                        <ref role="3cqZAo" node="1JTgXSYNMAU" resolve="i" />
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -1206,10 +1329,10 @@
           </node>
           <node concept="3eOVzh" id="1JTgXSYNNwL" role="1Dwp0S">
             <node concept="2OqwBi" id="1JTgXSYNNQ5" role="3uHU7w">
-              <node concept="37vLTw" id="1JTgXSYNNBG" role="2Oq$k0">
-                <ref role="3cqZAo" node="1JTgXSYNc2$" resolve="expectedUnitReferences" />
+              <node concept="37vLTw" id="6q$NxWg9yUI" role="2Oq$k0">
+                <ref role="3cqZAo" node="6q$NxWg9sy6" resolve="sortedExpectedUnitReferences" />
               </node>
-              <node concept="1Rwk04" id="1JTgXSYNNWG" role="2OqNvi" />
+              <node concept="34oBXx" id="6q$NxWg9zVd" role="2OqNvi" />
             </node>
             <node concept="37vLTw" id="1JTgXSYNMDS" role="3uHU7B">
               <ref role="3cqZAo" node="1JTgXSYNMAU" resolve="i" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
@@ -9,6 +9,9 @@
     <use id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base" version="5" />
     <use id="cb91a38e-738a-4811-a96d-448d08f526fa" name="org.iets3.core.expr.typetags.units" version="0" />
     <use id="6fadc44e-69c2-4a4a-9d16-7ebf5f8d3ba0" name="org.iets3.core.expr.math" version="0" />
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="4" />
+    <use id="f47b95d4-5e73-4c04-9204-18076950153b" name="com.mbeddr.mpsutil.compare" version="0" />
     <devkit ref="c4e521ab-b605-4ef9-a7c3-68075da058f0(org.iets3.core.expr.core.devkit)" />
   </languages>
   <imports>
@@ -16,6 +19,12 @@
     <import index="xqtf" ref="r:bf3cd5a0-eefc-4fd9-b3a6-b57643c9d80c(org.iets3.core.expr.typetags.units.typesystem)" />
     <import index="t4jv" ref="r:80cf2246-750c-4158-9056-a619ebcf894c(org.iets3.core.expr.base.typesystem)" />
     <import index="eppz" ref="r:42a3bc53-29b1-44d6-9767-7c921cef7ba0(org.iets3.core.expr.typetags.typesystem)" />
+    <import index="w1hl" ref="r:04b74a30-84ff-4d44-89e3-8084278f9c79(org.iets3.core.expr.typetags.structure)" />
+    <import index="b0gq" ref="r:1eb914ff-b91c-4cbc-93c6-3ecde7821894(org.iets3.core.expr.typetags.units.structure)" />
+    <import index="1qv1" ref="r:c53b8bbc-6142-4787-a6e4-66310b772b37(org.iets3.core.expr.math.structure)" />
+    <import index="8do3" ref="r:cea04c4b-adba-417e-a192-34c7a8799ac1(com.mbeddr.mpsutil.compare.structure)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -37,11 +46,99 @@
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
       </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <child id="1216993439383" name="methods" index="1qtyYc" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
+        <child id="1217501895093" name="testMethods" index="1SL9yI" />
       </concept>
       <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
         <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
       </concept>
+      <concept id="1210673684636" name="jetbrains.mps.lang.test.structure.TestNodeAnnotation" flags="ng" index="3xLA65" />
+      <concept id="1210674524691" name="jetbrains.mps.lang.test.structure.TestNodeReference" flags="nn" index="3xONca">
+        <reference id="1210674534086" name="declaration" index="3xOPvv" />
+      </concept>
+      <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1219920932475" name="jetbrains.mps.baseLanguage.structure.VariableArityType" flags="in" index="8X2XB">
+        <child id="1219921048460" name="componentType" index="8Xvag" />
+      </concept>
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+        <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
+      <concept id="1173175405605" name="jetbrains.mps.baseLanguage.structure.ArrayAccessExpression" flags="nn" index="AH0OO">
+        <child id="1173175577737" name="index" index="AHEQo" />
+        <child id="1173175590490" name="array" index="AHHXb" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
+        <child id="1144231399730" name="condition" index="1Dwp0S" />
+        <child id="1144231408325" name="iteration" index="1Dwrff" />
+      </concept>
+      <concept id="1208890769693" name="jetbrains.mps.baseLanguage.structure.ArrayLengthOperation" flags="nn" index="1Rwk04" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
     </language>
     <language id="cb91a38e-738a-4811-a96d-448d08f526fa" name="org.iets3.core.expr.typetags.units">
       <concept id="1741902046311368052" name="org.iets3.core.expr.typetags.units.structure.ConversionSpecifier" flags="ng" index="27LzZq">
@@ -143,11 +240,50 @@
         <reference id="747084250476878887" name="chunk" index="3GEb4d" />
       </concept>
     </language>
+    <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
+      <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
+      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ng" index="2WEnae">
+        <reference id="1205756909548" name="member" index="2WH_rO" />
+      </concept>
+      <concept id="1205769003971" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodDeclaration" flags="ng" index="2XrIbr" />
+      <concept id="1205769149993" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodCallOperation" flags="nn" index="2XshWL">
+        <child id="1205770614681" name="actualArgument" index="2XxRq1" />
+      </concept>
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+        <child id="1595412875168045827" name="initValue" index="28nt2d" />
+      </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
+        <child id="8182547171709752112" name="expression" index="36biLW" />
+      </concept>
+      <concept id="8182547171709614739" name="jetbrains.mps.lang.quotation.structure.NodeBuilderRef" flags="nn" index="36bGnv">
+        <reference id="8182547171709614741" name="target" index="36bGnp" />
+      </concept>
+    </language>
     <language id="6fadc44e-69c2-4a4a-9d16-7ebf5f8d3ba0" name="org.iets3.core.expr.math">
+      <concept id="4944417823362158056" name="org.iets3.core.expr.math.structure.SqrtExpression" flags="ng" index="a0DgS">
+        <child id="4944417823362162236" name="expr" index="a0CvG" />
+      </concept>
       <concept id="4944417823362108742" name="org.iets3.core.expr.math.structure.FractionExpression" flags="ng" index="a1tim">
         <child id="4944417823362108743" name="numerator" index="a1tin" />
         <child id="4944417823362108746" name="denominator" index="a1tiq" />
       </concept>
+    </language>
+    <language id="f47b95d4-5e73-4c04-9204-18076950153b" name="com.mbeddr.mpsutil.compare">
+      <concept id="756135271275943220" name="com.mbeddr.mpsutil.compare.structure.AssertNodeEquals" flags="ng" index="3GXo0L" />
     </language>
     <language id="5186c6ce-428c-4f09-a9df-73d9e86c27d3" name="org.iets3.core.expr.typetags">
       <concept id="1759375669591494838" name="org.iets3.core.expr.typetags.structure.TaggedType" flags="ng" index="2c7tTJ">
@@ -160,6 +296,47 @@
         <child id="3359996257534647724" name="expr" index="1YnStB" />
       </concept>
     </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+      <concept id="1172073500303" name="jetbrains.mps.baseLanguage.unitTest.structure.Message" flags="ng" index="3_1$Yv">
+        <child id="1172073511101" name="message" index="3_1BAH" />
+      </concept>
+      <concept id="1172075514136" name="jetbrains.mps.baseLanguage.unitTest.structure.MessageHolder" flags="ng" index="3_9gw8">
+        <child id="1172075534298" name="message" index="3_9lra" />
+      </concept>
+    </language>
+    <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
+        <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
+      </concept>
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+    </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
@@ -167,6 +344,14 @@
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
     </language>
   </registry>
   <node concept="1lH9Xt" id="2JXkwhJfxJF">
@@ -760,6 +945,519 @@
   </node>
   <node concept="1lH9Xt" id="1fzaMYHrHpe">
     <property role="TrG5h" value="ExpressionsPart2" />
+    <node concept="2XrIbr" id="1JTgXSYMRE7" role="1qtyYc">
+      <property role="TrG5h" value="assertNodeUnitType" />
+      <node concept="3cqZAl" id="1JTgXSYMREk" role="3clF45" />
+      <node concept="3clFbS" id="1JTgXSYMRE9" role="3clF47">
+        <node concept="3cpWs8" id="1JTgXSYMSaX" role="3cqZAp">
+          <node concept="3cpWsn" id="1JTgXSYMSaY" role="3cpWs9">
+            <property role="TrG5h" value="actualType" />
+            <node concept="3Tqbb2" id="1JTgXSYMSaU" role="1tU5fm" />
+            <node concept="2OqwBi" id="1JTgXSYMSaZ" role="33vP2m">
+              <node concept="37vLTw" id="1JTgXSYMSb0" role="2Oq$k0">
+                <ref role="3cqZAo" node="1JTgXSYMREu" resolve="node" />
+              </node>
+              <node concept="3JvlWi" id="1JTgXSYMSb1" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1JTgXSYNdjj" role="3cqZAp">
+          <node concept="2OqwBi" id="1JTgXSYNd_E" role="3vwVQn">
+            <node concept="37vLTw" id="1JTgXSYNdkw" role="2Oq$k0">
+              <ref role="3cqZAo" node="1JTgXSYMSaY" resolve="actualType" />
+            </node>
+            <node concept="1mIQ4w" id="1JTgXSYNdLU" role="2OqNvi">
+              <node concept="chp4Y" id="1JTgXSYNdNM" role="cj9EA">
+                <ref role="cht4Q" to="w1hl:1xEzHAktP2Q" resolve="TaggedType" />
+              </node>
+            </node>
+          </node>
+          <node concept="3_1$Yv" id="1JTgXSYNdQf" role="3_9lra">
+            <node concept="2YIFZM" id="1JTgXSYNe7t" role="3_1BAH">
+              <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+              <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
+              <node concept="Xl_RD" id="1JTgXSYNegl" role="37wK5m">
+                <property role="Xl_RC" value="Expected type of node %s is TaggedType, but was %s" />
+              </node>
+              <node concept="37vLTw" id="1JTgXSYNeRl" role="37wK5m">
+                <ref role="3cqZAo" node="1JTgXSYMREu" resolve="node" />
+              </node>
+              <node concept="37vLTw" id="1JTgXSYNfdF" role="37wK5m">
+                <ref role="3cqZAo" node="1JTgXSYMSaY" resolve="actualType" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1JTgXSYNobr" role="3cqZAp">
+          <node concept="3cpWsn" id="1JTgXSYNobs" role="3cpWs9">
+            <property role="TrG5h" value="actualTaggedType" />
+            <node concept="3Tqbb2" id="1JTgXSYNmwE" role="1tU5fm">
+              <ref role="ehGHo" to="w1hl:1xEzHAktP2Q" resolve="TaggedType" />
+            </node>
+            <node concept="1PxgMI" id="1JTgXSYNobt" role="33vP2m">
+              <node concept="chp4Y" id="1JTgXSYNobu" role="3oSUPX">
+                <ref role="cht4Q" to="w1hl:1xEzHAktP2Q" resolve="TaggedType" />
+              </node>
+              <node concept="37vLTw" id="1JTgXSYNobv" role="1m5AlR">
+                <ref role="3cqZAo" node="1JTgXSYMSaY" resolve="actualType" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="1JTgXSYNllx" role="3cqZAp">
+          <node concept="3cmrfG" id="1JTgXSYNlnz" role="3tpDZB">
+            <property role="3cmrfH" value="1" />
+          </node>
+          <node concept="2OqwBi" id="1JTgXSYO6NI" role="3tpDZA">
+            <node concept="2OqwBi" id="1JTgXSYNmok" role="2Oq$k0">
+              <node concept="37vLTw" id="1JTgXSYNobw" role="2Oq$k0">
+                <ref role="3cqZAo" node="1JTgXSYNobs" resolve="actualTaggedType" />
+              </node>
+              <node concept="3Tsc0h" id="1JTgXSYNmYp" role="2OqNvi">
+                <ref role="3TtcxE" to="w1hl:1xEzHAktP2R" resolve="tags" />
+              </node>
+            </node>
+            <node concept="34oBXx" id="1JTgXSYO927" role="2OqNvi" />
+          </node>
+          <node concept="3_1$Yv" id="1JTgXSYNn1n" role="3_9lra">
+            <node concept="3cpWs3" id="1JTgXSYNnRf" role="3_1BAH">
+              <node concept="Xl_RD" id="1JTgXSYNnRJ" role="3uHU7w">
+                <property role="Xl_RC" value=" must be 1" />
+              </node>
+              <node concept="3cpWs3" id="1JTgXSYNnHe" role="3uHU7B">
+                <node concept="Xl_RD" id="1JTgXSYNnv7" role="3uHU7B">
+                  <property role="Xl_RC" value="Tag size of type " />
+                </node>
+                <node concept="37vLTw" id="1JTgXSYNnHw" role="3uHU7w">
+                  <ref role="3cqZAo" node="1JTgXSYMSaY" resolve="actualType" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1JTgXSYNvpW" role="3cqZAp">
+          <node concept="3cpWsn" id="1JTgXSYNvpX" role="3cpWs9">
+            <property role="TrG5h" value="tag" />
+            <node concept="3Tqbb2" id="1JTgXSYNu3y" role="1tU5fm">
+              <ref role="ehGHo" to="w1hl:4HxogODR$_x" resolve="ITag" />
+            </node>
+            <node concept="2OqwBi" id="1JTgXSYNvpY" role="33vP2m">
+              <node concept="2OqwBi" id="1JTgXSYNvpZ" role="2Oq$k0">
+                <node concept="37vLTw" id="1JTgXSYNvq0" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1JTgXSYNobs" resolve="actualTaggedType" />
+                </node>
+                <node concept="3Tsc0h" id="1JTgXSYNvq1" role="2OqNvi">
+                  <ref role="3TtcxE" to="w1hl:1xEzHAktP2R" resolve="tags" />
+                </node>
+              </node>
+              <node concept="1uHKPH" id="1JTgXSYNvq2" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vwNmj" id="1JTgXSYNp2a" role="3cqZAp">
+          <node concept="2OqwBi" id="1JTgXSYNtUW" role="3vwVQn">
+            <node concept="37vLTw" id="1JTgXSYNvq3" role="2Oq$k0">
+              <ref role="3cqZAo" node="1JTgXSYNvpX" resolve="tag" />
+            </node>
+            <node concept="1mIQ4w" id="1JTgXSYNuq4" role="2OqNvi">
+              <node concept="chp4Y" id="1JTgXSYNusa" role="cj9EA">
+                <ref role="cht4Q" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+              </node>
+            </node>
+          </node>
+          <node concept="3_1$Yv" id="1JTgXSYNuuo" role="3_9lra">
+            <node concept="2YIFZM" id="1JTgXSYNuK3" role="3_1BAH">
+              <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+              <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
+              <node concept="Xl_RD" id="1JTgXSYNuOU" role="37wK5m">
+                <property role="Xl_RC" value="The tag of of type %s must be UnitSpecification, but was %s" />
+              </node>
+              <node concept="37vLTw" id="1JTgXSYNvIB" role="37wK5m">
+                <ref role="3cqZAo" node="1JTgXSYNobs" resolve="actualTaggedType" />
+              </node>
+              <node concept="37vLTw" id="1JTgXSYNw1g" role="37wK5m">
+                <ref role="3cqZAo" node="1JTgXSYNvpX" resolve="tag" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1JTgXSYNx9v" role="3cqZAp">
+          <node concept="3cpWsn" id="1JTgXSYNx9w" role="3cpWs9">
+            <property role="TrG5h" value="actualUnitReferences" />
+            <node concept="2I9FWS" id="1JTgXSYNx7a" role="1tU5fm">
+              <ref role="2I9WkF" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+            </node>
+            <node concept="2OqwBi" id="1JTgXSYNx9x" role="33vP2m">
+              <node concept="1PxgMI" id="1JTgXSYNx9y" role="2Oq$k0">
+                <node concept="chp4Y" id="1JTgXSYNx9z" role="3oSUPX">
+                  <ref role="cht4Q" to="b0gq:7eOyx9r3k4t" resolve="UnitSpecification" />
+                </node>
+                <node concept="37vLTw" id="1JTgXSYNx9$" role="1m5AlR">
+                  <ref role="3cqZAo" node="1JTgXSYNvpX" resolve="tag" />
+                </node>
+              </node>
+              <node concept="3Tsc0h" id="1JTgXSYNx9_" role="2OqNvi">
+                <ref role="3TtcxE" to="b0gq:7eOyx9r3qG3" resolve="components" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="1JTgXSYNxIo" role="3cqZAp">
+          <node concept="2OqwBi" id="1JTgXSYNye8" role="3tpDZB">
+            <node concept="37vLTw" id="1JTgXSYNxWY" role="2Oq$k0">
+              <ref role="3cqZAo" node="1JTgXSYNc2$" resolve="expectedUnitReferences" />
+            </node>
+            <node concept="1Rwk04" id="1JTgXSYNyM2" role="2OqNvi" />
+          </node>
+          <node concept="2OqwBi" id="1JTgXSYN$gd" role="3tpDZA">
+            <node concept="37vLTw" id="1JTgXSYNyMa" role="2Oq$k0">
+              <ref role="3cqZAo" node="1JTgXSYNx9w" resolve="actualUnitReferences" />
+            </node>
+            <node concept="34oBXx" id="1JTgXSYNB7M" role="2OqNvi" />
+          </node>
+          <node concept="3_1$Yv" id="1JTgXSYNBkD" role="3_9lra">
+            <node concept="Xl_RD" id="1JTgXSYNBlX" role="3_1BAH">
+              <property role="Xl_RC" value="Wrong number of unit references found" />
+            </node>
+          </node>
+        </node>
+        <node concept="1Dw8fO" id="1JTgXSYNMAR" role="3cqZAp">
+          <node concept="3clFbS" id="1JTgXSYNMAT" role="2LFqv$">
+            <node concept="3clFbF" id="1JTgXSYNOQn" role="3cqZAp">
+              <node concept="2OqwBi" id="1JTgXSYNOQh" role="3clFbG">
+                <node concept="2WthIp" id="1JTgXSYNOQk" role="2Oq$k0" />
+                <node concept="2XshWL" id="1JTgXSYNOQm" role="2OqNvi">
+                  <ref role="2WH_rO" node="1JTgXSYNDVk" resolve="assertUnitReference" />
+                  <node concept="2OqwBi" id="1JTgXSYNQqT" role="2XxRq1">
+                    <node concept="37vLTw" id="1JTgXSYNOQ$" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1JTgXSYNx9w" resolve="actualUnitReferences" />
+                    </node>
+                    <node concept="34jXtK" id="1JTgXSYNWeO" role="2OqNvi">
+                      <node concept="37vLTw" id="1JTgXSYNWgh" role="25WWJ7">
+                        <ref role="3cqZAo" node="1JTgXSYNMAU" resolve="i" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="AH0OO" id="1JTgXSYNTy3" role="2XxRq1">
+                    <node concept="37vLTw" id="1JTgXSYNT_1" role="AHEQo">
+                      <ref role="3cqZAo" node="1JTgXSYNMAU" resolve="i" />
+                    </node>
+                    <node concept="37vLTw" id="1JTgXSYNTtA" role="AHHXb">
+                      <ref role="3cqZAo" node="1JTgXSYNc2$" resolve="expectedUnitReferences" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="1JTgXSYNMAU" role="1Duv9x">
+            <property role="TrG5h" value="i" />
+            <node concept="10Oyi0" id="1JTgXSYNMDt" role="1tU5fm" />
+            <node concept="3cmrfG" id="1JTgXSYNMDJ" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+          <node concept="3eOVzh" id="1JTgXSYNNwL" role="1Dwp0S">
+            <node concept="2OqwBi" id="1JTgXSYNNQ5" role="3uHU7w">
+              <node concept="37vLTw" id="1JTgXSYNNBG" role="2Oq$k0">
+                <ref role="3cqZAo" node="1JTgXSYNc2$" resolve="expectedUnitReferences" />
+              </node>
+              <node concept="1Rwk04" id="1JTgXSYNNWG" role="2OqNvi" />
+            </node>
+            <node concept="37vLTw" id="1JTgXSYNMDS" role="3uHU7B">
+              <ref role="3cqZAo" node="1JTgXSYNMAU" resolve="i" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="1JTgXSYNOEG" role="1Dwrff">
+            <node concept="37vLTw" id="1JTgXSYNOEI" role="2$L3a6">
+              <ref role="3cqZAo" node="1JTgXSYNMAU" resolve="i" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="1JTgXSYMREf" role="1B3o_S" />
+      <node concept="37vLTG" id="1JTgXSYMREu" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="1JTgXSYMRFN" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="1JTgXSYNc2$" role="3clF46">
+        <property role="TrG5h" value="expectedUnitReferences" />
+        <node concept="8X2XB" id="1JTgXSYNyGF" role="1tU5fm">
+          <node concept="3Tqbb2" id="1JTgXSYNxH4" role="8Xvag">
+            <ref role="ehGHo" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2XrIbr" id="1JTgXSYNDVk" role="1qtyYc">
+      <property role="TrG5h" value="assertUnitReference" />
+      <node concept="3cqZAl" id="1JTgXSYNDWR" role="3clF45" />
+      <node concept="3clFbS" id="1JTgXSYNDVm" role="3clF47">
+        <node concept="3GXo0L" id="1JTgXSYPwXW" role="3cqZAp">
+          <node concept="37vLTw" id="1JTgXSYPwYB" role="3tpDZB">
+            <ref role="3cqZAo" node="1JTgXSYNDXf" resolve="expectedUnitReference" />
+          </node>
+          <node concept="37vLTw" id="1JTgXSYPwZg" role="3tpDZA">
+            <ref role="3cqZAo" node="1JTgXSYNDX1" resolve="actualUnitRef" />
+          </node>
+          <node concept="3_1$Yv" id="1JTgXSYPyHK" role="3_9lra">
+            <node concept="Xl_RD" id="1JTgXSYPyI2" role="3_1BAH">
+              <property role="Xl_RC" value="Unit references are not equal" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="1JTgXSYNDWM" role="1B3o_S" />
+      <node concept="37vLTG" id="1JTgXSYNDX1" role="3clF46">
+        <property role="TrG5h" value="actualUnitRef" />
+        <node concept="3Tqbb2" id="1JTgXSYNDX0" role="1tU5fm">
+          <ref role="ehGHo" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1JTgXSYNDXf" role="3clF46">
+        <property role="TrG5h" value="expectedUnitReference" />
+        <node concept="3Tqbb2" id="1JTgXSYNDXt" role="1tU5fm">
+          <ref role="ehGHo" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+        </node>
+      </node>
+    </node>
+    <node concept="2XrIbr" id="1JTgXSYOKDT" role="1qtyYc">
+      <property role="TrG5h" value="createFractionalExponent" />
+      <node concept="3Tqbb2" id="1JTgXSYOKIf" role="3clF45">
+        <ref role="ehGHo" to="b0gq:3j3yk3gAgiT" resolve="FractionalExponent" />
+      </node>
+      <node concept="3clFbS" id="1JTgXSYOKDV" role="3clF47">
+        <node concept="3clFbF" id="1JTgXSYOKXx" role="3cqZAp">
+          <node concept="2pJPEk" id="1JTgXSYOKXv" role="3clFbG">
+            <node concept="2pJPED" id="1JTgXSYOKZh" role="2pJPEn">
+              <ref role="2pJxaS" to="b0gq:3j3yk3gAgiT" resolve="FractionalExponent" />
+              <node concept="2pIpSj" id="1JTgXSYOKZw" role="2pJxcM">
+                <ref role="2pIpSl" to="b0gq:3j3yk3gAnBu" resolve="fraction" />
+                <node concept="2pJPED" id="1JTgXSYOKZI" role="28nt2d">
+                  <ref role="2pJxaS" to="1qv1:4iu6t1eAWP6" resolve="FractionExpression" />
+                  <node concept="2pIpSj" id="1JTgXSYOKZX" role="2pJxcM">
+                    <ref role="2pIpSl" to="1qv1:4iu6t1eAWP7" resolve="numerator" />
+                    <node concept="2pJPED" id="1JTgXSYOLdy" role="28nt2d">
+                      <ref role="2pJxaS" to="5qo5:4rZeNQ6Oerq" resolve="NumberLiteral" />
+                      <node concept="2pJxcG" id="1JTgXSYOLdE" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:4rZeNQ6Oert" resolve="value" />
+                        <node concept="37vLTw" id="1JTgXSYOLdQ" role="28ntcv">
+                          <ref role="3cqZAo" node="1JTgXSYOKIz" resolve="expectedNumerator" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="1JTgXSYOL4V" role="2pJxcM">
+                    <ref role="2pIpSl" to="1qv1:4iu6t1eAWPa" resolve="denominator" />
+                    <node concept="2pJPED" id="1JTgXSYOLe7" role="28nt2d">
+                      <ref role="2pJxaS" to="5qo5:4rZeNQ6Oerq" resolve="NumberLiteral" />
+                      <node concept="2pJxcG" id="1JTgXSYOLeg" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:4rZeNQ6Oert" resolve="value" />
+                        <node concept="37vLTw" id="1JTgXSYOLes" role="28ntcv">
+                          <ref role="3cqZAo" node="1JTgXSYOKNn" resolve="expectedDenominator" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="1JTgXSYOKI7" role="1B3o_S" />
+      <node concept="37vLTG" id="1JTgXSYOKIz" role="3clF46">
+        <property role="TrG5h" value="expectedNumerator" />
+        <node concept="17QB3L" id="1JTgXSYOKNG" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="1JTgXSYOKNn" role="3clF46">
+        <property role="TrG5h" value="expectedDenominator" />
+        <node concept="17QB3L" id="1JTgXSYOKN$" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="1LZb2c" id="1JTgXSYMM_w" role="1SL9yI">
+      <property role="TrG5h" value="testSqrtExpressionType" />
+      <node concept="3cqZAl" id="1JTgXSYMM_x" role="3clF45" />
+      <node concept="3clFbS" id="1JTgXSYMM__" role="3clF47">
+        <node concept="3vwNmj" id="1JTgXSYN8hk" role="3cqZAp">
+          <node concept="2OqwBi" id="1JTgXSYN9k3" role="3vwVQn">
+            <node concept="2OqwBi" id="1JTgXSYN8pt" role="2Oq$k0">
+              <node concept="3xONca" id="1JTgXSYN8ho" role="2Oq$k0">
+                <ref role="3xOPvv" node="1JTgXSYMNUM" resolve="withoutUnit" />
+              </node>
+              <node concept="3JvlWi" id="1JTgXSYN8I4" role="2OqNvi" />
+            </node>
+            <node concept="1mIQ4w" id="1JTgXSYN9DM" role="2OqNvi">
+              <node concept="chp4Y" id="1JTgXSYN9FH" role="cj9EA">
+                <ref role="cht4Q" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+              </node>
+            </node>
+          </node>
+          <node concept="3_1$Yv" id="1JTgXSYN9$o" role="3_9lra">
+            <node concept="3cpWs3" id="1JTgXSYN9V$" role="3_1BAH">
+              <node concept="2OqwBi" id="1JTgXSYNa8l" role="3uHU7w">
+                <node concept="3xONca" id="1JTgXSYN9VQ" role="2Oq$k0">
+                  <ref role="3xOPvv" node="1JTgXSYMNUM" resolve="withoutUnit" />
+                </node>
+                <node concept="3JvlWi" id="1JTgXSYNat5" role="2OqNvi" />
+              </node>
+              <node concept="Xl_RD" id="1JTgXSYN9$s" role="3uHU7B">
+                <property role="Xl_RC" value="Sqrt without units must have real type, but was " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1JTgXSYOpOK" role="3cqZAp" />
+        <node concept="3clFbF" id="1JTgXSYNbwq" role="3cqZAp">
+          <node concept="2OqwBi" id="1JTgXSYNbwk" role="3clFbG">
+            <node concept="2WthIp" id="1JTgXSYNbwn" role="2Oq$k0" />
+            <node concept="2XshWL" id="1JTgXSYNbwp" role="2OqNvi">
+              <ref role="2WH_rO" node="1JTgXSYMRE7" resolve="assertNodeUnitType" />
+              <node concept="3xONca" id="1JTgXSYNWvg" role="2XxRq1">
+                <ref role="3xOPvv" node="1JTgXSYMNZa" resolve="simpleUnit" />
+              </node>
+              <node concept="2pJPEk" id="1JTgXSYNYwP" role="2XxRq1">
+                <node concept="2pJPED" id="1JTgXSYNYNl" role="2pJPEn">
+                  <ref role="2pJxaS" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+                  <node concept="2pIpSj" id="1JTgXSYNYNX" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFY" resolve="exponent" />
+                    <node concept="36biLy" id="1JTgXSYObhi" role="28nt2d">
+                      <node concept="10Nm6u" id="1JTgXSYObhe" role="36biLW" />
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="1JTgXSYNYY1" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                    <node concept="36bGnv" id="1JTgXSYNYZ2" role="28nt2d">
+                      <ref role="36bGnp" to="ku0a:5XaocLWHSS5" resolve="s" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1JTgXSYOpQf" role="3cqZAp" />
+        <node concept="3clFbF" id="1JTgXSYOeHm" role="3cqZAp">
+          <node concept="2OqwBi" id="1JTgXSYOeKI" role="3clFbG">
+            <node concept="2WthIp" id="1JTgXSYOeHk" role="2Oq$k0" />
+            <node concept="2XshWL" id="1JTgXSYOeOI" role="2OqNvi">
+              <ref role="2WH_rO" node="1JTgXSYMRE7" resolve="assertNodeUnitType" />
+              <node concept="3xONca" id="1JTgXSYOeOS" role="2XxRq1">
+                <ref role="3xOPvv" node="1JTgXSYMP5j" resolve="combinedUnit" />
+              </node>
+              <node concept="2pJPEk" id="1JTgXSYOnrH" role="2XxRq1">
+                <node concept="2pJPED" id="1JTgXSYOntZ" role="2pJPEn">
+                  <ref role="2pJxaS" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+                  <node concept="2pIpSj" id="1JTgXSYOo5A" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                    <node concept="36bGnv" id="1JTgXSYOo6w" role="28nt2d">
+                      <ref role="36bGnp" to="ku0a:5XaocLWHSS4" resolve="m" />
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="1JTgXSYOnuj" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFY" resolve="exponent" />
+                    <node concept="36biLy" id="1JTgXSYOKSy" role="28nt2d">
+                      <node concept="2OqwBi" id="1JTgXSYOKSF" role="36biLW">
+                        <node concept="2WthIp" id="1JTgXSYOKSI" role="2Oq$k0" />
+                        <node concept="2XshWL" id="1JTgXSYOKSK" role="2OqNvi">
+                          <ref role="2WH_rO" node="1JTgXSYOKDT" resolve="createFractionalExponent" />
+                          <node concept="Xl_RD" id="1JTgXSYOKTX" role="2XxRq1">
+                            <property role="Xl_RC" value="1" />
+                          </node>
+                          <node concept="Xl_RD" id="1JTgXSYOKUU" role="2XxRq1">
+                            <property role="Xl_RC" value="2" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2pJPEk" id="1JTgXSYOo7f" role="2XxRq1">
+                <node concept="2pJPED" id="1JTgXSYOo9y" role="2pJPEn">
+                  <ref role="2pJxaS" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+                  <node concept="2pIpSj" id="1JTgXSYOoaf" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                    <node concept="36bGnv" id="1JTgXSYOob0" role="28nt2d">
+                      <ref role="36bGnp" to="ku0a:5XaocLWHSS5" resolve="s" />
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="1JTgXSYOobw" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFY" resolve="exponent" />
+                    <node concept="2pJPED" id="1JTgXSYOocr" role="28nt2d">
+                      <ref role="2pJxaS" to="b0gq:7eOyx9r3kR6" resolve="IntegerExponent" />
+                      <node concept="2pJxcG" id="1JTgXSYOocx" role="2pJxcM">
+                        <ref role="2pJxcJ" to="b0gq:7eOyx9r3kR7" resolve="value" />
+                        <node concept="3cmrfG" id="1JTgXSYOocS" role="28ntcv">
+                          <property role="3cmrfH" value="3" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1JTgXSYOKpb" role="3cqZAp" />
+        <node concept="3clFbF" id="1JTgXSYOKs0" role="3cqZAp">
+          <node concept="2OqwBi" id="1JTgXSYOKxp" role="3clFbG">
+            <node concept="2WthIp" id="1JTgXSYOKrY" role="2Oq$k0" />
+            <node concept="2XshWL" id="1JTgXSYOK_p" role="2OqNvi">
+              <ref role="2WH_rO" node="1JTgXSYMRE7" resolve="assertNodeUnitType" />
+              <node concept="3xONca" id="1JTgXSYOKBf" role="2XxRq1">
+                <ref role="3xOPvv" node="1JTgXSYMRgF" resolve="complexUnit" />
+              </node>
+              <node concept="2pJPEk" id="1JTgXSYOMLT" role="2XxRq1">
+                <node concept="2pJPED" id="1JTgXSYOMMh" role="2pJPEn">
+                  <ref role="2pJxaS" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+                  <node concept="2pIpSj" id="1JTgXSYOMNc" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                    <node concept="36bGnv" id="1JTgXSYOMNA" role="28nt2d">
+                      <ref role="36bGnp" to="ku0a:5XaocLWHSS4" resolve="m" />
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="1JTgXSYOMOl" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFY" resolve="exponent" />
+                    <node concept="36biLy" id="1JTgXSYON6L" role="28nt2d">
+                      <node concept="10Nm6u" id="1JTgXSYON6W" role="36biLW" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2pJPEk" id="1JTgXSYON7V" role="2XxRq1">
+                <node concept="2pJPED" id="1JTgXSYON8N" role="2pJPEn">
+                  <ref role="2pJxaS" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+                  <node concept="2pIpSj" id="1JTgXSYON9$" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                    <node concept="36bGnv" id="1JTgXSYONat" role="28nt2d">
+                      <ref role="36bGnp" to="ku0a:5XaocLWHSS5" resolve="s" />
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="1JTgXSYONaX" role="2pJxcM">
+                    <ref role="2pIpSl" to="b0gq:7eOyx9r3qFY" resolve="exponent" />
+                    <node concept="36biLy" id="1JTgXSYONbu" role="28nt2d">
+                      <node concept="2OqwBi" id="1JTgXSYONbD" role="36biLW">
+                        <node concept="2WthIp" id="1JTgXSYONbG" role="2Oq$k0" />
+                        <node concept="2XshWL" id="1JTgXSYONbI" role="2OqNvi">
+                          <ref role="2WH_rO" node="1JTgXSYOKDT" resolve="createFractionalExponent" />
+                          <node concept="Xl_RD" id="1JTgXSYONAS" role="2XxRq1">
+                            <property role="Xl_RC" value="3" />
+                          </node>
+                          <node concept="Xl_RD" id="1JTgXSYONBY" role="2XxRq1">
+                            <property role="Xl_RC" value="-2" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="1qefOq" id="1fzaMYHrHpf" role="1SKRRt">
       <node concept="_iOnU" id="7Z_pmaBI0dk" role="1qenE9">
         <property role="TrG5h" value="ExpressionsPart2_a" />
@@ -1012,11 +1710,137 @@
             <node concept="mLuIC" id="1fzaMYHvUD$" role="2c7tTw" />
           </node>
         </node>
+        <node concept="_ixoA" id="2OGPkCTiMF6" role="_iOnB" />
+        <node concept="2zPypq" id="1JTgXSYMNAl" role="_iOnB">
+          <property role="TrG5h" value="sqrtWithoutUnit" />
+          <node concept="a0DgS" id="1JTgXSYMNCP" role="2zPyp_">
+            <node concept="30dDZf" id="1JTgXSYMNFE" role="a0CvG">
+              <node concept="30bXRB" id="1JTgXSYMNGd" role="30dEs_">
+                <property role="30bXRw" value="15" />
+              </node>
+              <node concept="30bXRB" id="1JTgXSYMND4" role="30dEsF">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="3xLA65" id="1JTgXSYMNUM" role="lGtFl">
+              <property role="TrG5h" value="withoutUnit" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="2OGPkCTlLFT" role="_iOnB">
+          <property role="TrG5h" value="sqrtSimple" />
+          <node concept="a0DgS" id="2OGPkCTlLIA" role="2zPyp_">
+            <node concept="30dDTi" id="2OGPkCTlLKo" role="a0CvG">
+              <node concept="1YnStw" id="3htFKtcnBul" role="30dEs_">
+                <node concept="CIsGf" id="3htFKtcnBuc" role="2c7tTI">
+                  <node concept="CIsvn" id="3htFKtcnBud" role="CIi4h">
+                    <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                  </node>
+                </node>
+                <node concept="30bXRB" id="2OGPkCTlLL1" role="1YnStB">
+                  <property role="30bXRw" value="16" />
+                </node>
+              </node>
+              <node concept="1YnStw" id="2OGPkCTlLOt" role="30dEsF">
+                <node concept="CIsGf" id="2OGPkCTlLOe" role="2c7tTI">
+                  <node concept="CIsvn" id="2OGPkCTlLOf" role="CIi4h">
+                    <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                  </node>
+                </node>
+                <node concept="30bXRB" id="2OGPkCTlLIV" role="1YnStB">
+                  <property role="30bXRw" value="1" />
+                </node>
+              </node>
+            </node>
+            <node concept="3xLA65" id="1JTgXSYMNZa" role="lGtFl">
+              <property role="TrG5h" value="simpleUnit" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="2OGPkCTiMK1" role="_iOnB">
+          <property role="TrG5h" value="sqrtCombine" />
+          <node concept="a0DgS" id="2OGPkCTiMLX" role="2zPyp_">
+            <node concept="30dDTi" id="3htFKtcmIFN" role="a0CvG">
+              <node concept="1YnStw" id="2OGPkCTiMO_" role="30dEsF">
+                <node concept="CIsGf" id="2OGPkCTiMOn" role="2c7tTI">
+                  <node concept="CIsvn" id="2OGPkCTiMOo" role="CIi4h">
+                    <ref role="CIi3I" to="ku0a:5XaocLWHSS4" resolve="m" />
+                  </node>
+                </node>
+                <node concept="30bXRB" id="2OGPkCTiMMc" role="1YnStB">
+                  <property role="30bXRw" value="1" />
+                </node>
+              </node>
+              <node concept="1YnStw" id="3htFKtcd8iN" role="30dEs_">
+                <node concept="CIsGf" id="3htFKtcd8iE" role="2c7tTI">
+                  <node concept="CIsvn" id="3htFKtcd8iF" role="CIi4h">
+                    <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                  </node>
+                  <node concept="CIsvn" id="1JTgXSYMjUP" role="CIi4h">
+                    <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                  </node>
+                  <node concept="CIsvn" id="3htFKtcmIOB" role="CIi4h">
+                    <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                  </node>
+                  <node concept="CIsvn" id="3htFKtcmOXe" role="CIi4h">
+                    <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                  </node>
+                  <node concept="CIsvn" id="3htFKtcmPca" role="CIi4h">
+                    <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                  </node>
+                  <node concept="CIsvn" id="3htFKtcmWkI" role="CIi4h">
+                    <ref role="CIi3I" to="ku0a:5XaocLWHSS5" resolve="s" />
+                  </node>
+                </node>
+                <node concept="30bXRB" id="2OGPkCTiMWE" role="1YnStB">
+                  <property role="30bXRw" value="1" />
+                </node>
+              </node>
+            </node>
+            <node concept="3xLA65" id="1JTgXSYMP5j" role="lGtFl">
+              <property role="TrG5h" value="combinedUnit" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="1JTgXSYMQpW" role="_iOnB">
+          <property role="TrG5h" value="sqrtUnitRef" />
+          <node concept="a0DgS" id="1JTgXSYMQss" role="2zPyp_">
+            <node concept="30dDTi" id="1JTgXSYMR8y" role="a0CvG">
+              <node concept="1YnStw" id="1JTgXSYMQC1" role="30dEsF">
+                <node concept="CIsGf" id="1JTgXSYMQBA" role="2c7tTI">
+                  <node concept="CIsvn" id="1JTgXSYMQGA" role="CIi4h">
+                    <ref role="CIi3I" node="5XaocLWJ9Gy" resolve="acc" />
+                  </node>
+                </node>
+                <node concept="30bXRB" id="1JTgXSYMQ_C" role="1YnStB">
+                  <property role="30bXRw" value="1" />
+                </node>
+              </node>
+              <node concept="1YnStw" id="1JTgXSYMR5o" role="30dEs_">
+                <node concept="CIsGf" id="1JTgXSYMR5f" role="2c7tTI">
+                  <node concept="CIsvn" id="1JTgXSYMR5g" role="CIi4h">
+                    <ref role="CIi3I" node="5XaocLWIt6X" resolve="mps" />
+                  </node>
+                </node>
+                <node concept="30bXRB" id="1JTgXSYMR0K" role="1YnStB">
+                  <property role="30bXRw" value="1" />
+                </node>
+              </node>
+            </node>
+            <node concept="3xLA65" id="1JTgXSYMRgF" role="lGtFl">
+              <property role="TrG5h" value="complexUnit" />
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="2OGPkCTiNPx" role="_iOnB" />
         <node concept="7CXmI" id="1fzaMYHrHph" role="lGtFl">
           <node concept="7OXhh" id="1fzaMYHrHpi" role="7EUXB" />
         </node>
         <node concept="3GEVxB" id="7Z_pmaBR9ZD" role="3i6evy">
           <ref role="3GEb4d" to="ku0a:5XaocLWHGMs" resolve="SIUnits" />
+        </node>
+        <node concept="3GEVxB" id="1JTgXSYMQsF" role="3i6evy">
+          <ref role="3GEb4d" node="2JXkwhJfMDf" resolve="UnitsAndConversions" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
@@ -25,6 +25,7 @@
     <dependency reexport="false">5186c6ce-428c-4f09-a9df-73d9e86c27d3(org.iets3.core.expr.typetags)</dependency>
     <dependency reexport="false">6fadc44e-69c2-4a4a-9d16-7ebf5f8d3ba0(org.iets3.core.expr.math)</dependency>
     <dependency reexport="false">f47b95d4-5e73-4c04-9204-18076950153b(com.mbeddr.mpsutil.compare)</dependency>
+    <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="5" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
@@ -22,10 +22,14 @@
     <dependency reexport="false">2614fab6-e994-4127-9a5d-8c8cd7ba2833(test.in.expr.os)</dependency>
     <dependency reexport="false">8bb1251e-eae5-47ab-9843-33adfae8edaa(org.iets3.core.expr.util)</dependency>
     <dependency reexport="false">5fe6cb13-2fbd-4e21-9842-785bdd6fc5b1(org.iets3.core.expr.adt)</dependency>
+    <dependency reexport="false">5186c6ce-428c-4f09-a9df-73d9e86c27d3(org.iets3.core.expr.typetags)</dependency>
+    <dependency reexport="false">6fadc44e-69c2-4a4a-9d16-7ebf5f8d3ba0(org.iets3.core.expr.math)</dependency>
+    <dependency reexport="false">f47b95d4-5e73-4c04-9204-18076950153b(com.mbeddr.mpsutil.compare)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="5" />
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
+    <language slang="l:f47b95d4-5e73-4c04-9204-18076950153b:com.mbeddr.mpsutil.compare" version="0" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />
     <language slang="l:47f075a6-558e-4640-a606-7ce0236c8023:com.mbeddr.mpsutil.interpreter" version="1" />
     <language slang="l:1c897ba5-9d43-4035-ac7f-0306495743ac:com.mbeddr.mpsutil.interpreter.test" version="0" />
@@ -80,6 +84,7 @@
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
+    <module reference="f47b95d4-5e73-4c04-9204-18076950153b(com.mbeddr.mpsutil.compare)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
     <module reference="47f075a6-558e-4640-a606-7ce0236c8023(com.mbeddr.mpsutil.interpreter)" version="0" />
     <module reference="735f86bc-17fb-4d1c-a664-82c2b8e8a34e(com.mbeddr.mpsutil.interpreter.rt)" version="0" />
@@ -97,6 +102,7 @@
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="f61473f9-130f-42f6-b98d-6c438812c2f6(jetbrains.mps.baseLanguage.unitTest)" version="0" />
     <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
     <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
@@ -114,6 +120,7 @@
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="0" />
     <module reference="8ba65567-1c8a-4983-beb8-0482324d7e44(org.iets3.core.expr.lambda.interpreter)" version="0" />
     <module reference="0495221f-9fd1-41d6-bf26-b3b8aeb7eb7b(org.iets3.core.expr.lambda.plugin)" version="0" />
+    <module reference="6fadc44e-69c2-4a4a-9d16-7ebf5f8d3ba0(org.iets3.core.expr.math)" version="0" />
     <module reference="dff61827-7f11-4bfe-aeb1-6491ed8a49b2(org.iets3.core.expr.metafunction.interpreter)" version="0" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="c008c84a-6d05-4b6f-82f0-5cb6c0231a11(org.iets3.core.expr.path.interpreter)" version="0" />


### PR DESCRIPTION
The PR allows to combine units with math expressions, i.e., units can be used within math expressions.

For LogExpression, PowerExpression, and ProductLoopExpression, however, I was not sure how to calculate the power of the units and created checks in order to issue an error to the users.