### PR TITLE
Provide mechanism to replace port/connection checking rules

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
@@ -107,6 +107,14 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1083245097125" name="jetbrains.mps.baseLanguage.structure.EnumClass" flags="ig" index="Qs71p">
+        <child id="1083245396908" name="enumConstant" index="Qtgdg" />
+      </concept>
+      <concept id="1083245299891" name="jetbrains.mps.baseLanguage.structure.EnumConstantDeclaration" flags="ig" index="QsSxf" />
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
+      </concept>
       <concept id="1164879751025" name="jetbrains.mps.baseLanguage.structure.TryCatchStatement" flags="nn" index="SfApY">
         <child id="1164879758292" name="body" index="SfCbr" />
         <child id="1164903496223" name="catchClause" index="TEbGg" />
@@ -121,6 +129,7 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
@@ -146,6 +155,7 @@
       </concept>
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <property id="1075300953594" name="abstractClass" index="1sVAO0" />
+        <child id="1095933932569" name="implementedInterface" index="EKbjA" />
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
@@ -187,6 +197,7 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
@@ -236,6 +247,7 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
+      <concept id="1107796713796" name="jetbrains.mps.baseLanguage.structure.Interface" flags="ig" index="3HP615" />
       <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
         <child id="1163668914799" name="condition" index="3K4Cdx" />
         <child id="1163668922816" name="ifTrue" index="3K4E3e" />
@@ -361,6 +373,7 @@
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
+      <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
       <concept id="1145567426890" name="jetbrains.mps.lang.smodel.structure.SNodeListCreator" flags="nn" index="2T8Vx0">
         <child id="1145567471833" name="createdType" index="2T96Bj" />
       </concept>
@@ -389,6 +402,9 @@
       </concept>
       <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
@@ -479,6 +495,7 @@
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
+      <concept id="1178894719932" name="jetbrains.mps.baseLanguage.collections.structure.DistinctOperation" flags="nn" index="1VAtEI" />
     </language>
   </registry>
   <node concept="13h7C7" id="6LfBX8YiJ5N">
@@ -1862,6 +1879,253 @@
         <property role="TrG5h" value="kind" />
         <node concept="2ZThk1" id="mIQkxf$E5N" role="1tU5fm">
           <ref role="2ZWj4r" to="w9y2:17Nm8oCo8NH" resolve="PortCategoryKind" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4$W25$gx1L4" role="13h7CS">
+      <property role="TrG5h" value="getInstanceChecker" />
+      <node concept="3Tm1VV" id="4$W25$gx1L5" role="1B3o_S" />
+      <node concept="3uibUv" id="4$W25$gx6cA" role="3clF45">
+        <ref role="3uigEE" node="4$W25$gwNkI" resolve="IComponentInstanceChecker" />
+      </node>
+      <node concept="3clFbS" id="4$W25$gx1L7" role="3clF47">
+        <node concept="3cpWs8" id="4$W25$gxKwK" role="3cqZAp">
+          <node concept="3cpWsn" id="4$W25$gxKwL" role="3cpWs9">
+            <property role="TrG5h" value="checkers" />
+            <node concept="A3Dl8" id="4$W25$gxKr6" role="1tU5fm">
+              <node concept="3uibUv" id="4$W25$gxKr9" role="A3Ik2">
+                <ref role="3uigEE" node="4$W25$gwNkI" resolve="IComponentInstanceChecker" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4$W25$gxKwM" role="33vP2m">
+              <node concept="2OqwBi" id="4$W25$gxKwN" role="2Oq$k0">
+                <node concept="2OqwBi" id="4$W25$gxKwO" role="2Oq$k0">
+                  <node concept="13iPFW" id="4$W25$gxKwP" role="2Oq$k0" />
+                  <node concept="2Rf3mk" id="4$W25$gxKwQ" role="2OqNvi">
+                    <node concept="1xMEDy" id="4$W25$gxKwR" role="1xVPHs">
+                      <node concept="chp4Y" id="4$W25$gxKwS" role="ri$Ld">
+                        <ref role="cht4Q" to="w9y2:4$W25$gwO5f" resolve="IComponentCheckerProvider" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3$u5V9" id="4$W25$gxKwT" role="2OqNvi">
+                  <node concept="1bVj0M" id="4$W25$gxKwU" role="23t8la">
+                    <node concept="3clFbS" id="4$W25$gxKwV" role="1bW5cS">
+                      <node concept="3clFbF" id="4$W25$gxKwW" role="3cqZAp">
+                        <node concept="2OqwBi" id="4$W25$gxKwX" role="3clFbG">
+                          <node concept="37vLTw" id="4$W25$gxKwY" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4$W25$gxKx0" resolve="it" />
+                          </node>
+                          <node concept="2qgKlT" id="4$W25$gxKwZ" role="2OqNvi">
+                            <ref role="37wK5l" node="4$W25$gwO5Q" resolve="getComponentInstanceChecker" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="4$W25$gxKx0" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="4$W25$gxKx1" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1VAtEI" id="4$W25$gxKx2" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5KMsIrXTwRK" role="3cqZAp">
+          <node concept="3clFbS" id="5KMsIrXTwRM" role="3clFbx">
+            <node concept="3SKdUt" id="5KMsIrXTzbJ" role="3cqZAp">
+              <node concept="1PaTwC" id="5KMsIrXTzbK" role="3ndbpf">
+                <node concept="3oM_SD" id="5KMsIrXTzbM" role="1PaTwD">
+                  <property role="3oM_SC" value="use" />
+                </node>
+                <node concept="3oM_SD" id="5KMsIrXTzc5" role="1PaTwD">
+                  <property role="3oM_SC" value="a" />
+                </node>
+                <node concept="3oM_SD" id="5KMsIrXTzci" role="1PaTwD">
+                  <property role="3oM_SC" value="checker" />
+                </node>
+                <node concept="3oM_SD" id="5KMsIrXTzcx" role="1PaTwD">
+                  <property role="3oM_SC" value="provided" />
+                </node>
+                <node concept="3oM_SD" id="5KMsIrXTzcM" role="1PaTwD">
+                  <property role="3oM_SC" value="by" />
+                </node>
+                <node concept="3oM_SD" id="5KMsIrXTzd5" role="1PaTwD">
+                  <property role="3oM_SC" value="some" />
+                </node>
+                <node concept="3oM_SD" id="5KMsIrXTzdi" role="1PaTwD">
+                  <property role="3oM_SC" value="extension" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="5KMsIrXTzdM" role="3cqZAp">
+              <node concept="3clFbS" id="5KMsIrXTzdO" role="3clFbx">
+                <node concept="3SKdUt" id="5KMsIrXTHQR" role="3cqZAp">
+                  <node concept="1PaTwC" id="5KMsIrXTHQS" role="3ndbpf">
+                    <node concept="3oM_SD" id="5KMsIrXTIaG" role="1PaTwD">
+                      <property role="3oM_SC" value="more" />
+                    </node>
+                    <node concept="3oM_SD" id="5KMsIrXTIcZ" role="1PaTwD">
+                      <property role="3oM_SC" value="than" />
+                    </node>
+                    <node concept="3oM_SD" id="5KMsIrXTIds" role="1PaTwD">
+                      <property role="3oM_SC" value="one" />
+                    </node>
+                    <node concept="3oM_SD" id="5KMsIrXTIdV" role="1PaTwD">
+                      <property role="3oM_SC" value="checker" />
+                    </node>
+                    <node concept="3oM_SD" id="5KMsIrXTIe$" role="1PaTwD">
+                      <property role="3oM_SC" value="-" />
+                    </node>
+                    <node concept="3oM_SD" id="5KMsIrXTIeZ" role="1PaTwD">
+                      <property role="3oM_SC" value="we" />
+                    </node>
+                    <node concept="3oM_SD" id="5KMsIrXTIaR" role="1PaTwD">
+                      <property role="3oM_SC" value="issue" />
+                    </node>
+                    <node concept="3oM_SD" id="5KMsIrXTIb4" role="1PaTwD">
+                      <property role="3oM_SC" value="a" />
+                    </node>
+                    <node concept="3oM_SD" id="5KMsIrXTIbb" role="1PaTwD">
+                      <property role="3oM_SC" value="warning" />
+                    </node>
+                    <node concept="3oM_SD" id="5KMsIrXTIbs" role="1PaTwD">
+                      <property role="3oM_SC" value="on" />
+                    </node>
+                    <node concept="3oM_SD" id="5KMsIrXTIbB" role="1PaTwD">
+                      <property role="3oM_SC" value="console" />
+                    </node>
+                    <node concept="3oM_SD" id="5KMsIrXTIbO" role="1PaTwD">
+                      <property role="3oM_SC" value="and" />
+                    </node>
+                    <node concept="3oM_SD" id="5KMsIrXTIcb" role="1PaTwD">
+                      <property role="3oM_SC" value="just" />
+                    </node>
+                    <node concept="3oM_SD" id="5KMsIrXTIc$" role="1PaTwD">
+                      <property role="3oM_SC" value="use" />
+                    </node>
+                    <node concept="3oM_SD" id="5KMsIrXTIf$" role="1PaTwD">
+                      <property role="3oM_SC" value="one" />
+                    </node>
+                    <node concept="3oM_SD" id="5KMsIrXTIgb" role="1PaTwD">
+                      <property role="3oM_SC" value="of" />
+                    </node>
+                    <node concept="3oM_SD" id="5KMsIrXTIgO" role="1PaTwD">
+                      <property role="3oM_SC" value="them" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="5KMsIrXTAZr" role="3cqZAp">
+                  <node concept="2OqwBi" id="5KMsIrXTAZo" role="3clFbG">
+                    <node concept="10M0yZ" id="5KMsIrXTAZp" role="2Oq$k0">
+                      <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                      <ref role="3cqZAo" to="wyt6:~System.err" resolve="err" />
+                    </node>
+                    <node concept="liA8E" id="5KMsIrXTAZq" role="2OqNvi">
+                      <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                      <node concept="3cpWs3" id="5KMsIrXTGC2" role="37wK5m">
+                        <node concept="Xl_RD" id="5KMsIrXTGC5" role="3uHU7w">
+                          <property role="Xl_RC" value=")" />
+                        </node>
+                        <node concept="3cpWs3" id="5KMsIrXTCcE" role="3uHU7B">
+                          <node concept="Xl_RD" id="5KMsIrXTB0T" role="3uHU7B">
+                            <property role="Xl_RC" value="Component.getInstanceChecker: Extended checker not unique (is: " />
+                          </node>
+                          <node concept="2OqwBi" id="5KMsIrXTCAe" role="3uHU7w">
+                            <node concept="37vLTw" id="5KMsIrXTCeN" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4$W25$gxKwL" resolve="checkers" />
+                            </node>
+                            <node concept="3$u5V9" id="5KMsIrXTDhT" role="2OqNvi">
+                              <node concept="1bVj0M" id="5KMsIrXTDhV" role="23t8la">
+                                <node concept="3clFbS" id="5KMsIrXTDhW" role="1bW5cS">
+                                  <node concept="3clFbF" id="5KMsIrXTDyo" role="3cqZAp">
+                                    <node concept="2OqwBi" id="5KMsIrXTFiG" role="3clFbG">
+                                      <node concept="2OqwBi" id="5KMsIrXTDJ_" role="2Oq$k0">
+                                        <node concept="37vLTw" id="5KMsIrXTDyn" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="5KMsIrXTDhX" resolve="it" />
+                                        </node>
+                                        <node concept="liA8E" id="5KMsIrXTDWG" role="2OqNvi">
+                                          <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                                        </node>
+                                      </node>
+                                      <node concept="liA8E" id="5KMsIrXTG6_" role="2OqNvi">
+                                        <ref role="37wK5l" to="wyt6:~Class.getName()" resolve="getName" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="Rh6nW" id="5KMsIrXTDhX" role="1bW2Oz">
+                                  <property role="TrG5h" value="it" />
+                                  <node concept="2jxLKc" id="5KMsIrXTDhY" role="1tU5fm" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3eOSWO" id="5KMsIrXT_zQ" role="3clFbw">
+                <node concept="2OqwBi" id="5KMsIrXTzsp" role="3uHU7B">
+                  <node concept="37vLTw" id="5KMsIrXTzev" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4$W25$gxKwL" resolve="checkers" />
+                  </node>
+                  <node concept="34oBXx" id="5KMsIrXTzBO" role="2OqNvi" />
+                </node>
+                <node concept="3cmrfG" id="5KMsIrXT$Hq" role="3uHU7w">
+                  <property role="3cmrfH" value="1" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="5KMsIrXT_Be" role="3cqZAp">
+              <node concept="2OqwBi" id="5KMsIrXTA78" role="3cqZAk">
+                <node concept="37vLTw" id="5KMsIrXT_KH" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4$W25$gxKwL" resolve="checkers" />
+                </node>
+                <node concept="1uHKPH" id="5KMsIrXTAr8" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="5KMsIrXTy_B" role="3clFbw">
+            <node concept="37vLTw" id="5KMsIrXTymX" role="2Oq$k0">
+              <ref role="3cqZAo" node="4$W25$gxKwL" resolve="checkers" />
+            </node>
+            <node concept="3GX2aA" id="5KMsIrXTyOR" role="2OqNvi" />
+          </node>
+          <node concept="9aQIb" id="5KMsIrXTyPU" role="9aQIa">
+            <node concept="3clFbS" id="5KMsIrXTyPV" role="9aQI4">
+              <node concept="3SKdUt" id="5KMsIrXTza6" role="3cqZAp">
+                <node concept="1PaTwC" id="5KMsIrXTza7" role="3ndbpf">
+                  <node concept="3oM_SD" id="5KMsIrXTzaN" role="1PaTwD">
+                    <property role="3oM_SC" value="use" />
+                  </node>
+                  <node concept="3oM_SD" id="5KMsIrXTzar" role="1PaTwD">
+                    <property role="3oM_SC" value="the" />
+                  </node>
+                  <node concept="3oM_SD" id="5KMsIrXTzay" role="1PaTwD">
+                    <property role="3oM_SC" value="default" />
+                  </node>
+                  <node concept="3oM_SD" id="5KMsIrXTzba" role="1PaTwD">
+                    <property role="3oM_SC" value="checker" />
+                  </node>
+                  <node concept="3oM_SD" id="5KMsIrXTzbj" role="1PaTwD">
+                    <property role="3oM_SC" value="implementation" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs6" id="5KMsIrXTAP6" role="3cqZAp">
+                <node concept="10M0yZ" id="5KMsIrXTAP8" role="3cqZAk">
+                  <ref role="3cqZAo" node="4$W25$gxJij" resolve="instance" />
+                  <ref role="1PxDUh" node="4$W25$gwNoP" resolve="DefaultComponentInstanceChecker" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
       </node>
     </node>
@@ -3646,278 +3910,150 @@
         </node>
       </node>
     </node>
-    <node concept="13i0hz" id="7Atos1y63VI" role="13h7CS">
-      <property role="TrG5h" value="getConnectionMulitplicityError" />
-      <node concept="37vLTG" id="4VHfdEqk8ZH" role="3clF46">
+    <node concept="13i0hz" id="5KMsIrXUhY0" role="13h7CS">
+      <property role="TrG5h" value="filterOwnConnections" />
+      <node concept="37vLTG" id="5KMsIrXUl0G" role="3clF46">
         <property role="TrG5h" value="instance" />
-        <node concept="3Tqbb2" id="4VHfdEqkaep" role="1tU5fm">
+        <node concept="3Tqbb2" id="5KMsIrXUl0H" role="1tU5fm">
           <ref role="ehGHo" to="w9y2:77HYM7HomhL" resolve="AbstractComponentInstanceBase" />
         </node>
       </node>
-      <node concept="3Tm1VV" id="7Atos1y63VJ" role="1B3o_S" />
-      <node concept="17QB3L" id="7Atos1y641A" role="3clF45" />
-      <node concept="3clFbS" id="7Atos1y63VL" role="3clF47">
-        <node concept="3cpWs8" id="7Atos1y666u" role="3cqZAp">
-          <node concept="3cpWsn" id="7Atos1y666v" role="3cpWs9">
-            <property role="TrG5h" value="connectedToMe" />
-            <node concept="A3Dl8" id="7Atos1y665p" role="1tU5fm">
-              <node concept="3Tqbb2" id="7Atos1y665s" role="A3Ik2">
-                <ref role="ehGHo" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="7Atos1y666w" role="33vP2m">
-              <node concept="37vLTw" id="7Atos1y666x" role="2Oq$k0">
-                <ref role="3cqZAo" node="7Atos1y641F" resolve="allConnectors" />
-              </node>
-              <node concept="3zZkjj" id="7Atos1y666y" role="2OqNvi">
-                <node concept="1bVj0M" id="7Atos1y666z" role="23t8la">
-                  <node concept="3clFbS" id="7Atos1y666$" role="1bW5cS">
-                    <node concept="3cpWs8" id="7Atos1y666_" role="3cqZAp">
-                      <node concept="3cpWsn" id="7Atos1y666A" role="3cpWs9">
-                        <property role="TrG5h" value="ports" />
-                        <node concept="1LlUBW" id="7Atos1y666B" role="1tU5fm">
-                          <node concept="3Tqbb2" id="7Atos1y666C" role="1Lm7xW">
-                            <ref role="ehGHo" to="w9y2:6LfBX8YkpdW" resolve="Port" />
-                          </node>
-                          <node concept="3Tqbb2" id="7Atos1y666D" role="1Lm7xW">
-                            <ref role="ehGHo" to="w9y2:6LfBX8YkpdW" resolve="Port" />
-                          </node>
-                        </node>
-                        <node concept="2OqwBi" id="7Atos1y666E" role="33vP2m">
-                          <node concept="37vLTw" id="7Atos1y666F" role="2Oq$k0">
-                            <ref role="3cqZAo" node="7Atos1y666T" resolve="it" />
-                          </node>
-                          <node concept="2qgKlT" id="7Atos1y666G" role="2OqNvi">
-                            <ref role="37wK5l" node="mIQkxg5ZT6" resolve="getPorts" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="7Atos1y666H" role="3cqZAp">
-                      <node concept="22lmx$" id="7Atos1y666I" role="3clFbG">
-                        <node concept="1eOMI4" id="4VHfdEqkKQ9" role="3uHU7w">
-                          <node concept="1Wc70l" id="4VHfdEqkKQa" role="1eOMHV">
-                            <node concept="1eOMI4" id="4VHfdEqkKQb" role="3uHU7B">
-                              <node concept="3clFbC" id="4VHfdEqkKQc" role="1eOMHV">
-                                <node concept="1LFfDK" id="4VHfdEqkKQd" role="3uHU7B">
-                                  <node concept="3cmrfG" id="4VHfdEqkKQe" role="1LF_Uc">
-                                    <property role="3cmrfH" value="1" />
-                                  </node>
-                                  <node concept="37vLTw" id="4VHfdEqkKQf" role="1LFl5Q">
-                                    <ref role="3cqZAo" node="7Atos1y666A" resolve="ports" />
-                                  </node>
-                                </node>
-                                <node concept="13iPFW" id="4VHfdEqkKQg" role="3uHU7w" />
-                              </node>
-                            </node>
-                            <node concept="1eOMI4" id="4VHfdEqkKQh" role="3uHU7w">
-                              <node concept="3clFbC" id="4VHfdEqkKQi" role="1eOMHV">
-                                <node concept="2OqwBi" id="4VHfdEqkKQj" role="3uHU7B">
-                                  <node concept="37vLTw" id="4VHfdEqkKQk" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="7Atos1y666T" resolve="it" />
-                                  </node>
-                                  <node concept="2qgKlT" id="4VHfdEqkKQl" role="2OqNvi">
-                                    <ref role="37wK5l" node="4VHfdEqkeO4" resolve="getInstanceForPort" />
-                                    <node concept="1LFfDK" id="4VHfdEqkKQm" role="37wK5m">
-                                      <node concept="3cmrfG" id="4VHfdEqkKQn" role="1LF_Uc">
-                                        <property role="3cmrfH" value="1" />
-                                      </node>
-                                      <node concept="37vLTw" id="4VHfdEqkKQo" role="1LFl5Q">
-                                        <ref role="3cqZAo" node="7Atos1y666A" resolve="ports" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="37vLTw" id="4VHfdEqkKQp" role="3uHU7w">
-                                  <ref role="3cqZAo" node="4VHfdEqk8ZH" resolve="instance" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="1eOMI4" id="4VHfdEqkEuQ" role="3uHU7B">
-                          <node concept="1Wc70l" id="4VHfdEqkzu3" role="1eOMHV">
-                            <node concept="1eOMI4" id="4VHfdEqkDnh" role="3uHU7w">
-                              <node concept="3clFbC" id="4VHfdEqkBOj" role="1eOMHV">
-                                <node concept="2OqwBi" id="4VHfdEqk$mS" role="3uHU7B">
-                                  <node concept="37vLTw" id="4VHfdEqkzO7" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="7Atos1y666T" resolve="it" />
-                                  </node>
-                                  <node concept="2qgKlT" id="4VHfdEqk$Ya" role="2OqNvi">
-                                    <ref role="37wK5l" node="4VHfdEqkeO4" resolve="getInstanceForPort" />
-                                    <node concept="1LFfDK" id="4VHfdEqkAcQ" role="37wK5m">
-                                      <node concept="3cmrfG" id="4VHfdEqkACK" role="1LF_Uc">
-                                        <property role="3cmrfH" value="0" />
-                                      </node>
-                                      <node concept="37vLTw" id="4VHfdEqk_mi" role="1LFl5Q">
-                                        <ref role="3cqZAo" node="7Atos1y666A" resolve="ports" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="37vLTw" id="4VHfdEqkCj1" role="3uHU7w">
-                                  <ref role="3cqZAo" node="4VHfdEqk8ZH" resolve="instance" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="1eOMI4" id="4VHfdEqkyRl" role="3uHU7B">
-                              <node concept="3clFbC" id="4VHfdEqkyRm" role="1eOMHV">
-                                <node concept="1LFfDK" id="4VHfdEqkyRn" role="3uHU7B">
-                                  <node concept="3cmrfG" id="4VHfdEqkyRo" role="1LF_Uc">
-                                    <property role="3cmrfH" value="0" />
-                                  </node>
-                                  <node concept="37vLTw" id="4VHfdEqkyRp" role="1LFl5Q">
-                                    <ref role="3cqZAo" node="7Atos1y666A" resolve="ports" />
-                                  </node>
-                                </node>
-                                <node concept="13iPFW" id="4VHfdEqkyRq" role="3uHU7w" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="Rh6nW" id="7Atos1y666T" role="1bW2Oz">
-                    <property role="TrG5h" value="it" />
-                    <node concept="2jxLKc" id="7Atos1y666U" role="1tU5fm" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="7Atos1y66NC" role="3cqZAp">
-          <node concept="3cpWsn" id="7Atos1y66ND" role="3cpWs9">
-            <property role="TrG5h" value="count" />
-            <node concept="10Oyi0" id="7Atos1y66Mp" role="1tU5fm" />
-            <node concept="2OqwBi" id="7Atos1y66NE" role="33vP2m">
-              <node concept="37vLTw" id="7Atos1y66NF" role="2Oq$k0">
-                <ref role="3cqZAo" node="7Atos1y666v" resolve="connectedToMe" />
-              </node>
-              <node concept="34oBXx" id="7Atos1y66NG" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="7Atos1y67YC" role="3cqZAp">
-          <node concept="3cpWsn" id="7Atos1y67YD" role="3cpWs9">
-            <property role="TrG5h" value="mult" />
-            <node concept="1LlUBW" id="7Atos1y67Yn" role="1tU5fm">
-              <node concept="10Oyi0" id="7Atos1y67Ys" role="1Lm7xW" />
-              <node concept="10Oyi0" id="7Atos1y67Yt" role="1Lm7xW" />
-            </node>
-            <node concept="2OqwBi" id="7Atos1y67YE" role="33vP2m">
-              <node concept="2OqwBi" id="7Atos1y67YF" role="2Oq$k0">
-                <node concept="13iPFW" id="7Atos1y67YG" role="2Oq$k0" />
-                <node concept="3TrEf2" id="7Atos1y67YH" role="2OqNvi">
-                  <ref role="3Tt5mk" to="w9y2:mIQkxfpv7_" resolve="category" />
-                </node>
-              </node>
-              <node concept="2qgKlT" id="7Atos1y67YI" role="2OqNvi">
-                <ref role="37wK5l" node="7Atos1y391f" resolve="multiplicity" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="7Atos1y66Yj" role="3cqZAp">
-          <node concept="3clFbS" id="7Atos1y66Yl" role="3clFbx">
-            <node concept="3cpWs6" id="7Atos1y68_O" role="3cqZAp">
-              <node concept="3cpWs3" id="7Atos1y6aFO" role="3cqZAk">
-                <node concept="Xl_RD" id="7Atos1y6aFR" role="3uHU7w">
-                  <property role="Xl_RC" value=" required." />
-                </node>
-                <node concept="3cpWs3" id="7Atos1y69Xa" role="3uHU7B">
-                  <node concept="Xl_RD" id="7Atos1y68Gg" role="3uHU7B">
-                    <property role="Xl_RC" value="Too few connectors; " />
-                  </node>
-                  <node concept="1LFfDK" id="7Atos1y6akr" role="3uHU7w">
-                    <node concept="3cmrfG" id="7Atos1y6auT" role="1LF_Uc">
-                      <property role="3cmrfH" value="0" />
-                    </node>
-                    <node concept="37vLTw" id="7Atos1y6a7q" role="1LFl5Q">
-                      <ref role="3cqZAo" node="7Atos1y67YD" resolve="mult" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3eOVzh" id="7Atos1y67b0" role="3clFbw">
-            <node concept="37vLTw" id="7Atos1y674D" role="3uHU7B">
-              <ref role="3cqZAo" node="7Atos1y66ND" resolve="count" />
-            </node>
-            <node concept="1LFfDK" id="7Atos1y68lt" role="3uHU7w">
-              <node concept="3cmrfG" id="7Atos1y68lW" role="1LF_Uc">
-                <property role="3cmrfH" value="0" />
-              </node>
-              <node concept="37vLTw" id="7Atos1y67YJ" role="1LFl5Q">
-                <ref role="3cqZAo" node="7Atos1y67YD" resolve="mult" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="7Atos1y6btF" role="3cqZAp">
-          <node concept="3clFbS" id="7Atos1y6btG" role="3clFbx">
-            <node concept="3cpWs6" id="7Atos1y6btH" role="3cqZAp">
-              <node concept="3cpWs3" id="7Atos1y6btI" role="3cqZAk">
-                <node concept="Xl_RD" id="7Atos1y6btJ" role="3uHU7w">
-                  <property role="Xl_RC" value=" allowed." />
-                </node>
-                <node concept="3cpWs3" id="7Atos1y6btK" role="3uHU7B">
-                  <node concept="Xl_RD" id="7Atos1y6btL" role="3uHU7B">
-                    <property role="Xl_RC" value="Too many connectors; " />
-                  </node>
-                  <node concept="1LFfDK" id="7Atos1y6btM" role="3uHU7w">
-                    <node concept="3cmrfG" id="7Atos1y6btN" role="1LF_Uc">
-                      <property role="3cmrfH" value="1" />
-                    </node>
-                    <node concept="37vLTw" id="7Atos1y6btO" role="1LFl5Q">
-                      <ref role="3cqZAo" node="7Atos1y67YD" resolve="mult" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="1Wc70l" id="7Atos1y6zi2" role="3clFbw">
-            <node concept="3eOSWO" id="7Atos1y6zOh" role="3uHU7B">
-              <node concept="1LFfDK" id="7Atos1y6z__" role="3uHU7B">
-                <node concept="3cmrfG" id="7Atos1y6zB_" role="1LF_Uc">
-                  <property role="3cmrfH" value="1" />
-                </node>
-                <node concept="37vLTw" id="7Atos1y6zv1" role="1LFl5Q">
-                  <ref role="3cqZAo" node="7Atos1y67YD" resolve="mult" />
-                </node>
-              </node>
-              <node concept="3cmrfG" id="7Atos1y6zM4" role="3uHU7w">
-                <property role="3cmrfH" value="0" />
-              </node>
-            </node>
-            <node concept="3eOSWO" id="7Atos1y6bFA" role="3uHU7w">
-              <node concept="37vLTw" id="7Atos1y6btQ" role="3uHU7B">
-                <ref role="3cqZAo" node="7Atos1y66ND" resolve="count" />
-              </node>
-              <node concept="1LFfDK" id="7Atos1y6btR" role="3uHU7w">
-                <node concept="3cmrfG" id="7Atos1y6btS" role="1LF_Uc">
-                  <property role="3cmrfH" value="1" />
-                </node>
-                <node concept="37vLTw" id="7Atos1y6btT" role="1LFl5Q">
-                  <ref role="3cqZAo" node="7Atos1y67YD" resolve="mult" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="7Atos1y6cVz" role="3cqZAp">
-          <node concept="10Nm6u" id="7Atos1y6cVx" role="3clFbG" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="7Atos1y641F" role="3clF46">
+      <node concept="37vLTG" id="5KMsIrXUjho" role="3clF46">
         <property role="TrG5h" value="allConnectors" />
-        <node concept="A3Dl8" id="7Atos1y641D" role="1tU5fm">
-          <node concept="3Tqbb2" id="7Atos1y641P" role="A3Ik2">
+        <node concept="A3Dl8" id="5KMsIrXUjhp" role="1tU5fm">
+          <node concept="3Tqbb2" id="5KMsIrXUjhq" role="A3Ik2">
             <ref role="ehGHo" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
           </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5KMsIrXUhY1" role="1B3o_S" />
+      <node concept="3clFbS" id="5KMsIrXUhY3" role="3clF47">
+        <node concept="3clFbF" id="5KMsIrXUjTH" role="3cqZAp">
+          <node concept="2OqwBi" id="5KMsIrXUji9" role="3clFbG">
+            <node concept="37vLTw" id="5KMsIrXUjia" role="2Oq$k0">
+              <ref role="3cqZAo" node="5KMsIrXUjho" resolve="allConnectors" />
+            </node>
+            <node concept="3zZkjj" id="5KMsIrXUjib" role="2OqNvi">
+              <node concept="1bVj0M" id="5KMsIrXUjic" role="23t8la">
+                <node concept="3clFbS" id="5KMsIrXUjid" role="1bW5cS">
+                  <node concept="3cpWs8" id="5KMsIrXUjie" role="3cqZAp">
+                    <node concept="3cpWsn" id="5KMsIrXUjif" role="3cpWs9">
+                      <property role="TrG5h" value="ports" />
+                      <node concept="1LlUBW" id="5KMsIrXUjig" role="1tU5fm">
+                        <node concept="3Tqbb2" id="5KMsIrXUjih" role="1Lm7xW">
+                          <ref role="ehGHo" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+                        </node>
+                        <node concept="3Tqbb2" id="5KMsIrXUjii" role="1Lm7xW">
+                          <ref role="ehGHo" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="5KMsIrXUjij" role="33vP2m">
+                        <node concept="37vLTw" id="5KMsIrXUjik" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5KMsIrXUjiU" resolve="it" />
+                        </node>
+                        <node concept="2qgKlT" id="5KMsIrXUjil" role="2OqNvi">
+                          <ref role="37wK5l" node="mIQkxg5ZT6" resolve="getPorts" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="5KMsIrXUjim" role="3cqZAp">
+                    <node concept="22lmx$" id="5KMsIrXUjin" role="3clFbG">
+                      <node concept="1eOMI4" id="5KMsIrXUjio" role="3uHU7w">
+                        <node concept="1Wc70l" id="5KMsIrXUjip" role="1eOMHV">
+                          <node concept="1eOMI4" id="5KMsIrXUjiq" role="3uHU7B">
+                            <node concept="3clFbC" id="5KMsIrXUjir" role="1eOMHV">
+                              <node concept="1LFfDK" id="5KMsIrXUjis" role="3uHU7B">
+                                <node concept="3cmrfG" id="5KMsIrXUjit" role="1LF_Uc">
+                                  <property role="3cmrfH" value="1" />
+                                </node>
+                                <node concept="37vLTw" id="5KMsIrXUjiu" role="1LFl5Q">
+                                  <ref role="3cqZAo" node="5KMsIrXUjif" resolve="ports" />
+                                </node>
+                              </node>
+                              <node concept="13iPFW" id="5KMsIrXUjiv" role="3uHU7w" />
+                            </node>
+                          </node>
+                          <node concept="1eOMI4" id="5KMsIrXUjiw" role="3uHU7w">
+                            <node concept="3clFbC" id="5KMsIrXUjix" role="1eOMHV">
+                              <node concept="2OqwBi" id="5KMsIrXUjiy" role="3uHU7B">
+                                <node concept="37vLTw" id="5KMsIrXUjiz" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5KMsIrXUjiU" resolve="it" />
+                                </node>
+                                <node concept="2qgKlT" id="5KMsIrXUji$" role="2OqNvi">
+                                  <ref role="37wK5l" node="4VHfdEqkeO4" resolve="getInstanceForPort" />
+                                  <node concept="1LFfDK" id="5KMsIrXUji_" role="37wK5m">
+                                    <node concept="3cmrfG" id="5KMsIrXUjiA" role="1LF_Uc">
+                                      <property role="3cmrfH" value="1" />
+                                    </node>
+                                    <node concept="37vLTw" id="5KMsIrXUjiB" role="1LFl5Q">
+                                      <ref role="3cqZAo" node="5KMsIrXUjif" resolve="ports" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="37vLTw" id="5KMsIrXUjiC" role="3uHU7w">
+                                <ref role="3cqZAo" node="5KMsIrXUl0G" resolve="instance" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="1eOMI4" id="5KMsIrXUjiD" role="3uHU7B">
+                        <node concept="1Wc70l" id="5KMsIrXUjiE" role="1eOMHV">
+                          <node concept="1eOMI4" id="5KMsIrXUjiF" role="3uHU7w">
+                            <node concept="3clFbC" id="5KMsIrXUjiG" role="1eOMHV">
+                              <node concept="2OqwBi" id="5KMsIrXUjiH" role="3uHU7B">
+                                <node concept="37vLTw" id="5KMsIrXUjiI" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5KMsIrXUjiU" resolve="it" />
+                                </node>
+                                <node concept="2qgKlT" id="5KMsIrXUjiJ" role="2OqNvi">
+                                  <ref role="37wK5l" node="4VHfdEqkeO4" resolve="getInstanceForPort" />
+                                  <node concept="1LFfDK" id="5KMsIrXUjiK" role="37wK5m">
+                                    <node concept="3cmrfG" id="5KMsIrXUjiL" role="1LF_Uc">
+                                      <property role="3cmrfH" value="0" />
+                                    </node>
+                                    <node concept="37vLTw" id="5KMsIrXUjiM" role="1LFl5Q">
+                                      <ref role="3cqZAo" node="5KMsIrXUjif" resolve="ports" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="37vLTw" id="5KMsIrXUjiN" role="3uHU7w">
+                                <ref role="3cqZAo" node="5KMsIrXUl0G" resolve="instance" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="1eOMI4" id="5KMsIrXUjiO" role="3uHU7B">
+                            <node concept="3clFbC" id="5KMsIrXUjiP" role="1eOMHV">
+                              <node concept="1LFfDK" id="5KMsIrXUjiQ" role="3uHU7B">
+                                <node concept="3cmrfG" id="5KMsIrXUjiR" role="1LF_Uc">
+                                  <property role="3cmrfH" value="0" />
+                                </node>
+                                <node concept="37vLTw" id="5KMsIrXUjiS" role="1LFl5Q">
+                                  <ref role="3cqZAo" node="5KMsIrXUjif" resolve="ports" />
+                                </node>
+                              </node>
+                              <node concept="13iPFW" id="5KMsIrXUjiT" role="3uHU7w" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="5KMsIrXUjiU" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="5KMsIrXUjiV" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="5KMsIrXUjeB" role="3clF45">
+        <node concept="3Tqbb2" id="5KMsIrXUjeC" role="A3Ik2">
+          <ref role="ehGHo" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
         </node>
       </node>
     </node>
@@ -8487,6 +8623,344 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="3HP615" id="4$W25$gwNkI">
+    <property role="3GE5qa" value="components.checker" />
+    <property role="TrG5h" value="IComponentInstanceChecker" />
+    <node concept="Qs71p" id="5KMsIrY4hNW" role="jymVt">
+      <property role="TrG5h" value="Severity" />
+      <node concept="3Tm1VV" id="5KMsIrY4hNX" role="1B3o_S" />
+      <node concept="QsSxf" id="5KMsIrY4i7B" role="Qtgdg">
+        <property role="TrG5h" value="ERROR" />
+        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+      </node>
+      <node concept="QsSxf" id="5KMsIrY4ieB" role="Qtgdg">
+        <property role="TrG5h" value="WARNING" />
+        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+      </node>
+      <node concept="QsSxf" id="5KMsIrY4it9" role="Qtgdg">
+        <property role="TrG5h" value="INFO" />
+        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5KMsIrY4iPf" role="jymVt" />
+    <node concept="3clFb_" id="4$W25$gwNlV" role="jymVt">
+      <property role="TrG5h" value="checkPortConnections" />
+      <node concept="3clFbS" id="4$W25$gwNlZ" role="3clF47" />
+      <node concept="1LlUBW" id="5KMsIrY4d9d" role="3clF45">
+        <node concept="17QB3L" id="5KMsIrY4dwo" role="1Lm7xW" />
+        <node concept="3uibUv" id="5KMsIrY4pYs" role="1Lm7xW">
+          <ref role="3uigEE" node="5KMsIrY4hNW" resolve="IComponentInstanceChecker.Severity" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4$W25$gwNm1" role="3clF46">
+        <property role="TrG5h" value="ci" />
+        <node concept="3Tqbb2" id="4$W25$gwNm2" role="1tU5fm">
+          <ref role="ehGHo" to="w9y2:77HYM7HomhL" resolve="AbstractComponentInstanceBase" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4$W25$gwNm3" role="3clF46">
+        <property role="TrG5h" value="port" />
+        <node concept="3Tqbb2" id="4$W25$gwNm4" role="1tU5fm">
+          <ref role="ehGHo" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4$W25$gwNm5" role="3clF46">
+        <property role="TrG5h" value="allConnectors" />
+        <node concept="A3Dl8" id="4$W25$gwNm6" role="1tU5fm">
+          <node concept="3Tqbb2" id="4$W25$gwNm7" role="A3Ik2">
+            <ref role="ehGHo" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4$W25$gwNm8" role="1B3o_S" />
+    </node>
+    <node concept="3Tm1VV" id="4$W25$gwNkJ" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="4$W25$gwNoP">
+    <property role="3GE5qa" value="components.checker" />
+    <property role="TrG5h" value="DefaultComponentInstanceChecker" />
+    <node concept="2tJIrI" id="4$W25$gxFTT" role="jymVt" />
+    <node concept="Wx3nA" id="4$W25$gxJij" role="jymVt">
+      <property role="TrG5h" value="instance" />
+      <node concept="3uibUv" id="4$W25$gxJil" role="1tU5fm">
+        <ref role="3uigEE" node="4$W25$gwNoP" resolve="DefaultComponentInstanceChecker" />
+      </node>
+      <node concept="2ShNRf" id="4$W25$gxJim" role="33vP2m">
+        <node concept="1pGfFk" id="4$W25$gxJin" role="2ShVmc">
+          <ref role="37wK5l" node="4$W25$gxHD6" resolve="DefaultComponentInstanceChecker" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4$W25$gxHrC" role="jymVt" />
+    <node concept="3clFbW" id="4$W25$gxHD6" role="jymVt">
+      <node concept="3cqZAl" id="4$W25$gxHD8" role="3clF45" />
+      <node concept="3Tm6S6" id="4$W25$gxHJq" role="1B3o_S" />
+      <node concept="3clFbS" id="4$W25$gxHDa" role="3clF47" />
+    </node>
+    <node concept="2tJIrI" id="4$W25$gxHLW" role="jymVt" />
+    <node concept="3Tm1VV" id="4$W25$gwNoQ" role="1B3o_S" />
+    <node concept="3uibUv" id="4$W25$gwNq3" role="EKbjA">
+      <ref role="3uigEE" node="4$W25$gwNkI" resolve="IComponentInstanceChecker" />
+    </node>
+    <node concept="3clFb_" id="4$W25$gwNrf" role="jymVt">
+      <property role="TrG5h" value="checkPortConnections" />
+      <node concept="37vLTG" id="4$W25$gwNri" role="3clF46">
+        <property role="TrG5h" value="ci" />
+        <node concept="3Tqbb2" id="4$W25$gwNrj" role="1tU5fm">
+          <ref role="ehGHo" to="w9y2:77HYM7HomhL" resolve="AbstractComponentInstanceBase" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4$W25$gwNrk" role="3clF46">
+        <property role="TrG5h" value="port" />
+        <node concept="3Tqbb2" id="4$W25$gwNrl" role="1tU5fm">
+          <ref role="ehGHo" to="w9y2:6LfBX8YkpdW" resolve="Port" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4$W25$gwNrm" role="3clF46">
+        <property role="TrG5h" value="allConnectors" />
+        <node concept="A3Dl8" id="4$W25$gwNrn" role="1tU5fm">
+          <node concept="3Tqbb2" id="4$W25$gwNro" role="A3Ik2">
+            <ref role="ehGHo" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4$W25$gwNrp" role="1B3o_S" />
+      <node concept="3clFbS" id="4$W25$gwNrq" role="3clF47">
+        <node concept="3cpWs8" id="5KMsIrXUofx" role="3cqZAp">
+          <node concept="3cpWsn" id="5KMsIrXUofy" role="3cpWs9">
+            <property role="TrG5h" value="connectedToMe" />
+            <node concept="A3Dl8" id="5KMsIrXUofz" role="1tU5fm">
+              <node concept="3Tqbb2" id="5KMsIrXUof$" role="A3Ik2">
+                <ref role="ehGHo" to="w9y2:mIQkxg5ZSA" resolve="AbstractPortToPortConnector" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="5KMsIrXUqi_" role="33vP2m">
+              <node concept="37vLTw" id="5KMsIrXUpHS" role="2Oq$k0">
+                <ref role="3cqZAo" node="4$W25$gwNrk" resolve="port" />
+              </node>
+              <node concept="2qgKlT" id="5KMsIrXUqVe" role="2OqNvi">
+                <ref role="37wK5l" node="5KMsIrXUhY0" resolve="filterOwnConnections" />
+                <node concept="37vLTw" id="5KMsIrXUrpx" role="37wK5m">
+                  <ref role="3cqZAo" node="4$W25$gwNri" resolve="ci" />
+                </node>
+                <node concept="37vLTw" id="5KMsIrXUrRI" role="37wK5m">
+                  <ref role="3cqZAo" node="4$W25$gwNrm" resolve="allConnectors" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5KMsIrXUZUX" role="3cqZAp" />
+        <node concept="3SKdUt" id="4$W25$gxpGX" role="3cqZAp">
+          <node concept="1PaTwC" id="4$W25$gxpGY" role="3ndbpf">
+            <node concept="3oM_SD" id="4$W25$gxpH0" role="1PaTwD">
+              <property role="3oM_SC" value="check" />
+            </node>
+            <node concept="3oM_SD" id="4$W25$gxpI0" role="1PaTwD">
+              <property role="3oM_SC" value="connections" />
+            </node>
+            <node concept="3oM_SD" id="4$W25$gxpId" role="1PaTwD">
+              <property role="3oM_SC" value="between" />
+            </node>
+            <node concept="3oM_SD" id="4$W25$gxpIG" role="1PaTwD">
+              <property role="3oM_SC" value="ports" />
+            </node>
+            <node concept="3oM_SD" id="4$W25$gxpIX" role="1PaTwD">
+              <property role="3oM_SC" value="based" />
+            </node>
+            <node concept="3oM_SD" id="4$W25$gxpJg" role="1PaTwD">
+              <property role="3oM_SC" value="on" />
+            </node>
+            <node concept="3oM_SD" id="4$W25$gxpJt" role="1PaTwD">
+              <property role="3oM_SC" value="multiplicities" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5KMsIrXUofC" role="3cqZAp">
+          <node concept="3cpWsn" id="5KMsIrXUofD" role="3cpWs9">
+            <property role="TrG5h" value="count" />
+            <node concept="10Oyi0" id="5KMsIrXUofE" role="1tU5fm" />
+            <node concept="2OqwBi" id="5KMsIrXUofF" role="33vP2m">
+              <node concept="37vLTw" id="5KMsIrXUofG" role="2Oq$k0">
+                <ref role="3cqZAo" node="5KMsIrXUofy" resolve="connectedToMe" />
+              </node>
+              <node concept="34oBXx" id="5KMsIrXUofH" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5KMsIrXUofI" role="3cqZAp">
+          <node concept="3cpWsn" id="5KMsIrXUofJ" role="3cpWs9">
+            <property role="TrG5h" value="mult" />
+            <node concept="1LlUBW" id="5KMsIrXUofK" role="1tU5fm">
+              <node concept="10Oyi0" id="5KMsIrXUofL" role="1Lm7xW" />
+              <node concept="10Oyi0" id="5KMsIrXUofM" role="1Lm7xW" />
+            </node>
+            <node concept="2OqwBi" id="5KMsIrXUofN" role="33vP2m">
+              <node concept="2OqwBi" id="5KMsIrXUofO" role="2Oq$k0">
+                <node concept="37vLTw" id="5KMsIrXUsoA" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4$W25$gwNrk" resolve="port" />
+                </node>
+                <node concept="3TrEf2" id="5KMsIrXUofQ" role="2OqNvi">
+                  <ref role="3Tt5mk" to="w9y2:mIQkxfpv7_" resolve="category" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="5KMsIrXUofR" role="2OqNvi">
+                <ref role="37wK5l" node="7Atos1y391f" resolve="multiplicity" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5KMsIrXUofS" role="3cqZAp">
+          <node concept="3clFbS" id="5KMsIrXUofT" role="3clFbx">
+            <node concept="3cpWs8" id="5KMsIrY4rbG" role="3cqZAp">
+              <node concept="3cpWsn" id="5KMsIrY4rbH" role="3cpWs9">
+                <property role="TrG5h" value="msg" />
+                <node concept="17QB3L" id="5KMsIrY4qWE" role="1tU5fm" />
+                <node concept="3cpWs3" id="5KMsIrY4rbI" role="33vP2m">
+                  <node concept="Xl_RD" id="5KMsIrY4rbJ" role="3uHU7w">
+                    <property role="Xl_RC" value=" required." />
+                  </node>
+                  <node concept="3cpWs3" id="5KMsIrY4rbK" role="3uHU7B">
+                    <node concept="Xl_RD" id="5KMsIrY4rbL" role="3uHU7B">
+                      <property role="Xl_RC" value="Too few connectors; " />
+                    </node>
+                    <node concept="1LFfDK" id="5KMsIrY4rbM" role="3uHU7w">
+                      <node concept="3cmrfG" id="5KMsIrY4rbN" role="1LF_Uc">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                      <node concept="37vLTw" id="5KMsIrY4rbO" role="1LFl5Q">
+                        <ref role="3cqZAo" node="5KMsIrXUofJ" resolve="mult" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="5KMsIrXUofU" role="3cqZAp">
+              <node concept="1Ls8ON" id="5KMsIrY4sSZ" role="3cqZAk">
+                <node concept="37vLTw" id="5KMsIrY4ueu" role="1Lso8e">
+                  <ref role="3cqZAo" node="5KMsIrY4rbH" resolve="msg" />
+                </node>
+                <node concept="Rm8GO" id="5KMsIrY4vU0" role="1Lso8e">
+                  <ref role="Rm8GQ" node="5KMsIrY4i7B" resolve="ERROR" />
+                  <ref role="1Px2BO" node="5KMsIrY4hNW" resolve="IComponentInstanceChecker.Severity" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3eOVzh" id="5KMsIrXUog2" role="3clFbw">
+            <node concept="37vLTw" id="5KMsIrXUog3" role="3uHU7B">
+              <ref role="3cqZAo" node="5KMsIrXUofD" resolve="count" />
+            </node>
+            <node concept="1LFfDK" id="5KMsIrXUog4" role="3uHU7w">
+              <node concept="3cmrfG" id="5KMsIrXUog5" role="1LF_Uc">
+                <property role="3cmrfH" value="0" />
+              </node>
+              <node concept="37vLTw" id="5KMsIrXUog6" role="1LFl5Q">
+                <ref role="3cqZAo" node="5KMsIrXUofJ" resolve="mult" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5KMsIrXUog7" role="3cqZAp">
+          <node concept="3clFbS" id="5KMsIrXUog8" role="3clFbx">
+            <node concept="3cpWs8" id="5KMsIrY4wmP" role="3cqZAp">
+              <node concept="3cpWsn" id="5KMsIrY4wmQ" role="3cpWs9">
+                <property role="TrG5h" value="msg" />
+                <node concept="17QB3L" id="5KMsIrY4vZS" role="1tU5fm" />
+                <node concept="3cpWs3" id="5KMsIrY4wmR" role="33vP2m">
+                  <node concept="Xl_RD" id="5KMsIrY4wmS" role="3uHU7w">
+                    <property role="Xl_RC" value=" allowed." />
+                  </node>
+                  <node concept="3cpWs3" id="5KMsIrY4wmT" role="3uHU7B">
+                    <node concept="Xl_RD" id="5KMsIrY4wmU" role="3uHU7B">
+                      <property role="Xl_RC" value="Too many connectors; " />
+                    </node>
+                    <node concept="1LFfDK" id="5KMsIrY4wmV" role="3uHU7w">
+                      <node concept="3cmrfG" id="5KMsIrY4wmW" role="1LF_Uc">
+                        <property role="3cmrfH" value="1" />
+                      </node>
+                      <node concept="37vLTw" id="5KMsIrY4wmX" role="1LFl5Q">
+                        <ref role="3cqZAo" node="5KMsIrXUofJ" resolve="mult" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="5KMsIrXUog9" role="3cqZAp">
+              <node concept="1Ls8ON" id="5KMsIrY4x5d" role="3cqZAk">
+                <node concept="37vLTw" id="5KMsIrY4x5e" role="1Lso8e">
+                  <ref role="3cqZAo" node="5KMsIrY4wmQ" resolve="msg" />
+                </node>
+                <node concept="Rm8GO" id="5KMsIrY4x5f" role="1Lso8e">
+                  <ref role="1Px2BO" node="5KMsIrY4hNW" resolve="IComponentInstanceChecker.Severity" />
+                  <ref role="Rm8GQ" node="5KMsIrY4i7B" resolve="ERROR" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1Wc70l" id="5KMsIrXUogh" role="3clFbw">
+            <node concept="3eOSWO" id="5KMsIrXUogi" role="3uHU7B">
+              <node concept="1LFfDK" id="5KMsIrXUogj" role="3uHU7B">
+                <node concept="3cmrfG" id="5KMsIrXUogk" role="1LF_Uc">
+                  <property role="3cmrfH" value="1" />
+                </node>
+                <node concept="37vLTw" id="5KMsIrXUogl" role="1LFl5Q">
+                  <ref role="3cqZAo" node="5KMsIrXUofJ" resolve="mult" />
+                </node>
+              </node>
+              <node concept="3cmrfG" id="5KMsIrXUogm" role="3uHU7w">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
+            <node concept="3eOSWO" id="5KMsIrXUogn" role="3uHU7w">
+              <node concept="37vLTw" id="5KMsIrXUogo" role="3uHU7B">
+                <ref role="3cqZAo" node="5KMsIrXUofD" resolve="count" />
+              </node>
+              <node concept="1LFfDK" id="5KMsIrXUogp" role="3uHU7w">
+                <node concept="3cmrfG" id="5KMsIrXUogq" role="1LF_Uc">
+                  <property role="3cmrfH" value="1" />
+                </node>
+                <node concept="37vLTw" id="5KMsIrXUogr" role="1LFl5Q">
+                  <ref role="3cqZAo" node="5KMsIrXUofJ" resolve="mult" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5KMsIrXUogs" role="3cqZAp">
+          <node concept="10Nm6u" id="5KMsIrXUogt" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="4$W25$gwNrr" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="1LlUBW" id="5KMsIrY4qJP" role="3clF45">
+        <node concept="17QB3L" id="5KMsIrY4qJQ" role="1Lm7xW" />
+        <node concept="3uibUv" id="5KMsIrY4qJR" role="1Lm7xW">
+          <ref role="3uigEE" node="5KMsIrY4hNW" resolve="IComponentInstanceChecker.Severity" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="4$W25$gwO5F">
+    <property role="3GE5qa" value="components.checker" />
+    <ref role="13h7C2" to="w9y2:4$W25$gwO5f" resolve="IComponentCheckerProvider" />
+    <node concept="13i0hz" id="4$W25$gwO5Q" role="13h7CS">
+      <property role="13i0iv" value="true" />
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="getComponentInstanceChecker" />
+      <node concept="3Tm1VV" id="4$W25$gwO5R" role="1B3o_S" />
+      <node concept="3uibUv" id="4$W25$gwOs6" role="3clF45">
+        <ref role="3uigEE" node="4$W25$gwNkI" resolve="IComponentInstanceChecker" />
+      </node>
+      <node concept="3clFbS" id="4$W25$gwO5T" role="3clF47" />
+    </node>
+    <node concept="13hLZK" id="4$W25$gwO5G" role="13h7CW">
+      <node concept="3clFbS" id="4$W25$gwO5H" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/structure.mps
@@ -1528,5 +1528,10 @@
       <ref role="2wpffI" node="siw10H0o$0" />
     </node>
   </node>
+  <node concept="PlHQZ" id="4$W25$gwO5f">
+    <property role="EcuMT" value="5277102041993527631" />
+    <property role="3GE5qa" value="components.checker" />
+    <property role="TrG5h" value="IComponentCheckerProvider" />
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/typesystem.mps
@@ -10,8 +10,10 @@
     <import index="3eba" ref="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
     <import index="700h" ref="r:61b1de80-490d-4fee-8e95-b956503290e9(org.iets3.core.expr.collections.structure)" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
-    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
     <import index="yv47" ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" implicit="true" />
   </imports>
   <registry>
@@ -29,12 +31,17 @@
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
@@ -45,6 +52,9 @@
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
@@ -109,13 +119,26 @@
       <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
         <property id="8355037393041754995" name="isNative" index="2aFKle" />
       </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1163670490218" name="jetbrains.mps.baseLanguage.structure.SwitchStatement" flags="nn" index="3KaCP$">
+        <child id="1163670592366" name="defaultBlock" index="3Kb1Dw" />
+        <child id="1163670766145" name="expression" index="3KbGdf" />
+        <child id="1163670772911" name="case" index="3KbHQx" />
+      </concept>
+      <concept id="1163670641947" name="jetbrains.mps.baseLanguage.structure.SwitchCase" flags="ng" index="3KbdKl">
+        <child id="1163670677455" name="expression" index="3Kbmr1" />
+        <child id="1163670683720" name="body" index="3Kbo56" />
       </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="1350122676458893092" name="text" index="3ndbpf" />
@@ -146,6 +169,9 @@
       </concept>
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1207055528241" name="jetbrains.mps.lang.typesystem.structure.WarningStatement" flags="nn" index="a7r0C">
+        <child id="1207055552304" name="warningText" index="a7wSD" />
+      </concept>
       <concept id="1185788614172" name="jetbrains.mps.lang.typesystem.structure.NormalTypeClause" flags="ng" index="mw_s8">
         <child id="1185788644032" name="normalType" index="mwGJk" />
       </concept>
@@ -153,6 +179,9 @@
         <child id="1185805047793" name="body" index="nvhr_" />
         <child id="1185805056450" name="argument" index="nvjzm" />
         <child id="1205761991995" name="argumentRepresentator" index="2X0Ygz" />
+      </concept>
+      <concept id="1224760201579" name="jetbrains.mps.lang.typesystem.structure.InfoStatement" flags="nn" index="Dpp1Q">
+        <child id="1224760230762" name="infoText" index="Dpw9R" />
       </concept>
       <concept id="1175517400280" name="jetbrains.mps.lang.typesystem.structure.AssertStatement" flags="nn" index="2Mj0R9">
         <child id="1175517761460" name="condition" index="2MkoU_" />
@@ -276,9 +305,17 @@
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
+        <property id="709746936026609031" name="linkId" index="3V$3ak" />
+        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
+      </concept>
+      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
+        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
       </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
@@ -2258,6 +2295,50 @@
           </node>
         </node>
       </node>
+      <node concept="3cpWs8" id="4$W25$gxht6" role="3cqZAp">
+        <node concept="3cpWsn" id="4$W25$gxht7" role="3cpWs9">
+          <property role="TrG5h" value="checker" />
+          <node concept="3uibUv" id="4$W25$gxhjm" role="1tU5fm">
+            <ref role="3uigEE" to="3eba:4$W25$gwNkI" resolve="IComponentInstanceChecker" />
+          </node>
+          <node concept="2OqwBi" id="4$W25$gxht8" role="33vP2m">
+            <node concept="1YBJjd" id="4$W25$gxht9" role="2Oq$k0">
+              <ref role="1YBMHb" node="PFqDnRTYsK" resolve="cmp" />
+            </node>
+            <node concept="2qgKlT" id="4$W25$gxhta" role="2OqNvi">
+              <ref role="37wK5l" to="3eba:4$W25$gx1L4" resolve="getInstanceChecker" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1X3_iC" id="5KMsIrY6sX$" role="lGtFl">
+        <property role="3V$3am" value="statement" />
+        <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+        <node concept="3clFbF" id="5KMsIrXVz8c" role="8Wnug">
+          <node concept="2OqwBi" id="5KMsIrXVz89" role="3clFbG">
+            <node concept="10M0yZ" id="5KMsIrXVz8a" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              <ref role="3cqZAo" to="wyt6:~System.err" resolve="err" />
+            </node>
+            <node concept="liA8E" id="5KMsIrXVz8b" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="3cpWs3" id="5KMsIrXVzKa" role="37wK5m">
+                <node concept="2OqwBi" id="5KMsIrXVzUY" role="3uHU7w">
+                  <node concept="37vLTw" id="5KMsIrXVzKl" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4$W25$gxht7" resolve="checker" />
+                  </node>
+                  <node concept="liA8E" id="5KMsIrXV$3J" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="5KMsIrXVzfq" role="3uHU7B">
+                  <property role="Xl_RC" value="checker: " />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
       <node concept="3clFbF" id="PFqDnRUcCc" role="3cqZAp">
         <node concept="2OqwBi" id="PFqDnRUibS" role="3clFbG">
           <node concept="37vLTw" id="PFqDnRUh_j" role="2Oq$k0">
@@ -2271,20 +2352,28 @@
                     <property role="TrG5h" value="p" />
                   </node>
                   <node concept="3clFbS" id="PFqDnRTYtC" role="2LFqv$">
-                    <node concept="3cpWs8" id="PFqDnRTYtD" role="3cqZAp">
-                      <node concept="3cpWsn" id="PFqDnRTYtE" role="3cpWs9">
-                        <property role="TrG5h" value="m" />
-                        <node concept="17QB3L" id="PFqDnRTYtF" role="1tU5fm" />
-                        <node concept="2OqwBi" id="PFqDnRTYtG" role="33vP2m">
-                          <node concept="2GrUjf" id="PFqDnRTYtH" role="2Oq$k0">
-                            <ref role="2Gs0qQ" node="PFqDnRTYtB" resolve="p" />
+                    <node concept="3cpWs8" id="5KMsIrY4y$t" role="3cqZAp">
+                      <node concept="3cpWsn" id="5KMsIrY4y$u" role="3cpWs9">
+                        <property role="TrG5h" value="res" />
+                        <node concept="1LlUBW" id="5KMsIrY4xOv" role="1tU5fm">
+                          <node concept="17QB3L" id="5KMsIrY4xO$" role="1Lm7xW" />
+                          <node concept="3uibUv" id="5KMsIrY4xO_" role="1Lm7xW">
+                            <ref role="3uigEE" to="3eba:5KMsIrY4hNW" resolve="IComponentInstanceChecker.Severity" />
                           </node>
-                          <node concept="2qgKlT" id="PFqDnRTYtI" role="2OqNvi">
-                            <ref role="37wK5l" to="3eba:7Atos1y63VI" resolve="getConnectionMulitplicityError" />
-                            <node concept="37vLTw" id="4VHfdEqk8tI" role="37wK5m">
+                        </node>
+                        <node concept="2OqwBi" id="5KMsIrY4y$v" role="33vP2m">
+                          <node concept="37vLTw" id="5KMsIrY4y$w" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4$W25$gxht7" resolve="checker" />
+                          </node>
+                          <node concept="liA8E" id="5KMsIrY4y$x" role="2OqNvi">
+                            <ref role="37wK5l" to="3eba:4$W25$gwNlV" resolve="checkPortConnections" />
+                            <node concept="37vLTw" id="5KMsIrY4y$y" role="37wK5m">
                               <ref role="3cqZAo" node="PFqDnRUiiL" resolve="ci" />
                             </node>
-                            <node concept="37vLTw" id="PFqDnRUaXo" role="37wK5m">
+                            <node concept="2GrUjf" id="5KMsIrY4y$z" role="37wK5m">
+                              <ref role="2Gs0qQ" node="PFqDnRTYtB" resolve="p" />
+                            </node>
+                            <node concept="37vLTw" id="5KMsIrY4y$$" role="37wK5m">
                               <ref role="3cqZAo" node="PFqDnRU9qz" resolve="allConnectors" />
                             </node>
                           </node>
@@ -2293,39 +2382,99 @@
                     </node>
                     <node concept="3clFbJ" id="PFqDnRTYtK" role="3cqZAp">
                       <node concept="3clFbS" id="PFqDnRTYtL" role="3clFbx">
-                        <node concept="2MkqsV" id="PFqDnRTYtM" role="3cqZAp">
-                          <node concept="3cpWs3" id="PFqDnRTYtO" role="2MkJ7o">
-                            <node concept="37vLTw" id="PFqDnRTYtP" role="3uHU7w">
-                              <ref role="3cqZAo" node="PFqDnRTYtE" resolve="m" />
-                            </node>
-                            <node concept="3cpWs3" id="PFqDnRTYtQ" role="3uHU7B">
-                              <node concept="3cpWs3" id="PFqDnRTYtR" role="3uHU7B">
-                                <node concept="Xl_RD" id="PFqDnRTYtS" role="3uHU7B">
-                                  <property role="Xl_RC" value="port " />
+                        <node concept="3cpWs8" id="5KMsIrY4ACh" role="3cqZAp">
+                          <node concept="3cpWsn" id="5KMsIrY4ACi" role="3cpWs9">
+                            <property role="TrG5h" value="msg" />
+                            <node concept="17QB3L" id="5KMsIrY4ABb" role="1tU5fm" />
+                            <node concept="3cpWs3" id="5KMsIrY4ACj" role="33vP2m">
+                              <node concept="1LFfDK" id="5KMsIrY4ACk" role="3uHU7w">
+                                <node concept="3cmrfG" id="5KMsIrY4ACl" role="1LF_Uc">
+                                  <property role="3cmrfH" value="0" />
                                 </node>
-                                <node concept="2OqwBi" id="PFqDnRTYtT" role="3uHU7w">
-                                  <node concept="2GrUjf" id="PFqDnRTYtU" role="2Oq$k0">
-                                    <ref role="2Gs0qQ" node="PFqDnRTYtB" resolve="p" />
-                                  </node>
-                                  <node concept="3TrcHB" id="PFqDnRTYtV" role="2OqNvi">
-                                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                  </node>
+                                <node concept="37vLTw" id="5KMsIrY4ACm" role="1LFl5Q">
+                                  <ref role="3cqZAo" node="5KMsIrY4y$u" resolve="res" />
                                 </node>
                               </node>
-                              <node concept="Xl_RD" id="PFqDnRTYtW" role="3uHU7w">
-                                <property role="Xl_RC" value=": " />
+                              <node concept="3cpWs3" id="5KMsIrY4ACn" role="3uHU7B">
+                                <node concept="3cpWs3" id="5KMsIrY4ACo" role="3uHU7B">
+                                  <node concept="Xl_RD" id="5KMsIrY4ACp" role="3uHU7B">
+                                    <property role="Xl_RC" value="port " />
+                                  </node>
+                                  <node concept="2OqwBi" id="5KMsIrY4ACq" role="3uHU7w">
+                                    <node concept="2GrUjf" id="5KMsIrY4ACr" role="2Oq$k0">
+                                      <ref role="2Gs0qQ" node="PFqDnRTYtB" resolve="p" />
+                                    </node>
+                                    <node concept="3TrcHB" id="5KMsIrY4ACs" role="2OqNvi">
+                                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="Xl_RD" id="5KMsIrY4ACt" role="3uHU7w">
+                                  <property role="Xl_RC" value=": " />
+                                </node>
                               </node>
                             </node>
                           </node>
-                          <node concept="37vLTw" id="PFqDnRUkwg" role="1urrMF">
-                            <ref role="3cqZAo" node="PFqDnRUiiL" resolve="ci" />
+                        </node>
+                        <node concept="3KaCP$" id="5KMsIrY4BL_" role="3cqZAp">
+                          <node concept="1LFfDK" id="5KMsIrY4CTx" role="3KbGdf">
+                            <node concept="3cmrfG" id="5KMsIrY4CTG" role="1LF_Uc">
+                              <property role="3cmrfH" value="1" />
+                            </node>
+                            <node concept="37vLTw" id="5KMsIrY4CiN" role="1LFl5Q">
+                              <ref role="3cqZAo" node="5KMsIrY4y$u" resolve="res" />
+                            </node>
+                          </node>
+                          <node concept="3KbdKl" id="5KMsIrY4Duo" role="3KbHQx">
+                            <node concept="Rm8GO" id="5KMsIrY4EgJ" role="3Kbmr1">
+                              <ref role="Rm8GQ" to="3eba:5KMsIrY4i7B" resolve="ERROR" />
+                              <ref role="1Px2BO" to="3eba:5KMsIrY4hNW" resolve="IComponentInstanceChecker.Severity" />
+                            </node>
+                            <node concept="3clFbS" id="5KMsIrY4Duq" role="3Kbo56">
+                              <node concept="2MkqsV" id="5KMsIrY4Erg" role="3cqZAp">
+                                <node concept="37vLTw" id="5KMsIrY4G74" role="2MkJ7o">
+                                  <ref role="3cqZAo" node="5KMsIrY4ACi" resolve="msg" />
+                                </node>
+                                <node concept="37vLTw" id="5KMsIrY4GFZ" role="1urrMF">
+                                  <ref role="3cqZAo" node="PFqDnRUiiL" resolve="ci" />
+                                </node>
+                              </node>
+                              <node concept="3zACq4" id="5KMsIrY625n" role="3cqZAp" />
+                            </node>
+                          </node>
+                          <node concept="3KbdKl" id="5KMsIrY4GMv" role="3KbHQx">
+                            <node concept="Rm8GO" id="5KMsIrY4GYm" role="3Kbmr1">
+                              <ref role="Rm8GQ" to="3eba:5KMsIrY4ieB" resolve="WARNING" />
+                              <ref role="1Px2BO" to="3eba:5KMsIrY4hNW" resolve="IComponentInstanceChecker.Severity" />
+                            </node>
+                            <node concept="3clFbS" id="5KMsIrY4GMx" role="3Kbo56">
+                              <node concept="a7r0C" id="5KMsIrY4Hw3" role="3cqZAp">
+                                <node concept="37vLTw" id="5KMsIrY4Hw5" role="a7wSD">
+                                  <ref role="3cqZAo" node="5KMsIrY4ACi" resolve="msg" />
+                                </node>
+                                <node concept="37vLTw" id="5KMsIrY4Hw6" role="1urrMF">
+                                  <ref role="3cqZAo" node="PFqDnRUiiL" resolve="ci" />
+                                </node>
+                              </node>
+                              <node concept="3zACq4" id="5KMsIrY63Hc" role="3cqZAp" />
+                            </node>
+                          </node>
+                          <node concept="3clFbS" id="5KMsIrY4HAR" role="3Kb1Dw">
+                            <node concept="Dpp1Q" id="5KMsIrY4Ice" role="3cqZAp">
+                              <node concept="37vLTw" id="5KMsIrY4Ijg" role="Dpw9R">
+                                <ref role="3cqZAo" node="5KMsIrY4ACi" resolve="msg" />
+                              </node>
+                              <node concept="37vLTw" id="5KMsIrY4J$g" role="1urrMF">
+                                <ref role="3cqZAo" node="PFqDnRUiiL" resolve="ci" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
                       <node concept="3y3z36" id="PFqDnRTYtX" role="3clFbw">
                         <node concept="10Nm6u" id="PFqDnRTYtY" role="3uHU7w" />
-                        <node concept="37vLTw" id="PFqDnRTYtZ" role="3uHU7B">
-                          <ref role="3cqZAo" node="PFqDnRTYtE" resolve="m" />
+                        <node concept="37vLTw" id="5KMsIrY4zOm" role="3uHU7B">
+                          <ref role="3cqZAo" node="5KMsIrY4y$u" resolve="res" />
                         </node>
                       </node>
                     </node>


### PR DESCRIPTION
The component model language has a hard-coded checking rule which checks the ports and component instances in a component's substructure. It especially checks that the connections of a port are consistent with the port's cardinality specification.

However, in some usecases this is too restrictive. E.g., when attaching presence conditions to connections (150% model for variability), more relaxed checks are needed. 

This PR establishes a mechanism which allows to replace the checking rule by a more specific one provided by a language extension.