### PR TITLE
Fix/modelchecker test in expr os

### DIFF
--- a/code/languages/org.iets3.opensource/_spreferences/TestExecutionPreferences/models/org.iets3.opensource.__spreferences.TestExecutionPreferences.mps
+++ b/code/languages/org.iets3.opensource/_spreferences/TestExecutionPreferences/models/org.iets3.opensource.__spreferences.TestExecutionPreferences.mps
@@ -20,7 +20,7 @@
   </registry>
   <node concept="3ZOQsN" id="6pNCASbHXH8">
     <property role="TrG5h" value="KernelFTestExecution" />
-    <node concept="3ZOXxk" id="4Uid4MjWPro" role="3ZOXzE" />
+    <node concept="3ZOXxk" id="2Y$0swB6KRb" role="3ZOXzE" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/mutable@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/mutable@tests.mps
@@ -4721,7 +4721,9 @@
       </node>
       <node concept="2lgajW" id="4pyjK6aOvwF" role="28QfE6" />
       <node concept="39w5ZF" id="4pyjK6aYTK9" role="1ahQXP">
-        <node concept="pf3Wd" id="5zQvLw7g6EF" role="pf3W8" />
+        <node concept="pf3Wd" id="5zQvLw7g6EF" role="pf3W8">
+          <node concept="UmHTt" id="2Y$0swAZK5R" role="pf3We" />
+        </node>
         <node concept="1QScDb" id="4pyjK6aYVBV" role="39w5ZG">
           <node concept="3sQ2Ir" id="4pyjK6aYWI4" role="1QScD9" />
           <node concept="1ZmhP4" id="4pyjK6aYV5v" role="30czhm">
@@ -5204,7 +5206,9 @@
           <node concept="17riQX" id="mQGcCvAozg" role="17vUwr">
             <node concept="1aduha" id="mQGcCvAozh" role="17vFbk">
               <node concept="39w5ZF" id="mQGcCvAozi" role="1aduh9">
-                <node concept="pf3Wd" id="5zQvLw7g6EG" role="pf3W8" />
+                <node concept="pf3Wd" id="5zQvLw7g6EG" role="pf3W8">
+                  <node concept="UmHTt" id="2Y$0swAZK66" role="pf3We" />
+                </node>
                 <node concept="UmaEC" id="mQGcCvAozj" role="39w5ZE">
                   <node concept="1af_rf" id="mQGcCvAozk" role="UmaED">
                     <ref role="1afhQb" node="4pyjK6aZ2Fb" resolve="offerBoxById" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.dectabs@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.dectabs@tests.mps
@@ -81,6 +81,10 @@
         <child id="5115872837156802411" name="expr" index="30czhm" />
       </concept>
       <concept id="5115872837156855227" name="org.iets3.core.expr.base.structure.UnaryMinusExpression" flags="ng" index="30cIq6" />
+      <concept id="5955298286257997823" name="org.iets3.core.expr.base.structure.ColonCast" flags="ng" index="1LgZZ2">
+        <child id="5955298286257997833" name="type" index="1LgZ0O" />
+        <child id="5955298286257997830" name="expr" index="1LgZ0V" />
+      </concept>
     </language>
     <language id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext">
       <concept id="2557074442922380897" name="de.slisson.mps.richtext.structure.Text" flags="ng" index="19SGf9">
@@ -209,14 +213,32 @@
           </node>
         </node>
         <node concept="UJIhM" id="5crSXLqhzY" role="UJIgW">
-          <node concept="30cIq6" id="5crSXM0kqz" role="UJIhC">
-            <node concept="30bXRB" id="5crSXM0kAi" role="30czhm">
-              <property role="30bXRw" value="1" />
+          <node concept="1LgZZ2" id="2Y$0swAEOyw" role="UJIhC">
+            <node concept="mLuIC" id="2Y$0swAEOHk" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swAEPdf" role="2gteSx">
+                <property role="2gteSQ" value="-2" />
+                <property role="2gteSD" value="-1" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swAEPHH" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="2Y$0swAEMNJ" role="1LgZ0V">
+              <property role="30bXRw" value="-2" />
             </node>
           </node>
-          <node concept="30cIq6" id="5crSXM0kO0" role="UJIhC">
-            <node concept="30bXRB" id="5crSXM0kOd" role="30czhm">
-              <property role="30bXRw" value="2" />
+          <node concept="1LgZZ2" id="2Y$0swAEQ2Y" role="UJIhC">
+            <node concept="mLuIC" id="2Y$0swAEQeR" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swAEQpO" role="2gteSx">
+                <property role="2gteSQ" value="-2" />
+                <property role="2gteSD" value="-1" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swAEQUu" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="2Y$0swAEKRs" role="1LgZ0V">
+              <property role="30bXRw" value="-1" />
             </node>
           </node>
         </node>
@@ -1933,51 +1955,183 @@
       <property role="0Rz4W" value="467264629" />
       <node concept="UJIhK" id="5crSXLPslp" role="1ahQXP">
         <node concept="UJIhL" id="5crSXLPsl$" role="UJIgT">
-          <node concept="30bXRB" id="5crSXLPsly" role="UJIhC">
-            <property role="30bXRw" value="1" />
+          <node concept="1LgZZ2" id="2Y$0swAF1fQ" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPsly" role="1LgZ0V">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swAF1sQ" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swAF1sR" role="2gteSx">
+                <property role="2gteSQ" value="1" />
+                <property role="2gteSD" value="2" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swAF1sS" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
-          <node concept="30bXRB" id="5crSXLPslz" role="UJIhC">
-            <property role="30bXRw" value="2" />
+          <node concept="1LgZZ2" id="2Y$0swAF1DH" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPslz" role="1LgZ0V">
+              <property role="30bXRw" value="2" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swAF1RA" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swAF1RB" role="2gteSx">
+                <property role="2gteSQ" value="1" />
+                <property role="2gteSD" value="2" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swAF1RC" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
         </node>
         <node concept="UJIhL" id="5crSXLPslB" role="UJIgT">
-          <node concept="30bXRB" id="5crSXLPsl_" role="UJIhC">
-            <property role="30bXRw" value="3" />
+          <node concept="1LgZZ2" id="2Y$0swAF24J" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPsl_" role="1LgZ0V">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swAF2iQ" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swAF2iR" role="2gteSx">
+                <property role="2gteSQ" value="3" />
+                <property role="2gteSD" value="4" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swAF2iS" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
-          <node concept="30bXRB" id="5crSXLPslA" role="UJIhC">
-            <property role="30bXRw" value="4" />
+          <node concept="1LgZZ2" id="2Y$0swAF2wh" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPslA" role="1LgZ0V">
+              <property role="30bXRw" value="4" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swAF2I6" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swAF2I7" role="2gteSx">
+                <property role="2gteSQ" value="3" />
+                <property role="2gteSD" value="4" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swAF2I8" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
         </node>
         <node concept="UJIhL" id="5crSXLPslE" role="UJIgT">
-          <node concept="30bXRB" id="5crSXLPslC" role="UJIhC">
-            <property role="30bXRw" value="5" />
+          <node concept="1LgZZ2" id="2Y$0swAF2Wr" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPslC" role="1LgZ0V">
+              <property role="30bXRw" value="5" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swAF448" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swAF449" role="2gteSx">
+                <property role="2gteSQ" value="5" />
+                <property role="2gteSD" value="6" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swAF44a" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
-          <node concept="30bXRB" id="5crSXLPslD" role="UJIhC">
-            <property role="30bXRw" value="6" />
+          <node concept="1LgZZ2" id="2Y$0swAF4iJ" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPslD" role="1LgZ0V">
+              <property role="30bXRw" value="6" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swAF4x8" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swAF4x9" role="2gteSx">
+                <property role="2gteSQ" value="5" />
+                <property role="2gteSD" value="6" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swAF4xa" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
         </node>
         <node concept="UJIhM" id="5crSXLPslH" role="UJIgW">
-          <node concept="30bXRB" id="5crSXLPslF" role="UJIhC">
-            <property role="30bXRw" value="1" />
+          <node concept="1LgZZ2" id="2Y$0swAEWJU" role="UJIhC">
+            <node concept="mLuIC" id="2Y$0swAEWVB" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swAEX7b" role="2gteSx">
+                <property role="2gteSQ" value="1" />
+                <property role="2gteSD" value="2" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swAEXtg" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="5crSXLPslF" role="1LgZ0V">
+              <property role="30bXRw" value="1" />
+            </node>
           </node>
-          <node concept="30bXRB" id="5crSXLPslG" role="UJIhC">
-            <property role="30bXRw" value="2" />
+          <node concept="1LgZZ2" id="2Y$0swAEXNo" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPslG" role="1LgZ0V">
+              <property role="30bXRw" value="2" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swAEXZr" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swAEXZs" role="2gteSx">
+                <property role="2gteSQ" value="1" />
+                <property role="2gteSD" value="2" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swAEXZt" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
         </node>
         <node concept="UJIhM" id="5crSXLPslK" role="UJIgW">
-          <node concept="30bXRB" id="5crSXLPslI" role="UJIhC">
-            <property role="30bXRw" value="3" />
+          <node concept="1LgZZ2" id="2Y$0swAEYaS" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPslI" role="1LgZ0V">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swAEYmF" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swAEYmG" role="2gteSx">
+                <property role="2gteSQ" value="3" />
+                <property role="2gteSD" value="4" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swAEYmH" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
-          <node concept="30bXRB" id="5crSXLPslJ" role="UJIhC">
-            <property role="30bXRw" value="4" />
+          <node concept="1LgZZ2" id="2Y$0swAEYyS" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPslJ" role="1LgZ0V">
+              <property role="30bXRw" value="4" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swAEYJ1" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swAEYJ2" role="2gteSx">
+                <property role="2gteSQ" value="3" />
+                <property role="2gteSD" value="4" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swAEYJ3" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
         </node>
         <node concept="UJIhM" id="5crSXLPslN" role="UJIgW">
-          <node concept="30bXRB" id="5crSXLPslL" role="UJIhC">
-            <property role="30bXRw" value="5" />
+          <node concept="1LgZZ2" id="2Y$0swAEZF2" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPslL" role="1LgZ0V">
+              <property role="30bXRw" value="5" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swAEZRp" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swAEZRq" role="2gteSx">
+                <property role="2gteSQ" value="5" />
+                <property role="2gteSD" value="6" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swAEZRr" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
-          <node concept="30bXRB" id="5crSXLPslM" role="UJIhC">
-            <property role="30bXRw" value="6" />
+          <node concept="1LgZZ2" id="2Y$0swAF04f" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPslM" role="1LgZ0V">
+              <property role="30bXRw" value="6" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swAF0gW" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swAF0gX" role="2gteSx">
+                <property role="2gteSQ" value="5" />
+                <property role="2gteSD" value="6" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swAF0gY" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
         </node>
         <node concept="UJIhQ" id="5crSXLPslP" role="UJIgL">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.numbers@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.numbers@tests.mps
@@ -1729,7 +1729,7 @@
         <property role="TrG5h" value="this" />
         <node concept="mLuIC" id="1IomA9vYtGy" role="3ix9CU">
           <node concept="2gteS_" id="1IomA9vYtHp" role="2gteVg">
-            <property role="2gteVv" value="2" />
+            <property role="2gteVv" value="3" />
           </node>
         </node>
       </node>
@@ -2000,8 +2000,8 @@
       </node>
       <node concept="_fkuZ" id="1IomA9wzlh_" role="_fkp5">
         <node concept="_fku$" id="1IomA9wzlhA" role="_fkur" />
-        <node concept="1QScDb" id="1IomA9wzwAM" role="_fkuY">
-          <node concept="1He9k6" id="1IomA9wzxix" role="1QScD9">
+        <node concept="1QScDb" id="2Y$0swB6fnn" role="_fkuY">
+          <node concept="1He9k6" id="2Y$0swB6fsD" role="1QScD9">
             <ref role="1He9kT" node="1IomA9vXFim" resolve="trunc0" />
           </node>
           <node concept="1aduha" id="1IomA9wzlhB" role="30czhm">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.options@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.options@tests.mps
@@ -119,6 +119,10 @@
         <child id="2396718651941969300" name="expr" index="12NKtY" />
         <child id="3281846772293355657" name="expectedType" index="1KhrV9" />
       </concept>
+      <concept id="5955298286257997823" name="org.iets3.core.expr.base.structure.ColonCast" flags="ng" index="1LgZZ2">
+        <child id="5955298286257997833" name="type" index="1LgZ0O" />
+        <child id="5955298286257997830" name="expr" index="1LgZ0V" />
+      </concept>
       <concept id="9002563722476995145" name="org.iets3.core.expr.base.structure.DotExpression" flags="ng" index="1QScDb">
         <child id="9002563722476995147" name="target" index="1QScD9" />
       </concept>
@@ -4235,13 +4239,16 @@
       <node concept="3iBYfx" id="6KhzXd8xA3o" role="2zPyp_">
         <node concept="ygwf7" id="6KhzXd8xA3p" role="ygBzB">
           <node concept="Uns6S" id="6KhzXd8xA3q" role="ygwf4">
-            <node concept="30bdrU" id="6KhzXd8xA3r" role="Uns6T" />
+            <node concept="30bdrU" id="2Y$0swB6Mt1" role="Uns6T" />
           </node>
         </node>
         <node concept="30bdrP" id="6KhzXd8xAdq" role="3iBYfI">
           <property role="30bdrQ" value="S1" />
         </node>
-        <node concept="UmHTt" id="6KhzXd8xAgt" role="3iBYfI" />
+        <node concept="1LgZZ2" id="2Y$0swB6OdG" role="3iBYfI">
+          <node concept="30bdrU" id="2Y$0swB6Oha" role="1LgZ0O" />
+          <node concept="UmHTt" id="6KhzXd8xAgt" role="1LgZ0V" />
+        </node>
         <node concept="30bdrP" id="6KhzXd8xAh6" role="3iBYfI">
           <property role="30bdrQ" value="S2" />
         </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/utils@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/utils@tests.mps
@@ -143,6 +143,10 @@
         <child id="2245119349904068815" name="max" index="1eiLjC" />
         <child id="2245119349904068814" name="min" index="1eiLjD" />
       </concept>
+      <concept id="5955298286257997823" name="org.iets3.core.expr.base.structure.ColonCast" flags="ng" index="1LgZZ2">
+        <child id="5955298286257997833" name="type" index="1LgZ0O" />
+        <child id="5955298286257997830" name="expr" index="1LgZ0V" />
+      </concept>
       <concept id="9002563722476995145" name="org.iets3.core.expr.base.structure.DotExpression" flags="ng" index="1QScDb">
         <child id="9002563722476995147" name="target" index="1QScD9" />
       </concept>
@@ -2974,51 +2978,183 @@
       <property role="0Rz4W" value="467264629" />
       <node concept="UJIhK" id="5crSXLPslp" role="1ahQXP">
         <node concept="UJIhL" id="5crSXLPsl$" role="UJIgT">
-          <node concept="30bXRB" id="5crSXLPsly" role="UJIhC">
-            <property role="30bXRw" value="1" />
+          <node concept="1LgZZ2" id="2Y$0swBeqO3" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPsly" role="1LgZ0V">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swBer1F" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swBer1G" role="2gteSx">
+                <property role="2gteSQ" value="1" />
+                <property role="2gteSD" value="2" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swBer1H" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
-          <node concept="30bXRB" id="5crSXLPslz" role="UJIhC">
-            <property role="30bXRw" value="2" />
+          <node concept="1LgZZ2" id="2Y$0swBerey" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPslz" role="1LgZ0V">
+              <property role="30bXRw" value="2" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swBerrN" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swBerrO" role="2gteSx">
+                <property role="2gteSQ" value="1" />
+                <property role="2gteSD" value="2" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swBerrP" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
         </node>
         <node concept="UJIhL" id="5crSXLPslB" role="UJIgT">
-          <node concept="30bXRB" id="5crSXLPsl_" role="UJIhC">
-            <property role="30bXRw" value="3" />
+          <node concept="1LgZZ2" id="2Y$0swBerD$" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPsl_" role="1LgZ0V">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swBerR3" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swBerR4" role="2gteSx">
+                <property role="2gteSQ" value="3" />
+                <property role="2gteSD" value="4" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swBerR5" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
-          <node concept="30bXRB" id="5crSXLPslA" role="UJIhC">
-            <property role="30bXRw" value="4" />
+          <node concept="1LgZZ2" id="2Y$0swBes4u" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPslA" role="1LgZ0V">
+              <property role="30bXRw" value="4" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swBesiV" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swBesiW" role="2gteSx">
+                <property role="2gteSQ" value="3" />
+                <property role="2gteSD" value="4" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swBesiX" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
         </node>
         <node concept="UJIhL" id="5crSXLPslE" role="UJIgT">
-          <node concept="30bXRB" id="5crSXLPslC" role="UJIhC">
-            <property role="30bXRw" value="5" />
+          <node concept="1LgZZ2" id="2Y$0swBeswC" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPslC" role="1LgZ0V">
+              <property role="30bXRw" value="5" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swBetbO" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swBetbP" role="2gteSx">
+                <property role="2gteSQ" value="5" />
+                <property role="2gteSD" value="6" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swBetbQ" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
-          <node concept="30bXRB" id="5crSXLPslD" role="UJIhC">
-            <property role="30bXRw" value="6" />
+          <node concept="1LgZZ2" id="2Y$0swBetpN" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPslD" role="1LgZ0V">
+              <property role="30bXRw" value="6" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swBetCO" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swBetCP" role="2gteSx">
+                <property role="2gteSQ" value="5" />
+                <property role="2gteSD" value="6" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swBetCQ" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
         </node>
         <node concept="UJIhM" id="5crSXLPslH" role="UJIgW">
-          <node concept="30bXRB" id="5crSXLPslF" role="UJIhC">
-            <property role="30bXRw" value="1" />
+          <node concept="1LgZZ2" id="2Y$0swBen6b" role="UJIhC">
+            <node concept="mLuIC" id="2Y$0swBenhS" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swBensY" role="2gteSx">
+                <property role="2gteSQ" value="1" />
+                <property role="2gteSD" value="2" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swBenN3" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="5crSXLPslF" role="1LgZ0V">
+              <property role="30bXRw" value="1" />
+            </node>
           </node>
-          <node concept="30bXRB" id="5crSXLPslG" role="UJIhC">
-            <property role="30bXRw" value="2" />
+          <node concept="1LgZZ2" id="2Y$0swBeo9P" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPslG" role="1LgZ0V">
+              <property role="30bXRw" value="2" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swBeolv" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swBeolw" role="2gteSx">
+                <property role="2gteSQ" value="1" />
+                <property role="2gteSD" value="2" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swBeolx" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
         </node>
         <node concept="UJIhM" id="5crSXLPslK" role="UJIgW">
-          <node concept="30bXRB" id="5crSXLPslI" role="UJIhC">
-            <property role="30bXRw" value="3" />
+          <node concept="1LgZZ2" id="2Y$0swBeoxq" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPslI" role="1LgZ0V">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swBeoHd" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swBeoHe" role="2gteSx">
+                <property role="2gteSQ" value="3" />
+                <property role="2gteSD" value="4" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swBeoHf" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
-          <node concept="30bXRB" id="5crSXLPslJ" role="UJIhC">
-            <property role="30bXRw" value="4" />
+          <node concept="1LgZZ2" id="2Y$0swBepgy" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPslJ" role="1LgZ0V">
+              <property role="30bXRw" value="4" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swBepte" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swBeptf" role="2gteSx">
+                <property role="2gteSQ" value="3" />
+                <property role="2gteSD" value="4" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swBeptg" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
         </node>
         <node concept="UJIhM" id="5crSXLPslN" role="UJIgW">
-          <node concept="30bXRB" id="5crSXLPslL" role="UJIhC">
-            <property role="30bXRw" value="5" />
+          <node concept="1LgZZ2" id="2Y$0swBepDf" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPslL" role="1LgZ0V">
+              <property role="30bXRw" value="5" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swBepPA" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swBepPB" role="2gteSx">
+                <property role="2gteSQ" value="5" />
+                <property role="2gteSD" value="6" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swBepPC" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
-          <node concept="30bXRB" id="5crSXLPslM" role="UJIhC">
-            <property role="30bXRw" value="6" />
+          <node concept="1LgZZ2" id="2Y$0swBeqqG" role="UJIhC">
+            <node concept="30bXRB" id="5crSXLPslM" role="1LgZ0V">
+              <property role="30bXRw" value="6" />
+            </node>
+            <node concept="mLuIC" id="2Y$0swBeqBu" role="1LgZ0O">
+              <node concept="2gteSW" id="2Y$0swBeqBv" role="2gteSx">
+                <property role="2gteSQ" value="5" />
+                <property role="2gteSD" value="6" />
+              </node>
+              <node concept="2gteS_" id="2Y$0swBeqBw" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
           </node>
         </node>
         <node concept="UJIhQ" id="5crSXLPslP" role="UJIgL">


### PR DESCRIPTION
### What changed
#### Minor: Fixing model-checker errors in tests of module tests.in.expr.os
- add explicit cast to *number* for descendants of `DecTabRowHeader`
- set *none* where `else.expr.isNull` in if-then-else statement
-  test-suite option: cast *none* to *string* in `list<opt<string>>`
-  test-suite precision: ext fun trunc0(): changed precision to 3

### Other
- mps-version: 2020.3.1
- no breaking changes
- [ ] Pull master


**See issue** [Fix model checker errors (tests.in.expr.os)](https://github.com/IETS3/iets3.opensource/issues/438)
