### PR TITLE
Allow solver check to optionally show subresults

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/behavior.mps
@@ -911,6 +911,18 @@
         </node>
       </node>
     </node>
+    <node concept="13i0hz" id="4MH81Y0VldB" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="showSubResults" />
+      <node concept="3Tm1VV" id="4MH81Y0VldC" role="1B3o_S" />
+      <node concept="10P_77" id="4MH81Y0VldD" role="3clF45" />
+      <node concept="3clFbS" id="4MH81Y0VldE" role="3clF47">
+        <node concept="3clFbF" id="4MH81Y0VldF" role="3cqZAp">
+          <node concept="3clFbT" id="4MH81Y0VldG" role="3clFbG" />
+        </node>
+      </node>
+    </node>
     <node concept="13i0hz" id="3R3AIvumAZH" role="13h7CS">
       <property role="13i0iv" value="true" />
       <property role="13i0it" value="true" />
@@ -2158,6 +2170,20 @@
     </node>
     <node concept="13hLZK" id="6BCTLIjCrat" role="13h7CW">
       <node concept="3clFbS" id="6BCTLIjCrau" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="3HP615" id="3q2wVepKU6u">
+    <property role="TrG5h" value="IHasSubResults" />
+    <node concept="3Tm1VV" id="3q2wVepKU6v" role="1B3o_S" />
+    <node concept="3clFb_" id="3q2wVepL0NY" role="jymVt">
+      <property role="TrG5h" value="getSubResults" />
+      <node concept="3clFbS" id="3q2wVepL0O1" role="3clF47" />
+      <node concept="3Tm1VV" id="3q2wVepL0O2" role="1B3o_S" />
+      <node concept="A3Dl8" id="3q2wVepMrG1" role="3clF45">
+        <node concept="3uibUv" id="3q2wVepMrG3" role="A3Ik2">
+          <ref role="3uigEE" node="5zG5$Lyex1G" resolve="IResult" />
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/behavior.mps
@@ -48,12 +48,16 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
+      <concept id="2323553266850475941" name="jetbrains.mps.baseLanguage.structure.IHasModifiers" flags="ng" index="2frcj7">
+        <child id="2323553266850475953" name="modifiers" index="2frcjj" />
+      </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="ng" index="2tJIrI" />
+      <concept id="4678410916365116210" name="jetbrains.mps.baseLanguage.structure.DefaultModifier" flags="ng" index="2JFqV2" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -260,7 +264,11 @@
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
     </language>
   </registry>
@@ -1254,6 +1262,27 @@
       </node>
     </node>
     <node concept="2tJIrI" id="7rOSrvnHq1O" role="jymVt" />
+    <node concept="3clFb_" id="4NNZM3RDny5" role="jymVt">
+      <property role="TrG5h" value="getSubResults" />
+      <node concept="3clFbS" id="4NNZM3RDny6" role="3clF47">
+        <node concept="3clFbF" id="4NNZM3RDnzW" role="3cqZAp">
+          <node concept="2ShNRf" id="4NNZM3RDnzU" role="3clFbG">
+            <node concept="Tc6Ow" id="4NNZM3RDoOz" role="2ShVmc">
+              <node concept="3uibUv" id="4NNZM3RDuec" role="HW$YZ">
+                <ref role="3uigEE" node="5zG5$Lyex1G" resolve="IResult" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4NNZM3RDny7" role="1B3o_S" />
+      <node concept="A3Dl8" id="4NNZM3RDny8" role="3clF45">
+        <node concept="3uibUv" id="4NNZM3RDny9" role="A3Ik2">
+          <ref role="3uigEE" node="5zG5$Lyex1G" resolve="IResult" />
+        </node>
+      </node>
+      <node concept="2JFqV2" id="4NNZM3RDnya" role="2frcjj" />
+    </node>
     <node concept="3Tm1VV" id="5zG5$Lyex1H" role="1B3o_S" />
   </node>
   <node concept="312cEu" id="5zG5$LyyJpW">
@@ -2170,20 +2199,6 @@
     </node>
     <node concept="13hLZK" id="6BCTLIjCrat" role="13h7CW">
       <node concept="3clFbS" id="6BCTLIjCrau" role="2VODD2" />
-    </node>
-  </node>
-  <node concept="3HP615" id="3q2wVepKU6u">
-    <property role="TrG5h" value="IHasSubResults" />
-    <node concept="3Tm1VV" id="3q2wVepKU6v" role="1B3o_S" />
-    <node concept="3clFb_" id="3q2wVepL0NY" role="jymVt">
-      <property role="TrG5h" value="getSubResults" />
-      <node concept="3clFbS" id="3q2wVepL0O1" role="3clF47" />
-      <node concept="3Tm1VV" id="3q2wVepL0O2" role="1B3o_S" />
-      <node concept="A3Dl8" id="3q2wVepMrG1" role="3clF45">
-        <node concept="3uibUv" id="3q2wVepMrG3" role="A3Ik2">
-          <ref role="3uigEE" node="5zG5$Lyex1G" resolve="IResult" />
-        </node>
-      </node>
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/typesystem.mps
@@ -45,10 +45,6 @@
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
-      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
-        <child id="1070534934091" name="type" index="10QFUM" />
-        <child id="1070534934092" name="expression" index="10QFUP" />
-      </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -82,9 +78,6 @@
       <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
         <child id="1206060619838" name="condition" index="3eO9$A" />
         <child id="1206060644605" name="statementList" index="3eOfB_" />
-      </concept>
-      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
-        <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
@@ -546,36 +539,16 @@
                       </node>
                       <node concept="3clFbJ" id="3q2wVepL68L" role="3cqZAp">
                         <node concept="3clFbS" id="3q2wVepL68N" role="3clFbx">
-                          <node concept="3cpWs8" id="BSB$UziF3a" role="3cqZAp">
-                            <node concept="3cpWsn" id="BSB$UziF3b" role="3cpWs9">
-                              <property role="TrG5h" value="subResults" />
-                              <node concept="A3Dl8" id="BSB$Uzi3EO" role="1tU5fm">
-                                <node concept="3uibUv" id="BSB$Uzi3ER" role="A3Ik2">
-                                  <ref role="3uigEE" to="gdgh:5zG5$Lyex1G" resolve="IResult" />
-                                </node>
-                              </node>
-                              <node concept="2OqwBi" id="BSB$UziF3c" role="33vP2m">
-                                <node concept="1eOMI4" id="BSB$UziF3d" role="2Oq$k0">
-                                  <node concept="10QFUN" id="BSB$UziF3e" role="1eOMHV">
-                                    <node concept="3uibUv" id="BSB$UziF3f" role="10QFUM">
-                                      <ref role="3uigEE" to="gdgh:3q2wVepKU6u" resolve="IHasSubResults" />
-                                    </node>
-                                    <node concept="37vLTw" id="BSB$UziF3g" role="10QFUP">
-                                      <ref role="3cqZAo" node="2BX$1355wSF" resolve="iResult" />
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="liA8E" id="BSB$UziF3h" role="2OqNvi">
-                                  <ref role="37wK5l" to="gdgh:3q2wVepL0NY" resolve="getSubResults" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
                           <node concept="3clFbF" id="4MH81Y0UkQP" role="3cqZAp">
                             <node concept="2OqwBi" id="4MH81Y0UniW" role="3clFbG">
                               <node concept="2OqwBi" id="4MH81Y0UlPj" role="2Oq$k0">
-                                <node concept="37vLTw" id="4MH81Y0UkQN" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="BSB$UziF3b" resolve="subResults" />
+                                <node concept="2OqwBi" id="4NNZM3RDK5V" role="2Oq$k0">
+                                  <node concept="37vLTw" id="4NNZM3RDJV0" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="2BX$1355wSF" resolve="iResult" />
+                                  </node>
+                                  <node concept="liA8E" id="4NNZM3RDKgs" role="2OqNvi">
+                                    <ref role="37wK5l" to="gdgh:4NNZM3RDny5" resolve="getSubResults" />
+                                  </node>
                                 </node>
                                 <node concept="3zZkjj" id="4MH81Y0UmJU" role="2OqNvi">
                                   <node concept="1bVj0M" id="4MH81Y0UmJW" role="23t8la">
@@ -625,22 +598,12 @@
                             </node>
                           </node>
                         </node>
-                        <node concept="1Wc70l" id="4MH81Y0VAE3" role="3clFbw">
-                          <node concept="2OqwBi" id="4MH81Y0VAUN" role="3uHU7w">
-                            <node concept="1YBJjd" id="4MH81Y0VAK7" role="2Oq$k0">
-                              <ref role="1YBMHb" node="2BX$1355fco" resolve="icrm" />
-                            </node>
-                            <node concept="2qgKlT" id="4MH81Y0VBYU" role="2OqNvi">
-                              <ref role="37wK5l" to="gdgh:4MH81Y0VldB" resolve="showSubResults" />
-                            </node>
+                        <node concept="2OqwBi" id="4MH81Y0VAUN" role="3clFbw">
+                          <node concept="1YBJjd" id="4MH81Y0VAK7" role="2Oq$k0">
+                            <ref role="1YBMHb" node="2BX$1355fco" resolve="icrm" />
                           </node>
-                          <node concept="2ZW3vV" id="3q2wVepL77X" role="3uHU7B">
-                            <node concept="3uibUv" id="3q2wVepL79y" role="2ZW6by">
-                              <ref role="3uigEE" to="gdgh:3q2wVepKU6u" resolve="IHasSubResults" />
-                            </node>
-                            <node concept="37vLTw" id="3q2wVepL713" role="2ZW6bz">
-                              <ref role="3cqZAo" node="2BX$1355wSF" resolve="iResult" />
-                            </node>
+                          <node concept="2qgKlT" id="4MH81Y0VBYU" role="2OqNvi">
+                            <ref role="37wK5l" to="gdgh:4MH81Y0VldB" resolve="showSubResults" />
                           </node>
                         </node>
                       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/typesystem.mps
@@ -10,6 +10,7 @@
     <import index="gdgh" ref="r:e4d9478b-ae0e-416e-be60-73d136571015(org.iets3.core.base.behavior)" />
     <import index="juu2" ref="r:197c9a7f-bef3-4d38-a48a-51524151fecf(org.iets3.core.base.plugin)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -39,14 +40,22 @@
         <child id="1081256993305" name="classType" index="2ZW6by" />
         <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -64,13 +73,18 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
         <child id="1206060619838" name="condition" index="3eO9$A" />
         <child id="1206060644605" name="statementList" index="3eOfB_" />
+      </concept>
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
@@ -96,9 +110,16 @@
       <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
+        <child id="1199542457201" name="resultType" index="1ajl9A" />
+        <child id="1199542501692" name="parameterType" index="1ajw0F" />
+      </concept>
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+      <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="nn" index="1Bd96e">
+        <child id="1225797361612" name="parameter" index="1BdPVh" />
       </concept>
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
@@ -136,9 +157,17 @@
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
+        <property id="709746936026609031" name="linkId" index="3V$3ak" />
+        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
+      </concept>
+      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
+        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
       </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
@@ -156,6 +185,7 @@
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -181,6 +211,29 @@
     <property role="TrG5h" value="check_ICanRunCheckManually" />
     <property role="3GE5qa" value="adapter" />
     <node concept="3clFbS" id="2BX$1355fcm" role="18ibNy">
+      <node concept="1X3_iC" id="4MH81Y0UuMn" role="lGtFl">
+        <property role="3V$3am" value="statement" />
+        <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+        <node concept="3clFbF" id="3q2wVepy$u2" role="8Wnug">
+          <node concept="2OqwBi" id="3q2wVepy$tZ" role="3clFbG">
+            <node concept="10M0yZ" id="3q2wVepy$u0" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              <ref role="3cqZAo" to="wyt6:~System.err" resolve="err" />
+            </node>
+            <node concept="liA8E" id="3q2wVepy$u1" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="3cpWs3" id="3q2wVepyTqZ" role="37wK5m">
+                <node concept="1YBJjd" id="3q2wVepyTr6" role="3uHU7w">
+                  <ref role="1YBMHb" node="2BX$1355fco" resolve="icrm" />
+                </node>
+                <node concept="Xl_RD" id="3q2wVepy$J3" role="3uHU7B">
+                  <property role="Xl_RC" value="CHECKING RULE check_ICanRunCheckManually begin " />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
       <node concept="3clFbJ" id="2BX$1355wSm" role="3cqZAp">
         <node concept="3clFbS" id="2BX$1355wSn" role="3clFbx">
           <node concept="3clFbJ" id="2BX$1355wSo" role="3cqZAp">
@@ -205,202 +258,388 @@
                 <node concept="3clFbS" id="2BX$1355wSL" role="3clFbx">
                   <node concept="3clFbJ" id="2BX$1355wSM" role="3cqZAp">
                     <node concept="3clFbS" id="2BX$1355wSN" role="3clFbx">
-                      <node concept="3cpWs8" id="2BX$1355wSO" role="3cqZAp">
-                        <node concept="3cpWsn" id="2BX$1355wSP" role="3cpWs9">
-                          <property role="TrG5h" value="errorMessage" />
-                          <node concept="17QB3L" id="2BX$1355wSQ" role="1tU5fm" />
-                          <node concept="2YIFZM" id="3SU4Z7BeLTI" role="33vP2m">
-                            <ref role="37wK5l" to="juu2:3SU4Z7BeLz4" resolve="reformatErrorMessage" />
-                            <ref role="1Pybhc" to="juu2:3SU4Z7BeswZ" resolve="Check_ICanRunCheckManuallyUtil" />
-                            <node concept="2OqwBi" id="3SU4Z7BeMbP" role="37wK5m">
-                              <node concept="37vLTw" id="3SU4Z7BeLX0" role="2Oq$k0">
-                                <ref role="3cqZAo" node="2BX$1355wSF" resolve="iResult" />
-                              </node>
-                              <node concept="liA8E" id="3SU4Z7BeMp$" role="2OqNvi">
-                                <ref role="37wK5l" to="gdgh:5zG5$LyexiK" resolve="getErrorMessage" />
-                              </node>
-                            </node>
+                      <node concept="3SKdUt" id="4MH81Y0Uw8T" role="3cqZAp">
+                        <node concept="1PaTwC" id="4MH81Y0Uw8U" role="1aUNEU">
+                          <node concept="3oM_SD" id="4MH81Y0Uw8V" role="1PaTwD">
+                            <property role="3oM_SC" value="function" />
+                          </node>
+                          <node concept="3oM_SD" id="4MH81Y0Ux7I" role="1PaTwD">
+                            <property role="3oM_SC" value="which" />
+                          </node>
+                          <node concept="3oM_SD" id="4MH81Y0Ux7M" role="1PaTwD">
+                            <property role="3oM_SC" value="reports" />
+                          </node>
+                          <node concept="3oM_SD" id="4MH81Y0Ux7R" role="1PaTwD">
+                            <property role="3oM_SC" value="a" />
+                          </node>
+                          <node concept="3oM_SD" id="4MH81Y0Ux7X" role="1PaTwD">
+                            <property role="3oM_SC" value="single" />
+                          </node>
+                          <node concept="3oM_SD" id="4MH81Y0Ux83" role="1PaTwD">
+                            <property role="3oM_SC" value="result" />
                           </node>
                         </node>
                       </node>
-                      <node concept="3clFbH" id="3SU4Z7BeLb0" role="3cqZAp" />
-                      <node concept="3cpWs8" id="2BX$1355wTY" role="3cqZAp">
-                        <node concept="3cpWsn" id="2BX$1355wTZ" role="3cpWs9">
-                          <property role="TrG5h" value="targetNodes" />
-                          <node concept="A3Dl8" id="2BX$1355wU0" role="1tU5fm">
-                            <node concept="3Tqbb2" id="2BX$1355wU1" role="A3Ik2" />
-                          </node>
-                          <node concept="2EnYce" id="2BX$1355wU2" role="33vP2m">
-                            <node concept="0kSF2" id="2BX$1355wU3" role="2Oq$k0">
-                              <node concept="3uibUv" id="2BX$1355wU4" role="0kSFW">
-                                <ref role="3uigEE" to="gdgh:5JinICPcACI" resolve="IResultWithTargetNodes" />
-                              </node>
-                              <node concept="37vLTw" id="2BX$1355wU5" role="0kSFX">
-                                <ref role="3cqZAo" node="2BX$1355wSF" resolve="iResult" />
-                              </node>
+                      <node concept="3cpWs8" id="4MH81Y0U2EC" role="3cqZAp">
+                        <node concept="3cpWsn" id="4MH81Y0U2ED" role="3cpWs9">
+                          <property role="TrG5h" value="reportResult" />
+                          <node concept="1ajhzC" id="4MH81Y0U2E_" role="1tU5fm">
+                            <node concept="3uibUv" id="4MH81Y0U2EA" role="1ajw0F">
+                              <ref role="3uigEE" to="gdgh:5zG5$Lyex1G" resolve="IResult" />
                             </node>
-                            <node concept="liA8E" id="2BX$1355wU6" role="2OqNvi">
-                              <ref role="37wK5l" to="gdgh:5JinICPcAPp" resolve="getMessageTargetNodes" />
-                            </node>
+                            <node concept="3cqZAl" id="4MH81Y0U2EB" role="1ajl9A" />
                           </node>
-                        </node>
-                      </node>
-                      <node concept="3cpWs8" id="3SU4Z7Bfw34" role="3cqZAp">
-                        <node concept="3cpWsn" id="3SU4Z7Bfw35" role="3cpWs9">
-                          <property role="TrG5h" value="knownTargetNodes" />
-                          <node concept="_YKpA" id="3SU4Z7Bfw1p" role="1tU5fm">
-                            <node concept="3Tqbb2" id="3SU4Z7Bfw1s" role="_ZDj9" />
-                          </node>
-                          <node concept="2OqwBi" id="3SU4Z7Bfw36" role="33vP2m">
-                            <node concept="2OqwBi" id="3SU4Z7Bfw37" role="2Oq$k0">
-                              <node concept="37vLTw" id="3SU4Z7Bfw38" role="2Oq$k0">
-                                <ref role="3cqZAo" node="2BX$1355wTZ" resolve="targetNodes" />
-                              </node>
-                              <node concept="3zZkjj" id="3SU4Z7Bfw39" role="2OqNvi">
-                                <node concept="1bVj0M" id="3SU4Z7Bfw3a" role="23t8la">
-                                  <node concept="3clFbS" id="3SU4Z7Bfw3b" role="1bW5cS">
-                                    <node concept="3clFbF" id="3SU4Z7Bfw3c" role="3cqZAp">
-                                      <node concept="2OqwBi" id="3SU4Z7Bfw3d" role="3clFbG">
-                                        <node concept="37vLTw" id="3SU4Z7Bfw3e" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="3SU4Z7Bfw3g" resolve="targetNode" />
-                                        </node>
-                                        <node concept="3x8VRR" id="3SU4Z7Bfw3f" role="2OqNvi" />
+                          <node concept="1bVj0M" id="4MH81Y0U2EE" role="33vP2m">
+                            <node concept="3clFbS" id="4MH81Y0U2EF" role="1bW5cS">
+                              <node concept="3cpWs8" id="2BX$1355wSO" role="3cqZAp">
+                                <node concept="3cpWsn" id="2BX$1355wSP" role="3cpWs9">
+                                  <property role="TrG5h" value="errorMessage" />
+                                  <node concept="17QB3L" id="2BX$1355wSQ" role="1tU5fm" />
+                                  <node concept="2YIFZM" id="3SU4Z7BeLTI" role="33vP2m">
+                                    <ref role="37wK5l" to="juu2:3SU4Z7BeLz4" resolve="reformatErrorMessage" />
+                                    <ref role="1Pybhc" to="juu2:3SU4Z7BeswZ" resolve="Check_ICanRunCheckManuallyUtil" />
+                                    <node concept="2OqwBi" id="3SU4Z7BeMbP" role="37wK5m">
+                                      <node concept="37vLTw" id="4MH81Y0U87I" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="4MH81Y0U2EG" resolve="result" />
+                                      </node>
+                                      <node concept="liA8E" id="3SU4Z7BeMp$" role="2OqNvi">
+                                        <ref role="37wK5l" to="gdgh:5zG5$LyexiK" resolve="getErrorMessage" />
                                       </node>
                                     </node>
                                   </node>
-                                  <node concept="Rh6nW" id="3SU4Z7Bfw3g" role="1bW2Oz">
-                                    <property role="TrG5h" value="targetNode" />
-                                    <node concept="2jxLKc" id="3SU4Z7Bfw3h" role="1tU5fm" />
+                                </node>
+                              </node>
+                              <node concept="3clFbH" id="3SU4Z7BeLb0" role="3cqZAp" />
+                              <node concept="3cpWs8" id="2BX$1355wTY" role="3cqZAp">
+                                <node concept="3cpWsn" id="2BX$1355wTZ" role="3cpWs9">
+                                  <property role="TrG5h" value="targetNodes" />
+                                  <node concept="A3Dl8" id="2BX$1355wU0" role="1tU5fm">
+                                    <node concept="3Tqbb2" id="2BX$1355wU1" role="A3Ik2" />
+                                  </node>
+                                  <node concept="2EnYce" id="2BX$1355wU2" role="33vP2m">
+                                    <node concept="0kSF2" id="2BX$1355wU3" role="2Oq$k0">
+                                      <node concept="3uibUv" id="2BX$1355wU4" role="0kSFW">
+                                        <ref role="3uigEE" to="gdgh:5JinICPcACI" resolve="IResultWithTargetNodes" />
+                                      </node>
+                                      <node concept="37vLTw" id="4MH81Y0U9oP" role="0kSFX">
+                                        <ref role="3cqZAo" node="4MH81Y0U2EG" resolve="result" />
+                                      </node>
+                                    </node>
+                                    <node concept="liA8E" id="2BX$1355wU6" role="2OqNvi">
+                                      <ref role="37wK5l" to="gdgh:5JinICPcAPp" resolve="getMessageTargetNodes" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3cpWs8" id="3SU4Z7Bfw34" role="3cqZAp">
+                                <node concept="3cpWsn" id="3SU4Z7Bfw35" role="3cpWs9">
+                                  <property role="TrG5h" value="knownTargetNodes" />
+                                  <node concept="_YKpA" id="3SU4Z7Bfw1p" role="1tU5fm">
+                                    <node concept="3Tqbb2" id="3SU4Z7Bfw1s" role="_ZDj9" />
+                                  </node>
+                                  <node concept="2OqwBi" id="3SU4Z7Bfw36" role="33vP2m">
+                                    <node concept="2OqwBi" id="3SU4Z7Bfw37" role="2Oq$k0">
+                                      <node concept="37vLTw" id="3SU4Z7Bfw38" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="2BX$1355wTZ" resolve="targetNodes" />
+                                      </node>
+                                      <node concept="3zZkjj" id="3SU4Z7Bfw39" role="2OqNvi">
+                                        <node concept="1bVj0M" id="3SU4Z7Bfw3a" role="23t8la">
+                                          <node concept="3clFbS" id="3SU4Z7Bfw3b" role="1bW5cS">
+                                            <node concept="3clFbF" id="3SU4Z7Bfw3c" role="3cqZAp">
+                                              <node concept="2OqwBi" id="3SU4Z7Bfw3d" role="3clFbG">
+                                                <node concept="37vLTw" id="3SU4Z7Bfw3e" role="2Oq$k0">
+                                                  <ref role="3cqZAo" node="3SU4Z7Bfw3g" resolve="targetNode" />
+                                                </node>
+                                                <node concept="3x8VRR" id="3SU4Z7Bfw3f" role="2OqNvi" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="Rh6nW" id="3SU4Z7Bfw3g" role="1bW2Oz">
+                                            <property role="TrG5h" value="targetNode" />
+                                            <node concept="2jxLKc" id="3SU4Z7Bfw3h" role="1tU5fm" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="ANE8D" id="3SU4Z7Bfw3i" role="2OqNvi" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3clFbJ" id="3SU4Z7BfwR9" role="3cqZAp">
+                                <node concept="3clFbS" id="3SU4Z7BfwRb" role="3clFbx">
+                                  <node concept="3SKdUt" id="3SU4Z7BfSId" role="3cqZAp">
+                                    <node concept="1PaTwC" id="3SU4Z7BfSIe" role="1aUNEU">
+                                      <node concept="3oM_SD" id="3SU4Z7BfSIg" role="1PaTwD">
+                                        <property role="3oM_SC" value="If" />
+                                      </node>
+                                      <node concept="3oM_SD" id="3SU4Z7BfSIr" role="1PaTwD">
+                                        <property role="3oM_SC" value="some" />
+                                      </node>
+                                      <node concept="3oM_SD" id="3SU4Z7BfSIu" role="1PaTwD">
+                                        <property role="3oM_SC" value="node" />
+                                      </node>
+                                      <node concept="3oM_SD" id="3SU4Z7BfSIy" role="1PaTwD">
+                                        <property role="3oM_SC" value="cannot" />
+                                      </node>
+                                      <node concept="3oM_SD" id="3SU4Z7BfSIB" role="1PaTwD">
+                                        <property role="3oM_SC" value="be" />
+                                      </node>
+                                      <node concept="3oM_SD" id="3SU4Z7BfSIH" role="1PaTwD">
+                                        <property role="3oM_SC" value="resolved" />
+                                      </node>
+                                      <node concept="3oM_SD" id="3SU4Z7BfSIO" role="1PaTwD">
+                                        <property role="3oM_SC" value="put" />
+                                      </node>
+                                      <node concept="3oM_SD" id="3SU4Z7BfSIW" role="1PaTwD">
+                                        <property role="3oM_SC" value="the" />
+                                      </node>
+                                      <node concept="3oM_SD" id="3SU4Z7BfSJ5" role="1PaTwD">
+                                        <property role="3oM_SC" value="message" />
+                                      </node>
+                                      <node concept="3oM_SD" id="3SU4Z7BfSJf" role="1PaTwD">
+                                        <property role="3oM_SC" value="on" />
+                                      </node>
+                                      <node concept="3oM_SD" id="3SU4Z7BfSJq" role="1PaTwD">
+                                        <property role="3oM_SC" value="the" />
+                                      </node>
+                                      <node concept="3oM_SD" id="3SU4Z7BfSJA" role="1PaTwD">
+                                        <property role="3oM_SC" value="root." />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3clFbF" id="3SU4Z7BfBd$" role="3cqZAp">
+                                    <node concept="2OqwBi" id="3SU4Z7BfC5k" role="3clFbG">
+                                      <node concept="37vLTw" id="3SU4Z7BfBdy" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="3SU4Z7Bfw35" resolve="knownTargetNodes" />
+                                      </node>
+                                      <node concept="TSZUe" id="3SU4Z7BfDKj" role="2OqNvi">
+                                        <node concept="1YBJjd" id="3SU4Z7BfDPX" role="25WWJ7">
+                                          <ref role="1YBMHb" node="2BX$1355fco" resolve="icrm" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="3y3z36" id="3SU4Z7Bf__o" role="3clFbw">
+                                  <node concept="2OqwBi" id="3SU4Z7BfAUw" role="3uHU7w">
+                                    <node concept="37vLTw" id="3SU4Z7BfA1A" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="2BX$1355wTZ" resolve="targetNodes" />
+                                    </node>
+                                    <node concept="34oBXx" id="3SU4Z7BfBbn" role="2OqNvi" />
+                                  </node>
+                                  <node concept="2OqwBi" id="3SU4Z7Bfyd7" role="3uHU7B">
+                                    <node concept="37vLTw" id="3SU4Z7Bfxap" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="3SU4Z7Bfw35" resolve="knownTargetNodes" />
+                                    </node>
+                                    <node concept="34oBXx" id="3SU4Z7BfzS8" role="2OqNvi" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3clFbH" id="3SU4Z7BfrpO" role="3cqZAp" />
+                              <node concept="3cpWs8" id="2BX$1355wSS" role="3cqZAp">
+                                <node concept="3cpWsn" id="2BX$1355wST" role="3cpWs9">
+                                  <property role="TrG5h" value="isWarning" />
+                                  <node concept="10P_77" id="2BX$1355wSU" role="1tU5fm" />
+                                  <node concept="2YIFZM" id="3SU4Z7Bggts" role="33vP2m">
+                                    <ref role="1Pybhc" to="juu2:3SU4Z7BeswZ" resolve="Check_ICanRunCheckManuallyUtil" />
+                                    <ref role="37wK5l" to="juu2:3SU4Z7BgfL$" resolve="isWarning" />
+                                    <node concept="2OqwBi" id="3SU4Z7Bgg$o" role="37wK5m">
+                                      <node concept="37vLTw" id="3SU4Z7BggtM" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="2BX$1355wSF" resolve="iResult" />
+                                      </node>
+                                      <node concept="liA8E" id="3SU4Z7BggJO" role="2OqNvi">
+                                        <ref role="37wK5l" to="gdgh:5zG5$LyexiK" resolve="getErrorMessage" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="2Gpval" id="2BX$1355wUc" role="3cqZAp">
+                                <node concept="2GrKxI" id="2BX$1355wUd" role="2Gsz3X">
+                                  <property role="TrG5h" value="target" />
+                                </node>
+                                <node concept="37vLTw" id="3SU4Z7BfEML" role="2GsD0m">
+                                  <ref role="3cqZAo" node="3SU4Z7Bfw35" resolve="knownTargetNodes" />
+                                </node>
+                                <node concept="3clFbS" id="2BX$1355wUf" role="2LFqv$">
+                                  <node concept="3clFbJ" id="2BX$1355wUi" role="3cqZAp">
+                                    <node concept="3clFbS" id="2BX$1355wUj" role="3clFbx">
+                                      <node concept="a7r0C" id="2BX$1355wUr" role="3cqZAp">
+                                        <node concept="37vLTw" id="2BX$1355wUs" role="a7wSD">
+                                          <ref role="3cqZAo" node="2BX$1355wSP" resolve="errorMessage" />
+                                        </node>
+                                        <node concept="2GrUjf" id="2BX$1355wUt" role="1urrMF">
+                                          <ref role="2Gs0qQ" node="2BX$1355wUd" resolve="target" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="37vLTw" id="2BX$1355wUo" role="3clFbw">
+                                      <ref role="3cqZAo" node="2BX$1355wST" resolve="isWarning" />
+                                    </node>
+                                    <node concept="9aQIb" id="2BX$1355wUp" role="9aQIa">
+                                      <node concept="3clFbS" id="2BX$1355wUq" role="9aQI4">
+                                        <node concept="2MkqsV" id="2BX$1355wUk" role="3cqZAp">
+                                          <node concept="37vLTw" id="2BX$1355wUl" role="2MkJ7o">
+                                            <ref role="3cqZAo" node="2BX$1355wSP" resolve="errorMessage" />
+                                          </node>
+                                          <node concept="2GrUjf" id="2BX$1355wUm" role="1urrMF">
+                                            <ref role="2Gs0qQ" node="2BX$1355wUd" resolve="target" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
                                   </node>
                                 </node>
                               </node>
                             </node>
-                            <node concept="ANE8D" id="3SU4Z7Bfw3i" role="2OqNvi" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbJ" id="3SU4Z7BfwR9" role="3cqZAp">
-                        <node concept="3clFbS" id="3SU4Z7BfwRb" role="3clFbx">
-                          <node concept="3SKdUt" id="3SU4Z7BfSId" role="3cqZAp">
-                            <node concept="1PaTwC" id="3SU4Z7BfSIe" role="1aUNEU">
-                              <node concept="3oM_SD" id="3SU4Z7BfSIg" role="1PaTwD">
-                                <property role="3oM_SC" value="If" />
-                              </node>
-                              <node concept="3oM_SD" id="3SU4Z7BfSIr" role="1PaTwD">
-                                <property role="3oM_SC" value="some" />
-                              </node>
-                              <node concept="3oM_SD" id="3SU4Z7BfSIu" role="1PaTwD">
-                                <property role="3oM_SC" value="node" />
-                              </node>
-                              <node concept="3oM_SD" id="3SU4Z7BfSIy" role="1PaTwD">
-                                <property role="3oM_SC" value="cannot" />
-                              </node>
-                              <node concept="3oM_SD" id="3SU4Z7BfSIB" role="1PaTwD">
-                                <property role="3oM_SC" value="be" />
-                              </node>
-                              <node concept="3oM_SD" id="3SU4Z7BfSIH" role="1PaTwD">
-                                <property role="3oM_SC" value="resolved" />
-                              </node>
-                              <node concept="3oM_SD" id="3SU4Z7BfSIO" role="1PaTwD">
-                                <property role="3oM_SC" value="put" />
-                              </node>
-                              <node concept="3oM_SD" id="3SU4Z7BfSIW" role="1PaTwD">
-                                <property role="3oM_SC" value="the" />
-                              </node>
-                              <node concept="3oM_SD" id="3SU4Z7BfSJ5" role="1PaTwD">
-                                <property role="3oM_SC" value="message" />
-                              </node>
-                              <node concept="3oM_SD" id="3SU4Z7BfSJf" role="1PaTwD">
-                                <property role="3oM_SC" value="on" />
-                              </node>
-                              <node concept="3oM_SD" id="3SU4Z7BfSJq" role="1PaTwD">
-                                <property role="3oM_SC" value="the" />
-                              </node>
-                              <node concept="3oM_SD" id="3SU4Z7BfSJA" role="1PaTwD">
-                                <property role="3oM_SC" value="root." />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="3clFbF" id="3SU4Z7BfBd$" role="3cqZAp">
-                            <node concept="2OqwBi" id="3SU4Z7BfC5k" role="3clFbG">
-                              <node concept="37vLTw" id="3SU4Z7BfBdy" role="2Oq$k0">
-                                <ref role="3cqZAo" node="3SU4Z7Bfw35" resolve="knownTargetNodes" />
-                              </node>
-                              <node concept="TSZUe" id="3SU4Z7BfDKj" role="2OqNvi">
-                                <node concept="1YBJjd" id="3SU4Z7BfDPX" role="25WWJ7">
-                                  <ref role="1YBMHb" node="2BX$1355fco" resolve="icrm" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3y3z36" id="3SU4Z7Bf__o" role="3clFbw">
-                          <node concept="2OqwBi" id="3SU4Z7BfAUw" role="3uHU7w">
-                            <node concept="37vLTw" id="3SU4Z7BfA1A" role="2Oq$k0">
-                              <ref role="3cqZAo" node="2BX$1355wTZ" resolve="targetNodes" />
-                            </node>
-                            <node concept="34oBXx" id="3SU4Z7BfBbn" role="2OqNvi" />
-                          </node>
-                          <node concept="2OqwBi" id="3SU4Z7Bfyd7" role="3uHU7B">
-                            <node concept="37vLTw" id="3SU4Z7Bfxap" role="2Oq$k0">
-                              <ref role="3cqZAo" node="3SU4Z7Bfw35" resolve="knownTargetNodes" />
-                            </node>
-                            <node concept="34oBXx" id="3SU4Z7BfzS8" role="2OqNvi" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbH" id="3SU4Z7BfrpO" role="3cqZAp" />
-                      <node concept="3cpWs8" id="2BX$1355wSS" role="3cqZAp">
-                        <node concept="3cpWsn" id="2BX$1355wST" role="3cpWs9">
-                          <property role="TrG5h" value="isWarning" />
-                          <node concept="10P_77" id="2BX$1355wSU" role="1tU5fm" />
-                          <node concept="2YIFZM" id="3SU4Z7Bggts" role="33vP2m">
-                            <ref role="37wK5l" to="juu2:3SU4Z7BgfL$" resolve="isWarning" />
-                            <ref role="1Pybhc" to="juu2:3SU4Z7BeswZ" resolve="Check_ICanRunCheckManuallyUtil" />
-                            <node concept="2OqwBi" id="3SU4Z7Bgg$o" role="37wK5m">
-                              <node concept="37vLTw" id="3SU4Z7BggtM" role="2Oq$k0">
-                                <ref role="3cqZAo" node="2BX$1355wSF" resolve="iResult" />
-                              </node>
-                              <node concept="liA8E" id="3SU4Z7BggJO" role="2OqNvi">
-                                <ref role="37wK5l" to="gdgh:5zG5$LyexiK" resolve="getErrorMessage" />
+                            <node concept="37vLTG" id="4MH81Y0U2EG" role="1bW2Oz">
+                              <property role="TrG5h" value="result" />
+                              <node concept="3uibUv" id="4MH81Y0U2EH" role="1tU5fm">
+                                <ref role="3uigEE" to="gdgh:5zG5$Lyex1G" resolve="IResult" />
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
-                      <node concept="2Gpval" id="2BX$1355wUc" role="3cqZAp">
-                        <node concept="2GrKxI" id="2BX$1355wUd" role="2Gsz3X">
-                          <property role="TrG5h" value="target" />
+                      <node concept="3clFbH" id="4MH81Y0U9RA" role="3cqZAp" />
+                      <node concept="3SKdUt" id="4MH81Y0Uy6X" role="3cqZAp">
+                        <node concept="1PaTwC" id="4MH81Y0Uy6Y" role="1aUNEU">
+                          <node concept="3oM_SD" id="4MH81Y0Uy6Z" role="1PaTwD">
+                            <property role="3oM_SC" value="report" />
+                          </node>
+                          <node concept="3oM_SD" id="4MH81Y0UyvG" role="1PaTwD">
+                            <property role="3oM_SC" value="main" />
+                          </node>
+                          <node concept="3oM_SD" id="4MH81Y0UyvJ" role="1PaTwD">
+                            <property role="3oM_SC" value="result" />
+                          </node>
                         </node>
-                        <node concept="37vLTw" id="3SU4Z7BfEML" role="2GsD0m">
-                          <ref role="3cqZAo" node="3SU4Z7Bfw35" resolve="knownTargetNodes" />
+                      </node>
+                      <node concept="3clFbF" id="4MH81Y0UbX4" role="3cqZAp">
+                        <node concept="2OqwBi" id="4MH81Y0Udow" role="3clFbG">
+                          <node concept="37vLTw" id="4MH81Y0UbX2" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4MH81Y0U2ED" resolve="reportResult" />
+                          </node>
+                          <node concept="1Bd96e" id="4MH81Y0Udrb" role="2OqNvi">
+                            <node concept="37vLTw" id="4MH81Y0Udrv" role="1BdPVh">
+                              <ref role="3cqZAo" node="2BX$1355wSF" resolve="iResult" />
+                            </node>
+                          </node>
                         </node>
-                        <node concept="3clFbS" id="2BX$1355wUf" role="2LFqv$">
-                          <node concept="3clFbJ" id="2BX$1355wUi" role="3cqZAp">
-                            <node concept="3clFbS" id="2BX$1355wUj" role="3clFbx">
-                              <node concept="a7r0C" id="2BX$1355wUr" role="3cqZAp">
-                                <node concept="37vLTw" id="2BX$1355wUs" role="a7wSD">
-                                  <ref role="3cqZAo" node="2BX$1355wSP" resolve="errorMessage" />
-                                </node>
-                                <node concept="2GrUjf" id="2BX$1355wUt" role="1urrMF">
-                                  <ref role="2Gs0qQ" node="2BX$1355wUd" resolve="target" />
+                      </node>
+                      <node concept="3clFbH" id="4MH81Y0UyvO" role="3cqZAp" />
+                      <node concept="3SKdUt" id="4MH81Y0Uzxb" role="3cqZAp">
+                        <node concept="1PaTwC" id="4MH81Y0Uzxc" role="1aUNEU">
+                          <node concept="3oM_SD" id="4MH81Y0Uzxd" role="1PaTwD">
+                            <property role="3oM_SC" value="report" />
+                          </node>
+                          <node concept="3oM_SD" id="4MH81Y0UzR$" role="1PaTwD">
+                            <property role="3oM_SC" value="sub-results," />
+                          </node>
+                          <node concept="3oM_SD" id="4MH81Y0UzRD" role="1PaTwD">
+                            <property role="3oM_SC" value="if" />
+                          </node>
+                          <node concept="3oM_SD" id="4MH81Y0UzRH" role="1PaTwD">
+                            <property role="3oM_SC" value="any" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbJ" id="3q2wVepL68L" role="3cqZAp">
+                        <node concept="3clFbS" id="3q2wVepL68N" role="3clFbx">
+                          <node concept="3cpWs8" id="BSB$UziF3a" role="3cqZAp">
+                            <node concept="3cpWsn" id="BSB$UziF3b" role="3cpWs9">
+                              <property role="TrG5h" value="subResults" />
+                              <node concept="A3Dl8" id="BSB$Uzi3EO" role="1tU5fm">
+                                <node concept="3uibUv" id="BSB$Uzi3ER" role="A3Ik2">
+                                  <ref role="3uigEE" to="gdgh:5zG5$Lyex1G" resolve="IResult" />
                                 </node>
                               </node>
-                            </node>
-                            <node concept="37vLTw" id="2BX$1355wUo" role="3clFbw">
-                              <ref role="3cqZAo" node="2BX$1355wST" resolve="isWarning" />
-                            </node>
-                            <node concept="9aQIb" id="2BX$1355wUp" role="9aQIa">
-                              <node concept="3clFbS" id="2BX$1355wUq" role="9aQI4">
-                                <node concept="2MkqsV" id="2BX$1355wUk" role="3cqZAp">
-                                  <node concept="37vLTw" id="2BX$1355wUl" role="2MkJ7o">
-                                    <ref role="3cqZAo" node="2BX$1355wSP" resolve="errorMessage" />
+                              <node concept="2OqwBi" id="BSB$UziF3c" role="33vP2m">
+                                <node concept="1eOMI4" id="BSB$UziF3d" role="2Oq$k0">
+                                  <node concept="10QFUN" id="BSB$UziF3e" role="1eOMHV">
+                                    <node concept="3uibUv" id="BSB$UziF3f" role="10QFUM">
+                                      <ref role="3uigEE" to="gdgh:3q2wVepKU6u" resolve="IHasSubResults" />
+                                    </node>
+                                    <node concept="37vLTw" id="BSB$UziF3g" role="10QFUP">
+                                      <ref role="3cqZAo" node="2BX$1355wSF" resolve="iResult" />
+                                    </node>
                                   </node>
-                                  <node concept="2GrUjf" id="2BX$1355wUm" role="1urrMF">
-                                    <ref role="2Gs0qQ" node="2BX$1355wUd" resolve="target" />
+                                </node>
+                                <node concept="liA8E" id="BSB$UziF3h" role="2OqNvi">
+                                  <ref role="37wK5l" to="gdgh:3q2wVepL0NY" resolve="getSubResults" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="4MH81Y0UkQP" role="3cqZAp">
+                            <node concept="2OqwBi" id="4MH81Y0UniW" role="3clFbG">
+                              <node concept="2OqwBi" id="4MH81Y0UlPj" role="2Oq$k0">
+                                <node concept="37vLTw" id="4MH81Y0UkQN" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="BSB$UziF3b" resolve="subResults" />
+                                </node>
+                                <node concept="3zZkjj" id="4MH81Y0UmJU" role="2OqNvi">
+                                  <node concept="1bVj0M" id="4MH81Y0UmJW" role="23t8la">
+                                    <node concept="3clFbS" id="4MH81Y0UmJX" role="1bW5cS">
+                                      <node concept="3clFbF" id="4MH81Y0UmLJ" role="3cqZAp">
+                                        <node concept="3fqX7Q" id="4MH81Y0Un4X" role="3clFbG">
+                                          <node concept="2OqwBi" id="4MH81Y0Un4Z" role="3fr31v">
+                                            <node concept="37vLTw" id="4MH81Y0Un50" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="4MH81Y0UmJY" resolve="it" />
+                                            </node>
+                                            <node concept="liA8E" id="4MH81Y0Un51" role="2OqNvi">
+                                              <ref role="37wK5l" to="gdgh:5zG5$Lyex2e" resolve="isOk" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="Rh6nW" id="4MH81Y0UmJY" role="1bW2Oz">
+                                      <property role="TrG5h" value="it" />
+                                      <node concept="2jxLKc" id="4MH81Y0UmJZ" role="1tU5fm" />
+                                    </node>
                                   </node>
                                 </node>
                               </node>
+                              <node concept="2es0OD" id="4MH81Y0Un_g" role="2OqNvi">
+                                <node concept="1bVj0M" id="4MH81Y0Un_i" role="23t8la">
+                                  <node concept="3clFbS" id="4MH81Y0Un_j" role="1bW5cS">
+                                    <node concept="3clFbF" id="4MH81Y0UnCq" role="3cqZAp">
+                                      <node concept="2OqwBi" id="4MH81Y0UnSu" role="3clFbG">
+                                        <node concept="37vLTw" id="4MH81Y0UnCp" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="4MH81Y0U2ED" resolve="reportResult" />
+                                        </node>
+                                        <node concept="1Bd96e" id="4MH81Y0UnYr" role="2OqNvi">
+                                          <node concept="37vLTw" id="4MH81Y0Uo2K" role="1BdPVh">
+                                            <ref role="3cqZAo" node="4MH81Y0Un_k" resolve="it" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="Rh6nW" id="4MH81Y0Un_k" role="1bW2Oz">
+                                    <property role="TrG5h" value="it" />
+                                    <node concept="2jxLKc" id="4MH81Y0Un_l" role="1tU5fm" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="1Wc70l" id="4MH81Y0VAE3" role="3clFbw">
+                          <node concept="2OqwBi" id="4MH81Y0VAUN" role="3uHU7w">
+                            <node concept="1YBJjd" id="4MH81Y0VAK7" role="2Oq$k0">
+                              <ref role="1YBMHb" node="2BX$1355fco" resolve="icrm" />
+                            </node>
+                            <node concept="2qgKlT" id="4MH81Y0VBYU" role="2OqNvi">
+                              <ref role="37wK5l" to="gdgh:4MH81Y0VldB" resolve="showSubResults" />
+                            </node>
+                          </node>
+                          <node concept="2ZW3vV" id="3q2wVepL77X" role="3uHU7B">
+                            <node concept="3uibUv" id="3q2wVepL79y" role="2ZW6by">
+                              <ref role="3uigEE" to="gdgh:3q2wVepKU6u" resolve="IHasSubResults" />
+                            </node>
+                            <node concept="37vLTw" id="3q2wVepL713" role="2ZW6bz">
+                              <ref role="3cqZAo" node="2BX$1355wSF" resolve="iResult" />
                             </node>
                           </node>
                         </node>
@@ -465,6 +704,7 @@
                   </node>
                 </node>
               </node>
+              <node concept="3clFbH" id="4MH81Y0UqQB" role="3cqZAp" />
               <node concept="3SKdUt" id="3SU4Z7BfRKw" role="3cqZAp">
                 <node concept="1PaTwC" id="3SU4Z7BfRKx" role="1aUNEU">
                   <node concept="3oM_SD" id="3SU4Z7BfSGh" role="1PaTwD">


### PR DESCRIPTION
The interface `ICanRunCheckManually` provides a checking rule which converts check results (e.g., from a Z3 solver run) into MPS typesystem errors and warnings. The check results to be converted have to implement the `IResult` interface.

This PR introduces a new interface `IHasSubResults` which can be used to attach additional results to an `IResult`. Via the behavior method `ICanRunCheckManually.showSubResults` (default: false) the subresults of an `IResult` can be converted to MPS typesystem errors and warnings during the conversion of the actual result (aka *main* result).

The sub-results mechanism is already being used by the Z3 solver integration of iets3.core, but there was no possibility to show more than one result in an editor up to now.