### PR TITLE
Record equality now uses KernelF number equality

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/generator/template/org.iets3.core.expr.genjava.toplevel@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/generator/template/org.iets3.core.expr.genjava.toplevel@generator.mps
@@ -10166,21 +10166,23 @@
                   </node>
                 </node>
               </node>
-              <node concept="3fqX7Q" id="6XE8Bc$gE33" role="3clFbw">
-                <node concept="2OqwBi" id="6XE8Bc$gE34" role="3fr31v">
-                  <node concept="2OqwBi" id="6XE8Bc$gE35" role="2Oq$k0">
-                    <node concept="Xjq3P" id="6XE8Bc$gE36" role="2Oq$k0" />
-                    <node concept="2OwXpG" id="6XE8Bc$gE37" role="2OqNvi">
+              <node concept="3fqX7Q" id="Wka9OVriuM" role="3clFbw">
+                <node concept="2YIFZM" id="Wka9OVriuO" role="3fr31v">
+                  <ref role="37wK5l" to="wfax:5hmZ_ho6_uZ" resolve="isEqual" />
+                  <ref role="1Pybhc" to="wfax:6IxV2nShzcy" resolve="AH" />
+                  <node concept="2OqwBi" id="Wka9OVriuP" role="37wK5m">
+                    <node concept="Xjq3P" id="Wka9OVriuQ" role="2Oq$k0" />
+                    <node concept="2OwXpG" id="Wka9OVriuR" role="2OqNvi">
                       <ref role="2Oxat5" node="6XE8Bc$gDWa" resolve="i" />
-                      <node concept="1ZhdrF" id="6XE8Bc$gE38" role="lGtFl">
+                      <node concept="1ZhdrF" id="Wka9OVriuS" role="lGtFl">
                         <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1197029447546/1197029500499" />
                         <property role="2qtEX8" value="fieldDeclaration" />
-                        <node concept="3$xsQk" id="6XE8Bc$gE39" role="3$ytzL">
-                          <node concept="3clFbS" id="6XE8Bc$gE3a" role="2VODD2">
-                            <node concept="3clFbF" id="6XE8Bc$gE3b" role="3cqZAp">
-                              <node concept="2OqwBi" id="6XE8Bc$gE3c" role="3clFbG">
-                                <node concept="30H73N" id="6XE8Bc$gE3d" role="2Oq$k0" />
-                                <node concept="3TrcHB" id="6XE8Bc$gE3e" role="2OqNvi">
+                        <node concept="3$xsQk" id="Wka9OVriuT" role="3$ytzL">
+                          <node concept="3clFbS" id="Wka9OVriuU" role="2VODD2">
+                            <node concept="3clFbF" id="Wka9OVriuV" role="3cqZAp">
+                              <node concept="2OqwBi" id="Wka9OVriuW" role="3clFbG">
+                                <node concept="30H73N" id="Wka9OVriuX" role="2Oq$k0" />
+                                <node concept="3TrcHB" id="Wka9OVriuY" role="2OqNvi">
                                   <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                                 </node>
                               </node>
@@ -10190,30 +10192,27 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="liA8E" id="6XE8Bc$gE3f" role="2OqNvi">
-                    <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                    <node concept="2OqwBi" id="6XE8Bc$gE3g" role="37wK5m">
-                      <node concept="37vLTw" id="6XE8Bc$gE3h" role="2Oq$k0">
-                        <ref role="3cqZAo" node="6XE8Bc$gE2E" resolve="rd" />
-                      </node>
-                      <node concept="liA8E" id="6XE8Bc$gE3i" role="2OqNvi">
-                        <ref role="37wK5l" node="6XE8Bc$gDXG" resolve="getI" />
-                        <node concept="1ZhdrF" id="6XE8Bc$gE3j" role="lGtFl">
-                          <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
-                          <property role="2qtEX8" value="baseMethodDeclaration" />
-                          <node concept="3$xsQk" id="6XE8Bc$gE3k" role="3$ytzL">
-                            <node concept="3clFbS" id="6XE8Bc$gE3l" role="2VODD2">
-                              <node concept="3clFbF" id="6XE8Bc$gE3m" role="3cqZAp">
-                                <node concept="3cpWs3" id="6XE8Bc$gE3n" role="3clFbG">
-                                  <node concept="2OqwBi" id="6XE8Bc$gE3o" role="3uHU7w">
-                                    <node concept="30H73N" id="6XE8Bc$gE3p" role="2Oq$k0" />
-                                    <node concept="3TrcHB" id="6XE8Bc$gE3q" role="2OqNvi">
-                                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                    </node>
+                  <node concept="2OqwBi" id="Wka9OVriuZ" role="37wK5m">
+                    <node concept="37vLTw" id="Wka9OVriv0" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6XE8Bc$gE2E" resolve="rd" />
+                    </node>
+                    <node concept="liA8E" id="Wka9OVriv1" role="2OqNvi">
+                      <ref role="37wK5l" node="6XE8Bc$gDXG" resolve="getI" />
+                      <node concept="1ZhdrF" id="Wka9OVriv2" role="lGtFl">
+                        <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
+                        <property role="2qtEX8" value="baseMethodDeclaration" />
+                        <node concept="3$xsQk" id="Wka9OVriv3" role="3$ytzL">
+                          <node concept="3clFbS" id="Wka9OVriv4" role="2VODD2">
+                            <node concept="3clFbF" id="Wka9OVriv5" role="3cqZAp">
+                              <node concept="3cpWs3" id="Wka9OVriv6" role="3clFbG">
+                                <node concept="2OqwBi" id="Wka9OVriv7" role="3uHU7w">
+                                  <node concept="30H73N" id="Wka9OVriv8" role="2Oq$k0" />
+                                  <node concept="3TrcHB" id="Wka9OVriv9" role="2OqNvi">
+                                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
                                   </node>
-                                  <node concept="Xl_RD" id="6XE8Bc$gE3r" role="3uHU7B">
-                                    <property role="Xl_RC" value="get" />
-                                  </node>
+                                </node>
+                                <node concept="Xl_RD" id="Wka9OVriva" role="3uHU7B">
+                                  <property role="Xl_RC" value="get" />
                                 </node>
                               </node>
                             </node>
@@ -10227,81 +10226,174 @@
               <node concept="1WS0z7" id="6XE8Bc$gE3s" role="lGtFl">
                 <node concept="3JmXsc" id="6XE8Bc$gE3t" role="3Jn$fo">
                   <node concept="3clFbS" id="6XE8Bc$gE3u" role="2VODD2">
-                    <node concept="3clFbF" id="6XE8Bc$gE3v" role="3cqZAp">
-                      <node concept="2OqwBi" id="6XE8Bc$gE3w" role="3clFbG">
-                        <node concept="2OqwBi" id="6XE8Bc$gE3x" role="2Oq$k0">
-                          <node concept="2qgKlT" id="57In_Tx4xCV" role="2OqNvi">
+                    <node concept="3clFbF" id="Wka9OVqY90" role="3cqZAp">
+                      <node concept="2OqwBi" id="Wka9OVqY91" role="3clFbG">
+                        <node concept="2OqwBi" id="Wka9OVqY92" role="2Oq$k0">
+                          <node concept="2qgKlT" id="Wka9OVqY93" role="2OqNvi">
                             <ref role="37wK5l" to="nu60:58eyHuUgYVm" resolve="nonEmptyMembers" />
                           </node>
-                          <node concept="30H73N" id="6XE8Bc$gE3z" role="2Oq$k0" />
+                          <node concept="30H73N" id="Wka9OVqY94" role="2Oq$k0" />
                         </node>
-                        <node concept="3zZkjj" id="6XE8Bc$gE3$" role="2OqNvi">
-                          <node concept="1bVj0M" id="6XE8Bc$gE3_" role="23t8la">
-                            <node concept="3clFbS" id="6XE8Bc$gE3A" role="1bW5cS">
-                              <node concept="3clFbF" id="6XE8Bc$gE3B" role="3cqZAp">
-                                <node concept="22lmx$" id="6XE8Bc$gE3C" role="3clFbG">
-                                  <node concept="2OqwBi" id="6XE8Bc$gE3D" role="3uHU7w">
-                                    <node concept="2OqwBi" id="6XE8Bc$gE3E" role="2Oq$k0">
-                                      <node concept="37vLTw" id="6XE8Bc$gE3F" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="6XE8Bc$gE43" resolve="it" />
+                        <node concept="3zZkjj" id="Wka9OVqY95" role="2OqNvi">
+                          <node concept="1bVj0M" id="Wka9OVqY96" role="23t8la">
+                            <node concept="3clFbS" id="Wka9OVqY97" role="1bW5cS">
+                              <node concept="3clFbF" id="Wka9OVqY98" role="3cqZAp">
+                                <node concept="22lmx$" id="Wka9OVqY9g" role="3clFbG">
+                                  <node concept="2OqwBi" id="Wka9OVqY9o" role="3uHU7B">
+                                    <node concept="2OqwBi" id="Wka9OVqY9p" role="2Oq$k0">
+                                      <node concept="37vLTw" id="Wka9OVqY9q" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="Wka9OVqY9$" resolve="it" />
                                       </node>
-                                      <node concept="3JvlWi" id="6XE8Bc$gE3G" role="2OqNvi" />
+                                      <node concept="3JvlWi" id="Wka9OVqY9r" role="2OqNvi" />
                                     </node>
-                                    <node concept="1mIQ4w" id="6XE8Bc$gE3H" role="2OqNvi">
-                                      <node concept="chp4Y" id="6XE8Bc$gE3I" role="cj9EA">
-                                        <ref role="cht4Q" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
+                                    <node concept="1mIQ4w" id="Wka9OVqY9s" role="2OqNvi">
+                                      <node concept="chp4Y" id="Wka9OVqY9t" role="cj9EA">
+                                        <ref role="cht4Q" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
                                       </node>
                                     </node>
                                   </node>
-                                  <node concept="22lmx$" id="6XE8Bc$gE3J" role="3uHU7B">
-                                    <node concept="22lmx$" id="6XE8Bc$gE3K" role="3uHU7B">
-                                      <node concept="2OqwBi" id="6XE8Bc$gE3L" role="3uHU7B">
-                                        <node concept="2OqwBi" id="6XE8Bc$gE3M" role="2Oq$k0">
-                                          <node concept="37vLTw" id="6XE8Bc$gE3N" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="6XE8Bc$gE43" resolve="it" />
-                                          </node>
-                                          <node concept="3JvlWi" id="6XE8Bc$gE3O" role="2OqNvi" />
-                                        </node>
-                                        <node concept="1mIQ4w" id="6XE8Bc$gE3P" role="2OqNvi">
-                                          <node concept="chp4Y" id="6XE8Bc$gE3Q" role="cj9EA">
-                                            <ref role="cht4Q" to="yv47:7D7uZV2dYz2" resolve="RecordType" />
-                                          </node>
-                                        </node>
+                                  <node concept="2OqwBi" id="Wka9OVqY9u" role="3uHU7w">
+                                    <node concept="2OqwBi" id="Wka9OVqY9v" role="2Oq$k0">
+                                      <node concept="37vLTw" id="Wka9OVqY9w" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="Wka9OVqY9$" resolve="it" />
                                       </node>
-                                      <node concept="2OqwBi" id="6XE8Bc$gE3R" role="3uHU7w">
-                                        <node concept="2OqwBi" id="6XE8Bc$gE3S" role="2Oq$k0">
-                                          <node concept="37vLTw" id="6XE8Bc$gE3T" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="6XE8Bc$gE43" resolve="it" />
-                                          </node>
-                                          <node concept="3JvlWi" id="6XE8Bc$gE3U" role="2OqNvi" />
-                                        </node>
-                                        <node concept="1mIQ4w" id="6XE8Bc$gE3V" role="2OqNvi">
-                                          <node concept="chp4Y" id="6XE8Bc$gE3W" role="cj9EA">
-                                            <ref role="cht4Q" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
-                                          </node>
-                                        </node>
-                                      </node>
+                                      <node concept="3JvlWi" id="Wka9OVqY9x" role="2OqNvi" />
                                     </node>
-                                    <node concept="2OqwBi" id="6XE8Bc$gE3X" role="3uHU7w">
-                                      <node concept="2OqwBi" id="6XE8Bc$gE3Y" role="2Oq$k0">
-                                        <node concept="37vLTw" id="6XE8Bc$gE3Z" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="6XE8Bc$gE43" resolve="it" />
-                                        </node>
-                                        <node concept="3JvlWi" id="6XE8Bc$gE40" role="2OqNvi" />
-                                      </node>
-                                      <node concept="1mIQ4w" id="6XE8Bc$gE41" role="2OqNvi">
-                                        <node concept="chp4Y" id="6XE8Bc$gE42" role="cj9EA">
-                                          <ref role="cht4Q" to="5qo5:4rZeNQ6Oero" resolve="NumericType" />
-                                        </node>
+                                    <node concept="1mIQ4w" id="Wka9OVqY9y" role="2OqNvi">
+                                      <node concept="chp4Y" id="Wka9OVqY9z" role="cj9EA">
+                                        <ref role="cht4Q" to="5qo5:4rZeNQ6Oero" resolve="NumericType" />
                                       </node>
                                     </node>
                                   </node>
                                 </node>
                               </node>
                             </node>
-                            <node concept="Rh6nW" id="6XE8Bc$gE43" role="1bW2Oz">
+                            <node concept="Rh6nW" id="Wka9OVqY9$" role="1bW2Oz">
                               <property role="TrG5h" value="it" />
-                              <node concept="2jxLKc" id="6XE8Bc$gE44" role="1tU5fm" />
+                              <node concept="2jxLKc" id="Wka9OVqY9_" role="1tU5fm" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="Wka9OVqY8w" role="3cqZAp">
+              <node concept="3clFbS" id="Wka9OVqY8x" role="3clFbx">
+                <node concept="3cpWs6" id="Wka9OVqY8y" role="3cqZAp">
+                  <node concept="3clFbT" id="Wka9OVqY8z" role="3cqZAk">
+                    <property role="3clFbU" value="false" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3fqX7Q" id="Wka9OVqY8$" role="3clFbw">
+                <node concept="2OqwBi" id="Wka9OVqY8_" role="3fr31v">
+                  <node concept="2OqwBi" id="Wka9OVqY8A" role="2Oq$k0">
+                    <node concept="Xjq3P" id="Wka9OVqY8B" role="2Oq$k0" />
+                    <node concept="2OwXpG" id="Wka9OVqY8C" role="2OqNvi">
+                      <ref role="2Oxat5" node="6XE8Bc$gDWa" resolve="i" />
+                      <node concept="1ZhdrF" id="Wka9OVqY8D" role="lGtFl">
+                        <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1197029447546/1197029500499" />
+                        <property role="2qtEX8" value="fieldDeclaration" />
+                        <node concept="3$xsQk" id="Wka9OVqY8E" role="3$ytzL">
+                          <node concept="3clFbS" id="Wka9OVqY8F" role="2VODD2">
+                            <node concept="3clFbF" id="Wka9OVqY8G" role="3cqZAp">
+                              <node concept="2OqwBi" id="Wka9OVqY8H" role="3clFbG">
+                                <node concept="30H73N" id="Wka9OVqY8I" role="2Oq$k0" />
+                                <node concept="3TrcHB" id="Wka9OVqY8J" role="2OqNvi">
+                                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="Wka9OVqY8K" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                    <node concept="2OqwBi" id="Wka9OVqY8L" role="37wK5m">
+                      <node concept="37vLTw" id="Wka9OVqY8M" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6XE8Bc$gE2E" resolve="rd" />
+                      </node>
+                      <node concept="liA8E" id="Wka9OVqY8N" role="2OqNvi">
+                        <ref role="37wK5l" node="6XE8Bc$gDXG" resolve="getI" />
+                        <node concept="1ZhdrF" id="Wka9OVqY8O" role="lGtFl">
+                          <property role="P3scX" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1204053956946/1068499141037" />
+                          <property role="2qtEX8" value="baseMethodDeclaration" />
+                          <node concept="3$xsQk" id="Wka9OVqY8P" role="3$ytzL">
+                            <node concept="3clFbS" id="Wka9OVqY8Q" role="2VODD2">
+                              <node concept="3clFbF" id="Wka9OVqY8R" role="3cqZAp">
+                                <node concept="3cpWs3" id="Wka9OVqY8S" role="3clFbG">
+                                  <node concept="2OqwBi" id="Wka9OVqY8T" role="3uHU7w">
+                                    <node concept="30H73N" id="Wka9OVqY8U" role="2Oq$k0" />
+                                    <node concept="3TrcHB" id="Wka9OVqY8V" role="2OqNvi">
+                                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                    </node>
+                                  </node>
+                                  <node concept="Xl_RD" id="Wka9OVqY8W" role="3uHU7B">
+                                    <property role="Xl_RC" value="get" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1WS0z7" id="Wka9OVqY8X" role="lGtFl">
+                <node concept="3JmXsc" id="Wka9OVqY8Y" role="3Jn$fo">
+                  <node concept="3clFbS" id="Wka9OVqY8Z" role="2VODD2">
+                    <node concept="3clFbF" id="Wka9OVsPNu" role="3cqZAp">
+                      <node concept="2OqwBi" id="Wka9OVsPNv" role="3clFbG">
+                        <node concept="2OqwBi" id="Wka9OVsPNw" role="2Oq$k0">
+                          <node concept="2qgKlT" id="Wka9OVsPNx" role="2OqNvi">
+                            <ref role="37wK5l" to="nu60:58eyHuUgYVm" resolve="nonEmptyMembers" />
+                          </node>
+                          <node concept="30H73N" id="Wka9OVsPNy" role="2Oq$k0" />
+                        </node>
+                        <node concept="3zZkjj" id="Wka9OVsPNz" role="2OqNvi">
+                          <node concept="1bVj0M" id="Wka9OVsPN$" role="23t8la">
+                            <node concept="3clFbS" id="Wka9OVsPN_" role="1bW5cS">
+                              <node concept="3clFbF" id="Wka9OVsPNA" role="3cqZAp">
+                                <node concept="22lmx$" id="Wka9OVsPNB" role="3clFbG">
+                                  <node concept="2OqwBi" id="Wka9OVsPNC" role="3uHU7w">
+                                    <node concept="2OqwBi" id="Wka9OVsPND" role="2Oq$k0">
+                                      <node concept="37vLTw" id="Wka9OVsPNE" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="Wka9OVsPNO" resolve="it" />
+                                      </node>
+                                      <node concept="3JvlWi" id="Wka9OVsPNF" role="2OqNvi" />
+                                    </node>
+                                    <node concept="1mIQ4w" id="Wka9OVsPNG" role="2OqNvi">
+                                      <node concept="chp4Y" id="Wka9OVsPNH" role="cj9EA">
+                                        <ref role="cht4Q" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="2OqwBi" id="Wka9OVsPNI" role="3uHU7B">
+                                    <node concept="2OqwBi" id="Wka9OVsPNJ" role="2Oq$k0">
+                                      <node concept="37vLTw" id="Wka9OVsPNK" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="Wka9OVsPNO" resolve="it" />
+                                      </node>
+                                      <node concept="3JvlWi" id="Wka9OVsPNL" role="2OqNvi" />
+                                    </node>
+                                    <node concept="1mIQ4w" id="Wka9OVsPNM" role="2OqNvi">
+                                      <node concept="chp4Y" id="Wka9OVsPNN" role="cj9EA">
+                                        <ref role="cht4Q" to="yv47:7D7uZV2dYz2" resolve="RecordType" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="Rh6nW" id="Wka9OVsPNO" role="1bW2Oz">
+                              <property role="TrG5h" value="it" />
+                              <node concept="2jxLKc" id="Wka9OVsPNP" role="1tU5fm" />
                             </node>
                           </node>
                         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -52,6 +52,7 @@
     <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
     <import index="w474" ref="r:06b241ed-1779-4f34-8d6f-e61e9dd94387(org.iets3.core.expr.testExecution.plugin)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="pq1l" ref="r:93cd1fe8-b296-405c-a6e6-040c940ccfa1(org.iets3.core.expr.toplevel.plugin)" />
     <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -294,6 +295,9 @@
         <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
       <concept id="1082113931046" name="jetbrains.mps.baseLanguage.structure.ContinueStatement" flags="nn" index="3N13vt" />
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="1350122676458893092" name="text" index="3ndbpf" />
+      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
@@ -450,6 +454,14 @@
         <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
       </concept>
     </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="ng" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="ng" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
     <language id="c3bfea76-7bba-4f0e-b5a2-ff4e7a8d7cf1" name="com.mbeddr.mpsutil.spreferences">
       <concept id="5615086488402953540" name="com.mbeddr.mpsutil.spreferences.structure.PreferencesRootExpression" flags="ng" index="9H$SH">
         <reference id="5615086488402976569" name="preferencePage" index="9Hxhg" />
@@ -459,6 +471,9 @@
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="nn" index="56pJg">
+        <child id="1176906787974" name="rightExpression" index="576Qk" />
       </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
@@ -489,6 +504,7 @@
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
       <concept id="1227022210526" name="jetbrains.mps.baseLanguage.collections.structure.ClearAllElementsOperation" flags="nn" index="2Kehj3" />
+      <concept id="1205598340672" name="jetbrains.mps.baseLanguage.collections.structure.DisjunctOperation" flags="nn" index="2NgGto" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
@@ -12814,6 +12830,252 @@
                       <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
                     </node>
                     <node concept="37vLTw" id="6z5WYdPaHB0" role="2ZW6bz">
+                      <ref role="3cqZAo" node="1EZBwZ4moPT" resolve="act" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="5CUQ8HxkYt" role="3cqZAp" />
+              <node concept="3clFbJ" id="5CUQ8HxmhD" role="3cqZAp">
+                <node concept="3clFbS" id="5CUQ8HxmhF" role="3clFbx">
+                  <node concept="3cpWs8" id="5CUQ8Hxo02" role="3cqZAp">
+                    <node concept="3cpWsn" id="5CUQ8Hxo03" role="3cpWs9">
+                      <property role="TrG5h" value="rva" />
+                      <node concept="3uibUv" id="5CUQ8Hxo04" role="1tU5fm">
+                        <ref role="3uigEE" to="pq1l:7D7uZV2szll" resolve="RecordValue" />
+                      </node>
+                      <node concept="10QFUN" id="5CUQ8Hxo6i" role="33vP2m">
+                        <node concept="3uibUv" id="5CUQ8Hxo6n" role="10QFUM">
+                          <ref role="3uigEE" to="pq1l:7D7uZV2szll" resolve="RecordValue" />
+                        </node>
+                        <node concept="37vLTw" id="5CUQ8Hxo7U" role="10QFUP">
+                          <ref role="3cqZAo" node="1EZBwZ4moPT" resolve="act" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="5CUQ8Hxo9w" role="3cqZAp">
+                    <node concept="3cpWsn" id="5CUQ8Hxo9x" role="3cpWs9">
+                      <property role="TrG5h" value="rve" />
+                      <node concept="3uibUv" id="5CUQ8Hxo9y" role="1tU5fm">
+                        <ref role="3uigEE" to="pq1l:7D7uZV2szll" resolve="RecordValue" />
+                      </node>
+                      <node concept="10QFUN" id="5CUQ8Hxo9$" role="33vP2m">
+                        <node concept="3uibUv" id="5CUQ8Hxo9_" role="10QFUM">
+                          <ref role="3uigEE" to="pq1l:7D7uZV2szll" resolve="RecordValue" />
+                        </node>
+                        <node concept="37vLTw" id="5CUQ8HxocL" role="10QFUP">
+                          <ref role="3cqZAo" node="1EZBwZ4mpvz" resolve="exp" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="5CUQ8Hxoju" role="3cqZAp" />
+                  <node concept="3clFbJ" id="5CUQ8HxoCW" role="3cqZAp">
+                    <node concept="3clFbS" id="5CUQ8HxoCY" role="3clFbx">
+                      <node concept="3cpWs6" id="5CUQ8Hxsrs" role="3cqZAp">
+                        <node concept="3clFbT" id="5CUQ8Hxs_x" role="3cqZAk" />
+                      </node>
+                    </node>
+                    <node concept="3y3z36" id="5CUQ8Hxpq6" role="3clFbw">
+                      <node concept="2OqwBi" id="5CUQ8Hxs1s" role="3uHU7w">
+                        <node concept="37vLTw" id="5CUQ8HxrLu" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5CUQ8Hxo9x" resolve="rve" />
+                        </node>
+                        <node concept="liA8E" id="5CUQ8Hxsp3" role="2OqNvi">
+                          <ref role="37wK5l" to="pq1l:3vxfdxaYUpD" resolve="recordDeclaration" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="5CUQ8HxoQc" role="3uHU7B">
+                        <node concept="37vLTw" id="5CUQ8HxoEC" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5CUQ8Hxo03" resolve="rva" />
+                        </node>
+                        <node concept="liA8E" id="5CUQ8Hxp09" role="2OqNvi">
+                          <ref role="37wK5l" to="pq1l:3vxfdxaYUpD" resolve="recordDeclaration" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="5CUQ8HxHLf" role="3cqZAp">
+                    <node concept="3clFbS" id="5CUQ8HxHLh" role="3clFbx">
+                      <node concept="3cpWs6" id="5CUQ8HxMlw" role="3cqZAp">
+                        <node concept="3clFbT" id="5CUQ8HxMmi" role="3cqZAk" />
+                      </node>
+                    </node>
+                    <node concept="3y3z36" id="5CUQ8HxKaz" role="3clFbw">
+                      <node concept="2OqwBi" id="5CUQ8HxLEO" role="3uHU7w">
+                        <node concept="2OqwBi" id="5CUQ8HxKwM" role="2Oq$k0">
+                          <node concept="37vLTw" id="5CUQ8HxKbu" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5CUQ8Hxo9x" resolve="rve" />
+                          </node>
+                          <node concept="liA8E" id="5CUQ8HxLaD" role="2OqNvi">
+                            <ref role="37wK5l" to="pq1l:35CkgbMKMzX" resolve="memberNames" />
+                          </node>
+                        </node>
+                        <node concept="34oBXx" id="5CUQ8HxLQX" role="2OqNvi" />
+                      </node>
+                      <node concept="2OqwBi" id="5CUQ8HxJ2t" role="3uHU7B">
+                        <node concept="2OqwBi" id="5CUQ8HxIpw" role="2Oq$k0">
+                          <node concept="37vLTw" id="5CUQ8HxIdK" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5CUQ8Hxo03" resolve="rva" />
+                          </node>
+                          <node concept="liA8E" id="5CUQ8HxIMD" role="2OqNvi">
+                            <ref role="37wK5l" to="pq1l:35CkgbMKMzX" resolve="memberNames" />
+                          </node>
+                        </node>
+                        <node concept="34oBXx" id="5CUQ8HxJdP" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="5jyJiPC7HhW" role="3cqZAp">
+                    <node concept="3clFbS" id="5jyJiPC7HhY" role="3clFbx">
+                      <node concept="3SKdUt" id="5jyJiPC7NhK" role="3cqZAp">
+                        <node concept="1PaTwC" id="5jyJiPC7NhL" role="3ndbpf">
+                          <node concept="3oM_SD" id="5jyJiPC7NhN" role="1PaTwD">
+                            <property role="3oM_SC" value="Record" />
+                          </node>
+                          <node concept="3oM_SD" id="5jyJiPC7Ym$" role="1PaTwD">
+                            <property role="3oM_SC" value="values" />
+                          </node>
+                          <node concept="3oM_SD" id="5jyJiPC7NLG" role="1PaTwD">
+                            <property role="3oM_SC" value="have" />
+                          </node>
+                          <node concept="3oM_SD" id="5jyJiPC7NLJ" role="1PaTwD">
+                            <property role="3oM_SC" value="values" />
+                          </node>
+                          <node concept="3oM_SD" id="5jyJiPC7YmU" role="1PaTwD">
+                            <property role="3oM_SC" value="for" />
+                          </node>
+                          <node concept="3oM_SD" id="5jyJiPC7Yn1" role="1PaTwD">
+                            <property role="3oM_SC" value="different" />
+                          </node>
+                          <node concept="3oM_SD" id="5jyJiPC7NLN" role="1PaTwD">
+                            <property role="3oM_SC" value="members" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs6" id="5jyJiPC7KwX" role="3cqZAp">
+                        <node concept="3clFbT" id="5jyJiPC7KxJ" role="3cqZAk" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="5jyJiPC7KrL" role="3clFbw">
+                      <node concept="2OqwBi" id="5jyJiPC7KrM" role="2Oq$k0">
+                        <node concept="2OqwBi" id="5jyJiPC7KrN" role="2Oq$k0">
+                          <node concept="37vLTw" id="5jyJiPC7KrO" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5CUQ8Hxo03" resolve="rva" />
+                          </node>
+                          <node concept="liA8E" id="5jyJiPC7KrP" role="2OqNvi">
+                            <ref role="37wK5l" to="pq1l:35CkgbMKMzX" resolve="memberNames" />
+                          </node>
+                        </node>
+                        <node concept="2NgGto" id="5jyJiPC7KrQ" role="2OqNvi">
+                          <node concept="2OqwBi" id="5jyJiPC7KrR" role="576Qk">
+                            <node concept="37vLTw" id="5jyJiPC7KrS" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5CUQ8Hxo9x" resolve="rve" />
+                            </node>
+                            <node concept="liA8E" id="5jyJiPC7KrT" role="2OqNvi">
+                              <ref role="37wK5l" to="pq1l:35CkgbMKMzX" resolve="memberNames" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3GX2aA" id="5jyJiPC7Y8i" role="2OqNvi" />
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="5CUQ8Hxt_K" role="3cqZAp" />
+                  <node concept="2Gpval" id="5CUQ8Hx_U2" role="3cqZAp">
+                    <node concept="2GrKxI" id="5CUQ8Hx_U4" role="2Gsz3X">
+                      <property role="TrG5h" value="member" />
+                    </node>
+                    <node concept="2OqwBi" id="5CUQ8HxAS5" role="2GsD0m">
+                      <node concept="37vLTw" id="5CUQ8HxAGb" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5CUQ8Hxo9x" resolve="rve" />
+                      </node>
+                      <node concept="liA8E" id="5CUQ8HxB1k" role="2OqNvi">
+                        <ref role="37wK5l" to="pq1l:35CkgbMKMzX" resolve="memberNames" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="5CUQ8Hx_U8" role="2LFqv$">
+                      <node concept="3cpWs8" id="5CUQ8HxB9E" role="3cqZAp">
+                        <node concept="3cpWsn" id="5CUQ8HxB9F" role="3cpWs9">
+                          <property role="TrG5h" value="expectedMember" />
+                          <node concept="3uibUv" id="5CUQ8HxB9G" role="1tU5fm">
+                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                          </node>
+                          <node concept="2OqwBi" id="5CUQ8HxByV" role="33vP2m">
+                            <node concept="37vLTw" id="5CUQ8HxBnO" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5CUQ8Hxo9x" resolve="rve" />
+                            </node>
+                            <node concept="liA8E" id="5CUQ8HxBGa" role="2OqNvi">
+                              <ref role="37wK5l" to="pq1l:7_$HJtBvdxi" resolve="getValueByName" />
+                              <node concept="2GrUjf" id="5CUQ8HxBIB" role="37wK5m">
+                                <ref role="2Gs0qQ" node="5CUQ8Hx_U4" resolve="member" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="5CUQ8HxBWp" role="3cqZAp">
+                        <node concept="3cpWsn" id="5CUQ8HxBWq" role="3cpWs9">
+                          <property role="TrG5h" value="actualMember" />
+                          <node concept="3uibUv" id="5CUQ8HxBWr" role="1tU5fm">
+                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                          </node>
+                          <node concept="2OqwBi" id="5CUQ8HxCh$" role="33vP2m">
+                            <node concept="37vLTw" id="5CUQ8HxCxs" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5CUQ8Hxo03" resolve="rva" />
+                            </node>
+                            <node concept="liA8E" id="5CUQ8HxCp$" role="2OqNvi">
+                              <ref role="37wK5l" to="pq1l:7_$HJtBvdxi" resolve="getValueByName" />
+                              <node concept="2GrUjf" id="5CUQ8HxCzD" role="37wK5m">
+                                <ref role="2Gs0qQ" node="5CUQ8Hx_U4" resolve="member" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbH" id="5CUQ8HxCWw" role="3cqZAp" />
+                      <node concept="3clFbJ" id="5CUQ8HxDzM" role="3cqZAp">
+                        <node concept="3clFbS" id="5CUQ8HxDzO" role="3clFbx">
+                          <node concept="3cpWs6" id="5CUQ8HxDVv" role="3cqZAp">
+                            <node concept="3clFbT" id="5CUQ8HxDWh" role="3cqZAk" />
+                          </node>
+                        </node>
+                        <node concept="3fqX7Q" id="5CUQ8HxDB$" role="3clFbw">
+                          <node concept="1rXfSq" id="5CUQ8HxDDa" role="3fr31v">
+                            <ref role="37wK5l" node="1EZBwZ4muLD" resolve="equals" />
+                            <node concept="37vLTw" id="5CUQ8HxDRb" role="37wK5m">
+                              <ref role="3cqZAo" node="5CUQ8HxB9F" resolve="expectedMember" />
+                            </node>
+                            <node concept="37vLTw" id="5CUQ8HxDTq" role="37wK5m">
+                              <ref role="3cqZAo" node="5CUQ8HxBWq" resolve="actualMember" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="5CUQ8HxDX6" role="3cqZAp" />
+                  <node concept="3cpWs6" id="7fOaqhi48pf" role="3cqZAp">
+                    <node concept="3clFbT" id="7fOaqhi48ph" role="3cqZAk">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="1Wc70l" id="5CUQ8Hxn_L" role="3clFbw">
+                  <node concept="2ZW3vV" id="5CUQ8HxnII" role="3uHU7w">
+                    <node concept="3uibUv" id="5CUQ8HxnLo" role="2ZW6by">
+                      <ref role="3uigEE" to="pq1l:7D7uZV2szll" resolve="RecordValue" />
+                    </node>
+                    <node concept="37vLTw" id="5CUQ8HxnCi" role="2ZW6bz">
+                      <ref role="3cqZAo" node="1EZBwZ4mpvz" resolve="exp" />
+                    </node>
+                  </node>
+                  <node concept="2ZW3vV" id="5CUQ8Hxngb" role="3uHU7B">
+                    <node concept="3uibUv" id="5CUQ8HxniX" role="2ZW6by">
+                      <ref role="3uigEE" to="pq1l:7D7uZV2szll" resolve="RecordValue" />
+                    </node>
+                    <node concept="37vLTw" id="5CUQ8Hxn9k" role="2ZW6bz">
                       <ref role="3cqZAo" node="1EZBwZ4moPT" resolve="act" />
                     </node>
                   </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.records@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.records@tests.mps
@@ -153,7 +153,12 @@
       <concept id="8293738266739943650" name="org.iets3.core.expr.simpleTypes.structure.InterpolExprWord" flags="ng" index="2206Zw">
         <child id="8293738266739943651" name="expr" index="2206Zx" />
       </concept>
-      <concept id="8219602584782245544" name="org.iets3.core.expr.simpleTypes.structure.NumberType" flags="ng" index="mLuIC" />
+      <concept id="1330041117646892924" name="org.iets3.core.expr.simpleTypes.structure.NumberPrecSpec" flags="ng" index="2gteS_">
+        <property id="1330041117646892934" name="prec" index="2gteVv" />
+      </concept>
+      <concept id="8219602584782245544" name="org.iets3.core.expr.simpleTypes.structure.NumberType" flags="ng" index="mLuIC">
+        <child id="1330041117646892937" name="prec" index="2gteVg" />
+      </concept>
       <concept id="7425695345928358745" name="org.iets3.core.expr.simpleTypes.structure.TrueLiteral" flags="ng" index="2vmpnb" />
       <concept id="7425695345928358774" name="org.iets3.core.expr.simpleTypes.structure.FalseLiteral" flags="ng" index="2vmpn$" />
       <concept id="5115872837157252552" name="org.iets3.core.expr.simpleTypes.structure.StringLiteral" flags="ng" index="30bdrP">
@@ -1072,7 +1077,64 @@
         </node>
       </node>
     </node>
+    <node concept="_ixoA" id="5CUQ8HxOXT" role="_iOnB" />
+    <node concept="2Ss9d8" id="5CUQ8HxPEi" role="_iOnB">
+      <property role="TrG5h" value="Point2" />
+      <node concept="2Ss9d7" id="5CUQ8HxQ0B" role="S5Trm">
+        <property role="TrG5h" value="x" />
+        <node concept="mLuIC" id="5CUQ8HxQ0H" role="2S399n">
+          <node concept="2gteS_" id="5CUQ8HxQ0Q" role="2gteVg">
+            <property role="2gteVv" value="1" />
+          </node>
+        </node>
+      </node>
+      <node concept="2Ss9d7" id="5CUQ8HxQ1q" role="S5Trm">
+        <property role="TrG5h" value="y" />
+        <node concept="mLuIC" id="5CUQ8HxQ1z" role="2S399n">
+          <node concept="2gteS_" id="5CUQ8HxQ1G" role="2gteVg">
+            <property role="2gteVv" value="1" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="_ixoA" id="5YygIlboZTl" role="_iOnB" />
+    <node concept="_fkuM" id="5CUQ8HxOBG" role="_iOnB">
+      <property role="TrG5h" value="recordWithDecimals" />
+      <node concept="_fkuZ" id="5CUQ8HyKN0" role="_fkp5">
+        <node concept="_fku$" id="5CUQ8HyKN1" role="_fkur" />
+        <node concept="30bXRB" id="5CUQ8HyKPt" role="_fkuY">
+          <property role="30bXRw" value="1.0" />
+        </node>
+        <node concept="30bXRB" id="5CUQ8HyKPM" role="_fkuS">
+          <property role="30bXRw" value="1" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="5CUQ8HxQ23" role="_fkp5">
+        <node concept="_fku$" id="5CUQ8HxQ24" role="_fkur" />
+        <node concept="2S399m" id="5CUQ8HxQ2h" role="_fkuY">
+          <node concept="2Ss9cW" id="5CUQ8HxQ2l" role="2S399n">
+            <ref role="2Ss9cX" node="5CUQ8HxPEi" resolve="Point2" />
+          </node>
+          <node concept="30bXRB" id="5CUQ8HxQ2_" role="2S399l">
+            <property role="30bXRw" value="1.0" />
+          </node>
+          <node concept="30bXRB" id="5CUQ8HxQ3J" role="2S399l">
+            <property role="30bXRw" value="2.0" />
+          </node>
+        </node>
+        <node concept="2S399m" id="5CUQ8HxQ4S" role="_fkuS">
+          <node concept="2Ss9cW" id="5CUQ8HxQ4W" role="2S399n">
+            <ref role="2Ss9cX" node="5CUQ8HxPEi" resolve="Point2" />
+          </node>
+          <node concept="30bXRB" id="5CUQ8HxQ6c" role="2S399l">
+            <property role="30bXRw" value="1" />
+          </node>
+          <node concept="30bXRB" id="5CUQ8HxQ6Z" role="2S399l">
+            <property role="30bXRw" value="2" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="_ixoA" id="5YygIlbp005" role="_iOnB" />
     <node concept="_ixoA" id="4ptnK4jeq01" role="_iOnB" />
   </node>


### PR DESCRIPTION
Number equality in KernelF ignores zeroes after the decimal point, so 1
== 1.0. This did not hold true for records containing numbers, however,
so Point{1,2} was different from Point{1.0,2.0}.

This commit fixes the generator and the interpreter so that Point{1,2}
now compares equal to Point{1.0,2.0}.