### PR TITLE
Migration of the context actions to the MPS context actions

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/editor.mps
@@ -6,6 +6,8 @@
     <use id="e359e0a2-368a-4c40-ae2a-e5a09f9cfd58" name="de.itemis.mps.editor.math.notations" version="-1" />
     <use id="766348f7-6a67-4b85-9323-384840132299" name="de.itemis.mps.editor.math" version="-1" />
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <use id="b1c7d06f-525d-43b5-9b0a-2fc8f7f076ba" name="jetbrains.mps.editor.contextActionsTool.lang.menus" version="0" />
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -13,11 +15,17 @@
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="ze1i" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.runtime(MPS.Core/)" />
+    <import index="vndm" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.language(MPS.Core/)" />
+    <import index="zce0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.smodel.action(MPS.Editor/)" />
+    <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="1qv1" ref="r:c53b8bbc-6142-4787-a6e4-66310b772b37(org.iets3.core.expr.math.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="itrz" ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)" implicit="true" />
     <import index="boxz" ref="r:89e950b9-8c66-4fca-a5c0-614e0548d83a(org.iets3.core.expr.math.behavior)" implicit="true" />
-    <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="u78q" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.typesystem.inference(MPS.Core/)" implicit="true" />
   </imports>
@@ -58,6 +66,10 @@
       <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ng" index="2Z_bC8">
         <reference id="1630016958698373342" name="concept" index="2ZyFGn" />
       </concept>
+      <concept id="1630016958697286851" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_parameterObject" flags="ng" index="2ZBlsa" />
+      <concept id="1630016958697057551" name="jetbrains.mps.lang.editor.structure.IMenuPartParameterized" flags="ng" index="2ZBHr6">
+        <child id="1630016958697057552" name="parameterType" index="2ZBHrp" />
+      </concept>
       <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
       <concept id="1233759184865" name="jetbrains.mps.lang.editor.structure.PunctuationRightStyleClassItem" flags="ln" index="11LMrY" />
       <concept id="1221057094638" name="jetbrains.mps.lang.editor.structure.QueryFunction_Integer" flags="in" index="1cFabM" />
@@ -68,9 +80,13 @@
       <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
         <child id="1088186146602" name="editorComponent" index="1sWHZn" />
       </concept>
+      <concept id="7291101478617127464" name="jetbrains.mps.lang.editor.structure.IExtensibleTransformationMenuPart" flags="ng" index="1joUw2">
+        <child id="8954657570916349207" name="features" index="2jZA2a" />
+      </concept>
       <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
       </concept>
+      <concept id="7580468736840446506" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_model" flags="nn" index="1rpKSd" />
       <concept id="1088185857835" name="jetbrains.mps.lang.editor.structure.InlineEditorComponent" flags="ig" index="1sVBvm" />
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
         <property id="1140017977771" name="readOnly" index="1Intyy" />
@@ -91,6 +107,11 @@
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
+      <concept id="4233361609415247331" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_Parameter" flags="ig" index="1GhMSn" />
+      <concept id="4233361609415240997" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_Parameterized" flags="ng" index="1GhOrh">
+        <child id="4233361609415240998" name="part" index="1GhOri" />
+        <child id="4233361609415241000" name="parameterQuery" index="1GhOrs" />
+      </concept>
       <concept id="1225898583838" name="jetbrains.mps.lang.editor.structure.ReadOnlyModelAccessor" flags="ng" index="1HfYo3">
         <child id="1225898971709" name="getter" index="1Hhtcw" />
       </concept>
@@ -113,10 +134,14 @@
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
@@ -136,11 +161,16 @@
         <child id="1070534934092" name="expression" index="10QFUP" />
       </concept>
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -158,6 +188,7 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <property id="4467513934994662257" name="forceMultiLine" index="TyiWK" />
         <property id="4467513934994662256" name="forceOneLine" index="TyiWL" />
@@ -176,8 +207,15 @@
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
@@ -187,14 +225,37 @@
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="b1c7d06f-525d-43b5-9b0a-2fc8f7f076ba" name="jetbrains.mps.editor.contextActionsTool.lang.menus">
+      <concept id="8954657570916343208" name="jetbrains.mps.editor.contextActionsTool.lang.menus.structure.TransformationLocation_ContextActionsTool" flags="ng" index="2jZ$wP" />
+      <concept id="8954657570916343205" name="jetbrains.mps.editor.contextActionsTool.lang.menus.structure.TransformationFeature_Tooltip" flags="ng" index="2jZ$wS" />
+      <concept id="8954657570916342474" name="jetbrains.mps.editor.contextActionsTool.lang.menus.structure.QueryFunction_TransformationMenu_Icon" flags="ig" index="2jZ$Xn" />
+      <concept id="8954657570916342471" name="jetbrains.mps.editor.contextActionsTool.lang.menus.structure.TransformationFeature_Icon" flags="ng" index="2jZ$Xq">
+        <child id="8954657570916343203" name="query" index="2jZ$wY" />
+      </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
@@ -221,6 +282,9 @@
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
       <concept id="1175594888091" name="jetbrains.mps.lang.typesystem.structure.TypeCheckerAccessExpression" flags="nn" index="2QUAEa" />
       <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
+    </language>
+    <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
+      <concept id="7776141288922801652" name="jetbrains.mps.lang.actions.structure.NF_Concept_NewInstance" flags="nn" index="q_SaT" />
     </language>
     <language id="e359e0a2-368a-4c40-ae2a-e5a09f9cfd58" name="de.itemis.mps.editor.math.notations">
       <concept id="8658283006837849794" name="de.itemis.mps.editor.math.notations.structure.SqrtEditor" flags="ng" index="jtDx7">
@@ -259,15 +323,47 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1204834851141" name="jetbrains.mps.lang.smodel.structure.PoundExpression" flags="ng" index="25Kdxt">
+        <child id="1204834868751" name="expression" index="25KhWn" />
+      </concept>
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
+      <concept id="4497478346159780083" name="jetbrains.mps.lang.smodel.structure.LanguageRefExpression" flags="ng" index="pHN19">
+        <child id="3542851458883491298" name="languageId" index="2V$M_3" />
+      </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
+      <concept id="1761385620274348152" name="jetbrains.mps.lang.smodel.structure.SConceptTypeCastExpression" flags="nn" index="2CBFar" />
+      <concept id="1181952871644" name="jetbrains.mps.lang.smodel.structure.Concept_GetAllSubConcepts" flags="nn" index="LSoRf">
+        <child id="1182506816063" name="smodel" index="1iTxcG" />
+      </concept>
+      <concept id="3542851458883438784" name="jetbrains.mps.lang.smodel.structure.LanguageId" flags="nn" index="2V$Bhx">
+        <property id="3542851458883439831" name="namespace" index="2V$B1Q" />
+        <property id="3542851458883439832" name="languageId" index="2V$B1T" />
+      </concept>
+      <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
+        <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
+      </concept>
+      <concept id="1171500988903" name="jetbrains.mps.lang.smodel.structure.Node_GetChildrenOperation" flags="nn" index="32TBzR" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
+      <concept id="5168775467716640652" name="jetbrains.mps.lang.smodel.structure.OperationParm_LinkQualifier" flags="ng" index="1aIX9F">
+        <child id="5168775467716640653" name="linkQualifier" index="1aIX9E" />
+      </concept>
+      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz">
+        <reference id="6677504323281689839" name="conceptDeclaraton" index="3bZ5Sy" />
+      </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
       <concept id="1140131837776" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithAnotherOperation" flags="nn" index="1P9Npp">
         <child id="1140131861877" name="replacementNode" index="1P9ThW" />
@@ -275,7 +371,9 @@
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
         <property id="1238684351431" name="asCast" index="1BlNFB" />
       </concept>
-      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
@@ -287,6 +385,33 @@
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="nn" index="56pJg">
+        <child id="1176906787974" name="rightExpression" index="576Qk" />
+      </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1176923520476" name="jetbrains.mps.baseLanguage.collections.structure.ExcludeOperation" flags="nn" index="66VNe" />
+      <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
+        <child id="1226511765987" name="elementType" index="2hN53Y" />
+      </concept>
+      <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1227022210526" name="jetbrains.mps.baseLanguage.collections.structure.ClearAllElementsOperation" flags="nn" index="2Kehj3" />
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
     </language>
   </registry>
   <node concept="24kQdi" id="4iu6t1eAWuQ">
@@ -971,6 +1096,360 @@
     <ref role="1XX52x" to="1qv1:1VqmZU7iMYf" resolve="ToReal" />
     <node concept="PMmxH" id="1VqmZU7jevz" role="2wV5jI">
       <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+    </node>
+  </node>
+  <node concept="3INDKC" id="1eTp1AxLPvh">
+    <property role="TrG5h" value="mathContextActions" />
+    <node concept="A1WHr" id="1eTp1AxLPvj" role="AmTjC">
+      <ref role="2ZyFGn" to="hm2y:6sdnDbSla17" resolve="Expression" />
+    </node>
+    <node concept="1Qtc8_" id="1eTp1AxLPEB" role="IW6Ez">
+      <node concept="1GhOrh" id="1eTp1AxLPEC" role="1Qtc8A">
+        <node concept="1GhMSn" id="1eTp1AxLPED" role="1GhOrs">
+          <node concept="3clFbS" id="1eTp1AxLPEE" role="2VODD2">
+            <node concept="3cpWs8" id="1eTp1AxLPEF" role="3cqZAp">
+              <node concept="3cpWsn" id="1eTp1AxLPEG" role="3cpWs9">
+                <property role="TrG5h" value="blacklist" />
+                <node concept="2hMVRd" id="1eTp1AxLPEH" role="1tU5fm">
+                  <node concept="3bZ5Sz" id="1eTp1AxLPEI" role="2hN53Y">
+                    <ref role="3bZ5Sy" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="1eTp1AxLPEJ" role="33vP2m">
+                  <node concept="2i4dXS" id="1eTp1AxLPEK" role="2ShVmc">
+                    <node concept="3bZ5Sz" id="1eTp1AxLPEL" role="HW$YZ">
+                      <ref role="3bZ5Sy" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="61R9vA3MUEg" role="3cqZAp">
+              <node concept="2OqwBi" id="61R9vA3MVuk" role="3clFbG">
+                <node concept="37vLTw" id="61R9vA3MUEe" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1eTp1AxLPEG" resolve="blacklist" />
+                </node>
+                <node concept="TSZUe" id="61R9vA3MWPP" role="2OqNvi">
+                  <node concept="35c_gC" id="61R9vA3MX2Y" role="25WWJ7">
+                    <ref role="35c_gD" to="1qv1:4iu6t1eAYrL" resolve="LoopVarRef" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="1eTp1AxLPEW" role="3cqZAp">
+              <node concept="2OqwBi" id="1eTp1AxLPEX" role="3clFbG">
+                <node concept="2OqwBi" id="1eTp1AxLPEY" role="2Oq$k0">
+                  <node concept="2OqwBi" id="1eTp1AxLPEZ" role="2Oq$k0">
+                    <node concept="2OqwBi" id="1eTp1AxLPF0" role="2Oq$k0">
+                      <node concept="35c_gC" id="1eTp1AxLPF1" role="2Oq$k0">
+                        <ref role="35c_gD" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                      </node>
+                      <node concept="LSoRf" id="1eTp1AxLPF2" role="2OqNvi">
+                        <node concept="1rpKSd" id="1eTp1AxLPF3" role="1iTxcG" />
+                      </node>
+                    </node>
+                    <node concept="3zZkjj" id="1eTp1AxLPF4" role="2OqNvi">
+                      <node concept="1bVj0M" id="1eTp1AxLPF5" role="23t8la">
+                        <node concept="3clFbS" id="1eTp1AxLPF6" role="1bW5cS">
+                          <node concept="3clFbF" id="1eTp1AxLPF7" role="3cqZAp">
+                            <node concept="3fqX7Q" id="1eTp1AxLPF8" role="3clFbG">
+                              <node concept="2OqwBi" id="1eTp1AxLPF9" role="3fr31v">
+                                <node concept="37vLTw" id="1eTp1AxLPFa" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1eTp1AxLPFc" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="1eTp1AxLPFb" role="2OqNvi">
+                                  <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="1eTp1AxLPFc" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="1eTp1AxLPFd" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3zZkjj" id="1eTp1AxLPFe" role="2OqNvi">
+                    <node concept="1bVj0M" id="1eTp1AxLPFf" role="23t8la">
+                      <node concept="3clFbS" id="1eTp1AxLPFg" role="1bW5cS">
+                        <node concept="3clFbF" id="1eTp1AxLPFh" role="3cqZAp">
+                          <node concept="17R0WA" id="1eTp1AxLPFi" role="3clFbG">
+                            <node concept="pHN19" id="1eTp1AxLPFj" role="3uHU7w">
+                              <node concept="2V$Bhx" id="61R9vA3M9y5" role="2V$M_3">
+                                <property role="2V$B1T" value="6fadc44e-69c2-4a4a-9d16-7ebf5f8d3ba0" />
+                                <property role="2V$B1Q" value="org.iets3.core.expr.math" />
+                              </node>
+                            </node>
+                            <node concept="2OqwBi" id="1eTp1AxLPFl" role="3uHU7B">
+                              <node concept="37vLTw" id="1eTp1AxLPFm" role="2Oq$k0">
+                                <ref role="3cqZAo" node="1eTp1AxLPFo" resolve="it" />
+                              </node>
+                              <node concept="liA8E" id="1eTp1AxLPFn" role="2OqNvi">
+                                <ref role="37wK5l" to="c17a:~SAbstractConcept.getLanguage()" resolve="getLanguage" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="1eTp1AxLPFo" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="1eTp1AxLPFp" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="66VNe" id="1eTp1AxLPFq" role="2OqNvi">
+                  <node concept="37vLTw" id="1eTp1AxLPFr" role="576Qk">
+                    <ref role="3cqZAo" node="1eTp1AxLPEG" resolve="blacklist" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3bZ5Sz" id="1eTp1AxLPFs" role="2ZBHrp">
+          <ref role="3bZ5Sy" to="hm2y:6sdnDbSla17" resolve="Expression" />
+        </node>
+        <node concept="IWgqT" id="1eTp1AxLPFt" role="1GhOri">
+          <node concept="2jZ$Xq" id="1eTp1AxLPFu" role="2jZA2a">
+            <node concept="2jZ$Xn" id="1eTp1AxLPFv" role="2jZ$wY">
+              <node concept="3clFbS" id="1eTp1AxLPFw" role="2VODD2">
+                <node concept="3clFbF" id="1eTp1AxLPFx" role="3cqZAp">
+                  <node concept="2OqwBi" id="1eTp1AxLPFy" role="3clFbG">
+                    <node concept="2OqwBi" id="1eTp1AxLPFz" role="2Oq$k0">
+                      <node concept="2YIFZM" id="1eTp1AxLPF$" role="2Oq$k0">
+                        <ref role="37wK5l" to="vndm:~ConceptRegistry.getInstance()" resolve="getInstance" />
+                        <ref role="1Pybhc" to="vndm:~ConceptRegistry" resolve="ConceptRegistry" />
+                      </node>
+                      <node concept="liA8E" id="1eTp1AxLPF_" role="2OqNvi">
+                        <ref role="37wK5l" to="vndm:~ConceptRegistry.getConceptProperties(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="getConceptProperties" />
+                        <node concept="2ZBlsa" id="1eTp1AxLPFA" role="37wK5m" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="1eTp1AxLPFB" role="2OqNvi">
+                      <ref role="37wK5l" to="ze1i:~ConceptPresentation.getIcon()" resolve="getIcon" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2jZ$wS" id="1eTp1AxLPFC" role="2jZA2a" />
+          <node concept="1hCUdq" id="1eTp1AxLPFD" role="1hCUd6">
+            <node concept="3clFbS" id="1eTp1AxLPFE" role="2VODD2">
+              <node concept="3clFbF" id="1eTp1AxMsxx" role="3cqZAp">
+                <node concept="3K4zz7" id="1eTp1AxMvqh" role="3clFbG">
+                  <node concept="2OqwBi" id="1eTp1AxMvNA" role="3K4E3e">
+                    <node concept="2ZBlsa" id="1eTp1AxMvsv" role="2Oq$k0" />
+                    <node concept="3n3YKJ" id="1eTp1AxMwkp" role="2OqNvi" />
+                  </node>
+                  <node concept="2OqwBi" id="1eTp1AxMxSq" role="3K4GZi">
+                    <node concept="2ZBlsa" id="1eTp1AxMwm_" role="2Oq$k0" />
+                    <node concept="liA8E" id="1eTp1AxMyDj" role="2OqNvi">
+                      <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="1eTp1AxMun6" role="3K4Cdx">
+                    <node concept="2OqwBi" id="1eTp1AxMsWg" role="2Oq$k0">
+                      <node concept="2ZBlsa" id="1eTp1AxMsxw" role="2Oq$k0" />
+                      <node concept="3n3YKJ" id="1eTp1AxMtTX" role="2OqNvi" />
+                    </node>
+                    <node concept="17RvpY" id="1eTp1AxMv0E" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="IWg2L" id="1eTp1AxLPFR" role="IWgqQ">
+            <node concept="3clFbS" id="1eTp1AxLPFS" role="2VODD2">
+              <node concept="3clFbJ" id="1eTp1AxN46Q" role="3cqZAp">
+                <node concept="3clFbS" id="1eTp1AxN46S" role="3clFbx">
+                  <node concept="3cpWs8" id="1yW0h04CBy_" role="3cqZAp">
+                    <node concept="3cpWsn" id="1yW0h04CByA" role="3cpWs9">
+                      <property role="TrG5h" value="newExpr" />
+                      <node concept="3Tqbb2" id="1yW0h04CByz" role="1tU5fm">
+                        <ref role="ehGHo" to="hm2y:91pmpwTPq5" resolve="IMainSlot" />
+                      </node>
+                      <node concept="2OqwBi" id="1yW0h04CByB" role="33vP2m">
+                        <node concept="q_SaT" id="1yW0h04CByD" role="2OqNvi" />
+                        <node concept="2CBFar" id="1eTp1AxNOm$" role="2Oq$k0">
+                          <node concept="chp4Y" id="1eTp1AxNOu9" role="3oSUPX">
+                            <ref role="cht4Q" to="hm2y:91pmpwTPq5" resolve="IMainSlot" />
+                          </node>
+                          <node concept="2CBFar" id="1eTp1AxNOJD" role="1m5AlR">
+                            <node concept="chp4Y" id="1eTp1AxNORx" role="3oSUPX">
+                              <ref role="cht4Q" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                            </node>
+                            <node concept="2ZBlsa" id="1eTp1AxNNX7" role="1m5AlR" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="1yW0h04CCW7" role="3cqZAp">
+                    <node concept="2OqwBi" id="1yW0h04CD43" role="3clFbG">
+                      <node concept="7Obwk" id="1eTp1AxNPh7" role="2Oq$k0" />
+                      <node concept="1P9Npp" id="1yW0h04CDsC" role="2OqNvi">
+                        <node concept="37vLTw" id="1yW0h04CDt5" role="1P9ThW">
+                          <ref role="3cqZAo" node="1yW0h04CByA" resolve="newExpr" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="1yW0h04CAU7" role="3cqZAp">
+                    <node concept="2OqwBi" id="1yW0h04CBGg" role="3clFbG">
+                      <node concept="37vLTw" id="1yW0h04CByE" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1yW0h04CByA" resolve="newExpr" />
+                      </node>
+                      <node concept="2qgKlT" id="1yW0h04CBRv" role="2OqNvi">
+                        <ref role="37wK5l" to="pbu6:91pmpwTPqy" resolve="addChildToMainSlot" />
+                        <node concept="7Obwk" id="1eTp1AxNPld" role="37wK5m" />
+                        <node concept="Xl_RD" id="1yW0h04CCCu" role="37wK5m">
+                          <property role="Xl_RC" value="" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs6" id="1eTp1AxNPGs" role="3cqZAp" />
+                </node>
+                <node concept="2OqwBi" id="1eTp1AxN4s0" role="3clFbw">
+                  <node concept="2ZBlsa" id="1eTp1AxN47$" role="2Oq$k0" />
+                  <node concept="2Zo12i" id="1eTp1AxN5Oy" role="2OqNvi">
+                    <node concept="chp4Y" id="1eTp1AxNNfZ" role="2Zo12j">
+                      <ref role="cht4Q" to="hm2y:91pmpwTPq5" resolve="IMainSlot" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="61R9vA3N_ka" role="3cqZAp" />
+              <node concept="3cpWs8" id="61R9vA3NADl" role="3cqZAp">
+                <node concept="3cpWsn" id="61R9vA3NADm" role="3cpWs9">
+                  <property role="TrG5h" value="newNode" />
+                  <node concept="3Tqbb2" id="61R9vA3O8mr" role="1tU5fm" />
+                  <node concept="2YIFZM" id="61R9vA3NADn" role="33vP2m">
+                    <ref role="37wK5l" to="zce0:~SNodeFactoryOperations.replaceWithNewChild(org.jetbrains.mps.openapi.model.SNode,org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="replaceWithNewChild" />
+                    <ref role="1Pybhc" to="zce0:~SNodeFactoryOperations" resolve="SNodeFactoryOperations" />
+                    <node concept="7Obwk" id="61R9vA3NADo" role="37wK5m" />
+                    <node concept="2ZBlsa" id="61R9vA3NADp" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="61R9vA3N_lp" role="3cqZAp" />
+              <node concept="3cpWs8" id="61R9vA3NsXq" role="3cqZAp">
+                <node concept="3cpWsn" id="61R9vA3NsXr" role="3cpWs9">
+                  <property role="TrG5h" value="links" />
+                  <node concept="A3Dl8" id="61R9vA3NtqC" role="1tU5fm">
+                    <node concept="3uibUv" id="61R9vA3NtqE" role="A3Ik2">
+                      <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="61R9vA3NsXs" role="33vP2m">
+                    <node concept="2ZBlsa" id="61R9vA3NsXt" role="2Oq$k0" />
+                    <node concept="liA8E" id="61R9vA3NsXu" role="2OqNvi">
+                      <ref role="37wK5l" to="c17a:~SAbstractConcept.getContainmentLinks()" resolve="getContainmentLinks" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="61R9vA3NxDD" role="3cqZAp">
+                <node concept="3cpWsn" id="61R9vA3NxDE" role="3cpWs9">
+                  <property role="TrG5h" value="link" />
+                  <node concept="3uibUv" id="61R9vA3NxCn" role="1tU5fm">
+                    <ref role="3uigEE" to="c17a:~SContainmentLink" resolve="SContainmentLink" />
+                  </node>
+                  <node concept="2OqwBi" id="61R9vA3NxDF" role="33vP2m">
+                    <node concept="37vLTw" id="61R9vA3NxDG" role="2Oq$k0">
+                      <ref role="3cqZAo" node="61R9vA3NsXr" resolve="links" />
+                    </node>
+                    <node concept="1z4cxt" id="61R9vA3NxDH" role="2OqNvi">
+                      <node concept="1bVj0M" id="61R9vA3NxDI" role="23t8la">
+                        <node concept="3clFbS" id="61R9vA3NxDJ" role="1bW5cS">
+                          <node concept="3clFbF" id="61R9vA3NxDK" role="3cqZAp">
+                            <node concept="2OqwBi" id="61R9vA3NxDL" role="3clFbG">
+                              <node concept="2OqwBi" id="61R9vA3NxDM" role="2Oq$k0">
+                                <node concept="7Obwk" id="61R9vA3NxDN" role="2Oq$k0" />
+                                <node concept="2yIwOk" id="61R9vA3NxDO" role="2OqNvi" />
+                              </node>
+                              <node concept="liA8E" id="61R9vA3NxDP" role="2OqNvi">
+                                <ref role="37wK5l" to="c17a:~SAbstractConcept.isSubConceptOf(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isSubConceptOf" />
+                                <node concept="2OqwBi" id="61R9vA3NxDQ" role="37wK5m">
+                                  <node concept="37vLTw" id="61R9vA3NxDR" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="61R9vA3NxDT" resolve="it" />
+                                  </node>
+                                  <node concept="liA8E" id="61R9vA3NxDS" role="2OqNvi">
+                                    <ref role="37wK5l" to="c17a:~SAbstractLink.getTargetConcept()" resolve="getTargetConcept" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="61R9vA3NxDT" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="61R9vA3NxDU" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="61R9vA3Ns6u" role="3cqZAp">
+                <node concept="3clFbS" id="61R9vA3Ns6w" role="3clFbx">
+                  <node concept="3clFbF" id="61R9vA3O8uC" role="3cqZAp">
+                    <node concept="2OqwBi" id="61R9vA3OaJo" role="3clFbG">
+                      <node concept="2OqwBi" id="61R9vA3O8Dd" role="2Oq$k0">
+                        <node concept="37vLTw" id="61R9vA3Ofbi" role="2Oq$k0">
+                          <ref role="3cqZAo" node="61R9vA3NADm" resolve="newNode" />
+                        </node>
+                        <node concept="32TBzR" id="61R9vA3O8Pv" role="2OqNvi">
+                          <node concept="1aIX9F" id="61R9vA3O9K3" role="1xVPHs">
+                            <node concept="25Kdxt" id="61R9vA3O9Ms" role="1aIX9E">
+                              <node concept="37vLTw" id="61R9vA3O9Ou" role="25KhWn">
+                                <ref role="3cqZAo" node="61R9vA3NxDE" resolve="link" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2Kehj3" id="61R9vA3ObNX" role="2OqNvi" />
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="61R9vA3Ocqz" role="3cqZAp">
+                    <node concept="2OqwBi" id="61R9vA3Ocq$" role="3clFbG">
+                      <node concept="2OqwBi" id="61R9vA3Ocq_" role="2Oq$k0">
+                        <node concept="37vLTw" id="61R9vA3OfKy" role="2Oq$k0">
+                          <ref role="3cqZAo" node="61R9vA3NADm" resolve="newNode" />
+                        </node>
+                        <node concept="32TBzR" id="61R9vA3OcqB" role="2OqNvi">
+                          <node concept="1aIX9F" id="61R9vA3OcqC" role="1xVPHs">
+                            <node concept="25Kdxt" id="61R9vA3OcqD" role="1aIX9E">
+                              <node concept="37vLTw" id="61R9vA3OcqE" role="25KhWn">
+                                <ref role="3cqZAo" node="61R9vA3NxDE" resolve="link" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="TSZUe" id="61R9vA3OeLr" role="2OqNvi">
+                        <node concept="7Obwk" id="61R9vA3OeP2" role="25WWJ7" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3y3z36" id="61R9vA3Nzp4" role="3clFbw">
+                  <node concept="10Nm6u" id="61R9vA3NzvD" role="3uHU7w" />
+                  <node concept="37vLTw" id="61R9vA3Nyja" role="3uHU7B">
+                    <ref role="3cqZAo" node="61R9vA3NxDE" resolve="link" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2jZ$wP" id="1eTp1AxLPFX" role="1Qtc8$" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/plugin.mps
@@ -3,13 +3,11 @@
   <persistence version="9" />
   <attribute name="doNotGenerate" value="false" />
   <languages>
-    <use id="677f00fb-4488-405e-9885-abb75d472fd1" name="com.mbeddr.mpsutil.contextactions" version="0" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <devkit ref="2677cb18-f558-4e33-bc38-a5139cee06dc(jetbrains.mps.devkit.language-design)" />
   </languages>
   <imports>
-    <import index="1ne1" ref="r:e9a49de8-6adf-4c2e-b5c2-32fc88189c93(com.mbeddr.mpsutil.contextactions.runtime)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
     <import index="sn11" ref="r:836426ab-a6f4-4fa3-9a9c-34c02ed6ab5d(jetbrains.mps.ide.icons)" />
@@ -19,8 +17,6 @@
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" />
     <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.libs/)" />
-    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
-    <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
     <import index="b1h1" ref="r:ac5f749f-6179-4d4f-ad24-ad9edbd8077b(org.iets3.core.expr.simpleTypes.behavior)" implicit="true" />
     <import index="6bz1" ref="r:d3905048-7598-4a84-931a-cbbcbcda146d(jetbrains.mps.lang.intentions.methods)" implicit="true" />
   </imports>
@@ -47,9 +43,6 @@
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
-      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
-        <child id="1137022507850" name="body" index="2VODD2" />
-      </concept>
       <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
@@ -65,10 +58,6 @@
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534513062" name="jetbrains.mps.baseLanguage.structure.DoubleType" flags="in" index="10P55v" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
-      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
-        <child id="1070534934091" name="type" index="10QFUM" />
-        <child id="1070534934092" name="expression" index="10QFUP" />
-      </concept>
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
@@ -116,9 +105,6 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
-        <child id="1079359253376" name="expression" index="1eOMHV" />
-      </concept>
       <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
@@ -149,9 +135,6 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
-    </language>
-    <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
-      <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -192,18 +175,12 @@
         <child id="8182547171709752112" name="expression" index="36biLW" />
       </concept>
     </language>
-    <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
-      <concept id="7776141288922801652" name="jetbrains.mps.lang.actions.structure.NF_Concept_NewInstance" flags="nn" index="q_SaT" />
-    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
       <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
         <child id="1144104376918" name="parameter" index="1xVPHs" />
-      </concept>
-      <concept id="4497478346159780083" name="jetbrains.mps.lang.smodel.structure.LanguageRefExpression" flags="ng" index="pHN19">
-        <child id="3542851458883491298" name="languageId" index="2V$M_3" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
@@ -220,23 +197,12 @@
       <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
       <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
-      <concept id="3542851458883438784" name="jetbrains.mps.lang.smodel.structure.LanguageId" flags="nn" index="2V$Bhx">
-        <property id="3542851458883439831" name="namespace" index="2V$B1Q" />
-        <property id="3542851458883439832" name="languageId" index="2V$B1T" />
-      </concept>
-      <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
-        <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
-      </concept>
       <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
         <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
-      </concept>
-      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz">
-        <reference id="6677504323281689839" name="conceptDeclaraton" index="3bZ5Sy" />
       </concept>
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
-      <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
@@ -246,9 +212,6 @@
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
       <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
-      <concept id="1140131837776" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithAnotherOperation" flags="nn" index="1P9Npp">
-        <child id="1140131861877" name="replacementNode" index="1P9ThW" />
-      </concept>
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
@@ -265,32 +228,6 @@
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
-    <language id="677f00fb-4488-405e-9885-abb75d472fd1" name="com.mbeddr.mpsutil.contextactions">
-      <concept id="5022141054904911899" name="com.mbeddr.mpsutil.contextactions.structure.SubstituteActionExpression" flags="ng" index="gcnaP" />
-      <concept id="5022141054905292858" name="com.mbeddr.mpsutil.contextactions.structure.GenericActionSource" flags="ng" index="geMak">
-        <child id="5022141054905292957" name="icon" index="geM8N" />
-        <child id="5022141054905292952" name="folder" index="geM8Q" />
-        <child id="5022141054905292863" name="parameterQuery" index="geMah" />
-        <child id="5022141054905292861" name="parameterType" index="geMaj" />
-        <child id="5022141054905292866" name="label" index="geMbG" />
-        <child id="5022141054905293092" name="execute" index="geMea" />
-      </concept>
-      <concept id="5022141054905293099" name="com.mbeddr.mpsutil.contextactions.structure.GenericActionSource_ExecuteFunction" flags="ig" index="geMe5" />
-      <concept id="5022141054905332478" name="com.mbeddr.mpsutil.contextactions.structure.ParameterObject" flags="ng" index="geSxg" />
-      <concept id="5022141054903714507" name="com.mbeddr.mpsutil.contextactions.structure.ContextExpression" flags="ng" index="gKNx_" />
-      <concept id="6294660000051228482" name="com.mbeddr.mpsutil.contextactions.structure.ContextActions" flags="ng" index="NGJ2D">
-        <child id="6294660000051228527" name="sources" index="NGJ24" />
-        <child id="8645458101902647485" name="isApplicable" index="3V_frF" />
-      </concept>
-      <concept id="6294660000051228497" name="com.mbeddr.mpsutil.contextactions.structure.SubstituteInfoSource" flags="ng" index="NGJ2U">
-        <child id="5022141054904911832" name="include" index="gcnPQ" />
-        <child id="573955333602854986" name="folder" index="37Ct4v" />
-      </concept>
-      <concept id="8009069486207462978" name="com.mbeddr.mpsutil.contextactions.structure.ActionSourceWithCondition" flags="ng" index="3_Xg01">
-        <child id="8009069486207463378" name="sources" index="3_Xg6h" />
-        <child id="8009069486207463329" name="condition" index="3_Xg7y" />
-      </concept>
-    </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
@@ -300,9 +237,6 @@
       </concept>
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
-      </concept>
-      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
-        <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
       <concept id="3358009230509553641" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListType" flags="in" index="2BANLN" />
       <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
@@ -319,281 +253,6 @@
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
     </language>
   </registry>
-  <node concept="NGJ2D" id="5tr7YH$UwTY">
-    <property role="TrG5h" value="MathContextActions" />
-    <node concept="3_Xg01" id="1yW0h04Dqdd" role="NGJ24">
-      <node concept="NGJ2U" id="5lGdLibZyEN" role="3_Xg6h">
-        <node concept="Xl_RD" id="vR6ln0lJV1" role="37Ct4v">
-          <property role="Xl_RC" value="Math Expressions" />
-        </node>
-        <node concept="2EnYce" id="6W_V$eaXQzr" role="gcnPQ">
-          <node concept="2OqwBi" id="13LyZYiLeRB" role="2Oq$k0">
-            <node concept="gcnaP" id="13LyZYiLeOf" role="2Oq$k0" />
-            <node concept="liA8E" id="13LyZYiLfmB" role="2OqNvi">
-              <ref role="37wK5l" to="1ne1:7vUP_qcwDWl" resolve="getOutputConceptLanguageName" />
-            </node>
-          </node>
-          <node concept="liA8E" id="13LyZYiLfUs" role="2OqNvi">
-            <ref role="37wK5l" to="wyt6:~String.contains(java.lang.CharSequence)" resolve="contains" />
-            <node concept="Xl_RD" id="13LyZYiLfVa" role="37wK5m">
-              <property role="Xl_RC" value="math" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1Wc70l" id="4v5hZncVr8y" role="3_Xg7y">
-        <node concept="2OqwBi" id="4v5hZncVr8z" role="3uHU7B">
-          <node concept="2OqwBi" id="4v5hZncVr8$" role="2Oq$k0">
-            <node concept="gKNx_" id="4v5hZncVr8_" role="2Oq$k0" />
-            <node concept="liA8E" id="4v5hZncVr8A" role="2OqNvi">
-              <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-            </node>
-          </node>
-          <node concept="1mIQ4w" id="4v5hZncVr8B" role="2OqNvi">
-            <node concept="chp4Y" id="4v5hZncVr8C" role="cj9EA">
-              <ref role="cht4Q" to="hm2y:6sdnDbSla17" resolve="Expression" />
-            </node>
-          </node>
-        </node>
-        <node concept="1eOMI4" id="4v5hZncVr8D" role="3uHU7w">
-          <node concept="22lmx$" id="4v5hZncVr8E" role="1eOMHV">
-            <node concept="2OqwBi" id="4v5hZncVr8F" role="3uHU7B">
-              <node concept="2OqwBi" id="4v5hZncVr8G" role="2Oq$k0">
-                <node concept="2OqwBi" id="4v5hZncVr8H" role="2Oq$k0">
-                  <node concept="gKNx_" id="4v5hZncVr8I" role="2Oq$k0" />
-                  <node concept="liA8E" id="4v5hZncVr8J" role="2OqNvi">
-                    <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                  </node>
-                </node>
-                <node concept="2yIwOk" id="4v5hZncVr8K" role="2OqNvi" />
-              </node>
-              <node concept="liA8E" id="4v5hZncVr8L" role="2OqNvi">
-                <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="4v5hZncVr8M" role="3uHU7w">
-              <node concept="2OqwBi" id="4v5hZncVr8N" role="2Oq$k0">
-                <node concept="2OqwBi" id="4v5hZncVr8O" role="2Oq$k0">
-                  <node concept="2OqwBi" id="4v5hZncVr8P" role="2Oq$k0">
-                    <node concept="gKNx_" id="4v5hZncVr8Q" role="2Oq$k0" />
-                    <node concept="liA8E" id="4v5hZncVr8R" role="2OqNvi">
-                      <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                    </node>
-                  </node>
-                  <node concept="2yIwOk" id="4v5hZncVr8S" role="2OqNvi" />
-                </node>
-                <node concept="liA8E" id="4v5hZncVr8T" role="2OqNvi">
-                  <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
-                </node>
-              </node>
-              <node concept="liA8E" id="4v5hZncVr8U" role="2OqNvi">
-                <ref role="37wK5l" to="wyt6:~String.contains(java.lang.CharSequence)" resolve="contains" />
-                <node concept="Xl_RD" id="4v5hZncVr8V" role="37wK5m">
-                  <property role="Xl_RC" value="EmptyExpression" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="3_Xg01" id="1yW0h04CGll" role="NGJ24">
-      <node concept="1Wc70l" id="4v5hZncUv3I" role="3_Xg7y">
-        <node concept="3fqX7Q" id="4v5hZncUvBK" role="3uHU7w">
-          <node concept="2OqwBi" id="4v5hZncURMY" role="3fr31v">
-            <node concept="2OqwBi" id="4v5hZncUvH2" role="2Oq$k0">
-              <node concept="2OqwBi" id="4v5hZncUvH3" role="2Oq$k0">
-                <node concept="2OqwBi" id="4v5hZncUvH4" role="2Oq$k0">
-                  <node concept="gKNx_" id="4v5hZncUvH5" role="2Oq$k0" />
-                  <node concept="liA8E" id="4v5hZncUvH6" role="2OqNvi">
-                    <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                  </node>
-                </node>
-                <node concept="2yIwOk" id="4v5hZncUvH7" role="2OqNvi" />
-              </node>
-              <node concept="liA8E" id="4v5hZncURoL" role="2OqNvi">
-                <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
-              </node>
-            </node>
-            <node concept="liA8E" id="4v5hZncUTp2" role="2OqNvi">
-              <ref role="37wK5l" to="wyt6:~String.contains(java.lang.CharSequence)" resolve="contains" />
-              <node concept="Xl_RD" id="4v5hZncUTrD" role="37wK5m">
-                <property role="Xl_RC" value="EmptyExpression" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1Wc70l" id="1yW0h04DvbP" role="3uHU7B">
-          <node concept="2OqwBi" id="1yW0h04CH4U" role="3uHU7B">
-            <node concept="2OqwBi" id="1yW0h04CGGm" role="2Oq$k0">
-              <node concept="gKNx_" id="1yW0h04CG_A" role="2Oq$k0" />
-              <node concept="liA8E" id="1yW0h04CGWl" role="2OqNvi">
-                <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-              </node>
-            </node>
-            <node concept="1mIQ4w" id="1yW0h04CHq9" role="2OqNvi">
-              <node concept="chp4Y" id="1yW0h04CHsc" role="cj9EA">
-                <ref role="cht4Q" to="hm2y:6sdnDbSla17" resolve="Expression" />
-              </node>
-            </node>
-          </node>
-          <node concept="3fqX7Q" id="1yW0h04Dx7u" role="3uHU7w">
-            <node concept="2OqwBi" id="1yW0h04Dxcq" role="3fr31v">
-              <node concept="2OqwBi" id="1yW0h04Dxcr" role="2Oq$k0">
-                <node concept="2OqwBi" id="1yW0h04Dxcs" role="2Oq$k0">
-                  <node concept="gKNx_" id="1yW0h04Dxct" role="2Oq$k0" />
-                  <node concept="liA8E" id="1yW0h04Dxcu" role="2OqNvi">
-                    <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                  </node>
-                </node>
-                <node concept="2yIwOk" id="1yW0h04Dxcv" role="2OqNvi" />
-              </node>
-              <node concept="liA8E" id="1yW0h04Dxcw" role="2OqNvi">
-                <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="geMak" id="1yW0h04Cvki" role="3_Xg6h">
-        <node concept="2OqwBi" id="1yW0h04CA2G" role="geMbG">
-          <node concept="geSxg" id="1yW0h04C_N_" role="2Oq$k0" />
-          <node concept="3n3YKJ" id="1yW0h04COSY" role="2OqNvi" />
-        </node>
-        <node concept="2OqwBi" id="1yW0h04Cx6s" role="geMah">
-          <node concept="1eOMI4" id="1yW0h04CwSR" role="2Oq$k0">
-            <node concept="10QFUN" id="1yW0h04CwD6" role="1eOMHV">
-              <node concept="2OqwBi" id="1yW0h04CwD1" role="10QFUP">
-                <node concept="pHN19" id="1yW0h04CwD2" role="2Oq$k0">
-                  <node concept="2V$Bhx" id="17Nm8oCo8Oa" role="2V$M_3">
-                    <property role="2V$B1T" value="6fadc44e-69c2-4a4a-9d16-7ebf5f8d3ba0" />
-                    <property role="2V$B1Q" value="org.iets3.core.expr.math" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="1yW0h04CwD5" role="2OqNvi">
-                  <ref role="37wK5l" to="c17a:~SLanguage.getConcepts()" resolve="getConcepts" />
-                </node>
-              </node>
-              <node concept="A3Dl8" id="1yW0h04CwK$" role="10QFUM">
-                <node concept="3bZ5Sz" id="1yW0h04CwRE" role="A3Ik2">
-                  <ref role="3bZ5Sy" to="hm2y:91pmpwTPq5" resolve="IMainSlot" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3zZkjj" id="1yW0h04CzsE" role="2OqNvi">
-            <node concept="1bVj0M" id="1yW0h04CzsG" role="23t8la">
-              <node concept="3clFbS" id="1yW0h04CzsH" role="1bW5cS">
-                <node concept="3clFbF" id="1yW0h04CzA4" role="3cqZAp">
-                  <node concept="1Wc70l" id="1yW0h04DCD$" role="3clFbG">
-                    <node concept="3fqX7Q" id="1yW0h04DHXR" role="3uHU7w">
-                      <node concept="2OqwBi" id="1yW0h04DHXT" role="3fr31v">
-                        <node concept="37vLTw" id="1yW0h04DHXU" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1yW0h04CzsI" resolve="it" />
-                        </node>
-                        <node concept="liA8E" id="1yW0h04DHXV" role="2OqNvi">
-                          <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2OqwBi" id="1yW0h04CzQj" role="3uHU7B">
-                      <node concept="37vLTw" id="1yW0h04CzA3" role="2Oq$k0">
-                        <ref role="3cqZAo" node="1yW0h04CzsI" resolve="it" />
-                      </node>
-                      <node concept="2Zo12i" id="1yW0h04C$p_" role="2OqNvi">
-                        <node concept="chp4Y" id="1yW0h04C$$k" role="2Zo12j">
-                          <ref role="cht4Q" to="hm2y:91pmpwTPq5" resolve="IMainSlot" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="Rh6nW" id="1yW0h04CzsI" role="1bW2Oz">
-                <property role="TrG5h" value="it" />
-                <node concept="2jxLKc" id="1yW0h04CzsJ" role="1tU5fm" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3bZ5Sz" id="1yW0h04C_tS" role="geMaj">
-          <ref role="3bZ5Sy" to="hm2y:91pmpwTPq5" resolve="IMainSlot" />
-        </node>
-        <node concept="Xl_RD" id="1yW0h04C_Hs" role="geM8Q">
-          <property role="Xl_RC" value="Math Expression (Wrap Selection)" />
-        </node>
-        <node concept="geMe5" id="1yW0h04CAE_" role="geMea">
-          <node concept="3clFbS" id="1yW0h04CAEA" role="2VODD2">
-            <node concept="3cpWs8" id="1yW0h04CBy_" role="3cqZAp">
-              <node concept="3cpWsn" id="1yW0h04CByA" role="3cpWs9">
-                <property role="TrG5h" value="newExpr" />
-                <node concept="3Tqbb2" id="1yW0h04CByz" role="1tU5fm">
-                  <ref role="ehGHo" to="hm2y:91pmpwTPq5" resolve="IMainSlot" />
-                </node>
-                <node concept="2OqwBi" id="1yW0h04CByB" role="33vP2m">
-                  <node concept="geSxg" id="1yW0h04CByC" role="2Oq$k0" />
-                  <node concept="q_SaT" id="1yW0h04CByD" role="2OqNvi" />
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="1yW0h04CCmZ" role="3cqZAp">
-              <node concept="3cpWsn" id="1yW0h04CCn0" role="3cpWs9">
-                <property role="TrG5h" value="sNode" />
-                <node concept="3Tqbb2" id="1yW0h04CCmY" role="1tU5fm" />
-                <node concept="2OqwBi" id="1yW0h04CCn1" role="33vP2m">
-                  <node concept="gKNx_" id="1yW0h04CCn2" role="2Oq$k0" />
-                  <node concept="liA8E" id="1yW0h04CCn3" role="2OqNvi">
-                    <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="1yW0h04CCW7" role="3cqZAp">
-              <node concept="2OqwBi" id="1yW0h04CD43" role="3clFbG">
-                <node concept="37vLTw" id="1yW0h04CCW5" role="2Oq$k0">
-                  <ref role="3cqZAo" node="1yW0h04CCn0" resolve="sNode" />
-                </node>
-                <node concept="1P9Npp" id="1yW0h04CDsC" role="2OqNvi">
-                  <node concept="37vLTw" id="1yW0h04CDt5" role="1P9ThW">
-                    <ref role="3cqZAo" node="1yW0h04CByA" resolve="newExpr" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="1yW0h04CAU7" role="3cqZAp">
-              <node concept="2OqwBi" id="1yW0h04CBGg" role="3clFbG">
-                <node concept="37vLTw" id="1yW0h04CByE" role="2Oq$k0">
-                  <ref role="3cqZAo" node="1yW0h04CByA" resolve="newExpr" />
-                </node>
-                <node concept="2qgKlT" id="1yW0h04CBRv" role="2OqNvi">
-                  <ref role="37wK5l" to="pbu6:91pmpwTPqy" resolve="addChildToMainSlot" />
-                  <node concept="37vLTw" id="1yW0h04CCn4" role="37wK5m">
-                    <ref role="3cqZAo" node="1yW0h04CCn0" resolve="sNode" />
-                  </node>
-                  <node concept="Xl_RD" id="1yW0h04CCCu" role="37wK5m">
-                    <property role="Xl_RC" value="" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2OqwBi" id="1yW0h04D5$r" role="geM8N">
-          <node concept="liA8E" id="1yW0h04D6ee" role="2OqNvi">
-            <ref role="37wK5l" to="sn11:192HKKPOcza" resolve="getIconFor" />
-            <node concept="geSxg" id="1yW0h04D6qS" role="37wK5m" />
-          </node>
-          <node concept="2YIFZM" id="3wY4OwVbd5m" role="2Oq$k0">
-            <ref role="37wK5l" to="sn11:5UC$YgehaLf" resolve="getInstance" />
-            <ref role="1Pybhc" to="sn11:192HKKPMXeL" resolve="GlobalIconManager" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="3clFbT" id="13LyZYiLqnI" role="3V_frF">
-      <property role="3clFbU" value="true" />
-    </node>
-  </node>
   <node concept="312cEu" id="3iWt5efKWGp">
     <property role="TrG5h" value="PolynomialExpressionUtil" />
     <node concept="2tJIrI" id="3iWt5efKYZS" role="jymVt" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/org.iets3.core.expr.math.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/org.iets3.core.expr.math.mpl
@@ -24,12 +24,7 @@
         </facet>
       </facets>
       <external-templates />
-      <languageVersions>
-        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="3" />
-        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-      </languageVersions>
+      <languageVersions />
       <dependencyVersions>
         <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
@@ -85,7 +80,6 @@
   <sourcePath />
   <dependencies>
     <dependency reexport="false">0fcee1cf-8f59-441b-b9c7-7ff7bdd6bc97(de.itemis.mps.editor.math.symbols)</dependency>
-    <dependency reexport="false">28583149-5b6e-4663-9c02-b9a8fa3cb099(com.mbeddr.mpsutil.contextactions.runtime)</dependency>
     <dependency reexport="false">6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)</dependency>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
@@ -100,7 +94,6 @@
     <dependency reexport="false">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.libs)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:677f00fb-4488-405e-9885-abb75d472fd1:com.mbeddr.mpsutil.contextactions" version="0" />
     <language slang="l:766348f7-6a67-4b85-9323-384840132299:de.itemis.mps.editor.math" version="0" />
     <language slang="l:e359e0a2-368a-4c40-ae2a-e5a09f9cfd58:de.itemis.mps.editor.math.notations" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
@@ -113,6 +106,7 @@
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:df345b11-b8c7-4213-ac66-48d2a9b75d88:jetbrains.mps.baseLanguageInternal" version="0" />
+    <language slang="l:b1c7d06f-525d-43b5-9b0a-2fc8f7f076ba:jetbrains.mps.editor.contextActionsTool.lang.menus" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
     <language slang="l:f159adf4-3c93-40f9-9c5a-1f245a8697af:jetbrains.mps.lang.aspect" version="2" />
     <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
@@ -162,7 +156,6 @@
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
-    <module reference="28583149-5b6e-4663-9c02-b9a8fa3cb099(com.mbeddr.mpsutil.contextactions.runtime)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
     <module reference="47f075a6-558e-4640-a606-7ce0236c8023(com.mbeddr.mpsutil.interpreter)" version="0" />
     <module reference="735f86bc-17fb-4d1c-a664-82c2b8e8a34e(com.mbeddr.mpsutil.interpreter.rt)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/plugin.mps
@@ -5,7 +5,6 @@
     <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="5" />
     <use id="f159adf4-3c93-40f9-9c5a-1f245a8697af" name="jetbrains.mps.lang.aspect" version="-1" />
     <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="-1" />
-    <use id="677f00fb-4488-405e-9885-abb75d472fd1" name="com.mbeddr.mpsutil.contextactions" version="-1" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="-1" />
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="-1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
@@ -16,7 +15,6 @@
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="yv47" ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
-    <import index="1ne1" ref="r:e9a49de8-6adf-4c2e-b5c2-32fc88189c93(com.mbeddr.mpsutil.contextactions.runtime)" />
     <import index="4k19" ref="1fd846c3-c5f9-4b9e-9ecc-e716f7149f86/java:org.hamcrest(Hamcrest/)" />
     <import index="pq1l" ref="r:93cd1fe8-b296-405c-a6e6-040c940ccfa1(org.iets3.core.expr.toplevel.plugin)" />
     <import index="2ahs" ref="r:ea6cf71d-29d2-478d-8027-a9f4a4de53c4(com.mbeddr.mpsutil.interpreter.rt)" />
@@ -26,7 +24,6 @@
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -165,16 +162,12 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
-      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
       <concept id="6626851894249711936" name="jetbrains.mps.lang.extension.structure.ExtensionPointExpression" flags="nn" index="2O5UvJ">
         <reference id="6626851894249712469" name="extensionPoint" index="2O5UnU" />
       </concept>
       <concept id="3175313036448560967" name="jetbrains.mps.lang.extension.structure.GetExtensionObjectsOperation" flags="nn" index="SfwO_" />
-    </language>
-    <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
-      <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
       <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
@@ -183,13 +176,9 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
-      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
-      </concept>
-      <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
-        <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
       </concept>
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
@@ -205,22 +194,6 @@
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
-      </concept>
-    </language>
-    <language id="677f00fb-4488-405e-9885-abb75d472fd1" name="com.mbeddr.mpsutil.contextactions">
-      <concept id="5022141054904911899" name="com.mbeddr.mpsutil.contextactions.structure.SubstituteActionExpression" flags="ng" index="gcnaP" />
-      <concept id="5022141054903714507" name="com.mbeddr.mpsutil.contextactions.structure.ContextExpression" flags="ng" index="gKNx_" />
-      <concept id="6294660000051228482" name="com.mbeddr.mpsutil.contextactions.structure.ContextActions" flags="ng" index="NGJ2D">
-        <child id="6294660000051228527" name="sources" index="NGJ24" />
-        <child id="8645458101902647485" name="isApplicable" index="3V_frF" />
-      </concept>
-      <concept id="6294660000051228497" name="com.mbeddr.mpsutil.contextactions.structure.SubstituteInfoSource" flags="ng" index="NGJ2U">
-        <child id="5022141054904911832" name="include" index="gcnPQ" />
-        <child id="573955333602854986" name="folder" index="37Ct4v" />
-      </concept>
-      <concept id="8009069486207462978" name="com.mbeddr.mpsutil.contextactions.structure.ActionSourceWithCondition" flags="ng" index="3_Xg01">
-        <child id="8009069486207463378" name="sources" index="3_Xg6h" />
-        <child id="8009069486207463329" name="condition" index="3_Xg7y" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
@@ -376,82 +349,6 @@
     <node concept="2tJIrI" id="2Qbt$1tTQfG" role="jymVt" />
     <node concept="2tJIrI" id="2Qbt$1tTQg5" role="jymVt" />
     <node concept="3Tm1VV" id="2Qbt$1tTQaI" role="1B3o_S" />
-  </node>
-  <node concept="NGJ2D" id="5tr7YH$UwTY">
-    <property role="TrG5h" value="TestsContextActions" />
-    <node concept="3_Xg01" id="1yW0h04Dqdd" role="NGJ24">
-      <node concept="NGJ2U" id="5lGdLibZyEN" role="3_Xg6h">
-        <node concept="Xl_RD" id="vR6ln0lJV1" role="37Ct4v">
-          <property role="Xl_RC" value="KernelF - Tests" />
-        </node>
-        <node concept="2EnYce" id="6W_V$eaXQzr" role="gcnPQ">
-          <node concept="2OqwBi" id="13LyZYiLeRB" role="2Oq$k0">
-            <node concept="gcnaP" id="13LyZYiLeOf" role="2Oq$k0" />
-            <node concept="liA8E" id="13LyZYiLfmB" role="2OqNvi">
-              <ref role="37wK5l" to="1ne1:7vUP_qcwDWl" resolve="getOutputConceptLanguageName" />
-            </node>
-          </node>
-          <node concept="liA8E" id="13LyZYiLfUs" role="2OqNvi">
-            <ref role="37wK5l" to="wyt6:~String.contains(java.lang.CharSequence)" resolve="contains" />
-            <node concept="Xl_RD" id="13LyZYiLfVa" role="37wK5m">
-              <property role="Xl_RC" value="test" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1Wc70l" id="4v5hZncVr8y" role="3_Xg7y">
-        <node concept="2OqwBi" id="4v5hZncVr8z" role="3uHU7B">
-          <node concept="2OqwBi" id="4v5hZncVr8$" role="2Oq$k0">
-            <node concept="gKNx_" id="4v5hZncVr8_" role="2Oq$k0" />
-            <node concept="liA8E" id="4v5hZncVr8A" role="2OqNvi">
-              <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-            </node>
-          </node>
-          <node concept="1mIQ4w" id="4v5hZncVr8B" role="2OqNvi">
-            <node concept="chp4Y" id="4v5hZncVEfD" role="cj9EA">
-              <ref role="cht4Q" to="yv47:2uR5X5ayM7T" resolve="IToplevelExprContent" />
-            </node>
-          </node>
-        </node>
-        <node concept="1eOMI4" id="4v5hZncVr8D" role="3uHU7w">
-          <node concept="22lmx$" id="4v5hZncVr8E" role="1eOMHV">
-            <node concept="2OqwBi" id="4v5hZncVr8F" role="3uHU7B">
-              <node concept="2OqwBi" id="4v5hZncVr8G" role="2Oq$k0">
-                <node concept="2OqwBi" id="4v5hZncVr8H" role="2Oq$k0">
-                  <node concept="gKNx_" id="4v5hZncVr8I" role="2Oq$k0" />
-                  <node concept="liA8E" id="4v5hZncVr8J" role="2OqNvi">
-                    <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                  </node>
-                </node>
-                <node concept="2yIwOk" id="4v5hZncVr8K" role="2OqNvi" />
-              </node>
-              <node concept="liA8E" id="4v5hZncVr8L" role="2OqNvi">
-                <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="4v5hZncVr8N" role="3uHU7w">
-              <node concept="2OqwBi" id="4v5hZncVr8O" role="2Oq$k0">
-                <node concept="2OqwBi" id="4v5hZncVr8P" role="2Oq$k0">
-                  <node concept="gKNx_" id="4v5hZncVr8Q" role="2Oq$k0" />
-                  <node concept="liA8E" id="4v5hZncVr8R" role="2OqNvi">
-                    <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                  </node>
-                </node>
-                <node concept="2yIwOk" id="4v5hZncVr8S" role="2OqNvi" />
-              </node>
-              <node concept="2Zo12i" id="4v5hZncVFbB" role="2OqNvi">
-                <node concept="chp4Y" id="4v5hZncVFhl" role="2Zo12j">
-                  <ref role="cht4Q" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="3clFbT" id="13LyZYiLqnI" role="3V_frF">
-      <property role="3clFbU" value="true" />
-    </node>
   </node>
   <node concept="312cEu" id="5Pgo_AS6VnV">
     <property role="TrG5h" value="ConstraintFailed" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/org.iets3.core.expr.tests.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/org.iets3.core.expr.tests.mpl
@@ -157,7 +157,6 @@
     <dependency reexport="false">f61473f9-130f-42f6-b98d-6c438812c2f6(jetbrains.mps.baseLanguage.unitTest)</dependency>
     <dependency reexport="false">8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)</dependency>
     <dependency reexport="false">707c4fde-f79a-44b5-b3d7-b5cef8844ccf(jetbrains.mps.lang.test.runtime)</dependency>
-    <dependency reexport="false">28583149-5b6e-4663-9c02-b9a8fa3cb099(com.mbeddr.mpsutil.contextactions.runtime)</dependency>
     <dependency reexport="false">2022a471-10ba-4431-ba5d-622df898f3c6(org.iets3.core.expr.testExecution)</dependency>
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
     <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
@@ -166,7 +165,6 @@
   </dependencies>
   <languageVersions>
     <language slang="l:f3b3dc28-fee3-49e1-a46e-685e96389094:com.mbeddr.mpsutil.bldoc" version="0" />
-    <language slang="l:677f00fb-4488-405e-9885-abb75d472fd1:com.mbeddr.mpsutil.contextactions" version="0" />
     <language slang="l:120e1c9d-4e27-4478-b2af-b2c3bd3850b0:com.mbeddr.mpsutil.editor.querylist" version="0" />
     <language slang="l:b33d119e-196d-4497-977c-5c167b21fe33:com.mbeddr.mpsutil.framecell" version="0" />
     <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="1" />
@@ -245,7 +243,6 @@
     <module reference="920eaa0e-ecca-46bc-bee7-4e5c59213dd6(Testbench)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
-    <module reference="28583149-5b6e-4663-9c02-b9a8fa3cb099(com.mbeddr.mpsutil.contextactions.runtime)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
     <module reference="b33d119e-196d-4497-977c-5c167b21fe33(com.mbeddr.mpsutil.framecell)" version="0" />
     <module reference="47f075a6-558e-4640-a606-7ce0236c8023(com.mbeddr.mpsutil.interpreter)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/plugin.mps
@@ -4,7 +4,6 @@
   <languages>
     <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="-1" />
     <use id="f159adf4-3c93-40f9-9c5a-1f245a8697af" name="jetbrains.mps.lang.aspect" version="-1" />
-    <use id="677f00fb-4488-405e-9885-abb75d472fd1" name="com.mbeddr.mpsutil.contextactions" version="-1" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="-1" />
     <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="-1" />
     <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="-1" />
@@ -19,15 +18,12 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="oq0c" ref="r:6c6155f0-4bbe-4af5-8c26-244d570e21e4(org.iets3.core.expr.base.plugin)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
-    <import index="1ne1" ref="r:e9a49de8-6adf-4c2e-b5c2-32fc88189c93(com.mbeddr.mpsutil.contextactions.runtime)" />
     <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" />
     <import index="nu60" ref="r:cfd59c48-ecc8-4b0c-8ae8-6d876c46ebbb(org.iets3.core.expr.toplevel.behavior)" implicit="true" />
     <import index="lmd" ref="r:a6074908-e483-4c8e-80b5-5dbf8b24df4c(org.iets3.core.expr.path.structure)" implicit="true" />
-    <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -180,7 +176,6 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
-      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
       <concept id="3729007189729192406" name="jetbrains.mps.lang.extension.structure.ExtensionPointDeclaration" flags="ng" index="vrV6u">
@@ -189,9 +184,6 @@
       <concept id="126958800891274162" name="jetbrains.mps.lang.extension.structure.Extension" flags="ig" index="1lYeZD">
         <reference id="126958800891274597" name="extensionPoint" index="1lYe$Y" />
       </concept>
-    </language>
-    <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
-      <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -220,11 +212,7 @@
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
-      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
-      <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
-        <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
-      </concept>
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
@@ -245,22 +233,6 @@
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
-      </concept>
-    </language>
-    <language id="677f00fb-4488-405e-9885-abb75d472fd1" name="com.mbeddr.mpsutil.contextactions">
-      <concept id="5022141054904911899" name="com.mbeddr.mpsutil.contextactions.structure.SubstituteActionExpression" flags="ng" index="gcnaP" />
-      <concept id="5022141054903714507" name="com.mbeddr.mpsutil.contextactions.structure.ContextExpression" flags="ng" index="gKNx_" />
-      <concept id="6294660000051228482" name="com.mbeddr.mpsutil.contextactions.structure.ContextActions" flags="ng" index="NGJ2D">
-        <child id="6294660000051228527" name="sources" index="NGJ24" />
-        <child id="8645458101902647485" name="isApplicable" index="3V_frF" />
-      </concept>
-      <concept id="6294660000051228497" name="com.mbeddr.mpsutil.contextactions.structure.SubstituteInfoSource" flags="ng" index="NGJ2U">
-        <child id="5022141054904911832" name="include" index="gcnPQ" />
-        <child id="573955333602854986" name="folder" index="37Ct4v" />
-      </concept>
-      <concept id="8009069486207462978" name="com.mbeddr.mpsutil.contextactions.structure.ActionSourceWithCondition" flags="ng" index="3_Xg01">
-        <child id="8009069486207463378" name="sources" index="3_Xg6h" />
-        <child id="8009069486207463329" name="condition" index="3_Xg7y" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
@@ -1036,82 +1008,6 @@
     </node>
     <node concept="2tJIrI" id="5iD_kvm6kQ0" role="jymVt" />
     <node concept="3Tm1VV" id="5iD_kvm6kPC" role="1B3o_S" />
-  </node>
-  <node concept="NGJ2D" id="5tr7YH$UwTY">
-    <property role="TrG5h" value="ToplevelContextActions" />
-    <node concept="3_Xg01" id="1yW0h04Dqdd" role="NGJ24">
-      <node concept="NGJ2U" id="5lGdLibZyEN" role="3_Xg6h">
-        <node concept="Xl_RD" id="vR6ln0lJV1" role="37Ct4v">
-          <property role="Xl_RC" value="KernelF - Toplevel" />
-        </node>
-        <node concept="2EnYce" id="6W_V$eaXQzr" role="gcnPQ">
-          <node concept="2OqwBi" id="13LyZYiLeRB" role="2Oq$k0">
-            <node concept="gcnaP" id="13LyZYiLeOf" role="2Oq$k0" />
-            <node concept="liA8E" id="13LyZYiLfmB" role="2OqNvi">
-              <ref role="37wK5l" to="1ne1:7vUP_qcwDWl" resolve="getOutputConceptLanguageName" />
-            </node>
-          </node>
-          <node concept="liA8E" id="13LyZYiLfUs" role="2OqNvi">
-            <ref role="37wK5l" to="wyt6:~String.contains(java.lang.CharSequence)" resolve="contains" />
-            <node concept="Xl_RD" id="13LyZYiLfVa" role="37wK5m">
-              <property role="Xl_RC" value="toplevel" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1Wc70l" id="4v5hZncVr8y" role="3_Xg7y">
-        <node concept="2OqwBi" id="4v5hZncVr8z" role="3uHU7B">
-          <node concept="2OqwBi" id="4v5hZncVr8$" role="2Oq$k0">
-            <node concept="gKNx_" id="4v5hZncVr8_" role="2Oq$k0" />
-            <node concept="liA8E" id="4v5hZncVr8A" role="2OqNvi">
-              <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-            </node>
-          </node>
-          <node concept="1mIQ4w" id="4v5hZncVr8B" role="2OqNvi">
-            <node concept="chp4Y" id="4v5hZncVEfD" role="cj9EA">
-              <ref role="cht4Q" to="yv47:2uR5X5ayM7T" resolve="IToplevelExprContent" />
-            </node>
-          </node>
-        </node>
-        <node concept="1eOMI4" id="4v5hZncVr8D" role="3uHU7w">
-          <node concept="22lmx$" id="4v5hZncVr8E" role="1eOMHV">
-            <node concept="2OqwBi" id="4v5hZncVr8F" role="3uHU7B">
-              <node concept="2OqwBi" id="4v5hZncVr8G" role="2Oq$k0">
-                <node concept="2OqwBi" id="4v5hZncVr8H" role="2Oq$k0">
-                  <node concept="gKNx_" id="4v5hZncVr8I" role="2Oq$k0" />
-                  <node concept="liA8E" id="4v5hZncVr8J" role="2OqNvi">
-                    <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                  </node>
-                </node>
-                <node concept="2yIwOk" id="4v5hZncVr8K" role="2OqNvi" />
-              </node>
-              <node concept="liA8E" id="4v5hZncVr8L" role="2OqNvi">
-                <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="4v5hZncVr8N" role="3uHU7w">
-              <node concept="2OqwBi" id="4v5hZncVr8O" role="2Oq$k0">
-                <node concept="2OqwBi" id="4v5hZncVr8P" role="2Oq$k0">
-                  <node concept="gKNx_" id="4v5hZncVr8Q" role="2Oq$k0" />
-                  <node concept="liA8E" id="4v5hZncVr8R" role="2OqNvi">
-                    <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                  </node>
-                </node>
-                <node concept="2yIwOk" id="4v5hZncVr8S" role="2OqNvi" />
-              </node>
-              <node concept="2Zo12i" id="4v5hZncVFbB" role="2OqNvi">
-                <node concept="chp4Y" id="4v5hZncVFhl" role="2Zo12j">
-                  <ref role="cht4Q" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="3clFbT" id="13LyZYiLqnI" role="3V_frF">
-      <property role="3clFbU" value="true" />
-    </node>
   </node>
   <node concept="312cEu" id="2nByCcy0n9q">
     <property role="TrG5h" value="CallInliner" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/org.iets3.core.expr.toplevel.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/org.iets3.core.expr.toplevel.mpl
@@ -27,11 +27,9 @@
     <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
     <dependency reexport="false">726886d1-ef90-4249-a08f-1e3ec23a7113(com.mbeddr.mpsutil.traceExplorer)</dependency>
-    <dependency reexport="false">28583149-5b6e-4663-9c02-b9a8fa3cb099(com.mbeddr.mpsutil.contextactions.runtime)</dependency>
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:677f00fb-4488-405e-9885-abb75d472fd1:com.mbeddr.mpsutil.contextactions" version="0" />
     <language slang="l:120e1c9d-4e27-4478-b2af-b2c3bd3850b0:com.mbeddr.mpsutil.editor.querylist" version="0" />
     <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="1" />
     <language slang="l:b4f35ed8-45af-4efa-abe4-00ac26956e69:com.mbeddr.mpsutil.grammarcells.runtimelang" version="0" />
@@ -101,7 +99,6 @@
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
-    <module reference="28583149-5b6e-4663-9c02-b9a8fa3cb099(com.mbeddr.mpsutil.contextactions.runtime)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
     <module reference="47f075a6-558e-4640-a606-7ce0236c8023(com.mbeddr.mpsutil.interpreter)" version="0" />
     <module reference="735f86bc-17fb-4d1c-a664-82c2b8e8a34e(com.mbeddr.mpsutil.interpreter.rt)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/editor.mps
@@ -11,6 +11,8 @@
     <use id="62a3babb-5d40-4920-897f-d4144dc99c9d" name="com.mbeddr.mpsutil.userstyles" version="0" />
     <use id="7e450f4e-1ac3-41ef-a851-4598161bdb94" name="de.slisson.mps.tables" version="0" />
     <use id="b1ab8c10-c118-4755-bf2a-cebab35cf533" name="jetbrains.mps.lang.editor.tooltips" version="0" />
+    <use id="b1c7d06f-525d-43b5-9b0a-2fc8f7f076ba" name="jetbrains.mps.editor.contextActionsTool.lang.menus" version="0" />
+    <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -23,19 +25,37 @@
     <import index="z726" ref="r:6b7eb85f-64d8-4de6-8906-0e18804729df(com.mbeddr.doc.editor)" />
     <import index="plfp" ref="r:82415404-e5c7-47c8-ae5b-951fc882e316(org.iets3.req.core.structure)" />
     <import index="btm1" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3(org.apache.commons/)" />
+    <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
+    <import index="xnls" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.icons(MPS.Platform/)" />
+    <import index="unno" ref="r:61e3d524-8c49-4491-b5e3-f6d6e9364527(jetbrains.mps.util)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="882r" ref="r:7c2726cf-5697-49bb-92f6-2986272fb311(com.mbeddr.doc.intentions)" />
+    <import index="bemq" ref="r:4cfa8b0a-7754-4d3d-9e06-0ce9d427860c(org.iets3.req.core.behavior)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
-    <import index="bemq" ref="r:4cfa8b0a-7754-4d3d-9e06-0ce9d427860c(org.iets3.req.core.behavior)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
+    <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" implicit="true" />
+    <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" implicit="true" />
+    <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" implicit="true" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="5991739802479784073" name="jetbrains.mps.lang.editor.structure.MenuTypeDefault" flags="ng" index="22hDWj" />
       <concept id="2000375450116423800" name="jetbrains.mps.lang.editor.structure.SubstituteMenu" flags="ng" index="22mcaB" />
+      <concept id="540685334799965957" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenuVariable_Initializer" flags="ig" index="23wN_R" />
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi">
         <child id="1078153129734" name="inspectedCellModel" index="6VMZX" />
         <child id="2597348684684069742" name="contextHints" index="CpUAK" />
       </concept>
       <concept id="1176897764478" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeFactory" flags="in" index="4$FPG" />
+      <concept id="1597643335227097138" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_TransformationMenu_node" flags="ng" index="7Obwk" />
+      <concept id="6516520003787916624" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_Condition" flags="ig" index="27VH4U" />
+      <concept id="2468431357014947084" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_Text" flags="ig" index="293xgL" />
+      <concept id="7429591467341004871" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_Group" flags="ng" index="aenpk">
+        <child id="7429591467341004872" name="parts" index="aenpr" />
+        <child id="7429591467341004877" name="condition" index="aenpu" />
+        <child id="7655327340756279373" name="variables" index="1b80Z_" />
+      </concept>
       <concept id="6822301196700715228" name="jetbrains.mps.lang.editor.structure.ConceptEditorHintDeclarationReference" flags="ig" index="2aJ2om">
         <reference id="5944657839026714445" name="hint" index="2$4xQ3" />
       </concept>
@@ -58,14 +78,24 @@
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
       <concept id="795210086017940429" name="jetbrains.mps.lang.editor.structure.ReadOnlyStyleClassItem" flags="lg" index="xShMh" />
+      <concept id="6718020819487620876" name="jetbrains.mps.lang.editor.structure.TransformationMenuReference_Default" flags="ng" index="A1WHr" />
       <concept id="5944657839000868711" name="jetbrains.mps.lang.editor.structure.ConceptEditorContextHints" flags="ig" index="2ABfQD">
         <child id="5944657839000877563" name="hints" index="2ABdcP" />
+      </concept>
+      <concept id="3547227755871693971" name="jetbrains.mps.lang.editor.structure.PredefinedSelector" flags="ng" index="2B6iha">
+        <property id="2162403111523065396" name="cellId" index="1lyBwo" />
       </concept>
       <concept id="5944657839003601246" name="jetbrains.mps.lang.editor.structure.ConceptEditorHintDeclaration" flags="ig" index="2BsEeg">
         <property id="168363875802087287" name="showInUI" index="2gpH_U" />
         <property id="5944657839012629576" name="presentation" index="2BUmq6" />
       </concept>
       <concept id="1239814640496" name="jetbrains.mps.lang.editor.structure.CellLayout_VerticalGrid" flags="nn" index="2EHx9g" />
+      <concept id="1638911550608610798" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_Execute" flags="ig" index="IWg2L" />
+      <concept id="1638911550608610278" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_Action" flags="ng" index="IWgqT">
+        <child id="6202297022026447496" name="canExecuteFunction" index="2jiSrf" />
+        <child id="1638911550608610281" name="executeFunction" index="IWgqQ" />
+        <child id="5692353713941573325" name="textFunction" index="1hCUd6" />
+      </concept>
       <concept id="1078938745671" name="jetbrains.mps.lang.editor.structure.EditorComponentDeclaration" flags="ig" index="PKFIW" />
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
         <reference id="1078939183255" name="editorComponent" index="PMmxG" />
@@ -89,24 +119,41 @@
       <concept id="1186415722038" name="jetbrains.mps.lang.editor.structure.FontSizeStyleClassItem" flags="ln" index="VSNWy">
         <child id="1221064706952" name="query" index="1d8cEk" />
       </concept>
+      <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ng" index="2Z_bC8">
+        <reference id="1630016958698373342" name="concept" index="2ZyFGn" />
+      </concept>
       <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ng" index="2ZABuq">
         <reference id="6591946374543067572" name="conceptDeclaration" index="aqKnT" />
         <child id="5991739802479788259" name="type" index="22hAXT" />
+      </concept>
+      <concept id="1630016958697286851" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_parameterObject" flags="ng" index="2ZBlsa" />
+      <concept id="1630016958697057551" name="jetbrains.mps.lang.editor.structure.IMenuPartParameterized" flags="ng" index="2ZBHr6">
+        <child id="1630016958697057552" name="parameterType" index="2ZBHrp" />
       </concept>
       <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
       <concept id="1233759184865" name="jetbrains.mps.lang.editor.structure.PunctuationRightStyleClassItem" flags="ln" index="11LMrY" />
       <concept id="3383245079137382180" name="jetbrains.mps.lang.editor.structure.StyleClass" flags="ig" index="14StLt" />
       <concept id="1221057094638" name="jetbrains.mps.lang.editor.structure.QueryFunction_Integer" flags="in" index="1cFabM" />
+      <concept id="5692353713941573329" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_ActionLabelText" flags="ig" index="1hCUdq" />
       <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
         <child id="1088186146602" name="editorComponent" index="1sWHZn" />
+      </concept>
+      <concept id="7291101478617127464" name="jetbrains.mps.lang.editor.structure.IExtensibleTransformationMenuPart" flags="ng" index="1joUw2">
+        <child id="8954657570916349207" name="features" index="2jZA2a" />
       </concept>
       <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
       </concept>
+      <concept id="7580468736840446506" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_model" flags="nn" index="1rpKSd" />
       <concept id="1088185857835" name="jetbrains.mps.lang.editor.structure.InlineEditorComponent" flags="ig" index="1sVBvm" />
+      <concept id="4056398722183895535" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_SubMenu" flags="ng" index="1vlq3a">
+        <child id="5692353713941631155" name="textFunction" index="1hCDOS" />
+        <child id="4056398722183895554" name="items" index="1vlqcB" />
+      </concept>
       <concept id="9122903797312246523" name="jetbrains.mps.lang.editor.structure.StyleReference" flags="ng" index="1wgc9g">
         <reference id="9122903797312247166" name="style" index="1wgcnl" />
       </concept>
+      <concept id="2314756748950088783" name="jetbrains.mps.lang.editor.structure.TransformationMenuVariableReference" flags="ng" index="3yx0qK" />
       <concept id="1215007762405" name="jetbrains.mps.lang.editor.structure.FloatStyleClassItem" flags="ln" index="3$6MrZ">
         <property id="1215007802031" name="value" index="3$6WeP" />
       </concept>
@@ -114,6 +161,9 @@
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
         <property id="1140017977771" name="readOnly" index="1Intyy" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
+      </concept>
+      <concept id="1178539929008" name="jetbrains.mps.lang.editor.structure.TransformationMenuVariableDeclaration" flags="ig" index="1At2My">
+        <child id="540685334799973431" name="initializerBlock" index="23wLD5" />
       </concept>
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
         <property id="1130859485024" name="attractsFocus" index="1cu_pB" />
@@ -133,11 +183,31 @@
       </concept>
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
       <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
+      <concept id="4233361609415247331" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_Parameter" flags="ig" index="1GhMSn" />
+      <concept id="4233361609415240997" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_Parameterized" flags="ng" index="1GhOrh">
+        <child id="4233361609415240998" name="part" index="1GhOri" />
+        <child id="4233361609415241000" name="parameterQuery" index="1GhOrs" />
+      </concept>
       <concept id="1225898583838" name="jetbrains.mps.lang.editor.structure.ReadOnlyModelAccessor" flags="ng" index="1HfYo3">
         <child id="1225898971709" name="getter" index="1Hhtcw" />
       </concept>
       <concept id="1225900081164" name="jetbrains.mps.lang.editor.structure.CellModel_ReadOnlyModelAccessor" flags="sg" stub="3708815482283559694" index="1HlG4h">
         <child id="1225900141900" name="modelAccessor" index="1HlULh" />
+      </concept>
+      <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ng" index="3INCJE">
+        <child id="1638911550608572412" name="sections" index="IW6Ez" />
+      </concept>
+      <concept id="5624877018228264944" name="jetbrains.mps.lang.editor.structure.TransformationMenuContribution" flags="ng" index="3INDKC">
+        <child id="6718020819489956031" name="menuReference" index="AmTjC" />
+      </concept>
+      <concept id="3647146066980922272" name="jetbrains.mps.lang.editor.structure.SelectInEditorOperation" flags="nn" index="1OKiuA">
+        <child id="1948540814633499358" name="editorContext" index="lBI5i" />
+        <child id="1948540814635895774" name="cellSelector" index="lGT1i" />
+      </concept>
+      <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
+      <concept id="7980428675268276156" name="jetbrains.mps.lang.editor.structure.TransformationMenuSection" flags="ng" index="1Qtc8_">
+        <child id="7980428675268276157" name="locations" index="1Qtc8$" />
+        <child id="7980428675268276159" name="parts" index="1Qtc8A" />
       </concept>
       <concept id="1176717841777" name="jetbrains.mps.lang.editor.structure.QueryFunction_ModelAccess_Getter" flags="in" index="3TQlhw" />
       <concept id="1176749715029" name="jetbrains.mps.lang.editor.structure.QueryFunction_CellProvider" flags="in" index="3VJUX4" />
@@ -150,10 +220,17 @@
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -167,17 +244,21 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
       </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -185,12 +266,24 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271369338" name="jetbrains.mps.baseLanguage.structure.IsEmptyOperation" flags="nn" index="17RlXB" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
       <concept id="1111509017652" name="jetbrains.mps.baseLanguage.structure.FloatingPointConstant" flags="nn" index="3b6qkQ">
         <property id="1113006610751" name="value" index="$nhwW" />
       </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <property id="4276006055363816570" name="isSynchronized" index="od$2w" />
+        <property id="1181808852946" name="isFinal" index="DiZV1" />
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -202,6 +295,7 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
@@ -216,14 +310,54 @@
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
+        <property id="8355037393041754995" name="isNative" index="2aFKle" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+    </language>
+    <language id="b1c7d06f-525d-43b5-9b0a-2fc8f7f076ba" name="jetbrains.mps.editor.contextActionsTool.lang.menus">
+      <concept id="8954657570916343208" name="jetbrains.mps.editor.contextActionsTool.lang.menus.structure.TransformationLocation_ContextActionsTool" flags="ng" index="2jZ$wP" />
+      <concept id="8954657570916343205" name="jetbrains.mps.editor.contextActionsTool.lang.menus.structure.TransformationFeature_Tooltip" flags="ng" index="2jZ$wS">
+        <child id="8954657570916343206" name="query" index="2jZ$wV" />
+      </concept>
+      <concept id="8954657570916342474" name="jetbrains.mps.editor.contextActionsTool.lang.menus.structure.QueryFunction_TransformationMenu_Icon" flags="ig" index="2jZ$Xn" />
+      <concept id="8954657570916342471" name="jetbrains.mps.editor.contextActionsTool.lang.menus.structure.TransformationFeature_Icon" flags="ng" index="2jZ$Xq">
+        <child id="8954657570916343203" name="query" index="2jZ$wY" />
+      </concept>
+      <concept id="7291101478621922220" name="jetbrains.mps.editor.contextActionsTool.lang.menus.structure.QueryFunction_TransformationMenu_Tooltip" flags="ig" index="1jIJ66" />
+    </language>
+    <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
+      <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
     <language id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells">
@@ -287,17 +421,38 @@
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
+        <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
+      </concept>
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="1173122760281" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorsOperation" flags="nn" index="z$bX8" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
+      <concept id="1143224066846" name="jetbrains.mps.lang.smodel.structure.Node_InsertNextSiblingOperation" flags="nn" index="HtI8k">
+        <child id="1143224066849" name="insertedNode" index="HtI8F" />
+      </concept>
+      <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1181949435690" name="jetbrains.mps.lang.smodel.structure.Concept_NewInstance" flags="nn" index="LFhST" />
+      <concept id="1181952871644" name="jetbrains.mps.lang.smodel.structure.Concept_GetAllSubConcepts" flags="nn" index="LSoRf">
+        <child id="1182506816063" name="smodel" index="1iTxcG" />
+      </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
+      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz">
+        <reference id="6677504323281689839" name="conceptDeclaraton" index="3bZ5Sy" />
+      </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
+      <concept id="6870613620391345436" name="jetbrains.mps.lang.smodel.structure.ConceptShortDescriptionOperation" flags="ng" index="3neUYN" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
@@ -317,6 +472,10 @@
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
+      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
+        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
+      </concept>
+      <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -327,8 +486,35 @@
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
     </language>
     <language id="62a3babb-5d40-4920-897f-d4144dc99c9d" name="com.mbeddr.mpsutil.userstyles">
       <concept id="8170319964140884845" name="com.mbeddr.mpsutil.userstyles.structure.UserConfigurable" flags="ng" index="1Ex9Rl">
@@ -2247,6 +2433,1377 @@
     <node concept="3F0ifn" id="6dXnuBU76k5" role="2wV5jI">
       <property role="3F0ifm" value="Workaround to fix contributions to BaseConcept generated by grammarCells." />
     </node>
+  </node>
+  <node concept="3INDKC" id="73kHms31EVf">
+    <property role="TrG5h" value="RequirementsContextActions" />
+    <node concept="A1WHr" id="73kHms31EVh" role="AmTjC">
+      <ref role="2ZyFGn" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    </node>
+    <node concept="1Qtc8_" id="73kHms31EVk" role="IW6Ez">
+      <node concept="2jZ$wP" id="73kHms31GTe" role="1Qtc8$" />
+      <node concept="1vlq3a" id="73kHms33CG9" role="1Qtc8A">
+        <node concept="IWgqT" id="73kHms33SOl" role="1vlqcB">
+          <node concept="2jZ$Xq" id="73kHms33SOm" role="2jZA2a" />
+          <node concept="2jZ$wS" id="73kHms33SOn" role="2jZA2a" />
+          <node concept="1hCUdq" id="73kHms33SOo" role="1hCUd6">
+            <node concept="3clFbS" id="73kHms33SOp" role="2VODD2">
+              <node concept="3clFbF" id="73kHms33SOq" role="3cqZAp">
+                <node concept="Xl_RD" id="73kHms33SOv" role="3clFbG">
+                  <property role="Xl_RC" value="Delete" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="IWg2L" id="73kHms33SOw" role="IWgqQ">
+            <node concept="3clFbS" id="73kHms33SOx" role="2VODD2">
+              <node concept="3clFbF" id="73kHms33Vy4" role="3cqZAp">
+                <node concept="2OqwBi" id="73kHms33VE$" role="3clFbG">
+                  <node concept="7Obwk" id="73kHms33Vy3" role="2Oq$k0" />
+                  <node concept="3YRAZt" id="73kHms33VP5" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="27VH4U" id="73kHms33Uy$" role="2jiSrf">
+            <node concept="3clFbS" id="73kHms33Uy_" role="2VODD2">
+              <node concept="3clFbF" id="73kHms33UAw" role="3cqZAp">
+                <node concept="2OqwBi" id="73kHms33UJw" role="3clFbG">
+                  <node concept="7Obwk" id="73kHms33UAv" role="2Oq$k0" />
+                  <node concept="1mIQ4w" id="73kHms33V1h" role="2OqNvi">
+                    <node concept="chp4Y" id="73kHms33V7j" role="cj9EA">
+                      <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="293xgL" id="73kHms33CGb" role="1hCDOS">
+          <node concept="3clFbS" id="73kHms33CGd" role="2VODD2">
+            <node concept="3clFbF" id="73kHms33Eb2" role="3cqZAp">
+              <node concept="2YIFZM" id="4OH$Ti$m$5D" role="3clFbG">
+                <ref role="1Pybhc" node="5Zn2KFQQ$_B" resolve="ContextActionsHelper" />
+                <ref role="37wK5l" node="4OH$Ti$mtsB" resolve="getReqStructureFolderName" />
+                <node concept="7Obwk" id="73kHms33F6g" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="aenpk" id="73kHms33Kij" role="1vlqcB">
+          <node concept="1At2My" id="73kHms33KMc" role="1b80Z_">
+            <property role="TrG5h" value="requirement" />
+            <node concept="23wN_R" id="73kHms33KMd" role="23wLD5">
+              <node concept="3clFbS" id="73kHms33KMe" role="2VODD2">
+                <node concept="3clFbF" id="73kHms33L5j" role="3cqZAp">
+                  <node concept="2OqwBi" id="73kHms33Lgw" role="3clFbG">
+                    <node concept="7Obwk" id="73kHms33L5i" role="2Oq$k0" />
+                    <node concept="2Xjw5R" id="73kHms33LBh" role="2OqNvi">
+                      <node concept="1xMEDy" id="73kHms33LBj" role="1xVPHs">
+                        <node concept="chp4Y" id="73kHms33LHL" role="ri$Ld">
+                          <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+                        </node>
+                      </node>
+                      <node concept="1xIGOp" id="73kHms33LZm" role="1xVPHs" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3Tqbb2" id="73kHms33KMA" role="1tU5fm">
+              <ref role="ehGHo" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+            </node>
+          </node>
+          <node concept="IWgqT" id="73kHms33KKz" role="aenpr">
+            <node concept="2jZ$Xq" id="73kHms33KK$" role="2jZA2a" />
+            <node concept="2jZ$wS" id="73kHms33KK_" role="2jZA2a" />
+            <node concept="1hCUdq" id="73kHms33KKA" role="1hCUd6">
+              <node concept="3clFbS" id="73kHms33KKB" role="2VODD2">
+                <node concept="3clFbF" id="73kHms33NvH" role="3cqZAp">
+                  <node concept="3cpWs3" id="73kHms33O3Z" role="3clFbG">
+                    <node concept="2OqwBi" id="73kHms33Ost" role="3uHU7w">
+                      <node concept="3yx0qK" id="73kHms33O8N" role="2Oq$k0">
+                        <ref role="3cqZAo" node="73kHms33KMc" resolve="requirement" />
+                      </node>
+                      <node concept="2qgKlT" id="73kHms33OWx" role="2OqNvi">
+                        <ref role="37wK5l" to="bemq:7gL8KYmPHWW" resolve="getDisplayName" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="73kHms33NvG" role="3uHU7B">
+                      <property role="Xl_RC" value="Add Child " />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="IWg2L" id="73kHms33KKC" role="IWgqQ">
+              <node concept="3clFbS" id="73kHms33KKD" role="2VODD2">
+                <node concept="3clFbF" id="73kHms33P79" role="3cqZAp">
+                  <node concept="2OqwBi" id="73kHms33Pj8" role="3clFbG">
+                    <node concept="3yx0qK" id="73kHms33P78" role="2Oq$k0">
+                      <ref role="3cqZAo" node="73kHms33KMc" resolve="requirement" />
+                    </node>
+                    <node concept="2qgKlT" id="73kHms33PIR" role="2OqNvi">
+                      <ref role="37wK5l" to="bemq:7Dcax7AeLVS" resolve="addChild" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="IWgqT" id="73kHms33QyV" role="aenpr">
+            <node concept="2jZ$Xq" id="73kHms33QyW" role="2jZA2a" />
+            <node concept="2jZ$wS" id="73kHms33QyX" role="2jZA2a" />
+            <node concept="1hCUdq" id="73kHms33QyY" role="1hCUd6">
+              <node concept="3clFbS" id="73kHms33QyZ" role="2VODD2">
+                <node concept="3clFbF" id="73kHms33Qz0" role="3cqZAp">
+                  <node concept="3cpWs3" id="73kHms33Qz1" role="3clFbG">
+                    <node concept="2OqwBi" id="73kHms33Qz2" role="3uHU7w">
+                      <node concept="3yx0qK" id="73kHms33Qz3" role="2Oq$k0">
+                        <ref role="3cqZAo" node="73kHms33KMc" resolve="requirement" />
+                      </node>
+                      <node concept="2qgKlT" id="73kHms33Qz4" role="2OqNvi">
+                        <ref role="37wK5l" to="bemq:7gL8KYmPHWW" resolve="getDisplayName" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="73kHms33Qz5" role="3uHU7B">
+                      <property role="Xl_RC" value="Add Sibling " />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="IWg2L" id="73kHms33Qz6" role="IWgqQ">
+              <node concept="3clFbS" id="73kHms33Qz7" role="2VODD2">
+                <node concept="3cpWs8" id="73kHms33RMJ" role="3cqZAp">
+                  <node concept="3cpWsn" id="73kHms33RMK" role="3cpWs9">
+                    <property role="TrG5h" value="r" />
+                    <node concept="3Tqbb2" id="73kHms33RMz" role="1tU5fm">
+                      <ref role="ehGHo" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+                    </node>
+                    <node concept="2OqwBi" id="73kHms33RML" role="33vP2m">
+                      <node concept="3yx0qK" id="73kHms33RMM" role="2Oq$k0">
+                        <ref role="3cqZAo" node="73kHms33KMc" resolve="requirement" />
+                      </node>
+                      <node concept="2qgKlT" id="73kHms33RMN" role="2OqNvi">
+                        <ref role="37wK5l" to="bemq:7Dcax7AghL2" resolve="addSibling" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="73kHms33Qz8" role="3cqZAp">
+                  <node concept="2OqwBi" id="73kHms33Sjx" role="3clFbG">
+                    <node concept="37vLTw" id="73kHms33RMO" role="2Oq$k0">
+                      <ref role="3cqZAo" node="73kHms33RMK" resolve="r" />
+                    </node>
+                    <node concept="1OKiuA" id="73kHms33SGp" role="2OqNvi">
+                      <node concept="1Q80Hx" id="73kHms33SIe" role="lBI5i" />
+                      <node concept="2B6iha" id="73kHms33SMa" role="lGT1i">
+                        <property role="1lyBwo" value="1S2pyLby17G/firstEditable" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="27VH4U" id="73kHms33M2t" role="aenpu">
+            <node concept="3clFbS" id="73kHms33M2u" role="2VODD2">
+              <node concept="3clFbF" id="73kHms33M6P" role="3cqZAp">
+                <node concept="2OqwBi" id="73kHms33Ms2" role="3clFbG">
+                  <node concept="3yx0qK" id="73kHms33M6O" role="2Oq$k0">
+                    <ref role="3cqZAo" node="73kHms33KMc" resolve="requirement" />
+                  </node>
+                  <node concept="3x8VRR" id="73kHms33Nis" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="aenpk" id="73kHms32zuA" role="1Qtc8A">
+        <node concept="27VH4U" id="73kHms32zuT" role="aenpu">
+          <node concept="3clFbS" id="73kHms32zuU" role="2VODD2">
+            <node concept="3clFbF" id="73kHms32zE7" role="3cqZAp">
+              <node concept="2OqwBi" id="3wHxcnxBP7Y" role="3clFbG">
+                <node concept="2OqwBi" id="3wHxcnxBOYP" role="2Oq$k0">
+                  <node concept="7Obwk" id="73kHms32zTQ" role="2Oq$k0" />
+                  <node concept="2Xjw5R" id="3wHxcnxBP3e" role="2OqNvi">
+                    <node concept="1xMEDy" id="3wHxcnxBP3g" role="1xVPHs">
+                      <node concept="chp4Y" id="3wHxcnxCFa4" role="ri$Ld">
+                        <ref role="cht4Q" to="plfp:3wHxcnxC3W5" resolve="IReqRefCtx" />
+                      </node>
+                    </node>
+                    <node concept="1xIGOp" id="3wHxcnxBP5I" role="1xVPHs" />
+                  </node>
+                </node>
+                <node concept="3x8VRR" id="3wHxcnxBPhy" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1vlq3a" id="73kHms32$hq" role="aenpr">
+          <node concept="293xgL" id="73kHms32$hr" role="1hCDOS">
+            <node concept="3clFbS" id="73kHms32$hs" role="2VODD2">
+              <node concept="3clFbF" id="73kHms33eGw" role="3cqZAp">
+                <node concept="2YIFZM" id="73kHms33eS2" role="3clFbG">
+                  <ref role="37wK5l" node="4OH$Ti$mxDm" resolve="getReqGeneralFolderName" />
+                  <ref role="1Pybhc" node="5Zn2KFQQ$_B" resolve="ContextActionsHelper" />
+                  <node concept="7Obwk" id="73kHms33eTi" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1GhOrh" id="73kHms32ACM" role="1vlqcB">
+            <node concept="1GhMSn" id="73kHms32ACN" role="1GhOrs">
+              <node concept="3clFbS" id="73kHms32ACO" role="2VODD2">
+                <node concept="3clFbF" id="73kHms32B7A" role="3cqZAp">
+                  <node concept="2OqwBi" id="3wHxcnxBS61" role="3clFbG">
+                    <node concept="2OqwBi" id="3wHxcnxBR8i" role="2Oq$k0">
+                      <node concept="2OqwBi" id="3wHxcnxBQXd" role="2Oq$k0">
+                        <node concept="7Obwk" id="73kHms32Blm" role="2Oq$k0" />
+                        <node concept="2Xjw5R" id="3wHxcnxBR4z" role="2OqNvi">
+                          <node concept="1xMEDy" id="3wHxcnxBR4_" role="1xVPHs">
+                            <node concept="chp4Y" id="3wHxcnxBR5D" role="ri$Ld">
+                              <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2qgKlT" id="3wHxcnxBRil" role="2OqNvi">
+                        <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
+                        <node concept="3TUQnm" id="3wHxcnxBRkh" role="37wK5m">
+                          <ref role="3TV0OU" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="v3k3i" id="3wHxcnxBSjt" role="2OqNvi">
+                      <node concept="chp4Y" id="3wHxcnxBSmo" role="v3oSu">
+                        <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="IWgqT" id="73kHms32EbD" role="1GhOri">
+              <node concept="2jZ$Xq" id="73kHms32EbF" role="2jZA2a">
+                <node concept="2jZ$Xn" id="73kHms32IGi" role="2jZ$wY">
+                  <node concept="3clFbS" id="73kHms32IGj" role="2VODD2">
+                    <node concept="3cpWs8" id="73kHms32Ksz" role="3cqZAp">
+                      <node concept="3cpWsn" id="73kHms32Ks$" role="3cpWs9">
+                        <property role="TrG5h" value="icon" />
+                        <node concept="3uibUv" id="73kHms32ITD" role="1tU5fm">
+                          <ref role="3uigEE" to="dxuu:~Icon" resolve="Icon" />
+                        </node>
+                        <node concept="2OqwBi" id="73kHms32Ks_" role="33vP2m">
+                          <node concept="liA8E" id="73kHms32KsA" role="2OqNvi">
+                            <ref role="37wK5l" to="xnls:~BaseIconManager.getIconFor(org.jetbrains.mps.openapi.model.SNode)" resolve="getIconFor" />
+                            <node concept="2ZBlsa" id="73kHms32KsB" role="37wK5m" />
+                          </node>
+                          <node concept="2YIFZM" id="73kHms32KsC" role="2Oq$k0">
+                            <ref role="37wK5l" to="xnls:~GlobalIconManager.getInstance()" resolve="getInstance" />
+                            <ref role="1Pybhc" to="xnls:~GlobalIconManager" resolve="GlobalIconManager" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="73kHms32NqQ" role="3cqZAp">
+                      <node concept="2ShNRf" id="73kHms32NqM" role="3clFbG">
+                        <node concept="1pGfFk" id="73kHms336aA" role="2ShVmc">
+                          <ref role="37wK5l" to="unno:Z6TQiSRD5N" resolve="Icon2IconResourceAdapter_Deprecated" />
+                          <node concept="37vLTw" id="73kHms336mf" role="37wK5m">
+                            <ref role="3cqZAo" node="73kHms32Ks$" resolve="icon" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2jZ$wS" id="73kHms32EbG" role="2jZA2a">
+                <node concept="1jIJ66" id="73kHms32Jev" role="2jZ$wV">
+                  <node concept="3clFbS" id="73kHms32Jew" role="2VODD2">
+                    <node concept="3clFbF" id="73kHms32Jj4" role="3cqZAp">
+                      <node concept="2OqwBi" id="73kHms32Jy5" role="3clFbG">
+                        <node concept="2ZBlsa" id="73kHms32Jj3" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="73kHms32JYM" role="2OqNvi">
+                          <ref role="3TsBF5" to="plfp:4tXyFaWwpnN" resolve="title" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1hCUdq" id="73kHms32EbH" role="1hCUd6">
+                <node concept="3clFbS" id="73kHms32EbJ" role="2VODD2">
+                  <node concept="3clFbF" id="73kHms32HrN" role="3cqZAp">
+                    <node concept="2OqwBi" id="73kHms32HJ1" role="3clFbG">
+                      <node concept="2ZBlsa" id="73kHms32HrM" role="2Oq$k0" />
+                      <node concept="2qgKlT" id="73kHms32IxU" role="2OqNvi">
+                        <ref role="37wK5l" to="tpcu:hEwIO9y" resolve="getFqName" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="IWg2L" id="73kHms32EbL" role="IWgqQ">
+                <node concept="3clFbS" id="73kHms32EbN" role="2VODD2">
+                  <node concept="3clFbF" id="3wHxcnxBYhy" role="3cqZAp">
+                    <node concept="2OqwBi" id="3wHxcnxBYrB" role="3clFbG">
+                      <node concept="2OqwBi" id="3wHxcnxBYh$" role="2Oq$k0">
+                        <node concept="7Obwk" id="73kHms32Ke1" role="2Oq$k0" />
+                        <node concept="2Xjw5R" id="3wHxcnxBYhC" role="2OqNvi">
+                          <node concept="1xMEDy" id="3wHxcnxBYhD" role="1xVPHs">
+                            <node concept="chp4Y" id="3wHxcnxCFcC" role="ri$Ld">
+                              <ref role="cht4Q" to="plfp:3wHxcnxC3W5" resolve="IReqRefCtx" />
+                            </node>
+                          </node>
+                          <node concept="1xIGOp" id="3wHxcnxBYhF" role="1xVPHs" />
+                        </node>
+                      </node>
+                      <node concept="2qgKlT" id="3wHxcnxCG4s" role="2OqNvi">
+                        <ref role="37wK5l" to="bemq:3wHxcnxC3Wx" resolve="insertRefTo" />
+                        <node concept="2ZBlsa" id="73kHms32Klg" role="37wK5m" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3Tqbb2" id="3wHxcnxBRFu" role="2ZBHrp">
+              <ref role="ehGHo" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1vlq3a" id="73kHms33azM" role="1Qtc8A">
+        <node concept="293xgL" id="73kHms33azO" role="1hCDOS">
+          <node concept="3clFbS" id="73kHms33azQ" role="2VODD2">
+            <node concept="3clFbF" id="73kHms33bdH" role="3cqZAp">
+              <node concept="Xl_RD" id="73kHms33bdG" role="3clFbG">
+                <property role="Xl_RC" value="Documentation" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="aenpk" id="73kHms33biX" role="1vlqcB">
+          <node concept="27VH4U" id="73kHms33bj3" role="aenpu">
+            <node concept="3clFbS" id="73kHms33bj4" role="2VODD2">
+              <node concept="3clFbF" id="73kHms33bmX" role="3cqZAp">
+                <node concept="2YIFZM" id="5Zn2KFQR6IH" role="3clFbG">
+                  <ref role="1Pybhc" node="5Zn2KFQQ$_B" resolve="ContextActionsHelper" />
+                  <ref role="37wK5l" node="5Zn2KFQR5HX" resolve="isUnderDoc" />
+                  <node concept="7Obwk" id="73kHms33f_z" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1vlq3a" id="73kHms33fNb" role="aenpr">
+            <node concept="293xgL" id="73kHms33fNc" role="1hCDOS">
+              <node concept="3clFbS" id="73kHms33fNd" role="2VODD2">
+                <node concept="3clFbF" id="73kHms33fW9" role="3cqZAp">
+                  <node concept="Xl_RD" id="7Ip2X68Oot6" role="3clFbG">
+                    <property role="Xl_RC" value="Insert Paragraph" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1GhOrh" id="73kHms33g5F" role="1vlqcB">
+              <node concept="1GhMSn" id="73kHms33g5G" role="1GhOrs">
+                <node concept="3clFbS" id="73kHms33g5H" role="2VODD2">
+                  <node concept="3clFbF" id="73kHms33gb8" role="3cqZAp">
+                    <node concept="2YIFZM" id="5Zn2KFQQWTp" role="3clFbG">
+                      <ref role="1Pybhc" node="5Zn2KFQQ$_B" resolve="ContextActionsHelper" />
+                      <ref role="37wK5l" node="5Zn2KFQQNJT" resolve="getValidDocContents" />
+                      <node concept="1rpKSd" id="73kHms33gAU" role="37wK5m" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="IWgqT" id="73kHms33gDV" role="1GhOri">
+                <node concept="2jZ$Xq" id="73kHms33gDX" role="2jZA2a">
+                  <node concept="2jZ$Xn" id="73kHms33hOY" role="2jZ$wY">
+                    <node concept="3clFbS" id="73kHms33hOZ" role="2VODD2">
+                      <node concept="3cpWs8" id="73kHms33i1m" role="3cqZAp">
+                        <node concept="3cpWsn" id="73kHms33i1n" role="3cpWs9">
+                          <property role="TrG5h" value="icon" />
+                          <node concept="3uibUv" id="73kHms33hSC" role="1tU5fm">
+                            <ref role="3uigEE" to="dxuu:~Icon" resolve="Icon" />
+                          </node>
+                          <node concept="2OqwBi" id="73kHms33i1o" role="33vP2m">
+                            <node concept="liA8E" id="73kHms33i1p" role="2OqNvi">
+                              <ref role="37wK5l" to="xnls:~BaseIconManager.getIconFor(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="getIconFor" />
+                              <node concept="2ZBlsa" id="73kHms33i89" role="37wK5m" />
+                            </node>
+                            <node concept="2YIFZM" id="73kHms33i1r" role="2Oq$k0">
+                              <ref role="1Pybhc" to="xnls:~GlobalIconManager" resolve="GlobalIconManager" />
+                              <ref role="37wK5l" to="xnls:~GlobalIconManager.getInstance()" resolve="getInstance" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="73kHms33ivP" role="3cqZAp">
+                        <node concept="2ShNRf" id="73kHms33ivQ" role="3clFbG">
+                          <node concept="1pGfFk" id="73kHms33ivR" role="2ShVmc">
+                            <ref role="37wK5l" to="unno:Z6TQiSRD5N" resolve="Icon2IconResourceAdapter_Deprecated" />
+                            <node concept="37vLTw" id="73kHms33ivS" role="37wK5m">
+                              <ref role="3cqZAo" node="73kHms33i1n" resolve="icon" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2jZ$wS" id="73kHms33gDY" role="2jZA2a">
+                  <node concept="1jIJ66" id="73kHms33iIz" role="2jZ$wV">
+                    <node concept="3clFbS" id="73kHms33iI$" role="2VODD2">
+                      <node concept="3clFbF" id="73kHms33iN8" role="3cqZAp">
+                        <node concept="2OqwBi" id="73kHms33j6a" role="3clFbG">
+                          <node concept="2ZBlsa" id="73kHms33iN7" role="2Oq$k0" />
+                          <node concept="3neUYN" id="73kHms33jt3" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1hCUdq" id="73kHms33gDZ" role="1hCUd6">
+                  <node concept="3clFbS" id="73kHms33gE1" role="2VODD2">
+                    <node concept="3clFbF" id="73kHms33gNy" role="3cqZAp">
+                      <node concept="3cpWs3" id="5Zn2KFQTIiN" role="3clFbG">
+                        <node concept="Xl_RD" id="5Zn2KFQTIiO" role="3uHU7w">
+                          <property role="Xl_RC" value=")" />
+                        </node>
+                        <node concept="3cpWs3" id="5Zn2KFQTIiP" role="3uHU7B">
+                          <node concept="3cpWs3" id="5Zn2KFQTIiQ" role="3uHU7B">
+                            <node concept="2OqwBi" id="5Zn2KFQTIiR" role="3uHU7B">
+                              <node concept="3n3YKJ" id="5Zn2KFQTIiT" role="2OqNvi" />
+                              <node concept="2ZBlsa" id="73kHms33hbc" role="2Oq$k0" />
+                            </node>
+                            <node concept="Xl_RD" id="5Zn2KFQTIiU" role="3uHU7w">
+                              <property role="Xl_RC" value=" (" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="5Zn2KFQTIiV" role="3uHU7w">
+                            <node concept="3neUYN" id="5Zn2KFQTIiX" role="2OqNvi" />
+                            <node concept="2ZBlsa" id="73kHms33hB2" role="2Oq$k0" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="IWg2L" id="73kHms33gE3" role="IWgqQ">
+                  <node concept="3clFbS" id="73kHms33gE5" role="2VODD2">
+                    <node concept="3clFbF" id="5Zn2KFQR6SE" role="3cqZAp">
+                      <node concept="2OqwBi" id="5Zn2KFQR7iR" role="3clFbG">
+                        <node concept="2YIFZM" id="5Zn2KFQR6Yf" role="2Oq$k0">
+                          <ref role="1Pybhc" node="5Zn2KFQQ$_B" resolve="ContextActionsHelper" />
+                          <ref role="37wK5l" node="5Zn2KFQR6fs" resolve="docContent" />
+                          <node concept="7Obwk" id="73kHms33jBh" role="37wK5m" />
+                        </node>
+                        <node concept="HtI8k" id="5Zn2KFQR7yT" role="2OqNvi">
+                          <node concept="2OqwBi" id="5Zn2KFQQzNG" role="HtI8F">
+                            <node concept="LFhST" id="5Zn2KFQQzNI" role="2OqNvi" />
+                            <node concept="2ZBlsa" id="73kHms33jGn" role="2Oq$k0" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3bZ5Sz" id="5Zn2KFQQzNJ" role="2ZBHrp" />
+            </node>
+          </node>
+        </node>
+        <node concept="aenpk" id="73kHms33kUN" role="1vlqcB">
+          <node concept="27VH4U" id="73kHms33ljV" role="aenpu">
+            <node concept="3clFbS" id="73kHms33ljW" role="2VODD2">
+              <node concept="3clFbF" id="73kHms33lkj" role="3cqZAp">
+                <node concept="2OqwBi" id="73kHms33lw_" role="3clFbG">
+                  <node concept="7Obwk" id="73kHms33lki" role="2Oq$k0" />
+                  <node concept="1mIQ4w" id="73kHms33lLk" role="2OqNvi">
+                    <node concept="chp4Y" id="73kHms33lUT" role="cj9EA">
+                      <ref role="cht4Q" to="87nw:2dWzqxEBMSc" resolve="Word" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1vlq3a" id="73kHms33m19" role="aenpr">
+            <node concept="293xgL" id="73kHms33m1a" role="1hCDOS">
+              <node concept="3clFbS" id="73kHms33m1b" role="2VODD2">
+                <node concept="3clFbF" id="73kHms33m6u" role="3cqZAp">
+                  <node concept="Xl_RD" id="3wHxcnxBkn1" role="3clFbG">
+                    <property role="Xl_RC" value="Formatting" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1GhOrh" id="73kHms33mfv" role="1vlqcB">
+              <node concept="1GhMSn" id="73kHms33mfw" role="1GhOrs">
+                <node concept="3clFbS" id="73kHms33mfx" role="2VODD2">
+                  <node concept="3clFbF" id="73kHms33mkW" role="3cqZAp">
+                    <node concept="2OqwBi" id="5Zn2KFQRMdY" role="3clFbG">
+                      <node concept="2OqwBi" id="5Zn2KFQRMdZ" role="2Oq$k0">
+                        <node concept="2OqwBi" id="5Zn2KFQRMe0" role="2Oq$k0">
+                          <node concept="35c_gC" id="5Zn2KFQRMe1" role="2Oq$k0">
+                            <ref role="35c_gD" to="2c95:5mf_X_La_N$" resolve="FormattedText" />
+                          </node>
+                          <node concept="LSoRf" id="5Zn2KFQRMe2" role="2OqNvi">
+                            <node concept="1rpKSd" id="73kHms33mOS" role="1iTxcG" />
+                          </node>
+                        </node>
+                        <node concept="3zZkjj" id="5Zn2KFQRMe6" role="2OqNvi">
+                          <node concept="1bVj0M" id="5Zn2KFQRMe7" role="23t8la">
+                            <node concept="3clFbS" id="5Zn2KFQRMe8" role="1bW5cS">
+                              <node concept="3clFbF" id="5Zn2KFQRMe9" role="3cqZAp">
+                                <node concept="1Wc70l" id="5Zn2KFQRMea" role="3clFbG">
+                                  <node concept="3fqX7Q" id="5Zn2KFQRMeb" role="3uHU7w">
+                                    <node concept="2OqwBi" id="5Zn2KFQRMec" role="3fr31v">
+                                      <node concept="2OqwBi" id="5Zn2KFQRMed" role="2Oq$k0">
+                                        <node concept="37vLTw" id="5Zn2KFQRMee" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="5Zn2KFQRMel" resolve="cc" />
+                                        </node>
+                                        <node concept="3n3YKJ" id="5Zn2KFQRMef" role="2OqNvi" />
+                                      </node>
+                                      <node concept="17RlXB" id="5Zn2KFQRMeg" role="2OqNvi" />
+                                    </node>
+                                  </node>
+                                  <node concept="3fqX7Q" id="5Zn2KFQRMeh" role="3uHU7B">
+                                    <node concept="2OqwBi" id="5Zn2KFQRMei" role="3fr31v">
+                                      <node concept="37vLTw" id="5Zn2KFQRMej" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="5Zn2KFQRMel" resolve="cc" />
+                                      </node>
+                                      <node concept="liA8E" id="5Zn2KFQRMek" role="2OqNvi">
+                                        <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="Rh6nW" id="5Zn2KFQRMel" role="1bW2Oz">
+                              <property role="TrG5h" value="cc" />
+                              <node concept="2jxLKc" id="5Zn2KFQRMem" role="1tU5fm" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="ANE8D" id="5Zn2KFQRMen" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="IWgqT" id="73kHms33mWv" role="1GhOri">
+                <node concept="2jZ$Xq" id="73kHms33mWx" role="2jZA2a" />
+                <node concept="2jZ$wS" id="73kHms33mWy" role="2jZA2a">
+                  <node concept="1jIJ66" id="73kHms33nWD" role="2jZ$wV">
+                    <node concept="3clFbS" id="73kHms33nWE" role="2VODD2">
+                      <node concept="3clFbF" id="73kHms33o1e" role="3cqZAp">
+                        <node concept="2OqwBi" id="73kHms33oko" role="3clFbG">
+                          <node concept="2ZBlsa" id="73kHms33o1d" role="2Oq$k0" />
+                          <node concept="3neUYN" id="73kHms33oQa" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1hCUdq" id="73kHms33mWz" role="1hCUd6">
+                  <node concept="3clFbS" id="73kHms33mW_" role="2VODD2">
+                    <node concept="3clFbF" id="73kHms33n7J" role="3cqZAp">
+                      <node concept="3cpWs3" id="5Zn2KFQTIDA" role="3clFbG">
+                        <node concept="Xl_RD" id="5Zn2KFQTIDB" role="3uHU7w">
+                          <property role="Xl_RC" value=")" />
+                        </node>
+                        <node concept="3cpWs3" id="5Zn2KFQTIDC" role="3uHU7B">
+                          <node concept="3cpWs3" id="5Zn2KFQTIDD" role="3uHU7B">
+                            <node concept="2OqwBi" id="5Zn2KFQTIDE" role="3uHU7B">
+                              <node concept="3n3YKJ" id="5Zn2KFQTIDG" role="2OqNvi" />
+                              <node concept="2ZBlsa" id="73kHms33nvj" role="2Oq$k0" />
+                            </node>
+                            <node concept="Xl_RD" id="5Zn2KFQTIDH" role="3uHU7w">
+                              <property role="Xl_RC" value=" (" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="5Zn2KFQTIDI" role="3uHU7w">
+                            <node concept="3neUYN" id="5Zn2KFQTIDK" role="2OqNvi" />
+                            <node concept="2ZBlsa" id="73kHms33nR7" role="2Oq$k0" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="IWg2L" id="73kHms33mWB" role="IWgqQ">
+                  <node concept="3clFbS" id="73kHms33mWD" role="2VODD2">
+                    <node concept="3SKdUt" id="5Zn2KFQRMcU" role="3cqZAp">
+                      <node concept="1PaTwC" id="17Nm8oCo8JX" role="1aUNEU">
+                        <node concept="3oM_SD" id="17Nm8oCo8JY" role="1PaTwD">
+                          <property role="3oM_SC" value="wrap" />
+                        </node>
+                        <node concept="3oM_SD" id="17Nm8oCo8JZ" role="1PaTwD">
+                          <property role="3oM_SC" value="current" />
+                        </node>
+                        <node concept="3oM_SD" id="17Nm8oCo8K0" role="1PaTwD">
+                          <property role="3oM_SC" value="word" />
+                        </node>
+                        <node concept="3oM_SD" id="17Nm8oCo8K1" role="1PaTwD">
+                          <property role="3oM_SC" value="with" />
+                        </node>
+                        <node concept="3oM_SD" id="17Nm8oCo8K2" role="1PaTwD">
+                          <property role="3oM_SC" value="the" />
+                        </node>
+                        <node concept="3oM_SD" id="17Nm8oCo8K3" role="1PaTwD">
+                          <property role="3oM_SC" value="formatted" />
+                        </node>
+                        <node concept="3oM_SD" id="17Nm8oCo8K4" role="1PaTwD">
+                          <property role="3oM_SC" value="text," />
+                        </node>
+                        <node concept="3oM_SD" id="17Nm8oCo8K5" role="1PaTwD">
+                          <property role="3oM_SC" value="if" />
+                        </node>
+                        <node concept="3oM_SD" id="17Nm8oCo8K6" role="1PaTwD">
+                          <property role="3oM_SC" value="selection" />
+                        </node>
+                        <node concept="3oM_SD" id="17Nm8oCo8K7" role="1PaTwD">
+                          <property role="3oM_SC" value="is" />
+                        </node>
+                        <node concept="3oM_SD" id="17Nm8oCo8K8" role="1PaTwD">
+                          <property role="3oM_SC" value="valid" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="5Zn2KFQRMde" role="3cqZAp">
+                      <node concept="3cpWsn" id="5Zn2KFQRMdf" role="3cpWs9">
+                        <property role="TrG5h" value="ec" />
+                        <node concept="3uibUv" id="73kHms33paR" role="1tU5fm">
+                          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                        </node>
+                        <node concept="1Q80Hx" id="73kHms33p4a" role="33vP2m" />
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="5Zn2KFQRMdm" role="3cqZAp">
+                      <node concept="3clFbS" id="5Zn2KFQRMdn" role="3clFbx">
+                        <node concept="3clFbF" id="5Zn2KFQRMdo" role="3cqZAp">
+                          <node concept="2YIFZM" id="5Zn2KFQRMdp" role="3clFbG">
+                            <ref role="37wK5l" to="882r:3OiIliPRxrU" resolve="performSurrounding" />
+                            <ref role="1Pybhc" to="882r:3OiIliPRxrd" resolve="SurroundWithHelper" />
+                            <node concept="37vLTw" id="5Zn2KFQRMdq" role="37wK5m">
+                              <ref role="3cqZAo" node="5Zn2KFQRMdf" resolve="ec" />
+                            </node>
+                            <node concept="2ZBlsa" id="73kHms33pgf" role="37wK5m" />
+                          </node>
+                        </node>
+                        <node concept="3cpWs6" id="5Zn2KFQRMdx" role="3cqZAp" />
+                      </node>
+                      <node concept="2YIFZM" id="5Zn2KFQRMdy" role="3clFbw">
+                        <ref role="37wK5l" to="882r:3OiIliPRxrf" resolve="isCorrectSelection" />
+                        <ref role="1Pybhc" to="882r:3OiIliPRxrd" resolve="SurroundWithHelper" />
+                        <node concept="37vLTw" id="5Zn2KFQRMdz" role="37wK5m">
+                          <ref role="3cqZAo" node="5Zn2KFQRMdf" resolve="ec" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3SKdUt" id="5Zn2KFQRMdC" role="3cqZAp">
+                      <node concept="1PaTwC" id="17Nm8oCo8K9" role="1aUNEU">
+                        <node concept="3oM_SD" id="17Nm8oCo8Ka" role="1PaTwD">
+                          <property role="3oM_SC" value="otherwise" />
+                        </node>
+                        <node concept="3oM_SD" id="17Nm8oCo8Kb" role="1PaTwD">
+                          <property role="3oM_SC" value="insert" />
+                        </node>
+                        <node concept="3oM_SD" id="17Nm8oCo8Kc" role="1PaTwD">
+                          <property role="3oM_SC" value="new" />
+                        </node>
+                        <node concept="3oM_SD" id="17Nm8oCo8Kd" role="1PaTwD">
+                          <property role="3oM_SC" value="word" />
+                        </node>
+                        <node concept="3oM_SD" id="17Nm8oCo8Ke" role="1PaTwD">
+                          <property role="3oM_SC" value="as" />
+                        </node>
+                        <node concept="3oM_SD" id="17Nm8oCo8Kf" role="1PaTwD">
+                          <property role="3oM_SC" value="next" />
+                        </node>
+                        <node concept="3oM_SD" id="17Nm8oCo8Kg" role="1PaTwD">
+                          <property role="3oM_SC" value="sibling" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="5Zn2KFQRMdE" role="3cqZAp">
+                      <node concept="2OqwBi" id="5Zn2KFQRMdF" role="3clFbG">
+                        <node concept="7Obwk" id="73kHms33pjc" role="2Oq$k0" />
+                        <node concept="HtI8k" id="5Zn2KFQRMdJ" role="2OqNvi">
+                          <node concept="2OqwBi" id="5Zn2KFQRMdK" role="HtI8F">
+                            <node concept="LFhST" id="5Zn2KFQRMdM" role="2OqNvi" />
+                            <node concept="2ZBlsa" id="73kHms33pp8" role="2Oq$k0" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3bZ5Sz" id="5Zn2KFQRMdN" role="2ZBHrp">
+                <ref role="3bZ5Sy" to="2c95:5mf_X_La_N$" resolve="FormattedText" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1vlq3a" id="73kHms33scB" role="1Qtc8A">
+        <node concept="293xgL" id="73kHms33scD" role="1hCDOS">
+          <node concept="3clFbS" id="73kHms33scF" role="2VODD2">
+            <node concept="3clFbF" id="73kHms33sry" role="3cqZAp">
+              <node concept="Xl_RD" id="73kHms33srx" role="3clFbG">
+                <property role="Xl_RC" value="Workflow" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1GhOrh" id="73kHms33swM" role="1vlqcB">
+          <node concept="1GhMSn" id="73kHms33swN" role="1GhOrs">
+            <node concept="3clFbS" id="73kHms33swO" role="2VODD2">
+              <node concept="3clFbF" id="73kHms33sAf" role="3cqZAp">
+                <node concept="2OqwBi" id="7Ip2X68OjY3" role="3clFbG">
+                  <node concept="2OqwBi" id="7Ip2X68OjJW" role="2Oq$k0">
+                    <node concept="2OqwBi" id="7Ip2X68Oj_1" role="2Oq$k0">
+                      <node concept="7Obwk" id="73kHms33t1h" role="2Oq$k0" />
+                      <node concept="2Xjw5R" id="7Ip2X68OjDG" role="2OqNvi">
+                        <node concept="1xMEDy" id="7Ip2X68OjDI" role="1xVPHs">
+                          <node concept="chp4Y" id="7Ip2X68OjEG" role="ri$Ld">
+                            <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+                          </node>
+                        </node>
+                        <node concept="1xIGOp" id="7Ip2X68OjH2" role="1xVPHs" />
+                      </node>
+                    </node>
+                    <node concept="3TrEf2" id="7Ip2X68OjQO" role="2OqNvi">
+                      <ref role="3Tt5mk" to="plfp:l6fPaF3tRV" resolve="state" />
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="7Ip2X68Ok30" role="2OqNvi">
+                    <ref role="37wK5l" to="bemq:7Ip2X68O2Sn" resolve="nextStates" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="IWgqT" id="73kHms33tbM" role="1GhOri">
+            <node concept="2jZ$Xq" id="73kHms33tbO" role="2jZA2a" />
+            <node concept="2jZ$wS" id="73kHms33tbP" role="2jZA2a" />
+            <node concept="1hCUdq" id="73kHms33tbQ" role="1hCUd6">
+              <node concept="3clFbS" id="73kHms33tbS" role="2VODD2">
+                <node concept="3clFbF" id="73kHms33tie" role="3cqZAp">
+                  <node concept="3cpWs3" id="7Ip2X68Ok85" role="3clFbG">
+                    <node concept="Xl_RD" id="7Ip2X68Ok40" role="3uHU7B">
+                      <property role="Xl_RC" value="Move to State " />
+                    </node>
+                    <node concept="2ZBlsa" id="73kHms33tnz" role="3uHU7w" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="IWg2L" id="73kHms33tbU" role="IWgqQ">
+              <node concept="3clFbS" id="73kHms33tbW" role="2VODD2">
+                <node concept="3clFbF" id="73kHms33tAG" role="3cqZAp">
+                  <node concept="37vLTI" id="7Ip2X68OkOv" role="3clFbG">
+                    <node concept="2OqwBi" id="7Ip2X68OkAZ" role="37vLTJ">
+                      <node concept="2OqwBi" id="7Ip2X68OkzP" role="2Oq$k0">
+                        <node concept="7Obwk" id="73kHms33tRR" role="2Oq$k0" />
+                        <node concept="2Xjw5R" id="7Ip2X68OkzT" role="2OqNvi">
+                          <node concept="1xMEDy" id="7Ip2X68OkzU" role="1xVPHs">
+                            <node concept="chp4Y" id="7Ip2X68OkzV" role="ri$Ld">
+                              <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+                            </node>
+                          </node>
+                          <node concept="1xIGOp" id="7Ip2X68OkzW" role="1xVPHs" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="7Ip2X68OkHx" role="2OqNvi">
+                        <ref role="3Tt5mk" to="plfp:l6fPaF3tRV" resolve="state" />
+                      </node>
+                    </node>
+                    <node concept="2ZBlsa" id="73kHms33u1L" role="37vLTx" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3Tqbb2" id="7Ip2X68OnKg" role="2ZBHrp">
+            <ref role="ehGHo" to="plfp:l6fPaF3tF7" resolve="State" />
+          </node>
+        </node>
+      </node>
+      <node concept="1vlq3a" id="73kHms33vAv" role="1Qtc8A">
+        <node concept="293xgL" id="73kHms33vAx" role="1hCDOS">
+          <node concept="3clFbS" id="73kHms33vAz" role="2VODD2">
+            <node concept="3clFbF" id="73kHms33wFt" role="3cqZAp">
+              <node concept="Xl_RD" id="73kHms33wFs" role="3clFbG">
+                <property role="Xl_RC" value="Tags" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1GhOrh" id="73kHms33wGw" role="1vlqcB">
+          <node concept="1GhMSn" id="73kHms33wGx" role="1GhOrs">
+            <node concept="3clFbS" id="73kHms33wGy" role="2VODD2">
+              <node concept="3clFbF" id="73kHms33wLX" role="3cqZAp">
+                <node concept="2OqwBi" id="1T$QQLd4dsx" role="3clFbG">
+                  <node concept="2OqwBi" id="1T$QQLd4dsy" role="2Oq$k0">
+                    <node concept="2OqwBi" id="1T$QQLd4dsz" role="2Oq$k0">
+                      <node concept="35c_gC" id="1T$QQLd4ds$" role="2Oq$k0">
+                        <ref role="35c_gD" to="plfp:4tXyFaWylGs" resolve="Tag" />
+                      </node>
+                      <node concept="LSoRf" id="1T$QQLd4ds_" role="2OqNvi">
+                        <node concept="1rpKSd" id="73kHms33xjp" role="1iTxcG" />
+                      </node>
+                    </node>
+                    <node concept="3zZkjj" id="1T$QQLd4dsD" role="2OqNvi">
+                      <node concept="1bVj0M" id="1T$QQLd4dsE" role="23t8la">
+                        <node concept="3clFbS" id="1T$QQLd4dsF" role="1bW5cS">
+                          <node concept="3clFbF" id="1T$QQLd4dsG" role="3cqZAp">
+                            <node concept="3fqX7Q" id="1T$QQLd4dsH" role="3clFbG">
+                              <node concept="2OqwBi" id="1T$QQLd4dsI" role="3fr31v">
+                                <node concept="37vLTw" id="1T$QQLd4dsJ" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1T$QQLd4dsL" resolve="tag" />
+                                </node>
+                                <node concept="liA8E" id="1T$QQLd4dsK" role="2OqNvi">
+                                  <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="1T$QQLd4dsL" role="1bW2Oz">
+                          <property role="TrG5h" value="tag" />
+                          <node concept="2jxLKc" id="1T$QQLd4dsM" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3zZkjj" id="1T$QQLd4dsN" role="2OqNvi">
+                    <node concept="1bVj0M" id="1T$QQLd4dsO" role="23t8la">
+                      <node concept="3clFbS" id="1T$QQLd4dsP" role="1bW5cS">
+                        <node concept="3clFbF" id="1T$QQLd4gVi" role="3cqZAp">
+                          <node concept="2YIFZM" id="1T$QQLd4hio" role="3clFbG">
+                            <ref role="1Pybhc" node="5Zn2KFQQ$_B" resolve="ContextActionsHelper" />
+                            <ref role="37wK5l" node="hzYhIjiQKh" resolve="checkTag" />
+                            <node concept="7Obwk" id="73kHms33$2H" role="37wK5m" />
+                            <node concept="37vLTw" id="1T$QQLd4kmr" role="37wK5m">
+                              <ref role="3cqZAo" node="1T$QQLd4dsU" resolve="tag" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="1T$QQLd4dsU" role="1bW2Oz">
+                        <property role="TrG5h" value="tag" />
+                        <node concept="2jxLKc" id="1T$QQLd4dsV" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="IWgqT" id="73kHms33$e8" role="1GhOri">
+            <node concept="2jZ$Xq" id="73kHms33$ea" role="2jZA2a" />
+            <node concept="2jZ$wS" id="73kHms33$eb" role="2jZA2a" />
+            <node concept="1hCUdq" id="73kHms33$ec" role="1hCUd6">
+              <node concept="3clFbS" id="73kHms33$ee" role="2VODD2">
+                <node concept="3clFbF" id="73kHms33$xS" role="3cqZAp">
+                  <node concept="3cpWs3" id="5Zn2KFQTHIY" role="3clFbG">
+                    <node concept="Xl_RD" id="5Zn2KFQTHJ1" role="3uHU7w">
+                      <property role="Xl_RC" value=")" />
+                    </node>
+                    <node concept="3cpWs3" id="5Zn2KFQTA7l" role="3uHU7B">
+                      <node concept="3cpWs3" id="5Zn2KFQT_Jr" role="3uHU7B">
+                        <node concept="2OqwBi" id="7Dcax7Aicxw" role="3uHU7B">
+                          <node concept="3n3YKJ" id="7Dcax7AicEM" role="2OqNvi" />
+                          <node concept="2ZBlsa" id="73kHms33_1W" role="2Oq$k0" />
+                        </node>
+                        <node concept="Xl_RD" id="5Zn2KFQT_Ju" role="3uHU7w">
+                          <property role="Xl_RC" value=" (" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="5Zn2KFQTHtS" role="3uHU7w">
+                        <node concept="3neUYN" id="5Zn2KFQTHBx" role="2OqNvi" />
+                        <node concept="2ZBlsa" id="73kHms33_pG" role="2Oq$k0" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="IWg2L" id="73kHms33$eg" role="IWgqQ">
+              <node concept="3clFbS" id="73kHms33$ei" role="2VODD2">
+                <node concept="3cpWs8" id="7Dcax7Ai8hU" role="3cqZAp">
+                  <node concept="3cpWsn" id="7Dcax7Ai8hV" role="3cpWs9">
+                    <property role="TrG5h" value="tag" />
+                    <node concept="3Tqbb2" id="7Dcax7Ai8hS" role="1tU5fm" />
+                    <node concept="2OqwBi" id="7Dcax7Ai8hW" role="33vP2m">
+                      <node concept="LFhST" id="7Dcax7Ai8hY" role="2OqNvi" />
+                      <node concept="2ZBlsa" id="73kHms33Aip" role="2Oq$k0" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="7Dcax7Ai8wl" role="3cqZAp">
+                  <node concept="2OqwBi" id="7Dcax7Ai9h9" role="3clFbG">
+                    <node concept="2OqwBi" id="7Dcax7Ai8Ih" role="2Oq$k0">
+                      <node concept="2OqwBi" id="7Dcax7Ai6l2" role="2Oq$k0">
+                        <node concept="7Obwk" id="73kHms33AHm" role="2Oq$k0" />
+                        <node concept="2Xjw5R" id="7Dcax7Ai6l6" role="2OqNvi">
+                          <node concept="1xMEDy" id="7Dcax7Ai6l7" role="1xVPHs">
+                            <node concept="chp4Y" id="7Dcax7Ai6l8" role="ri$Ld">
+                              <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+                            </node>
+                          </node>
+                          <node concept="1xIGOp" id="7Dcax7Ai6l9" role="1xVPHs" />
+                        </node>
+                      </node>
+                      <node concept="3Tsc0h" id="7Dcax7Ai8Qg" role="2OqNvi">
+                        <ref role="3TtcxE" to="plfp:4tXyFaWylGz" resolve="tags" />
+                      </node>
+                    </node>
+                    <node concept="TSZUe" id="7Dcax7Aia96" role="2OqNvi">
+                      <node concept="1PxgMI" id="7Dcax7Aif$j" role="25WWJ7">
+                        <node concept="chp4Y" id="6b_jefnKzVn" role="3oSUPX">
+                          <ref role="cht4Q" to="plfp:4tXyFaWylGs" resolve="Tag" />
+                        </node>
+                        <node concept="37vLTw" id="7Dcax7Aiaic" role="1m5AlR">
+                          <ref role="3cqZAo" node="7Dcax7Ai8hV" resolve="tag" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3bZ5Sz" id="7Dcax7Ai7wF" role="2ZBHrp">
+            <ref role="3bZ5Sy" to="plfp:4tXyFaWylGs" resolve="Tag" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="5Zn2KFQQ$_B">
+    <property role="TrG5h" value="ContextActionsHelper" />
+    <node concept="2tJIrI" id="5Zn2KFQQ_4B" role="jymVt" />
+    <node concept="2YIFZL" id="5Zn2KFQQ$Gt" role="jymVt">
+      <property role="TrG5h" value="isUnderRequirement" />
+      <node concept="10P_77" id="5Zn2KFQQM7w" role="3clF45" />
+      <node concept="3Tm1VV" id="5Zn2KFQQ$Gw" role="1B3o_S" />
+      <node concept="3clFbS" id="5Zn2KFQQ$Gx" role="3clF47">
+        <node concept="3clFbF" id="5Zn2KFQQBUk" role="3cqZAp">
+          <node concept="2OqwBi" id="5Zn2KFQQC1L" role="3clFbG">
+            <node concept="2OqwBi" id="5Zn2KFQQBVo" role="2Oq$k0">
+              <node concept="37vLTw" id="5Zn2KFQQBUj" role="2Oq$k0">
+                <ref role="3cqZAo" node="5Zn2KFQQBMK" resolve="ctx" />
+              </node>
+              <node concept="2Xjw5R" id="5Zn2KFQQBXw" role="2OqNvi">
+                <node concept="1xMEDy" id="5Zn2KFQQBXy" role="1xVPHs">
+                  <node concept="chp4Y" id="5Zn2KFQQBZ8" role="ri$Ld">
+                    <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3x8VRR" id="5Zn2KFQQCfn" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5Zn2KFQQBMK" role="3clF46">
+        <property role="TrG5h" value="ctx" />
+        <node concept="3Tqbb2" id="5Zn2KFQQBMJ" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5Zn2KFQR65D" role="jymVt" />
+    <node concept="2YIFZL" id="5Zn2KFQQZ$1" role="jymVt">
+      <property role="TrG5h" value="getRequirement" />
+      <node concept="3Tqbb2" id="5Zn2KFQR0G3" role="3clF45">
+        <ref role="ehGHo" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+      </node>
+      <node concept="3Tm1VV" id="5Zn2KFQQZ$3" role="1B3o_S" />
+      <node concept="3clFbS" id="5Zn2KFQQZ$4" role="3clF47">
+        <node concept="3clFbF" id="5Zn2KFQQZ$5" role="3cqZAp">
+          <node concept="2OqwBi" id="5Zn2KFQQZ$7" role="3clFbG">
+            <node concept="37vLTw" id="5Zn2KFQQZ$8" role="2Oq$k0">
+              <ref role="3cqZAo" node="5Zn2KFQQZ$d" resolve="ctx" />
+            </node>
+            <node concept="2Xjw5R" id="5Zn2KFQQZ$9" role="2OqNvi">
+              <node concept="1xMEDy" id="5Zn2KFQQZ$a" role="1xVPHs">
+                <node concept="chp4Y" id="5Zn2KFQQZ$b" role="ri$Ld">
+                  <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5Zn2KFQQZ$d" role="3clF46">
+        <property role="TrG5h" value="ctx" />
+        <node concept="3Tqbb2" id="5Zn2KFQQZ$e" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5Zn2KFQR67t" role="jymVt" />
+    <node concept="2YIFZL" id="5Zn2KFQR5HX" role="jymVt">
+      <property role="TrG5h" value="isUnderDoc" />
+      <node concept="10P_77" id="5Zn2KFQR5HY" role="3clF45" />
+      <node concept="3Tm1VV" id="5Zn2KFQR5HZ" role="1B3o_S" />
+      <node concept="3clFbS" id="5Zn2KFQR5I0" role="3clF47">
+        <node concept="3clFbF" id="5Zn2KFQR5I1" role="3cqZAp">
+          <node concept="2OqwBi" id="5Zn2KFQR5I2" role="3clFbG">
+            <node concept="2OqwBi" id="5Zn2KFQR5I3" role="2Oq$k0">
+              <node concept="37vLTw" id="5Zn2KFQR5I4" role="2Oq$k0">
+                <ref role="3cqZAo" node="5Zn2KFQR5I9" resolve="ctx" />
+              </node>
+              <node concept="2Xjw5R" id="5Zn2KFQR5I5" role="2OqNvi">
+                <node concept="1xMEDy" id="5Zn2KFQR5I6" role="1xVPHs">
+                  <node concept="chp4Y" id="5Zn2KFQR5RP" role="ri$Ld">
+                    <ref role="cht4Q" to="2c95:2TZO3DbuxwP" resolve="IDocumentContent" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3x8VRR" id="5Zn2KFQR5I8" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5Zn2KFQR5I9" role="3clF46">
+        <property role="TrG5h" value="ctx" />
+        <node concept="3Tqbb2" id="5Zn2KFQR5Ia" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2YIFZL" id="5Zn2KFQR6fs" role="jymVt">
+      <property role="TrG5h" value="docContent" />
+      <node concept="3Tqbb2" id="5Zn2KFQR6_j" role="3clF45">
+        <ref role="ehGHo" to="2c95:2TZO3DbuxwP" resolve="IDocumentContent" />
+      </node>
+      <node concept="3Tm1VV" id="5Zn2KFQR6fu" role="1B3o_S" />
+      <node concept="3clFbS" id="5Zn2KFQR6fv" role="3clF47">
+        <node concept="3clFbF" id="5Zn2KFQR6fw" role="3cqZAp">
+          <node concept="2OqwBi" id="5Zn2KFQR6fy" role="3clFbG">
+            <node concept="37vLTw" id="5Zn2KFQR6fz" role="2Oq$k0">
+              <ref role="3cqZAo" node="5Zn2KFQR6fC" resolve="ctx" />
+            </node>
+            <node concept="2Xjw5R" id="5Zn2KFQR6f$" role="2OqNvi">
+              <node concept="1xMEDy" id="5Zn2KFQR6f_" role="1xVPHs">
+                <node concept="chp4Y" id="5Zn2KFQR6fA" role="ri$Ld">
+                  <ref role="cht4Q" to="2c95:2TZO3DbuxwP" resolve="IDocumentContent" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5Zn2KFQR6fC" role="3clF46">
+        <property role="TrG5h" value="ctx" />
+        <node concept="3Tqbb2" id="5Zn2KFQR6fD" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5Zn2KFQR5VR" role="jymVt" />
+    <node concept="2tJIrI" id="5Zn2KFQQNDj" role="jymVt" />
+    <node concept="2YIFZL" id="5Zn2KFQQNJT" role="jymVt">
+      <property role="TrG5h" value="getValidDocContents" />
+      <node concept="_YKpA" id="5Zn2KFQQT4p" role="3clF45">
+        <node concept="3bZ5Sz" id="5Zn2KFQQTgt" role="_ZDj9" />
+      </node>
+      <node concept="3Tm1VV" id="5Zn2KFQQNJW" role="1B3o_S" />
+      <node concept="3clFbS" id="5Zn2KFQQNJX" role="3clF47">
+        <node concept="3cpWs8" id="5Zn2KFQQRmR" role="3cqZAp">
+          <node concept="3cpWsn" id="5Zn2KFQQRmU" role="3cpWs9">
+            <property role="TrG5h" value="res" />
+            <node concept="_YKpA" id="5Zn2KFQQRmN" role="1tU5fm">
+              <node concept="3bZ5Sz" id="5Zn2KFQQRxu" role="_ZDj9" />
+            </node>
+            <node concept="2ShNRf" id="5Zn2KFQQRyl" role="33vP2m">
+              <node concept="Tc6Ow" id="5Zn2KFQQSFD" role="2ShVmc">
+                <node concept="3bZ5Sz" id="5Zn2KFQQTw9" role="HW$YZ" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5Zn2KFQQUg$" role="3cqZAp">
+          <node concept="2OqwBi" id="5Zn2KFQQUsN" role="3clFbG">
+            <node concept="37vLTw" id="5Zn2KFQQUgy" role="2Oq$k0">
+              <ref role="3cqZAo" node="5Zn2KFQQRmU" resolve="res" />
+            </node>
+            <node concept="X8dFx" id="5Zn2KFQQUNp" role="2OqNvi">
+              <node concept="2OqwBi" id="5Zn2KFQQNNV" role="25WWJ7">
+                <node concept="2OqwBi" id="5Zn2KFQQNNW" role="2Oq$k0">
+                  <node concept="35c_gC" id="5Zn2KFQQNNX" role="2Oq$k0">
+                    <ref role="35c_gD" to="plfp:7Dcax7AgAPg" resolve="IReqDocContent" />
+                  </node>
+                  <node concept="LSoRf" id="5Zn2KFQQNNY" role="2OqNvi">
+                    <node concept="37vLTw" id="5Zn2KFQQTPT" role="1iTxcG">
+                      <ref role="3cqZAo" node="5Zn2KFQQTKZ" resolve="m" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3zZkjj" id="5Zn2KFQQNO2" role="2OqNvi">
+                  <node concept="1bVj0M" id="5Zn2KFQQNO3" role="23t8la">
+                    <node concept="3clFbS" id="5Zn2KFQQNO4" role="1bW5cS">
+                      <node concept="3clFbF" id="5Zn2KFQQNO5" role="3cqZAp">
+                        <node concept="1Wc70l" id="5Zn2KFQQNO6" role="3clFbG">
+                          <node concept="3fqX7Q" id="5Zn2KFQQNO7" role="3uHU7w">
+                            <node concept="2OqwBi" id="5Zn2KFQQNO8" role="3fr31v">
+                              <node concept="2OqwBi" id="5Zn2KFQQNO9" role="2Oq$k0">
+                                <node concept="37vLTw" id="5Zn2KFQQNOa" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="5Zn2KFQQNOh" resolve="cc" />
+                                </node>
+                                <node concept="3n3YKJ" id="5Zn2KFQQNOb" role="2OqNvi" />
+                              </node>
+                              <node concept="17RlXB" id="5Zn2KFQQNOc" role="2OqNvi" />
+                            </node>
+                          </node>
+                          <node concept="3fqX7Q" id="5Zn2KFQQNOd" role="3uHU7B">
+                            <node concept="2OqwBi" id="5Zn2KFQQNOe" role="3fr31v">
+                              <node concept="37vLTw" id="5Zn2KFQQNOf" role="2Oq$k0">
+                                <ref role="3cqZAo" node="5Zn2KFQQNOh" resolve="cc" />
+                              </node>
+                              <node concept="liA8E" id="5Zn2KFQQNOg" role="2OqNvi">
+                                <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="5Zn2KFQQNOh" role="1bW2Oz">
+                      <property role="TrG5h" value="cc" />
+                      <node concept="2jxLKc" id="5Zn2KFQQNOi" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5Zn2KFQQVjt" role="3cqZAp">
+          <node concept="2OqwBi" id="5Zn2KFQQVsf" role="3clFbG">
+            <node concept="37vLTw" id="5Zn2KFQQVjr" role="2Oq$k0">
+              <ref role="3cqZAo" node="5Zn2KFQQRmU" resolve="res" />
+            </node>
+            <node concept="TSZUe" id="5Zn2KFQQVMt" role="2OqNvi">
+              <node concept="35c_gC" id="5Zn2KFQQVPw" role="25WWJ7">
+                <ref role="35c_gD" to="2c95:2TZO3DbvcVM" resolve="TextParagraph" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5Zn2KFQQW0a" role="3cqZAp">
+          <node concept="2OqwBi" id="5Zn2KFQQW0b" role="3clFbG">
+            <node concept="37vLTw" id="5Zn2KFQQW0c" role="2Oq$k0">
+              <ref role="3cqZAo" node="5Zn2KFQQRmU" resolve="res" />
+            </node>
+            <node concept="TSZUe" id="5Zn2KFQQW0d" role="2OqNvi">
+              <node concept="35c_gC" id="5Zn2KFQQW0e" role="25WWJ7">
+                <ref role="35c_gD" to="2c95:5yxqZJwyOSj" resolve="ImageParagraph" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5Zn2KFQQWoQ" role="3cqZAp">
+          <node concept="2OqwBi" id="5Zn2KFQQWoR" role="3clFbG">
+            <node concept="37vLTw" id="5Zn2KFQQWoS" role="2Oq$k0">
+              <ref role="3cqZAo" node="5Zn2KFQQRmU" resolve="res" />
+            </node>
+            <node concept="TSZUe" id="5Zn2KFQQWoT" role="2OqNvi">
+              <node concept="35c_gC" id="5Zn2KFQQWoU" role="25WWJ7">
+                <ref role="35c_gD" to="2c95:4E$PniRJLTL" resolve="ItemList" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5Zn2KFQQSOT" role="3cqZAp">
+          <node concept="37vLTw" id="5Zn2KFQQSOR" role="3clFbG">
+            <ref role="3cqZAo" node="5Zn2KFQQRmU" resolve="res" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5Zn2KFQQTKZ" role="3clF46">
+        <property role="TrG5h" value="m" />
+        <node concept="H_c77" id="5Zn2KFQQTKY" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="hzYhIjhS1f" role="jymVt" />
+    <node concept="2YIFZL" id="hzYhIjiQKh" role="jymVt">
+      <property role="TrG5h" value="checkTag" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="37vLTG" id="hzYhIjiR18" role="3clF46">
+        <property role="TrG5h" value="ctx" />
+        <node concept="3Tqbb2" id="73kHms33xUM" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="hzYhIjjM66" role="3clF46">
+        <property role="TrG5h" value="tag" />
+        <node concept="3bZ5Sz" id="hzYhIjjMua" role="1tU5fm">
+          <ref role="3bZ5Sy" to="plfp:4tXyFaWylGs" resolve="Tag" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="hzYhIjiQKk" role="3clF47">
+        <node concept="3cpWs8" id="hzYhIjiS2O" role="3cqZAp">
+          <node concept="3cpWsn" id="hzYhIjiS2R" role="3cpWs9">
+            <property role="TrG5h" value="enclosingReq" />
+            <node concept="3Tqbb2" id="hzYhIjiS2M" role="1tU5fm">
+              <ref role="ehGHo" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+            </node>
+            <node concept="2OqwBi" id="hzYhIjiSph" role="33vP2m">
+              <node concept="37vLTw" id="hzYhIjiSpj" role="2Oq$k0">
+                <ref role="3cqZAo" node="hzYhIjiR18" resolve="ctx" />
+              </node>
+              <node concept="2Xjw5R" id="hzYhIjiSpl" role="2OqNvi">
+                <node concept="1xMEDy" id="hzYhIjiSpm" role="1xVPHs">
+                  <node concept="chp4Y" id="hzYhIjiSpn" role="ri$Ld">
+                    <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+                  </node>
+                </node>
+                <node concept="1xIGOp" id="hzYhIjiSpo" role="1xVPHs" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="1T$QQLd3utV" role="3cqZAp">
+          <node concept="22lmx$" id="6Q6YvW0ISkB" role="3clFbw">
+            <node concept="3clFbC" id="1T$QQLd3vyi" role="3uHU7B">
+              <node concept="37vLTw" id="1T$QQLd3u_4" role="3uHU7B">
+                <ref role="3cqZAo" node="hzYhIjiS2R" resolve="enclosingReq" />
+              </node>
+              <node concept="10Nm6u" id="1T$QQLd3vCU" role="3uHU7w" />
+            </node>
+            <node concept="2OqwBi" id="6Q6YvW0IVR8" role="3uHU7w">
+              <node concept="37vLTw" id="6Q6YvW0IVR9" role="2Oq$k0">
+                <ref role="3cqZAo" node="hzYhIjiS2R" resolve="enclosingReq" />
+              </node>
+              <node concept="2qgKlT" id="6Q6YvW0IVRa" role="2OqNvi">
+                <ref role="37wK5l" to="bemq:6Q6YvW0IOIs" resolve="suppressTags" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="1T$QQLd3utX" role="3clFbx">
+            <node concept="3cpWs6" id="1T$QQLd3y30" role="3cqZAp">
+              <node concept="3clFbT" id="1T$QQLd3yKP" role="3cqZAk" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1T$QQLd3x$K" role="3cqZAp">
+          <node concept="3fqX7Q" id="1T$QQLd3_2G" role="3clFbG">
+            <node concept="2OqwBi" id="1T$QQLd3_2I" role="3fr31v">
+              <node concept="2OqwBi" id="1T$QQLd3_2J" role="2Oq$k0">
+                <node concept="37vLTw" id="1T$QQLd3_2K" role="2Oq$k0">
+                  <ref role="3cqZAo" node="hzYhIjiS2R" resolve="enclosingReq" />
+                </node>
+                <node concept="3Tsc0h" id="1T$QQLd3_2L" role="2OqNvi">
+                  <ref role="3TtcxE" to="plfp:4tXyFaWylGz" resolve="tags" />
+                </node>
+              </node>
+              <node concept="2HwmR7" id="1T$QQLd3_2M" role="2OqNvi">
+                <node concept="1bVj0M" id="1T$QQLd3_2N" role="23t8la">
+                  <node concept="3clFbS" id="1T$QQLd3_2O" role="1bW5cS">
+                    <node concept="3clFbF" id="1T$QQLd3_2P" role="3cqZAp">
+                      <node concept="3clFbC" id="1T$QQLd3_2Q" role="3clFbG">
+                        <node concept="37vLTw" id="1T$QQLd3_2R" role="3uHU7w">
+                          <ref role="3cqZAo" node="hzYhIjjM66" resolve="tag" />
+                        </node>
+                        <node concept="2OqwBi" id="1T$QQLd3_2S" role="3uHU7B">
+                          <node concept="37vLTw" id="1T$QQLd3_2T" role="2Oq$k0">
+                            <ref role="3cqZAo" node="1T$QQLd3_2V" resolve="it" />
+                          </node>
+                          <node concept="2yIwOk" id="1T$QQLd3_2U" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="1T$QQLd3_2V" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="1T$QQLd3_2W" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1T$QQLd4cAa" role="1B3o_S" />
+      <node concept="10P_77" id="hzYhIjjRFA" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="5Zn2KFQQ$_R" role="jymVt" />
+    <node concept="2YIFZL" id="4OH$Ti$mtsB" role="jymVt">
+      <property role="TrG5h" value="getReqStructureFolderName" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="4OH$Ti$mtsE" role="3clF47">
+        <node concept="3clFbF" id="4OH$Ti$mu0J" role="3cqZAp">
+          <node concept="2EnYce" id="4OH$Ti$mwKl" role="3clFbG">
+            <node concept="2OqwBi" id="4OH$Ti$mu9l" role="2Oq$k0">
+              <node concept="37vLTw" id="4OH$Ti$mARq" role="2Oq$k0">
+                <ref role="3cqZAo" node="4OH$Ti$mAMH" resolve="ctx" />
+              </node>
+              <node concept="2Xjw5R" id="4OH$Ti$muoE" role="2OqNvi">
+                <node concept="1xMEDy" id="4OH$Ti$muoG" role="1xVPHs">
+                  <node concept="chp4Y" id="4OH$Ti$muqD" role="ri$Ld">
+                    <ref role="cht4Q" to="plfp:4OH$Ti$mobC" resolve="IReqContextLabelProvider" />
+                  </node>
+                </node>
+                <node concept="1xIGOp" id="4OH$Ti$muwf" role="1xVPHs" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="4OH$Ti$muX3" role="2OqNvi">
+              <ref role="37wK5l" to="bemq:4OH$Ti$mom4" resolve="getReqStructureFolderName" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4OH$Ti$mtez" role="1B3o_S" />
+      <node concept="17QB3L" id="4OH$Ti$mtsl" role="3clF45" />
+      <node concept="37vLTG" id="4OH$Ti$mAMH" role="3clF46">
+        <property role="TrG5h" value="ctx" />
+        <node concept="3Tqbb2" id="73kHms33ejI" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4OH$Ti$mxOq" role="jymVt" />
+    <node concept="2YIFZL" id="4OH$Ti$mxDm" role="jymVt">
+      <property role="TrG5h" value="getReqGeneralFolderName" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="4OH$Ti$mxDn" role="3clF47">
+        <node concept="3clFbF" id="73kHms33csr" role="3cqZAp">
+          <node concept="2EnYce" id="73kHms33css" role="3clFbG">
+            <node concept="2OqwBi" id="73kHms33cst" role="2Oq$k0">
+              <node concept="2Xjw5R" id="73kHms33csu" role="2OqNvi">
+                <node concept="1xMEDy" id="73kHms33csv" role="1xVPHs">
+                  <node concept="chp4Y" id="73kHms33csw" role="ri$Ld">
+                    <ref role="cht4Q" to="plfp:4OH$Ti$mobC" resolve="IReqContextLabelProvider" />
+                  </node>
+                </node>
+                <node concept="1xIGOp" id="73kHms33csx" role="1xVPHs" />
+              </node>
+              <node concept="37vLTw" id="4OH$Ti$mBtY" role="2Oq$k0">
+                <ref role="3cqZAo" node="4OH$Ti$mBpU" resolve="ctx" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="73kHms33csy" role="2OqNvi">
+              <ref role="37wK5l" to="bemq:4OH$Ti$momj" resolve="getReqGeneralFolderName" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4OH$Ti$mxDx" role="1B3o_S" />
+      <node concept="17QB3L" id="4OH$Ti$mxDy" role="3clF45" />
+      <node concept="37vLTG" id="4OH$Ti$mBpU" role="3clF46">
+        <property role="TrG5h" value="ctx" />
+        <node concept="3Tqbb2" id="73kHms33e5d" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5Zn2KFQQ$_U" role="jymVt" />
+    <node concept="3Tm1VV" id="5Zn2KFQQ$_C" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.core/org.iets3.req.core.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.core/org.iets3.req.core.mpl
@@ -23,6 +23,7 @@
     <dependency reexport="false">8e4e17de-bc10-4a34-a376-a243fbde540e(org.iets3.glossary)</dependency>
     <dependency reexport="false">92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)</dependency>
     <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
+    <dependency reexport="false">742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:120e1c9d-4e27-4478-b2af-b2c3bd3850b0:com.mbeddr.mpsutil.editor.querylist" version="0" />
@@ -33,6 +34,7 @@
     <language slang="l:62a3babb-5d40-4920-897f-d4144dc99c9d:com.mbeddr.mpsutil.userstyles" version="0" />
     <language slang="l:7e450f4e-1ac3-41ef-a851-4598161bdb94:de.slisson.mps.tables" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
@@ -40,6 +42,7 @@
     <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:b1c7d06f-525d-43b5-9b0a-2fc8f7f076ba:jetbrains.mps.editor.contextActionsTool.lang.menus" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
     <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
     <language slang="l:fe9d76d7-5809-45c9-ae28-a40915b4d6ff:jetbrains.mps.lang.checkedName" version="1" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.plugin/models/org/iets3/req/plugin/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.plugin/models/org/iets3/req/plugin/plugin.mps
@@ -4,7 +4,6 @@
   <languages>
     <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="-1" />
     <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="5" />
-    <use id="677f00fb-4488-405e-9885-abb75d472fd1" name="com.mbeddr.mpsutil.contextactions" version="-1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="17" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="-1" />
@@ -12,7 +11,6 @@
     <use id="1fc20ffe-f35b-4791-a0b7-d706bad5c49a" name="com.mbeddr.mpsutil.refactoring" version="-1" />
     <use id="1f1b4a81-113d-4b88-9b67-2bae3e4f8128" name="com.mbeddr.mpsutil.projectview" version="-1" />
     <use id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources" version="-1" />
-    <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="-1" />
   </languages>
   <imports>
     <import index="plfp" ref="r:82415404-e5c7-47c8-ae5b-951fc882e316(org.iets3.req.core.structure)" />
@@ -20,7 +18,6 @@
     <import index="xnls" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.icons(MPS.Platform/)" />
     <import index="882r" ref="r:7c2726cf-5697-49bb-92f6-2986272fb311(com.mbeddr.doc.intentions)" />
     <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" />
-    <import index="1ne1" ref="r:e9a49de8-6adf-4c2e-b5c2-32fc88189c93(com.mbeddr.mpsutil.contextactions.runtime)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="2c95" ref="r:5f7188a9-e7b4-4a2e-bef9-38d2cf379fdc(com.mbeddr.doc.structure)" />
     <import index="2j3g" ref="r:27a6aca5-5303-472c-ab94-c439b75def9c(org.iets3.req.core.editor)" />
@@ -32,17 +29,12 @@
     <import index="1m72" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.components(MPS.IDEA/)" />
     <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
     <import index="bemq" ref="r:4cfa8b0a-7754-4d3d-9e06-0ce9d427860c(org.iets3.req.core.behavior)" implicit="true" />
-    <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" implicit="true" />
-    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
     <import index="qkt" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem(MPS.IDEA/)" implicit="true" />
   </imports>
   <registry>
     <language id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources">
       <concept id="8974276187400029883" name="jetbrains.mps.lang.resources.structure.FileIcon" flags="ng" index="1QGGSu">
         <property id="2756621024541341363" name="file" index="1iqoE4" />
-      </concept>
-      <concept id="8974276187400029891" name="jetbrains.mps.lang.resources.structure.IconExpression" flags="nn" index="1QGGTA">
-        <child id="8974276187400029893" name="icon" index="1QGGTw" />
       </concept>
     </language>
     <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
@@ -81,11 +73,6 @@
       <concept id="7520713872864775836" name="jetbrains.mps.lang.plugin.standalone.structure.StandalonePluginDescriptor" flags="ng" index="2DaZZR" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
-      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
-        <child id="1068498886297" name="rValue" index="37vLTx" />
-        <child id="1068498886295" name="lValue" index="37vLTJ" />
-      </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
@@ -99,15 +86,10 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
-      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
-        <property id="1070475926801" name="value" index="Xl_RC" />
-      </concept>
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
-      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
-      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
@@ -116,9 +98,6 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
-      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
-      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
-      <concept id="1225271369338" name="jetbrains.mps.baseLanguage.structure.IsEmptyOperation" flags="nn" index="17RlXB" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -129,23 +108,14 @@
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
-      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
-      </concept>
-      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
-        <child id="1068580123160" name="condition" index="3clFbw" />
-        <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
-      </concept>
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
-      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
-        <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
@@ -161,28 +131,11 @@
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
-      <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
-        <property id="8355037393041754995" name="isNative" index="2aFKle" />
-      </concept>
-      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
-        <reference id="1107535924139" name="classifier" index="3uigEE" />
-      </concept>
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
-        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
-        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
-      </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
-      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
-        <child id="8356039341262087992" name="line" index="1aUNEU" />
-      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
-      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
-    </language>
-    <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
-      <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -228,45 +181,16 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
-      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
-        <child id="1144104376918" name="parameter" index="1xVPHs" />
-      </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
-      <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
-        <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
-      </concept>
-      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
-      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
-        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
-        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
-      </concept>
-      <concept id="1143224066846" name="jetbrains.mps.lang.smodel.structure.Node_InsertNextSiblingOperation" flags="nn" index="HtI8k">
-        <child id="1143224066849" name="insertedNode" index="HtI8F" />
-      </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
-      <concept id="1181949435690" name="jetbrains.mps.lang.smodel.structure.Concept_NewInstance" flags="nn" index="LFhST" />
-      <concept id="1181952871644" name="jetbrains.mps.lang.smodel.structure.Concept_GetAllSubConcepts" flags="nn" index="LSoRf">
-        <child id="1182506816063" name="smodel" index="1iTxcG" />
-      </concept>
       <concept id="1171315804604" name="jetbrains.mps.lang.smodel.structure.Model_RootsOperation" flags="nn" index="2RRcyG">
         <reference id="1171315804605" name="concept" index="2RRcyH" />
       </concept>
-      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
         <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
-      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz">
-        <reference id="6677504323281689839" name="conceptDeclaraton" index="3bZ5Sy" />
-      </concept>
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
-      </concept>
-      <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
-      <concept id="6870613620391345436" name="jetbrains.mps.lang.smodel.structure.ConceptShortDescriptionOperation" flags="ng" index="3neUYN" />
-      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
-      <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
-      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
-        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
@@ -274,21 +198,14 @@
       <concept id="1206482823744" name="jetbrains.mps.lang.smodel.structure.Model_AddRootOperation" flags="nn" index="3BYIHo">
         <child id="1206482823746" name="nodeArgument" index="3BYIHq" />
       </concept>
-      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
-      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
-        <reference id="1138056516764" name="link" index="3Tt5mk" />
-      </concept>
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
-      </concept>
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
       </concept>
       <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
     </language>
@@ -298,45 +215,6 @@
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
-      </concept>
-    </language>
-    <language id="677f00fb-4488-405e-9885-abb75d472fd1" name="com.mbeddr.mpsutil.contextactions">
-      <concept id="5022141054905292858" name="com.mbeddr.mpsutil.contextactions.structure.GenericActionSource" flags="ng" index="geMak">
-        <child id="5022141054905292957" name="icon" index="geM8N" />
-        <child id="5022141054905292863" name="parameterQuery" index="geMah" />
-        <child id="5022141054905292861" name="parameterType" index="geMaj" />
-        <child id="5022141054905292866" name="label" index="geMbG" />
-        <child id="5022141054905293092" name="execute" index="geMea" />
-        <child id="8645458101909773684" name="tooltip" index="3V80Gy" />
-      </concept>
-      <concept id="5022141054905293099" name="com.mbeddr.mpsutil.contextactions.structure.GenericActionSource_ExecuteFunction" flags="ig" index="geMe5" />
-      <concept id="5022141054905332478" name="com.mbeddr.mpsutil.contextactions.structure.ParameterObject" flags="ng" index="geSxg" />
-      <concept id="5022141054903714507" name="com.mbeddr.mpsutil.contextactions.structure.ContextExpression" flags="ng" index="gKNx_" />
-      <concept id="5143518692707292632" name="com.mbeddr.mpsutil.contextactions.structure.IntentionIdReference" flags="ng" index="2p1MsB">
-        <reference id="5143518692707296615" name="intention" index="2p1Luo" />
-      </concept>
-      <concept id="6294660000051228482" name="com.mbeddr.mpsutil.contextactions.structure.ContextActions" flags="ng" index="NGJ2D">
-        <child id="6294660000051228527" name="sources" index="NGJ24" />
-      </concept>
-      <concept id="8009069486209215732" name="com.mbeddr.mpsutil.contextactions.structure.IntentionsActionSource_Compact" flags="ng" index="3_N$aR">
-        <child id="8009069486209215751" name="intentionId" index="3_N$d4" />
-        <child id="8009069486209215752" name="icon" index="3_N$db" />
-      </concept>
-      <concept id="8009069486207462978" name="com.mbeddr.mpsutil.contextactions.structure.ActionSourceWithCondition" flags="ng" index="3_Xg01">
-        <child id="8009069486207463378" name="sources" index="3_Xg6h" />
-        <child id="8009069486207463329" name="condition" index="3_Xg7y" />
-      </concept>
-      <concept id="8009069486207417460" name="com.mbeddr.mpsutil.contextactions.structure.ActionSourceWithFolder" flags="ng" index="3_Xt8R">
-        <child id="8009069486207417477" name="folder" index="3_Xtb6" />
-        <child id="8009069486207417616" name="sources" index="3_Xtdj" />
-      </concept>
-    </language>
-    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
-      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
-        <property id="155656958578482949" name="value" index="3oM_SC" />
-      </concept>
-      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
-        <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
     <language id="1fc20ffe-f35b-4791-a0b7-d706bad5c49a" name="com.mbeddr.mpsutil.refactoring">
@@ -357,1146 +235,19 @@
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
-      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
-        <child id="1151688676805" name="elementType" index="_ZDj9" />
-      </concept>
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
-      </concept>
-      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
-      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
-      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
-        <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1205679737078" name="jetbrains.mps.baseLanguage.collections.structure.SortOperation" flags="nn" index="2S7cBI">
         <child id="1205679832066" name="ascending" index="2S7zOq" />
       </concept>
-      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
-      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
     </language>
   </registry>
-  <node concept="NGJ2D" id="4tXyFaWyBuB">
-    <property role="TrG5h" value="RequirementsContextActions" />
-    <node concept="3_Xt8R" id="7Ip2X68Oobn" role="NGJ24">
-      <node concept="2YIFZM" id="4OH$Ti$m$5D" role="3_Xtb6">
-        <ref role="37wK5l" node="4OH$Ti$mtsB" resolve="getReqStructureFolderName" />
-        <ref role="1Pybhc" node="5Zn2KFQQ$_B" resolve="Helper" />
-        <node concept="gKNx_" id="4OH$Ti$m$xg" role="37wK5m" />
-      </node>
-      <node concept="3_N$aR" id="4tXyFaWyEn2" role="3_Xtdj">
-        <node concept="2p1MsB" id="4tXyFaWyEzd" role="3_N$d4">
-          <ref role="2p1Luo" to="m4ta:4tXyFaWyCnG" resolve="AddChildRequirement" />
-        </node>
-        <node concept="1QGGTA" id="pK4$jT2ZLt" role="3_N$db">
-          <node concept="1QGGSu" id="pK4$jT2ZLD" role="1QGGTw">
-            <property role="1iqoE4" value="${module}/icons/addChild.png" />
-          </node>
-        </node>
-      </node>
-      <node concept="3_N$aR" id="7Dcax7Agm1L" role="3_Xtdj">
-        <node concept="1QGGTA" id="pK4$jT3ShS" role="3_N$db">
-          <node concept="1QGGSu" id="pK4$jT3Skv" role="1QGGTw">
-            <property role="1iqoE4" value="${module}/icons/addSibling.png" />
-          </node>
-        </node>
-        <node concept="2p1MsB" id="7Dcax7Agm25" role="3_N$d4">
-          <ref role="2p1Luo" to="m4ta:7Dcax7Agh7q" resolve="AddSiblingRequirement" />
-        </node>
-      </node>
-      <node concept="3_N$aR" id="4Etk_BWsbo0" role="3_Xtdj">
-        <node concept="1QGGTA" id="pK4$jT3SAi" role="3_N$db">
-          <node concept="1QGGSu" id="pK4$jT3SA_" role="1QGGTw">
-            <property role="1iqoE4" value="${module}/icons/delete.png" />
-          </node>
-        </node>
-        <node concept="2p1MsB" id="4Etk_BWsbpq" role="3_N$d4">
-          <ref role="2p1Luo" to="m4ta:4Etk_BWsaOu" resolve="DeleteRequirement" />
-        </node>
-      </node>
-    </node>
-    <node concept="3_Xg01" id="3wHxcnxB$v$" role="NGJ24">
-      <node concept="3_Xt8R" id="3wHxcnxBQBA" role="3_Xg6h">
-        <node concept="2YIFZM" id="4OH$Ti$mCNB" role="3_Xtb6">
-          <ref role="37wK5l" node="4OH$Ti$mxDm" resolve="getReqGeneralFolderName" />
-          <ref role="1Pybhc" node="5Zn2KFQQ$_B" resolve="Helper" />
-          <node concept="gKNx_" id="4OH$Ti$mCNC" role="37wK5m" />
-        </node>
-        <node concept="geMak" id="3wHxcnxBQe5" role="3_Xtdj">
-          <node concept="2OqwBi" id="6b_jefnVxCN" role="geM8N">
-            <node concept="liA8E" id="6b_jefnVxCS" role="2OqNvi">
-              <ref role="37wK5l" to="xnls:~BaseIconManager.getIconFor(org.jetbrains.mps.openapi.model.SNode)" resolve="getIconFor" />
-              <node concept="geSxg" id="6b_jefnVxCT" role="37wK5m" />
-            </node>
-            <node concept="2YIFZM" id="7qOtjYQNOzs" role="2Oq$k0">
-              <ref role="1Pybhc" to="xnls:~GlobalIconManager" resolve="GlobalIconManager" />
-              <ref role="37wK5l" to="xnls:~GlobalIconManager.getInstance()" resolve="getInstance" />
-            </node>
-          </node>
-          <node concept="geMe5" id="3wHxcnxBQe6" role="geMea">
-            <node concept="3clFbS" id="3wHxcnxBQe7" role="2VODD2">
-              <node concept="3clFbF" id="3wHxcnxBYhy" role="3cqZAp">
-                <node concept="2OqwBi" id="3wHxcnxBYrB" role="3clFbG">
-                  <node concept="2OqwBi" id="3wHxcnxBYh$" role="2Oq$k0">
-                    <node concept="2OqwBi" id="3wHxcnxBYh_" role="2Oq$k0">
-                      <node concept="gKNx_" id="3wHxcnxBYhA" role="2Oq$k0" />
-                      <node concept="liA8E" id="3wHxcnxBYhB" role="2OqNvi">
-                        <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                      </node>
-                    </node>
-                    <node concept="2Xjw5R" id="3wHxcnxBYhC" role="2OqNvi">
-                      <node concept="1xMEDy" id="3wHxcnxBYhD" role="1xVPHs">
-                        <node concept="chp4Y" id="3wHxcnxCFcC" role="ri$Ld">
-                          <ref role="cht4Q" to="plfp:3wHxcnxC3W5" resolve="IReqRefCtx" />
-                        </node>
-                      </node>
-                      <node concept="1xIGOp" id="3wHxcnxBYhF" role="1xVPHs" />
-                    </node>
-                  </node>
-                  <node concept="2qgKlT" id="3wHxcnxCG4s" role="2OqNvi">
-                    <ref role="37wK5l" to="bemq:3wHxcnxC3Wx" resolve="insertRefTo" />
-                    <node concept="geSxg" id="3wHxcnxCGe3" role="37wK5m" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3Tqbb2" id="3wHxcnxBRFu" role="geMaj">
-            <ref role="ehGHo" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
-          </node>
-          <node concept="2OqwBi" id="3wHxcnxBQej" role="3V80Gy">
-            <node concept="geSxg" id="3wHxcnxBQek" role="2Oq$k0" />
-            <node concept="3TrcHB" id="3wHxcnxBXZK" role="2OqNvi">
-              <ref role="3TsBF5" to="plfp:4tXyFaWwpnN" resolve="title" />
-            </node>
-          </node>
-          <node concept="2OqwBi" id="3wHxcnxBQeu" role="geMbG">
-            <node concept="geSxg" id="3wHxcnxBQev" role="2Oq$k0" />
-            <node concept="2qgKlT" id="3wHxcnxBTtJ" role="2OqNvi">
-              <ref role="37wK5l" to="tpcu:hEwIO9y" resolve="getFqName" />
-            </node>
-          </node>
-          <node concept="2OqwBi" id="3wHxcnxBS61" role="geMah">
-            <node concept="2OqwBi" id="3wHxcnxBR8i" role="2Oq$k0">
-              <node concept="2OqwBi" id="3wHxcnxBQXd" role="2Oq$k0">
-                <node concept="2OqwBi" id="3wHxcnxBQr9" role="2Oq$k0">
-                  <node concept="gKNx_" id="3wHxcnxBQnU" role="2Oq$k0" />
-                  <node concept="liA8E" id="3wHxcnxBQVB" role="2OqNvi">
-                    <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                  </node>
-                </node>
-                <node concept="2Xjw5R" id="3wHxcnxBR4z" role="2OqNvi">
-                  <node concept="1xMEDy" id="3wHxcnxBR4_" role="1xVPHs">
-                    <node concept="chp4Y" id="3wHxcnxBR5D" role="ri$Ld">
-                      <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2qgKlT" id="3wHxcnxBRil" role="2OqNvi">
-                <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                <node concept="3TUQnm" id="3wHxcnxBRkh" role="37wK5m">
-                  <ref role="3TV0OU" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
-                </node>
-              </node>
-            </node>
-            <node concept="v3k3i" id="3wHxcnxBSjt" role="2OqNvi">
-              <node concept="chp4Y" id="3wHxcnxBSmo" role="v3oSu">
-                <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2OqwBi" id="3wHxcnxBP7Y" role="3_Xg7y">
-        <node concept="2OqwBi" id="3wHxcnxBOYP" role="2Oq$k0">
-          <node concept="2OqwBi" id="3wHxcnxBOWc" role="2Oq$k0">
-            <node concept="gKNx_" id="3wHxcnxBOVC" role="2Oq$k0" />
-            <node concept="liA8E" id="3wHxcnxBOX$" role="2OqNvi">
-              <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-            </node>
-          </node>
-          <node concept="2Xjw5R" id="3wHxcnxBP3e" role="2OqNvi">
-            <node concept="1xMEDy" id="3wHxcnxBP3g" role="1xVPHs">
-              <node concept="chp4Y" id="3wHxcnxCFa4" role="ri$Ld">
-                <ref role="cht4Q" to="plfp:3wHxcnxC3W5" resolve="IReqRefCtx" />
-              </node>
-            </node>
-            <node concept="1xIGOp" id="3wHxcnxBP5I" role="1xVPHs" />
-          </node>
-        </node>
-        <node concept="3x8VRR" id="3wHxcnxBPhy" role="2OqNvi" />
-      </node>
-    </node>
-    <node concept="3_Xt8R" id="5Zn2KFQSio0" role="NGJ24">
-      <node concept="Xl_RD" id="5Zn2KFQSiWx" role="3_Xtb6">
-        <property role="Xl_RC" value="Documentation" />
-      </node>
-      <node concept="3_Xg01" id="3wHxcnxBlRA" role="3_Xtdj">
-        <node concept="2YIFZM" id="5Zn2KFQR6IH" role="3_Xg7y">
-          <ref role="1Pybhc" node="5Zn2KFQQ$_B" resolve="Helper" />
-          <ref role="37wK5l" node="5Zn2KFQR5HX" resolve="isUnderDoc" />
-          <node concept="2OqwBi" id="5Zn2KFQR6II" role="37wK5m">
-            <node concept="gKNx_" id="5Zn2KFQR6IJ" role="2Oq$k0" />
-            <node concept="liA8E" id="5Zn2KFQR6IK" role="2OqNvi">
-              <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-            </node>
-          </node>
-        </node>
-        <node concept="3_Xt8R" id="7Ip2X68Ooq2" role="3_Xg6h">
-          <node concept="Xl_RD" id="7Ip2X68Oot6" role="3_Xtb6">
-            <property role="Xl_RC" value="Insert Paragraph" />
-          </node>
-          <node concept="geMak" id="5Zn2KFQQzNw" role="3_Xtdj">
-            <node concept="2OqwBi" id="6b_jefnVuY0" role="geM8N">
-              <node concept="liA8E" id="6b_jefnVvpI" role="2OqNvi">
-                <ref role="37wK5l" to="xnls:~BaseIconManager.getIconFor(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="getIconFor" />
-                <node concept="geSxg" id="6b_jefnVxyD" role="37wK5m" />
-              </node>
-              <node concept="2YIFZM" id="7qOtjYQNTOI" role="2Oq$k0">
-                <ref role="1Pybhc" to="xnls:~GlobalIconManager" resolve="GlobalIconManager" />
-                <ref role="37wK5l" to="xnls:~GlobalIconManager.getInstance()" resolve="getInstance" />
-              </node>
-            </node>
-            <node concept="geMe5" id="5Zn2KFQQzN$" role="geMea">
-              <node concept="3clFbS" id="5Zn2KFQQzN_" role="2VODD2">
-                <node concept="3clFbF" id="5Zn2KFQR6SE" role="3cqZAp">
-                  <node concept="2OqwBi" id="5Zn2KFQR7iR" role="3clFbG">
-                    <node concept="2YIFZM" id="5Zn2KFQR6Yf" role="2Oq$k0">
-                      <ref role="37wK5l" node="5Zn2KFQR6fs" resolve="docContent" />
-                      <ref role="1Pybhc" node="5Zn2KFQQ$_B" resolve="Helper" />
-                      <node concept="2OqwBi" id="5Zn2KFQR1hn" role="37wK5m">
-                        <node concept="gKNx_" id="5Zn2KFQR1ca" role="2Oq$k0" />
-                        <node concept="liA8E" id="5Zn2KFQR1mT" role="2OqNvi">
-                          <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="HtI8k" id="5Zn2KFQR7yT" role="2OqNvi">
-                      <node concept="2OqwBi" id="5Zn2KFQQzNG" role="HtI8F">
-                        <node concept="geSxg" id="5Zn2KFQQzNH" role="2Oq$k0" />
-                        <node concept="LFhST" id="5Zn2KFQQzNI" role="2OqNvi" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3bZ5Sz" id="5Zn2KFQQzNJ" role="geMaj" />
-            <node concept="2OqwBi" id="5Zn2KFQQzOk" role="3V80Gy">
-              <node concept="geSxg" id="5Zn2KFQQzOl" role="2Oq$k0" />
-              <node concept="3neUYN" id="5Zn2KFQQzOm" role="2OqNvi" />
-            </node>
-            <node concept="3cpWs3" id="5Zn2KFQTIiN" role="geMbG">
-              <node concept="Xl_RD" id="5Zn2KFQTIiO" role="3uHU7w">
-                <property role="Xl_RC" value=")" />
-              </node>
-              <node concept="3cpWs3" id="5Zn2KFQTIiP" role="3uHU7B">
-                <node concept="3cpWs3" id="5Zn2KFQTIiQ" role="3uHU7B">
-                  <node concept="2OqwBi" id="5Zn2KFQTIiR" role="3uHU7B">
-                    <node concept="geSxg" id="5Zn2KFQTIiS" role="2Oq$k0" />
-                    <node concept="3n3YKJ" id="5Zn2KFQTIiT" role="2OqNvi" />
-                  </node>
-                  <node concept="Xl_RD" id="5Zn2KFQTIiU" role="3uHU7w">
-                    <property role="Xl_RC" value=" (" />
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="5Zn2KFQTIiV" role="3uHU7w">
-                  <node concept="geSxg" id="5Zn2KFQTIiW" role="2Oq$k0" />
-                  <node concept="3neUYN" id="5Zn2KFQTIiX" role="2OqNvi" />
-                </node>
-              </node>
-            </node>
-            <node concept="2YIFZM" id="5Zn2KFQQWTp" role="geMah">
-              <ref role="37wK5l" node="5Zn2KFQQNJT" resolve="getValidDocContents" />
-              <ref role="1Pybhc" node="5Zn2KFQQ$_B" resolve="Helper" />
-              <node concept="2OqwBi" id="5Zn2KFQQY7t" role="37wK5m">
-                <node concept="gKNx_" id="5Zn2KFQQXxb" role="2Oq$k0" />
-                <node concept="liA8E" id="5Zn2KFQQYIx" role="2OqNvi">
-                  <ref role="37wK5l" to="1ne1:5tr7YH$UxYk" resolve="getModel" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3_Xg01" id="5Zn2KFQU4K5" role="3_Xtdj">
-        <node concept="3_Xt8R" id="3wHxcnxBkfp" role="3_Xg6h">
-          <node concept="Xl_RD" id="3wHxcnxBkn1" role="3_Xtb6">
-            <property role="Xl_RC" value="Formatting" />
-          </node>
-          <node concept="geMak" id="5Zn2KFQRMcO" role="3_Xtdj">
-            <node concept="geMe5" id="5Zn2KFQRMcS" role="geMea">
-              <node concept="3clFbS" id="5Zn2KFQRMcT" role="2VODD2">
-                <node concept="3SKdUt" id="5Zn2KFQRMcU" role="3cqZAp">
-                  <node concept="1PaTwC" id="17Nm8oCo8JX" role="1aUNEU">
-                    <node concept="3oM_SD" id="17Nm8oCo8JY" role="1PaTwD">
-                      <property role="3oM_SC" value="wrap" />
-                    </node>
-                    <node concept="3oM_SD" id="17Nm8oCo8JZ" role="1PaTwD">
-                      <property role="3oM_SC" value="current" />
-                    </node>
-                    <node concept="3oM_SD" id="17Nm8oCo8K0" role="1PaTwD">
-                      <property role="3oM_SC" value="word" />
-                    </node>
-                    <node concept="3oM_SD" id="17Nm8oCo8K1" role="1PaTwD">
-                      <property role="3oM_SC" value="with" />
-                    </node>
-                    <node concept="3oM_SD" id="17Nm8oCo8K2" role="1PaTwD">
-                      <property role="3oM_SC" value="the" />
-                    </node>
-                    <node concept="3oM_SD" id="17Nm8oCo8K3" role="1PaTwD">
-                      <property role="3oM_SC" value="formatted" />
-                    </node>
-                    <node concept="3oM_SD" id="17Nm8oCo8K4" role="1PaTwD">
-                      <property role="3oM_SC" value="text," />
-                    </node>
-                    <node concept="3oM_SD" id="17Nm8oCo8K5" role="1PaTwD">
-                      <property role="3oM_SC" value="if" />
-                    </node>
-                    <node concept="3oM_SD" id="17Nm8oCo8K6" role="1PaTwD">
-                      <property role="3oM_SC" value="selection" />
-                    </node>
-                    <node concept="3oM_SD" id="17Nm8oCo8K7" role="1PaTwD">
-                      <property role="3oM_SC" value="is" />
-                    </node>
-                    <node concept="3oM_SD" id="17Nm8oCo8K8" role="1PaTwD">
-                      <property role="3oM_SC" value="valid" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs8" id="5Zn2KFQRMde" role="3cqZAp">
-                  <node concept="3cpWsn" id="5Zn2KFQRMdf" role="3cpWs9">
-                    <property role="TrG5h" value="ec" />
-                    <node concept="3uibUv" id="5Zn2KFQRMdg" role="1tU5fm">
-                      <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
-                    </node>
-                    <node concept="2OqwBi" id="5Zn2KFQRMdh" role="33vP2m">
-                      <node concept="2OqwBi" id="5Zn2KFQRMdi" role="2Oq$k0">
-                        <node concept="gKNx_" id="5Zn2KFQRMdj" role="2Oq$k0" />
-                        <node concept="liA8E" id="5Zn2KFQRMdk" role="2OqNvi">
-                          <ref role="37wK5l" to="1ne1:5tr7YH$UFTD" resolve="getEditorComponent" />
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="5Zn2KFQRMdl" role="2OqNvi">
-                        <ref role="37wK5l" to="cj4x:~EditorComponent.getEditorContext()" resolve="getEditorContext" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="5Zn2KFQRMdm" role="3cqZAp">
-                  <node concept="3clFbS" id="5Zn2KFQRMdn" role="3clFbx">
-                    <node concept="3clFbF" id="5Zn2KFQRMdo" role="3cqZAp">
-                      <node concept="2YIFZM" id="5Zn2KFQRMdp" role="3clFbG">
-                        <ref role="1Pybhc" to="882r:3OiIliPRxrd" resolve="SurroundWithHelper" />
-                        <ref role="37wK5l" to="882r:3OiIliPRxrU" resolve="performSurrounding" />
-                        <node concept="37vLTw" id="5Zn2KFQRMdq" role="37wK5m">
-                          <ref role="3cqZAo" node="5Zn2KFQRMdf" resolve="ec" />
-                        </node>
-                        <node concept="geSxg" id="5Zn2KFQS1JA" role="37wK5m" />
-                      </node>
-                    </node>
-                    <node concept="3cpWs6" id="5Zn2KFQRMdx" role="3cqZAp" />
-                  </node>
-                  <node concept="2YIFZM" id="5Zn2KFQRMdy" role="3clFbw">
-                    <ref role="1Pybhc" to="882r:3OiIliPRxrd" resolve="SurroundWithHelper" />
-                    <ref role="37wK5l" to="882r:3OiIliPRxrf" resolve="isCorrectSelection" />
-                    <node concept="37vLTw" id="5Zn2KFQRMdz" role="37wK5m">
-                      <ref role="3cqZAo" node="5Zn2KFQRMdf" resolve="ec" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3SKdUt" id="5Zn2KFQRMdC" role="3cqZAp">
-                  <node concept="1PaTwC" id="17Nm8oCo8K9" role="1aUNEU">
-                    <node concept="3oM_SD" id="17Nm8oCo8Ka" role="1PaTwD">
-                      <property role="3oM_SC" value="otherwise" />
-                    </node>
-                    <node concept="3oM_SD" id="17Nm8oCo8Kb" role="1PaTwD">
-                      <property role="3oM_SC" value="insert" />
-                    </node>
-                    <node concept="3oM_SD" id="17Nm8oCo8Kc" role="1PaTwD">
-                      <property role="3oM_SC" value="new" />
-                    </node>
-                    <node concept="3oM_SD" id="17Nm8oCo8Kd" role="1PaTwD">
-                      <property role="3oM_SC" value="word" />
-                    </node>
-                    <node concept="3oM_SD" id="17Nm8oCo8Ke" role="1PaTwD">
-                      <property role="3oM_SC" value="as" />
-                    </node>
-                    <node concept="3oM_SD" id="17Nm8oCo8Kf" role="1PaTwD">
-                      <property role="3oM_SC" value="next" />
-                    </node>
-                    <node concept="3oM_SD" id="17Nm8oCo8Kg" role="1PaTwD">
-                      <property role="3oM_SC" value="sibling" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="5Zn2KFQRMdE" role="3cqZAp">
-                  <node concept="2OqwBi" id="5Zn2KFQRMdF" role="3clFbG">
-                    <node concept="2OqwBi" id="5Zn2KFQRMdG" role="2Oq$k0">
-                      <node concept="gKNx_" id="5Zn2KFQRMdH" role="2Oq$k0" />
-                      <node concept="liA8E" id="5Zn2KFQRMdI" role="2OqNvi">
-                        <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                      </node>
-                    </node>
-                    <node concept="HtI8k" id="5Zn2KFQRMdJ" role="2OqNvi">
-                      <node concept="2OqwBi" id="5Zn2KFQRMdK" role="HtI8F">
-                        <node concept="geSxg" id="5Zn2KFQRMdL" role="2Oq$k0" />
-                        <node concept="LFhST" id="5Zn2KFQRMdM" role="2OqNvi" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3bZ5Sz" id="5Zn2KFQRMdN" role="geMaj">
-              <ref role="3bZ5Sy" to="2c95:5mf_X_La_N$" resolve="FormattedText" />
-            </node>
-            <node concept="2OqwBi" id="5Zn2KFQRMeo" role="3V80Gy">
-              <node concept="geSxg" id="5Zn2KFQRMep" role="2Oq$k0" />
-              <node concept="3neUYN" id="5Zn2KFQRMeq" role="2OqNvi" />
-            </node>
-            <node concept="3cpWs3" id="5Zn2KFQTIDA" role="geMbG">
-              <node concept="Xl_RD" id="5Zn2KFQTIDB" role="3uHU7w">
-                <property role="Xl_RC" value=")" />
-              </node>
-              <node concept="3cpWs3" id="5Zn2KFQTIDC" role="3uHU7B">
-                <node concept="3cpWs3" id="5Zn2KFQTIDD" role="3uHU7B">
-                  <node concept="2OqwBi" id="5Zn2KFQTIDE" role="3uHU7B">
-                    <node concept="geSxg" id="5Zn2KFQTIDF" role="2Oq$k0" />
-                    <node concept="3n3YKJ" id="5Zn2KFQTIDG" role="2OqNvi" />
-                  </node>
-                  <node concept="Xl_RD" id="5Zn2KFQTIDH" role="3uHU7w">
-                    <property role="Xl_RC" value=" (" />
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="5Zn2KFQTIDI" role="3uHU7w">
-                  <node concept="geSxg" id="5Zn2KFQTIDJ" role="2Oq$k0" />
-                  <node concept="3neUYN" id="5Zn2KFQTIDK" role="2OqNvi" />
-                </node>
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5Zn2KFQRMdY" role="geMah">
-              <node concept="2OqwBi" id="5Zn2KFQRMdZ" role="2Oq$k0">
-                <node concept="2OqwBi" id="5Zn2KFQRMe0" role="2Oq$k0">
-                  <node concept="35c_gC" id="5Zn2KFQRMe1" role="2Oq$k0">
-                    <ref role="35c_gD" to="2c95:5mf_X_La_N$" resolve="FormattedText" />
-                  </node>
-                  <node concept="LSoRf" id="5Zn2KFQRMe2" role="2OqNvi">
-                    <node concept="2OqwBi" id="5Zn2KFQRMe3" role="1iTxcG">
-                      <node concept="gKNx_" id="5Zn2KFQRMe4" role="2Oq$k0" />
-                      <node concept="liA8E" id="5Zn2KFQRMe5" role="2OqNvi">
-                        <ref role="37wK5l" to="1ne1:5tr7YH$UxYk" resolve="getModel" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3zZkjj" id="5Zn2KFQRMe6" role="2OqNvi">
-                  <node concept="1bVj0M" id="5Zn2KFQRMe7" role="23t8la">
-                    <node concept="3clFbS" id="5Zn2KFQRMe8" role="1bW5cS">
-                      <node concept="3clFbF" id="5Zn2KFQRMe9" role="3cqZAp">
-                        <node concept="1Wc70l" id="5Zn2KFQRMea" role="3clFbG">
-                          <node concept="3fqX7Q" id="5Zn2KFQRMeb" role="3uHU7w">
-                            <node concept="2OqwBi" id="5Zn2KFQRMec" role="3fr31v">
-                              <node concept="2OqwBi" id="5Zn2KFQRMed" role="2Oq$k0">
-                                <node concept="37vLTw" id="5Zn2KFQRMee" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="5Zn2KFQRMel" resolve="cc" />
-                                </node>
-                                <node concept="3n3YKJ" id="5Zn2KFQRMef" role="2OqNvi" />
-                              </node>
-                              <node concept="17RlXB" id="5Zn2KFQRMeg" role="2OqNvi" />
-                            </node>
-                          </node>
-                          <node concept="3fqX7Q" id="5Zn2KFQRMeh" role="3uHU7B">
-                            <node concept="2OqwBi" id="5Zn2KFQRMei" role="3fr31v">
-                              <node concept="37vLTw" id="5Zn2KFQRMej" role="2Oq$k0">
-                                <ref role="3cqZAo" node="5Zn2KFQRMel" resolve="cc" />
-                              </node>
-                              <node concept="liA8E" id="5Zn2KFQRMek" role="2OqNvi">
-                                <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="Rh6nW" id="5Zn2KFQRMel" role="1bW2Oz">
-                      <property role="TrG5h" value="cc" />
-                      <node concept="2jxLKc" id="5Zn2KFQRMem" role="1tU5fm" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="ANE8D" id="5Zn2KFQRMen" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="2OqwBi" id="3wHxcnxBjeq" role="3_Xg7y">
-          <node concept="2OqwBi" id="3wHxcnxBiCl" role="2Oq$k0">
-            <node concept="gKNx_" id="5Zn2KFQU4Wi" role="2Oq$k0" />
-            <node concept="liA8E" id="3wHxcnxBj9u" role="2OqNvi">
-              <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-            </node>
-          </node>
-          <node concept="1mIQ4w" id="3wHxcnxBjiN" role="2OqNvi">
-            <node concept="chp4Y" id="3wHxcnxCQrH" role="cj9EA">
-              <ref role="cht4Q" to="87nw:2dWzqxEBMSc" resolve="Word" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="3_Xt8R" id="7Ip2X68Oj7X" role="NGJ24">
-      <node concept="Xl_RD" id="7Ip2X68Oj8f" role="3_Xtb6">
-        <property role="Xl_RC" value="Workflow" />
-      </node>
-      <node concept="geMak" id="7Ip2X68Oj8t" role="3_Xtdj">
-        <node concept="3cpWs3" id="7Ip2X68Ok85" role="geMbG">
-          <node concept="geSxg" id="7Ip2X68Ok9k" role="3uHU7w" />
-          <node concept="Xl_RD" id="7Ip2X68Ok40" role="3uHU7B">
-            <property role="Xl_RC" value="Move to State " />
-          </node>
-        </node>
-        <node concept="2OqwBi" id="7Ip2X68OjY3" role="geMah">
-          <node concept="2OqwBi" id="7Ip2X68OjJW" role="2Oq$k0">
-            <node concept="2OqwBi" id="7Ip2X68Oj_1" role="2Oq$k0">
-              <node concept="2OqwBi" id="7Ip2X68Ojad" role="2Oq$k0">
-                <node concept="gKNx_" id="7Ip2X68Oj9n" role="2Oq$k0" />
-                <node concept="liA8E" id="7Ip2X68Ojzx" role="2OqNvi">
-                  <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                </node>
-              </node>
-              <node concept="2Xjw5R" id="7Ip2X68OjDG" role="2OqNvi">
-                <node concept="1xMEDy" id="7Ip2X68OjDI" role="1xVPHs">
-                  <node concept="chp4Y" id="7Ip2X68OjEG" role="ri$Ld">
-                    <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
-                  </node>
-                </node>
-                <node concept="1xIGOp" id="7Ip2X68OjH2" role="1xVPHs" />
-              </node>
-            </node>
-            <node concept="3TrEf2" id="7Ip2X68OjQO" role="2OqNvi">
-              <ref role="3Tt5mk" to="plfp:l6fPaF3tRV" resolve="state" />
-            </node>
-          </node>
-          <node concept="2qgKlT" id="7Ip2X68Ok30" role="2OqNvi">
-            <ref role="37wK5l" to="bemq:7Ip2X68O2Sn" resolve="nextStates" />
-          </node>
-        </node>
-        <node concept="geMe5" id="7Ip2X68OkaL" role="geMea">
-          <node concept="3clFbS" id="7Ip2X68OkaM" role="2VODD2">
-            <node concept="3clFbF" id="7Ip2X68OkzN" role="3cqZAp">
-              <node concept="37vLTI" id="7Ip2X68OkOv" role="3clFbG">
-                <node concept="geSxg" id="7Ip2X68OkQ2" role="37vLTx" />
-                <node concept="2OqwBi" id="7Ip2X68OkAZ" role="37vLTJ">
-                  <node concept="2OqwBi" id="7Ip2X68OkzP" role="2Oq$k0">
-                    <node concept="2OqwBi" id="7Ip2X68OkzQ" role="2Oq$k0">
-                      <node concept="gKNx_" id="7Ip2X68OkzR" role="2Oq$k0" />
-                      <node concept="liA8E" id="7Ip2X68OkzS" role="2OqNvi">
-                        <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                      </node>
-                    </node>
-                    <node concept="2Xjw5R" id="7Ip2X68OkzT" role="2OqNvi">
-                      <node concept="1xMEDy" id="7Ip2X68OkzU" role="1xVPHs">
-                        <node concept="chp4Y" id="7Ip2X68OkzV" role="ri$Ld">
-                          <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
-                        </node>
-                      </node>
-                      <node concept="1xIGOp" id="7Ip2X68OkzW" role="1xVPHs" />
-                    </node>
-                  </node>
-                  <node concept="3TrEf2" id="7Ip2X68OkHx" role="2OqNvi">
-                    <ref role="3Tt5mk" to="plfp:l6fPaF3tRV" resolve="state" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3Tqbb2" id="7Ip2X68OnKg" role="geMaj">
-          <ref role="ehGHo" to="plfp:l6fPaF3tF7" resolve="State" />
-        </node>
-      </node>
-    </node>
-    <node concept="3_Xt8R" id="7Dcax7Ai6kE" role="NGJ24">
-      <node concept="Xl_RD" id="7Dcax7Ai6kF" role="3_Xtb6">
-        <property role="Xl_RC" value="Tags" />
-      </node>
-      <node concept="geMak" id="7Dcax7Ai6kG" role="3_Xtdj">
-        <node concept="3cpWs3" id="5Zn2KFQTHIY" role="geMbG">
-          <node concept="Xl_RD" id="5Zn2KFQTHJ1" role="3uHU7w">
-            <property role="Xl_RC" value=")" />
-          </node>
-          <node concept="3cpWs3" id="5Zn2KFQTA7l" role="3uHU7B">
-            <node concept="3cpWs3" id="5Zn2KFQT_Jr" role="3uHU7B">
-              <node concept="2OqwBi" id="7Dcax7Aicxw" role="3uHU7B">
-                <node concept="geSxg" id="7Dcax7Ai6kI" role="2Oq$k0" />
-                <node concept="3n3YKJ" id="7Dcax7AicEM" role="2OqNvi" />
-              </node>
-              <node concept="Xl_RD" id="5Zn2KFQT_Ju" role="3uHU7w">
-                <property role="Xl_RC" value=" (" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="5Zn2KFQTHtS" role="3uHU7w">
-              <node concept="geSxg" id="5Zn2KFQTHr3" role="2Oq$k0" />
-              <node concept="3neUYN" id="5Zn2KFQTHBx" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="geMe5" id="7Dcax7Ai6kW" role="geMea">
-          <node concept="3clFbS" id="7Dcax7Ai6kX" role="2VODD2">
-            <node concept="3cpWs8" id="7Dcax7Ai8hU" role="3cqZAp">
-              <node concept="3cpWsn" id="7Dcax7Ai8hV" role="3cpWs9">
-                <property role="TrG5h" value="tag" />
-                <node concept="3Tqbb2" id="7Dcax7Ai8hS" role="1tU5fm" />
-                <node concept="2OqwBi" id="7Dcax7Ai8hW" role="33vP2m">
-                  <node concept="geSxg" id="7Dcax7Ai8hX" role="2Oq$k0" />
-                  <node concept="LFhST" id="7Dcax7Ai8hY" role="2OqNvi" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="7Dcax7Ai8wl" role="3cqZAp">
-              <node concept="2OqwBi" id="7Dcax7Ai9h9" role="3clFbG">
-                <node concept="2OqwBi" id="7Dcax7Ai8Ih" role="2Oq$k0">
-                  <node concept="2OqwBi" id="7Dcax7Ai6l2" role="2Oq$k0">
-                    <node concept="2OqwBi" id="7Dcax7Ai6l3" role="2Oq$k0">
-                      <node concept="gKNx_" id="7Dcax7Ai6l4" role="2Oq$k0" />
-                      <node concept="liA8E" id="7Dcax7Ai6l5" role="2OqNvi">
-                        <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                      </node>
-                    </node>
-                    <node concept="2Xjw5R" id="7Dcax7Ai6l6" role="2OqNvi">
-                      <node concept="1xMEDy" id="7Dcax7Ai6l7" role="1xVPHs">
-                        <node concept="chp4Y" id="7Dcax7Ai6l8" role="ri$Ld">
-                          <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
-                        </node>
-                      </node>
-                      <node concept="1xIGOp" id="7Dcax7Ai6l9" role="1xVPHs" />
-                    </node>
-                  </node>
-                  <node concept="3Tsc0h" id="7Dcax7Ai8Qg" role="2OqNvi">
-                    <ref role="3TtcxE" to="plfp:4tXyFaWylGz" resolve="tags" />
-                  </node>
-                </node>
-                <node concept="TSZUe" id="7Dcax7Aia96" role="2OqNvi">
-                  <node concept="1PxgMI" id="7Dcax7Aif$j" role="25WWJ7">
-                    <node concept="chp4Y" id="6b_jefnKzVn" role="3oSUPX">
-                      <ref role="cht4Q" to="plfp:4tXyFaWylGs" resolve="Tag" />
-                    </node>
-                    <node concept="37vLTw" id="7Dcax7Aiaic" role="1m5AlR">
-                      <ref role="3cqZAo" node="7Dcax7Ai8hV" resolve="tag" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3bZ5Sz" id="7Dcax7Ai7wF" role="geMaj">
-          <ref role="3bZ5Sy" to="plfp:4tXyFaWylGs" resolve="Tag" />
-        </node>
-        <node concept="2OqwBi" id="1T$QQLd4dsx" role="geMah">
-          <node concept="2OqwBi" id="1T$QQLd4dsy" role="2Oq$k0">
-            <node concept="2OqwBi" id="1T$QQLd4dsz" role="2Oq$k0">
-              <node concept="35c_gC" id="1T$QQLd4ds$" role="2Oq$k0">
-                <ref role="35c_gD" to="plfp:4tXyFaWylGs" resolve="Tag" />
-              </node>
-              <node concept="LSoRf" id="1T$QQLd4ds_" role="2OqNvi">
-                <node concept="2OqwBi" id="1T$QQLd4dsA" role="1iTxcG">
-                  <node concept="gKNx_" id="1T$QQLd4lko" role="2Oq$k0" />
-                  <node concept="liA8E" id="1T$QQLd4dsC" role="2OqNvi">
-                    <ref role="37wK5l" to="1ne1:5tr7YH$UxYk" resolve="getModel" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3zZkjj" id="1T$QQLd4dsD" role="2OqNvi">
-              <node concept="1bVj0M" id="1T$QQLd4dsE" role="23t8la">
-                <node concept="3clFbS" id="1T$QQLd4dsF" role="1bW5cS">
-                  <node concept="3clFbF" id="1T$QQLd4dsG" role="3cqZAp">
-                    <node concept="3fqX7Q" id="1T$QQLd4dsH" role="3clFbG">
-                      <node concept="2OqwBi" id="1T$QQLd4dsI" role="3fr31v">
-                        <node concept="37vLTw" id="1T$QQLd4dsJ" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1T$QQLd4dsL" resolve="tag" />
-                        </node>
-                        <node concept="liA8E" id="1T$QQLd4dsK" role="2OqNvi">
-                          <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="Rh6nW" id="1T$QQLd4dsL" role="1bW2Oz">
-                  <property role="TrG5h" value="tag" />
-                  <node concept="2jxLKc" id="1T$QQLd4dsM" role="1tU5fm" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3zZkjj" id="1T$QQLd4dsN" role="2OqNvi">
-            <node concept="1bVj0M" id="1T$QQLd4dsO" role="23t8la">
-              <node concept="3clFbS" id="1T$QQLd4dsP" role="1bW5cS">
-                <node concept="3clFbF" id="1T$QQLd4gVi" role="3cqZAp">
-                  <node concept="2YIFZM" id="1T$QQLd4hio" role="3clFbG">
-                    <ref role="37wK5l" node="hzYhIjiQKh" resolve="checkTag" />
-                    <ref role="1Pybhc" node="5Zn2KFQQ$_B" resolve="Helper" />
-                    <node concept="gKNx_" id="1T$QQLd4jKE" role="37wK5m" />
-                    <node concept="37vLTw" id="1T$QQLd4kmr" role="37wK5m">
-                      <ref role="3cqZAo" node="1T$QQLd4dsU" resolve="tag" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="Rh6nW" id="1T$QQLd4dsU" role="1bW2Oz">
-                <property role="TrG5h" value="tag" />
-                <node concept="2jxLKc" id="1T$QQLd4dsV" role="1tU5fm" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
   <node concept="2DaZZR" id="4tXyFaWyEHl" />
-  <node concept="312cEu" id="5Zn2KFQQ$_B">
-    <property role="TrG5h" value="Helper" />
-    <node concept="2tJIrI" id="5Zn2KFQQ_4B" role="jymVt" />
-    <node concept="2YIFZL" id="5Zn2KFQQ$Gt" role="jymVt">
-      <property role="TrG5h" value="isUnderRequirement" />
-      <node concept="10P_77" id="5Zn2KFQQM7w" role="3clF45" />
-      <node concept="3Tm1VV" id="5Zn2KFQQ$Gw" role="1B3o_S" />
-      <node concept="3clFbS" id="5Zn2KFQQ$Gx" role="3clF47">
-        <node concept="3clFbF" id="5Zn2KFQQBUk" role="3cqZAp">
-          <node concept="2OqwBi" id="5Zn2KFQQC1L" role="3clFbG">
-            <node concept="2OqwBi" id="5Zn2KFQQBVo" role="2Oq$k0">
-              <node concept="37vLTw" id="5Zn2KFQQBUj" role="2Oq$k0">
-                <ref role="3cqZAo" node="5Zn2KFQQBMK" resolve="ctx" />
-              </node>
-              <node concept="2Xjw5R" id="5Zn2KFQQBXw" role="2OqNvi">
-                <node concept="1xMEDy" id="5Zn2KFQQBXy" role="1xVPHs">
-                  <node concept="chp4Y" id="5Zn2KFQQBZ8" role="ri$Ld">
-                    <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3x8VRR" id="5Zn2KFQQCfn" role="2OqNvi" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="5Zn2KFQQBMK" role="3clF46">
-        <property role="TrG5h" value="ctx" />
-        <node concept="3Tqbb2" id="5Zn2KFQQBMJ" role="1tU5fm" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5Zn2KFQR65D" role="jymVt" />
-    <node concept="2YIFZL" id="5Zn2KFQQZ$1" role="jymVt">
-      <property role="TrG5h" value="getRequirement" />
-      <node concept="3Tqbb2" id="5Zn2KFQR0G3" role="3clF45">
-        <ref role="ehGHo" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
-      </node>
-      <node concept="3Tm1VV" id="5Zn2KFQQZ$3" role="1B3o_S" />
-      <node concept="3clFbS" id="5Zn2KFQQZ$4" role="3clF47">
-        <node concept="3clFbF" id="5Zn2KFQQZ$5" role="3cqZAp">
-          <node concept="2OqwBi" id="5Zn2KFQQZ$7" role="3clFbG">
-            <node concept="37vLTw" id="5Zn2KFQQZ$8" role="2Oq$k0">
-              <ref role="3cqZAo" node="5Zn2KFQQZ$d" resolve="ctx" />
-            </node>
-            <node concept="2Xjw5R" id="5Zn2KFQQZ$9" role="2OqNvi">
-              <node concept="1xMEDy" id="5Zn2KFQQZ$a" role="1xVPHs">
-                <node concept="chp4Y" id="5Zn2KFQQZ$b" role="ri$Ld">
-                  <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="5Zn2KFQQZ$d" role="3clF46">
-        <property role="TrG5h" value="ctx" />
-        <node concept="3Tqbb2" id="5Zn2KFQQZ$e" role="1tU5fm" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5Zn2KFQR67t" role="jymVt" />
-    <node concept="2YIFZL" id="5Zn2KFQR5HX" role="jymVt">
-      <property role="TrG5h" value="isUnderDoc" />
-      <node concept="10P_77" id="5Zn2KFQR5HY" role="3clF45" />
-      <node concept="3Tm1VV" id="5Zn2KFQR5HZ" role="1B3o_S" />
-      <node concept="3clFbS" id="5Zn2KFQR5I0" role="3clF47">
-        <node concept="3clFbF" id="5Zn2KFQR5I1" role="3cqZAp">
-          <node concept="2OqwBi" id="5Zn2KFQR5I2" role="3clFbG">
-            <node concept="2OqwBi" id="5Zn2KFQR5I3" role="2Oq$k0">
-              <node concept="37vLTw" id="5Zn2KFQR5I4" role="2Oq$k0">
-                <ref role="3cqZAo" node="5Zn2KFQR5I9" resolve="ctx" />
-              </node>
-              <node concept="2Xjw5R" id="5Zn2KFQR5I5" role="2OqNvi">
-                <node concept="1xMEDy" id="5Zn2KFQR5I6" role="1xVPHs">
-                  <node concept="chp4Y" id="5Zn2KFQR5RP" role="ri$Ld">
-                    <ref role="cht4Q" to="2c95:2TZO3DbuxwP" resolve="IDocumentContent" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3x8VRR" id="5Zn2KFQR5I8" role="2OqNvi" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="5Zn2KFQR5I9" role="3clF46">
-        <property role="TrG5h" value="ctx" />
-        <node concept="3Tqbb2" id="5Zn2KFQR5Ia" role="1tU5fm" />
-      </node>
-    </node>
-    <node concept="2YIFZL" id="5Zn2KFQR6fs" role="jymVt">
-      <property role="TrG5h" value="docContent" />
-      <node concept="3Tqbb2" id="5Zn2KFQR6_j" role="3clF45">
-        <ref role="ehGHo" to="2c95:2TZO3DbuxwP" resolve="IDocumentContent" />
-      </node>
-      <node concept="3Tm1VV" id="5Zn2KFQR6fu" role="1B3o_S" />
-      <node concept="3clFbS" id="5Zn2KFQR6fv" role="3clF47">
-        <node concept="3clFbF" id="5Zn2KFQR6fw" role="3cqZAp">
-          <node concept="2OqwBi" id="5Zn2KFQR6fy" role="3clFbG">
-            <node concept="37vLTw" id="5Zn2KFQR6fz" role="2Oq$k0">
-              <ref role="3cqZAo" node="5Zn2KFQR6fC" resolve="ctx" />
-            </node>
-            <node concept="2Xjw5R" id="5Zn2KFQR6f$" role="2OqNvi">
-              <node concept="1xMEDy" id="5Zn2KFQR6f_" role="1xVPHs">
-                <node concept="chp4Y" id="5Zn2KFQR6fA" role="ri$Ld">
-                  <ref role="cht4Q" to="2c95:2TZO3DbuxwP" resolve="IDocumentContent" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="5Zn2KFQR6fC" role="3clF46">
-        <property role="TrG5h" value="ctx" />
-        <node concept="3Tqbb2" id="5Zn2KFQR6fD" role="1tU5fm" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5Zn2KFQR5VR" role="jymVt" />
-    <node concept="2tJIrI" id="5Zn2KFQQNDj" role="jymVt" />
-    <node concept="2YIFZL" id="5Zn2KFQQNJT" role="jymVt">
-      <property role="TrG5h" value="getValidDocContents" />
-      <node concept="_YKpA" id="5Zn2KFQQT4p" role="3clF45">
-        <node concept="3bZ5Sz" id="5Zn2KFQQTgt" role="_ZDj9" />
-      </node>
-      <node concept="3Tm1VV" id="5Zn2KFQQNJW" role="1B3o_S" />
-      <node concept="3clFbS" id="5Zn2KFQQNJX" role="3clF47">
-        <node concept="3cpWs8" id="5Zn2KFQQRmR" role="3cqZAp">
-          <node concept="3cpWsn" id="5Zn2KFQQRmU" role="3cpWs9">
-            <property role="TrG5h" value="res" />
-            <node concept="_YKpA" id="5Zn2KFQQRmN" role="1tU5fm">
-              <node concept="3bZ5Sz" id="5Zn2KFQQRxu" role="_ZDj9" />
-            </node>
-            <node concept="2ShNRf" id="5Zn2KFQQRyl" role="33vP2m">
-              <node concept="Tc6Ow" id="5Zn2KFQQSFD" role="2ShVmc">
-                <node concept="3bZ5Sz" id="5Zn2KFQQTw9" role="HW$YZ" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5Zn2KFQQUg$" role="3cqZAp">
-          <node concept="2OqwBi" id="5Zn2KFQQUsN" role="3clFbG">
-            <node concept="37vLTw" id="5Zn2KFQQUgy" role="2Oq$k0">
-              <ref role="3cqZAo" node="5Zn2KFQQRmU" resolve="res" />
-            </node>
-            <node concept="X8dFx" id="5Zn2KFQQUNp" role="2OqNvi">
-              <node concept="2OqwBi" id="5Zn2KFQQNNV" role="25WWJ7">
-                <node concept="2OqwBi" id="5Zn2KFQQNNW" role="2Oq$k0">
-                  <node concept="35c_gC" id="5Zn2KFQQNNX" role="2Oq$k0">
-                    <ref role="35c_gD" to="plfp:7Dcax7AgAPg" resolve="IReqDocContent" />
-                  </node>
-                  <node concept="LSoRf" id="5Zn2KFQQNNY" role="2OqNvi">
-                    <node concept="37vLTw" id="5Zn2KFQQTPT" role="1iTxcG">
-                      <ref role="3cqZAo" node="5Zn2KFQQTKZ" resolve="m" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3zZkjj" id="5Zn2KFQQNO2" role="2OqNvi">
-                  <node concept="1bVj0M" id="5Zn2KFQQNO3" role="23t8la">
-                    <node concept="3clFbS" id="5Zn2KFQQNO4" role="1bW5cS">
-                      <node concept="3clFbF" id="5Zn2KFQQNO5" role="3cqZAp">
-                        <node concept="1Wc70l" id="5Zn2KFQQNO6" role="3clFbG">
-                          <node concept="3fqX7Q" id="5Zn2KFQQNO7" role="3uHU7w">
-                            <node concept="2OqwBi" id="5Zn2KFQQNO8" role="3fr31v">
-                              <node concept="2OqwBi" id="5Zn2KFQQNO9" role="2Oq$k0">
-                                <node concept="37vLTw" id="5Zn2KFQQNOa" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="5Zn2KFQQNOh" resolve="cc" />
-                                </node>
-                                <node concept="3n3YKJ" id="5Zn2KFQQNOb" role="2OqNvi" />
-                              </node>
-                              <node concept="17RlXB" id="5Zn2KFQQNOc" role="2OqNvi" />
-                            </node>
-                          </node>
-                          <node concept="3fqX7Q" id="5Zn2KFQQNOd" role="3uHU7B">
-                            <node concept="2OqwBi" id="5Zn2KFQQNOe" role="3fr31v">
-                              <node concept="37vLTw" id="5Zn2KFQQNOf" role="2Oq$k0">
-                                <ref role="3cqZAo" node="5Zn2KFQQNOh" resolve="cc" />
-                              </node>
-                              <node concept="liA8E" id="5Zn2KFQQNOg" role="2OqNvi">
-                                <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="Rh6nW" id="5Zn2KFQQNOh" role="1bW2Oz">
-                      <property role="TrG5h" value="cc" />
-                      <node concept="2jxLKc" id="5Zn2KFQQNOi" role="1tU5fm" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5Zn2KFQQVjt" role="3cqZAp">
-          <node concept="2OqwBi" id="5Zn2KFQQVsf" role="3clFbG">
-            <node concept="37vLTw" id="5Zn2KFQQVjr" role="2Oq$k0">
-              <ref role="3cqZAo" node="5Zn2KFQQRmU" resolve="res" />
-            </node>
-            <node concept="TSZUe" id="5Zn2KFQQVMt" role="2OqNvi">
-              <node concept="35c_gC" id="5Zn2KFQQVPw" role="25WWJ7">
-                <ref role="35c_gD" to="2c95:2TZO3DbvcVM" resolve="TextParagraph" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5Zn2KFQQW0a" role="3cqZAp">
-          <node concept="2OqwBi" id="5Zn2KFQQW0b" role="3clFbG">
-            <node concept="37vLTw" id="5Zn2KFQQW0c" role="2Oq$k0">
-              <ref role="3cqZAo" node="5Zn2KFQQRmU" resolve="res" />
-            </node>
-            <node concept="TSZUe" id="5Zn2KFQQW0d" role="2OqNvi">
-              <node concept="35c_gC" id="5Zn2KFQQW0e" role="25WWJ7">
-                <ref role="35c_gD" to="2c95:5yxqZJwyOSj" resolve="ImageParagraph" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5Zn2KFQQWoQ" role="3cqZAp">
-          <node concept="2OqwBi" id="5Zn2KFQQWoR" role="3clFbG">
-            <node concept="37vLTw" id="5Zn2KFQQWoS" role="2Oq$k0">
-              <ref role="3cqZAo" node="5Zn2KFQQRmU" resolve="res" />
-            </node>
-            <node concept="TSZUe" id="5Zn2KFQQWoT" role="2OqNvi">
-              <node concept="35c_gC" id="5Zn2KFQQWoU" role="25WWJ7">
-                <ref role="35c_gD" to="2c95:4E$PniRJLTL" resolve="ItemList" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5Zn2KFQQSOT" role="3cqZAp">
-          <node concept="37vLTw" id="5Zn2KFQQSOR" role="3clFbG">
-            <ref role="3cqZAo" node="5Zn2KFQQRmU" resolve="res" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="5Zn2KFQQTKZ" role="3clF46">
-        <property role="TrG5h" value="m" />
-        <node concept="H_c77" id="5Zn2KFQQTKY" role="1tU5fm" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="hzYhIjhS1f" role="jymVt" />
-    <node concept="2YIFZL" id="hzYhIjiQKh" role="jymVt">
-      <property role="TrG5h" value="checkTag" />
-      <property role="od$2w" value="false" />
-      <property role="DiZV1" value="false" />
-      <property role="2aFKle" value="false" />
-      <node concept="37vLTG" id="hzYhIjiR18" role="3clF46">
-        <property role="TrG5h" value="ctx" />
-        <node concept="3uibUv" id="hzYhIjiR19" role="1tU5fm">
-          <ref role="3uigEE" to="1ne1:5tr7YH$Ux6m" resolve="IContext" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="hzYhIjjM66" role="3clF46">
-        <property role="TrG5h" value="tag" />
-        <node concept="3bZ5Sz" id="hzYhIjjMua" role="1tU5fm">
-          <ref role="3bZ5Sy" to="plfp:4tXyFaWylGs" resolve="Tag" />
-        </node>
-      </node>
-      <node concept="3clFbS" id="hzYhIjiQKk" role="3clF47">
-        <node concept="3cpWs8" id="hzYhIjiS2O" role="3cqZAp">
-          <node concept="3cpWsn" id="hzYhIjiS2R" role="3cpWs9">
-            <property role="TrG5h" value="enclosingReq" />
-            <node concept="3Tqbb2" id="hzYhIjiS2M" role="1tU5fm">
-              <ref role="ehGHo" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
-            </node>
-            <node concept="2OqwBi" id="hzYhIjiSph" role="33vP2m">
-              <node concept="2OqwBi" id="hzYhIjiSpi" role="2Oq$k0">
-                <node concept="37vLTw" id="hzYhIjiSpj" role="2Oq$k0">
-                  <ref role="3cqZAo" node="hzYhIjiR18" resolve="ctx" />
-                </node>
-                <node concept="liA8E" id="hzYhIjiSpk" role="2OqNvi">
-                  <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                </node>
-              </node>
-              <node concept="2Xjw5R" id="hzYhIjiSpl" role="2OqNvi">
-                <node concept="1xMEDy" id="hzYhIjiSpm" role="1xVPHs">
-                  <node concept="chp4Y" id="hzYhIjiSpn" role="ri$Ld">
-                    <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
-                  </node>
-                </node>
-                <node concept="1xIGOp" id="hzYhIjiSpo" role="1xVPHs" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="1T$QQLd3utV" role="3cqZAp">
-          <node concept="22lmx$" id="6Q6YvW0ISkB" role="3clFbw">
-            <node concept="3clFbC" id="1T$QQLd3vyi" role="3uHU7B">
-              <node concept="37vLTw" id="1T$QQLd3u_4" role="3uHU7B">
-                <ref role="3cqZAo" node="hzYhIjiS2R" resolve="enclosingReq" />
-              </node>
-              <node concept="10Nm6u" id="1T$QQLd3vCU" role="3uHU7w" />
-            </node>
-            <node concept="2OqwBi" id="6Q6YvW0IVR8" role="3uHU7w">
-              <node concept="37vLTw" id="6Q6YvW0IVR9" role="2Oq$k0">
-                <ref role="3cqZAo" node="hzYhIjiS2R" resolve="enclosingReq" />
-              </node>
-              <node concept="2qgKlT" id="6Q6YvW0IVRa" role="2OqNvi">
-                <ref role="37wK5l" to="bemq:6Q6YvW0IOIs" resolve="suppressTags" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbS" id="1T$QQLd3utX" role="3clFbx">
-            <node concept="3cpWs6" id="1T$QQLd3y30" role="3cqZAp">
-              <node concept="3clFbT" id="1T$QQLd3yKP" role="3cqZAk" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="1T$QQLd3x$K" role="3cqZAp">
-          <node concept="3fqX7Q" id="1T$QQLd3_2G" role="3clFbG">
-            <node concept="2OqwBi" id="1T$QQLd3_2I" role="3fr31v">
-              <node concept="2OqwBi" id="1T$QQLd3_2J" role="2Oq$k0">
-                <node concept="37vLTw" id="1T$QQLd3_2K" role="2Oq$k0">
-                  <ref role="3cqZAo" node="hzYhIjiS2R" resolve="enclosingReq" />
-                </node>
-                <node concept="3Tsc0h" id="1T$QQLd3_2L" role="2OqNvi">
-                  <ref role="3TtcxE" to="plfp:4tXyFaWylGz" resolve="tags" />
-                </node>
-              </node>
-              <node concept="2HwmR7" id="1T$QQLd3_2M" role="2OqNvi">
-                <node concept="1bVj0M" id="1T$QQLd3_2N" role="23t8la">
-                  <node concept="3clFbS" id="1T$QQLd3_2O" role="1bW5cS">
-                    <node concept="3clFbF" id="1T$QQLd3_2P" role="3cqZAp">
-                      <node concept="3clFbC" id="1T$QQLd3_2Q" role="3clFbG">
-                        <node concept="37vLTw" id="1T$QQLd3_2R" role="3uHU7w">
-                          <ref role="3cqZAo" node="hzYhIjjM66" resolve="tag" />
-                        </node>
-                        <node concept="2OqwBi" id="1T$QQLd3_2S" role="3uHU7B">
-                          <node concept="37vLTw" id="1T$QQLd3_2T" role="2Oq$k0">
-                            <ref role="3cqZAo" node="1T$QQLd3_2V" resolve="it" />
-                          </node>
-                          <node concept="2yIwOk" id="1T$QQLd3_2U" role="2OqNvi" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="Rh6nW" id="1T$QQLd3_2V" role="1bW2Oz">
-                    <property role="TrG5h" value="it" />
-                    <node concept="2jxLKc" id="1T$QQLd3_2W" role="1tU5fm" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="1T$QQLd4cAa" role="1B3o_S" />
-      <node concept="10P_77" id="hzYhIjjRFA" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="5Zn2KFQQ$_R" role="jymVt" />
-    <node concept="2YIFZL" id="4OH$Ti$mtsB" role="jymVt">
-      <property role="TrG5h" value="getReqStructureFolderName" />
-      <property role="od$2w" value="false" />
-      <property role="DiZV1" value="false" />
-      <property role="2aFKle" value="false" />
-      <node concept="3clFbS" id="4OH$Ti$mtsE" role="3clF47">
-        <node concept="3clFbF" id="4OH$Ti$mu0J" role="3cqZAp">
-          <node concept="2EnYce" id="4OH$Ti$mwKl" role="3clFbG">
-            <node concept="2OqwBi" id="4OH$Ti$mu9l" role="2Oq$k0">
-              <node concept="2OqwBi" id="4OH$Ti$mB1e" role="2Oq$k0">
-                <node concept="37vLTw" id="4OH$Ti$mARq" role="2Oq$k0">
-                  <ref role="3cqZAo" node="4OH$Ti$mAMH" resolve="ctx" />
-                </node>
-                <node concept="liA8E" id="4OH$Ti$mBlM" role="2OqNvi">
-                  <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                </node>
-              </node>
-              <node concept="2Xjw5R" id="4OH$Ti$muoE" role="2OqNvi">
-                <node concept="1xMEDy" id="4OH$Ti$muoG" role="1xVPHs">
-                  <node concept="chp4Y" id="4OH$Ti$muqD" role="ri$Ld">
-                    <ref role="cht4Q" to="plfp:4OH$Ti$mobC" resolve="IReqContextLabelProvider" />
-                  </node>
-                </node>
-                <node concept="1xIGOp" id="4OH$Ti$muwf" role="1xVPHs" />
-              </node>
-            </node>
-            <node concept="2qgKlT" id="4OH$Ti$muX3" role="2OqNvi">
-              <ref role="37wK5l" to="bemq:4OH$Ti$mom4" resolve="getReqStructureFolderName" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="4OH$Ti$mtez" role="1B3o_S" />
-      <node concept="17QB3L" id="4OH$Ti$mtsl" role="3clF45" />
-      <node concept="37vLTG" id="4OH$Ti$mAMH" role="3clF46">
-        <property role="TrG5h" value="ctx" />
-        <node concept="3uibUv" id="4OH$Ti$mAMI" role="1tU5fm">
-          <ref role="3uigEE" to="1ne1:5tr7YH$Ux6m" resolve="IContext" />
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="4OH$Ti$mxOq" role="jymVt" />
-    <node concept="2YIFZL" id="4OH$Ti$mxDm" role="jymVt">
-      <property role="TrG5h" value="getReqGeneralFolderName" />
-      <property role="od$2w" value="false" />
-      <property role="DiZV1" value="false" />
-      <property role="2aFKle" value="false" />
-      <node concept="3clFbS" id="4OH$Ti$mxDn" role="3clF47">
-        <node concept="3clFbF" id="4OH$Ti$mxDo" role="3cqZAp">
-          <node concept="2EnYce" id="4OH$Ti$mxDp" role="3clFbG">
-            <node concept="2OqwBi" id="4OH$Ti$mxDq" role="2Oq$k0">
-              <node concept="2Xjw5R" id="4OH$Ti$mxDs" role="2OqNvi">
-                <node concept="1xMEDy" id="4OH$Ti$mxDt" role="1xVPHs">
-                  <node concept="chp4Y" id="4OH$Ti$mxDu" role="ri$Ld">
-                    <ref role="cht4Q" to="plfp:4OH$Ti$mobC" resolve="IReqContextLabelProvider" />
-                  </node>
-                </node>
-                <node concept="1xIGOp" id="4OH$Ti$mxDv" role="1xVPHs" />
-              </node>
-              <node concept="2OqwBi" id="4OH$Ti$mBtX" role="2Oq$k0">
-                <node concept="37vLTw" id="4OH$Ti$mBtY" role="2Oq$k0">
-                  <ref role="3cqZAo" node="4OH$Ti$mBpU" resolve="ctx" />
-                </node>
-                <node concept="liA8E" id="4OH$Ti$mBtZ" role="2OqNvi">
-                  <ref role="37wK5l" to="1ne1:5tr7YH$Ux7R" resolve="getSNode" />
-                </node>
-              </node>
-            </node>
-            <node concept="2qgKlT" id="4OH$Ti$myYm" role="2OqNvi">
-              <ref role="37wK5l" to="bemq:4OH$Ti$momj" resolve="getReqGeneralFolderName" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="4OH$Ti$mxDx" role="1B3o_S" />
-      <node concept="17QB3L" id="4OH$Ti$mxDy" role="3clF45" />
-      <node concept="37vLTG" id="4OH$Ti$mBpU" role="3clF46">
-        <property role="TrG5h" value="ctx" />
-        <node concept="3uibUv" id="4OH$Ti$mBpV" role="1tU5fm">
-          <ref role="3uigEE" to="1ne1:5tr7YH$Ux6m" resolve="IContext" />
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="5Zn2KFQQ$_U" role="jymVt" />
-    <node concept="3Tm1VV" id="5Zn2KFQQ$_C" role="1B3o_S" />
-  </node>
   <node concept="33ghlw" id="3onExzPnGul">
     <property role="3GE5qa" value="" />
     <property role="TrG5h" value="requirementsAsTables" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.plugin/org.iets3.req.plugin.msd
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.plugin/org.iets3.req.plugin.msd
@@ -26,11 +26,9 @@
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:677f00fb-4488-405e-9885-abb75d472fd1:com.mbeddr.mpsutil.contextactions" version="0" />
     <language slang="l:1f1b4a81-113d-4b88-9b67-2bae3e4f8128:com.mbeddr.mpsutil.projectview" version="1" />
     <language slang="l:1fc20ffe-f35b-4791-a0b7-d706bad5c49a:com.mbeddr.mpsutil.refactoring" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-    <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -3606,11 +3606,6 @@
             <ref role="3bR37D" to="al5i:43aY2QmUMhq" resolve="com.mbeddr.mpsutil.traceExplorer" />
           </node>
         </node>
-        <node concept="1SiIV0" id="4v5hZnddhgY" role="3bR37C">
-          <node concept="3bR9La" id="4v5hZnddhgZ" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:7vUP_qcXuSh" resolve="com.mbeddr.mpsutil.contextactions.runtime" />
-          </node>
-        </node>
         <node concept="1SiIV0" id="hh65augxfh" role="3bR37C">
           <node concept="3bR9La" id="hh65augxfi" role="1SiIV1">
             <ref role="3bR37D" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -990,11 +990,6 @@
             <ref role="1Busuk" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
           </node>
         </node>
-        <node concept="1SiIV0" id="2xnqcRXwt4m" role="3bR37C">
-          <node concept="3bR9La" id="2xnqcRXwt4n" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:7vUP_qcXuSh" resolve="com.mbeddr.mpsutil.contextactions.runtime" />
-          </node>
-        </node>
         <node concept="1SiIV0" id="5RmkFk6TxOP" role="3bR37C">
           <node concept="3bR9La" id="5RmkFk6TxOQ" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -4768,11 +4768,6 @@
             <ref role="1Busuk" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
           </node>
         </node>
-        <node concept="1SiIV0" id="4v5hZnddhiw" role="3bR37C">
-          <node concept="3bR9La" id="4v5hZnddhix" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:7vUP_qcXuSh" resolve="com.mbeddr.mpsutil.contextactions.runtime" />
-          </node>
-        </node>
         <node concept="1SiIV0" id="hh65augxhX" role="3bR37C">
           <node concept="3bR9La" id="hh65augxhY" role="1SiIV1">
             <ref role="3bR37D" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -7941,6 +7941,105 @@
         <node concept="3LEz8M" id="kEKsc8qBa7" role="3LEz9a">
           <ref role="3LEz8N" node="2zpAVpC$xZc" resolve="org.iets3.core.expr.genjava.core.devkit" />
         </node>
+        <node concept="3LEDTy" id="73kHms34GKl" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKm" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKn" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKo" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKp" role="3LEDUa">
+          <ref role="3LEDTV" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKq" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKr" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKs" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKt" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKu" role="3LEDUa">
+          <ref role="3LEDTV" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKv" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKw" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRRB" resolve="org.iets3.core.base" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKx" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKy" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKz" role="3LEDUa">
+          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GK$" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAaa" resolve="org.iets3.analysis.base" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GK_" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKA" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKB" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKC" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKD" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKE" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKF" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKG" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKH" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKI" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKJ" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKK" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKL" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKM" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKN" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKO" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GKP" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
+        </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC_4Ut" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10112,6 +10211,15 @@
         <node concept="3LEDTM" id="1RMC8GHEwZG" role="3LEDUa">
           <ref role="3LEDTN" node="5khwDRKS378" resolve="org.iets3.core.expr.base.collections.stubs" />
         </node>
+        <node concept="3LEDTy" id="73kHms34GQz" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQ$" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQ_" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC$OJa" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10156,6 +10264,30 @@
         <node concept="3LEDTM" id="6wnckeEe9TH" role="3LEDUa">
           <ref role="3LEDTN" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
         </node>
+        <node concept="3LEDTy" id="73kHms34GQA" role="3LEDUa">
+          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQB" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQC" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQD" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQE" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQF" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQG" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQH" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
       </node>
       <node concept="3LEwk6" id="j5CxBKa9ks" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10181,6 +10313,123 @@
         </node>
         <node concept="3LEDTM" id="1RMC8GHEwZU" role="3LEDUa">
           <ref role="3LEDTN" node="2zpAVpC$IQf" resolve="org.iets3.core.expr.genjava.advanced.genplan" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQI" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQJ" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQK" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQL" role="3LEDUa">
+          <ref role="3LEDTV" node="5zQvLw7dsP5" resolve="org.iets3.core.expr.temporal" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQM" role="3LEDUa">
+          <ref role="3LEDTV" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQN" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQO" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQP" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQQ" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQR" role="3LEDUa">
+          <ref role="3LEDTV" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQS" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQT" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRRB" resolve="org.iets3.core.base" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQU" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQV" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQW" role="3LEDUa">
+          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQX" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAaa" resolve="org.iets3.analysis.base" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQY" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GQZ" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GR0" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GR1" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GR2" role="3LEDUa">
+          <ref role="3LEDTV" node="5Y0kZK1N637" resolve="org.iets3.core.expr.genjava.datetime" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GR3" role="3LEDUa">
+          <ref role="3LEDTV" node="6hYPZtwrWbD" resolve="org.iets3.core.expr.genjava.util" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GR4" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GR5" role="3LEDUa">
+          <ref role="3LEDTV" node="23q4CrmMjzr" resolve="org.iets3.core.expr.genjava.messages" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GR6" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GR7" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GR8" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GR9" role="3LEDUa">
+          <ref role="3LEDTV" node="7sID8G9sQTG" resolve="org.iets3.core.expr.genjava.temporal" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GRa" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GRb" role="3LEDUa">
+          <ref role="3LEDTV" node="5zQvLw7dx1X" resolve="org.iets3.core.expr.datetime" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GRc" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GRd" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GRe" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GRf" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GRg" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GRh" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GRi" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GRj" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GRk" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
         </node>
       </node>
       <node concept="3LEwk6" id="26tZ$Z4sNNn" role="2G$12L">
@@ -10213,6 +10462,15 @@
         </node>
         <node concept="3LEDTy" id="3vxfdxbuHow" role="3LEDUa">
           <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GRl" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GRm" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="73kHms34GRn" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
         </node>
       </node>
     </node>
@@ -10856,6 +11114,11 @@
             <node concept="3qWCbU" id="1RMC8GHEx2C" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="73kHms34GSf" role="3bR37C">
+          <node concept="3bR9La" id="73kHms34GSg" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
           </node>
         </node>
       </node>


### PR DESCRIPTION
This moves the actions from the "Context Actions 2" to the "Context Actions" tool window. The goal is to remove the "Context Actions 2" tool from the mbeddr platform.

The actions after the migration are not identical to the ones before the migration. Some were just removed, that don't appear to be useful and are not worth the effort to reimplement them.