### PR TITLE
Units: make units migration rerunable

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/behavior.mps
@@ -1505,29 +1505,34 @@
       <node concept="3Tm1VV" id="76ZhK6XViWp" role="1B3o_S" />
       <node concept="3clFbS" id="76ZhK6XViWu" role="3clF47">
         <node concept="3cpWs6" id="76ZhK6XVjhi" role="3cqZAp">
-          <node concept="2OqwBi" id="76ZhK6XVlNx" role="3cqZAk">
-            <node concept="1PxgMI" id="76ZhK6XVlxG" role="2Oq$k0">
-              <property role="1BlNFB" value="true" />
-              <node concept="2OqwBi" id="76ZhK6XVjsp" role="1m5AlR">
-                <node concept="3TrEf2" id="76ZhK6XVjEf" role="2OqNvi">
-                  <ref role="3Tt5mk" to="b0gq:7eOyx9r3qFW" resolve="unit" />
-                </node>
-                <node concept="2OqwBi" id="76ZhK6XZ2Dt" role="2Oq$k0">
-                  <node concept="2OqwBi" id="76ZhK6XZ2Du" role="2Oq$k0">
-                    <node concept="13iPFW" id="76ZhK6XZ2Dv" role="2Oq$k0" />
-                    <node concept="3Tsc0h" id="76ZhK6XZ2Dw" role="2OqNvi">
-                      <ref role="3TtcxE" to="b0gq:7eOyx9r3qG3" resolve="components" />
-                    </node>
+          <node concept="2OqwBi" id="6Z6cUqSNnYt" role="3cqZAk">
+            <node concept="2OqwBi" id="76ZhK6XVlNx" role="2Oq$k0">
+              <node concept="1PxgMI" id="76ZhK6XVlxG" role="2Oq$k0">
+                <property role="1BlNFB" value="true" />
+                <node concept="2OqwBi" id="76ZhK6XVjsp" role="1m5AlR">
+                  <node concept="3TrEf2" id="76ZhK6XVjEf" role="2OqNvi">
+                    <ref role="3Tt5mk" to="b0gq:7eOyx9r3qFW" resolve="unit" />
                   </node>
-                  <node concept="1uHKPH" id="76ZhK6XZ2Dx" role="2OqNvi" />
+                  <node concept="2OqwBi" id="76ZhK6XZ2Dt" role="2Oq$k0">
+                    <node concept="2OqwBi" id="76ZhK6XZ2Du" role="2Oq$k0">
+                      <node concept="13iPFW" id="76ZhK6XZ2Dv" role="2Oq$k0" />
+                      <node concept="3Tsc0h" id="76ZhK6XZ2Dw" role="2OqNvi">
+                        <ref role="3TtcxE" to="b0gq:7eOyx9r3qG3" resolve="components" />
+                      </node>
+                    </node>
+                    <node concept="1uHKPH" id="76ZhK6XZ2Dx" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="chp4Y" id="72_xmu9hWoN" role="3oSUPX">
+                  <ref role="cht4Q" to="b0gq:7eOyx9r3jsZ" resolve="Unit" />
                 </node>
               </node>
-              <node concept="chp4Y" id="72_xmu9hWoN" role="3oSUPX">
-                <ref role="cht4Q" to="b0gq:7eOyx9r3jsZ" resolve="Unit" />
+              <node concept="3TrEf2" id="6Z6cUqSNnFN" role="2OqNvi">
+                <ref role="3Tt5mk" to="b0gq:1KUmgSFpwWq" resolve="dimension" />
               </node>
             </node>
-            <node concept="3TrcHB" id="76ZhK6XVm7v" role="2OqNvi">
-              <ref role="3TsBF5" to="b0gq:7eOyx9r3jQ8" resolve="description" />
+            <node concept="3TrcHB" id="6Z6cUqSNoKC" role="2OqNvi">
+              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/org.iets3.core.expr.typetags.units.migration.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/org.iets3.core.expr.typetags.units.migration.mps
@@ -62,6 +62,7 @@
       </concept>
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -113,6 +114,7 @@
         <child id="1144230900587" name="variable" index="1Duv9x" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -174,6 +176,7 @@
         <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
       </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -244,6 +247,7 @@
         <child id="1197687026896" name="keyType" index="3rHrn6" />
         <child id="1197687035757" name="valueType" index="3rHtpV" />
       </concept>
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1240824834947" name="jetbrains.mps.baseLanguage.collections.structure.ValueAccessOperation" flags="nn" index="3AV6Ez" />
       <concept id="1240825616499" name="jetbrains.mps.baseLanguage.collections.structure.KeyAccessOperation" flags="nn" index="3AY5_j" />
       <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
@@ -2166,8 +2170,46 @@
             </node>
             <node concept="3clFbF" id="1KUmgSFqa3j" role="3cqZAp">
               <node concept="2OqwBi" id="1KUmgSFqe9q" role="3clFbG">
-                <node concept="37vLTw" id="1KUmgSFqa3h" role="2Oq$k0">
-                  <ref role="3cqZAo" node="1KUmgSFpOE5" resolve="allUnits" />
+                <node concept="2OqwBi" id="6Z6cUqSMGwk" role="2Oq$k0">
+                  <node concept="37vLTw" id="1KUmgSFqa3h" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1KUmgSFpOE5" resolve="allUnits" />
+                  </node>
+                  <node concept="3zZkjj" id="6Z6cUqSMLb8" role="2OqNvi">
+                    <node concept="1bVj0M" id="6Z6cUqSMLba" role="23t8la">
+                      <node concept="3clFbS" id="6Z6cUqSMLbb" role="1bW5cS">
+                        <node concept="3clFbF" id="6Z6cUqSMLst" role="3cqZAp">
+                          <node concept="1Wc70l" id="6Z6cUqSMPS_" role="3clFbG">
+                            <node concept="2OqwBi" id="6Z6cUqSMRQ_" role="3uHU7w">
+                              <node concept="2OqwBi" id="6Z6cUqSMQwj" role="2Oq$k0">
+                                <node concept="37vLTw" id="6Z6cUqSMQ3Q" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="6Z6cUqSMLbc" resolve="it" />
+                                </node>
+                                <node concept="3TrEf2" id="6Z6cUqSMRlx" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="b0gq:1KUmgSFpwWq" resolve="dimension" />
+                                </node>
+                              </node>
+                              <node concept="3w_OXm" id="6Z6cUqSPU2o" role="2OqNvi" />
+                            </node>
+                            <node concept="2OqwBi" id="6Z6cUqSMOPl" role="3uHU7B">
+                              <node concept="2OqwBi" id="6Z6cUqSMLWz" role="2Oq$k0">
+                                <node concept="37vLTw" id="6Z6cUqSMLss" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="6Z6cUqSMLbc" resolve="it" />
+                                </node>
+                                <node concept="3TrcHB" id="6Z6cUqSMMJw" role="2OqNvi">
+                                  <ref role="3TsBF5" to="b0gq:7eOyx9r3jQ8" resolve="description" />
+                                </node>
+                              </node>
+                              <node concept="17RvpY" id="6Z6cUqSMPqV" role="2OqNvi" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="6Z6cUqSMLbc" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="6Z6cUqSMLbd" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
                 <node concept="2es0OD" id="1KUmgSFqiQD" role="2OqNvi">
                   <node concept="1bVj0M" id="1KUmgSFqiQF" role="23t8la">
@@ -2510,6 +2552,61 @@
                     <node concept="Rh6nW" id="1KUmgSFqCAe" role="1bW2Oz">
                       <property role="TrG5h" value="parentAndUnits" />
                       <node concept="2jxLKc" id="1KUmgSFqCAf" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="6Z6cUqSMW3u" role="3cqZAp">
+              <node concept="2OqwBi" id="6Z6cUqSN6ln" role="3clFbG">
+                <node concept="2OqwBi" id="6Z6cUqSMZG1" role="2Oq$k0">
+                  <node concept="37vLTw" id="6Z6cUqSMW3s" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1KUmgSFpOE5" resolve="allUnits" />
+                  </node>
+                  <node concept="3zZkjj" id="6Z6cUqSN40U" role="2OqNvi">
+                    <node concept="1bVj0M" id="6Z6cUqSN40W" role="23t8la">
+                      <node concept="3clFbS" id="6Z6cUqSN40X" role="1bW5cS">
+                        <node concept="3clFbF" id="6Z6cUqSN48i" role="3cqZAp">
+                          <node concept="2OqwBi" id="6Z6cUqSN5Dy" role="3clFbG">
+                            <node concept="2OqwBi" id="6Z6cUqSN4u8" role="2Oq$k0">
+                              <node concept="37vLTw" id="6Z6cUqSN48h" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6Z6cUqSN40Y" resolve="it" />
+                              </node>
+                              <node concept="3TrcHB" id="6Z6cUqSN582" role="2OqNvi">
+                                <ref role="3TsBF5" to="b0gq:7eOyx9r3jQ8" resolve="description" />
+                              </node>
+                            </node>
+                            <node concept="17RvpY" id="6Z6cUqSN63x" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="6Z6cUqSN40Y" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="6Z6cUqSN40Z" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2es0OD" id="6Z6cUqSN6Dt" role="2OqNvi">
+                  <node concept="1bVj0M" id="6Z6cUqSN6Dv" role="23t8la">
+                    <node concept="3clFbS" id="6Z6cUqSN6Dw" role="1bW5cS">
+                      <node concept="3clFbF" id="6Z6cUqSN6IH" role="3cqZAp">
+                        <node concept="37vLTI" id="6Z6cUqSN85Q" role="3clFbG">
+                          <node concept="10Nm6u" id="6Z6cUqSN8e$" role="37vLTx" />
+                          <node concept="2OqwBi" id="6Z6cUqSN71A" role="37vLTJ">
+                            <node concept="37vLTw" id="6Z6cUqSN6IG" role="2Oq$k0">
+                              <ref role="3cqZAo" node="6Z6cUqSN6Dx" resolve="it" />
+                            </node>
+                            <node concept="3TrcHB" id="6Z6cUqSN7I8" role="2OqNvi">
+                              <ref role="3TsBF5" to="b0gq:7eOyx9r3jQ8" resolve="description" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="6Z6cUqSN6Dx" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="6Z6cUqSN6Dy" role="1tU5fm" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.units.si/models/units.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.units.si/models/units.mps
@@ -14,7 +14,6 @@
       </concept>
       <concept id="5185104661801317038" name="org.iets3.core.expr.typetags.units.structure.ValExpression" flags="ng" index="2m5Cep" />
       <concept id="8337440621611267903" name="org.iets3.core.expr.typetags.units.structure.Unit" flags="ng" index="CIrOH">
-        <property id="8337440621611269512" name="description" index="CIruq" />
         <reference id="2034036099103723290" name="dimension" index="Rn5ok" />
         <child id="8337440621611270427" name="specification" index="CIsG9" />
       </concept>
@@ -120,42 +119,34 @@
     </node>
     <node concept="CIrOH" id="5XaocLWHSS4" role="_iOnB">
       <property role="TrG5h" value="m" />
-      <property role="CIruq" value="distance" />
       <ref role="Rn5ok" node="1KUmgSFvJUm" resolve="metre" />
     </node>
     <node concept="CIrOH" id="5XaocLWHSS5" role="_iOnB">
       <property role="TrG5h" value="s" />
-      <property role="CIruq" value="time" />
       <ref role="Rn5ok" node="1KUmgSFvJUr" resolve="time" />
     </node>
     <node concept="CIrOH" id="5XaocLWHSS6" role="_iOnB">
       <property role="TrG5h" value="kg" />
-      <property role="CIruq" value="weight" />
       <ref role="Rn5ok" node="1KUmgSFvJUq" resolve="weight" />
     </node>
     <node concept="CIrOH" id="5XaocLWHSS7" role="_iOnB">
       <property role="TrG5h" value="mol" />
-      <property role="CIruq" value="amount of chemical substance" />
       <ref role="Rn5ok" node="1KUmgSFvJUn" resolve="amount of chemical substance" />
     </node>
     <node concept="CIrOH" id="5XaocLWHSS8" role="_iOnB">
       <property role="TrG5h" value="K" />
-      <property role="CIruq" value="temperature" />
       <ref role="Rn5ok" node="1KUmgSFvJUp" resolve="temperature" />
     </node>
     <node concept="CIrOH" id="5XaocLWHSS9" role="_iOnB">
       <property role="TrG5h" value="A" />
-      <property role="CIruq" value="current" />
       <ref role="Rn5ok" node="1KUmgSFvJUk" resolve="current" />
     </node>
     <node concept="CIrOH" id="5XaocLWHSSa" role="_iOnB">
       <property role="TrG5h" value="cd" />
-      <property role="CIruq" value="luminous intensity" />
       <ref role="Rn5ok" node="1KUmgSFvJUo" resolve="luminous intensity" />
     </node>
     <node concept="CIrOH" id="5XaocLWHSSb" role="_iOnB">
       <property role="TrG5h" value="nounit" />
-      <property role="CIruq" value="undefined unit (helper)" />
       <ref role="Rn5ok" node="1KUmgSFvJUl" resolve="undefined unit (helper)" />
       <node concept="CIsGf" id="5XaocLWHSSc" role="CIsG9">
         <node concept="CIsvn" id="5XaocLWHSSd" role="CIi4h">
@@ -245,7 +236,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5F$rs" role="_iOnB">
       <property role="TrG5h" value="Hz" />
-      <property role="CIruq" value="frequency" />
       <ref role="Rn5ok" node="1KUmgSFvJUB" resolve="frequency" />
       <node concept="CIsGf" id="69HsIy5F$vp" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5F$vq" role="CIi4h">
@@ -258,7 +248,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5F$DR" role="_iOnB">
       <property role="TrG5h" value="rad" />
-      <property role="CIruq" value="angle" />
       <ref role="Rn5ok" node="1KUmgSFvJUI" resolve="angle" />
       <node concept="CIsGf" id="69HsIy5F$FX" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5F$FY" role="CIi4h">
@@ -274,7 +263,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5F$Io" role="_iOnB">
       <property role="TrG5h" value="sr" />
-      <property role="CIruq" value="angle" />
       <ref role="Rn5ok" node="1KUmgSFvJUI" resolve="angle" />
       <node concept="CIsGf" id="69HsIy5F$K$" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5F$KI" role="CIi4h">
@@ -293,7 +281,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5F$TY" role="_iOnB">
       <property role="TrG5h" value="N" />
-      <property role="CIruq" value="force" />
       <ref role="Rn5ok" node="1KUmgSFvJUJ" resolve="force" />
       <node concept="CIsGf" id="69HsIy5F$Wh" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5F$Wi" role="CIi4h">
@@ -312,7 +299,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5F_3N" role="_iOnB">
       <property role="TrG5h" value="Pa" />
-      <property role="CIruq" value="pressure" />
       <ref role="Rn5ok" node="1KUmgSFvJUA" resolve="pressure" />
       <node concept="CIsGf" id="69HsIy5F_6e" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5F_6d" role="CIi4h">
@@ -328,7 +314,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5F_gq" role="_iOnB">
       <property role="TrG5h" value="J" />
-      <property role="CIruq" value="energy" />
       <ref role="Rn5ok" node="1KUmgSFvJUM" resolve="energy" />
       <node concept="CIsGf" id="69HsIy5F_iW" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5F_iV" role="CIi4h">
@@ -341,7 +326,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5F_JE" role="_iOnB">
       <property role="TrG5h" value="W" />
-      <property role="CIruq" value="power" />
       <ref role="Rn5ok" node="1KUmgSFvJUK" resolve="power" />
       <node concept="CIsGf" id="69HsIy5F_Mq" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5F_Mp" role="CIi4h">
@@ -357,7 +341,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5F_XK" role="_iOnB">
       <property role="TrG5h" value="C" />
-      <property role="CIruq" value="electric charge" />
       <ref role="Rn5ok" node="1KUmgSFvJUG" resolve="electric charge" />
       <node concept="CIsGf" id="69HsIy5FA0A" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5FA0_" role="CIi4h">
@@ -370,7 +353,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5FANF" role="_iOnB">
       <property role="TrG5h" value="V" />
-      <property role="CIruq" value="voltage" />
       <ref role="Rn5ok" node="1KUmgSFvJUC" resolve="voltage" />
       <node concept="CIsGf" id="69HsIy5FAQG" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5FAQF" role="CIi4h">
@@ -386,7 +368,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5FDQP" role="_iOnB">
       <property role="TrG5h" value="F" />
-      <property role="CIruq" value="capacitance" />
       <ref role="Rn5ok" node="1KUmgSFvJUw" resolve="capacitance" />
       <node concept="CIsGf" id="69HsIy5FDU3" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5FDU2" role="CIi4h">
@@ -402,7 +383,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5FE7r" role="_iOnB">
       <property role="TrG5h" value="ohm" />
-      <property role="CIruq" value="electrical resistance" />
       <ref role="Rn5ok" node="1KUmgSFvJU$" resolve="electrical resistance" />
       <node concept="CIsGf" id="69HsIy5FEuO" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5FEuN" role="CIi4h">
@@ -418,7 +398,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5FErr" role="_iOnB">
       <property role="TrG5h" value="S" />
-      <property role="CIruq" value="electrical conductance" />
       <ref role="Rn5ok" node="1KUmgSFvJUu" resolve="electrical conductance" />
       <node concept="CIsGf" id="69HsIy5FEvr" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5FEvs" role="CIi4h">
@@ -434,7 +413,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5FEE9" role="_iOnB">
       <property role="TrG5h" value="Wb" />
-      <property role="CIruq" value="magnetic flux" />
       <ref role="Rn5ok" node="1KUmgSFvJUs" resolve="magnetic flux" />
       <node concept="CIsGf" id="69HsIy5FEHG" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5FEHF" role="CIi4h">
@@ -450,7 +428,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5FF00" role="_iOnB">
       <property role="TrG5h" value="T" />
-      <property role="CIruq" value="magnetic induction" />
       <ref role="Rn5ok" node="1KUmgSFvJUy" resolve="magnetic induction" />
       <node concept="CIsGf" id="69HsIy5FF3F" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5FF3E" role="CIi4h">
@@ -469,7 +446,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5FFfg" role="_iOnB">
       <property role="TrG5h" value="H" />
-      <property role="CIruq" value="inductance" />
       <ref role="Rn5ok" node="1KUmgSFvJUx" resolve="inductance" />
       <node concept="CIsGf" id="69HsIy5FFj2" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5FFj1" role="CIi4h">
@@ -488,7 +464,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5FFAH" role="_iOnB">
       <property role="TrG5h" value="lm" />
-      <property role="CIruq" value="luminous flux" />
       <ref role="Rn5ok" node="1KUmgSFvJUD" resolve="luminous flux" />
       <node concept="CIsGf" id="69HsIy5FFEC" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5FFEB" role="CIi4h">
@@ -501,7 +476,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5FFQF" role="_iOnB">
       <property role="TrG5h" value="lx" />
-      <property role="CIruq" value="illuminance" />
       <ref role="Rn5ok" node="1KUmgSFvJUE" resolve="illuminance" />
       <node concept="CIsGf" id="69HsIy5FFUF" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5FFUE" role="CIi4h">
@@ -517,7 +491,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5FGfl" role="_iOnB">
       <property role="TrG5h" value="Bq" />
-      <property role="CIruq" value="radioactivity" />
       <ref role="Rn5ok" node="1KUmgSFvJUN" resolve="radioactivity" />
       <node concept="CIsGf" id="69HsIy5FGjt" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5FGjs" role="CIi4h">
@@ -530,7 +503,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5FGw8" role="_iOnB">
       <property role="TrG5h" value="Gy" />
-      <property role="CIruq" value="absorbed dose" />
       <ref role="Rn5ok" node="1KUmgSFvJUv" resolve="absorbed dose" />
       <node concept="CIsGf" id="69HsIy5FG$l" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5FG$k" role="CIi4h">
@@ -546,7 +518,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5FGPD" role="_iOnB">
       <property role="TrG5h" value="Sv" />
-      <property role="CIruq" value="equivalent dose" />
       <ref role="Rn5ok" node="1KUmgSFvJUz" resolve="equivalent dose" />
       <node concept="CIsGf" id="69HsIy5FGTX" role="CIsG9">
         <node concept="CIsvn" id="69HsIy5FGTW" role="CIi4h">
@@ -561,7 +532,6 @@
       </node>
     </node>
     <node concept="CIrOH" id="69HsIy5FH2V" role="_iOnB">
-      <property role="CIruq" value="catalytic activity" />
       <property role="TrG5h" value="kat" />
       <ref role="Rn5ok" node="1KUmgSFvJUF" resolve="catalytic activity" />
       <node concept="CIsGf" id="69HsIy5FHg8" role="CIsG9">
@@ -582,7 +552,6 @@
     </node>
     <node concept="CIrOH" id="69HsIy5FyRU" role="_iOnB">
       <property role="TrG5h" value="degC" />
-      <property role="CIruq" value="temperature" />
       <ref role="Rn5ok" node="1KUmgSFvJUp" resolve="temperature" />
     </node>
     <node concept="TRoc0" id="69HsIy5FyVs" role="_iOnB">
@@ -602,7 +571,6 @@
       <property role="1WsWdv" value="metre scaled" />
     </node>
     <node concept="CIrOH" id="69HsIy5FvYH" role="_iOnB">
-      <property role="CIruq" value="metre" />
       <property role="TrG5h" value="nm" />
       <ref role="Rn5ok" node="1KUmgSFvJUm" resolve="metre" />
       <node concept="1z9TsT" id="_I$tx9N8BM" role="lGtFl">
@@ -616,22 +584,18 @@
       </node>
     </node>
     <node concept="CIrOH" id="69HsIy5FvXj" role="_iOnB">
-      <property role="CIruq" value="metre" />
       <property role="TrG5h" value="µm" />
       <ref role="Rn5ok" node="1KUmgSFvJUm" resolve="metre" />
     </node>
     <node concept="CIrOH" id="69HsIy5FvWm" role="_iOnB">
-      <property role="CIruq" value="metre" />
       <property role="TrG5h" value="mm" />
       <ref role="Rn5ok" node="1KUmgSFvJUm" resolve="metre" />
     </node>
     <node concept="CIrOH" id="69HsIy5FvZe" role="_iOnB">
-      <property role="CIruq" value="metre" />
       <property role="TrG5h" value="cm" />
       <ref role="Rn5ok" node="1KUmgSFvJUm" resolve="metre" />
     </node>
     <node concept="CIrOH" id="69HsIy5FvYB" role="_iOnB">
-      <property role="CIruq" value="metre" />
       <property role="TrG5h" value="km" />
       <ref role="Rn5ok" node="1KUmgSFvJUm" resolve="metre" />
     </node>
@@ -701,32 +665,26 @@
     </node>
     <node concept="CIrOH" id="69HsIy5Fwrk" role="_iOnB">
       <property role="TrG5h" value="ns" />
-      <property role="CIruq" value="time" />
       <ref role="Rn5ok" node="1KUmgSFvJUr" resolve="time" />
     </node>
     <node concept="CIrOH" id="69HsIy5Fwvr" role="_iOnB">
       <property role="TrG5h" value="µs" />
-      <property role="CIruq" value="time" />
       <ref role="Rn5ok" node="1KUmgSFvJUr" resolve="time" />
     </node>
     <node concept="CIrOH" id="69HsIy5FwuN" role="_iOnB">
       <property role="TrG5h" value="ms" />
-      <property role="CIruq" value="time" />
       <ref role="Rn5ok" node="1KUmgSFvJUr" resolve="time" />
     </node>
     <node concept="CIrOH" id="69HsIy5Fwuc" role="_iOnB">
       <property role="TrG5h" value="min" />
-      <property role="CIruq" value="time" />
       <ref role="Rn5ok" node="1KUmgSFvJUr" resolve="time" />
     </node>
     <node concept="CIrOH" id="69HsIy5Fwt1" role="_iOnB">
       <property role="TrG5h" value="h" />
-      <property role="CIruq" value="time" />
       <ref role="Rn5ok" node="1KUmgSFvJUr" resolve="time" />
     </node>
     <node concept="CIrOH" id="69HsIy5FwtA" role="_iOnB">
       <property role="TrG5h" value="day" />
-      <property role="CIruq" value="time" />
       <ref role="Rn5ok" node="1KUmgSFvJUr" resolve="time" />
     </node>
     <node concept="TRoc0" id="69HsIy5FwwI" role="_iOnB">
@@ -933,27 +891,22 @@
     </node>
     <node concept="CIrOH" id="69HsIy5Fy7C" role="_iOnB">
       <property role="TrG5h" value="ngramm" />
-      <property role="CIruq" value="weight" />
       <ref role="Rn5ok" node="1KUmgSFvJUq" resolve="weight" />
     </node>
     <node concept="CIrOH" id="69HsIy5Fye0" role="_iOnB">
       <property role="TrG5h" value="µgramm" />
-      <property role="CIruq" value="weight" />
       <ref role="Rn5ok" node="1KUmgSFvJUq" resolve="weight" />
     </node>
     <node concept="CIrOH" id="69HsIy5Fy6n" role="_iOnB">
       <property role="TrG5h" value="mgramm" />
-      <property role="CIruq" value="weight" />
       <ref role="Rn5ok" node="1KUmgSFvJUq" resolve="weight" />
     </node>
     <node concept="CIrOH" id="69HsIy5FxTe" role="_iOnB">
       <property role="TrG5h" value="gramm" />
-      <property role="CIruq" value="weight" />
       <ref role="Rn5ok" node="1KUmgSFvJUq" resolve="weight" />
     </node>
     <node concept="CIrOH" id="69HsIy5FyhU" role="_iOnB">
       <property role="TrG5h" value="ton" />
-      <property role="CIruq" value="weight" />
       <ref role="Rn5ok" node="1KUmgSFvJUq" resolve="weight" />
     </node>
     <node concept="TRoc0" id="69HsIy5Fyjf" role="_iOnB">

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
@@ -167,7 +167,6 @@
       <concept id="5185104661801317038" name="org.iets3.core.expr.typetags.units.structure.ValExpression" flags="ng" index="2m5Cep" />
       <concept id="624957442818070507" name="org.iets3.core.expr.typetags.units.structure.StripUnitExpression" flags="ng" index="2yh1Mg" />
       <concept id="8337440621611267903" name="org.iets3.core.expr.typetags.units.structure.Unit" flags="ng" index="CIrOH">
-        <property id="8337440621611269512" name="description" index="CIruq" />
         <reference id="2034036099103723290" name="dimension" index="Rn5ok" />
         <child id="8337440621611270427" name="specification" index="CIsG9" />
       </concept>
@@ -998,17 +997,14 @@
         <node concept="_ixoA" id="2JXkwhJhlUu" role="_iOnC" />
         <node concept="CIrOH" id="2JXkwhJhWCi" role="_iOnC">
           <property role="TrG5h" value="u1" />
-          <property role="CIruq" value="u1" />
           <ref role="Rn5ok" node="1KUmgSFvJZW" resolve="u1d" />
         </node>
         <node concept="CIrOH" id="2JXkwhJhWH5" role="_iOnC">
           <property role="TrG5h" value="u2" />
-          <property role="CIruq" value="u2" />
           <ref role="Rn5ok" node="1KUmgSFvJZX" resolve="u2d" />
         </node>
         <node concept="CIrOH" id="2JXkwhJhWIP" role="_iOnC">
           <property role="TrG5h" value="u3" />
-          <property role="CIruq" value="u3" />
           <ref role="Rn5ok" node="1KUmgSFvJZY" resolve="u3d" />
         </node>
         <node concept="_ixoA" id="2JXkwhJhWEZ" role="_iOnC" />
@@ -1062,7 +1058,6 @@
         <property role="TrG5h" value="Conversion_c" />
         <node concept="CIrOH" id="4UY$tRc1Vet" role="_iOnC">
           <property role="TrG5h" value="myMs" />
-          <property role="CIruq" value="myMillisecond" />
           <ref role="Rn5ok" node="1KUmgSFvJZT" resolve="myMillisecond" />
         </node>
         <node concept="TRoc0" id="4UY$tRc1Vbb" role="_iOnC">
@@ -1099,7 +1094,6 @@
         </node>
         <node concept="CIrOH" id="3FpaOZJSpOY" role="_iOnC">
           <property role="TrG5h" value="myC" />
-          <property role="CIruq" value="myCs" />
           <ref role="Rn5ok" node="1KUmgSFvJZV" resolve="myCs" />
         </node>
         <node concept="TRoc0" id="3FpaOZJSp$f" role="_iOnC">
@@ -1120,7 +1114,6 @@
         </node>
         <node concept="CIrOH" id="3FpaOZK6fQ9" role="_iOnC">
           <property role="TrG5h" value="squareMetre" />
-          <property role="CIruq" value="squareMetre" />
           <ref role="Rn5ok" node="1KUmgSFvJZU" resolve="squareMetred" />
         </node>
         <node concept="TRoc0" id="3FpaOZK6fSJ" role="_iOnC">
@@ -1517,12 +1510,10 @@
         <property role="TrG5h" value="Conversion_errors" />
         <node concept="CIrOH" id="6rhVuic9JQF" role="_iOnC">
           <property role="TrG5h" value="myMs" />
-          <property role="CIruq" value="myMillisecond" />
           <ref role="Rn5ok" node="1KUmgSFvJZZ" resolve="myMillisecond" />
         </node>
         <node concept="CIrOH" id="6rhVuic9JQT" role="_iOnC">
           <property role="TrG5h" value="myC" />
-          <property role="CIruq" value="myCs" />
           <ref role="Rn5ok" node="1KUmgSFvK00" resolve="myCs" />
         </node>
         <node concept="TRoc0" id="6rhVuic9JQU" role="_iOnC">
@@ -5697,27 +5688,22 @@
     <property role="TrG5h" value="UnitsAndConversions" />
     <node concept="CIrOH" id="2JXkwhJfMYw" role="_iOnC">
       <property role="TrG5h" value="mm" />
-      <property role="CIruq" value="millimetre" />
       <ref role="Rn5ok" node="1KUmgSFvJZN" resolve="millimetre" />
     </node>
     <node concept="CIrOH" id="2JXkwhJfNt9" role="_iOnC">
       <property role="TrG5h" value="dm" />
-      <property role="CIruq" value="decimetre" />
       <ref role="Rn5ok" node="1KUmgSFvJZS" resolve="decimetre" />
     </node>
     <node concept="CIrOH" id="2JXkwhJfQ5c" role="_iOnC">
       <property role="TrG5h" value="cm" />
-      <property role="CIruq" value="centimetre" />
       <ref role="Rn5ok" node="1KUmgSFvJZQ" resolve="centimetre" />
     </node>
     <node concept="CIrOH" id="2JXkwhJfWHv" role="_iOnC">
       <property role="TrG5h" value="percent" />
-      <property role="CIruq" value="percent" />
       <ref role="Rn5ok" node="1KUmgSFvJZR" resolve="percent" />
     </node>
     <node concept="CIrOH" id="5XaocLWIt6X" role="_iOnC">
       <property role="TrG5h" value="mps" />
-      <property role="CIruq" value="metre per second" />
       <ref role="Rn5ok" node="1KUmgSFvJZP" resolve="metre per second" />
       <node concept="CIsGf" id="5XaocLWIt7Y" role="CIsG9">
         <node concept="CIsvn" id="5XaocLWIt85" role="CIi4h">
@@ -5733,7 +5719,6 @@
     </node>
     <node concept="CIrOH" id="5XaocLWJ9Gy" role="_iOnC">
       <property role="TrG5h" value="acc" />
-      <property role="CIruq" value="acceleration" />
       <ref role="Rn5ok" node="1KUmgSFvJZO" resolve="acceleration" />
       <node concept="CIsGf" id="5XaocLWJadY" role="CIsG9">
         <node concept="CIsvn" id="5XaocLWJae5" role="CIi4h">


### PR DESCRIPTION
A bug in the units migration didn't set the now deprecated "description" property to null therefor
every execution of the rerunable migration would create new quantities. The migration was updated
to detect this case properly and not change the model in this case. In addition the migration now
sets the deprecated property to null.

fixes #423