### PR TITLE
Fix bug in editor update after solver has been executed

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/plugin.mps
@@ -482,48 +482,6 @@
           </node>
           <node concept="9aQIb" id="2s2qa7R0OUG" role="9aQIa">
             <node concept="3clFbS" id="2s2qa7R0OUH" role="9aQI4">
-              <node concept="3clFbF" id="4kpiU1vG1O2" role="3cqZAp">
-                <node concept="2OqwBi" id="4kpiU1vG1NZ" role="3clFbG">
-                  <node concept="10M0yZ" id="4kpiU1vG1O0" role="2Oq$k0">
-                    <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-                    <ref role="3cqZAo" to="wyt6:~System.err" resolve="err" />
-                  </node>
-                  <node concept="liA8E" id="4kpiU1vG1O1" role="2OqNvi">
-                    <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
-                    <node concept="3cpWs3" id="4kpiU1vG5am" role="37wK5m">
-                      <node concept="2OqwBi" id="4kpiU1vG8pA" role="3uHU7w">
-                        <node concept="2OqwBi" id="4kpiU1vG5Jx" role="2Oq$k0">
-                          <node concept="37vLTw" id="4kpiU1vG5vm" role="2Oq$k0">
-                            <ref role="3cqZAo" node="2s2qa7R0LJk" resolve="factory" />
-                          </node>
-                          <node concept="liA8E" id="4kpiU1vG7pI" role="2OqNvi">
-                            <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
-                          </node>
-                        </node>
-                        <node concept="liA8E" id="4kpiU1vG9lJ" role="2OqNvi">
-                          <ref role="37wK5l" to="wyt6:~Class.getName()" resolve="getName" />
-                        </node>
-                      </node>
-                      <node concept="3cpWs3" id="4kpiU1vG4jj" role="3uHU7B">
-                        <node concept="3cpWs3" id="4kpiU1vG32F" role="3uHU7B">
-                          <node concept="Xl_RD" id="4kpiU1vG23h" role="3uHU7B">
-                            <property role="Xl_RC" value="STF: found factory for concept " />
-                          </node>
-                          <node concept="2OqwBi" id="4kpiU1vG3ie" role="3uHU7w">
-                            <node concept="37vLTw" id="4kpiU1vG32Z" role="2Oq$k0">
-                              <ref role="3cqZAo" node="7rOSrvnITgx" resolve="n" />
-                            </node>
-                            <node concept="2yIwOk" id="4kpiU1vG3RI" role="2OqNvi" />
-                          </node>
-                        </node>
-                        <node concept="Xl_RD" id="4kpiU1vG4jB" role="3uHU7w">
-                          <property role="Xl_RC" value=": " />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
               <node concept="3cpWs6" id="XhdFKvXRue" role="3cqZAp">
                 <node concept="2OqwBi" id="XhdFKvXRug" role="3cqZAk">
                   <node concept="37vLTw" id="2s2qa7R0LJq" role="2Oq$k0">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/behavior.mps
@@ -1145,7 +1145,7 @@
               <property role="3oM_SC" value="problem" />
             </node>
             <node concept="3oM_SD" id="17Nm8oCo8uS" role="1PaTwD">
-              <property role="3oM_SC" value="ist" />
+              <property role="3oM_SC" value="is" />
             </node>
             <node concept="3oM_SD" id="17Nm8oCo8uT" role="1PaTwD">
               <property role="3oM_SC" value="that" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/typesystem.mps
@@ -204,7 +204,7 @@
     <property role="TrG5h" value="check_ICanRunCheckManually" />
     <property role="3GE5qa" value="adapter" />
     <node concept="3clFbS" id="2BX$1355fcm" role="18ibNy">
-      <node concept="1X3_iC" id="4MH81Y0UuMn" role="lGtFl">
+      <node concept="1X3_iC" id="7pGmjNvY8bF" role="lGtFl">
         <property role="3V$3am" value="statement" />
         <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
         <node concept="3clFbF" id="3q2wVepy$u2" role="8Wnug">
@@ -215,12 +215,42 @@
             </node>
             <node concept="liA8E" id="3q2wVepy$u1" role="2OqNvi">
               <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
-              <node concept="3cpWs3" id="3q2wVepyTqZ" role="37wK5m">
-                <node concept="1YBJjd" id="3q2wVepyTr6" role="3uHU7w">
-                  <ref role="1YBMHb" node="2BX$1355fco" resolve="icrm" />
+              <node concept="3cpWs3" id="2NazPIlIH6$" role="37wK5m">
+                <node concept="2OqwBi" id="2NazPIlIHBc" role="3uHU7w">
+                  <node concept="1YBJjd" id="2NazPIlIH70" role="2Oq$k0">
+                    <ref role="1YBMHb" node="2BX$1355fco" resolve="icrm" />
+                  </node>
+                  <node concept="2qgKlT" id="2NazPIlIITU" role="2OqNvi">
+                    <ref role="37wK5l" to="gdgh:3R3AIvumwpO" resolve="hasExistingResult" />
+                  </node>
                 </node>
-                <node concept="Xl_RD" id="3q2wVepy$J3" role="3uHU7B">
-                  <property role="Xl_RC" value="CHECKING RULE check_ICanRunCheckManually begin " />
+                <node concept="3cpWs3" id="2NazPIlICW$" role="3uHU7B">
+                  <node concept="3cpWs3" id="2NazPIlIA_7" role="3uHU7B">
+                    <node concept="3cpWs3" id="2NazPIlIyoD" role="3uHU7B">
+                      <node concept="3cpWs3" id="3q2wVepyTqZ" role="3uHU7B">
+                        <node concept="Xl_RD" id="3q2wVepy$J3" role="3uHU7B">
+                          <property role="Xl_RC" value="CHECKING RULE check_ICanRunCheckManually begin " />
+                        </node>
+                        <node concept="1YBJjd" id="3q2wVepyTr6" role="3uHU7w">
+                          <ref role="1YBMHb" node="2BX$1355fco" resolve="icrm" />
+                        </node>
+                      </node>
+                      <node concept="Xl_RD" id="2NazPIlIyoG" role="3uHU7w">
+                        <property role="Xl_RC" value=" mustBeRunMan=" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="2NazPIlIB2D" role="3uHU7w">
+                      <node concept="1YBJjd" id="2NazPIlIA_n" role="2Oq$k0">
+                        <ref role="1YBMHb" node="2BX$1355fco" resolve="icrm" />
+                      </node>
+                      <node concept="2qgKlT" id="2NazPIlICes" role="2OqNvi">
+                        <ref role="37wK5l" to="gdgh:3R3AIvumAZH" resolve="mustBeRunManually" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="2NazPIlICWB" role="3uHU7w">
+                    <property role="Xl_RC" value=" hasExistingRes=" />
+                  </node>
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.plugin/models/org/iets3/core/plugin/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.plugin/models/org/iets3/core/plugin/plugin.mps
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:cdcdec44-a636-42c8-b599-c146eb2ca77d(org.iets3.core.plugin.plugin)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="-1" />
     <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="4" />
@@ -684,43 +685,51 @@
                           </node>
                         </node>
                       </node>
-                      <node concept="3clFbF" id="4Pi6J8Cbqv4" role="3cqZAp">
-                        <node concept="2OqwBi" id="4Pi6J8Cbqv5" role="3clFbG">
-                          <node concept="2OqwBi" id="4Pi6J8Cbqv6" role="2Oq$k0">
-                            <node concept="2YIFZM" id="4Pi6J8Cbqv7" role="2Oq$k0">
-                              <ref role="1Pybhc" to="kvq8:2WlJ6VKOwRU" resolve="EditorComponentHacks" />
-                              <ref role="37wK5l" to="kvq8:2WlJ6VKOSU7" resolve="findAllInstances" />
+                      <node concept="3cpWs8" id="2NazPIlP$3P" role="3cqZAp">
+                        <node concept="3cpWsn" id="2NazPIlP$3Q" role="3cpWs9">
+                          <property role="TrG5h" value="rootECs" />
+                          <node concept="A3Dl8" id="2NazPIlPyWX" role="1tU5fm">
+                            <node concept="3uibUv" id="2NazPIlPyX0" role="A3Ik2">
+                              <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
                             </node>
-                            <node concept="3zZkjj" id="4Pi6J8Cbqv8" role="2OqNvi">
-                              <node concept="1bVj0M" id="4Pi6J8Cbqv9" role="23t8la">
-                                <node concept="3clFbS" id="4Pi6J8Cbqva" role="1bW5cS">
-                                  <node concept="3clFbF" id="4Pi6J8Cbqvb" role="3cqZAp">
-                                    <node concept="3clFbC" id="4Pi6J8Cbqvc" role="3clFbG">
-                                      <node concept="2OqwBi" id="4Pi6J8Cbqvd" role="3uHU7B">
-                                        <node concept="2OqwBi" id="4Pi6J8Cbqve" role="2Oq$k0">
-                                          <node concept="37vLTw" id="4Pi6J8Cbqvf" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="4Pi6J8Cbqvj" resolve="it" />
-                                          </node>
-                                          <node concept="liA8E" id="4Pi6J8Cbqvg" role="2OqNvi">
-                                            <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
-                                          </node>
+                          </node>
+                          <node concept="2OqwBi" id="2NazPIlP$3R" role="33vP2m">
+                            <node concept="3zZkjj" id="2NazPIlP$3T" role="2OqNvi">
+                              <node concept="1bVj0M" id="2NazPIlP$3U" role="23t8la">
+                                <node concept="3clFbS" id="2NazPIlP$3V" role="1bW5cS">
+                                  <node concept="3clFbF" id="2NazPIlP$3W" role="3cqZAp">
+                                    <node concept="3clFbC" id="2NazPIlP$3X" role="3clFbG">
+                                      <node concept="2OqwBi" id="2NazPIlP$3Z" role="3uHU7B">
+                                        <node concept="37vLTw" id="2NazPIlP$40" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="2NazPIlP$44" resolve="it" />
                                         </node>
-                                        <node concept="liA8E" id="4Pi6J8Cbqvh" role="2OqNvi">
-                                          <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                                        <node concept="liA8E" id="2NazPIlRoYW" role="2OqNvi">
+                                          <ref role="37wK5l" to="exr9:~EditorComponent.getEditedNode()" resolve="getEditedNode" />
                                         </node>
                                       </node>
-                                      <node concept="37vLTw" id="4Pi6J8Cbqvi" role="3uHU7w">
+                                      <node concept="37vLTw" id="2NazPIlP$43" role="3uHU7w">
                                         <ref role="3cqZAo" node="4Pi6J8CbquR" resolve="cr" />
                                       </node>
                                     </node>
                                   </node>
                                 </node>
-                                <node concept="Rh6nW" id="4Pi6J8Cbqvj" role="1bW2Oz">
+                                <node concept="Rh6nW" id="2NazPIlP$44" role="1bW2Oz">
                                   <property role="TrG5h" value="it" />
-                                  <node concept="2jxLKc" id="4Pi6J8Cbqvk" role="1tU5fm" />
+                                  <node concept="2jxLKc" id="2NazPIlP$45" role="1tU5fm" />
                                 </node>
                               </node>
                             </node>
+                            <node concept="2YIFZM" id="2NazPIlPVql" role="2Oq$k0">
+                              <ref role="37wK5l" to="kvq8:2WlJ6VKOSU7" resolve="findAllInstances" />
+                              <ref role="1Pybhc" to="kvq8:2WlJ6VKOwRU" resolve="EditorComponentHacks" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4Pi6J8Cbqv4" role="3cqZAp">
+                        <node concept="2OqwBi" id="4Pi6J8Cbqv5" role="3clFbG">
+                          <node concept="37vLTw" id="2NazPIlP$46" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2NazPIlP$3Q" resolve="rootECs" />
                           </node>
                           <node concept="2es0OD" id="4Pi6J8Cbqvl" role="2OqNvi">
                             <node concept="1bVj0M" id="4Pi6J8Cbqvm" role="23t8la">


### PR DESCRIPTION
Action `runManuallyOnNode` executes an `ICanRunCheckManually` node and updates the editor afterwards. The UI updating only worked if the `ICanRunCheckManually` is the root node of the editor to be updated.

With this PR, this also works if the `ICanRunCheckManually` is a node attribute attached to the root node.

The PR also resolves some minor typos and removes debug outputs.