### PR TITLE
kernelf: fix firstN, lanstN cast exception in Generator

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
@@ -5100,68 +5100,64 @@
                       </node>
                     </node>
                     <node concept="3cpWs6" id="7Pk458Eqr4h" role="3cqZAp">
-                      <node concept="2YIFZM" id="7Pk458EqtLl" role="3cqZAk">
-                        <ref role="1Pybhc" to="j10v:~TreePVector" resolve="TreePVector" />
-                        <ref role="37wK5l" to="j10v:~TreePVector.from(java.util.Collection)" resolve="from" />
-                        <node concept="2OqwBi" id="7Pk458Eqvjj" role="37wK5m">
-                          <node concept="37vLTw" id="7Pk458EquhC" role="2Oq$k0">
-                            <ref role="3cqZAo" node="7Pk458DyXut" resolve="tpv" />
-                            <node concept="29HgVG" id="7Pk458EsNZD" role="lGtFl">
-                              <node concept="3NFfHV" id="7Pk458EsNZE" role="3NFExx">
-                                <node concept="3clFbS" id="7Pk458EsNZF" role="2VODD2">
-                                  <node concept="3clFbF" id="7Pk458EsNZL" role="3cqZAp">
-                                    <node concept="2OqwBi" id="7Pk458EsNZG" role="3clFbG">
-                                      <node concept="3TrEf2" id="7Pk458EsNZJ" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
-                                      </node>
-                                      <node concept="30H73N" id="7Pk458EsNZK" role="2Oq$k0" />
+                      <node concept="2OqwBi" id="JK8zDWpaoq" role="3cqZAk">
+                        <node concept="37vLTw" id="JK8zDWpaor" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7Pk458DyXut" resolve="tpv" />
+                          <node concept="29HgVG" id="JK8zDWpaos" role="lGtFl">
+                            <node concept="3NFfHV" id="JK8zDWpaot" role="3NFExx">
+                              <node concept="3clFbS" id="JK8zDWpaou" role="2VODD2">
+                                <node concept="3clFbF" id="JK8zDWpaov" role="3cqZAp">
+                                  <node concept="2OqwBi" id="JK8zDWpaow" role="3clFbG">
+                                    <node concept="3TrEf2" id="JK8zDWpaox" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
                                     </node>
+                                    <node concept="30H73N" id="JK8zDWpaoy" role="2Oq$k0" />
                                   </node>
                                 </node>
                               </node>
                             </node>
                           </node>
-                          <node concept="liA8E" id="7Pk458EqwcT" role="2OqNvi">
-                            <ref role="37wK5l" to="j10v:~PVector.subList(int,int)" resolve="subList" />
-                            <node concept="3cmrfG" id="7Pk458EqwVc" role="37wK5m">
-                              <property role="3cmrfH" value="0" />
-                            </node>
-                            <node concept="2OqwBi" id="7Pk458EDuW5" role="37wK5m">
-                              <node concept="2ShNRf" id="7Pk458EDq8R" role="2Oq$k0">
-                                <node concept="1pGfFk" id="7Pk458EDsbo" role="2ShVmc">
-                                  <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
-                                  <node concept="Xl_RD" id="7Pk458EDu5A" role="37wK5m">
-                                    <property role="Xl_RC" value="5" />
-                                  </node>
+                        </node>
+                        <node concept="liA8E" id="JK8zDWpaoz" role="2OqNvi">
+                          <ref role="37wK5l" to="j10v:~PVector.subList(int,int)" resolve="subList" />
+                          <node concept="3cmrfG" id="JK8zDWpao$" role="37wK5m">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="2OqwBi" id="JK8zDWpao_" role="37wK5m">
+                            <node concept="2ShNRf" id="JK8zDWpaoA" role="2Oq$k0">
+                              <node concept="1pGfFk" id="JK8zDWpaoB" role="2ShVmc">
+                                <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
+                                <node concept="Xl_RD" id="JK8zDWpaoC" role="37wK5m">
+                                  <property role="Xl_RC" value="5" />
                                 </node>
-                                <node concept="29HgVG" id="7Pk458EDwvr" role="lGtFl">
-                                  <node concept="3NFfHV" id="7Pk458EDwvs" role="3NFExx">
-                                    <node concept="3clFbS" id="7Pk458EDwvt" role="2VODD2">
-                                      <node concept="3clFbF" id="7Pk458EDwvz" role="3cqZAp">
-                                        <node concept="2OqwBi" id="7Pk458EDFpF" role="3clFbG">
-                                          <node concept="1PxgMI" id="7Pk458EDCtA" role="2Oq$k0">
-                                            <node concept="chp4Y" id="7Pk458EDCw4" role="3oSUPX">
-                                              <ref role="cht4Q" to="700h:4Q4DxjDGLlO" resolve="FirstNOp" />
-                                            </node>
-                                            <node concept="2OqwBi" id="7Pk458EDwvu" role="1m5AlR">
-                                              <node concept="3TrEf2" id="7Pk458EDzTa" role="2OqNvi">
-                                                <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
-                                              </node>
-                                              <node concept="30H73N" id="7Pk458EDwvy" role="2Oq$k0" />
-                                            </node>
+                              </node>
+                              <node concept="29HgVG" id="JK8zDWpaoD" role="lGtFl">
+                                <node concept="3NFfHV" id="JK8zDWpaoE" role="3NFExx">
+                                  <node concept="3clFbS" id="JK8zDWpaoF" role="2VODD2">
+                                    <node concept="3clFbF" id="JK8zDWpaoG" role="3cqZAp">
+                                      <node concept="2OqwBi" id="JK8zDWpaoH" role="3clFbG">
+                                        <node concept="1PxgMI" id="JK8zDWpaoI" role="2Oq$k0">
+                                          <node concept="chp4Y" id="JK8zDWpaoJ" role="3oSUPX">
+                                            <ref role="cht4Q" to="700h:4Q4DxjDGLlO" resolve="FirstNOp" />
                                           </node>
-                                          <node concept="3TrEf2" id="7Pk458EDImN" role="2OqNvi">
-                                            <ref role="3Tt5mk" to="700h:6zmBjqUjnKt" resolve="arg" />
+                                          <node concept="2OqwBi" id="JK8zDWpaoK" role="1m5AlR">
+                                            <node concept="3TrEf2" id="JK8zDWpaoL" role="2OqNvi">
+                                              <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                                            </node>
+                                            <node concept="30H73N" id="JK8zDWpaoM" role="2Oq$k0" />
                                           </node>
+                                        </node>
+                                        <node concept="3TrEf2" id="JK8zDWpaoN" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="700h:6zmBjqUjnKt" resolve="arg" />
                                         </node>
                                       </node>
                                     </node>
                                   </node>
                                 </node>
                               </node>
-                              <node concept="liA8E" id="7Pk458EDvU7" role="2OqNvi">
-                                <ref role="37wK5l" to="xlxw:~BigInteger.intValue()" resolve="intValue" />
-                              </node>
+                            </node>
+                            <node concept="liA8E" id="JK8zDWpaoO" role="2OqNvi">
+                              <ref role="37wK5l" to="xlxw:~BigInteger.intValue()" resolve="intValue" />
                             </node>
                           </node>
                         </node>
@@ -5271,111 +5267,107 @@
                       </node>
                     </node>
                     <node concept="3cpWs6" id="7Pk458EORa6" role="3cqZAp">
-                      <node concept="2YIFZM" id="7Pk458EORa7" role="3cqZAk">
-                        <ref role="1Pybhc" to="j10v:~TreePVector" resolve="TreePVector" />
-                        <ref role="37wK5l" to="j10v:~TreePVector.from(java.util.Collection)" resolve="from" />
-                        <node concept="2OqwBi" id="7Pk458EORa8" role="37wK5m">
-                          <node concept="37vLTw" id="7Pk458EORa9" role="2Oq$k0">
-                            <ref role="3cqZAo" node="7Pk458EOR9D" resolve="tpv" />
-                            <node concept="29HgVG" id="7Pk458EORaa" role="lGtFl">
-                              <node concept="3NFfHV" id="7Pk458EORab" role="3NFExx">
-                                <node concept="3clFbS" id="7Pk458EORac" role="2VODD2">
-                                  <node concept="3clFbF" id="7Pk458EORad" role="3cqZAp">
-                                    <node concept="2OqwBi" id="7Pk458EORae" role="3clFbG">
-                                      <node concept="3TrEf2" id="7Pk458EORaf" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
-                                      </node>
-                                      <node concept="30H73N" id="7Pk458EORag" role="2Oq$k0" />
+                      <node concept="2OqwBi" id="JK8zDWpmB2" role="3cqZAk">
+                        <node concept="37vLTw" id="JK8zDWpmB3" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7Pk458EOR9D" resolve="tpv" />
+                          <node concept="29HgVG" id="JK8zDWpmB4" role="lGtFl">
+                            <node concept="3NFfHV" id="JK8zDWpmB5" role="3NFExx">
+                              <node concept="3clFbS" id="JK8zDWpmB6" role="2VODD2">
+                                <node concept="3clFbF" id="JK8zDWpmB7" role="3cqZAp">
+                                  <node concept="2OqwBi" id="JK8zDWpmB8" role="3clFbG">
+                                    <node concept="3TrEf2" id="JK8zDWpmB9" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
                                     </node>
+                                    <node concept="30H73N" id="JK8zDWpmBa" role="2Oq$k0" />
                                   </node>
                                 </node>
                               </node>
                             </node>
                           </node>
-                          <node concept="liA8E" id="7Pk458EORah" role="2OqNvi">
-                            <ref role="37wK5l" to="j10v:~PVector.subList(int,int)" resolve="subList" />
-                            <node concept="3cpWsd" id="7Pk458EPmdg" role="37wK5m">
-                              <node concept="2OqwBi" id="7Pk458EORaj" role="3uHU7w">
-                                <node concept="2ShNRf" id="7Pk458EORak" role="2Oq$k0">
-                                  <node concept="1pGfFk" id="7Pk458EORal" role="2ShVmc">
-                                    <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
-                                    <node concept="Xl_RD" id="7Pk458EORam" role="37wK5m">
-                                      <property role="Xl_RC" value="5" />
-                                    </node>
+                        </node>
+                        <node concept="liA8E" id="JK8zDWpmBb" role="2OqNvi">
+                          <ref role="37wK5l" to="j10v:~PVector.subList(int,int)" resolve="subList" />
+                          <node concept="3cpWsd" id="JK8zDWpmBc" role="37wK5m">
+                            <node concept="2OqwBi" id="JK8zDWpmBd" role="3uHU7w">
+                              <node concept="2ShNRf" id="JK8zDWpmBe" role="2Oq$k0">
+                                <node concept="1pGfFk" id="JK8zDWpmBf" role="2ShVmc">
+                                  <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
+                                  <node concept="Xl_RD" id="JK8zDWpmBg" role="37wK5m">
+                                    <property role="Xl_RC" value="5" />
                                   </node>
-                                  <node concept="29HgVG" id="7Pk458EORan" role="lGtFl">
-                                    <node concept="3NFfHV" id="7Pk458EORao" role="3NFExx">
-                                      <node concept="3clFbS" id="7Pk458EORap" role="2VODD2">
-                                        <node concept="3clFbF" id="7Pk458EORaq" role="3cqZAp">
-                                          <node concept="2OqwBi" id="7Pk458EORar" role="3clFbG">
-                                            <node concept="1PxgMI" id="7Pk458EORas" role="2Oq$k0">
-                                              <node concept="chp4Y" id="7Pk458ESWdb" role="3oSUPX">
-                                                <ref role="cht4Q" to="700h:4Q4DxjDLg_t" resolve="LastNOp" />
-                                              </node>
-                                              <node concept="2OqwBi" id="7Pk458EORau" role="1m5AlR">
-                                                <node concept="3TrEf2" id="7Pk458EORav" role="2OqNvi">
-                                                  <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
-                                                </node>
-                                                <node concept="30H73N" id="7Pk458EORaw" role="2Oq$k0" />
-                                              </node>
+                                </node>
+                                <node concept="29HgVG" id="JK8zDWpmBh" role="lGtFl">
+                                  <node concept="3NFfHV" id="JK8zDWpmBi" role="3NFExx">
+                                    <node concept="3clFbS" id="JK8zDWpmBj" role="2VODD2">
+                                      <node concept="3clFbF" id="JK8zDWpmBk" role="3cqZAp">
+                                        <node concept="2OqwBi" id="JK8zDWpmBl" role="3clFbG">
+                                          <node concept="1PxgMI" id="JK8zDWpmBm" role="2Oq$k0">
+                                            <node concept="chp4Y" id="JK8zDWpmBn" role="3oSUPX">
+                                              <ref role="cht4Q" to="700h:4Q4DxjDLg_t" resolve="LastNOp" />
                                             </node>
-                                            <node concept="3TrEf2" id="7Pk458EORax" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="700h:6zmBjqUjnKt" resolve="arg" />
+                                            <node concept="2OqwBi" id="JK8zDWpmBo" role="1m5AlR">
+                                              <node concept="3TrEf2" id="JK8zDWpmBp" role="2OqNvi">
+                                                <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                                              </node>
+                                              <node concept="30H73N" id="JK8zDWpmBq" role="2Oq$k0" />
                                             </node>
+                                          </node>
+                                          <node concept="3TrEf2" id="JK8zDWpmBr" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="700h:6zmBjqUjnKt" resolve="arg" />
                                           </node>
                                         </node>
                                       </node>
                                     </node>
                                   </node>
-                                </node>
-                                <node concept="liA8E" id="7Pk458EORay" role="2OqNvi">
-                                  <ref role="37wK5l" to="xlxw:~BigInteger.intValue()" resolve="intValue" />
                                 </node>
                               </node>
-                              <node concept="2OqwBi" id="7Pk458EPd1U" role="3uHU7B">
-                                <node concept="37vLTw" id="7Pk458EPd1V" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="7Pk458EOR9D" resolve="tpv" />
-                                  <node concept="29HgVG" id="7Pk458EPd1W" role="lGtFl">
-                                    <node concept="3NFfHV" id="7Pk458EPd1X" role="3NFExx">
-                                      <node concept="3clFbS" id="7Pk458EPd1Y" role="2VODD2">
-                                        <node concept="3clFbF" id="7Pk458EPd1Z" role="3cqZAp">
-                                          <node concept="2OqwBi" id="7Pk458EPd20" role="3clFbG">
-                                            <node concept="3TrEf2" id="7Pk458EPd21" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
-                                            </node>
-                                            <node concept="30H73N" id="7Pk458EPd22" role="2Oq$k0" />
+                              <node concept="liA8E" id="JK8zDWpmBs" role="2OqNvi">
+                                <ref role="37wK5l" to="xlxw:~BigInteger.intValue()" resolve="intValue" />
+                              </node>
+                            </node>
+                            <node concept="2OqwBi" id="JK8zDWpmBt" role="3uHU7B">
+                              <node concept="37vLTw" id="JK8zDWpmBu" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7Pk458EOR9D" resolve="tpv" />
+                                <node concept="29HgVG" id="JK8zDWpmBv" role="lGtFl">
+                                  <node concept="3NFfHV" id="JK8zDWpmBw" role="3NFExx">
+                                    <node concept="3clFbS" id="JK8zDWpmBx" role="2VODD2">
+                                      <node concept="3clFbF" id="JK8zDWpmBy" role="3cqZAp">
+                                        <node concept="2OqwBi" id="JK8zDWpmBz" role="3clFbG">
+                                          <node concept="3TrEf2" id="JK8zDWpmB$" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
                                           </node>
+                                          <node concept="30H73N" id="JK8zDWpmB_" role="2Oq$k0" />
                                         </node>
                                       </node>
                                     </node>
                                   </node>
                                 </node>
-                                <node concept="liA8E" id="7Pk458EPd23" role="2OqNvi">
-                                  <ref role="37wK5l" to="33ny:~Collection.size()" resolve="size" />
+                              </node>
+                              <node concept="liA8E" id="JK8zDWpmBA" role="2OqNvi">
+                                <ref role="37wK5l" to="33ny:~Collection.size()" resolve="size" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="JK8zDWpmBB" role="37wK5m">
+                            <node concept="37vLTw" id="JK8zDWpmBC" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7Pk458EOR9D" resolve="tpv" />
+                              <node concept="29HgVG" id="JK8zDWpmBD" role="lGtFl">
+                                <node concept="3NFfHV" id="JK8zDWpmBE" role="3NFExx">
+                                  <node concept="3clFbS" id="JK8zDWpmBF" role="2VODD2">
+                                    <node concept="3clFbF" id="JK8zDWpmBG" role="3cqZAp">
+                                      <node concept="2OqwBi" id="JK8zDWpmBH" role="3clFbG">
+                                        <node concept="3TrEf2" id="JK8zDWpmBI" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                                        </node>
+                                        <node concept="30H73N" id="JK8zDWpmBJ" role="2Oq$k0" />
+                                      </node>
+                                    </node>
+                                  </node>
                                 </node>
                               </node>
                             </node>
-                            <node concept="2OqwBi" id="7Pk458EP4F7" role="37wK5m">
-                              <node concept="37vLTw" id="7Pk458EP3O1" role="2Oq$k0">
-                                <ref role="3cqZAo" node="7Pk458EOR9D" resolve="tpv" />
-                                <node concept="29HgVG" id="7Pk458EP6B$" role="lGtFl">
-                                  <node concept="3NFfHV" id="7Pk458EP6B_" role="3NFExx">
-                                    <node concept="3clFbS" id="7Pk458EP6BA" role="2VODD2">
-                                      <node concept="3clFbF" id="7Pk458EP6BG" role="3cqZAp">
-                                        <node concept="2OqwBi" id="7Pk458EP6BB" role="3clFbG">
-                                          <node concept="3TrEf2" id="7Pk458EP6BE" role="2OqNvi">
-                                            <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
-                                          </node>
-                                          <node concept="30H73N" id="7Pk458EP6BF" role="2Oq$k0" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="liA8E" id="7Pk458EP5X6" role="2OqNvi">
-                                <ref role="37wK5l" to="33ny:~Collection.size()" resolve="size" />
-                              </node>
+                            <node concept="liA8E" id="JK8zDWpmBK" role="2OqNvi">
+                              <ref role="37wK5l" to="33ny:~Collection.size()" resolve="size" />
                             </node>
                           </node>
                         </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.collections@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.collections@tests.mps
@@ -19187,6 +19187,97 @@
         </node>
       </node>
     </node>
+    <node concept="_ixoA" id="JK8zDWa7ex" role="_iOnB" />
+    <node concept="_fkuM" id="JK8zDWafd4" role="_iOnB">
+      <property role="TrG5h" value="firstNLastN" />
+      <node concept="_fkuZ" id="JK8zDWajcn" role="_fkp5">
+        <node concept="_fku$" id="JK8zDWajco" role="_fkur" />
+        <node concept="1QScDb" id="JK8zDWajdk" role="_fkuY">
+          <node concept="2$dVdw" id="JK8zDWajSO" role="1QScD9">
+            <node concept="30bXRB" id="JK8zDWxiRf" role="3iAY4F">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="_emDc" id="JK8zDWajcX" role="30czhm">
+            <ref role="_emDf" node="twWOnQO_lJ" resolve="zahlen" />
+          </node>
+        </node>
+        <node concept="3iBYfx" id="JK8zDWakXT" role="_fkuS">
+          <node concept="30bXRB" id="JK8zDWakY4" role="3iBYfI">
+            <property role="30bXRw" value="100" />
+          </node>
+          <node concept="30bXRB" id="JK8zDWal0C" role="3iBYfI">
+            <property role="30bXRw" value="200" />
+          </node>
+          <node concept="30bXRB" id="JK8zDWxjyZ" role="3iBYfI">
+            <property role="30bXRw" value="300" />
+          </node>
+          <node concept="30bXRB" id="JK8zDWxjBZ" role="3iBYfI">
+            <property role="30bXRw" value="400" />
+          </node>
+        </node>
+      </node>
+      <node concept="_fkuZ" id="JK8zDWev7E" role="_fkp5">
+        <node concept="_fku$" id="JK8zDWev7F" role="_fkur" />
+        <node concept="1QScDb" id="JK8zDWev8N" role="_fkuY">
+          <node concept="2$gqX9" id="JK8zDWevQO" role="1QScD9">
+            <node concept="30bXRB" id="JK8zDWewrL" role="3iAY4F">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="JK8zDWxjPg" role="30czhm">
+            <node concept="30bXRB" id="JK8zDWxksi" role="3iBYfI">
+              <property role="30bXRw" value="100" />
+            </node>
+            <node concept="30bXRB" id="JK8zDWxmjr" role="3iBYfI">
+              <property role="30bXRw" value="200" />
+            </node>
+            <node concept="30bXRB" id="JK8zDWxoJA" role="3iBYfI">
+              <property role="30bXRw" value="300" />
+            </node>
+            <node concept="30bXRB" id="JK8zDWxrfN" role="3iBYfI">
+              <property role="30bXRw" value="400" />
+            </node>
+          </node>
+        </node>
+        <node concept="3iBYfx" id="JK8zDWex0T" role="_fkuS">
+          <node concept="30bXRB" id="JK8zDWex14" role="3iBYfI">
+            <property role="30bXRw" value="300" />
+          </node>
+          <node concept="30bXRB" id="JK8zDWex3C" role="3iBYfI">
+            <property role="30bXRw" value="400" />
+          </node>
+        </node>
+      </node>
+      <node concept="_fkuZ" id="JK8zDWjj2m" role="_fkp5">
+        <node concept="_fku$" id="JK8zDWjo9_" role="_fkur" />
+        <node concept="1QScDb" id="JK8zDWjmd3" role="_fkuY">
+          <node concept="2$gqX9" id="JK8zDWjmTu" role="1QScD9">
+            <node concept="30bXRB" id="JK8zDWjnwA" role="3iAY4F">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="1QScDb" id="JK8zDWjj3C" role="30czhm">
+            <node concept="2$dVdw" id="JK8zDWjjQt" role="1QScD9">
+              <node concept="30bXRB" id="JK8zDWjlCR" role="3iAY4F">
+                <property role="30bXRw" value="4" />
+              </node>
+            </node>
+            <node concept="_emDc" id="JK8zDWjj3h" role="30czhm">
+              <ref role="_emDf" node="twWOnQO_lJ" resolve="zahlen" />
+            </node>
+          </node>
+        </node>
+        <node concept="3iBYfx" id="JK8zDWjoa2" role="_fkuS">
+          <node concept="30bXRB" id="JK8zDWjoad" role="3iBYfI">
+            <property role="30bXRw" value="300" />
+          </node>
+          <node concept="30bXRB" id="JK8zDWjocL" role="3iBYfI">
+            <property role="30bXRw" value="400" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="_ixoA" id="2ufoZQJ2tm0" role="_iOnB" />
     <node concept="_ixoA" id="2ufoZQIV1H2" role="_iOnB" />
     <node concept="_ixoA" id="1$1rueeqtL1" role="_iOnB" />


### PR DESCRIPTION
Generating a expression like `list.first(5).last(2)` lead to a cast exception due to a mix of `PVector`s and `TreePVector`s in the generated code. This is fixed with this PR.