### PR TITLE
fix soe in transitive dependencies

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
@@ -5136,6 +5136,18 @@
             <property role="TrG5h" value="d" />
           </node>
           <node concept="3clFbS" id="1WCh2the7ko" role="2LFqv$">
+            <node concept="3clFbF" id="1WCh2the7rH" role="3cqZAp">
+              <node concept="2OqwBi" id="1WCh2the7AB" role="3clFbG">
+                <node concept="37vLTw" id="1WCh2the7rG" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1WCh2the69s" resolve="collector" />
+                </node>
+                <node concept="TSZUe" id="1WCh2the7QH" role="2OqNvi">
+                  <node concept="2GrUjf" id="1WCh2the7Ui" role="25WWJ7">
+                    <ref role="2Gs0qQ" node="1WCh2the7kl" resolve="d" />
+                  </node>
+                </node>
+              </node>
+            </node>
             <node concept="3clFbF" id="1WCh2the831" role="3cqZAp">
               <node concept="2OqwBi" id="1WCh2the8bn" role="3clFbG">
                 <node concept="2GrUjf" id="1WCh2the84k" role="2Oq$k0">
@@ -5145,18 +5157,6 @@
                   <ref role="37wK5l" node="1WCh2the630" resolve="addDependencies" />
                   <node concept="37vLTw" id="1WCh2the8sI" role="37wK5m">
                     <ref role="3cqZAo" node="1WCh2the69s" resolve="collector" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="1WCh2the7rH" role="3cqZAp">
-              <node concept="2OqwBi" id="1WCh2the7AB" role="3clFbG">
-                <node concept="37vLTw" id="1WCh2the7rG" role="2Oq$k0">
-                  <ref role="3cqZAo" node="1WCh2the69s" resolve="collector" />
-                </node>
-                <node concept="TSZUe" id="1WCh2the7QH" role="2OqNvi">
-                  <node concept="2GrUjf" id="1WCh2the7Ui" role="25WWJ7">
-                    <ref role="2Gs0qQ" node="1WCh2the7kl" resolve="d" />
                   </node>
                 </node>
               </node>


### PR DESCRIPTION
Adding itself to the list of visited dependencies can cause a stack over flow in
case a cycle between types exists