### PR TITLE
empty in data tables

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/structure.mps
@@ -566,9 +566,6 @@
       <property role="IQ2ns" value="8355348994405084500" />
       <ref role="20lvS9" node="6sdnDbSlaok" resolve="Type" />
     </node>
-    <node concept="PrWs8" id="MNXm1ElbHv" role="PzmwI">
-      <ref role="PrY4T" node="MNXm1ElbHo" resolve="IEmptyLiteral" />
-    </node>
   </node>
   <node concept="1TIwiD" id="2rOWEwsEji_">
     <property role="3GE5qa" value="option" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/structure.mps
@@ -566,6 +566,9 @@
       <property role="IQ2ns" value="8355348994405084500" />
       <ref role="20lvS9" node="6sdnDbSlaok" resolve="Type" />
     </node>
+    <node concept="PrWs8" id="MNXm1ElbHv" role="PzmwI">
+      <ref role="PrY4T" node="MNXm1ElbHo" resolve="IEmptyLiteral" />
+    </node>
   </node>
   <node concept="1TIwiD" id="2rOWEwsEji_">
     <property role="3GE5qa" value="option" />
@@ -2140,11 +2143,24 @@
       <property role="20lbJX" value="fLJekj4/_1" />
       <ref role="20lvS9" node="6sdnDbSlaok" resolve="Type" />
     </node>
+    <node concept="PrWs8" id="MNXm1ElbHt" role="PzmwI">
+      <ref role="PrY4T" node="MNXm1ElbHo" resolve="IEmptyLiteral" />
+    </node>
   </node>
   <node concept="PlHQZ" id="26cjRADipGQ">
     <property role="EcuMT" value="2417394483940924214" />
     <property role="3GE5qa" value="nix" />
     <property role="TrG5h" value="ITargetThatCanDealWithNix" />
+  </node>
+  <node concept="PlHQZ" id="MNXm1ElbHo">
+    <property role="EcuMT" value="915344943735946072" />
+    <property role="TrG5h" value="IEmptyLiteral" />
+    <node concept="PrWs8" id="MNXm1ElbHp" role="PrDN$">
+      <ref role="PrY4T" node="6JZACDWQJu4" resolve="ILiteral" />
+    </node>
+    <node concept="t5JxF" id="MNXm1ElbHr" role="lGtFl">
+      <property role="t5JxN" value="Marker interface used to marke literals that at runtime evaluate to None/Nix." />
+    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.behavior.mps
@@ -1365,5 +1365,28 @@
       <node concept="17QB3L" id="3y6PJwOpQ2s" role="3clF45" />
     </node>
   </node>
+  <node concept="13h7C7" id="2KRUNf1kSya">
+    <ref role="13h7C2" to="e9k1:2KRUNf1kRPn" resolve="EmptyInput" />
+    <node concept="13hLZK" id="2KRUNf1kSyb" role="13h7CW">
+      <node concept="3clFbS" id="2KRUNf1kSyc" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="2KRUNf1mcKv" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="2KRUNf1mcKw" role="1B3o_S" />
+      <node concept="3clFbS" id="2KRUNf1mcKH" role="3clF47">
+        <node concept="3clFbF" id="2KRUNf1mcUc" role="3cqZAp">
+          <node concept="2OqwBi" id="2KRUNf1mdFn" role="3clFbG">
+            <node concept="2OqwBi" id="2KRUNf1md6e" role="2Oq$k0">
+              <node concept="13iPFW" id="2KRUNf1mcU7" role="2Oq$k0" />
+              <node concept="2yIwOk" id="2KRUNf1mdrf" role="2OqNvi" />
+            </node>
+            <node concept="3n3YKJ" id="2KRUNf1mefA" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="2KRUNf1mcKI" role="3clF45" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.constraints.mps
@@ -24,6 +24,7 @@
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -46,6 +47,13 @@
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
     </language>
     <language id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints">
@@ -109,6 +117,14 @@
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="ng" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="ng" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
   </registry>
@@ -448,6 +464,88 @@
               </node>
               <node concept="3clFbT" id="6WstIz8MKEx" role="37wK5m">
                 <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="2KRUNf1kRP_">
+    <ref role="1M2myG" to="e9k1:2KRUNf1kRPn" resolve="EmptyInput" />
+    <node concept="9S07l" id="2KRUNf1kRXL" role="9Vyp8">
+      <node concept="3clFbS" id="2KRUNf1kRXM" role="2VODD2">
+        <node concept="3SKdUt" id="2KRUNf1m7lT" role="3cqZAp">
+          <node concept="1PaTwC" id="2KRUNf1m7lU" role="1aUNEU">
+            <node concept="3oM_SD" id="2KRUNf1m7nx" role="1PaTwD">
+              <property role="3oM_SC" value="DataRow" />
+            </node>
+            <node concept="3oM_SD" id="2KRUNf1m7nR" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="2KRUNf1m7oj" role="1PaTwD">
+              <property role="3oM_SC" value="cover" />
+            </node>
+            <node concept="3oM_SD" id="2KRUNf1m7oK" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="2KRUNf1m7oQ" role="1PaTwD">
+              <property role="3oM_SC" value="&quot;wrap&quot;" />
+            </node>
+            <node concept="3oM_SD" id="2KRUNf1m7pl" role="1PaTwD">
+              <property role="3oM_SC" value="case" />
+            </node>
+            <node concept="3oM_SD" id="2KRUNf1m7pD" role="1PaTwD">
+              <property role="3oM_SC" value="when" />
+            </node>
+            <node concept="3oM_SD" id="2KRUNf1m7pM" role="1PaTwD">
+              <property role="3oM_SC" value="no" />
+            </node>
+            <node concept="3oM_SD" id="2KRUNf1m7q8" role="1PaTwD">
+              <property role="3oM_SC" value="expression" />
+            </node>
+            <node concept="3oM_SD" id="2KRUNf1m7qj" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="2KRUNf1m7rQ" role="1PaTwD">
+              <property role="3oM_SC" value="typed" />
+            </node>
+            <node concept="3oM_SD" id="2KRUNf1m7s3" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="2KRUNf1m7sh" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="2KRUNf1m7sG" role="1PaTwD">
+              <property role="3oM_SC" value="cell" />
+            </node>
+            <node concept="3oM_SD" id="2KRUNf1m7sW" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="2KRUNf1m7td" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="2KRUNf1m7uQ" role="1PaTwD">
+              <property role="3oM_SC" value="datarow" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2KRUNf1kRY9" role="3cqZAp">
+          <node concept="22lmx$" id="2KRUNf1m6tl" role="3clFbG">
+            <node concept="2OqwBi" id="2KRUNf1m6I2" role="3uHU7w">
+              <node concept="nLn13" id="2KRUNf1m6uu" role="2Oq$k0" />
+              <node concept="1mIQ4w" id="2KRUNf1m71d" role="2OqNvi">
+                <node concept="chp4Y" id="2KRUNf1m761" role="cj9EA">
+                  <ref role="cht4Q" to="e9k1:cPLa7FpcCS" resolve="DataCell" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="2KRUNf1kS8P" role="3uHU7B">
+              <node concept="nLn13" id="2KRUNf1kRY8" role="2Oq$k0" />
+              <node concept="1mIQ4w" id="2KRUNf1kSjq" role="2OqNvi">
+                <node concept="chp4Y" id="2KRUNf1kSpn" role="cj9EA">
+                  <ref role="cht4Q" to="e9k1:cPLa7Fpiy9" resolve="DataRow" />
+                </node>
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
@@ -1070,5 +1070,12 @@
       </node>
     </node>
   </node>
+  <node concept="24kQdi" id="2KRUNf1kRPv">
+    <ref role="1XX52x" to="e9k1:2KRUNf1kRPn" resolve="EmptyInput" />
+    <node concept="PMmxH" id="2KRUNf1kRPx" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.structure.mps
@@ -272,5 +272,15 @@
       <ref role="20lvS9" node="cPLa7Fpiy9" resolve="DataRow" />
     </node>
   </node>
+  <node concept="1TIwiD" id="2KRUNf1kRPn">
+    <property role="EcuMT" value="3186273868907248983" />
+    <property role="TrG5h" value="EmptyInput" />
+    <property role="R4oN_" value="value that is matched if the input is none" />
+    <property role="34LRSv" value="emptyInput" />
+    <ref role="1TJDcQ" to="hm2y:6sdnDbSla17" resolve="Expression" />
+    <node concept="PrWs8" id="2KRUNf1m9jS" role="PzmwI">
+      <ref role="PrY4T" to="hm2y:6JZACDWQJu4" resolve="ILiteral" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.structure.mps
@@ -278,8 +278,8 @@
     <property role="R4oN_" value="value that is matched if the input is none" />
     <property role="34LRSv" value="emptyInput" />
     <ref role="1TJDcQ" to="hm2y:6sdnDbSla17" resolve="Expression" />
-    <node concept="PrWs8" id="2KRUNf1m9jS" role="PzmwI">
-      <ref role="PrY4T" to="hm2y:6JZACDWQJu4" resolve="ILiteral" />
+    <node concept="PrWs8" id="MNXm1EqQbF" role="PzmwI">
+      <ref role="PrY4T" to="hm2y:MNXm1ElbHo" resolve="IEmptyLiteral" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.typesystem.mps
@@ -489,7 +489,7 @@
                                         </node>
                                         <node concept="2OqwBi" id="2KRUNf1mG2Z" role="3uHU7B">
                                           <node concept="37vLTw" id="2KRUNf1mG30" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="2KRUNf1mG38" resolve="row" />
+                                            <ref role="3cqZAo" node="2KRUNf1mG38" resolve="cell" />
                                           </node>
                                           <node concept="3TrEf2" id="2KRUNf1mG31" role="2OqNvi">
                                             <ref role="3Tt5mk" to="e9k1:cPLa7FpdsY" resolve="col" />
@@ -499,7 +499,7 @@
                                       <node concept="2OqwBi" id="2KRUNf1mG32" role="3uHU7B">
                                         <node concept="2OqwBi" id="2KRUNf1mG33" role="2Oq$k0">
                                           <node concept="37vLTw" id="2KRUNf1mG34" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="2KRUNf1mG38" resolve="row" />
+                                            <ref role="3cqZAo" node="2KRUNf1mG38" resolve="cell" />
                                           </node>
                                           <node concept="3TrEf2" id="2KRUNf1mG35" role="2OqNvi">
                                             <ref role="3Tt5mk" to="e9k1:cPLa7Fpe9f" resolve="value" />
@@ -515,7 +515,7 @@
                                   </node>
                                 </node>
                                 <node concept="Rh6nW" id="2KRUNf1mG38" role="1bW2Oz">
-                                  <property role="TrG5h" value="row" />
+                                  <property role="TrG5h" value="cell" />
                                   <node concept="2jxLKc" id="2KRUNf1mG39" role="1tU5fm" />
                                 </node>
                               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.typesystem.mps
@@ -44,6 +44,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -62,6 +63,9 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
@@ -70,6 +74,7 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
@@ -190,11 +195,15 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="3562215692195599741" name="jetbrains.mps.lang.smodel.structure.SLinkImplicitSelect" flags="nn" index="13MTOL">
         <reference id="3562215692195600259" name="link" index="13MTZf" />
       </concept>
@@ -207,6 +216,9 @@
       </concept>
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
@@ -238,8 +250,21 @@
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
+      <concept id="1172650591544" name="jetbrains.mps.baseLanguage.collections.structure.SkipOperation" flags="nn" index="7r0gD">
+        <child id="1172658456740" name="elementsToSkip" index="7T0AP" />
+      </concept>
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
     </language>
   </registry>
   <node concept="1YbPZF" id="cPLa7Fper3">
@@ -409,6 +434,177 @@
               </node>
             </node>
             <node concept="3x8VRR" id="7F9023_N61N" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="2KRUNf1mgcM" role="3cqZAp" />
+      <node concept="3clFbJ" id="2KRUNf1mgem" role="3cqZAp">
+        <node concept="3clFbS" id="2KRUNf1mgeo" role="3clFbx">
+          <node concept="3cpWs8" id="2KRUNf1mG2B" role="3cqZAp">
+            <node concept="3cpWsn" id="2KRUNf1mG2C" role="3cpWs9">
+              <property role="TrG5h" value="columnDefaultValues" />
+              <node concept="A3Dl8" id="2KRUNf1mFYp" role="1tU5fm">
+                <node concept="_YKpA" id="2KRUNf1mFYv" role="A3Ik2">
+                  <node concept="3Tqbb2" id="2KRUNf1mFYw" role="_ZDj9">
+                    <ref role="ehGHo" to="e9k1:cPLa7FpcCS" resolve="DataCell" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="2KRUNf1mG2D" role="33vP2m">
+                <node concept="2OqwBi" id="2KRUNf1mG2E" role="2Oq$k0">
+                  <node concept="1YBJjd" id="2KRUNf1mG2F" role="2Oq$k0">
+                    <ref role="1YBMHb" node="cPLa7FrPf0" resolve="dataTable" />
+                  </node>
+                  <node concept="3Tsc0h" id="2KRUNf1mG2G" role="2OqNvi">
+                    <ref role="3TtcxE" to="e9k1:cPLa7FpckA" resolve="dataCols" />
+                  </node>
+                </node>
+                <node concept="3$u5V9" id="2KRUNf1mG2H" role="2OqNvi">
+                  <node concept="1bVj0M" id="2KRUNf1mG2I" role="23t8la">
+                    <node concept="3clFbS" id="2KRUNf1mG2J" role="1bW5cS">
+                      <node concept="3clFbF" id="2KRUNf1mG2K" role="3cqZAp">
+                        <node concept="2OqwBi" id="2KRUNf1mG2L" role="3clFbG">
+                          <node concept="2OqwBi" id="2KRUNf1mG2M" role="2Oq$k0">
+                            <node concept="2OqwBi" id="2KRUNf1mG2N" role="2Oq$k0">
+                              <node concept="2OqwBi" id="2KRUNf1mG2O" role="2Oq$k0">
+                                <node concept="1YBJjd" id="2KRUNf1mG2P" role="2Oq$k0">
+                                  <ref role="1YBMHb" node="cPLa7FrPf0" resolve="dataTable" />
+                                </node>
+                                <node concept="3Tsc0h" id="2KRUNf1mG2Q" role="2OqNvi">
+                                  <ref role="3TtcxE" to="e9k1:cPLa7FpRVO" resolve="rows" />
+                                </node>
+                              </node>
+                              <node concept="13MTOL" id="2KRUNf1mG2R" role="2OqNvi">
+                                <ref role="13MTZf" to="e9k1:cPLa7FpcRm" resolve="cells" />
+                              </node>
+                            </node>
+                            <node concept="3zZkjj" id="2KRUNf1mG2S" role="2OqNvi">
+                              <node concept="1bVj0M" id="2KRUNf1mG2T" role="23t8la">
+                                <node concept="3clFbS" id="2KRUNf1mG2U" role="1bW5cS">
+                                  <node concept="3clFbF" id="2KRUNf1mG2V" role="3cqZAp">
+                                    <node concept="1Wc70l" id="2KRUNf1mG2W" role="3clFbG">
+                                      <node concept="17R0WA" id="2KRUNf1mG2X" role="3uHU7w">
+                                        <node concept="37vLTw" id="2KRUNf1mG2Y" role="3uHU7w">
+                                          <ref role="3cqZAo" node="2KRUNf1mG3b" resolve="col" />
+                                        </node>
+                                        <node concept="2OqwBi" id="2KRUNf1mG2Z" role="3uHU7B">
+                                          <node concept="37vLTw" id="2KRUNf1mG30" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="2KRUNf1mG38" resolve="row" />
+                                          </node>
+                                          <node concept="3TrEf2" id="2KRUNf1mG31" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="e9k1:cPLa7FpdsY" resolve="col" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="2OqwBi" id="2KRUNf1mG32" role="3uHU7B">
+                                        <node concept="2OqwBi" id="2KRUNf1mG33" role="2Oq$k0">
+                                          <node concept="37vLTw" id="2KRUNf1mG34" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="2KRUNf1mG38" resolve="row" />
+                                          </node>
+                                          <node concept="3TrEf2" id="2KRUNf1mG35" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="e9k1:cPLa7Fpe9f" resolve="value" />
+                                          </node>
+                                        </node>
+                                        <node concept="1mIQ4w" id="2KRUNf1mG36" role="2OqNvi">
+                                          <node concept="chp4Y" id="2KRUNf1mG37" role="cj9EA">
+                                            <ref role="cht4Q" to="e9k1:2KRUNf1kRPn" resolve="EmptyInput" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="Rh6nW" id="2KRUNf1mG38" role="1bW2Oz">
+                                  <property role="TrG5h" value="row" />
+                                  <node concept="2jxLKc" id="2KRUNf1mG39" role="1tU5fm" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="ANE8D" id="2KRUNf1mG3a" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="2KRUNf1mG3b" role="1bW2Oz">
+                      <property role="TrG5h" value="col" />
+                      <node concept="2jxLKc" id="2KRUNf1mG3c" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="2KRUNf1miEw" role="3cqZAp">
+            <node concept="2OqwBi" id="2KRUNf1mGLF" role="3clFbG">
+              <node concept="37vLTw" id="2KRUNf1mG3d" role="2Oq$k0">
+                <ref role="3cqZAo" node="2KRUNf1mG2C" resolve="columnDefaultValues" />
+              </node>
+              <node concept="2es0OD" id="2KRUNf1mHhE" role="2OqNvi">
+                <node concept="1bVj0M" id="2KRUNf1mHhG" role="23t8la">
+                  <node concept="3clFbS" id="2KRUNf1mHhH" role="1bW5cS">
+                    <node concept="3clFbJ" id="2KRUNf1mKTH" role="3cqZAp">
+                      <node concept="3clFbS" id="2KRUNf1mL4_" role="3clFbx">
+                        <node concept="3clFbF" id="2KRUNf1mL8g" role="3cqZAp">
+                          <node concept="2OqwBi" id="2KRUNf1mNSP" role="3clFbG">
+                            <node concept="2OqwBi" id="2KRUNf1mMwl" role="2Oq$k0">
+                              <node concept="37vLTw" id="2KRUNf1mL8f" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2KRUNf1mHhI" resolve="defaultValues" />
+                              </node>
+                              <node concept="7r0gD" id="2KRUNf1mNvp" role="2OqNvi">
+                                <node concept="3cmrfG" id="2KRUNf1mND7" role="7T0AP">
+                                  <property role="3cmrfH" value="1" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="2es0OD" id="2KRUNf1mOct" role="2OqNvi">
+                              <node concept="1bVj0M" id="2KRUNf1mOcv" role="23t8la">
+                                <node concept="3clFbS" id="2KRUNf1mOcw" role="1bW5cS">
+                                  <node concept="2MkqsV" id="2KRUNf1mOp9" role="3cqZAp">
+                                    <node concept="Xl_RD" id="2KRUNf1mOvi" role="2MkJ7o">
+                                      <property role="Xl_RC" value="only one empty input value per column is allowed." />
+                                    </node>
+                                    <node concept="37vLTw" id="2KRUNf1mR8t" role="1urrMF">
+                                      <ref role="3cqZAo" node="2KRUNf1mOcx" resolve="def" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="Rh6nW" id="2KRUNf1mOcx" role="1bW2Oz">
+                                  <property role="TrG5h" value="def" />
+                                  <node concept="2jxLKc" id="2KRUNf1mOcy" role="1tU5fm" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3eOSWO" id="2KRUNf1mKDA" role="3clFbw">
+                        <node concept="3cmrfG" id="2KRUNf1mKDL" role="3uHU7w">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                        <node concept="2OqwBi" id="2KRUNf1mIsD" role="3uHU7B">
+                          <node concept="37vLTw" id="2KRUNf1mHlr" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2KRUNf1mHhI" resolve="defaultValues" />
+                          </node>
+                          <node concept="34oBXx" id="2KRUNf1mJG3" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="2KRUNf1mHhI" role="1bW2Oz">
+                    <property role="TrG5h" value="defaultValues" />
+                    <node concept="2jxLKc" id="2KRUNf1mHhJ" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2OqwBi" id="2KRUNf1mhVG" role="3clFbw">
+          <node concept="1YBJjd" id="2KRUNf1mhBV" role="2Oq$k0">
+            <ref role="1YBMHb" node="cPLa7FrPf0" resolve="dataTable" />
+          </node>
+          <node concept="3TrcHB" id="2KRUNf1miEh" role="2OqNvi">
+            <ref role="3TsBF5" to="e9k1:2SzGbCMIroO" resolve="allowLookup" />
           </node>
         </node>
       </node>
@@ -932,6 +1128,95 @@
     <node concept="1YaCAy" id="3y6PJwOq5o$" role="1YuTPh">
       <property role="TrG5h" value="dataIsInTarget" />
       <ref role="1YaFvo" to="e9k1:3y6PJwOpPmR" resolve="DataIsInTarget" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="2KRUNf1megK">
+    <property role="TrG5h" value="check_DefaultValue" />
+    <node concept="3clFbS" id="2KRUNf1megL" role="18ibNy">
+      <node concept="3cpWs8" id="2KRUNf1mfRC" role="3cqZAp">
+        <node concept="3cpWsn" id="2KRUNf1mfRD" role="3cpWs9">
+          <property role="TrG5h" value="table" />
+          <node concept="3Tqbb2" id="2KRUNf1mfN8" role="1tU5fm">
+            <ref role="ehGHo" to="e9k1:cPLa7Fp8FI" resolve="DataTable" />
+          </node>
+          <node concept="2OqwBi" id="2KRUNf1mfRE" role="33vP2m">
+            <node concept="1YBJjd" id="2KRUNf1mfRF" role="2Oq$k0">
+              <ref role="1YBMHb" node="2KRUNf1megN" resolve="defaultValue" />
+            </node>
+            <node concept="2Xjw5R" id="2KRUNf1mfRG" role="2OqNvi">
+              <node concept="1xMEDy" id="2KRUNf1mfRH" role="1xVPHs">
+                <node concept="chp4Y" id="2KRUNf1mfRI" role="ri$Ld">
+                  <ref role="cht4Q" to="e9k1:cPLa7Fp8FI" resolve="DataTable" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2Mj0R9" id="2KRUNf1megR" role="3cqZAp">
+        <node concept="2OqwBi" id="2KRUNf1mf9f" role="2MkoU_">
+          <node concept="37vLTw" id="2KRUNf1mfRJ" role="2Oq$k0">
+            <ref role="3cqZAo" node="2KRUNf1mfRD" resolve="table" />
+          </node>
+          <node concept="3TrcHB" id="2KRUNf1mfEy" role="2OqNvi">
+            <ref role="3TsBF5" to="e9k1:2SzGbCMIroO" resolve="allowLookup" />
+          </node>
+        </node>
+        <node concept="Xl_RD" id="2KRUNf1mfIE" role="2MkJ7o">
+          <property role="Xl_RC" value="empty input is only allowed in data tables that support look up" />
+        </node>
+        <node concept="1YBJjd" id="2KRUNf1mfLA" role="1urrMF">
+          <ref role="1YBMHb" node="2KRUNf1megN" resolve="defaultValue" />
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="2KRUNf1megN" role="1YuTPh">
+      <property role="TrG5h" value="defaultValue" />
+      <ref role="1YaFvo" to="e9k1:2KRUNf1kRPn" resolve="EmptyInput" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="2KRUNf1sXsr">
+    <property role="TrG5h" value="typeof_EmptyInput" />
+    <node concept="3clFbS" id="2KRUNf1sXss" role="18ibNy">
+      <node concept="1Z5TYs" id="2KRUNf1sYYR" role="3cqZAp">
+        <node concept="mw_s8" id="2KRUNf1sYZb" role="1ZfhKB">
+          <node concept="1Z2H0r" id="2KRUNf1sYZ7" role="mwGJk">
+            <node concept="2OqwBi" id="2KRUNf1sYwQ" role="1Z2MuG">
+              <node concept="2OqwBi" id="2KRUNf1sYb3" role="2Oq$k0">
+                <node concept="2OqwBi" id="2KRUNf1sXHV" role="2Oq$k0">
+                  <node concept="1YBJjd" id="2KRUNf1sXvd" role="2Oq$k0">
+                    <ref role="1YBMHb" node="2KRUNf1sXsu" resolve="emptyInput" />
+                  </node>
+                  <node concept="2Xjw5R" id="2KRUNf1sY0r" role="2OqNvi">
+                    <node concept="1xMEDy" id="2KRUNf1sY0t" role="1xVPHs">
+                      <node concept="chp4Y" id="2KRUNf1sY2H" role="ri$Ld">
+                        <ref role="cht4Q" to="e9k1:cPLa7FpcCS" resolve="DataCell" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3TrEf2" id="2KRUNf1sYjW" role="2OqNvi">
+                  <ref role="3Tt5mk" to="e9k1:cPLa7FpdsY" resolve="col" />
+                </node>
+              </node>
+              <node concept="3TrEf2" id="2KRUNf1sYNJ" role="2OqNvi">
+                <ref role="3Tt5mk" to="e9k1:cPLa7FpbAi" resolve="type" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="2KRUNf1sYYU" role="1ZfhK$">
+          <node concept="1Z2H0r" id="2KRUNf1sYQu" role="mwGJk">
+            <node concept="1YBJjd" id="2KRUNf1sYQF" role="1Z2MuG">
+              <ref role="1YBMHb" node="2KRUNf1sXsu" resolve="emptyInput" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="2KRUNf1sXsu" role="1YuTPh">
+      <property role="TrG5h" value="emptyInput" />
+      <ref role="1YaFvo" to="e9k1:2KRUNf1kRPn" resolve="EmptyInput" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.typesystem.mps
@@ -506,8 +506,8 @@
                                           </node>
                                         </node>
                                         <node concept="1mIQ4w" id="2KRUNf1mG36" role="2OqNvi">
-                                          <node concept="chp4Y" id="2KRUNf1mG37" role="cj9EA">
-                                            <ref role="cht4Q" to="e9k1:2KRUNf1kRPn" resolve="EmptyInput" />
+                                          <node concept="chp4Y" id="MNXm1Elemj" role="cj9EA">
+                                            <ref role="cht4Q" to="hm2y:MNXm1ElbHo" resolve="IEmptyLiteral" />
                                           </node>
                                         </node>
                                       </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.data.interpreter/models/org.iets3.core.expr.data.interpreter.plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.data.interpreter/models/org.iets3.core.expr.data.interpreter.plugin.mps
@@ -12,6 +12,8 @@
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
     <import index="xk6s" ref="r:7961970e-5737-42e2-b144-9bef3ad8d077(org.iets3.core.expr.tests.behavior)" />
     <import index="dj6k" ref="r:59d52af6-663b-49dc-8980-30d79b8dffa1(org.iets3.core.expr.simpleTypes.runtime)" />
+    <import index="oq0c" ref="r:6c6155f0-4bbe-4af5-8c26-244d570e21e4(org.iets3.core.expr.base.plugin)" />
+    <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -35,9 +37,15 @@
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
@@ -66,6 +74,7 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
@@ -334,6 +343,7 @@
                         </node>
                       </node>
                     </node>
+                    <node concept="3clFbH" id="2KRUNf1rDRY" role="3cqZAp" />
                     <node concept="3cpWs8" id="stdmzxodlc" role="3cqZAp">
                       <node concept="3cpWsn" id="stdmzxodld" role="3cpWs9">
                         <property role="TrG5h" value="s" />
@@ -565,10 +575,25 @@
                   </node>
                 </node>
                 <node concept="3cpWs6" id="stdmzxodlE" role="3cqZAp">
-                  <node concept="10Nm6u" id="stdmzxodlF" role="3cqZAk" />
+                  <node concept="2ShNRf" id="2KRUNf1roOK" role="3cqZAk">
+                    <node concept="HV5vD" id="2KRUNf1rwGu" role="2ShVmc">
+                      <ref role="HV5vE" to="xfg9:3nVyItrYWd7" resolve="DefaultNix" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="qq9P1" id="2KRUNf1otlQ" role="qq9xR">
+      <property role="2TnfIJ" value="true" />
+      <ref role="qq9wM" to="e9k1:2KRUNf1kRPn" resolve="EmptyInput" />
+      <node concept="3vetai" id="2KRUNf1otKX" role="3vQZUl">
+        <node concept="2ShNRf" id="1$1rueeG3FX" role="3vdyny">
+          <node concept="HV5vD" id="2KRUNf1rwEU" role="2ShVmc">
+            <ref role="HV5vE" to="xfg9:3nVyItrYWd7" resolve="DefaultNix" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.data.interpreter/org.iets3.core.expr.data.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.data.interpreter/org.iets3.core.expr.data.interpreter.msd
@@ -17,6 +17,7 @@
     <dependency reexport="false">cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</dependency>
     <dependency reexport="false">d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)</dependency>
     <dependency reexport="false">52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)</dependency>
+    <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:47f075a6-558e-4640-a606-7ce0236c8023:com.mbeddr.mpsutil.interpreter" version="1" />
@@ -72,6 +73,7 @@
     <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="0" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
     <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="1" />
+    <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="5" />
     <module reference="b25b8ad1-4d3d-4e45-8c78-72091b39fdda(org.iets3.core.expr.data)" version="0" />
     <module reference="21d0de5b-f228-4080-9857-7315c7a77001(org.iets3.core.expr.data.interpreter)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -2,11 +2,11 @@
 <model ref="r:c3d6ae0c-8b10-477f-a3e9-5dc8700ceb13(org.iets3.opensource.build.build)">
   <persistence version="9" />
   <languages>
-    <use id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps" version="7" />
-    <use id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build" version="0" />
-    <use id="3600cb0a-44dd-4a5b-9968-22924406419e" name="jetbrains.mps.build.mps.tests" version="1" />
-    <use id="9d000fbd-bdca-4a46-b39b-c5ba9e79b38c" name="org.iets3.opensource.build.gentests" version="0" />
-    <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
+    <use id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps" version="-1" />
+    <use id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build" version="-1" />
+    <use id="3600cb0a-44dd-4a5b-9968-22924406419e" name="jetbrains.mps.build.mps.tests" version="-1" />
+    <use id="9d000fbd-bdca-4a46-b39b-c5ba9e79b38c" name="org.iets3.opensource.build.gentests" version="-1" />
+    <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="-1" />
   </languages>
   <imports>
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
@@ -247,7 +247,7 @@
     <node concept="398rNT" id="5wLtKNeTaqD" role="1l3spd">
       <property role="TrG5h" value="iets3.lang.opensource" />
       <node concept="398BVA" id="44RyrhrBoWI" role="398pKh">
-        <ref role="398BVh" node="44RyrhrBozY" resolve="iets3.github.opensource.home" />
+        <ref role="398BVh" node="44RyrhrBozY" />
         <node concept="2Ry0Ak" id="44RyrhrBoWR" role="iGT6I">
           <property role="2Ry0Am" value="code" />
           <node concept="2Ry0Ak" id="44RyrhrBoWS" role="2Ry0An">
@@ -3417,6 +3417,11 @@
         <node concept="1SiIV0" id="2SzGbCMNPS1" role="3bR37C">
           <node concept="3bR9La" id="2SzGbCMNPS2" role="1SiIV1">
             <ref role="3bR37D" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2KRUNf2Ebub" role="3bR37C">
+          <node concept="3bR9La" id="2KRUNf2Ebuc" role="1SiIV1">
+            <ref role="3bR37D" node="4C_RnzfEE1P" resolve="org.iets3.core.expr.base.runtime" />
           </node>
         </node>
       </node>
@@ -12072,26 +12077,17 @@
         </node>
       </node>
     </node>
-    <node concept="2sgV4H" id="OJuIQp$deC" role="1l3spa">
-      <ref role="1l3spb" node="5wLtKNeSRPl" resolve="org.iets3.opensource" />
-      <node concept="398BVA" id="OJuIQpVvYC" role="2JcizS">
-        <ref role="398BVh" node="OJuIQp_r_l" resolve="iets3.artifacts.root" />
-        <node concept="2Ry0Ak" id="OJuIQpVvZ4" role="iGT6I">
-          <property role="2Ry0Am" value="org.iets3.opensource" />
-        </node>
-      </node>
-    </node>
     <node concept="22LTRH" id="OJuIQq2vpw" role="1hWBAP">
       <property role="TrG5h" value="tests" />
       <node concept="24cAiW" id="1D8fMMrKjeD" role="24cAkG">
-        <node concept="NbPM2" id="71zSQigZ6J1" role="XX84c">
-          <node concept="3Mxwew" id="71zSQigZ6J0" role="3MwsjC">
-            <property role="3MwjfP" value="true" />
-          </node>
-        </node>
         <node concept="NbPM2" id="1DM13XazKfA" role="1psgkv">
           <node concept="3Mxwew" id="1DM13Xaw8ZX" role="3MwsjC">
             <property role="3MwjfP" value="-Xss2048k -Xmx2048m" />
+          </node>
+        </node>
+        <node concept="NbPM2" id="71zSQigZ6J1" role="XX84c">
+          <node concept="3Mxwew" id="71zSQigZ6J0" role="3MwsjC">
+            <property role="3MwjfP" value="true" />
           </node>
         </node>
       </node>
@@ -12113,6 +12109,15 @@
     </node>
     <node concept="2vP9LM" id="3ZBI8Awdbww" role="1hWBAP">
       <ref role="2vP9LP" node="OJuIQq2vpw" resolve="tests" />
+    </node>
+    <node concept="2sgV4H" id="OJuIQp$deC" role="1l3spa">
+      <ref role="1l3spb" node="5wLtKNeSRPl" resolve="org.iets3.opensource" />
+      <node concept="398BVA" id="OJuIQpVvYC" role="2JcizS">
+        <ref role="398BVh" node="OJuIQp_r_l" resolve="iets3.artifacts.root" />
+        <node concept="2Ry0Ak" id="OJuIQpVvZ4" role="iGT6I">
+          <property role="2Ry0Am" value="org.iets3.opensource" />
+        </node>
+      </node>
     </node>
   </node>
   <node concept="1l3spW" id="71zSQigYEMA">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.datatable@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.datatable@tests.mps
@@ -31,6 +31,9 @@
         <child id="5115872837156576280" name="right" index="30dEs_" />
         <child id="5115872837156576278" name="left" index="30dEsF" />
       </concept>
+      <concept id="3889855429450038473" name="org.iets3.core.expr.base.structure.EmptyValue" flags="ng" index="1I1voI">
+        <child id="3889855429450038474" name="type" index="1I1voH" />
+      </concept>
       <concept id="9002563722476995145" name="org.iets3.core.expr.base.structure.DotExpression" flags="ng" index="1QScDb">
         <child id="9002563722476995147" name="target" index="1QScD9" />
       </concept>
@@ -114,6 +117,7 @@
       <concept id="231307155597471414" name="org.iets3.core.expr.data.structure.DataColDef" flags="ng" index="3CkmCn">
         <child id="231307155597474194" name="type" index="3CknON" />
       </concept>
+      <concept id="3186273868907248983" name="org.iets3.core.expr.data.structure.EmptyInput" flags="ng" index="3Hp9p$" />
     </language>
   </registry>
   <node concept="2XOHcx" id="cPLa7FqXwt">
@@ -223,6 +227,19 @@
       </node>
       <node concept="2v6aBJ" id="6_rxy3GUKe3" role="2v6UlH">
         <ref role="2v6aBK" node="7F9023_N8E$" resolve="val1" />
+      </node>
+      <node concept="3CkeKC" id="2KRUNf1m5M7" role="3CkFDl">
+        <property role="TrG5h" value="keyC" />
+        <node concept="3CkgUp" id="2KRUNf1m5YW" role="3Ckg_R">
+          <ref role="3Ckhev" node="7F9023_N8E$" resolve="val1" />
+          <node concept="3Hp9p$" id="2KRUNf1m5YV" role="3CkirI" />
+        </node>
+        <node concept="3CkgUp" id="2KRUNf1n553" role="3Ckg_R">
+          <ref role="3Ckhev" node="7F9023_N8EA" resolve="val2" />
+          <node concept="30bXRB" id="2KRUNf1n552" role="3CkirI">
+            <property role="30bXRw" value="42" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="2zPypq" id="cPLa7Ft_oJ" role="_iOnB">
@@ -463,6 +480,45 @@
           </node>
         </node>
         <node concept="2vmpn$" id="3y6PJwOvBT0" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="2KRUNf1n5gW" role="_fkp5">
+        <node concept="_fku$" id="2KRUNf1n5gX" role="_fkur" />
+        <node concept="1QScDb" id="2KRUNf1n5EO" role="_fkuY">
+          <node concept="3Cgsri" id="2KRUNf1n5I$" role="1QScD9">
+            <ref role="3Cgs9T" node="7F9023_N8EA" resolve="val2" />
+          </node>
+          <node concept="wdKpt" id="2KRUNf1n5Bt" role="30czhm">
+            <node concept="1QScDb" id="2KRUNf1n5rX" role="30czhm">
+              <node concept="3AhkFE" id="2KRUNf1n5sy" role="1QScD9">
+                <node concept="1I1voI" id="2KRUNf1rBtV" role="3AhkFJ">
+                  <node concept="30bXR$" id="2KRUNf1rBxD" role="1I1voH" />
+                </node>
+              </node>
+              <node concept="3Ch18X" id="2KRUNf1n5rN" role="30czhm">
+                <ref role="3Ch1V_" node="7F9023_N8Ey" resolve="WithDefault" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="30bXRB" id="2KRUNf1n5Mq" role="_fkuS">
+          <property role="30bXRw" value="42" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="2KRUNf1rI3W" role="_fkp5">
+        <node concept="_fku$" id="2KRUNf1rI3X" role="_fkur" />
+        <node concept="1QScDb" id="2KRUNf1rI41" role="_fkuY">
+          <node concept="3AhkFE" id="2KRUNf1rI42" role="1QScD9">
+            <node concept="30bXRB" id="2KRUNf1rIlH" role="3AhkFJ">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3Ch18X" id="2KRUNf1rI45" role="30czhm">
+            <ref role="3Ch1V_" node="7F9023_N8Ey" resolve="WithDefault" />
+          </node>
+        </node>
+        <node concept="1I1voI" id="2KRUNf1rIyP" role="_fkuS">
+          <node concept="30bXR$" id="2KRUNf1rIBk" role="1I1voH" />
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -296,6 +296,9 @@
       <concept id="3352322994211036342" name="org.iets3.core.expr.base.structure.OneOfTarget" flags="ng" index="1kPOiQ">
         <child id="3352322994211036351" name="values" index="1kPOiZ" />
       </concept>
+      <concept id="3889855429450038473" name="org.iets3.core.expr.base.structure.EmptyValue" flags="ng" index="1I1voI">
+        <child id="3889855429450038474" name="type" index="1I1voH" />
+      </concept>
       <concept id="3281846772293355652" name="org.iets3.core.expr.base.structure.CastExpression" flags="ng" index="1KhrV4">
         <child id="2396718651941969300" name="expr" index="12NKtY" />
         <child id="3281846772293355657" name="expectedType" index="1KhrV9" />
@@ -15412,6 +15415,84 @@
             <node concept="3CkgUp" id="2KRUNf1qvqK" role="3Ckg_R">
               <ref role="3Ckhev" node="2KRUNf1n4ie" resolve="val3" />
               <node concept="30bdrP" id="2KRUNf1qvrE" role="3CkirI" />
+            </node>
+          </node>
+        </node>
+        <node concept="3CkkTf" id="MNXm1ErN04" role="_iOnC">
+          <property role="TrG5h" value="myTableWithDefaultsEmptyMixed" />
+          <property role="sAwqe" value="true" />
+          <node concept="3CkmCn" id="MNXm1ErN05" role="3Ckg67">
+            <property role="TrG5h" value="val1" />
+            <node concept="30bXR$" id="MNXm1ErN06" role="3CknON" />
+          </node>
+          <node concept="3CkmCn" id="MNXm1ErN07" role="3Ckg67">
+            <property role="TrG5h" value="val2" />
+            <node concept="30bXR$" id="MNXm1ErN08" role="3CknON" />
+          </node>
+          <node concept="3CkeKC" id="MNXm1ErN09" role="3CkFDl">
+            <property role="TrG5h" value="keyA" />
+            <node concept="3CkgUp" id="MNXm1ErN0a" role="3Ckg_R">
+              <ref role="3Ckhev" node="MNXm1ErN05" resolve="val1" />
+              <node concept="30bXRB" id="MNXm1ErN0b" role="3CkirI">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="MNXm1ErN0c" role="3Ckg_R">
+              <ref role="3Ckhev" node="MNXm1ErN07" resolve="val2" />
+              <node concept="30bXRB" id="MNXm1ErN0d" role="3CkirI">
+                <property role="30bXRw" value="2" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="MNXm1ErN0e" role="3Ckg_R">
+              <ref role="3Ckhev" node="MNXm1ErN0q" resolve="val3" />
+              <node concept="3Hp9p$" id="MNXm1ErN0f" role="3CkirI" />
+            </node>
+          </node>
+          <node concept="3CkeKC" id="MNXm1ErN0g" role="3CkFDl">
+            <property role="TrG5h" value="keyB" />
+            <node concept="3CkgUp" id="MNXm1ErN0h" role="3Ckg_R">
+              <ref role="3Ckhev" node="MNXm1ErN05" resolve="val1" />
+              <node concept="30bXRB" id="MNXm1ErN0i" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="MNXm1ErN0j" role="3Ckg_R">
+              <ref role="3Ckhev" node="MNXm1ErN07" resolve="val2" />
+              <node concept="30bXRB" id="MNXm1ErN0k" role="3CkirI">
+                <property role="30bXRw" value="4" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="MNXm1ErN0l" role="3Ckg_R">
+              <ref role="3Ckhev" node="MNXm1ErN0q" resolve="val3" />
+              <node concept="1I1voI" id="MNXm1ErN4w" role="3CkirI">
+                <node concept="30bdrU" id="MNXm1ErN4U" role="1I1voH" />
+              </node>
+              <node concept="7CXmI" id="MNXm1ErN0n" role="lGtFl">
+                <node concept="1TM$A" id="MNXm1ErN0o" role="7EUXB">
+                  <node concept="2PYRI3" id="MNXm1ErN0p" role="3lydEf">
+                    <ref role="39XzEq" to="rpit:2KRUNf1mOp9" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3CkmCn" id="MNXm1ErN0q" role="3Ckg67">
+            <property role="TrG5h" value="val3" />
+            <node concept="30bdrU" id="MNXm1ErN0r" role="3CknON" />
+          </node>
+          <node concept="3CkeKC" id="MNXm1ErN0s" role="3CkFDl">
+            <property role="TrG5h" value="keyC" />
+            <node concept="3CkgUp" id="MNXm1ErN0t" role="3Ckg_R">
+              <ref role="3Ckhev" node="MNXm1ErN05" resolve="val1" />
+              <node concept="3Hp9p$" id="MNXm1ErN0u" role="3CkirI" />
+            </node>
+            <node concept="3CkgUp" id="MNXm1ErN0v" role="3Ckg_R">
+              <ref role="3Ckhev" node="MNXm1ErN07" resolve="val2" />
+              <node concept="3Hp9p$" id="MNXm1ErN0w" role="3CkirI" />
+            </node>
+            <node concept="3CkgUp" id="MNXm1ErN0x" role="3Ckg_R">
+              <ref role="3Ckhev" node="MNXm1ErN0q" resolve="val3" />
+              <node concept="30bdrP" id="MNXm1ErN0y" role="3CkirI" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -646,6 +646,7 @@
       <concept id="231307155597471414" name="org.iets3.core.expr.data.structure.DataColDef" flags="ng" index="3CkmCn">
         <child id="231307155597474194" name="type" index="3CknON" />
       </concept>
+      <concept id="3186273868907248983" name="org.iets3.core.expr.data.structure.EmptyInput" flags="ng" index="3Hp9p$" />
     </language>
     <language id="f3eafff0-30d2-46d6-9150-f0f3b880ce27" name="org.iets3.core.expr.path">
       <concept id="7814222126786013807" name="org.iets3.core.expr.path.structure.PathElement" flags="ng" index="3o_JK">
@@ -15335,6 +15336,130 @@
           <node concept="7CXmI" id="4PRpvcZw5K1" role="lGtFl">
             <node concept="7OXhh" id="4PRpvcZw5K4" role="7EUXB">
               <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="3CkkTf" id="2KRUNf1mScG" role="_iOnC">
+          <property role="TrG5h" value="myTableWithDefaults" />
+          <property role="sAwqe" value="true" />
+          <node concept="3CkmCn" id="2KRUNf1mScI" role="3Ckg67">
+            <property role="TrG5h" value="val1" />
+            <node concept="30bXR$" id="2KRUNf1mScH" role="3CknON" />
+          </node>
+          <node concept="3CkmCn" id="2KRUNf1mScK" role="3Ckg67">
+            <property role="TrG5h" value="val2" />
+            <node concept="30bXR$" id="2KRUNf1mScJ" role="3CknON" />
+          </node>
+          <node concept="3CkeKC" id="2KRUNf1mScN" role="3CkFDl">
+            <property role="TrG5h" value="keyA" />
+            <node concept="3CkgUp" id="2KRUNf1mScO" role="3Ckg_R">
+              <ref role="3Ckhev" node="2KRUNf1mScI" resolve="val1" />
+              <node concept="30bXRB" id="2KRUNf1mScL" role="3CkirI">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="2KRUNf1mScP" role="3Ckg_R">
+              <ref role="3Ckhev" node="2KRUNf1mScK" resolve="val2" />
+              <node concept="30bXRB" id="2KRUNf1mScM" role="3CkirI">
+                <property role="30bXRw" value="2" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="2KRUNf1n4iJ" role="3Ckg_R">
+              <ref role="3Ckhev" node="2KRUNf1n4ie" resolve="val3" />
+              <node concept="3Hp9p$" id="2KRUNf1n4jc" role="3CkirI" />
+            </node>
+          </node>
+          <node concept="3CkeKC" id="2KRUNf1mScS" role="3CkFDl">
+            <property role="TrG5h" value="keyB" />
+            <node concept="3CkgUp" id="2KRUNf1mScT" role="3Ckg_R">
+              <ref role="3Ckhev" node="2KRUNf1mScI" resolve="val1" />
+              <node concept="30bXRB" id="2KRUNf1mScQ" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="2KRUNf1mScU" role="3Ckg_R">
+              <ref role="3Ckhev" node="2KRUNf1mScK" resolve="val2" />
+              <node concept="30bXRB" id="2KRUNf1qvm7" role="3CkirI">
+                <property role="30bXRw" value="4" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="2KRUNf1n4js" role="3Ckg_R">
+              <ref role="3Ckhev" node="2KRUNf1n4ie" resolve="val3" />
+              <node concept="3Hp9p$" id="2KRUNf1n4jr" role="3CkirI" />
+              <node concept="7CXmI" id="2KRUNf1n4Hs" role="lGtFl">
+                <node concept="1TM$A" id="2KRUNf1n4TX" role="7EUXB">
+                  <node concept="2PYRI3" id="2KRUNf1n4TY" role="3lydEf">
+                    <ref role="39XzEq" to="rpit:2KRUNf1mOp9" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3CkmCn" id="2KRUNf1n4ie" role="3Ckg67">
+            <property role="TrG5h" value="val3" />
+            <node concept="30bdrU" id="2KRUNf1n4i_" role="3CknON" />
+          </node>
+          <node concept="3CkeKC" id="2KRUNf1qvjX" role="3CkFDl">
+            <property role="TrG5h" value="keyC" />
+            <node concept="3CkgUp" id="2KRUNf1qvmY" role="3Ckg_R">
+              <ref role="3Ckhev" node="2KRUNf1mScI" resolve="val1" />
+              <node concept="3Hp9p$" id="2KRUNf1qvpI" role="3CkirI" />
+            </node>
+            <node concept="3CkgUp" id="2KRUNf1qvnz" role="3Ckg_R">
+              <ref role="3Ckhev" node="2KRUNf1mScK" resolve="val2" />
+              <node concept="3Hp9p$" id="2KRUNf1qvoK" role="3CkirI" />
+            </node>
+            <node concept="3CkgUp" id="2KRUNf1qvqK" role="3Ckg_R">
+              <ref role="3Ckhev" node="2KRUNf1n4ie" resolve="val3" />
+              <node concept="30bdrP" id="2KRUNf1qvrE" role="3CkirI" />
+            </node>
+          </node>
+        </node>
+        <node concept="3CkkTf" id="2KRUNf1n43w" role="_iOnC">
+          <property role="TrG5h" value="myTableNoLookup" />
+          <property role="sAwqe" value="false" />
+          <node concept="3CkmCn" id="2KRUNf1n43x" role="3Ckg67">
+            <property role="TrG5h" value="val1" />
+            <node concept="30bXR$" id="2KRUNf1n43y" role="3CknON" />
+          </node>
+          <node concept="3CkmCn" id="2KRUNf1n43z" role="3Ckg67">
+            <property role="TrG5h" value="val2" />
+            <node concept="30bXR$" id="2KRUNf1n43$" role="3CknON" />
+          </node>
+          <node concept="3CkeKC" id="2KRUNf1n43_" role="3CkFDl">
+            <property role="TrG5h" value="keyA" />
+            <node concept="3CkgUp" id="2KRUNf1n43A" role="3Ckg_R">
+              <ref role="3Ckhev" node="2KRUNf1n43x" resolve="val1" />
+              <node concept="30bXRB" id="2KRUNf1n43B" role="3CkirI">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="2KRUNf1n43C" role="3Ckg_R">
+              <ref role="3Ckhev" node="2KRUNf1n43z" resolve="val2" />
+              <node concept="30bXRB" id="2KRUNf1n43D" role="3CkirI">
+                <property role="30bXRw" value="2" />
+              </node>
+            </node>
+          </node>
+          <node concept="3CkeKC" id="2KRUNf1n43E" role="3CkFDl">
+            <property role="TrG5h" value="keyB" />
+            <node concept="3CkgUp" id="2KRUNf1n43F" role="3Ckg_R">
+              <ref role="3Ckhev" node="2KRUNf1n43x" resolve="val1" />
+              <node concept="30bXRB" id="2KRUNf1n43G" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="2KRUNf1n43H" role="3Ckg_R">
+              <ref role="3Ckhev" node="2KRUNf1n43z" resolve="val2" />
+              <node concept="3Hp9p$" id="2KRUNf1n43I" role="3CkirI">
+                <node concept="7CXmI" id="2KRUNf1n45X" role="lGtFl">
+                  <node concept="1TM$A" id="2KRUNf1n4i1" role="7EUXB">
+                    <node concept="2PYRI3" id="2KRUNf1n4i2" role="3lydEf">
+                      <ref role="39XzEq" to="rpit:2KRUNf1megR" />
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>


### PR DESCRIPTION
Adds support for `empty` inside of data tables that are marked for look ups. 

Adds a new interface for literals that represent `empty` to allow reuse of the logic when using language extensions that create domain specific representations of `empty`.

For more details on the design see the commit messages.

No breaking changes are introduced with this PR. 
