### PR TITLE
small fixes in KernelF

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
@@ -590,10 +590,11 @@
               <ref role="2pJxaS" to="700h:6zmBjqUinsw" resolve="ListType" />
               <node concept="2pIpSj" id="50smQ1VdESb" role="2pJxcM">
                 <ref role="2pIpSl" to="700h:6zmBjqUily6" resolve="baseType" />
-                <node concept="36biLy" id="50smQ1VdET_" role="28nt2d">
-                  <node concept="2YIFZM" id="5wDe8wA6zrn" role="36biLW">
-                    <ref role="37wK5l" to="xfg9:4bUWUHVjHt" resolve="createPositiveIntegerType" />
-                    <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+                <node concept="36biLy" id="2Q9SoGTmAxn" role="28nt2d">
+                  <node concept="2pJPEk" id="2Q9SoGTmJp3" role="36biLW">
+                    <node concept="2pJPED" id="2Q9SoGTmJqR" role="2pJPEn">
+                      <ref role="2pJxaS" to="mi3w:3nGzaxU$Pz8" resolve="DateType" />
+                    </node>
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -15033,26 +15033,88 @@
                                       </node>
                                     </node>
                                   </node>
-                                  <node concept="3clFbF" id="5Pgo_AS7kiX" role="3cqZAp">
-                                    <node concept="37vLTI" id="5Pgo_AS7lJY" role="3clFbG">
-                                      <node concept="2OqwBi" id="5Pgo_AS7kru" role="37vLTJ">
-                                        <node concept="37vLTw" id="5Pgo_AS7kiV" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="5Pgo_AS66To" resolve="result" />
-                                        </node>
-                                        <node concept="2OwXpG" id="5Pgo_AS7kUw" role="2OqNvi">
-                                          <ref role="2Oxat5" node="ub9nkyQiZj" resolve="errorMessage" />
+                                  <node concept="3clFbJ" id="2Q9SoGTc87g" role="3cqZAp">
+                                    <node concept="3clFbS" id="2Q9SoGTc87i" role="3clFbx">
+                                      <node concept="3clFbF" id="2Q9SoGTc9zr" role="3cqZAp">
+                                        <node concept="37vLTI" id="2Q9SoGTcbWi" role="3clFbG">
+                                          <node concept="2ShNRf" id="2Q9SoGTcceg" role="37vLTx">
+                                            <node concept="1pGfFk" id="2Q9SoGTcDI8" role="2ShVmc">
+                                              <ref role="37wK5l" to="oq0c:4AahbtULJ$q" resolve="MessageValue" />
+                                              <node concept="BsUDl" id="2Q9SoGTcE4L" role="37wK5m">
+                                                <ref role="37wK5l" node="5Pgo_AS7m_e" resolve="formatErrorMessage" />
+                                                <node concept="37vLTw" id="2Q9SoGTcEr$" role="37wK5m">
+                                                  <ref role="3cqZAo" node="6vw$0gDvv6e" resolve="value" />
+                                                </node>
+                                                <node concept="37vLTw" id="2Q9SoGTcES$" role="37wK5m">
+                                                  <ref role="3cqZAo" node="6vw$0gDw5_l" resolve="matcher" />
+                                                </node>
+                                              </node>
+                                              <node concept="2OqwBi" id="2Q9SoGTcIR4" role="37wK5m">
+                                                <node concept="2OqwBi" id="2Q9SoGTcHOK" role="2Oq$k0">
+                                                  <node concept="1eOMI4" id="2Q9SoGTcFyU" role="2Oq$k0">
+                                                    <node concept="10QFUN" id="2Q9SoGTcFyR" role="1eOMHV">
+                                                      <node concept="3uibUv" id="2Q9SoGTcFV$" role="10QFUM">
+                                                        <ref role="3uigEE" to="vzlu:5Pgo_AS6VnV" resolve="ConstraintFailed" />
+                                                      </node>
+                                                      <node concept="37vLTw" id="2Q9SoGTcHl4" role="10QFUP">
+                                                        <ref role="3cqZAo" node="6vw$0gDvv6e" resolve="value" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                  <node concept="2OwXpG" id="2Q9SoGTcIl1" role="2OqNvi">
+                                                    <ref role="2Oxat5" to="vzlu:5Pgo_ASlIQD" resolve="msg" />
+                                                  </node>
+                                                </node>
+                                                <node concept="liA8E" id="2Q9SoGTcJoG" role="2OqNvi">
+                                                  <ref role="37wK5l" to="oq0c:4AahbtURenE" resolve="source" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="2OqwBi" id="2Q9SoGTca13" role="37vLTJ">
+                                            <node concept="37vLTw" id="2Q9SoGTc9zp" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="5Pgo_AS66To" resolve="result" />
+                                            </node>
+                                            <node concept="2OwXpG" id="2Q9SoGTca$w" role="2OqNvi">
+                                              <ref role="2Oxat5" node="ub9nkyQiZj" resolve="errorMessage" />
+                                            </node>
+                                          </node>
                                         </node>
                                       </node>
-                                      <node concept="2ShNRf" id="6C0OSEaHFUJ" role="37vLTx">
-                                        <node concept="1pGfFk" id="6C0OSEaHGIy" role="2ShVmc">
-                                          <ref role="37wK5l" to="oq0c:4AahbtULK5l" resolve="MessageValue" />
-                                          <node concept="BsUDl" id="5Pgo_AS7sYK" role="37wK5m">
-                                            <ref role="37wK5l" node="5Pgo_AS7m_e" resolve="formatErrorMessage" />
-                                            <node concept="37vLTw" id="5Pgo_AS7tmT" role="37wK5m">
-                                              <ref role="3cqZAo" node="6vw$0gDvv6e" resolve="value" />
+                                    </node>
+                                    <node concept="2ZW3vV" id="2Q9SoGTc8RX" role="3clFbw">
+                                      <node concept="3uibUv" id="2Q9SoGTc9dW" role="2ZW6by">
+                                        <ref role="3uigEE" to="vzlu:5Pgo_AS6VnV" resolve="ConstraintFailed" />
+                                      </node>
+                                      <node concept="37vLTw" id="2Q9SoGTc8u2" role="2ZW6bz">
+                                        <ref role="3cqZAo" node="6vw$0gDvv6e" resolve="value" />
+                                      </node>
+                                    </node>
+                                    <node concept="9aQIb" id="2Q9SoGTcKc4" role="9aQIa">
+                                      <node concept="3clFbS" id="2Q9SoGTcKc5" role="9aQI4">
+                                        <node concept="3clFbF" id="5Pgo_AS7kiX" role="3cqZAp">
+                                          <node concept="37vLTI" id="5Pgo_AS7lJY" role="3clFbG">
+                                            <node concept="2OqwBi" id="5Pgo_AS7kru" role="37vLTJ">
+                                              <node concept="37vLTw" id="5Pgo_AS7kiV" role="2Oq$k0">
+                                                <ref role="3cqZAo" node="5Pgo_AS66To" resolve="result" />
+                                              </node>
+                                              <node concept="2OwXpG" id="5Pgo_AS7kUw" role="2OqNvi">
+                                                <ref role="2Oxat5" node="ub9nkyQiZj" resolve="errorMessage" />
+                                              </node>
                                             </node>
-                                            <node concept="37vLTw" id="5Pgo_AS7vkf" role="37wK5m">
-                                              <ref role="3cqZAo" node="6vw$0gDw5_l" resolve="matcher" />
+                                            <node concept="2ShNRf" id="6C0OSEaHFUJ" role="37vLTx">
+                                              <node concept="1pGfFk" id="6C0OSEaHGIy" role="2ShVmc">
+                                                <ref role="37wK5l" to="oq0c:4AahbtULK5l" resolve="MessageValue" />
+                                                <node concept="BsUDl" id="5Pgo_AS7sYK" role="37wK5m">
+                                                  <ref role="37wK5l" node="5Pgo_AS7m_e" resolve="formatErrorMessage" />
+                                                  <node concept="37vLTw" id="5Pgo_AS7tmT" role="37wK5m">
+                                                    <ref role="3cqZAo" node="6vw$0gDvv6e" resolve="value" />
+                                                  </node>
+                                                  <node concept="37vLTw" id="5Pgo_AS7vkf" role="37wK5m">
+                                                    <ref role="3cqZAo" node="6vw$0gDw5_l" resolve="matcher" />
+                                                  </node>
+                                                </node>
+                                              </node>
                                             </node>
                                           </node>
                                         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -9278,6 +9278,22 @@
         <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
       </node>
       <node concept="3clFbS" id="4CksDrmwwe0" role="3clF47">
+        <node concept="3clFbJ" id="2Q9SoGTlFLk" role="3cqZAp">
+          <node concept="3clFbS" id="2Q9SoGTlFLm" role="3clFbx">
+            <node concept="3cpWs6" id="2Q9SoGTlJho" role="3cqZAp">
+              <node concept="10Nm6u" id="2Q9SoGTlJQK" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="2Q9SoGTlHUm" role="3clFbw">
+            <node concept="2OqwBi" id="2Q9SoGTlG6m" role="2Oq$k0">
+              <node concept="13iPFW" id="2Q9SoGTlFPK" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="2Q9SoGTlGjE" role="2OqNvi">
+                <ref role="3TtcxE" to="yv47:6WstIz8MK6a" resolve="selectors" />
+              </node>
+            </node>
+            <node concept="1v1jN8" id="2Q9SoGTlJgs" role="2OqNvi" />
+          </node>
+        </node>
         <node concept="3cpWs8" id="7rdMSLlhcYT" role="3cqZAp">
           <node concept="3cpWsn" id="7rdMSLlhcYU" role="3cpWs9">
             <property role="TrG5h" value="ctx" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/structure.mps
@@ -1172,7 +1172,7 @@
       <property role="IQ2ns" value="8006404979731136906" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="selectors" />
-      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <property role="20lbJX" value="fLJekj6/_1__n" />
       <ref role="20lvS9" node="6WstIz8MKZd" resolve="EnumIsInSelector" />
     </node>
   </node>


### PR DESCRIPTION
- On assert-that test cases, there is the option `go to constraint`. This was broken and is fixed  for all cases in which a constraint fail leads to a failing interpreter test

- `enum-literal.isIn()` lead to an exception, because an empty `IsInTarget`  could not be processed. The case that the `IsInTarget` is empty is now handled. In addition, an empty `IsInTarget` is not allowed anymore, because it is not meaningful

- The type inference os the `IntervalsOp` now returns a list<DateType> instead of a list<NumberType> which is
consistent with the interpreter.

This PR does not contain breaking changes 