### PR TITLE
Fix BracketOP for IOrderedCollection

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/structure.mps
@@ -2,8 +2,8 @@
 <model ref="r:61b1de80-490d-4fee-8e95-b956503290e9(org.iets3.core.expr.collections.structure)">
   <persistence version="9" />
   <languages>
-    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="9" />
-    <use id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources" version="2" />
+    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="-1" />
+    <use id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources" version="-1" />
     <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
   <imports>
@@ -193,6 +193,9 @@
     <property role="TrG5h" value="IOrderedCollection" />
     <property role="3GE5qa" value="ordered" />
     <property role="EcuMT" value="7554398283339848519" />
+    <node concept="PrWs8" id="1SHQl3yge92" role="PrDN$">
+      <ref role="PrY4T" to="hm2y:5WNmJ7DoRmx" resolve="ICollectionType" />
+    </node>
   </node>
   <node concept="PlHQZ" id="6zmBjqUiHHJ">
     <property role="TrG5h" value="IOrderedCollectionOp" />
@@ -614,6 +617,9 @@
     <property role="EcuMT" value="890435239346753529" />
     <property role="R4oN_" value="sorts collection" />
     <ref role="1TJDcQ" node="6zmBjqUiwKw" resolve="NoArgCollectionOp" />
+    <node concept="PrWs8" id="Lrty7CKd03" role="PzmwI">
+      <ref role="PrY4T" node="6zmBjqUiHHJ" resolve="IOrderedCollectionOp" />
+    </node>
     <node concept="1TJgyi" id="17Nm8oCo8O4" role="1TKVEl">
       <property role="TrG5h" value="order" />
       <property role="IQ2nx" value="890435239346753553" />
@@ -625,9 +631,6 @@
           <ref role="AX2Wp" node="Lrty7CKd06" resolve="SortOrder" />
         </node>
       </node>
-    </node>
-    <node concept="PrWs8" id="Lrty7CKd03" role="PzmwI">
-      <ref role="PrY4T" node="6zmBjqUiHHJ" resolve="IOrderedCollectionOp" />
     </node>
   </node>
   <node concept="1TIwiD" id="6HHp2WnvluK">
@@ -1154,6 +1157,23 @@
       <ref role="PrY4T" node="thkha3aNEl" resolve="ISetOneArgOp" />
     </node>
   </node>
+  <node concept="1TIwiD" id="twWOnQMGuT">
+    <property role="EcuMT" value="531692237848496057" />
+    <property role="3GE5qa" value="list" />
+    <property role="TrG5h" value="ListPickOp" />
+    <property role="34LRSv" value="pick" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="twWOnQMH4e" role="PzmwI">
+      <ref role="PrY4T" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
+    </node>
+    <node concept="1TJgyj" id="twWOnQMHdg" role="1TKVEi">
+      <property role="IQ2ns" value="531692237848499024" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="selectorList" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="hm2y:6sdnDbSla17" resolve="Expression" />
+    </node>
+  </node>
   <node concept="25R3W" id="17Nm8oCo8NN">
     <property role="TrG5h" value="SortOrder" />
     <property role="3GE5qa" value="ordered.numeric" />
@@ -1187,23 +1207,6 @@
       <property role="TrG5h" value="DESC" />
       <property role="3tVfz5" value="890435239346753550" />
       <ref role="2wpffI" node="Lrty7CKd0e" />
-    </node>
-  </node>
-  <node concept="1TIwiD" id="twWOnQMGuT">
-    <property role="EcuMT" value="531692237848496057" />
-    <property role="3GE5qa" value="list" />
-    <property role="TrG5h" value="ListPickOp" />
-    <property role="34LRSv" value="pick" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
-    <node concept="PrWs8" id="twWOnQMH4e" role="PzmwI">
-      <ref role="PrY4T" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
-    </node>
-    <node concept="1TJgyj" id="twWOnQMHdg" role="1TKVEi">
-      <property role="IQ2ns" value="531692237848499024" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="selectorList" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" to="hm2y:6sdnDbSla17" resolve="Expression" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/typesystem.mps
@@ -2,10 +2,10 @@
 <model ref="r:1fd78142-d7d8-42c9-9cbb-0609b1bc5311(org.iets3.core.expr.collections.typesystem)">
   <persistence version="9" />
   <languages>
-    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
-    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="9" />
-    <use id="9464fa06-5ab9-409b-9274-64ab29588457" name="org.iets3.core.expr.lambda" version="1" />
-    <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="1" />
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="-1" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="-1" />
+    <use id="9464fa06-5ab9-409b-9274-64ab29588457" name="org.iets3.core.expr.lambda" version="-1" />
+    <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="-1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -2216,15 +2216,15 @@
                 <node concept="mw_s8" id="7kYh9Ws$4ah" role="1ZfhKB">
                   <node concept="2OqwBi" id="7kYh9Ws$4ai" role="mwGJk">
                     <node concept="1PxgMI" id="7kYh9Ws$4aj" role="2Oq$k0">
-                      <node concept="chp4Y" id="2uo6UInBSUx" role="3oSUPX">
-                        <ref role="cht4Q" to="700h:6zmBjqUinsw" resolve="ListType" />
-                      </node>
                       <node concept="2X3wrD" id="7kYh9Ws$4ak" role="1m5AlR">
                         <ref role="2X3Bk0" node="54HsVvNVcz_" resolve="contextType" />
                       </node>
+                      <node concept="chp4Y" id="1SHQl3ygg3H" role="3oSUPX">
+                        <ref role="cht4Q" to="700h:6zmBjqUiHH7" resolve="IOrderedCollection" />
+                      </node>
                     </node>
-                    <node concept="3TrEf2" id="7kYh9Ws$4al" role="2OqNvi">
-                      <ref role="3Tt5mk" to="700h:6zmBjqUily6" resolve="baseType" />
+                    <node concept="2qgKlT" id="1SHQl3yggm5" role="2OqNvi">
+                      <ref role="37wK5l" to="pbu6:3oWFox95OZf" resolve="getBaseType" />
                     </node>
                   </node>
                 </node>
@@ -2263,8 +2263,8 @@
                 <ref role="2X3Bk0" node="54HsVvNVcz_" resolve="contextType" />
               </node>
               <node concept="1mIQ4w" id="54HsVvNVczz" role="2OqNvi">
-                <node concept="chp4Y" id="2uo6UInBSPy" role="cj9EA">
-                  <ref role="cht4Q" to="700h:6zmBjqUinsw" resolve="ListType" />
+                <node concept="chp4Y" id="1SHQl3ygfZQ" role="cj9EA">
+                  <ref role="cht4Q" to="700h:6zmBjqUiHH7" resolve="IOrderedCollection" />
                 </node>
               </node>
             </node>


### PR DESCRIPTION
The BracketOP editor worked with any IOrderedCollection, but the typesystem would fail with a runtime error if it wasn't a list. To fix the typesystem rule IOrderedCollection is now inheriting from ICollectionType. Since ICollectionType extends IHasBaseType, we can use getBaseType() to fix the typesystem rule.

This replaces #257 