### PR TITLE
expr.core: fix node cast exception in wrapWith

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -2837,22 +2837,15 @@
         <node concept="3cpWs8" id="5WNmJ7Ez2n0" role="3cqZAp">
           <node concept="3cpWsn" id="5WNmJ7Ez2n1" role="3cpWs9">
             <property role="TrG5h" value="tt" />
-            <node concept="3Tqbb2" id="5WNmJ7Ez2n2" role="1tU5fm">
-              <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
-            </node>
-            <node concept="1PxgMI" id="5WNmJ7Ez2n3" role="33vP2m">
-              <node concept="chp4Y" id="6b_jefnKxAK" role="3oSUPX">
-                <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
-              </node>
-              <node concept="2OqwBi" id="5WNmJ7Ez2n4" role="1m5AlR">
-                <node concept="2OqwBi" id="5WNmJ7Ez2n5" role="2Oq$k0">
-                  <node concept="13iPFW" id="5WNmJ7Ez2n6" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="5WNmJ7Ez4_V" role="2OqNvi">
-                    <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
-                  </node>
+            <node concept="3Tqbb2" id="5WNmJ7Ez2n2" role="1tU5fm" />
+            <node concept="2OqwBi" id="5WNmJ7Ez2n4" role="33vP2m">
+              <node concept="2OqwBi" id="5WNmJ7Ez2n5" role="2Oq$k0">
+                <node concept="13iPFW" id="5WNmJ7Ez2n6" role="2Oq$k0" />
+                <node concept="3TrEf2" id="5WNmJ7Ez4_V" role="2OqNvi">
+                  <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
                 </node>
-                <node concept="3JvlWi" id="5WNmJ7Ez2n8" role="2OqNvi" />
               </node>
+              <node concept="3JvlWi" id="5WNmJ7Ez2n8" role="2OqNvi" />
             </node>
           </node>
         </node>
@@ -2915,8 +2908,14 @@
           </node>
         </node>
         <node concept="3cpWs6" id="5WNmJ7Ez2nv" role="3cqZAp">
-          <node concept="37vLTw" id="5WNmJ7Ez2nw" role="3cqZAk">
-            <ref role="3cqZAo" node="5WNmJ7Ez2n1" resolve="tt" />
+          <node concept="1PxgMI" id="4UkwzkGxBGk" role="3cqZAk">
+            <property role="1BlNFB" value="true" />
+            <node concept="chp4Y" id="4UkwzkGxC1o" role="3oSUPX">
+              <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+            </node>
+            <node concept="37vLTw" id="4UkwzkGxBgz" role="1m5AlR">
+              <ref role="3cqZAo" node="5WNmJ7Ez2n1" resolve="tt" />
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/intentions.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/intentions.mps
@@ -2669,8 +2669,9 @@
           <node concept="2YIFZM" id="5LjCoy7TVr2" role="3clFbG">
             <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
             <ref role="37wK5l" to="xfg9:2Qbt$1tTWDY" resolve="isBooleanType" />
-            <node concept="1PxgMI" id="5LjCoy7TVr3" role="37wK5m">
-              <node concept="chp4Y" id="5LjCoy7TVr4" role="3oSUPX">
+            <node concept="1PxgMI" id="o83N5rjnPB" role="37wK5m">
+              <property role="1BlNFB" value="true" />
+              <node concept="chp4Y" id="o83N5rjnVx" role="3oSUPX">
                 <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
               </node>
               <node concept="2OqwBi" id="5LjCoy7TVr5" role="1m5AlR">
@@ -2758,8 +2759,9 @@
           <node concept="2YIFZM" id="5LjCoy7TUdH" role="3clFbG">
             <ref role="37wK5l" to="xfg9:2Qbt$1tTWDY" resolve="isBooleanType" />
             <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-            <node concept="1PxgMI" id="5LjCoy7TUVK" role="37wK5m">
-              <node concept="chp4Y" id="5LjCoy7TV1j" role="3oSUPX">
+            <node concept="1PxgMI" id="o83N5rjp3x" role="37wK5m">
+              <property role="1BlNFB" value="true" />
+              <node concept="chp4Y" id="o83N5rjp5x" role="3oSUPX">
                 <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
               </node>
               <node concept="2OqwBi" id="5LjCoy7TUqZ" role="1m5AlR">


### PR DESCRIPTION
In case the type could not get calculated correctly e.g. because of an
incomplete AST the intentions would throw a node case exception in their
isApplicable function rendering the complete intentions subsystem
unusable.