### PR TITLE
expr.data: allow lookups in data tables

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.behavior.mps
@@ -61,6 +61,7 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
@@ -68,6 +69,10 @@
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
@@ -98,6 +103,9 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
+      <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -502,6 +510,70 @@
         </node>
       </node>
       <node concept="17QB3L" id="6EEZHsfkftf" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="stdmzxr6jt">
+    <ref role="13h7C2" to="e9k1:stdmzxm7Y2" resolve="DataTableLookUp" />
+    <node concept="13hLZK" id="stdmzxr6ju" role="13h7CW">
+      <node concept="3clFbS" id="stdmzxr6jv" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="stdmzxr6jC" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:6kR0qIbI2yi" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="stdmzxr6jD" role="1B3o_S" />
+      <node concept="3clFbS" id="stdmzxr6jG" role="3clF47">
+        <node concept="3clFbF" id="stdmzxr6jV" role="3cqZAp">
+          <node concept="3cpWs3" id="stdmzxrbEO" role="3clFbG">
+            <node concept="Xl_RD" id="stdmzxrbER" role="3uHU7w">
+              <property role="Xl_RC" value=")" />
+            </node>
+            <node concept="3cpWs3" id="stdmzxrap6" role="3uHU7B">
+              <node concept="3cpWs3" id="stdmzxra7F" role="3uHU7B">
+                <node concept="3cpWs3" id="stdmzxr82z" role="3uHU7B">
+                  <node concept="3cpWs3" id="stdmzxr7Wf" role="3uHU7B">
+                    <node concept="2OqwBi" id="stdmzxr6TS" role="3uHU7B">
+                      <node concept="2OqwBi" id="stdmzxr6tr" role="2Oq$k0">
+                        <node concept="13iPFW" id="stdmzxr6jU" role="2Oq$k0" />
+                        <node concept="2yIwOk" id="stdmzxr6EA" role="2OqNvi" />
+                      </node>
+                      <node concept="3n3YKJ" id="stdmzxr7cd" role="2OqNvi" />
+                    </node>
+                    <node concept="Xl_RD" id="stdmzxr7Wu" role="3uHU7w">
+                      <property role="Xl_RC" value="&lt;" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="stdmzxr8ss" role="3uHU7w">
+                    <node concept="2OqwBi" id="stdmzxr8aK" role="2Oq$k0">
+                      <node concept="13iPFW" id="stdmzxr83y" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="stdmzxr8ha" role="2OqNvi">
+                        <ref role="3Tt5mk" to="e9k1:stdmzxm7Y5" resolve="col" />
+                      </node>
+                    </node>
+                    <node concept="3TrcHB" id="stdmzxr8L3" role="2OqNvi">
+                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="stdmzxra7I" role="3uHU7w">
+                  <property role="Xl_RC" value="&gt;(" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="stdmzxraSY" role="3uHU7w">
+                <node concept="2OqwBi" id="stdmzxrayv" role="2Oq$k0">
+                  <node concept="13iPFW" id="stdmzxraqT" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="stdmzxraHV" role="2OqNvi">
+                    <ref role="3Tt5mk" to="e9k1:stdmzxm7Y7" resolve="arg" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="stdmzxrbhG" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="stdmzxr6jH" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.constraints.mps
@@ -328,5 +328,76 @@
       </node>
     </node>
   </node>
+  <node concept="1M2fIO" id="stdmzxmerM">
+    <ref role="1M2myG" to="e9k1:stdmzxm7Y2" resolve="DataTableLookUp" />
+    <node concept="1N5Pfh" id="stdmzxmeQG" role="1Mr941">
+      <ref role="1N5Vy1" to="e9k1:stdmzxm7Y5" resolve="col" />
+      <node concept="3dgokm" id="stdmzxmeUq" role="1N6uqs">
+        <node concept="3clFbS" id="stdmzxmeUr" role="2VODD2">
+          <node concept="3clFbF" id="stdmzxmf41" role="3cqZAp">
+            <node concept="2YIFZM" id="stdmzxmf42" role="3clFbG">
+              <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+              <ref role="37wK5l" to="o8zo:4IP40Bi3eAf" resolve="forNamedElements" />
+              <node concept="2OqwBi" id="stdmzxmf43" role="37wK5m">
+                <node concept="2OqwBi" id="stdmzxmf44" role="2Oq$k0">
+                  <node concept="1PxgMI" id="stdmzxmf45" role="2Oq$k0">
+                    <node concept="chp4Y" id="stdmzxmf46" role="3oSUPX">
+                      <ref role="cht4Q" to="e9k1:cPLa7Fstqs" resolve="DataSelector" />
+                    </node>
+                    <node concept="2OqwBi" id="stdmzxmf47" role="1m5AlR">
+                      <node concept="2OqwBi" id="stdmzxmf48" role="2Oq$k0">
+                        <node concept="2rP1CM" id="stdmzxmf49" role="2Oq$k0" />
+                        <node concept="2Xjw5R" id="stdmzxmf4a" role="2OqNvi">
+                          <node concept="1xMEDy" id="stdmzxmf4b" role="1xVPHs">
+                            <node concept="chp4Y" id="stdmzxmf4c" role="ri$Ld">
+                              <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+                            </node>
+                          </node>
+                          <node concept="1xIGOp" id="stdmzxmf4d" role="1xVPHs" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="stdmzxmf4e" role="2OqNvi">
+                        <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3TrEf2" id="stdmzxmf4f" role="2OqNvi">
+                    <ref role="3Tt5mk" to="e9k1:cPLa7FstD4" resolve="table" />
+                  </node>
+                </node>
+                <node concept="3Tsc0h" id="stdmzxmg0j" role="2OqNvi">
+                  <ref role="3TtcxE" to="e9k1:cPLa7FpckA" resolve="dataCols" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="9S07l" id="stdmzxmerN" role="9Vyp8">
+      <node concept="3clFbS" id="stdmzxmerO" role="2VODD2">
+        <node concept="3clFbF" id="stdmzxmerU" role="3cqZAp">
+          <node concept="2OqwBi" id="stdmzxmerV" role="3clFbG">
+            <node concept="2OqwBi" id="stdmzxmerW" role="2Oq$k0">
+              <node concept="1PxgMI" id="stdmzxmerX" role="2Oq$k0">
+                <node concept="chp4Y" id="stdmzxmerY" role="3oSUPX">
+                  <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+                </node>
+                <node concept="nLn13" id="stdmzxmerZ" role="1m5AlR" />
+              </node>
+              <node concept="3TrEf2" id="stdmzxmes0" role="2OqNvi">
+                <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+              </node>
+            </node>
+            <node concept="1mIQ4w" id="stdmzxmes1" role="2OqNvi">
+              <node concept="chp4Y" id="stdmzxmes2" role="cj9EA">
+                <ref role="cht4Q" to="e9k1:cPLa7Fstqs" resolve="DataSelector" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
@@ -4,6 +4,7 @@
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="13" />
     <use id="7e450f4e-1ac3-41ef-a851-4598161bdb94" name="de.slisson.mps.tables" version="0" />
+    <use id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -13,6 +14,7 @@
     <import index="e9k1" ref="r:00903dee-f0b0-48de-9335-7cb3f90ae462(org.iets3.core.expr.data.structure)" implicit="true" />
     <import index="itrz" ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -22,10 +24,15 @@
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
+      <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
+        <reference id="1078939183255" name="editorComponent" index="PMmxG" />
+      </concept>
       <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
         <property id="1186414551515" name="flag" index="VOm3f" />
       </concept>
       <concept id="1186414928363" name="jetbrains.mps.lang.editor.structure.SelectableStyleSheetItem" flags="ln" index="VPM3Z" />
+      <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
+      <concept id="1233759184865" name="jetbrains.mps.lang.editor.structure.PunctuationRightStyleClassItem" flags="ln" index="11LMrY" />
       <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
         <child id="1088186146602" name="editorComponent" index="1sWHZn" />
       </concept>
@@ -123,6 +130,11 @@
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells">
+      <concept id="7363578995839203705" name="com.mbeddr.mpsutil.grammarcells.structure.FlagCell" flags="sg" stub="1984422498400729024" index="1kHk_G">
+        <property id="7617962380315063287" name="flagText" index="ZjSer" />
       </concept>
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
@@ -288,6 +300,11 @@
         </node>
         <node concept="3F0A7n" id="cPLa7FpjmS" role="3EZMnx">
           <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+        </node>
+        <node concept="1kHk_G" id="2SzGbCMIG4t" role="3EZMnx">
+          <property role="ZjSer" value="allows lookup" />
+          <ref role="1NtTu8" to="e9k1:2SzGbCMIroO" resolve="allowLookup" />
+          <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
         </node>
       </node>
       <node concept="2rfBfz" id="8XWEtdXA0W" role="3EZMnx">
@@ -781,6 +798,51 @@
           <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="stdmzxm7Yq">
+    <ref role="1XX52x" to="e9k1:stdmzxm7Y2" resolve="DataTableLookUp" />
+    <node concept="3EZMnI" id="stdmzxm7Ys" role="2wV5jI">
+      <node concept="PMmxH" id="stdmzxm7Yz" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      </node>
+      <node concept="3F0ifn" id="stdmzxm7YC" role="3EZMnx">
+        <property role="3F0ifm" value="&lt;" />
+        <node concept="11L4FC" id="stdmzxnarh" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="11LMrY" id="stdmzxnarm" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="1iCGBv" id="stdmzxm7YK" role="3EZMnx">
+        <ref role="1NtTu8" to="e9k1:stdmzxm7Y5" resolve="col" />
+        <node concept="1sVBvm" id="stdmzxm7YM" role="1sWHZn">
+          <node concept="3F0A7n" id="stdmzxm7YV" role="2wV5jI">
+            <property role="1Intyy" value="true" />
+            <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="stdmzxm7Z5" role="3EZMnx">
+        <property role="3F0ifm" value="&gt;(" />
+        <node concept="11L4FC" id="stdmzxnuUq" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="11LMrY" id="stdmzxnuUv" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F1sOY" id="stdmzxm7Zz" role="3EZMnx">
+        <ref role="1NtTu8" to="e9k1:stdmzxm7Y7" resolve="arg" />
+      </node>
+      <node concept="3F0ifn" id="stdmzxm7ZP" role="3EZMnx">
+        <property role="3F0ifm" value=")" />
+        <node concept="11L4FC" id="stdmzxnNpV" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="2iRfu4" id="stdmzxm7Yv" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.structure.mps
@@ -18,6 +18,7 @@
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
         <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
         <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
+        <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
       </concept>
       <concept id="1169127622168" name="jetbrains.mps.lang.structure.structure.InterfaceConceptReference" flags="ig" index="PrWs8">
         <reference id="1169127628841" name="intfc" index="PrY4T" />
@@ -25,6 +26,10 @@
       <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
         <reference id="1071489389519" name="extends" index="1TJDcQ" />
         <child id="1169129564478" name="implements" index="PzmwI" />
+      </concept>
+      <concept id="1071489288299" name="jetbrains.mps.lang.structure.structure.PropertyDeclaration" flags="ig" index="1TJgyi">
+        <property id="241647608299431129" name="propertyId" index="IQ2nx" />
+        <reference id="1082985295845" name="dataType" index="AX2Wp" />
       </concept>
       <concept id="1071489288298" name="jetbrains.mps.lang.structure.structure.LinkDeclaration" flags="ig" index="1TJgyj">
         <property id="1071599776563" name="role" index="20kJfa" />
@@ -45,6 +50,11 @@
     <property role="TrG5h" value="DataTable" />
     <property role="34LRSv" value="data" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyi" id="2SzGbCMIroO" role="1TKVEl">
+      <property role="IQ2nx" value="3324695263690995252" />
+      <property role="TrG5h" value="allowLookup" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
     <node concept="PrWs8" id="cPLa7Fp9qy" role="PzmwI">
       <ref role="PrY4T" to="yv47:2uR5X5ayM7T" resolve="IToplevelExprContent" />
     </node>
@@ -168,6 +178,28 @@
     <property role="EcuMT" value="231307155598768343" />
     <property role="TrG5h" value="DummyDataSelectorType" />
     <ref role="1TJDcQ" to="hm2y:6sdnDbSlaok" resolve="Type" />
+  </node>
+  <node concept="1TIwiD" id="stdmzxm7Y2">
+    <property role="EcuMT" value="512624657163648898" />
+    <property role="TrG5h" value="DataTableLookUp" />
+    <property role="34LRSv" value="lookUpBy" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="stdmzxm7Y7" role="1TKVEi">
+      <property role="IQ2ns" value="512624657163648903" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="arg" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="hm2y:6sdnDbSla17" resolve="Expression" />
+    </node>
+    <node concept="1TJgyj" id="stdmzxm7Y5" role="1TKVEi">
+      <property role="IQ2ns" value="512624657163648901" />
+      <property role="20kJfa" value="col" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="cPLa7FpaUQ" resolve="DataColDef" />
+    </node>
+    <node concept="PrWs8" id="stdmzxm7Y3" role="PzmwI">
+      <ref role="PrY4T" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
+    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.typesystem.mps
@@ -9,10 +9,15 @@
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="oq0c" ref="r:6c6155f0-4bbe-4af5-8c26-244d570e21e4(org.iets3.core.expr.base.plugin)" />
-    <import index="e9k1" ref="r:00903dee-f0b0-48de-9335-7cb3f90ae462(org.iets3.core.expr.data.structure)" implicit="true" />
+    <import index="e9k1" ref="r:00903dee-f0b0-48de-9335-7cb3f90ae462(org.iets3.core.expr.data.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -30,10 +35,21 @@
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
       <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
@@ -41,9 +57,17 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
@@ -81,9 +105,32 @@
         <child id="1175147624276" name="body" index="2sgrp5" />
       </concept>
       <concept id="1175147670730" name="jetbrains.mps.lang.typesystem.structure.SubtypingRule" flags="ig" index="2sgARr" />
+      <concept id="1224760201579" name="jetbrains.mps.lang.typesystem.structure.InfoStatement" flags="nn" index="Dpp1Q">
+        <child id="1224760230762" name="infoText" index="Dpw9R" />
+      </concept>
+      <concept id="1175517400280" name="jetbrains.mps.lang.typesystem.structure.AssertStatement" flags="nn" index="2Mj0R9">
+        <child id="1175517761460" name="condition" index="2MkoU_" />
+      </concept>
       <concept id="1175517767210" name="jetbrains.mps.lang.typesystem.structure.ReportErrorStatement" flags="nn" index="2MkqsV">
         <child id="1175517851849" name="errorString" index="2MkJ7o" />
       </concept>
+      <concept id="1179832490862" name="jetbrains.mps.lang.typesystem.structure.CreateStrongLessThanInequationStatement" flags="nn" index="2NvLDW" />
+      <concept id="1227096498176" name="jetbrains.mps.lang.typesystem.structure.PropertyMessageTarget" flags="ng" index="2ODE4t">
+        <reference id="1227096521710" name="propertyDeclaration" index="2ODJFN" />
+      </concept>
+      <concept id="1216383170661" name="jetbrains.mps.lang.typesystem.structure.TypesystemQuickFix" flags="ng" index="Q5z_Y">
+        <child id="1216383424566" name="executeBlock" index="Q6x$H" />
+        <child id="1216383476350" name="quickFixArgument" index="Q6Id_" />
+        <child id="1216391046856" name="descriptionBlock" index="QzAvj" />
+      </concept>
+      <concept id="1216383287005" name="jetbrains.mps.lang.typesystem.structure.QuickFixExecuteBlock" flags="in" index="Q5ZZ6" />
+      <concept id="1216383482742" name="jetbrains.mps.lang.typesystem.structure.QuickFixArgument" flags="ng" index="Q6JDH">
+        <child id="1216383511839" name="argumentType" index="Q6QK4" />
+      </concept>
+      <concept id="1216390348809" name="jetbrains.mps.lang.typesystem.structure.QuickFixArgumentReference" flags="nn" index="QwW4i">
+        <reference id="1216390348810" name="quickFixArgument" index="QwW4h" />
+      </concept>
+      <concept id="1216390987552" name="jetbrains.mps.lang.typesystem.structure.QuickFixDescriptionBlock" flags="in" index="QznSV" />
       <concept id="8124453027370845339" name="jetbrains.mps.lang.typesystem.structure.AbstractOverloadedOpsTypeRule" flags="ng" index="32tDTw">
         <child id="8124453027370845343" name="function" index="32tDT$" />
         <child id="8124453027370845341" name="operationConcept" index="32tDTA" />
@@ -104,7 +151,17 @@
         <child id="1236165725858" name="rule" index="3he0YX" />
       </concept>
       <concept id="3937244445246642777" name="jetbrains.mps.lang.typesystem.structure.AbstractReportStatement" flags="ng" index="1urrMJ">
+        <child id="3937244445246643443" name="messageTarget" index="1urrC5" />
+        <child id="3937244445246643221" name="helginsIntention" index="1urrFz" />
         <child id="3937244445246642781" name="nodeToReport" index="1urrMF" />
+      </concept>
+      <concept id="1210784285454" name="jetbrains.mps.lang.typesystem.structure.TypesystemIntention" flags="ng" index="3Cnw8n">
+        <reference id="1216388525179" name="quickFix" index="QpYPw" />
+        <child id="1210784493590" name="actualArgument" index="3Coj4f" />
+      </concept>
+      <concept id="1210784384552" name="jetbrains.mps.lang.typesystem.structure.TypesystemIntentionArgument" flags="ng" index="3CnSsL">
+        <reference id="1216386999476" name="quickFixArgument" index="QkamJ" />
+        <child id="1210784642750" name="value" index="3CoRuB" />
       </concept>
       <concept id="6136676636349908958" name="jetbrains.mps.lang.typesystem.structure.OverloadedOpIsApplicableFunction" flags="in" index="1QeDOX" />
       <concept id="1174642788531" name="jetbrains.mps.lang.typesystem.structure.ConceptReference" flags="ig" index="1YaCAy">
@@ -145,9 +202,14 @@
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
-      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
@@ -229,7 +291,31 @@
   </node>
   <node concept="18kY7G" id="cPLa7FrPeX">
     <property role="TrG5h" value="check_DataTable" />
-    <node concept="3clFbS" id="cPLa7FrPeY" role="18ibNy" />
+    <node concept="3clFbS" id="cPLa7FrPeY" role="18ibNy">
+      <node concept="3clFbJ" id="2SzGbCMNMJX" role="3cqZAp">
+        <node concept="2OqwBi" id="2SzGbCMNN2U" role="3clFbw">
+          <node concept="1YBJjd" id="2SzGbCMNMK9" role="2Oq$k0">
+            <ref role="1YBMHb" node="cPLa7FrPf0" resolve="dataTable" />
+          </node>
+          <node concept="3TrcHB" id="2SzGbCMNNxF" role="2OqNvi">
+            <ref role="3TsBF5" to="e9k1:2SzGbCMIroO" resolve="allowLookup" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="2SzGbCMNMJZ" role="3clFbx">
+          <node concept="Dpp1Q" id="2SzGbCMNN_x" role="3cqZAp">
+            <node concept="Xl_RD" id="2SzGbCMNN_N" role="Dpw9R">
+              <property role="Xl_RC" value="No static check applied, make sure each value in a column is unique to avoid undefined behavior" />
+            </node>
+            <node concept="1YBJjd" id="2SzGbCMNNFV" role="1urrMF">
+              <ref role="1YBMHb" node="cPLa7FrPf0" resolve="dataTable" />
+            </node>
+            <node concept="2ODE4t" id="2SzGbCMNNGM" role="1urrC5">
+              <ref role="2ODJFN" to="e9k1:2SzGbCMIroO" resolve="allowLookup" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="1YaCAy" id="cPLa7FrPf0" role="1YuTPh">
       <property role="TrG5h" value="dataTable" />
       <ref role="1YaFvo" to="e9k1:cPLa7Fp8FI" resolve="DataTable" />
@@ -480,6 +566,214 @@
     <node concept="1YaCAy" id="66pf9vFaGEP" role="1YuTPh">
       <property role="TrG5h" value="dtt" />
       <ref role="1YaFvo" to="e9k1:cPLa7Fs1v4" resolve="DataTableType" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="stdmzxmgmi">
+    <property role="TrG5h" value="typeof_DataTableLookUp" />
+    <node concept="3clFbS" id="stdmzxmgmj" role="18ibNy">
+      <node concept="1Z5TYs" id="stdmzxmgmp" role="3cqZAp">
+        <node concept="mw_s8" id="stdmzxmgmq" role="1ZfhK$">
+          <node concept="1Z2H0r" id="stdmzxmgmr" role="mwGJk">
+            <node concept="1YBJjd" id="stdmzxmg$D" role="1Z2MuG">
+              <ref role="1YBMHb" node="stdmzxmgml" resolve="dataTableLookUp" />
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="stdmzxmgmt" role="1ZfhKB">
+          <node concept="2YIFZM" id="stdmzxmgmu" role="mwGJk">
+            <ref role="37wK5l" to="oq0c:4$QBvTqTZCM" resolve="override" />
+            <ref role="1Pybhc" to="oq0c:4$QBvTqTPch" resolve="TOF" />
+            <node concept="1YBJjd" id="stdmzxmgHP" role="37wK5m">
+              <ref role="1YBMHb" node="stdmzxmgml" resolve="dataTableLookUp" />
+            </node>
+            <node concept="2pJPEk" id="stdmzxmgmw" role="37wK5m">
+              <node concept="2pJPED" id="stdmzxotTZ" role="2pJPEn">
+                <ref role="2pJxaS" to="hm2y:2rOWEwsEjcg" resolve="OptionType" />
+                <node concept="2pIpSj" id="stdmzxotXA" role="2pJxcM">
+                  <ref role="2pIpSl" to="hm2y:2rOWEwsEjch" resolve="baseType" />
+                  <node concept="2pJPED" id="stdmzxmgmx" role="28nt2d">
+                    <ref role="2pJxaS" to="e9k1:cPLa7Fs1v4" resolve="DataTableType" />
+                    <node concept="2pIpSj" id="stdmzxmgmy" role="2pJxcM">
+                      <ref role="2pIpSl" to="e9k1:cPLa7Fs1QU" resolve="table" />
+                      <node concept="36biLy" id="stdmzxmgmz" role="28nt2d">
+                        <node concept="1PxgMI" id="stdmzxmgm$" role="36biLW">
+                          <node concept="chp4Y" id="stdmzxmgm_" role="3oSUPX">
+                            <ref role="cht4Q" to="e9k1:cPLa7Fp8FI" resolve="DataTable" />
+                          </node>
+                          <node concept="2OqwBi" id="stdmzxmgmA" role="1m5AlR">
+                            <node concept="2OqwBi" id="stdmzxmgmB" role="2Oq$k0">
+                              <node concept="1YBJjd" id="stdmzxmgJa" role="2Oq$k0">
+                                <ref role="1YBMHb" node="stdmzxmgml" resolve="dataTableLookUp" />
+                              </node>
+                              <node concept="3TrEf2" id="stdmzxmh4O" role="2OqNvi">
+                                <ref role="3Tt5mk" to="e9k1:stdmzxm7Y5" resolve="col" />
+                              </node>
+                            </node>
+                            <node concept="1mfA1w" id="stdmzxmgmE" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="2SzGbCMNHiI" role="3cqZAp" />
+      <node concept="2NvLDW" id="2SzGbCMNHZs" role="3cqZAp">
+        <node concept="mw_s8" id="2SzGbCMNI69" role="1ZfhKB">
+          <node concept="1Z2H0r" id="2SzGbCMNI65" role="mwGJk">
+            <node concept="2OqwBi" id="2SzGbCMNIW0" role="1Z2MuG">
+              <node concept="2OqwBi" id="2SzGbCMNIfT" role="2Oq$k0">
+                <node concept="1YBJjd" id="2SzGbCMNI6q" role="2Oq$k0">
+                  <ref role="1YBMHb" node="stdmzxmgml" resolve="dataTableLookUp" />
+                </node>
+                <node concept="3TrEf2" id="2SzGbCMNItx" role="2OqNvi">
+                  <ref role="3Tt5mk" to="e9k1:stdmzxm7Y5" resolve="col" />
+                </node>
+              </node>
+              <node concept="3TrEf2" id="2SzGbCMNJdr" role="2OqNvi">
+                <ref role="3Tt5mk" to="e9k1:cPLa7FpbAi" resolve="type" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="2SzGbCMNHZv" role="1ZfhK$">
+          <node concept="1Z2H0r" id="2SzGbCMNHl9" role="mwGJk">
+            <node concept="2OqwBi" id="2SzGbCMNHym" role="1Z2MuG">
+              <node concept="1YBJjd" id="2SzGbCMNHoo" role="2Oq$k0">
+                <ref role="1YBMHb" node="stdmzxmgml" resolve="dataTableLookUp" />
+              </node>
+              <node concept="3TrEf2" id="2SzGbCMNHP8" role="2OqNvi">
+                <ref role="3Tt5mk" to="e9k1:stdmzxm7Y7" resolve="arg" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="stdmzxmgml" role="1YuTPh">
+      <property role="TrG5h" value="dataTableLookUp" />
+      <ref role="1YaFvo" to="e9k1:stdmzxm7Y2" resolve="DataTableLookUp" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="2SzGbCMLSpP">
+    <property role="TrG5h" value="check_DataTableLookUp" />
+    <node concept="3clFbS" id="2SzGbCMLSpQ" role="18ibNy">
+      <node concept="3cpWs8" id="2SzGbCMN8yu" role="3cqZAp">
+        <node concept="3cpWsn" id="2SzGbCMN8yv" role="3cpWs9">
+          <property role="TrG5h" value="table" />
+          <node concept="3Tqbb2" id="2SzGbCMN8uj" role="1tU5fm">
+            <ref role="ehGHo" to="e9k1:cPLa7Fp8FI" resolve="DataTable" />
+          </node>
+          <node concept="2OqwBi" id="2SzGbCMN8yw" role="33vP2m">
+            <node concept="1PxgMI" id="2SzGbCMN8yx" role="2Oq$k0">
+              <property role="1BlNFB" value="true" />
+              <node concept="chp4Y" id="2SzGbCMN8yy" role="3oSUPX">
+                <ref role="cht4Q" to="e9k1:cPLa7Fstqs" resolve="DataSelector" />
+              </node>
+              <node concept="2OqwBi" id="2SzGbCMN8yz" role="1m5AlR">
+                <node concept="1PxgMI" id="2SzGbCMN8y$" role="2Oq$k0">
+                  <property role="1BlNFB" value="true" />
+                  <node concept="chp4Y" id="2SzGbCMN8y_" role="3oSUPX">
+                    <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+                  </node>
+                  <node concept="2OqwBi" id="2SzGbCMN8yA" role="1m5AlR">
+                    <node concept="1YBJjd" id="2SzGbCMN8yB" role="2Oq$k0">
+                      <ref role="1YBMHb" node="2SzGbCMLSpS" resolve="dataTableLookUp" />
+                    </node>
+                    <node concept="1mfA1w" id="2SzGbCMN8yC" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="3TrEf2" id="2SzGbCMN8yD" role="2OqNvi">
+                  <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                </node>
+              </node>
+            </node>
+            <node concept="3TrEf2" id="2SzGbCMN8yE" role="2OqNvi">
+              <ref role="3Tt5mk" to="e9k1:cPLa7FstD4" resolve="table" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2Mj0R9" id="2SzGbCMLSq3" role="3cqZAp">
+        <node concept="2OqwBi" id="2SzGbCMLVuy" role="2MkoU_">
+          <node concept="37vLTw" id="2SzGbCMN8yF" role="2Oq$k0">
+            <ref role="3cqZAo" node="2SzGbCMN8yv" resolve="table" />
+          </node>
+          <node concept="3TrcHB" id="2SzGbCMLVVP" role="2OqNvi">
+            <ref role="3TsBF5" to="e9k1:2SzGbCMIroO" resolve="allowLookup" />
+          </node>
+        </node>
+        <node concept="Xl_RD" id="2SzGbCMLVZH" role="2MkJ7o">
+          <property role="Xl_RC" value="Data Table doesn't allow look ups." />
+        </node>
+        <node concept="1YBJjd" id="2SzGbCMLXsI" role="1urrMF">
+          <ref role="1YBMHb" node="2SzGbCMLSpS" resolve="dataTableLookUp" />
+        </node>
+        <node concept="3Cnw8n" id="2SzGbCMM1bU" role="1urrFz">
+          <ref role="QpYPw" node="2SzGbCMLX$N" resolve="addLookup" />
+          <node concept="3CnSsL" id="2SzGbCMM1nU" role="3Coj4f">
+            <ref role="QkamJ" node="2SzGbCMLXDI" resolve="table" />
+            <node concept="37vLTw" id="2SzGbCMN8_p" role="3CoRuB">
+              <ref role="3cqZAo" node="2SzGbCMN8yv" resolve="table" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="2SzGbCMLSpS" role="1YuTPh">
+      <property role="TrG5h" value="dataTableLookUp" />
+      <ref role="1YaFvo" to="e9k1:stdmzxm7Y2" resolve="DataTableLookUp" />
+    </node>
+  </node>
+  <node concept="Q5z_Y" id="2SzGbCMLX$N">
+    <property role="TrG5h" value="addLookup" />
+    <node concept="Q6JDH" id="2SzGbCMLXDI" role="Q6Id_">
+      <property role="TrG5h" value="table" />
+      <node concept="3Tqbb2" id="2SzGbCMLXDQ" role="Q6QK4">
+        <ref role="ehGHo" to="e9k1:cPLa7Fp8FI" resolve="DataTable" />
+      </node>
+    </node>
+    <node concept="Q5ZZ6" id="2SzGbCMLX$O" role="Q6x$H">
+      <node concept="3clFbS" id="2SzGbCMLX$P" role="2VODD2">
+        <node concept="3clFbF" id="2SzGbCMLZYW" role="3cqZAp">
+          <node concept="37vLTI" id="2SzGbCMM0Yd" role="3clFbG">
+            <node concept="3clFbT" id="2SzGbCMM17w" role="37vLTx">
+              <property role="3clFbU" value="true" />
+            </node>
+            <node concept="2OqwBi" id="2SzGbCMLZZS" role="37vLTJ">
+              <node concept="QwW4i" id="2SzGbCMLZYV" role="2Oq$k0">
+                <ref role="QwW4h" node="2SzGbCMLXDI" resolve="table" />
+              </node>
+              <node concept="3TrcHB" id="2SzGbCMM0Fz" role="2OqNvi">
+                <ref role="3TsBF5" to="e9k1:2SzGbCMIroO" resolve="allowLookup" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="QznSV" id="2SzGbCMLX_8" role="QzAvj">
+      <node concept="3clFbS" id="2SzGbCMLX_9" role="2VODD2">
+        <node concept="3clFbF" id="2SzGbCMLXE0" role="3cqZAp">
+          <node concept="3cpWs3" id="2SzGbCMLYV2" role="3clFbG">
+            <node concept="2OqwBi" id="2SzGbCMLZn8" role="3uHU7w">
+              <node concept="QwW4i" id="2SzGbCMLYVC" role="2Oq$k0">
+                <ref role="QwW4h" node="2SzGbCMLXDI" resolve="table" />
+              </node>
+              <node concept="3TrcHB" id="2SzGbCMLZQe" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+            <node concept="Xl_RD" id="2SzGbCMLXDZ" role="3uHU7B">
+              <property role="Xl_RC" value="Enable look ups on " />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.typesystem.mps
@@ -18,6 +18,7 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -81,6 +82,12 @@
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
     </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
         <reference id="5455284157994012188" name="link" index="2pIpSl" />
@@ -105,9 +112,6 @@
         <child id="1175147624276" name="body" index="2sgrp5" />
       </concept>
       <concept id="1175147670730" name="jetbrains.mps.lang.typesystem.structure.SubtypingRule" flags="ig" index="2sgARr" />
-      <concept id="1224760201579" name="jetbrains.mps.lang.typesystem.structure.InfoStatement" flags="nn" index="Dpp1Q">
-        <child id="1224760230762" name="infoText" index="Dpw9R" />
-      </concept>
       <concept id="1175517400280" name="jetbrains.mps.lang.typesystem.structure.AssertStatement" flags="nn" index="2Mj0R9">
         <child id="1175517761460" name="condition" index="2MkoU_" />
       </concept>
@@ -115,9 +119,6 @@
         <child id="1175517851849" name="errorString" index="2MkJ7o" />
       </concept>
       <concept id="1179832490862" name="jetbrains.mps.lang.typesystem.structure.CreateStrongLessThanInequationStatement" flags="nn" index="2NvLDW" />
-      <concept id="1227096498176" name="jetbrains.mps.lang.typesystem.structure.PropertyMessageTarget" flags="ng" index="2ODE4t">
-        <reference id="1227096521710" name="propertyDeclaration" index="2ODJFN" />
-      </concept>
       <concept id="1216383170661" name="jetbrains.mps.lang.typesystem.structure.TypesystemQuickFix" flags="ng" index="Q5z_Y">
         <child id="1216383424566" name="executeBlock" index="Q6x$H" />
         <child id="1216383476350" name="quickFixArgument" index="Q6Id_" />
@@ -151,7 +152,6 @@
         <child id="1236165725858" name="rule" index="3he0YX" />
       </concept>
       <concept id="3937244445246642777" name="jetbrains.mps.lang.typesystem.structure.AbstractReportStatement" flags="ng" index="1urrMJ">
-        <child id="3937244445246643443" name="messageTarget" index="1urrC5" />
         <child id="3937244445246643221" name="helginsIntention" index="1urrFz" />
         <child id="3937244445246642781" name="nodeToReport" index="1urrMF" />
       </concept>
@@ -192,6 +192,9 @@
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
+      <concept id="3562215692195599741" name="jetbrains.mps.lang.smodel.structure.SLinkImplicitSelect" flags="nn" index="13MTOL">
+        <reference id="3562215692195600259" name="link" index="13MTZf" />
+      </concept>
       <concept id="1154546950173" name="jetbrains.mps.lang.smodel.structure.ConceptReference" flags="ng" index="3gn64h">
         <reference id="1154546997487" name="concept" index="3gnhBz" />
       </concept>
@@ -214,6 +217,9 @@
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -222,6 +228,13 @@
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
     </language>
   </registry>
   <node concept="1YbPZF" id="cPLa7Fper3">
@@ -302,15 +315,59 @@
           </node>
         </node>
         <node concept="3clFbS" id="2SzGbCMNMJZ" role="3clFbx">
-          <node concept="Dpp1Q" id="2SzGbCMNN_x" role="3cqZAp">
-            <node concept="Xl_RD" id="2SzGbCMNN_N" role="Dpw9R">
-              <property role="Xl_RC" value="No static check applied, make sure each value in a column is unique to avoid undefined behavior" />
-            </node>
-            <node concept="1YBJjd" id="2SzGbCMNNFV" role="1urrMF">
-              <ref role="1YBMHb" node="cPLa7FrPf0" resolve="dataTable" />
-            </node>
-            <node concept="2ODE4t" id="2SzGbCMNNGM" role="1urrC5">
-              <ref role="2ODJFN" to="e9k1:2SzGbCMIroO" resolve="allowLookup" />
+          <node concept="3clFbF" id="4PRpvcZvt4$" role="3cqZAp">
+            <node concept="2OqwBi" id="4PRpvcZvB8E" role="3clFbG">
+              <node concept="2OqwBi" id="4PRpvcZv$Hq" role="2Oq$k0">
+                <node concept="2OqwBi" id="4PRpvcZvtk7" role="2Oq$k0">
+                  <node concept="1YBJjd" id="4PRpvcZvt4z" role="2Oq$k0">
+                    <ref role="1YBMHb" node="cPLa7FrPf0" resolve="dataTable" />
+                  </node>
+                  <node concept="3Tsc0h" id="4PRpvcZvyFn" role="2OqNvi">
+                    <ref role="3TtcxE" to="e9k1:cPLa7FpRVO" resolve="rows" />
+                  </node>
+                </node>
+                <node concept="13MTOL" id="4PRpvcZvA$E" role="2OqNvi">
+                  <ref role="13MTZf" to="e9k1:cPLa7FpcRm" resolve="cells" />
+                </node>
+              </node>
+              <node concept="2es0OD" id="4PRpvcZvBh8" role="2OqNvi">
+                <node concept="1bVj0M" id="4PRpvcZvBha" role="23t8la">
+                  <node concept="3clFbS" id="4PRpvcZvBhb" role="1bW5cS">
+                    <node concept="2Mj0R9" id="4PRpvcZvBk8" role="3cqZAp">
+                      <node concept="2OqwBi" id="4PRpvcZvBVD" role="2MkoU_">
+                        <node concept="2OqwBi" id="4PRpvcZvBxb" role="2Oq$k0">
+                          <node concept="37vLTw" id="4PRpvcZvBlZ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4PRpvcZvBhc" resolve="it" />
+                          </node>
+                          <node concept="3TrEf2" id="4PRpvcZvBFF" role="2OqNvi">
+                            <ref role="3Tt5mk" to="e9k1:cPLa7Fpe9f" resolve="value" />
+                          </node>
+                        </node>
+                        <node concept="1mIQ4w" id="4PRpvcZvCdD" role="2OqNvi">
+                          <node concept="chp4Y" id="4PRpvcZvChV" role="cj9EA">
+                            <ref role="cht4Q" to="hm2y:6JZACDWQJu4" resolve="ILiteral" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Xl_RD" id="4PRpvcZvCrf" role="2MkJ7o">
+                        <property role="Xl_RC" value="Only literals are allowed in data tables that support look ups" />
+                      </node>
+                      <node concept="2OqwBi" id="4PRpvcZw7qS" role="1urrMF">
+                        <node concept="37vLTw" id="4PRpvcZvD72" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4PRpvcZvBhc" resolve="it" />
+                        </node>
+                        <node concept="3TrEf2" id="4PRpvcZw7_B" role="2OqNvi">
+                          <ref role="3Tt5mk" to="e9k1:cPLa7Fpe9f" resolve="value" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="4PRpvcZvBhc" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="4PRpvcZvBhd" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/org.iets3.core.expr.data.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/org.iets3.core.expr.data.mpl
@@ -98,6 +98,8 @@
     <dependency reexport="false">d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)</dependency>
   </dependencies>
   <languageVersions>
+    <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="0" />
+    <language slang="l:b4f35ed8-45af-4efa-abe4-00ac26956e69:com.mbeddr.mpsutil.grammarcells.runtimelang" version="0" />
     <language slang="l:7e450f4e-1ac3-41ef-a851-4598161bdb94:de.slisson.mps.tables" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="9" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.data.interpreter/models/org.iets3.core.expr.data.interpreter.plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.data.interpreter/models/org.iets3.core.expr.data.interpreter.plugin.mps
@@ -4,13 +4,28 @@
   <languages>
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
     <use id="47f075a6-558e-4640-a606-7ce0236c8023" name="com.mbeddr.mpsutil.interpreter" version="1" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="e9k1" ref="r:00903dee-f0b0-48de-9335-7cb3f90ae462(org.iets3.core.expr.data.structure)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
+    <import index="xk6s" ref="r:7961970e-5737-42e2-b144-9bef3ad8d077(org.iets3.core.expr.tests.behavior)" />
+    <import index="dj6k" ref="r:59d52af6-663b-49dc-8980-30d79b8dffa1(org.iets3.core.expr.simpleTypes.runtime)" />
   </imports>
   <registry>
+    <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
+      <concept id="1238852151516" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleType" flags="in" index="1LlUBW">
+        <child id="1238852204892" name="componentType" index="1Lm7xW" />
+      </concept>
+      <concept id="1238853782547" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleLiteral" flags="nn" index="1Ls8ON">
+        <child id="1238853845806" name="component" index="1Lso8e" />
+      </concept>
+      <concept id="1238857743184" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleMemberAccessExpression" flags="nn" index="1LFfDK">
+        <child id="1238857764950" name="tuple" index="1LFl5Q" />
+        <child id="1238857834412" name="index" index="1LF_Uc" />
+      </concept>
+    </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
@@ -19,6 +34,9 @@
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
         <child id="1081256993305" name="classType" index="2ZW6by" />
@@ -35,6 +53,7 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -49,6 +68,9 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -58,6 +80,7 @@
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
@@ -66,6 +89,7 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
     </language>
     <language id="47f075a6-558e-4640-a606-7ce0236c8023" name="com.mbeddr.mpsutil.interpreter">
       <concept id="5293529713177831489" name="com.mbeddr.mpsutil.interpreter.structure.NodeExpression" flags="ng" index="oxGPV" />
@@ -77,6 +101,7 @@
       <concept id="8615074351687301435" name="com.mbeddr.mpsutil.interpreter.structure.ConceptEvaluator" flags="ng" index="qq9P1">
         <reference id="8615074351687302216" name="concept" index="qq9wM" />
       </concept>
+      <concept id="5293529713180742448" name="com.mbeddr.mpsutil.interpreter.structure.InterpretConstraintExpression" flags="ng" index="rqRoa" />
       <concept id="3406009787378976616" name="com.mbeddr.mpsutil.interpreter.structure.EnvExpression" flags="ng" index="TvHiN" />
       <concept id="5712773029518214110" name="com.mbeddr.mpsutil.interpreter.structure.ConceptEvaluatorBody" flags="ng" index="3dA_Gj">
         <child id="5934114435582613364" name="body" index="3vcmbn" />
@@ -90,6 +115,9 @@
       </concept>
       <concept id="8511326569641889031" name="com.mbeddr.mpsutil.interpreter.structure.AbstractRecursionExpression" flags="ng" index="3SLKdG">
         <child id="8511326569641873009" name="node" index="3SLO0q" />
+      </concept>
+      <concept id="8511326569641917307" name="com.mbeddr.mpsutil.interpreter.structure.AbstractConstraintRecursionExpression" flags="ng" index="3SLZkg">
+        <reference id="5293529713180742449" name="child" index="rqRob" />
       </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
@@ -121,6 +149,7 @@
       </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
         <child id="1197932505799" name="map" index="3ElQJh" />
         <child id="1197932525128" name="key" index="3ElVtu" />
@@ -249,6 +278,226 @@
             </node>
             <node concept="3cpWs6" id="cPLa7FuuOK" role="3cqZAp">
               <node concept="10Nm6u" id="cPLa7Fuv76" role="3cqZAk" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="qq9P1" id="stdmzxodfo" role="qq9xR">
+      <property role="2TnfIJ" value="true" />
+      <ref role="qq9wM" to="e9k1:stdmzxm7Y2" resolve="DataTableLookUp" />
+      <node concept="3dA_Gj" id="stdmzxodkJ" role="3vQZUl">
+        <node concept="9aQIb" id="stdmzxodkL" role="3vcmbn">
+          <node concept="3clFbS" id="stdmzxodkN" role="9aQI4">
+            <node concept="9aQIb" id="stdmzxodl0" role="3cqZAp">
+              <node concept="3clFbS" id="stdmzxodl1" role="9aQI4">
+                <node concept="3cpWs8" id="stdmzxodl2" role="3cqZAp">
+                  <node concept="3cpWsn" id="stdmzxodl3" role="3cpWs9">
+                    <property role="TrG5h" value="ctx" />
+                    <node concept="3uibUv" id="stdmzxodl4" role="1tU5fm">
+                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                    </node>
+                    <node concept="3EllGN" id="stdmzxodl5" role="33vP2m">
+                      <node concept="2OqwBi" id="stdmzxodl6" role="3ElVtu">
+                        <node concept="oxGPV" id="stdmzxodl7" role="2Oq$k0" />
+                        <node concept="2qgKlT" id="stdmzxodl8" role="2OqNvi">
+                          <ref role="37wK5l" to="pbu6:6zmBjqUivyF" resolve="contextExpression" />
+                        </node>
+                      </node>
+                      <node concept="TvHiN" id="stdmzxodl9" role="3ElQJh" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="stdmzxodla" role="3cqZAp">
+                  <node concept="3clFbS" id="stdmzxodlb" role="3clFbx">
+                    <node concept="3cpWs8" id="stdmzxpVy0" role="3cqZAp">
+                      <node concept="3cpWsn" id="stdmzxpVy1" role="3cpWs9">
+                        <property role="TrG5h" value="searchValue" />
+                        <node concept="3uibUv" id="stdmzxpVxZ" role="1tU5fm">
+                          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                        </node>
+                        <node concept="rqRoa" id="stdmzxpVy2" role="33vP2m">
+                          <ref role="rqRob" to="e9k1:stdmzxm7Y7" resolve="arg" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="stdmzxodlc" role="3cqZAp">
+                      <node concept="3cpWsn" id="stdmzxodld" role="3cpWs9">
+                        <property role="TrG5h" value="s" />
+                        <node concept="3Tqbb2" id="stdmzxodle" role="1tU5fm">
+                          <ref role="ehGHo" to="e9k1:cPLa7Fstqs" resolve="DataSelector" />
+                        </node>
+                        <node concept="10QFUN" id="stdmzxodlf" role="33vP2m">
+                          <node concept="37vLTw" id="stdmzxodlg" role="10QFUP">
+                            <ref role="3cqZAo" node="stdmzxodl3" resolve="ctx" />
+                          </node>
+                          <node concept="3Tqbb2" id="stdmzxodlh" role="10QFUM">
+                            <ref role="ehGHo" to="e9k1:cPLa7Fstqs" resolve="DataSelector" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="stdmzxpIwy" role="3cqZAp">
+                      <node concept="2OqwBi" id="stdmzxpIDK" role="3clFbG">
+                        <node concept="oxGPV" id="stdmzxpIww" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="stdmzxpJ4c" role="2OqNvi">
+                          <ref role="3Tt5mk" to="e9k1:stdmzxm7Y5" resolve="col" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="stdmzxqE5Q" role="3cqZAp">
+                      <node concept="3cpWsn" id="stdmzxqE5R" role="3cpWs9">
+                        <property role="TrG5h" value="found" />
+                        <node concept="1LlUBW" id="stdmzxqE2F" role="1tU5fm">
+                          <node concept="3Tqbb2" id="stdmzxqE2L" role="1Lm7xW">
+                            <ref role="ehGHo" to="e9k1:cPLa7Fpiy9" resolve="DataRow" />
+                          </node>
+                          <node concept="3Tqbb2" id="stdmzxqE2K" role="1Lm7xW">
+                            <ref role="ehGHo" to="e9k1:cPLa7FpcCS" resolve="DataCell" />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="stdmzxqE5S" role="33vP2m">
+                          <node concept="2OqwBi" id="stdmzxqE5T" role="2Oq$k0">
+                            <node concept="2OqwBi" id="stdmzxqE5U" role="2Oq$k0">
+                              <node concept="2OqwBi" id="stdmzxqE5V" role="2Oq$k0">
+                                <node concept="37vLTw" id="stdmzxqE5W" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="stdmzxodld" resolve="s" />
+                                </node>
+                                <node concept="3TrEf2" id="stdmzxqE5X" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="e9k1:cPLa7FstD4" resolve="table" />
+                                </node>
+                              </node>
+                              <node concept="3Tsc0h" id="stdmzxqE5Y" role="2OqNvi">
+                                <ref role="3TtcxE" to="e9k1:cPLa7FpRVO" resolve="rows" />
+                              </node>
+                            </node>
+                            <node concept="3$u5V9" id="stdmzxqE5Z" role="2OqNvi">
+                              <node concept="1bVj0M" id="stdmzxqE60" role="23t8la">
+                                <node concept="3clFbS" id="stdmzxqE61" role="1bW5cS">
+                                  <node concept="3clFbF" id="stdmzxqE62" role="3cqZAp">
+                                    <node concept="1Ls8ON" id="stdmzxqE63" role="3clFbG">
+                                      <node concept="37vLTw" id="stdmzxqE64" role="1Lso8e">
+                                        <ref role="3cqZAo" node="stdmzxqE6m" resolve="it" />
+                                      </node>
+                                      <node concept="2OqwBi" id="stdmzxqE65" role="1Lso8e">
+                                        <node concept="2OqwBi" id="stdmzxqE66" role="2Oq$k0">
+                                          <node concept="37vLTw" id="stdmzxqE67" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="stdmzxqE6m" resolve="it" />
+                                          </node>
+                                          <node concept="3Tsc0h" id="stdmzxqE68" role="2OqNvi">
+                                            <ref role="3TtcxE" to="e9k1:cPLa7FpcRm" resolve="cells" />
+                                          </node>
+                                        </node>
+                                        <node concept="1z4cxt" id="stdmzxqE69" role="2OqNvi">
+                                          <node concept="1bVj0M" id="stdmzxqE6a" role="23t8la">
+                                            <node concept="3clFbS" id="stdmzxqE6b" role="1bW5cS">
+                                              <node concept="3clFbF" id="stdmzxqE6c" role="3cqZAp">
+                                                <node concept="17R0WA" id="stdmzxqE6d" role="3clFbG">
+                                                  <node concept="2OqwBi" id="stdmzxqE6e" role="3uHU7w">
+                                                    <node concept="oxGPV" id="stdmzxqE6f" role="2Oq$k0" />
+                                                    <node concept="3TrEf2" id="stdmzxqE6g" role="2OqNvi">
+                                                      <ref role="3Tt5mk" to="e9k1:stdmzxm7Y5" resolve="col" />
+                                                    </node>
+                                                  </node>
+                                                  <node concept="2OqwBi" id="stdmzxqE6h" role="3uHU7B">
+                                                    <node concept="37vLTw" id="stdmzxqE6i" role="2Oq$k0">
+                                                      <ref role="3cqZAo" node="stdmzxqE6k" resolve="it" />
+                                                    </node>
+                                                    <node concept="3TrEf2" id="stdmzxqE6j" role="2OqNvi">
+                                                      <ref role="3Tt5mk" to="e9k1:cPLa7FpdsY" resolve="col" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="Rh6nW" id="stdmzxqE6k" role="1bW2Oz">
+                                              <property role="TrG5h" value="it" />
+                                              <node concept="2jxLKc" id="stdmzxqE6l" role="1tU5fm" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="Rh6nW" id="stdmzxqE6m" role="1bW2Oz">
+                                  <property role="TrG5h" value="it" />
+                                  <node concept="2jxLKc" id="stdmzxqE6n" role="1tU5fm" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="1z4cxt" id="stdmzxqE6o" role="2OqNvi">
+                            <node concept="1bVj0M" id="stdmzxqE6p" role="23t8la">
+                              <node concept="3clFbS" id="stdmzxqE6q" role="1bW5cS">
+                                <node concept="3clFbF" id="stdmzxqE6r" role="3cqZAp">
+                                  <node concept="2YIFZM" id="stdmzxqE6s" role="3clFbG">
+                                    <ref role="37wK5l" to="dj6k:VFjlN6eV5u" resolve="eq" />
+                                    <ref role="1Pybhc" to="dj6k:VFjlN6eQjY" resolve="ComparisonHelper" />
+                                    <node concept="qpA2v" id="stdmzxqE6t" role="37wK5m">
+                                      <node concept="2OqwBi" id="stdmzxqE6u" role="3SLO0q">
+                                        <node concept="1LFfDK" id="stdmzxqE6v" role="2Oq$k0">
+                                          <node concept="3cmrfG" id="stdmzxqE6w" role="1LF_Uc">
+                                            <property role="3cmrfH" value="1" />
+                                          </node>
+                                          <node concept="37vLTw" id="stdmzxqE6x" role="1LFl5Q">
+                                            <ref role="3cqZAo" node="stdmzxqE6$" resolve="it" />
+                                          </node>
+                                        </node>
+                                        <node concept="3TrEf2" id="stdmzxqE6y" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="e9k1:cPLa7Fpe9f" resolve="value" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="37vLTw" id="stdmzxqE6z" role="37wK5m">
+                                      <ref role="3cqZAo" node="stdmzxpVy1" resolve="searchValue" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="Rh6nW" id="stdmzxqE6$" role="1bW2Oz">
+                                <property role="TrG5h" value="it" />
+                                <node concept="2jxLKc" id="stdmzxqE6_" role="1tU5fm" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="stdmzxqERV" role="3cqZAp">
+                      <node concept="3clFbS" id="stdmzxqERX" role="3clFbx">
+                        <node concept="3cpWs6" id="stdmzxq5uX" role="3cqZAp">
+                          <node concept="1LFfDK" id="stdmzxqBUX" role="3cqZAk">
+                            <node concept="3cmrfG" id="stdmzxqC7t" role="1LF_Uc">
+                              <property role="3cmrfH" value="0" />
+                            </node>
+                            <node concept="37vLTw" id="stdmzxqE6A" role="1LFl5Q">
+                              <ref role="3cqZAo" node="stdmzxqE5R" resolve="found" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3y3z36" id="stdmzxqFM5" role="3clFbw">
+                        <node concept="10Nm6u" id="stdmzxqGd3" role="3uHU7w" />
+                        <node concept="37vLTw" id="stdmzxqF4w" role="3uHU7B">
+                          <ref role="3cqZAo" node="stdmzxqE5R" resolve="found" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2ZW3vV" id="stdmzxodlB" role="3clFbw">
+                    <node concept="3Tqbb2" id="stdmzxodlC" role="2ZW6by">
+                      <ref role="ehGHo" to="e9k1:cPLa7Fstqs" resolve="DataSelector" />
+                    </node>
+                    <node concept="37vLTw" id="stdmzxodlD" role="2ZW6bz">
+                      <ref role="3cqZAo" node="stdmzxodl3" resolve="ctx" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="stdmzxodlE" role="3cqZAp">
+                  <node concept="10Nm6u" id="stdmzxodlF" role="3cqZAk" />
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.data.interpreter/org.iets3.core.expr.data.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.data.interpreter/org.iets3.core.expr.data.interpreter.msd
@@ -15,15 +15,22 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">b25b8ad1-4d3d-4e45-8c78-72091b39fdda(org.iets3.core.expr.data)</dependency>
     <dependency reexport="false">cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</dependency>
+    <dependency reexport="false">d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)</dependency>
+    <dependency reexport="false">52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:47f075a6-558e-4640-a606-7ce0236c8023:com.mbeddr.mpsutil.interpreter" version="1" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="9" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="4" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="17" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
@@ -39,6 +46,7 @@
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
     <module reference="47f075a6-558e-4640-a606-7ce0236c8023(com.mbeddr.mpsutil.interpreter)" version="0" />
     <module reference="735f86bc-17fb-4d1c-a664-82c2b8e8a34e(com.mbeddr.mpsutil.interpreter.rt)" version="0" />
+    <module reference="1c897ba5-9d43-4035-ac7f-0306495743ac(com.mbeddr.mpsutil.interpreter.test)" version="0" />
     <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />
     <module reference="b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)" version="0" />
     <module reference="726886d1-ef90-4249-a08f-1e3ec23a7113(com.mbeddr.mpsutil.traceExplorer)" version="0" />
@@ -50,14 +58,17 @@
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="f61473f9-130f-42f6-b98d-6c438812c2f6(jetbrains.mps.baseLanguage.unitTest)" version="0" />
     <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
     <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
+    <module reference="8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
     <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="0" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
@@ -67,6 +78,8 @@
     <module reference="21d0de5b-f228-4080-9857-7315c7a77001(org.iets3.core.expr.data.interpreter)" version="0" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="0" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
+    <module reference="52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)" version="0" />
+    <module reference="d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)" version="0" />
     <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="2" />
   </dependencyVersions>
 </solution>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -12753,6 +12753,11 @@
           <ref role="3bR37D" to="ffeo:7Kfy9QB6Lc2" resolve="jetbrains.mps.lang.typesystem" />
         </node>
       </node>
+      <node concept="1SiIV0" id="4PRpvcZJQ0m" role="3bR37C">
+        <node concept="3bR9La" id="4PRpvcZJQ0n" role="1SiIV1">
+          <ref role="3bR37D" node="cPLa7FuMZR" resolve="org.iets3.core.expr.data" />
+        </node>
+      </node>
     </node>
     <node concept="1E1JtA" id="OJuIQp$d7j" role="3989C9">
       <property role="BnDLt" value="true" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -3517,6 +3517,16 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="2SzGbCMNPRZ" role="3bR37C">
+          <node concept="3bR9La" id="2SzGbCMNPS0" role="1SiIV1">
+            <ref role="3bR37D" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2SzGbCMNPS1" role="3bR37C">
+          <node concept="3bR9La" id="2SzGbCMNPS2" role="1SiIV1">
+            <ref role="3bR37D" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="2uR5X5azttH" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -8420,6 +8430,105 @@
         <node concept="3LEz8M" id="kEKsc8qBa7" role="3LEz9a">
           <ref role="3LEz8N" node="2zpAVpC$xZc" resolve="org.iets3.core.expr.genjava.core.devkit" />
         </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3D" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3E" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAaa" resolve="org.iets3.analysis.base" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3F" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3G" role="3LEDUa">
+          <ref role="3LEDTV" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3H" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3I" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3J" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3K" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3L" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3M" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3N" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3O" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3P" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3Q" role="3LEDUa">
+          <ref role="3LEDTV" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3R" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3S" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3T" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3U" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3V" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3W" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3X" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3Y" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ3Z" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ40" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ41" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ42" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ43" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ44" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ45" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ46" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ47" role="3LEDUa">
+          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ48" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRRB" resolve="org.iets3.core.base" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQ49" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
+        </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC_4Ut" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10599,6 +10708,15 @@
         <node concept="3LEDTM" id="1RMC8GHEwZG" role="3LEDUa">
           <ref role="3LEDTN" node="5khwDRKS378" resolve="org.iets3.core.expr.base.collections.stubs" />
         </node>
+        <node concept="3LEDTy" id="2SzGbCMNQa2" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQa3" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQa4" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC$OJa" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10643,6 +10761,30 @@
         <node concept="3LEDTM" id="6wnckeEe9TH" role="3LEDUa">
           <ref role="3LEDTN" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
         </node>
+        <node concept="3LEDTy" id="2SzGbCMNQa5" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQa6" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQa7" role="3LEDUa">
+          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQa8" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQa9" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaa" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQab" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQac" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
       </node>
       <node concept="3LEwk6" id="j5CxBKa9ks" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10668,6 +10810,123 @@
         </node>
         <node concept="3LEDTM" id="1RMC8GHEwZU" role="3LEDUa">
           <ref role="3LEDTN" node="2zpAVpC$IQf" resolve="org.iets3.core.expr.genjava.advanced.genplan" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQad" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQae" role="3LEDUa">
+          <ref role="3LEDTV" node="5Y0kZK1N637" resolve="org.iets3.core.expr.genjava.datetime" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaf" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAaa" resolve="org.iets3.analysis.base" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQag" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQah" role="3LEDUa">
+          <ref role="3LEDTV" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQai" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaj" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQak" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQal" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQam" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQan" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQao" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQap" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaq" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQar" role="3LEDUa">
+          <ref role="3LEDTV" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQas" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQat" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQau" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQav" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaw" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQax" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQay" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaz" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQa$" role="3LEDUa">
+          <ref role="3LEDTV" node="23q4CrmMjzr" resolve="org.iets3.core.expr.genjava.messages" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQa_" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaA" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaB" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaC" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaD" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaE" role="3LEDUa">
+          <ref role="3LEDTV" node="5zQvLw7dx1X" resolve="org.iets3.core.expr.datetime" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaF" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaG" role="3LEDUa">
+          <ref role="3LEDTV" node="7sID8G9sQTG" resolve="org.iets3.core.expr.genjava.temporal" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaH" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaI" role="3LEDUa">
+          <ref role="3LEDTV" node="6hYPZtwrWbD" resolve="org.iets3.core.expr.genjava.util" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaJ" role="3LEDUa">
+          <ref role="3LEDTV" node="5zQvLw7dsP5" resolve="org.iets3.core.expr.temporal" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaK" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaL" role="3LEDUa">
+          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaM" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRRB" resolve="org.iets3.core.base" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaN" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
         </node>
       </node>
       <node concept="3LEwk6" id="26tZ$Z4sNNn" role="2G$12L">
@@ -10700,6 +10959,15 @@
         </node>
         <node concept="3LEDTy" id="3vxfdxbuHow" role="3LEDUa">
           <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaO" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaP" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
+        <node concept="3LEDTy" id="2SzGbCMNQaQ" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.datatable@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.datatable@tests.mps
@@ -17,6 +17,7 @@
       </concept>
     </language>
     <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
+      <concept id="2390066428848651932" name="org.iets3.core.expr.base.structure.BangOp" flags="ng" index="wdKpt" />
       <concept id="7089558164905593724" name="org.iets3.core.expr.base.structure.IOptionallyTyped" flags="ng" index="2zM23E">
         <child id="7089558164905593725" name="type" index="2zM23F" />
       </concept>
@@ -71,6 +72,10 @@
       </concept>
     </language>
     <language id="b25b8ad1-4d3d-4e45-8c78-72091b39fdda" name="org.iets3.core.expr.data">
+      <concept id="512624657163648898" name="org.iets3.core.expr.data.structure.DataTableLookUp" flags="ng" index="3AhkFE">
+        <reference id="512624657163648901" name="col" index="3AhkFH" />
+        <child id="512624657163648903" name="arg" index="3AhkFJ" />
+      </concept>
       <concept id="231307155598475891" name="org.iets3.core.expr.data.structure.DataColOp" flags="ng" index="3Cgsri">
         <reference id="231307155598477016" name="col" index="3Cgs9T" />
       </concept>
@@ -91,6 +96,7 @@
         <child id="231307155597484623" name="value" index="3CkirI" />
       </concept>
       <concept id="231307155597462254" name="org.iets3.core.expr.data.structure.DataTable" flags="ng" index="3CkkTf">
+        <property id="3324695263690995252" name="allowLookup" index="sAwqe" />
         <child id="231307155597477158" name="dataCols" index="3Ckg67" />
         <child id="231307155597655796" name="rows" index="3CkFDl" />
       </concept>
@@ -107,6 +113,7 @@
     <property role="TrG5h" value="DataTable" />
     <node concept="3CkkTf" id="cPLa7FroL4" role="_iOnB">
       <property role="TrG5h" value="ExampleTable" />
+      <property role="sAwqe" value="true" />
       <node concept="3CkmCn" id="cPLa7FroL6" role="3Ckg67">
         <property role="TrG5h" value="val1" />
         <node concept="30bXR$" id="cPLa7FroL5" role="3CknON" />
@@ -266,6 +273,52 @@
         </node>
         <node concept="30bXRB" id="cPLa7FuF8s" role="_fkuS">
           <property role="30bXRw" value="5" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="stdmzxnajI" role="_fkp5">
+        <node concept="_fku$" id="stdmzxnajJ" role="_fkur" />
+        <node concept="1QScDb" id="stdmzxnaoG" role="_fkuY">
+          <node concept="3AhkFE" id="stdmzxnap5" role="1QScD9">
+            <ref role="3AhkFH" node="cPLa7FroL6" resolve="val1" />
+            <node concept="30bXRB" id="stdmzxnapE" role="3AhkFJ">
+              <property role="30bXRw" value="1" />
+            </node>
+          </node>
+          <node concept="3Ch18X" id="stdmzxnaox" role="30czhm">
+            <ref role="3Ch1V_" node="cPLa7FroL4" resolve="ExampleTable" />
+          </node>
+        </node>
+        <node concept="1QScDb" id="stdmzxnaqu" role="_fkuS">
+          <node concept="3CgUdp" id="stdmzxnar2" role="1QScD9">
+            <ref role="3CgUW3" node="cPLa7FroLb" resolve="keyA" />
+          </node>
+          <node concept="3Ch18X" id="stdmzxnaq8" role="30czhm">
+            <ref role="3Ch1V_" node="cPLa7FroL4" resolve="ExampleTable" />
+          </node>
+        </node>
+      </node>
+      <node concept="_fkuZ" id="2SzGbCMLQct" role="_fkp5">
+        <node concept="_fku$" id="2SzGbCMLQcu" role="_fkur" />
+        <node concept="30bXRB" id="2SzGbCMLQoC" role="_fkuS">
+          <property role="30bXRw" value="2" />
+        </node>
+        <node concept="1QScDb" id="2SzGbCMLQmA" role="_fkuY">
+          <node concept="3Cgsri" id="2SzGbCMLQnR" role="1QScD9">
+            <ref role="3Cgs9T" node="cPLa7FroL8" resolve="val2" />
+          </node>
+          <node concept="wdKpt" id="2SzGbCMLQlI" role="30czhm">
+            <node concept="1QScDb" id="2SzGbCMLQhK" role="30czhm">
+              <node concept="3AhkFE" id="2SzGbCMLQhL" role="1QScD9">
+                <ref role="3AhkFH" node="cPLa7FroL6" resolve="val1" />
+                <node concept="30bXRB" id="2SzGbCMLQhM" role="3AhkFJ">
+                  <property role="30bXRw" value="1" />
+                </node>
+              </node>
+              <node concept="3Ch18X" id="2SzGbCMLQhN" role="30czhm">
+                <ref role="3Ch1V_" node="cPLa7FroL4" resolve="ExampleTable" />
+              </node>
+            </node>
+          </node>
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -15,6 +15,7 @@
     <use id="5fe6cb13-2fbd-4e21-9842-785bdd6fc5b1" name="org.iets3.core.expr.adt" version="-1" />
     <use id="289fb12b-7f53-4ef7-bc2e-1ed2c6a7c998" name="org.iets3.core.expr.datetime" version="-1" />
     <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="2" />
+    <use id="b25b8ad1-4d3d-4e45-8c78-72091b39fdda" name="org.iets3.core.expr.data" version="0" />
     <devkit ref="c4e521ab-b605-4ef9-a7c3-68075da058f0(org.iets3.core.expr.core.devkit)" />
   </languages>
   <imports>
@@ -26,6 +27,7 @@
     <import index="ut5p" ref="r:ae52e1b7-6479-4187-9e09-836b57124d46(test.in.expr.os.utils@tests)" />
     <import index="523r" ref="r:9c5c2614-fd32-4054-b6ea-f1ceb6bdd369(org.iets3.core.expr.util.typesystem)" />
     <import index="byea" ref="r:55ae05df-8f25-48f0-a826-0655584ce598(org.iets3.core.expr.adt.typesystem)" />
+    <import index="rpit" ref="r:e29c70b2-feb7-465e-9534-7fdb395635c2(org.iets3.core.expr.data.typesystem)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
   </imports>
@@ -40,6 +42,7 @@
       </concept>
       <concept id="1215607067978" name="jetbrains.mps.lang.test.structure.CheckNodeForErrorMessagesOperation" flags="ng" index="7OXhh">
         <property id="852155438140865198" name="allowWarnings" index="G7GLP" />
+        <property id="3743352646565420194" name="includeSelf" index="GvXf4" />
       </concept>
       <concept id="5476670926298696679" name="jetbrains.mps.lang.test.structure.MigrationTestCase" flags="lg" index="2lJO3n">
         <child id="5476670926298696680" name="inputNodes" index="2lJO3o" />
@@ -615,6 +618,23 @@
       </concept>
       <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
         <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
+      </concept>
+    </language>
+    <language id="b25b8ad1-4d3d-4e45-8c78-72091b39fdda" name="org.iets3.core.expr.data">
+      <concept id="231307155597502601" name="org.iets3.core.expr.data.structure.DataRow" flags="ng" index="3CkeKC">
+        <child id="231307155597479382" name="cells" index="3Ckg_R" />
+      </concept>
+      <concept id="231307155597478456" name="org.iets3.core.expr.data.structure.DataCell" flags="ng" index="3CkgUp">
+        <reference id="231307155597481790" name="col" index="3Ckhev" />
+        <child id="231307155597484623" name="value" index="3CkirI" />
+      </concept>
+      <concept id="231307155597462254" name="org.iets3.core.expr.data.structure.DataTable" flags="ng" index="3CkkTf">
+        <property id="3324695263690995252" name="allowLookup" index="sAwqe" />
+        <child id="231307155597477158" name="dataCols" index="3Ckg67" />
+        <child id="231307155597655796" name="rows" index="3CkFDl" />
+      </concept>
+      <concept id="231307155597471414" name="org.iets3.core.expr.data.structure.DataColDef" flags="ng" index="3CkmCn">
+        <child id="231307155597474194" name="type" index="3CknON" />
       </concept>
     </language>
     <language id="f3eafff0-30d2-46d6-9150-f0f3b880ce27" name="org.iets3.core.expr.path">
@@ -14931,6 +14951,116 @@
             </node>
             <node concept="uhfPG" id="6hYPZtwvBHL" role="1aduh9">
               <ref role="uhfO8" node="6hYPZtwvBuy" resolve="x" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="4PRpvcZw5Fx">
+    <property role="TrG5h" value="datatable" />
+    <node concept="1qefOq" id="4PRpvcZw5HP" role="1SKRRt">
+      <node concept="_iOnU" id="4PRpvcZw5HT" role="1qenE9">
+        <property role="1XBH2A" value="true" />
+        <property role="TrG5h" value="myTest" />
+        <node concept="3CkkTf" id="4PRpvcZw5HZ" role="_iOnB">
+          <property role="TrG5h" value="myTable" />
+          <property role="sAwqe" value="true" />
+          <node concept="3CkmCn" id="4PRpvcZw5I1" role="3Ckg67">
+            <property role="TrG5h" value="val1" />
+            <node concept="30bXR$" id="4PRpvcZw5I0" role="3CknON" />
+          </node>
+          <node concept="3CkmCn" id="4PRpvcZw5I3" role="3Ckg67">
+            <property role="TrG5h" value="val2" />
+            <node concept="30bXR$" id="4PRpvcZw5I2" role="3CknON" />
+          </node>
+          <node concept="3CkeKC" id="4PRpvcZw5I6" role="3CkFDl">
+            <property role="TrG5h" value="keyA" />
+            <node concept="3CkgUp" id="4PRpvcZw5I7" role="3Ckg_R">
+              <ref role="3Ckhev" node="4PRpvcZw5I1" resolve="val1" />
+              <node concept="30bXRB" id="4PRpvcZw5I4" role="3CkirI">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="4PRpvcZw5I8" role="3Ckg_R">
+              <ref role="3Ckhev" node="4PRpvcZw5I3" resolve="val2" />
+              <node concept="30bXRB" id="4PRpvcZw5I5" role="3CkirI">
+                <property role="30bXRw" value="2" />
+              </node>
+            </node>
+          </node>
+          <node concept="3CkeKC" id="4PRpvcZw5Ib" role="3CkFDl">
+            <property role="TrG5h" value="keyB" />
+            <node concept="3CkgUp" id="4PRpvcZw5Ic" role="3Ckg_R">
+              <ref role="3Ckhev" node="4PRpvcZw5I1" resolve="val1" />
+              <node concept="30bXRB" id="4PRpvcZw5I9" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="4PRpvcZw5Id" role="3Ckg_R">
+              <ref role="3Ckhev" node="4PRpvcZw5I3" resolve="val2" />
+              <node concept="30bXRB" id="4PRpvcZw5Ia" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+          </node>
+          <node concept="7CXmI" id="4PRpvcZw5K1" role="lGtFl">
+            <node concept="7OXhh" id="4PRpvcZw5K4" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="3CkkTf" id="4PRpvcZw5Kr" role="_iOnB">
+          <property role="TrG5h" value="myTableWithError" />
+          <property role="sAwqe" value="true" />
+          <node concept="3CkmCn" id="4PRpvcZw5Kt" role="3Ckg67">
+            <property role="TrG5h" value="val1" />
+            <node concept="30bXR$" id="4PRpvcZw5Ks" role="3CknON" />
+          </node>
+          <node concept="3CkmCn" id="4PRpvcZw5Kv" role="3Ckg67">
+            <property role="TrG5h" value="val2" />
+            <node concept="30bXR$" id="4PRpvcZw5Ku" role="3CknON" />
+          </node>
+          <node concept="3CkeKC" id="4PRpvcZw5Ky" role="3CkFDl">
+            <property role="TrG5h" value="keyA" />
+            <node concept="3CkgUp" id="4PRpvcZw5Kz" role="3Ckg_R">
+              <ref role="3Ckhev" node="4PRpvcZw5Kt" resolve="val1" />
+              <node concept="30bXRB" id="4PRpvcZw5Kw" role="3CkirI">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="4PRpvcZw5K$" role="3Ckg_R">
+              <ref role="3Ckhev" node="4PRpvcZw5Kv" resolve="val2" />
+              <node concept="30dDZf" id="4PRpvcZw5N6" role="3CkirI">
+                <node concept="30bXRB" id="4PRpvcZw5O9" role="30dEs_">
+                  <property role="30bXRw" value="2" />
+                </node>
+                <node concept="30bXRB" id="4PRpvcZw5Kx" role="30dEsF">
+                  <property role="30bXRw" value="2" />
+                </node>
+                <node concept="7CXmI" id="4PRpvcZw6jN" role="lGtFl">
+                  <node concept="1TM$A" id="4PRpvcZw9Js" role="7EUXB">
+                    <node concept="2PYRI3" id="4PRpvcZw9Jt" role="3lydEf">
+                      <ref role="39XzEq" to="rpit:4PRpvcZvBk8" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3CkeKC" id="4PRpvcZw5KB" role="3CkFDl">
+            <property role="TrG5h" value="keyB" />
+            <node concept="3CkgUp" id="4PRpvcZw5KC" role="3Ckg_R">
+              <ref role="3Ckhev" node="4PRpvcZw5Kt" resolve="val1" />
+              <node concept="30bXRB" id="4PRpvcZw5K_" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="4PRpvcZw5KD" role="3Ckg_R">
+              <ref role="3Ckhev" node="4PRpvcZw5Kv" resolve="val2" />
+              <node concept="30bXRB" id="4PRpvcZw5KA" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
@@ -29,6 +29,7 @@
     <dependency reexport="false">cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</dependency>
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
     <dependency reexport="false">7a5dda62-9140-4668-ab76-d5ed1746f2b2(jetbrains.mps.lang.typesystem)</dependency>
+    <dependency reexport="false">b25b8ad1-4d3d-4e45-8c78-72091b39fdda(org.iets3.core.expr.data)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="5" />
@@ -61,6 +62,7 @@
     <language slang="l:5fe6cb13-2fbd-4e21-9842-785bdd6fc5b1:org.iets3.core.expr.adt" version="0" />
     <language slang="l:cfaa4966-b7d5-4b69-b66a-309a6e1a7290:org.iets3.core.expr.base" version="3" />
     <language slang="l:2f7e2e35-6e74-4c43-9fa5-2465d68f5996:org.iets3.core.expr.collections" version="5" />
+    <language slang="l:b25b8ad1-4d3d-4e45-8c78-72091b39fdda:org.iets3.core.expr.data" version="0" />
     <language slang="l:289fb12b-7f53-4ef7-bc2e-1ed2c6a7c998:org.iets3.core.expr.datetime" version="0" />
     <language slang="l:9464fa06-5ab9-409b-9274-64ab29588457:org.iets3.core.expr.lambda" version="1" />
     <language slang="l:6fadc44e-69c2-4a4a-9d16-7ebf5f8d3ba0:org.iets3.core.expr.math" version="0" />
@@ -127,6 +129,7 @@
     <module reference="cf90f965-8554-4a16-aa0b-6387f27474ab(org.iets3.core.expr.base.interpreter)" version="0" />
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="5" />
     <module reference="07f696b4-29e7-4878-aefb-39cac5e8c6cc(org.iets3.core.expr.collections.interpreter)" version="0" />
+    <module reference="b25b8ad1-4d3d-4e45-8c78-72091b39fdda(org.iets3.core.expr.data)" version="0" />
     <module reference="289fb12b-7f53-4ef7-bc2e-1ed2c6a7c998(org.iets3.core.expr.datetime)" version="1" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="0" />
     <module reference="8ba65567-1c8a-4983-beb8-0482324d7e44(org.iets3.core.expr.lambda.interpreter)" version="0" />


### PR DESCRIPTION
New lookUp operation allowed on data tables. The operation
will look up the row based on the column and value provided
to the expression.

New flag "allows lookup" on data tables which is at the
moment only a flag to allow the operation. If the flag is
present the type system provides an info message about the
uniqueness requirements for values in a column. Right now no
static checks for uniqueness of all values in a column exists.
Since each cell can contain an arbitrary expression we would
need to run the interpreter in the checking rule to find
duplicate values.