### PR TITLE
expr.util: Fix cast exception for typesystem

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/behavior.mps
@@ -8,6 +8,7 @@
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="-1" />
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="-1" />
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="-1" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -169,6 +170,30 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5858074156537516430" name="jetbrains.mps.baseLanguage.javadoc.structure.ReturnBlockDocTag" flags="ng" index="x79VA">
+        <property id="5858074156537516431" name="text" index="x79VB" />
+      </concept>
+      <concept id="6832197706140518104" name="jetbrains.mps.baseLanguage.javadoc.structure.DocMethodParameterReference" flags="ng" index="zr_55" />
+      <concept id="6832197706140518103" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseParameterReference" flags="ng" index="zr_5a">
+        <reference id="6832197706140518108" name="param" index="zr_51" />
+      </concept>
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
+        <child id="5383422241790532083" name="tags" index="3nqlJM" />
+      </concept>
+      <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690881930" name="jetbrains.mps.baseLanguage.javadoc.structure.ParameterBlockDocTag" flags="ng" index="TUZQ0">
+        <property id="8465538089690881934" name="text" index="TUZQ4" />
+        <child id="6832197706140518123" name="parameter" index="zr_5Q" />
+      </concept>
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
+      </concept>
+    </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
         <reference id="5455284157994012188" name="link" index="2pIpSl" />
@@ -265,6 +290,7 @@
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
@@ -1507,25 +1533,18 @@
       <node concept="3Tm1VV" id="22hm_0zjC8P" role="1B3o_S" />
       <node concept="3clFbS" id="22hm_0zjC8S" role="3clF47">
         <node concept="3clFbF" id="22hm_0zjC9l" role="3cqZAp">
-          <node concept="1PxgMI" id="22hm_0zjCxy" role="3clFbG">
-            <node concept="chp4Y" id="1Ap9E00ArpL" role="3oSUPX">
-              <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
-            </node>
-            <node concept="2OqwBi" id="22hm_0zjCmR" role="1m5AlR">
-              <node concept="2OqwBi" id="22hm_0zjCbJ" role="2Oq$k0">
-                <node concept="13iPFW" id="22hm_0zjC9k" role="2Oq$k0" />
-                <node concept="3TrEf2" id="22hm_0zjCgn" role="2OqNvi">
-                  <ref role="3Tt5mk" to="kfo3:22hm_0z9Lca" resolve="expression" />
-                </node>
+          <node concept="2OqwBi" id="22hm_0zjCmR" role="3clFbG">
+            <node concept="2OqwBi" id="22hm_0zjCbJ" role="2Oq$k0">
+              <node concept="13iPFW" id="22hm_0zjC9k" role="2Oq$k0" />
+              <node concept="3TrEf2" id="22hm_0zjCgn" role="2OqNvi">
+                <ref role="3Tt5mk" to="kfo3:22hm_0z9Lca" resolve="expression" />
               </node>
-              <node concept="3JvlWi" id="22hm_0zjCsY" role="2OqNvi" />
             </node>
+            <node concept="3JvlWi" id="22hm_0zjCsY" role="2OqNvi" />
           </node>
         </node>
       </node>
-      <node concept="3Tqbb2" id="7vcJOhhECks" role="3clF45">
-        <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
-      </node>
+      <node concept="3Tqbb2" id="7vcJOhhECks" role="3clF45" />
       <node concept="37vLTG" id="7vcJOhhECkt" role="3clF46">
         <property role="TrG5h" value="currentNode" />
         <node concept="3Tqbb2" id="7vcJOhhECku" role="1tU5fm" />
@@ -1682,12 +1701,36 @@
       <property role="TrG5h" value="getRangeType" />
       <node concept="3Tm1VV" id="22hm_0zj$Sc" role="1B3o_S" />
       <node concept="3clFbS" id="22hm_0zj$Sd" role="3clF47" />
-      <node concept="3Tqbb2" id="22hm_0zj$Sj" role="3clF45">
-        <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
-      </node>
+      <node concept="3Tqbb2" id="22hm_0zj$Sj" role="3clF45" />
       <node concept="37vLTG" id="7vcJOhhEp3c" role="3clF46">
         <property role="TrG5h" value="currentNode" />
         <node concept="3Tqbb2" id="7vcJOhhEp3b" role="1tU5fm" />
+      </node>
+      <node concept="P$JXv" id="pMMd3fGZuG" role="lGtFl">
+        <node concept="TZ5HA" id="pMMd3fGZuH" role="TZ5H$">
+          <node concept="1dT_AC" id="pMMd3fGZuI" role="1dT_Ay">
+            <property role="1dT_AB" value="Returns the rangeType as node, but it has to be cast to node&lt;Type&gt; when used in the typesystem with a &quot;when concrete&quot;" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="pMMd3fGZJB" role="TZ5H$">
+          <node concept="1dT_AC" id="pMMd3fGZJC" role="1dT_Ay">
+            <property role="1dT_AB" value="It cannot be casted here, since it leads to cast exceptions, when this method is called from the typesystem and the" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="pMMd3fGZIn" role="TZ5H$">
+          <node concept="1dT_AC" id="pMMd3fGZIo" role="1dT_Ay">
+            <property role="1dT_AB" value="calculated type is still an intermediate type, because the typesystem is not finished with its calculation." />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="pMMd3fGZuJ" role="3nqlJM">
+          <property role="TUZQ4" value="to calculate the rangeType from" />
+          <node concept="zr_55" id="pMMd3fGZuL" role="zr_5Q">
+            <ref role="zr_51" node="7vcJOhhEp3c" resolve="currentNode" />
+          </node>
+        </node>
+        <node concept="x79VA" id="pMMd3fGZuM" role="3nqlJM">
+          <property role="x79VB" value="type as node&lt;&gt;" />
+        </node>
       </node>
     </node>
     <node concept="13hLZK" id="22hm_0zj$S1" role="13h7CW">
@@ -3924,38 +3967,31 @@
       <ref role="13i0hy" node="22hm_0zj$Sb" resolve="getRangeType" />
       <node concept="3Tm1VV" id="7vcJOhhDO7a" role="1B3o_S" />
       <node concept="3clFbS" id="7vcJOhhDO7d" role="3clF47">
-        <node concept="3clFbF" id="7vcJOhhHbKg" role="3cqZAp">
-          <node concept="1PxgMI" id="7vcJOhhHcDc" role="3clFbG">
-            <node concept="chp4Y" id="7vcJOhhHcEm" role="3oSUPX">
-              <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
-            </node>
-            <node concept="2OqwBi" id="7vcJOhhHcc0" role="1m5AlR">
-              <node concept="2OqwBi" id="7vcJOhhHbi7" role="2Oq$k0">
-                <node concept="2OqwBi" id="7PlS3092CjD" role="2Oq$k0">
-                  <node concept="37vLTw" id="7vcJOhhEwRQ" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7vcJOhhEpat" resolve="currentNode" />
-                  </node>
-                  <node concept="2Xjw5R" id="7PlS3092Cz$" role="2OqNvi">
-                    <node concept="1xMEDy" id="7PlS3092CzA" role="1xVPHs">
-                      <node concept="chp4Y" id="7PlS3092CBo" role="ri$Ld">
-                        <ref role="cht4Q" to="kfo3:8XWEtdYkhC" resolve="Content" />
-                      </node>
-                    </node>
-                    <node concept="1xIGOp" id="7PlS3092CIe" role="1xVPHs" />
-                  </node>
+        <node concept="3clFbF" id="pMMd3fGEoH" role="3cqZAp">
+          <node concept="2OqwBi" id="pMMd3fs71_" role="3clFbG">
+            <node concept="2OqwBi" id="pMMd3fs71A" role="2Oq$k0">
+              <node concept="2OqwBi" id="pMMd3fs71B" role="2Oq$k0">
+                <node concept="37vLTw" id="pMMd3fs71C" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7vcJOhhEpat" resolve="currentNode" />
                 </node>
-                <node concept="3TrEf2" id="7vcJOhhHbzO" role="2OqNvi">
-                  <ref role="3Tt5mk" to="kfo3:8XWEtdYkmU" resolve="col" />
+                <node concept="2Xjw5R" id="pMMd3fs71D" role="2OqNvi">
+                  <node concept="1xMEDy" id="pMMd3fs71E" role="1xVPHs">
+                    <node concept="chp4Y" id="pMMd3fs71F" role="ri$Ld">
+                      <ref role="cht4Q" to="kfo3:8XWEtdYkhC" resolve="Content" />
+                    </node>
+                  </node>
+                  <node concept="1xIGOp" id="pMMd3fs71G" role="1xVPHs" />
                 </node>
               </node>
-              <node concept="3JvlWi" id="7vcJOhhHcpT" role="2OqNvi" />
+              <node concept="3TrEf2" id="pMMd3fs71H" role="2OqNvi">
+                <ref role="3Tt5mk" to="kfo3:8XWEtdYkmU" resolve="col" />
+              </node>
             </node>
+            <node concept="3JvlWi" id="pMMd3fs71I" role="2OqNvi" />
           </node>
         </node>
       </node>
-      <node concept="3Tqbb2" id="7vcJOhhEpas" role="3clF45">
-        <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
-      </node>
+      <node concept="3Tqbb2" id="7vcJOhhEpas" role="3clF45" />
       <node concept="37vLTG" id="7vcJOhhEpat" role="3clF46">
         <property role="TrG5h" value="currentNode" />
         <node concept="3Tqbb2" id="7vcJOhhEpau" role="1tU5fm" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/typesystem.mps
@@ -759,68 +759,78 @@
     <property role="TrG5h" value="typeof_IntermediateRS" />
     <property role="3GE5qa" value="range" />
     <node concept="3clFbS" id="22hm_0zjRzX" role="18ibNy">
-      <node concept="3cpWs8" id="22hm_0zjR$3" role="3cqZAp">
-        <node concept="3cpWsn" id="22hm_0zjR$4" role="3cpWs9">
-          <property role="TrG5h" value="rt" />
-          <node concept="3Tqbb2" id="22hm_0zjR$5" role="1tU5fm">
-            <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
-          </node>
-          <node concept="2OqwBi" id="22hm_0zjR$6" role="33vP2m">
-            <node concept="2OqwBi" id="22hm_0zjR$7" role="2Oq$k0">
-              <node concept="1YBJjd" id="22hm_0zjRRf" role="2Oq$k0">
-                <ref role="1YBMHb" node="22hm_0zjRzZ" resolve="ir" />
+      <node concept="nvevp" id="pMMd3fCJ1J" role="3cqZAp">
+        <node concept="3clFbS" id="pMMd3fCJ1L" role="nvhr_">
+          <node concept="1ZobV4" id="22hm_0zjR$d" role="3cqZAp">
+            <node concept="mw_s8" id="22hm_0zjR$e" role="1ZfhKB">
+              <node concept="1PxgMI" id="pMMd3fCJxG" role="mwGJk">
+                <node concept="chp4Y" id="pMMd3fCJyi" role="3oSUPX">
+                  <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                </node>
+                <node concept="2X3wrD" id="pMMd3fCJqF" role="1m5AlR">
+                  <ref role="2X3Bk0" node="pMMd3fCJ1P" resolve="rangeType" />
+                </node>
               </node>
-              <node concept="2Xjw5R" id="22hm_0zjR$9" role="2OqNvi">
-                <node concept="1xMEDy" id="22hm_0zjR$a" role="1xVPHs">
-                  <node concept="chp4Y" id="22hm_0zjR$b" role="ri$Ld">
-                    <ref role="cht4Q" to="kfo3:22hm_0zj$RB" resolve="IRangeContext" />
+            </node>
+            <node concept="mw_s8" id="22hm_0zjR$g" role="1ZfhK$">
+              <node concept="1Z2H0r" id="22hm_0zjR$h" role="mwGJk">
+                <node concept="2OqwBi" id="22hm_0zjR$i" role="1Z2MuG">
+                  <node concept="1YBJjd" id="22hm_0zjRTp" role="2Oq$k0">
+                    <ref role="1YBMHb" node="22hm_0zjRzZ" resolve="ir" />
+                  </node>
+                  <node concept="3TrEf2" id="22hm_0zjS92" role="2OqNvi">
+                    <ref role="3Tt5mk" to="kfo3:1tPb0nsnb7k" resolve="lower" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="2qgKlT" id="22hm_0zjR$c" role="2OqNvi">
-              <ref role="37wK5l" to="wthy:22hm_0zj$Sb" resolve="getRangeType" />
-              <node concept="1YBJjd" id="7vcJOhhECl7" role="37wK5m">
-                <ref role="1YBMHb" node="22hm_0zjRzZ" resolve="ir" />
+          </node>
+          <node concept="1ZobV4" id="22hm_0zjS9s" role="3cqZAp">
+            <node concept="mw_s8" id="22hm_0zjS9t" role="1ZfhKB">
+              <node concept="1PxgMI" id="pMMd3fCJEl" role="mwGJk">
+                <node concept="chp4Y" id="pMMd3fCJEK" role="3oSUPX">
+                  <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                </node>
+                <node concept="2X3wrD" id="pMMd3fCJzl" role="1m5AlR">
+                  <ref role="2X3Bk0" node="pMMd3fCJ1P" resolve="rangeType" />
+                </node>
+              </node>
+            </node>
+            <node concept="mw_s8" id="22hm_0zjS9v" role="1ZfhK$">
+              <node concept="1Z2H0r" id="22hm_0zjS9w" role="mwGJk">
+                <node concept="2OqwBi" id="22hm_0zjS9x" role="1Z2MuG">
+                  <node concept="1YBJjd" id="22hm_0zjS9y" role="2Oq$k0">
+                    <ref role="1YBMHb" node="22hm_0zjRzZ" resolve="ir" />
+                  </node>
+                  <node concept="3TrEf2" id="22hm_0zjSfn" role="2OqNvi">
+                    <ref role="3Tt5mk" to="kfo3:1tPb0nsnb7m" resolve="upper" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
         </node>
-      </node>
-      <node concept="1ZobV4" id="22hm_0zjR$d" role="3cqZAp">
-        <node concept="mw_s8" id="22hm_0zjR$e" role="1ZfhKB">
-          <node concept="37vLTw" id="22hm_0zjR$f" role="mwGJk">
-            <ref role="3cqZAo" node="22hm_0zjR$4" resolve="rt" />
-          </node>
+        <node concept="2X1qdy" id="pMMd3fCJ1P" role="2X0Ygz">
+          <property role="TrG5h" value="rangeType" />
+          <node concept="2jxLKc" id="pMMd3fCJ1Q" role="1tU5fm" />
         </node>
-        <node concept="mw_s8" id="22hm_0zjR$g" role="1ZfhK$">
-          <node concept="1Z2H0r" id="22hm_0zjR$h" role="mwGJk">
-            <node concept="2OqwBi" id="22hm_0zjR$i" role="1Z2MuG">
-              <node concept="1YBJjd" id="22hm_0zjRTp" role="2Oq$k0">
-                <ref role="1YBMHb" node="22hm_0zjRzZ" resolve="ir" />
-              </node>
-              <node concept="3TrEf2" id="22hm_0zjS92" role="2OqNvi">
-                <ref role="3Tt5mk" to="kfo3:1tPb0nsnb7k" resolve="lower" />
+        <node concept="2OqwBi" id="22hm_0zjR$6" role="nvjzm">
+          <node concept="2OqwBi" id="22hm_0zjR$7" role="2Oq$k0">
+            <node concept="1YBJjd" id="22hm_0zjRRf" role="2Oq$k0">
+              <ref role="1YBMHb" node="22hm_0zjRzZ" resolve="ir" />
+            </node>
+            <node concept="2Xjw5R" id="22hm_0zjR$9" role="2OqNvi">
+              <node concept="1xMEDy" id="22hm_0zjR$a" role="1xVPHs">
+                <node concept="chp4Y" id="22hm_0zjR$b" role="ri$Ld">
+                  <ref role="cht4Q" to="kfo3:22hm_0zj$RB" resolve="IRangeContext" />
+                </node>
               </node>
             </node>
           </node>
-        </node>
-      </node>
-      <node concept="1ZobV4" id="22hm_0zjS9s" role="3cqZAp">
-        <node concept="mw_s8" id="22hm_0zjS9t" role="1ZfhKB">
-          <node concept="37vLTw" id="22hm_0zjS9u" role="mwGJk">
-            <ref role="3cqZAo" node="22hm_0zjR$4" resolve="rt" />
-          </node>
-        </node>
-        <node concept="mw_s8" id="22hm_0zjS9v" role="1ZfhK$">
-          <node concept="1Z2H0r" id="22hm_0zjS9w" role="mwGJk">
-            <node concept="2OqwBi" id="22hm_0zjS9x" role="1Z2MuG">
-              <node concept="1YBJjd" id="22hm_0zjS9y" role="2Oq$k0">
-                <ref role="1YBMHb" node="22hm_0zjRzZ" resolve="ir" />
-              </node>
-              <node concept="3TrEf2" id="22hm_0zjSfn" role="2OqNvi">
-                <ref role="3Tt5mk" to="kfo3:1tPb0nsnb7m" resolve="upper" />
-              </node>
+          <node concept="2qgKlT" id="22hm_0zjR$c" role="2OqNvi">
+            <ref role="37wK5l" to="wthy:22hm_0zj$Sb" resolve="getRangeType" />
+            <node concept="1YBJjd" id="7vcJOhhECl7" role="37wK5m">
+              <ref role="1YBMHb" node="22hm_0zjRzZ" resolve="ir" />
             </node>
           </node>
         </node>
@@ -835,49 +845,54 @@
     <property role="TrG5h" value="typeof_SingleValueRS" />
     <property role="3GE5qa" value="range" />
     <node concept="3clFbS" id="22hm_0zjKnV" role="18ibNy">
-      <node concept="3cpWs8" id="22hm_0zjKTL" role="3cqZAp">
-        <node concept="3cpWsn" id="22hm_0zjKTM" role="3cpWs9">
-          <property role="TrG5h" value="rt" />
-          <node concept="3Tqbb2" id="22hm_0zjKTF" role="1tU5fm">
-            <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
-          </node>
-          <node concept="2OqwBi" id="22hm_0zjKTN" role="33vP2m">
-            <node concept="2OqwBi" id="22hm_0zjKTO" role="2Oq$k0">
-              <node concept="1YBJjd" id="22hm_0zjKTP" role="2Oq$k0">
-                <ref role="1YBMHb" node="22hm_0zjKnX" resolve="sv" />
+      <node concept="nvevp" id="pMMd3fswmD" role="3cqZAp">
+        <node concept="3clFbS" id="pMMd3fswmF" role="nvhr_">
+          <node concept="1ZobV4" id="pMMd3fswu$" role="3cqZAp">
+            <node concept="mw_s8" id="pMMd3fswu_" role="1ZfhKB">
+              <node concept="1PxgMI" id="pMMd3f_Scx" role="mwGJk">
+                <node concept="chp4Y" id="pMMd3f_Scy" role="3oSUPX">
+                  <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                </node>
+                <node concept="2X3wrD" id="pMMd3f_Scz" role="1m5AlR">
+                  <ref role="2X3Bk0" node="pMMd3fswmJ" resolve="rangeType" />
+                </node>
               </node>
-              <node concept="2Xjw5R" id="22hm_0zjKTQ" role="2OqNvi">
-                <node concept="1xMEDy" id="22hm_0zjKTR" role="1xVPHs">
-                  <node concept="chp4Y" id="22hm_0zjKTS" role="ri$Ld">
-                    <ref role="cht4Q" to="kfo3:22hm_0zj$RB" resolve="IRangeContext" />
+            </node>
+            <node concept="mw_s8" id="pMMd3fswuB" role="1ZfhK$">
+              <node concept="1Z2H0r" id="pMMd3fswuC" role="mwGJk">
+                <node concept="2OqwBi" id="pMMd3fswuD" role="1Z2MuG">
+                  <node concept="1YBJjd" id="pMMd3fswuE" role="2Oq$k0">
+                    <ref role="1YBMHb" node="22hm_0zjKnX" resolve="sv" />
+                  </node>
+                  <node concept="3TrEf2" id="pMMd3fswuF" role="2OqNvi">
+                    <ref role="3Tt5mk" to="kfo3:22hm_0zjCPL" resolve="bound" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="2qgKlT" id="22hm_0zjKTT" role="2OqNvi">
-              <ref role="37wK5l" to="wthy:22hm_0zj$Sb" resolve="getRangeType" />
-              <node concept="1YBJjd" id="7vcJOhhECv3" role="37wK5m">
-                <ref role="1YBMHb" node="22hm_0zjKnX" resolve="sv" />
+          </node>
+        </node>
+        <node concept="2X1qdy" id="pMMd3fswmJ" role="2X0Ygz">
+          <property role="TrG5h" value="rangeType" />
+          <node concept="2jxLKc" id="pMMd3fswmK" role="1tU5fm" />
+        </node>
+        <node concept="2OqwBi" id="pMMd3fyUJ6" role="nvjzm">
+          <node concept="2OqwBi" id="pMMd3fyUJ7" role="2Oq$k0">
+            <node concept="1YBJjd" id="pMMd3fyUJ8" role="2Oq$k0">
+              <ref role="1YBMHb" node="22hm_0zjKnX" resolve="sv" />
+            </node>
+            <node concept="2Xjw5R" id="pMMd3fyUJ9" role="2OqNvi">
+              <node concept="1xMEDy" id="pMMd3fyUJa" role="1xVPHs">
+                <node concept="chp4Y" id="pMMd3fyUJb" role="ri$Ld">
+                  <ref role="cht4Q" to="kfo3:22hm_0zj$RB" resolve="IRangeContext" />
+                </node>
               </node>
             </node>
           </node>
-        </node>
-      </node>
-      <node concept="1ZobV4" id="22hm_0zjRv6" role="3cqZAp">
-        <node concept="mw_s8" id="22hm_0zjRwq" role="1ZfhKB">
-          <node concept="37vLTw" id="22hm_0zjRwo" role="mwGJk">
-            <ref role="3cqZAo" node="22hm_0zjKTM" resolve="rt" />
-          </node>
-        </node>
-        <node concept="mw_s8" id="22hm_0zjRv9" role="1ZfhK$">
-          <node concept="1Z2H0r" id="22hm_0zjRjx" role="mwGJk">
-            <node concept="2OqwBi" id="22hm_0zjRmM" role="1Z2MuG">
-              <node concept="1YBJjd" id="22hm_0zjRkZ" role="2Oq$k0">
-                <ref role="1YBMHb" node="22hm_0zjKnX" resolve="sv" />
-              </node>
-              <node concept="3TrEf2" id="22hm_0zjRr_" role="2OqNvi">
-                <ref role="3Tt5mk" to="kfo3:22hm_0zjCPL" resolve="bound" />
-              </node>
+          <node concept="2qgKlT" id="pMMd3fyUJc" role="2OqNvi">
+            <ref role="37wK5l" to="wthy:22hm_0zj$Sb" resolve="getRangeType" />
+            <node concept="1YBJjd" id="pMMd3fyUJd" role="37wK5m">
+              <ref role="1YBMHb" node="22hm_0zjKnX" resolve="sv" />
             </node>
           </node>
         </node>


### PR DESCRIPTION
Two inference rules use behavior methods to infer types. But these behavior methods use the typesystem themselves (`.type:Type`) which leads to exceptions, since `.type` provides an intermediate type when the calculation is not finished.

If there is a better solution to solve this problem I am eager to see it.