### PR TITLE
[breaking] Extract shared runtime from base runtime to reduce runtime dependencies

### DIFF
--- a/code/languages/org.iets3.opensource/.mps/modules.xml
+++ b/code/languages/org.iets3.opensource/.mps/modules.xml
@@ -78,6 +78,7 @@
       <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.base.collections.stubs/org.iets3.core.expr.base.collections.stubs.msd" folder="expr.lang-core" />
       <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.base.interpreter/org.iets3.core.expr.base.interpreter.msd" folder="expr.lang-core" />
       <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.base.runtime/org.iets3.core.expr.base.runtime.msd" folder="expr.lang-core" />
+      <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.base.shared.runtime/org.iets3.core.expr.base.shared.runtime.msd" folder="expr.lang-core" />
       <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.collections.interpreter/org.iets3.core.expr.collections.interpreter.msd" folder="expr.lang-core" />
       <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.data.interpreter/org.iets3.core.expr.data.interpreter.msd" folder="expr.lang-advanced" />
       <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.dataflow.interpreter/org.iets3.core.expr.dataflow.interpreter.msd" folder="expr.lang-advanced" />

--- a/code/languages/org.iets3.opensource/devkits/org.iets3.core.expr.genjava.core.devkit/org.iets3.core.expr.genjava.core.devkit.devkit
+++ b/code/languages/org.iets3.opensource/devkits/org.iets3.core.expr.genjava.core.devkit/org.iets3.core.expr.genjava.core.devkit.devkit
@@ -16,6 +16,7 @@
     <exported-solution>dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</exported-solution>
     <exported-solution>b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)</exported-solution>
     <exported-solution>52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)</exported-solution>
+    <exported-solution>00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)</exported-solution>
   </exported-solutions>
   <generation-plan model="r:44582398-dfcf-40ad-bb09-b88bb3cc5de2(org.iets3.core.expr.genjava.core.genplan.genplan)" />
 </dev-kit>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/plugin.mps
@@ -42,6 +42,7 @@
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="z1c4" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
+    <import index="ppzb" ref="r:5db517a0-f62d-4841-a421-11bb7269799d(org.iets3.core.expr.base.shared.runtime)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
@@ -3080,8 +3081,9 @@
       <property role="TrG5h" value="INF_PREC" />
       <node concept="3Tm1VV" id="7kyIuXqewWi" role="1B3o_S" />
       <node concept="10Oyi0" id="7Wa2sv3XRPN" role="1tU5fm" />
-      <node concept="3cmrfG" id="7Wa2sv3XRPO" role="33vP2m">
-        <property role="3cmrfH" value="16" />
+      <node concept="10M0yZ" id="3qKzW8Qyh_E" role="33vP2m">
+        <ref role="3cqZAo" to="ppzb:7Wa2sv3XRPP" resolve="INF_PREC" />
+        <ref role="1PxDUh" to="ppzb:3qKzW8QxL7h" resolve="SharedInfHelper" />
       </node>
       <node concept="z59LJ" id="1VqmZU7jL_C" role="lGtFl">
         <node concept="TZ5HA" id="1VqmZU7jL_D" role="TZ5H$">
@@ -3098,9 +3100,9 @@
       <node concept="3uibUv" id="7Wa2sv3XSnp" role="1tU5fm">
         <ref role="3uigEE" to="xlxw:~RoundingMode" resolve="RoundingMode" />
       </node>
-      <node concept="Rm8GO" id="7Wa2sv3XSnq" role="33vP2m">
-        <ref role="Rm8GQ" to="xlxw:~RoundingMode.HALF_UP" resolve="HALF_UP" />
-        <ref role="1Px2BO" to="xlxw:~RoundingMode" resolve="RoundingMode" />
+      <node concept="10M0yZ" id="3qKzW8QEegO" role="33vP2m">
+        <ref role="3cqZAo" to="ppzb:7Wa2sv3XSnr" resolve="DEFAULT_ROUNDING" />
+        <ref role="1PxDUh" to="ppzb:3qKzW8QxL7h" resolve="SharedInfHelper" />
       </node>
       <node concept="z59LJ" id="6zU$Zuz6NV7" role="lGtFl">
         <node concept="TZ5HA" id="6zU$Zuz6NV8" role="TZ5H$">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/org.iets3.core.expr.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/org.iets3.core.expr.base.mpl
@@ -25,6 +25,7 @@
     <dependency reexport="false">726886d1-ef90-4249-a08f-1e3ec23a7113(com.mbeddr.mpsutil.traceExplorer)</dependency>
     <dependency reexport="false">c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)</dependency>
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
+    <dependency reexport="false">00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
@@ -140,6 +141,7 @@
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
     <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="3" />
     <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
+    <module reference="00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)" version="0" />
   </dependencyVersions>
   <runtime>
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
@@ -31,6 +31,7 @@
     <import index="fwk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.textgen.trace(MPS.Core/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="j10v" ref="b76a0f63-5959-456b-993a-c796cc0d0c13/java:org.pcollections(org.iets3.core.expr.base.collections.stubs/)" />
+    <import index="ppzb" ref="r:5db517a0-f62d-4841-a421-11bb7269799d(org.iets3.core.expr.base.shared.runtime)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
     <import index="4kwy" ref="r:657c9fde-2f36-4e61-ae17-20f02b8630ad(org.iets3.core.base.structure)" implicit="true" />
     <import index="5s8v" ref="r:06389a24-a77a-450d-bc88-bccec0aae7d8(org.iets3.core.expr.lambda.behavior)" implicit="true" />
@@ -15327,8 +15328,8 @@
       <ref role="30HIoZ" to="hm2y:1RwPUjzgIEq" resolve="MinExpression" />
       <node concept="gft3U" id="5wDe8wERizE" role="1lVwrX">
         <node concept="2YIFZM" id="5wDe8wERiG5" role="gfFT$">
-          <ref role="37wK5l" to="xfg9:1RwPUjzjkk_" resolve="min" />
-          <ref role="1Pybhc" to="xfg9:1RwPUjziune" resolve="MinMaxHelper" />
+          <ref role="1Pybhc" to="ppzb:1RwPUjziune" resolve="SharedMinMaxHelper" />
+          <ref role="37wK5l" to="ppzb:1RwPUjzjkk_" resolve="min" />
           <node concept="2OqwBi" id="5wDe8wERYDF" role="37wK5m">
             <node concept="1bVj0M" id="5wDe8wERkh0" role="2Oq$k0">
               <node concept="3clFbS" id="5wDe8wERkh2" role="1bW5cS">
@@ -15417,8 +15418,8 @@
       <ref role="30HIoZ" to="hm2y:1RwPUjzgIEq" resolve="MinExpression" />
       <node concept="gft3U" id="5wDe8wESNoU" role="1lVwrX">
         <node concept="2YIFZM" id="5wDe8wESNoV" role="gfFT$">
-          <ref role="37wK5l" to="xfg9:1RwPUjzjkk_" resolve="min" />
-          <ref role="1Pybhc" to="xfg9:1RwPUjziune" resolve="MinMaxHelper" />
+          <ref role="1Pybhc" to="ppzb:1RwPUjziune" resolve="SharedMinMaxHelper" />
+          <ref role="37wK5l" to="ppzb:1RwPUjzjkk_" resolve="min" />
           <node concept="2OqwBi" id="5wDe8wESNoW" role="37wK5m">
             <node concept="1bVj0M" id="5wDe8wESNoX" role="2Oq$k0">
               <node concept="3clFbS" id="5wDe8wESNoY" role="1bW5cS">
@@ -15515,8 +15516,8 @@
       <ref role="30HIoZ" to="hm2y:1RwPUjzgIEp" resolve="MaxExpression" />
       <node concept="gft3U" id="5wDe8wEV1vn" role="1lVwrX">
         <node concept="2YIFZM" id="5wDe8wEWqt2" role="gfFT$">
-          <ref role="37wK5l" to="xfg9:1RwPUjziwEu" resolve="max" />
-          <ref role="1Pybhc" to="xfg9:1RwPUjziune" resolve="MinMaxHelper" />
+          <ref role="1Pybhc" to="ppzb:1RwPUjziune" resolve="SharedMinMaxHelper" />
+          <ref role="37wK5l" to="ppzb:1RwPUjziwEu" resolve="max" />
           <node concept="2OqwBi" id="5wDe8wEWqt3" role="37wK5m">
             <node concept="1bVj0M" id="5wDe8wEWqt4" role="2Oq$k0">
               <node concept="3clFbS" id="5wDe8wEWqt5" role="1bW5cS">
@@ -15611,8 +15612,8 @@
       <ref role="30HIoZ" to="hm2y:1RwPUjzgIEp" resolve="MaxExpression" />
       <node concept="gft3U" id="5wDe8wEV1w0" role="1lVwrX">
         <node concept="2YIFZM" id="5wDe8wEWqMm" role="gfFT$">
-          <ref role="37wK5l" to="xfg9:1RwPUjziwEu" resolve="max" />
-          <ref role="1Pybhc" to="xfg9:1RwPUjziune" resolve="MinMaxHelper" />
+          <ref role="1Pybhc" to="ppzb:1RwPUjziune" resolve="SharedMinMaxHelper" />
+          <ref role="37wK5l" to="ppzb:1RwPUjziwEu" resolve="max" />
           <node concept="2OqwBi" id="5wDe8wEWqMn" role="37wK5m">
             <node concept="1bVj0M" id="5wDe8wEWqMo" role="2Oq$k0">
               <node concept="3clFbS" id="5wDe8wEWqMp" role="1bW5cS">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/org.iets3.core.expr.genjava.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/org.iets3.core.expr.genjava.base.mpl
@@ -77,7 +77,6 @@
         <module reference="735f86bc-17fb-4d1c-a664-82c2b8e8a34e(com.mbeddr.mpsutil.interpreter.rt)" version="0" />
         <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />
         <module reference="b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)" version="0" />
-        <module reference="d7931714-a11c-4108-aa0e-246d86070dad(com.mbeddr.mpsutil.smodule.runtime)" version="0" />
         <module reference="726886d1-ef90-4249-a08f-1e3ec23a7113(com.mbeddr.mpsutil.traceExplorer)" version="0" />
         <module reference="3819ba36-98f4-49ac-b779-34f3a458c09b(com.mbeddr.mpsutil.varscope)" version="0" />
         <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
@@ -95,18 +94,17 @@
         <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
-        <module reference="d936855b-48da-4812-a8a0-2bfddd633ac4(jetbrains.mps.lang.behavior.runtime)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
         <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
         <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
         <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
         <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
-        <module reference="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" version="0" />
         <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="1" />
         <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
         <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="3" />
         <module reference="b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)" version="0" />
         <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
+        <module reference="00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)" version="0" />
         <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="5" />
         <module reference="30254c5b-f87e-4bb3-a60a-77a7ec6ed411(org.iets3.core.expr.genjava.base)" version="0" />
         <module reference="4517af98-2eaa-4f19-a962-92df60010094(org.iets3.core.expr.genjava.base#8286534136181746510)" version="0" />
@@ -129,9 +127,7 @@
   <dependencies>
     <dependency reexport="false" scope="generate-into">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
     <dependency reexport="false" scope="generate-into">fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)</dependency>
-    <dependency reexport="false">cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</dependency>
     <dependency reexport="false" scope="generate-into">83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)</dependency>
-    <dependency reexport="false" scope="generate-into">3eada220-3310-4fd3-b794-ff924add7d8a(com.mbeddr.mpsutil.smodule)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
@@ -182,50 +178,22 @@
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
-    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
-    <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
-    <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
-    <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
-    <module reference="47f075a6-558e-4640-a606-7ce0236c8023(com.mbeddr.mpsutil.interpreter)" version="0" />
-    <module reference="735f86bc-17fb-4d1c-a664-82c2b8e8a34e(com.mbeddr.mpsutil.interpreter.rt)" version="0" />
-    <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />
-    <module reference="b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)" version="0" />
-    <module reference="3eada220-3310-4fd3-b794-ff924add7d8a(com.mbeddr.mpsutil.smodule)" version="0" />
-    <module reference="d7931714-a11c-4108-aa0e-246d86070dad(com.mbeddr.mpsutil.smodule.runtime)" version="0" />
-    <module reference="726886d1-ef90-4249-a08f-1e3ec23a7113(com.mbeddr.mpsutil.traceExplorer)" version="0" />
-    <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
-    <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
-    <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
-    <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
-    <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
-    <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
-    <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
-    <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
-    <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
     <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-    <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
-    <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
-    <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
-    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
-    <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="1" />
-    <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
-    <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="1" />
     <module reference="30254c5b-f87e-4bb3-a60a-77a7ec6ed411(org.iets3.core.expr.genjava.base)" version="0" />
   </dependencyVersions>
   <runtime>
     <dependency reexport="false">3a6ebc02-087e-4791-9854-65244ce22d8d(org.iets3.core.expr.genjava.base.rt)</dependency>
     <dependency reexport="false">646d63c6-d580-4c19-8759-e3a3123f5424(org.iets3.core.expr.genjava.messages.rt)</dependency>
+    <dependency reexport="false">00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)</dependency>
   </runtime>
   <extendedLanguages />
 </language>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.interpreter/models/plugin.mps
@@ -22,6 +22,7 @@
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="j10v" ref="b76a0f63-5959-456b-993a-c796cc0d0c13/java:org.pcollections(org.iets3.core.expr.base.collections.stubs/)" />
+    <import index="ppzb" ref="r:5db517a0-f62d-4841-a421-11bb7269799d(org.iets3.core.expr.base.shared.runtime)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -375,7 +376,7 @@
               </node>
               <node concept="2ZW3vV" id="3nVyItrZwgD" role="3clFbw">
                 <node concept="3uibUv" id="3nVyItrZwh$" role="2ZW6by">
-                  <ref role="3uigEE" to="xfg9:3nVyItrYNyp" resolve="INixValue" />
+                  <ref role="3uigEE" to="ppzb:3nVyItrYNyp" resolve="INixValue" />
                 </node>
                 <node concept="37vLTw" id="3nVyItrZwdx" role="2ZW6bz">
                   <ref role="3cqZAo" node="3nVyItrZv_N" resolve="val" />
@@ -761,8 +762,8 @@
               <node concept="3clFbS" id="1RwPUjzndP$" role="3clFbx">
                 <node concept="3cpWs6" id="1RwPUjzndP_" role="3cqZAp">
                   <node concept="2YIFZM" id="5wDe8wDIecM" role="3cqZAk">
-                    <ref role="37wK5l" to="xfg9:1RwPUjzjkk_" resolve="min" />
-                    <ref role="1Pybhc" to="xfg9:1RwPUjziune" resolve="MinMaxHelper" />
+                    <ref role="1Pybhc" to="ppzb:1RwPUjziune" resolve="SharedMinMaxHelper" />
+                    <ref role="37wK5l" to="ppzb:1RwPUjzjkk_" resolve="min" />
                     <node concept="rqRoa" id="1RwPUjzne3T" role="37wK5m">
                       <ref role="rqRob" to="hm2y:1RwPUjzgk0z" resolve="values" />
                     </node>
@@ -786,8 +787,8 @@
               <node concept="3clFbS" id="1RwPUjzndPq" role="3clFbx">
                 <node concept="3cpWs6" id="1RwPUjzndPr" role="3cqZAp">
                   <node concept="2YIFZM" id="5wDe8wDIecL" role="3cqZAk">
-                    <ref role="37wK5l" to="xfg9:1RwPUjzjkk_" resolve="min" />
-                    <ref role="1Pybhc" to="xfg9:1RwPUjziune" resolve="MinMaxHelper" />
+                    <ref role="1Pybhc" to="ppzb:1RwPUjziune" resolve="SharedMinMaxHelper" />
+                    <ref role="37wK5l" to="ppzb:1RwPUjzjkk_" resolve="min" />
                     <node concept="rqRoa" id="1RwPUjzndYK" role="37wK5m">
                       <ref role="rqRob" to="hm2y:1RwPUjzgk0z" resolve="values" />
                     </node>
@@ -824,8 +825,8 @@
               <node concept="3clFbS" id="6HHp2WnvqWu" role="3clFbx">
                 <node concept="3cpWs6" id="1RwPUjzjzYw" role="3cqZAp">
                   <node concept="2YIFZM" id="5wDe8wDIecI" role="3cqZAk">
-                    <ref role="37wK5l" to="xfg9:1RwPUjziwEu" resolve="max" />
-                    <ref role="1Pybhc" to="xfg9:1RwPUjziune" resolve="MinMaxHelper" />
+                    <ref role="1Pybhc" to="ppzb:1RwPUjziune" resolve="SharedMinMaxHelper" />
+                    <ref role="37wK5l" to="ppzb:1RwPUjziwEu" resolve="max" />
                     <node concept="rqRoa" id="1RwPUjzncJq" role="37wK5m">
                       <ref role="rqRob" to="hm2y:1RwPUjzgk0z" resolve="values" />
                     </node>
@@ -849,8 +850,8 @@
               <node concept="3clFbS" id="1RwPUjznbP$" role="3clFbx">
                 <node concept="3cpWs6" id="1RwPUjznbP_" role="3cqZAp">
                   <node concept="2YIFZM" id="5wDe8wDIecH" role="3cqZAk">
-                    <ref role="37wK5l" to="xfg9:1RwPUjziwEu" resolve="max" />
-                    <ref role="1Pybhc" to="xfg9:1RwPUjziune" resolve="MinMaxHelper" />
+                    <ref role="1Pybhc" to="ppzb:1RwPUjziune" resolve="SharedMinMaxHelper" />
+                    <ref role="37wK5l" to="ppzb:1RwPUjziwEu" resolve="max" />
                     <node concept="rqRoa" id="1RwPUjzncOy" role="37wK5m">
                       <ref role="rqRob" to="hm2y:1RwPUjzgk0z" resolve="values" />
                     </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.interpreter/org.iets3.core.expr.base.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.interpreter/org.iets3.core.expr.base.interpreter.msd
@@ -18,6 +18,7 @@
     <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
     <dependency reexport="false">b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)</dependency>
+    <dependency reexport="false">00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:47f075a6-558e-4640-a606-7ce0236c8023:com.mbeddr.mpsutil.interpreter" version="1" />
@@ -71,6 +72,7 @@
     <module reference="b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)" version="0" />
     <module reference="cf90f965-8554-4a16-aa0b-6387f27474ab(org.iets3.core.expr.base.interpreter)" version="0" />
     <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
+    <module reference="00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.runtime/models/runtime.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.runtime/models/runtime.mps
@@ -17,6 +17,7 @@
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="xlxw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.math(JDK/)" />
     <import index="2ahs" ref="r:ea6cf71d-29d2-478d-8027-a9f4a4de53c4(com.mbeddr.mpsutil.interpreter.rt)" />
+    <import index="ppzb" ref="r:5db517a0-f62d-4841-a421-11bb7269799d(org.iets3.core.expr.base.shared.runtime)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -34,17 +35,19 @@
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
-      <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
-        <child id="1076505808688" name="condition" index="2$JKZa" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+        <child id="1188214630783" name="value" index="2B76xF" />
       </concept>
-      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
-        <child id="1239714902950" name="expression" index="2$L3a6" />
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="1188214545140" name="jetbrains.mps.baseLanguage.structure.AnnotationInstanceValue" flags="ng" index="2B6LJw">
+        <reference id="1188214555875" name="key" index="2B6OnR" />
+        <child id="1188214607812" name="value" index="2B70Vg" />
       </concept>
       <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
         <reference id="2820489544401957798" name="classifier" index="HV5vE" />
-      </concept>
-      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
-        <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
@@ -116,7 +119,6 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
-      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
@@ -130,9 +132,6 @@
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
-      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
-        <property id="1068580320021" name="value" index="3cmrfH" />
-      </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
@@ -149,8 +148,6 @@
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
-      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
-      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
@@ -168,7 +165,6 @@
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
-        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -182,13 +178,9 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
-      <concept id="1107796713796" name="jetbrains.mps.baseLanguage.structure.Interface" flags="ig" index="3HP615" />
       <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
         <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
         <child id="8276990574886367508" name="body" index="1zxBo7" />
-      </concept>
-      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
-        <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
@@ -196,7 +188,6 @@
         <reference id="1116615189566" name="classifier" index="3VsUkX" />
       </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
-      <concept id="8064396509828172209" name="jetbrains.mps.baseLanguage.structure.UnaryMinus" flags="nn" index="1ZRNhn" />
     </language>
     <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
       <concept id="6626851894249711936" name="jetbrains.mps.lang.extension.structure.ExtensionPointExpression" flags="nn" index="2O5UvJ">
@@ -221,11 +212,24 @@
       </concept>
     </language>
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="2546654756694997551" name="jetbrains.mps.baseLanguage.javadoc.structure.LinkInlineDocTag" flags="ng" index="92FcH">
+        <child id="2546654756694997556" name="reference" index="92FcQ" />
+        <child id="3106559687488913694" name="line" index="2XjZqd" />
+      </concept>
       <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
-        <child id="8465538089690331502" name="body" index="TZ5H$" />
+        <child id="5383422241790532083" name="tags" index="3nqlJM" />
       </concept>
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
         <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8465538089690331492" name="jetbrains.mps.baseLanguage.javadoc.structure.DeprecatedBlockDocTag" flags="ng" index="TZ5HI">
+        <child id="2667874559098216723" name="text" index="3HnX3l" />
+      </concept>
+      <concept id="2217234381367530212" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocReference" flags="ng" index="VXe08">
+        <reference id="2217234381367530213" name="classifier" index="VXe09" />
+      </concept>
+      <concept id="8970989240999019145" name="jetbrains.mps.baseLanguage.javadoc.structure.InlineTagCommentLinePart" flags="ng" index="1dT_AA">
+        <child id="6962838954693749192" name="tag" index="qph3F" />
       </concept>
       <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
         <property id="8970989240999019144" name="text" index="1dT_AB" />
@@ -249,14 +253,6 @@
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
-      </concept>
-    </language>
-    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
-      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
-        <property id="155656958578482949" name="value" index="3oM_SC" />
-      </concept>
-      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
-        <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
@@ -1196,689 +1192,18 @@
       </node>
       <node concept="3Tm1VV" id="1RwPUjziwEx" role="1B3o_S" />
       <node concept="3clFbS" id="1RwPUjziwEy" role="3clF47">
-        <node concept="3clFbJ" id="4Q4DxjDbM3I" role="3cqZAp">
-          <node concept="37vLTw" id="1RwPUjziSd$" role="3clFbw">
-            <ref role="3cqZAo" node="1RwPUjziBhK" resolve="isReal" />
-          </node>
-          <node concept="3clFbS" id="4Q4DxjDbM3J" role="3clFbx">
-            <node concept="3cpWs8" id="4Q4DxjDbM3V" role="3cqZAp">
-              <node concept="3cpWsn" id="4Q4DxjDbM3W" role="3cpWs9">
-                <property role="TrG5h" value="iterator" />
-                <node concept="3uibUv" id="4Q4DxjDbM3X" role="1tU5fm">
-                  <ref role="3uigEE" to="33ny:~Iterator" resolve="Iterator" />
-                  <node concept="3uibUv" id="4Q4DxjDbM3Y" role="11_B2D">
-                    <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="4Q4DxjDbM3Z" role="33vP2m">
-                  <node concept="37vLTw" id="1RwPUjziSJF" role="2Oq$k0">
-                    <ref role="3cqZAo" node="1RwPUjzi$ax" resolve="values" />
-                  </node>
-                  <node concept="liA8E" id="4Q4DxjDbM41" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~Collection.iterator()" resolve="iterator" />
-                  </node>
-                </node>
-              </node>
+        <node concept="3cpWs6" id="3qKzW8QEkzd" role="3cqZAp">
+          <node concept="2YIFZM" id="3qKzW8QElKq" role="3cqZAk">
+            <ref role="37wK5l" to="ppzb:1RwPUjziwEu" resolve="max" />
+            <ref role="1Pybhc" to="ppzb:1RwPUjziune" resolve="SharedMinMaxHelper" />
+            <node concept="37vLTw" id="3qKzW8QEm7B" role="37wK5m">
+              <ref role="3cqZAo" node="1RwPUjzi$ax" resolve="values" />
             </node>
-            <node concept="3cpWs8" id="4Q4DxjDbM42" role="3cqZAp">
-              <node concept="3cpWsn" id="4Q4DxjDbM43" role="3cpWs9">
-                <property role="TrG5h" value="max" />
-                <node concept="3uibUv" id="ncXQh4_agi" role="1tU5fm">
-                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                </node>
-                <node concept="10Nm6u" id="3SMYSUUjsni" role="33vP2m" />
-              </node>
+            <node concept="37vLTw" id="3qKzW8QEmZS" role="37wK5m">
+              <ref role="3cqZAo" node="1RwPUjziBhK" resolve="isReal" />
             </node>
-            <node concept="2$JKZl" id="4Q4DxjDbM46" role="3cqZAp">
-              <node concept="3clFbS" id="4Q4DxjDbM47" role="2LFqv$">
-                <node concept="3cpWs8" id="4Q4DxjDbM48" role="3cqZAp">
-                  <node concept="3cpWsn" id="4Q4DxjDbM49" role="3cpWs9">
-                    <property role="TrG5h" value="next" />
-                    <node concept="3uibUv" id="4Q4DxjDbM4a" role="1tU5fm">
-                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                    </node>
-                    <node concept="2OqwBi" id="4Q4DxjDbM4b" role="33vP2m">
-                      <node concept="37vLTw" id="4Q4DxjDbM4c" role="2Oq$k0">
-                        <ref role="3cqZAo" node="4Q4DxjDbM3W" resolve="iterator" />
-                      </node>
-                      <node concept="liA8E" id="4Q4DxjDbM4d" role="2OqNvi">
-                        <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs8" id="3SMYSUUk50$" role="3cqZAp">
-                  <node concept="3cpWsn" id="3SMYSUUk50_" role="3cpWs9">
-                    <property role="TrG5h" value="element" />
-                    <node concept="3uibUv" id="ncXQh4_8Lb" role="1tU5fm">
-                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                    </node>
-                    <node concept="10Nm6u" id="3SMYSUUkcey" role="33vP2m" />
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="3SMYSUUk8tA" role="3cqZAp">
-                  <node concept="3clFbS" id="3SMYSUUk8tC" role="3clFbx">
-                    <node concept="3clFbF" id="3SMYSUUkapJ" role="3cqZAp">
-                      <node concept="37vLTI" id="3SMYSUUkbAq" role="3clFbG">
-                        <node concept="37vLTw" id="3SMYSUUkapH" role="37vLTJ">
-                          <ref role="3cqZAo" node="3SMYSUUk50_" resolve="element" />
-                        </node>
-                        <node concept="1eOMI4" id="3SMYSUUk50A" role="37vLTx">
-                          <node concept="10QFUN" id="3SMYSUUk50B" role="1eOMHV">
-                            <node concept="3uibUv" id="3SMYSUUkvcE" role="10QFUM">
-                              <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
-                            </node>
-                            <node concept="37vLTw" id="3SMYSUUk50D" role="10QFUP">
-                              <ref role="3cqZAo" node="4Q4DxjDbM49" resolve="next" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2ZW3vV" id="3SMYSUUk7C9" role="3clFbw">
-                    <node concept="3uibUv" id="3SMYSUUkvDc" role="2ZW6by">
-                      <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
-                    </node>
-                    <node concept="37vLTw" id="3SMYSUUk6lR" role="2ZW6bz">
-                      <ref role="3cqZAo" node="4Q4DxjDbM49" resolve="next" />
-                    </node>
-                  </node>
-                  <node concept="3eNFk2" id="3SMYSUUkcu1" role="3eNLev">
-                    <node concept="2ZW3vV" id="3SMYSUUkdm$" role="3eO9$A">
-                      <node concept="3uibUv" id="3SMYSUUkd$N" role="2ZW6by">
-                        <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
-                      </node>
-                      <node concept="37vLTw" id="3SMYSUUkc_Q" role="2ZW6bz">
-                        <ref role="3cqZAo" node="4Q4DxjDbM49" resolve="next" />
-                      </node>
-                    </node>
-                    <node concept="3clFbS" id="3SMYSUUkcu3" role="3eOfB_">
-                      <node concept="3clFbF" id="3SMYSUUkdOU" role="3cqZAp">
-                        <node concept="37vLTI" id="3SMYSUUkevP" role="3clFbG">
-                          <node concept="37vLTw" id="3SMYSUUkdOT" role="37vLTJ">
-                            <ref role="3cqZAo" node="3SMYSUUk50_" resolve="element" />
-                          </node>
-                          <node concept="2ShNRf" id="3SMYSUUkh2y" role="37vLTx">
-                            <node concept="1pGfFk" id="3SMYSUUkhPF" role="2ShVmc">
-                              <ref role="37wK5l" to="xlxw:~BigDecimal.&lt;init&gt;(java.lang.String)" resolve="BigDecimal" />
-                              <node concept="2OqwBi" id="3SMYSUUkfnB" role="37wK5m">
-                                <node concept="1eOMI4" id="3SMYSUUkeVF" role="2Oq$k0">
-                                  <node concept="10QFUN" id="3SMYSUUkeVC" role="1eOMHV">
-                                    <node concept="3uibUv" id="3SMYSUUkf9v" role="10QFUM">
-                                      <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
-                                    </node>
-                                    <node concept="37vLTw" id="3SMYSUUkeFE" role="10QFUP">
-                                      <ref role="3cqZAo" node="4Q4DxjDbM49" resolve="next" />
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="liA8E" id="3SMYSUUkg6k" role="2OqNvi">
-                                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3eNFk2" id="ncXQh4_8hD" role="3eNLev">
-                    <node concept="1Wc70l" id="ncXQh4_8hE" role="3eO9$A">
-                      <node concept="2OqwBi" id="ncXQh4_8hF" role="3uHU7w">
-                        <node concept="37vLTw" id="ncXQh4_8hG" role="2Oq$k0">
-                          <ref role="3cqZAo" node="ncXQh4q5UR" resolve="nothingType" />
-                        </node>
-                        <node concept="liA8E" id="ncXQh4_8hH" role="2OqNvi">
-                          <ref role="37wK5l" to="wyt6:~Class.isInstance(java.lang.Object)" resolve="isInstance" />
-                          <node concept="37vLTw" id="ncXQh4_8hI" role="37wK5m">
-                            <ref role="3cqZAo" node="4Q4DxjDbM49" resolve="next" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3y3z36" id="ncXQh4_8hJ" role="3uHU7B">
-                        <node concept="37vLTw" id="ncXQh4_8hK" role="3uHU7B">
-                          <ref role="3cqZAo" node="ncXQh4q5UR" resolve="nothingType" />
-                        </node>
-                        <node concept="10Nm6u" id="ncXQh4_8hL" role="3uHU7w" />
-                      </node>
-                    </node>
-                    <node concept="3clFbS" id="ncXQh4_8hM" role="3eOfB_">
-                      <node concept="3clFbF" id="ncXQh4_8hN" role="3cqZAp">
-                        <node concept="37vLTI" id="ncXQh4_8hO" role="3clFbG">
-                          <node concept="37vLTw" id="ncXQh4_8hP" role="37vLTx">
-                            <ref role="3cqZAo" node="4Q4DxjDbM49" resolve="next" />
-                          </node>
-                          <node concept="37vLTw" id="ncXQh4_8hQ" role="37vLTJ">
-                            <ref role="3cqZAo" node="3SMYSUUk50_" resolve="element" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="9aQIb" id="3SMYSUUki9H" role="9aQIa">
-                    <node concept="3clFbS" id="3SMYSUUki9I" role="9aQI4">
-                      <node concept="YS8fn" id="3SMYSUUkivC" role="3cqZAp">
-                        <node concept="2ShNRf" id="3SMYSUUkiBe" role="YScLw">
-                          <node concept="1pGfFk" id="3SMYSUUkjme" role="2ShVmc">
-                            <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
-                            <node concept="3cpWs3" id="3SMYSUUknhu" role="37wK5m">
-                              <node concept="Xl_RD" id="3SMYSUUkow0" role="3uHU7w">
-                                <property role="Xl_RC" value=" to BigDecimal." />
-                              </node>
-                              <node concept="3cpWs3" id="3SMYSUUkl7o" role="3uHU7B">
-                                <node concept="Xl_RD" id="3SMYSUUkjv8" role="3uHU7B">
-                                  <property role="Xl_RC" value="Don't know how to cast element " />
-                                </node>
-                                <node concept="2OqwBi" id="3SMYSUUklx$" role="3uHU7w">
-                                  <node concept="37vLTw" id="3SMYSUUklgU" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="4Q4DxjDbM49" resolve="next" />
-                                  </node>
-                                  <node concept="liA8E" id="3SMYSUUklLA" role="2OqNvi">
-                                    <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="3SMYSUUpnLi" role="3cqZAp">
-                  <node concept="3clFbS" id="3SMYSUUpnLk" role="3clFbx">
-                    <node concept="3clFbF" id="3SMYSUUppE7" role="3cqZAp">
-                      <node concept="37vLTI" id="3SMYSUUppE8" role="3clFbG">
-                        <node concept="37vLTw" id="3SMYSUUppE9" role="37vLTJ">
-                          <ref role="3cqZAo" node="4Q4DxjDbM43" resolve="max" />
-                        </node>
-                        <node concept="37vLTw" id="3SMYSUUppEa" role="37vLTx">
-                          <ref role="3cqZAo" node="3SMYSUUk50_" resolve="element" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbC" id="3SMYSUUpoRC" role="3clFbw">
-                    <node concept="10Nm6u" id="3SMYSUUpp3y" role="3uHU7w" />
-                    <node concept="37vLTw" id="3SMYSUUpo8$" role="3uHU7B">
-                      <ref role="3cqZAo" node="4Q4DxjDbM43" resolve="max" />
-                    </node>
-                  </node>
-                  <node concept="9aQIb" id="3SMYSUUppeH" role="9aQIa">
-                    <node concept="3clFbS" id="3SMYSUUppeI" role="9aQI4">
-                      <node concept="3clFbJ" id="3SMYSUUjuQV" role="3cqZAp">
-                        <node concept="3clFbS" id="3SMYSUUjuQX" role="3clFbx">
-                          <node concept="3clFbF" id="3SMYSUUksLR" role="3cqZAp">
-                            <node concept="37vLTI" id="3SMYSUUktHB" role="3clFbG">
-                              <node concept="37vLTw" id="3SMYSUUksLP" role="37vLTJ">
-                                <ref role="3cqZAo" node="4Q4DxjDbM43" resolve="max" />
-                              </node>
-                              <node concept="37vLTw" id="3SMYSUUkucI" role="37vLTx">
-                                <ref role="3cqZAo" node="3SMYSUUk50_" resolve="element" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3eOSWO" id="3SMYSUUk3Nu" role="3clFbw">
-                          <node concept="3cmrfG" id="3SMYSUUk4la" role="3uHU7w">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="2OqwBi" id="3SMYSUUjZTO" role="3uHU7B">
-                            <node concept="1rXfSq" id="ncXQh4_fbQ" role="2Oq$k0">
-                              <ref role="37wK5l" node="ncXQh4_bka" resolve="nothingToDec" />
-                              <node concept="37vLTw" id="ncXQh4_fqs" role="37wK5m">
-                                <ref role="3cqZAo" node="3SMYSUUk50_" resolve="element" />
-                              </node>
-                              <node concept="37vLTw" id="ncXQh4_hIt" role="37wK5m">
-                                <ref role="3cqZAo" node="ncXQh4q5UR" resolve="nothingType" />
-                              </node>
-                            </node>
-                            <node concept="liA8E" id="3SMYSUUk0pU" role="2OqNvi">
-                              <ref role="37wK5l" to="xlxw:~BigDecimal.compareTo(java.math.BigDecimal)" resolve="compareTo" />
-                              <node concept="1rXfSq" id="ncXQh4_fHo" role="37wK5m">
-                                <ref role="37wK5l" node="ncXQh4_bka" resolve="nothingToDec" />
-                                <node concept="37vLTw" id="ncXQh4_fWx" role="37wK5m">
-                                  <ref role="3cqZAo" node="4Q4DxjDbM43" resolve="max" />
-                                </node>
-                                <node concept="37vLTw" id="ncXQh4_i6M" role="37wK5m">
-                                  <ref role="3cqZAo" node="ncXQh4q5UR" resolve="nothingType" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="4Q4DxjDbM4w" role="2$JKZa">
-                <node concept="37vLTw" id="4Q4DxjDbM4x" role="2Oq$k0">
-                  <ref role="3cqZAo" node="4Q4DxjDbM3W" resolve="iterator" />
-                </node>
-                <node concept="liA8E" id="4Q4DxjDbM4y" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~Iterator.hasNext()" resolve="hasNext" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="3SMYSUUkyZp" role="3cqZAp">
-              <node concept="3clFbS" id="3SMYSUUkyZr" role="3clFbx">
-                <node concept="3cpWs6" id="4Q4DxjDbM4z" role="3cqZAp">
-                  <node concept="37vLTw" id="3SMYSUUkybf" role="3cqZAk">
-                    <ref role="3cqZAo" node="4Q4DxjDbM43" resolve="max" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3y3z36" id="3SMYSUUk$5o" role="3clFbw">
-                <node concept="10Nm6u" id="3SMYSUUk$da" role="3uHU7w" />
-                <node concept="37vLTw" id="3SMYSUUkzmn" role="3uHU7B">
-                  <ref role="3cqZAo" node="4Q4DxjDbM43" resolve="max" />
-                </node>
-              </node>
-            </node>
-            <node concept="3SKdUt" id="3SMYSUUkBZX" role="3cqZAp">
-              <node concept="1PaTwC" id="17Nm8oCo8Kh" role="1aUNEU">
-                <node concept="3oM_SD" id="17Nm8oCo8Ki" role="1PaTwD">
-                  <property role="3oM_SC" value="max" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8Kj" role="1PaTwD">
-                  <property role="3oM_SC" value="of" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8Kk" role="1PaTwD">
-                  <property role="3oM_SC" value="the" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8Kl" role="1PaTwD">
-                  <property role="3oM_SC" value="empty" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8Km" role="1PaTwD">
-                  <property role="3oM_SC" value="list" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8Kn" role="1PaTwD">
-                  <property role="3oM_SC" value="(arbitrarily" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8Ko" role="1PaTwD">
-                  <property role="3oM_SC" value="chosen" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8Kp" role="1PaTwD">
-                  <property role="3oM_SC" value="as" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8Kq" role="1PaTwD">
-                  <property role="3oM_SC" value="-Double.MAX_VALUE" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8Kr" role="1PaTwD">
-                  <property role="3oM_SC" value="since" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8Ks" role="1PaTwD">
-                  <property role="3oM_SC" value="there" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8Kt" role="1PaTwD">
-                  <property role="3oM_SC" value="is" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8Ku" role="1PaTwD">
-                  <property role="3oM_SC" value="no" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8Kv" role="1PaTwD">
-                  <property role="3oM_SC" value="-INF" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8Kw" role="1PaTwD">
-                  <property role="3oM_SC" value="in" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8Kx" role="1PaTwD">
-                  <property role="3oM_SC" value="type" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8Ky" role="1PaTwD">
-                  <property role="3oM_SC" value="BigDecimal)" />
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs6" id="3SMYSUUk_xj" role="3cqZAp">
-              <node concept="2YIFZM" id="3SMYSUUkAqv" role="3cqZAk">
-                <ref role="37wK5l" to="xlxw:~BigDecimal.valueOf(double)" resolve="valueOf" />
-                <ref role="1Pybhc" to="xlxw:~BigDecimal" resolve="BigDecimal" />
-                <node concept="1ZRNhn" id="3SMYSUUkBhn" role="37wK5m">
-                  <node concept="10M0yZ" id="3SMYSUUkAYT" role="2$L3a6">
-                    <ref role="3cqZAo" to="wyt6:~Double.MAX_VALUE" resolve="MAX_VALUE" />
-                    <ref role="1PxDUh" to="wyt6:~Double" resolve="Double" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="9aQIb" id="1RwPUjziTDj" role="9aQIa">
-            <node concept="3clFbS" id="1RwPUjziTDk" role="9aQI4">
-              <node concept="3cpWs8" id="4Q4DxjDbJJf" role="3cqZAp">
-                <node concept="3cpWsn" id="4Q4DxjDbJJg" role="3cpWs9">
-                  <property role="TrG5h" value="iterator" />
-                  <node concept="3uibUv" id="4Q4DxjDbJJb" role="1tU5fm">
-                    <ref role="3uigEE" to="33ny:~Iterator" resolve="Iterator" />
-                    <node concept="3uibUv" id="4Q4DxjDbJJe" role="11_B2D">
-                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="4Q4DxjDbJJh" role="33vP2m">
-                    <node concept="37vLTw" id="1RwPUjziWys" role="2Oq$k0">
-                      <ref role="3cqZAo" node="1RwPUjzi$ax" resolve="values" />
-                    </node>
-                    <node concept="liA8E" id="4Q4DxjDbJJj" role="2OqNvi">
-                      <ref role="37wK5l" to="33ny:~Collection.iterator()" resolve="iterator" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3cpWs8" id="4Q4DxjDbLbP" role="3cqZAp">
-                <node concept="3cpWsn" id="4Q4DxjDbLbS" role="3cpWs9">
-                  <property role="TrG5h" value="max" />
-                  <node concept="3uibUv" id="ncXQh4z0IV" role="1tU5fm">
-                    <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                  </node>
-                  <node concept="10Nm6u" id="3SMYSUUkOd$" role="33vP2m" />
-                </node>
-              </node>
-              <node concept="2$JKZl" id="4Q4DxjDbJWs" role="3cqZAp">
-                <node concept="3clFbS" id="4Q4DxjDbJWv" role="2LFqv$">
-                  <node concept="3cpWs8" id="4Q4DxjDbKiZ" role="3cqZAp">
-                    <node concept="3cpWsn" id="4Q4DxjDbKj0" role="3cpWs9">
-                      <property role="TrG5h" value="next" />
-                      <node concept="3uibUv" id="4Q4DxjDbKiY" role="1tU5fm">
-                        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                      </node>
-                      <node concept="2OqwBi" id="4Q4DxjDbKj1" role="33vP2m">
-                        <node concept="37vLTw" id="4Q4DxjDbKj2" role="2Oq$k0">
-                          <ref role="3cqZAo" node="4Q4DxjDbJJg" resolve="iterator" />
-                        </node>
-                        <node concept="liA8E" id="4Q4DxjDbKj3" role="2OqNvi">
-                          <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3cpWs8" id="3SMYSUUkVke" role="3cqZAp">
-                    <node concept="3cpWsn" id="3SMYSUUkVkf" role="3cpWs9">
-                      <property role="TrG5h" value="element" />
-                      <node concept="3uibUv" id="ncXQh4zkYJ" role="1tU5fm">
-                        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                      </node>
-                      <node concept="10Nm6u" id="3SMYSUUkVOv" role="33vP2m" />
-                    </node>
-                  </node>
-                  <node concept="3clFbJ" id="3SMYSUUkPo2" role="3cqZAp">
-                    <node concept="3clFbS" id="3SMYSUUkPo4" role="3clFbx">
-                      <node concept="3clFbF" id="3SMYSUUkWeJ" role="3cqZAp">
-                        <node concept="37vLTI" id="3SMYSUUkWTS" role="3clFbG">
-                          <node concept="37vLTw" id="3SMYSUUkWeH" role="37vLTJ">
-                            <ref role="3cqZAo" node="3SMYSUUkVkf" resolve="element" />
-                          </node>
-                          <node concept="10QFUN" id="3SMYSUUkSCD" role="37vLTx">
-                            <node concept="3uibUv" id="3SMYSUUkSQg" role="10QFUM">
-                              <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
-                            </node>
-                            <node concept="37vLTw" id="3SMYSUUkSmD" role="10QFUP">
-                              <ref role="3cqZAo" node="4Q4DxjDbKj0" resolve="next" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2ZW3vV" id="3SMYSUUkQvh" role="3clFbw">
-                      <node concept="3uibUv" id="3SMYSUUkQHz" role="2ZW6by">
-                        <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
-                      </node>
-                      <node concept="37vLTw" id="3SMYSUUkPLM" role="2ZW6bz">
-                        <ref role="3cqZAo" node="4Q4DxjDbKj0" resolve="next" />
-                      </node>
-                    </node>
-                    <node concept="3eNFk2" id="3SMYSUUkXAO" role="3eNLev">
-                      <node concept="2ZW3vV" id="3SMYSUUkYvv" role="3eO9$A">
-                        <node concept="3uibUv" id="3SMYSUUkYHM" role="2ZW6by">
-                          <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
-                        </node>
-                        <node concept="37vLTw" id="3SMYSUUkXIH" role="2ZW6bz">
-                          <ref role="3cqZAo" node="4Q4DxjDbKj0" resolve="next" />
-                        </node>
-                      </node>
-                      <node concept="3clFbS" id="3SMYSUUkXAQ" role="3eOfB_">
-                        <node concept="3clFbF" id="3SMYSUUl0il" role="3cqZAp">
-                          <node concept="37vLTI" id="3SMYSUUl11T" role="3clFbG">
-                            <node concept="2ShNRf" id="3SMYSUUl1iQ" role="37vLTx">
-                              <node concept="1pGfFk" id="3SMYSUUl263" role="2ShVmc">
-                                <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
-                                <node concept="2OqwBi" id="3SMYSUUkZ_s" role="37wK5m">
-                                  <node concept="37vLTw" id="3SMYSUUkYSR" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="4Q4DxjDbKj0" resolve="next" />
-                                  </node>
-                                  <node concept="liA8E" id="3SMYSUUkZPY" role="2OqNvi">
-                                    <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="37vLTw" id="3SMYSUUl0ij" role="37vLTJ">
-                              <ref role="3cqZAo" node="3SMYSUUkVkf" resolve="element" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3eNFk2" id="ncXQh4zW8S" role="3eNLev">
-                      <node concept="1Wc70l" id="ncXQh4zW8T" role="3eO9$A">
-                        <node concept="2OqwBi" id="ncXQh4zW8U" role="3uHU7w">
-                          <node concept="37vLTw" id="ncXQh4zW8V" role="2Oq$k0">
-                            <ref role="3cqZAo" node="ncXQh4q5UR" resolve="nothingType" />
-                          </node>
-                          <node concept="liA8E" id="ncXQh4zW8W" role="2OqNvi">
-                            <ref role="37wK5l" to="wyt6:~Class.isInstance(java.lang.Object)" resolve="isInstance" />
-                            <node concept="37vLTw" id="ncXQh4zW8X" role="37wK5m">
-                              <ref role="3cqZAo" node="4Q4DxjDbKj0" resolve="next" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3y3z36" id="ncXQh4zW8Y" role="3uHU7B">
-                          <node concept="37vLTw" id="ncXQh4zW8Z" role="3uHU7B">
-                            <ref role="3cqZAo" node="ncXQh4q5UR" resolve="nothingType" />
-                          </node>
-                          <node concept="10Nm6u" id="ncXQh4zW90" role="3uHU7w" />
-                        </node>
-                      </node>
-                      <node concept="3clFbS" id="ncXQh4zW91" role="3eOfB_">
-                        <node concept="3clFbF" id="ncXQh4zW92" role="3cqZAp">
-                          <node concept="37vLTI" id="ncXQh4zW93" role="3clFbG">
-                            <node concept="37vLTw" id="ncXQh4zW94" role="37vLTx">
-                              <ref role="3cqZAo" node="4Q4DxjDbKj0" resolve="next" />
-                            </node>
-                            <node concept="37vLTw" id="ncXQh4zW95" role="37vLTJ">
-                              <ref role="3cqZAo" node="3SMYSUUkVkf" resolve="element" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="9aQIb" id="3SMYSUUlazq" role="9aQIa">
-                      <node concept="3clFbS" id="3SMYSUUlazr" role="9aQI4">
-                        <node concept="YS8fn" id="3SMYSUUlaJ2" role="3cqZAp">
-                          <node concept="2ShNRf" id="3SMYSUUlaQG" role="YScLw">
-                            <node concept="1pGfFk" id="3SMYSUUlb_K" role="2ShVmc">
-                              <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
-                              <node concept="3cpWs3" id="3SMYSUUlfG8" role="37wK5m">
-                                <node concept="Xl_RD" id="3SMYSUUlgUH" role="3uHU7w">
-                                  <property role="Xl_RC" value=" to BigInteger." />
-                                </node>
-                                <node concept="3cpWs3" id="3SMYSUUldnr" role="3uHU7B">
-                                  <node concept="Xl_RD" id="3SMYSUUlbPW" role="3uHU7B">
-                                    <property role="Xl_RC" value="Don't know how to cast element " />
-                                  </node>
-                                  <node concept="2OqwBi" id="3SMYSUUldW7" role="3uHU7w">
-                                    <node concept="37vLTw" id="3SMYSUUldpg" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="4Q4DxjDbKj0" resolve="next" />
-                                    </node>
-                                    <node concept="liA8E" id="3SMYSUUlecc" role="2OqNvi">
-                                      <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbJ" id="3SMYSUUpkfR" role="3cqZAp">
-                    <node concept="3clFbS" id="3SMYSUUpkfT" role="3clFbx">
-                      <node concept="3clFbF" id="3SMYSUUplOt" role="3cqZAp">
-                        <node concept="37vLTI" id="3SMYSUUpmvt" role="3clFbG">
-                          <node concept="37vLTw" id="3SMYSUUpmH3" role="37vLTx">
-                            <ref role="3cqZAo" node="3SMYSUUkVkf" resolve="element" />
-                          </node>
-                          <node concept="37vLTw" id="3SMYSUUplOr" role="37vLTJ">
-                            <ref role="3cqZAo" node="4Q4DxjDbLbS" resolve="max" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbC" id="3SMYSUUpl$4" role="3clFbw">
-                      <node concept="37vLTw" id="3SMYSUUpkAP" role="3uHU7B">
-                        <ref role="3cqZAo" node="4Q4DxjDbLbS" resolve="max" />
-                      </node>
-                      <node concept="10Nm6u" id="3SMYSUUpltI" role="3uHU7w" />
-                    </node>
-                    <node concept="9aQIb" id="3SMYSUUpmSd" role="9aQIa">
-                      <node concept="3clFbS" id="3SMYSUUpmSe" role="9aQI4">
-                        <node concept="3clFbJ" id="3SMYSUUl4gs" role="3cqZAp">
-                          <node concept="3clFbS" id="3SMYSUUl4gu" role="3clFbx">
-                            <node concept="3clFbF" id="3SMYSUUl9jz" role="3cqZAp">
-                              <node concept="37vLTI" id="3SMYSUUl9Y$" role="3clFbG">
-                                <node concept="37vLTw" id="3SMYSUUlacb" role="37vLTx">
-                                  <ref role="3cqZAo" node="3SMYSUUkVkf" resolve="element" />
-                                </node>
-                                <node concept="37vLTw" id="3SMYSUUl9jx" role="37vLTJ">
-                                  <ref role="3cqZAo" node="4Q4DxjDbLbS" resolve="max" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="3eOSWO" id="3SMYSUUl8MY" role="3clFbw">
-                            <node concept="3cmrfG" id="3SMYSUUl8Zq" role="3uHU7w">
-                              <property role="3cmrfH" value="0" />
-                            </node>
-                            <node concept="2OqwBi" id="3SMYSUUl5ap" role="3uHU7B">
-                              <node concept="1rXfSq" id="ncXQh4zmpC" role="2Oq$k0">
-                                <ref role="37wK5l" node="ncXQh4z3V8" resolve="nothingToInt" />
-                                <node concept="37vLTw" id="ncXQh4zmNY" role="37wK5m">
-                                  <ref role="3cqZAo" node="3SMYSUUkVkf" resolve="element" />
-                                </node>
-                                <node concept="37vLTw" id="ncXQh4znfB" role="37wK5m">
-                                  <ref role="3cqZAo" node="ncXQh4q5UR" resolve="nothingType" />
-                                </node>
-                              </node>
-                              <node concept="liA8E" id="3SMYSUUl63$" role="2OqNvi">
-                                <ref role="37wK5l" to="xlxw:~BigInteger.compareTo(java.math.BigInteger)" resolve="compareTo" />
-                                <node concept="1rXfSq" id="ncXQh4z5iv" role="37wK5m">
-                                  <ref role="37wK5l" node="ncXQh4z3V8" resolve="nothingToInt" />
-                                  <node concept="37vLTw" id="ncXQh4z5J2" role="37wK5m">
-                                    <ref role="3cqZAo" node="4Q4DxjDbLbS" resolve="max" />
-                                  </node>
-                                  <node concept="37vLTw" id="ncXQh4z6vc" role="37wK5m">
-                                    <ref role="3cqZAo" node="ncXQh4q5UR" resolve="nothingType" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="4Q4DxjDbK1R" role="2$JKZa">
-                  <node concept="37vLTw" id="4Q4DxjDbK0n" role="2Oq$k0">
-                    <ref role="3cqZAo" node="4Q4DxjDbJJg" resolve="iterator" />
-                  </node>
-                  <node concept="liA8E" id="4Q4DxjDbK5j" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~Iterator.hasNext()" resolve="hasNext" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbJ" id="3SMYSUUkE9g" role="3cqZAp">
-                <node concept="3clFbS" id="3SMYSUUkE9i" role="3clFbx">
-                  <node concept="3cpWs6" id="3SMYSUUkInv" role="3cqZAp">
-                    <node concept="37vLTw" id="3SMYSUUkJ1d" role="3cqZAk">
-                      <ref role="3cqZAo" node="4Q4DxjDbLbS" resolve="max" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3y3z36" id="3SMYSUUkIav" role="3clFbw">
-                  <node concept="10Nm6u" id="3SMYSUUkIck" role="3uHU7w" />
-                  <node concept="37vLTw" id="3SMYSUUkELW" role="3uHU7B">
-                    <ref role="3cqZAo" node="4Q4DxjDbLbS" resolve="max" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3SKdUt" id="3SMYSUUkN4N" role="3cqZAp">
-                <node concept="1PaTwC" id="17Nm8oCo8Kz" role="1aUNEU">
-                  <node concept="3oM_SD" id="17Nm8oCo8K$" role="1PaTwD">
-                    <property role="3oM_SC" value="max" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8K_" role="1PaTwD">
-                    <property role="3oM_SC" value="of" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8KA" role="1PaTwD">
-                    <property role="3oM_SC" value="the" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8KB" role="1PaTwD">
-                    <property role="3oM_SC" value="empty" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8KC" role="1PaTwD">
-                    <property role="3oM_SC" value="list" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8KD" role="1PaTwD">
-                    <property role="3oM_SC" value="(arbitrarily" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8KE" role="1PaTwD">
-                    <property role="3oM_SC" value="chosen" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8KF" role="1PaTwD">
-                    <property role="3oM_SC" value="as" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8KG" role="1PaTwD">
-                    <property role="3oM_SC" value="Long.MIN_VALUE" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8KH" role="1PaTwD">
-                    <property role="3oM_SC" value="since" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8KI" role="1PaTwD">
-                    <property role="3oM_SC" value="there" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8KJ" role="1PaTwD">
-                    <property role="3oM_SC" value="is" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8KK" role="1PaTwD">
-                    <property role="3oM_SC" value="no" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8KL" role="1PaTwD">
-                    <property role="3oM_SC" value="-INF" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8KM" role="1PaTwD">
-                    <property role="3oM_SC" value="in" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8KN" role="1PaTwD">
-                    <property role="3oM_SC" value="type" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8KO" role="1PaTwD">
-                    <property role="3oM_SC" value="BigInteger)" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3cpWs6" id="1RwPUjzjmil" role="3cqZAp">
-                <node concept="2YIFZM" id="1RwPUjzjmim" role="3cqZAk">
-                  <ref role="1Pybhc" to="xlxw:~BigInteger" resolve="BigInteger" />
-                  <ref role="37wK5l" to="xlxw:~BigInteger.valueOf(long)" resolve="valueOf" />
-                  <node concept="10M0yZ" id="3SMYSUUkLkN" role="37wK5m">
-                    <ref role="3cqZAo" to="wyt6:~Long.MIN_VALUE" resolve="MIN_VALUE" />
-                    <ref role="1PxDUh" to="wyt6:~Long" resolve="Long" />
-                  </node>
-                </node>
-              </node>
+            <node concept="37vLTw" id="3qKzW8QEnrY" role="37wK5m">
+              <ref role="3cqZAo" node="ncXQh4q5UR" resolve="nothingType" />
             </node>
           </node>
         </node>
@@ -1899,8 +1224,16 @@
           <ref role="3uigEE" to="wyt6:~Class" resolve="Class" />
         </node>
       </node>
+      <node concept="2AHcQZ" id="3qKzW8QEo4a" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+        <node concept="2B6LJw" id="3qKzW8QEqsZ" role="2B76xF">
+          <ref role="2B6OnR" to="wyt6:~Deprecated.forRemoval()" resolve="forRemoval" />
+          <node concept="3clFbT" id="3qKzW8QEqtF" role="2B70Vg">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
     </node>
-    <node concept="2tJIrI" id="ncXQh4pyFZ" role="jymVt" />
     <node concept="2tJIrI" id="ncXQh4pyTo" role="jymVt" />
     <node concept="2YIFZL" id="1RwPUjzjkk_" role="jymVt">
       <property role="TrG5h" value="min" />
@@ -1909,689 +1242,18 @@
       </node>
       <node concept="3Tm1VV" id="1RwPUjzjkkB" role="1B3o_S" />
       <node concept="3clFbS" id="1RwPUjzjkkC" role="3clF47">
-        <node concept="3clFbJ" id="1RwPUjzjkkD" role="3cqZAp">
-          <node concept="37vLTw" id="1RwPUjzjkkE" role="3clFbw">
-            <ref role="3cqZAo" node="1RwPUjzjkm5" resolve="isReal" />
-          </node>
-          <node concept="3clFbS" id="1RwPUjzjkkF" role="3clFbx">
-            <node concept="3cpWs8" id="6HHp2WnvqX_" role="3cqZAp">
-              <node concept="3cpWsn" id="6HHp2WnvqXA" role="3cpWs9">
-                <property role="TrG5h" value="iterator" />
-                <node concept="3uibUv" id="6HHp2WnvqXB" role="1tU5fm">
-                  <ref role="3uigEE" to="33ny:~Iterator" resolve="Iterator" />
-                  <node concept="3uibUv" id="6HHp2WnvqXC" role="11_B2D">
-                    <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="6HHp2WnvqXD" role="33vP2m">
-                  <node concept="37vLTw" id="1RwPUjzjwhC" role="2Oq$k0">
-                    <ref role="3cqZAo" node="1RwPUjzjkm3" resolve="values" />
-                  </node>
-                  <node concept="liA8E" id="6HHp2WnvqXF" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~Collection.iterator()" resolve="iterator" />
-                  </node>
-                </node>
-              </node>
+        <node concept="3clFbF" id="3qKzW8QEqWn" role="3cqZAp">
+          <node concept="2YIFZM" id="3qKzW8QEqXk" role="3clFbG">
+            <ref role="37wK5l" to="ppzb:1RwPUjzjkk_" resolve="min" />
+            <ref role="1Pybhc" to="ppzb:1RwPUjziune" resolve="SharedMinMaxHelper" />
+            <node concept="37vLTw" id="3qKzW8QEqXQ" role="37wK5m">
+              <ref role="3cqZAo" node="1RwPUjzjkm3" resolve="values" />
             </node>
-            <node concept="3cpWs8" id="6HHp2WnvqXG" role="3cqZAp">
-              <node concept="3cpWsn" id="6HHp2WnvqXH" role="3cpWs9">
-                <property role="TrG5h" value="min" />
-                <node concept="3uibUv" id="ncXQh4_iu4" role="1tU5fm">
-                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                </node>
-                <node concept="10Nm6u" id="3SMYSUUtxJx" role="33vP2m" />
-              </node>
+            <node concept="37vLTw" id="3qKzW8QEqY_" role="37wK5m">
+              <ref role="3cqZAo" node="1RwPUjzjkm5" resolve="isReal" />
             </node>
-            <node concept="2$JKZl" id="6HHp2WnvqXK" role="3cqZAp">
-              <node concept="3clFbS" id="6HHp2WnvqXL" role="2LFqv$">
-                <node concept="3cpWs8" id="6HHp2WnvqXM" role="3cqZAp">
-                  <node concept="3cpWsn" id="6HHp2WnvqXN" role="3cpWs9">
-                    <property role="TrG5h" value="next" />
-                    <node concept="3uibUv" id="6HHp2WnvqXO" role="1tU5fm">
-                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                    </node>
-                    <node concept="2OqwBi" id="6HHp2WnvqXP" role="33vP2m">
-                      <node concept="37vLTw" id="6HHp2WnvqXQ" role="2Oq$k0">
-                        <ref role="3cqZAo" node="6HHp2WnvqXA" resolve="iterator" />
-                      </node>
-                      <node concept="liA8E" id="6HHp2WnvqXR" role="2OqNvi">
-                        <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs8" id="3SMYSUUtzES" role="3cqZAp">
-                  <node concept="3cpWsn" id="3SMYSUUtzET" role="3cpWs9">
-                    <property role="TrG5h" value="element" />
-                    <node concept="3uibUv" id="ncXQh4_jv1" role="1tU5fm">
-                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                    </node>
-                    <node concept="10Nm6u" id="3SMYSUUtzEV" role="33vP2m" />
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="3SMYSUUtzEW" role="3cqZAp">
-                  <node concept="3clFbS" id="3SMYSUUtzEX" role="3clFbx">
-                    <node concept="3clFbF" id="3SMYSUUtzEY" role="3cqZAp">
-                      <node concept="37vLTI" id="3SMYSUUtzEZ" role="3clFbG">
-                        <node concept="37vLTw" id="3SMYSUUtzF0" role="37vLTJ">
-                          <ref role="3cqZAo" node="3SMYSUUtzET" resolve="element" />
-                        </node>
-                        <node concept="1eOMI4" id="3SMYSUUtzF1" role="37vLTx">
-                          <node concept="10QFUN" id="3SMYSUUtzF2" role="1eOMHV">
-                            <node concept="3uibUv" id="3SMYSUUtzF3" role="10QFUM">
-                              <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
-                            </node>
-                            <node concept="37vLTw" id="3SMYSUUtzF4" role="10QFUP">
-                              <ref role="3cqZAo" node="6HHp2WnvqXN" resolve="next" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2ZW3vV" id="3SMYSUUtzF5" role="3clFbw">
-                    <node concept="3uibUv" id="3SMYSUUtzF6" role="2ZW6by">
-                      <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
-                    </node>
-                    <node concept="37vLTw" id="3SMYSUUtzF7" role="2ZW6bz">
-                      <ref role="3cqZAo" node="6HHp2WnvqXN" resolve="next" />
-                    </node>
-                  </node>
-                  <node concept="3eNFk2" id="3SMYSUUtzF8" role="3eNLev">
-                    <node concept="2ZW3vV" id="3SMYSUUtzF9" role="3eO9$A">
-                      <node concept="3uibUv" id="3SMYSUUtzFa" role="2ZW6by">
-                        <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
-                      </node>
-                      <node concept="37vLTw" id="3SMYSUUtzFb" role="2ZW6bz">
-                        <ref role="3cqZAo" node="6HHp2WnvqXN" resolve="next" />
-                      </node>
-                    </node>
-                    <node concept="3clFbS" id="3SMYSUUtzFc" role="3eOfB_">
-                      <node concept="3clFbF" id="3SMYSUUtzFd" role="3cqZAp">
-                        <node concept="37vLTI" id="3SMYSUUtzFe" role="3clFbG">
-                          <node concept="37vLTw" id="3SMYSUUtzFf" role="37vLTJ">
-                            <ref role="3cqZAo" node="3SMYSUUtzET" resolve="element" />
-                          </node>
-                          <node concept="2ShNRf" id="3SMYSUUtzFg" role="37vLTx">
-                            <node concept="1pGfFk" id="3SMYSUUtzFh" role="2ShVmc">
-                              <ref role="37wK5l" to="xlxw:~BigDecimal.&lt;init&gt;(java.lang.String)" resolve="BigDecimal" />
-                              <node concept="2OqwBi" id="3SMYSUUtzFi" role="37wK5m">
-                                <node concept="1eOMI4" id="3SMYSUUtzFj" role="2Oq$k0">
-                                  <node concept="10QFUN" id="3SMYSUUtzFk" role="1eOMHV">
-                                    <node concept="3uibUv" id="3SMYSUUtzFl" role="10QFUM">
-                                      <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
-                                    </node>
-                                    <node concept="37vLTw" id="3SMYSUUtzFm" role="10QFUP">
-                                      <ref role="3cqZAo" node="6HHp2WnvqXN" resolve="next" />
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="liA8E" id="3SMYSUUtzFn" role="2OqNvi">
-                                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3eNFk2" id="5QDPRL$feXr" role="3eNLev">
-                    <node concept="1Wc70l" id="5QDPRL$feXs" role="3eO9$A">
-                      <node concept="2OqwBi" id="5QDPRL$feXt" role="3uHU7w">
-                        <node concept="37vLTw" id="5QDPRL$feXu" role="2Oq$k0">
-                          <ref role="3cqZAo" node="ncXQh4qfxK" resolve="nothingType" />
-                        </node>
-                        <node concept="liA8E" id="5QDPRL$feXv" role="2OqNvi">
-                          <ref role="37wK5l" to="wyt6:~Class.isInstance(java.lang.Object)" resolve="isInstance" />
-                          <node concept="37vLTw" id="5QDPRL$feXw" role="37wK5m">
-                            <ref role="3cqZAo" node="6HHp2WnvqXN" resolve="next" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3y3z36" id="5QDPRL$feXx" role="3uHU7B">
-                        <node concept="37vLTw" id="5QDPRL$feXy" role="3uHU7B">
-                          <ref role="3cqZAo" node="ncXQh4qfxK" resolve="nothingType" />
-                        </node>
-                        <node concept="10Nm6u" id="5QDPRL$feXz" role="3uHU7w" />
-                      </node>
-                    </node>
-                    <node concept="3clFbS" id="5QDPRL$feX$" role="3eOfB_">
-                      <node concept="3clFbF" id="5QDPRL$feX_" role="3cqZAp">
-                        <node concept="37vLTI" id="5QDPRL$feXA" role="3clFbG">
-                          <node concept="37vLTw" id="5QDPRL$feXB" role="37vLTx">
-                            <ref role="3cqZAo" node="6HHp2WnvqXN" resolve="next" />
-                          </node>
-                          <node concept="37vLTw" id="5QDPRL$feXC" role="37vLTJ">
-                            <ref role="3cqZAo" node="3SMYSUUtzET" resolve="element" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="9aQIb" id="3SMYSUUtzFo" role="9aQIa">
-                    <node concept="3clFbS" id="3SMYSUUtzFp" role="9aQI4">
-                      <node concept="YS8fn" id="3SMYSUUtzFq" role="3cqZAp">
-                        <node concept="2ShNRf" id="3SMYSUUtzFr" role="YScLw">
-                          <node concept="1pGfFk" id="3SMYSUUtzFs" role="2ShVmc">
-                            <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
-                            <node concept="3cpWs3" id="3SMYSUUtzFt" role="37wK5m">
-                              <node concept="Xl_RD" id="3SMYSUUtzFu" role="3uHU7w">
-                                <property role="Xl_RC" value=" to BigDecimal." />
-                              </node>
-                              <node concept="3cpWs3" id="3SMYSUUtzFv" role="3uHU7B">
-                                <node concept="Xl_RD" id="3SMYSUUtzFw" role="3uHU7B">
-                                  <property role="Xl_RC" value="Don't know how to cast element " />
-                                </node>
-                                <node concept="2OqwBi" id="3SMYSUUtzFx" role="3uHU7w">
-                                  <node concept="37vLTw" id="3SMYSUUtzFy" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="6HHp2WnvqXN" resolve="next" />
-                                  </node>
-                                  <node concept="liA8E" id="3SMYSUUtzFz" role="2OqNvi">
-                                    <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbH" id="3SMYSUUtzm4" role="3cqZAp" />
-                <node concept="3clFbJ" id="3SMYSUUt_9X" role="3cqZAp">
-                  <node concept="3clFbS" id="3SMYSUUt_9Z" role="3clFbx">
-                    <node concept="3clFbF" id="3SMYSUUtAQe" role="3cqZAp">
-                      <node concept="37vLTI" id="3SMYSUUtBxd" role="3clFbG">
-                        <node concept="37vLTw" id="3SMYSUUtBIM" role="37vLTx">
-                          <ref role="3cqZAo" node="3SMYSUUtzET" resolve="element" />
-                        </node>
-                        <node concept="37vLTw" id="3SMYSUUtAQc" role="37vLTJ">
-                          <ref role="3cqZAo" node="6HHp2WnvqXH" resolve="min" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbC" id="3SMYSUUtAq8" role="3clFbw">
-                    <node concept="10Nm6u" id="3SMYSUUtAA1" role="3uHU7w" />
-                    <node concept="37vLTw" id="3SMYSUUt_F5" role="3uHU7B">
-                      <ref role="3cqZAo" node="6HHp2WnvqXH" resolve="min" />
-                    </node>
-                  </node>
-                  <node concept="9aQIb" id="3SMYSUUtBY0" role="9aQIa">
-                    <node concept="3clFbS" id="3SMYSUUtBY1" role="9aQI4">
-                      <node concept="3clFbJ" id="3SMYSUUtCeh" role="3cqZAp">
-                        <node concept="3eOVzh" id="3SMYSUUtGx$" role="3clFbw">
-                          <node concept="3cmrfG" id="3SMYSUUtGHy" role="3uHU7w">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="2OqwBi" id="3SMYSUUtCS9" role="3uHU7B">
-                            <node concept="liA8E" id="3SMYSUUtDLe" role="2OqNvi">
-                              <ref role="37wK5l" to="xlxw:~BigDecimal.compareTo(java.math.BigDecimal)" resolve="compareTo" />
-                              <node concept="1rXfSq" id="ncXQh4_kWc" role="37wK5m">
-                                <ref role="37wK5l" node="ncXQh4_bka" resolve="nothingToDec" />
-                                <node concept="37vLTw" id="ncXQh4_lev" role="37wK5m">
-                                  <ref role="3cqZAo" node="6HHp2WnvqXH" resolve="min" />
-                                </node>
-                                <node concept="37vLTw" id="ncXQh4_lz5" role="37wK5m">
-                                  <ref role="3cqZAo" node="ncXQh4qfxK" resolve="nothingType" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="1rXfSq" id="ncXQh4_khP" role="2Oq$k0">
-                              <ref role="37wK5l" node="ncXQh4_bka" resolve="nothingToDec" />
-                              <node concept="37vLTw" id="ncXQh4_khQ" role="37wK5m">
-                                <ref role="3cqZAo" node="3SMYSUUtzET" resolve="element" />
-                              </node>
-                              <node concept="37vLTw" id="ncXQh4_kI0" role="37wK5m">
-                                <ref role="3cqZAo" node="ncXQh4qfxK" resolve="nothingType" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3clFbS" id="3SMYSUUtCej" role="3clFbx">
-                          <node concept="3clFbF" id="3SMYSUUtH1C" role="3cqZAp">
-                            <node concept="37vLTI" id="3SMYSUUtHGy" role="3clFbG">
-                              <node concept="37vLTw" id="3SMYSUUtHU7" role="37vLTx">
-                                <ref role="3cqZAo" node="3SMYSUUtzET" resolve="element" />
-                              </node>
-                              <node concept="37vLTw" id="3SMYSUUtH1B" role="37vLTJ">
-                                <ref role="3cqZAo" node="6HHp2WnvqXH" resolve="min" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="6HHp2WnvqYa" role="2$JKZa">
-                <node concept="37vLTw" id="6HHp2WnvqYb" role="2Oq$k0">
-                  <ref role="3cqZAo" node="6HHp2WnvqXA" resolve="iterator" />
-                </node>
-                <node concept="liA8E" id="6HHp2WnvqYc" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~Iterator.hasNext()" resolve="hasNext" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="3SMYSUUts5J" role="3cqZAp">
-              <node concept="3clFbS" id="3SMYSUUts5L" role="3clFbx">
-                <node concept="3cpWs6" id="3SMYSUUtvhC" role="3cqZAp">
-                  <node concept="37vLTw" id="3SMYSUUtvN9" role="3cqZAk">
-                    <ref role="3cqZAo" node="6HHp2WnvqXH" resolve="min" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3y3z36" id="3SMYSUUtv6p" role="3clFbw">
-                <node concept="37vLTw" id="3SMYSUUtsyU" role="3uHU7B">
-                  <ref role="3cqZAo" node="6HHp2WnvqXH" resolve="min" />
-                </node>
-                <node concept="10Nm6u" id="3SMYSUUtv0q" role="3uHU7w" />
-              </node>
-            </node>
-            <node concept="3SKdUt" id="3SMYSUUtyy8" role="3cqZAp">
-              <node concept="1PaTwC" id="17Nm8oCo8KP" role="1aUNEU">
-                <node concept="3oM_SD" id="17Nm8oCo8KQ" role="1PaTwD">
-                  <property role="3oM_SC" value="min" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8KR" role="1PaTwD">
-                  <property role="3oM_SC" value="of" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8KS" role="1PaTwD">
-                  <property role="3oM_SC" value="the" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8KT" role="1PaTwD">
-                  <property role="3oM_SC" value="empty" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8KU" role="1PaTwD">
-                  <property role="3oM_SC" value="list" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8KV" role="1PaTwD">
-                  <property role="3oM_SC" value="(arbitrarily" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8KW" role="1PaTwD">
-                  <property role="3oM_SC" value="chosen" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8KX" role="1PaTwD">
-                  <property role="3oM_SC" value="as" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8KY" role="1PaTwD">
-                  <property role="3oM_SC" value="Double.MAX_VALUE" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8KZ" role="1PaTwD">
-                  <property role="3oM_SC" value="since" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8L0" role="1PaTwD">
-                  <property role="3oM_SC" value="there" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8L1" role="1PaTwD">
-                  <property role="3oM_SC" value="is" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8L2" role="1PaTwD">
-                  <property role="3oM_SC" value="no" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8L3" role="1PaTwD">
-                  <property role="3oM_SC" value="INF" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8L4" role="1PaTwD">
-                  <property role="3oM_SC" value="in" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8L5" role="1PaTwD">
-                  <property role="3oM_SC" value="type" />
-                </node>
-                <node concept="3oM_SD" id="17Nm8oCo8L6" role="1PaTwD">
-                  <property role="3oM_SC" value="BigDecimal)" />
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs6" id="6HHp2WnvqYd" role="3cqZAp">
-              <node concept="2YIFZM" id="s2V0$62ke1" role="3cqZAk">
-                <ref role="1Pybhc" to="xlxw:~BigDecimal" resolve="BigDecimal" />
-                <ref role="37wK5l" to="xlxw:~BigDecimal.valueOf(double)" resolve="valueOf" />
-                <node concept="10M0yZ" id="oG0sI$C_Yh" role="37wK5m">
-                  <ref role="1PxDUh" to="wyt6:~Double" resolve="Double" />
-                  <ref role="3cqZAo" to="wyt6:~Double.MAX_VALUE" resolve="MAX_VALUE" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="9aQIb" id="1RwPUjzjkln" role="9aQIa">
-            <node concept="3clFbS" id="1RwPUjzjklo" role="9aQI4">
-              <node concept="3cpWs8" id="6HHp2WnvqWE" role="3cqZAp">
-                <node concept="3cpWsn" id="6HHp2WnvqWF" role="3cpWs9">
-                  <property role="TrG5h" value="iterator" />
-                  <node concept="3uibUv" id="6HHp2WnvqWG" role="1tU5fm">
-                    <ref role="3uigEE" to="33ny:~Iterator" resolve="Iterator" />
-                    <node concept="3uibUv" id="6HHp2WnvqWH" role="11_B2D">
-                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="6HHp2WnvqWI" role="33vP2m">
-                    <node concept="37vLTw" id="1RwPUjzjrG3" role="2Oq$k0">
-                      <ref role="3cqZAo" node="1RwPUjzjkm3" resolve="values" />
-                    </node>
-                    <node concept="liA8E" id="6HHp2WnvqWK" role="2OqNvi">
-                      <ref role="37wK5l" to="33ny:~Collection.iterator()" resolve="iterator" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3cpWs8" id="6HHp2WnvqWL" role="3cqZAp">
-                <node concept="3cpWsn" id="6HHp2WnvqWM" role="3cpWs9">
-                  <property role="TrG5h" value="min" />
-                  <node concept="3uibUv" id="ncXQh4zfR2" role="1tU5fm">
-                    <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                  </node>
-                  <node concept="10Nm6u" id="3SMYSUUtQXX" role="33vP2m" />
-                </node>
-              </node>
-              <node concept="2$JKZl" id="6HHp2WnvqWP" role="3cqZAp">
-                <node concept="3clFbS" id="6HHp2WnvqWQ" role="2LFqv$">
-                  <node concept="3cpWs8" id="6HHp2WnvqWR" role="3cqZAp">
-                    <node concept="3cpWsn" id="6HHp2WnvqWS" role="3cpWs9">
-                      <property role="TrG5h" value="next" />
-                      <node concept="3uibUv" id="6HHp2WnvqWT" role="1tU5fm">
-                        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                      </node>
-                      <node concept="2OqwBi" id="6HHp2WnvqWU" role="33vP2m">
-                        <node concept="37vLTw" id="6HHp2WnvqWV" role="2Oq$k0">
-                          <ref role="3cqZAo" node="6HHp2WnvqWF" resolve="iterator" />
-                        </node>
-                        <node concept="liA8E" id="6HHp2WnvqWW" role="2OqNvi">
-                          <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3cpWs8" id="3SMYSUUtT$I" role="3cqZAp">
-                    <node concept="3cpWsn" id="3SMYSUUtT$J" role="3cpWs9">
-                      <property role="TrG5h" value="element" />
-                      <node concept="3uibUv" id="ncXQh4ze7w" role="1tU5fm">
-                        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                      </node>
-                      <node concept="10Nm6u" id="3SMYSUUtT$L" role="33vP2m" />
-                    </node>
-                  </node>
-                  <node concept="3clFbJ" id="3SMYSUUtT$M" role="3cqZAp">
-                    <node concept="3clFbS" id="3SMYSUUtT$N" role="3clFbx">
-                      <node concept="3clFbF" id="3SMYSUUtT$O" role="3cqZAp">
-                        <node concept="37vLTI" id="3SMYSUUtT$P" role="3clFbG">
-                          <node concept="37vLTw" id="3SMYSUUtT$Q" role="37vLTJ">
-                            <ref role="3cqZAo" node="3SMYSUUtT$J" resolve="element" />
-                          </node>
-                          <node concept="10QFUN" id="3SMYSUUtT$R" role="37vLTx">
-                            <node concept="3uibUv" id="3SMYSUUtT$S" role="10QFUM">
-                              <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
-                            </node>
-                            <node concept="37vLTw" id="3SMYSUUtT$T" role="10QFUP">
-                              <ref role="3cqZAo" node="6HHp2WnvqWS" resolve="next" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2ZW3vV" id="3SMYSUUtT$U" role="3clFbw">
-                      <node concept="3uibUv" id="3SMYSUUtT$V" role="2ZW6by">
-                        <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
-                      </node>
-                      <node concept="37vLTw" id="3SMYSUUtT$W" role="2ZW6bz">
-                        <ref role="3cqZAo" node="6HHp2WnvqWS" resolve="next" />
-                      </node>
-                    </node>
-                    <node concept="3eNFk2" id="3SMYSUUtT$X" role="3eNLev">
-                      <node concept="2ZW3vV" id="3SMYSUUtT$Y" role="3eO9$A">
-                        <node concept="3uibUv" id="3SMYSUUtT$Z" role="2ZW6by">
-                          <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
-                        </node>
-                        <node concept="37vLTw" id="3SMYSUUtT_0" role="2ZW6bz">
-                          <ref role="3cqZAo" node="6HHp2WnvqWS" resolve="next" />
-                        </node>
-                      </node>
-                      <node concept="3clFbS" id="3SMYSUUtT_1" role="3eOfB_">
-                        <node concept="3clFbF" id="3SMYSUUtT_2" role="3cqZAp">
-                          <node concept="37vLTI" id="3SMYSUUtT_3" role="3clFbG">
-                            <node concept="2ShNRf" id="3SMYSUUtT_4" role="37vLTx">
-                              <node concept="1pGfFk" id="3SMYSUUtT_5" role="2ShVmc">
-                                <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
-                                <node concept="2OqwBi" id="3SMYSUUtT_6" role="37wK5m">
-                                  <node concept="37vLTw" id="3SMYSUUtT_7" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="6HHp2WnvqWS" resolve="next" />
-                                  </node>
-                                  <node concept="liA8E" id="3SMYSUUtT_8" role="2OqNvi">
-                                    <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="37vLTw" id="3SMYSUUtT_9" role="37vLTJ">
-                              <ref role="3cqZAo" node="3SMYSUUtT$J" resolve="element" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3eNFk2" id="ncXQh4zRwQ" role="3eNLev">
-                      <node concept="1Wc70l" id="ncXQh4zTX0" role="3eO9$A">
-                        <node concept="2OqwBi" id="ncXQh4zUx3" role="3uHU7w">
-                          <node concept="37vLTw" id="ncXQh4zUae" role="2Oq$k0">
-                            <ref role="3cqZAo" node="ncXQh4qfxK" resolve="nothingType" />
-                          </node>
-                          <node concept="liA8E" id="ncXQh4zUZy" role="2OqNvi">
-                            <ref role="37wK5l" to="wyt6:~Class.isInstance(java.lang.Object)" resolve="isInstance" />
-                            <node concept="37vLTw" id="ncXQh4zVca" role="37wK5m">
-                              <ref role="3cqZAo" node="6HHp2WnvqWS" resolve="next" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3y3z36" id="ncXQh4zTGP" role="3uHU7B">
-                          <node concept="37vLTw" id="ncXQh4zTmf" role="3uHU7B">
-                            <ref role="3cqZAo" node="ncXQh4qfxK" resolve="nothingType" />
-                          </node>
-                          <node concept="10Nm6u" id="ncXQh4zTQG" role="3uHU7w" />
-                        </node>
-                      </node>
-                      <node concept="3clFbS" id="ncXQh4zRwS" role="3eOfB_">
-                        <node concept="3clFbF" id="ncXQh4zVrS" role="3cqZAp">
-                          <node concept="37vLTI" id="ncXQh4zV_c" role="3clFbG">
-                            <node concept="37vLTw" id="ncXQh4zVFj" role="37vLTx">
-                              <ref role="3cqZAo" node="6HHp2WnvqWS" resolve="next" />
-                            </node>
-                            <node concept="37vLTw" id="ncXQh4zVrR" role="37vLTJ">
-                              <ref role="3cqZAo" node="3SMYSUUtT$J" resolve="element" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="9aQIb" id="3SMYSUUtT_a" role="9aQIa">
-                      <node concept="3clFbS" id="3SMYSUUtT_b" role="9aQI4">
-                        <node concept="YS8fn" id="3SMYSUUtT_c" role="3cqZAp">
-                          <node concept="2ShNRf" id="3SMYSUUtT_d" role="YScLw">
-                            <node concept="1pGfFk" id="3SMYSUUtT_e" role="2ShVmc">
-                              <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
-                              <node concept="3cpWs3" id="3SMYSUUtT_f" role="37wK5m">
-                                <node concept="Xl_RD" id="3SMYSUUtT_g" role="3uHU7w">
-                                  <property role="Xl_RC" value=" to BigInteger." />
-                                </node>
-                                <node concept="3cpWs3" id="3SMYSUUtT_h" role="3uHU7B">
-                                  <node concept="Xl_RD" id="3SMYSUUtT_i" role="3uHU7B">
-                                    <property role="Xl_RC" value="Don't know how to cast element " />
-                                  </node>
-                                  <node concept="2OqwBi" id="3SMYSUUtT_j" role="3uHU7w">
-                                    <node concept="37vLTw" id="3SMYSUUtT_k" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="6HHp2WnvqWS" resolve="next" />
-                                    </node>
-                                    <node concept="liA8E" id="3SMYSUUtT_l" role="2OqNvi">
-                                      <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbH" id="3SMYSUUtTcS" role="3cqZAp" />
-                  <node concept="3clFbJ" id="3SMYSUUtV6$" role="3cqZAp">
-                    <node concept="3clFbS" id="3SMYSUUtV6A" role="3clFbx">
-                      <node concept="3clFbF" id="3SMYSUUtWPD" role="3cqZAp">
-                        <node concept="37vLTI" id="3SMYSUUtXwE" role="3clFbG">
-                          <node concept="37vLTw" id="3SMYSUUtXIc" role="37vLTx">
-                            <ref role="3cqZAo" node="3SMYSUUtT$J" resolve="element" />
-                          </node>
-                          <node concept="37vLTw" id="3SMYSUUtWPB" role="37vLTJ">
-                            <ref role="3cqZAo" node="6HHp2WnvqWM" resolve="min" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbC" id="3SMYSUUtWpv" role="3clFbw">
-                      <node concept="10Nm6u" id="3SMYSUUtW_q" role="3uHU7w" />
-                      <node concept="37vLTw" id="3SMYSUUtVEq" role="3uHU7B">
-                        <ref role="3cqZAo" node="6HHp2WnvqWM" resolve="min" />
-                      </node>
-                    </node>
-                    <node concept="9aQIb" id="3SMYSUUtXTp" role="9aQIa">
-                      <node concept="3clFbS" id="3SMYSUUtXTq" role="9aQI4">
-                        <node concept="3clFbJ" id="3SMYSUUtY9G" role="3cqZAp">
-                          <node concept="3eOVzh" id="3SMYSUUu2pb" role="3clFbw">
-                            <node concept="3cmrfG" id="3SMYSUUu2_b" role="3uHU7w">
-                              <property role="3cmrfH" value="0" />
-                            </node>
-                            <node concept="2OqwBi" id="3SMYSUUtYJ_" role="3uHU7B">
-                              <node concept="1rXfSq" id="ncXQh4zhMR" role="2Oq$k0">
-                                <ref role="37wK5l" node="ncXQh4z3V8" resolve="nothingToInt" />
-                                <node concept="37vLTw" id="ncXQh4zicr" role="37wK5m">
-                                  <ref role="3cqZAo" node="3SMYSUUtT$J" resolve="element" />
-                                </node>
-                                <node concept="37vLTw" id="ncXQh4ziBj" role="37wK5m">
-                                  <ref role="3cqZAo" node="ncXQh4qfxK" resolve="nothingType" />
-                                </node>
-                              </node>
-                              <node concept="liA8E" id="3SMYSUUtZCG" role="2OqNvi">
-                                <ref role="37wK5l" to="xlxw:~BigInteger.compareTo(java.math.BigInteger)" resolve="compareTo" />
-                                <node concept="1rXfSq" id="ncXQh4zj9r" role="37wK5m">
-                                  <ref role="37wK5l" node="ncXQh4z3V8" resolve="nothingToInt" />
-                                  <node concept="37vLTw" id="ncXQh4zjyv" role="37wK5m">
-                                    <ref role="3cqZAo" node="6HHp2WnvqWM" resolve="min" />
-                                  </node>
-                                  <node concept="37vLTw" id="ncXQh4zkaX" role="37wK5m">
-                                    <ref role="3cqZAo" node="ncXQh4qfxK" resolve="nothingType" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="3clFbS" id="3SMYSUUtY9I" role="3clFbx">
-                            <node concept="3clFbF" id="3SMYSUUu2Tj" role="3cqZAp">
-                              <node concept="37vLTI" id="3SMYSUUu3$f" role="3clFbG">
-                                <node concept="37vLTw" id="3SMYSUUu3LQ" role="37vLTx">
-                                  <ref role="3cqZAo" node="3SMYSUUtT$J" resolve="element" />
-                                </node>
-                                <node concept="37vLTw" id="3SMYSUUu2Ti" role="37vLTJ">
-                                  <ref role="3cqZAo" node="6HHp2WnvqWM" resolve="min" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="6HHp2WnvqXf" role="2$JKZa">
-                  <node concept="37vLTw" id="6HHp2WnvqXg" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6HHp2WnvqWF" resolve="iterator" />
-                  </node>
-                  <node concept="liA8E" id="6HHp2WnvqXh" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~Iterator.hasNext()" resolve="hasNext" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbJ" id="3SMYSUUtJBp" role="3cqZAp">
-                <node concept="3clFbS" id="3SMYSUUtJBr" role="3clFbx">
-                  <node concept="3cpWs6" id="3SMYSUUtO8f" role="3cqZAp">
-                    <node concept="37vLTw" id="3SMYSUUtOLO" role="3cqZAk">
-                      <ref role="3cqZAo" node="6HHp2WnvqWM" resolve="min" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3y3z36" id="3SMYSUUtNPl" role="3clFbw">
-                  <node concept="10Nm6u" id="3SMYSUUtNX9" role="3uHU7w" />
-                  <node concept="37vLTw" id="3SMYSUUtKcA" role="3uHU7B">
-                    <ref role="3cqZAo" node="6HHp2WnvqWM" resolve="min" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3SKdUt" id="3SMYSUUtS4K" role="3cqZAp">
-                <node concept="1PaTwC" id="17Nm8oCo8L7" role="1aUNEU">
-                  <node concept="3oM_SD" id="17Nm8oCo8L8" role="1PaTwD">
-                    <property role="3oM_SC" value="min" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8L9" role="1PaTwD">
-                    <property role="3oM_SC" value="of" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8La" role="1PaTwD">
-                    <property role="3oM_SC" value="the" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8Lb" role="1PaTwD">
-                    <property role="3oM_SC" value="empty" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8Lc" role="1PaTwD">
-                    <property role="3oM_SC" value="list" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8Ld" role="1PaTwD">
-                    <property role="3oM_SC" value="(arbitrarily" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8Le" role="1PaTwD">
-                    <property role="3oM_SC" value="chosen" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8Lf" role="1PaTwD">
-                    <property role="3oM_SC" value="as" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8Lg" role="1PaTwD">
-                    <property role="3oM_SC" value="Long.MAX_VALUE" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8Lh" role="1PaTwD">
-                    <property role="3oM_SC" value="since" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8Li" role="1PaTwD">
-                    <property role="3oM_SC" value="there" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8Lj" role="1PaTwD">
-                    <property role="3oM_SC" value="is" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8Lk" role="1PaTwD">
-                    <property role="3oM_SC" value="no" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8Ll" role="1PaTwD">
-                    <property role="3oM_SC" value="INF" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8Lm" role="1PaTwD">
-                    <property role="3oM_SC" value="in" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8Ln" role="1PaTwD">
-                    <property role="3oM_SC" value="type" />
-                  </node>
-                  <node concept="3oM_SD" id="17Nm8oCo8Lo" role="1PaTwD">
-                    <property role="3oM_SC" value="BigInteger)" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3cpWs6" id="6HHp2WnvqXi" role="3cqZAp">
-                <node concept="2YIFZM" id="s2V0$62kcN" role="3cqZAk">
-                  <ref role="1Pybhc" to="xlxw:~BigInteger" resolve="BigInteger" />
-                  <ref role="37wK5l" to="xlxw:~BigInteger.valueOf(long)" resolve="valueOf" />
-                  <node concept="10M0yZ" id="6HHp2Wnvrjy" role="37wK5m">
-                    <ref role="3cqZAo" to="wyt6:~Long.MAX_VALUE" resolve="MAX_VALUE" />
-                    <ref role="1PxDUh" to="wyt6:~Long" resolve="Long" />
-                  </node>
-                </node>
-              </node>
+            <node concept="37vLTw" id="3qKzW8QEqZU" role="37wK5m">
+              <ref role="3cqZAo" node="ncXQh4qfxK" resolve="nothingType" />
             </node>
           </node>
         </node>
@@ -2612,63 +1274,29 @@
           <ref role="3uigEE" to="wyt6:~Class" resolve="Class" />
         </node>
       </node>
+      <node concept="2AHcQZ" id="3qKzW8QEpi3" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+        <node concept="2B6LJw" id="3qKzW8QEqtU" role="2B76xF">
+          <ref role="2B6OnR" to="wyt6:~Deprecated.forRemoval()" resolve="forRemoval" />
+          <node concept="3clFbT" id="3qKzW8QEqv8" role="2B70Vg">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="ncXQh4yF7B" role="jymVt" />
     <node concept="2YIFZL" id="ncXQh4z3V8" role="jymVt">
       <property role="TrG5h" value="nothingToInt" />
       <node concept="3clFbS" id="ncXQh4yGlh" role="3clF47">
-        <node concept="3clFbJ" id="ncXQh4yOpz" role="3cqZAp">
-          <node concept="3clFbS" id="ncXQh4yOp_" role="3clFbx">
-            <node concept="3cpWs6" id="ncXQh4yOSw" role="3cqZAp">
-              <node concept="10QFUN" id="ncXQh4ySX4" role="3cqZAk">
-                <node concept="37vLTw" id="ncXQh4ySX3" role="10QFUP">
-                  <ref role="3cqZAo" node="ncXQh4yIPs" resolve="value" />
-                </node>
-                <node concept="3uibUv" id="ncXQh4z9Mv" role="10QFUM">
-                  <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbC" id="ncXQh4yONj" role="3clFbw">
-            <node concept="10Nm6u" id="ncXQh4yONA" role="3uHU7w" />
-            <node concept="37vLTw" id="ncXQh4yOq0" role="3uHU7B">
-              <ref role="3cqZAo" node="ncXQh4yJLG" resolve="nothingClass" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="ncXQh4yPG1" role="3cqZAp">
-          <node concept="3clFbS" id="ncXQh4yPG3" role="3clFbx">
-            <node concept="3cpWs6" id="ncXQh4yV8H" role="3cqZAp">
-              <node concept="2ShNRf" id="ncXQh4yVcu" role="3cqZAk">
-                <node concept="1pGfFk" id="ncXQh4yVcl" role="2ShVmc">
-                  <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
-                  <node concept="Xl_RD" id="ncXQh4yW8i" role="37wK5m">
-                    <property role="Xl_RC" value="0" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="2OqwBi" id="ncXQh4yUxS" role="3clFbw">
-            <node concept="37vLTw" id="ncXQh4yUgY" role="2Oq$k0">
-              <ref role="3cqZAo" node="ncXQh4yJLG" resolve="nothingClass" />
-            </node>
-            <node concept="liA8E" id="ncXQh4yUVk" role="2OqNvi">
-              <ref role="37wK5l" to="wyt6:~Class.isInstance(java.lang.Object)" resolve="isInstance" />
-              <node concept="37vLTw" id="ncXQh4yV2Y" role="37wK5m">
-                <ref role="3cqZAo" node="ncXQh4yIPs" resolve="value" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs6" id="ncXQh4yYtV" role="3cqZAp">
-          <node concept="10QFUN" id="ncXQh4yZqY" role="3cqZAk">
-            <node concept="37vLTw" id="ncXQh4yZqX" role="10QFUP">
+        <node concept="3clFbF" id="3qKzW8QEr0Q" role="3cqZAp">
+          <node concept="2YIFZM" id="3qKzW8QEr29" role="3clFbG">
+            <ref role="37wK5l" to="ppzb:ncXQh4z3V8" resolve="nothingToInt" />
+            <ref role="1Pybhc" to="ppzb:1RwPUjziune" resolve="SharedMinMaxHelper" />
+            <node concept="37vLTw" id="3qKzW8QEr2G" role="37wK5m">
               <ref role="3cqZAo" node="ncXQh4yIPs" resolve="value" />
             </node>
-            <node concept="3uibUv" id="ncXQh4zclf" role="10QFUM">
-              <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+            <node concept="37vLTw" id="3qKzW8QEr46" role="37wK5m">
+              <ref role="3cqZAo" node="ncXQh4yJLG" resolve="nothingClass" />
             </node>
           </node>
         </node>
@@ -2689,89 +1317,29 @@
         <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
       </node>
       <node concept="3Tm1VV" id="ncXQh4yGlg" role="1B3o_S" />
+      <node concept="2AHcQZ" id="3qKzW8QEqKI" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+        <node concept="2B6LJw" id="3qKzW8QEqNh" role="2B76xF">
+          <ref role="2B6OnR" to="wyt6:~Deprecated.forRemoval()" resolve="forRemoval" />
+          <node concept="3clFbT" id="3qKzW8QEqNX" role="2B70Vg">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
     </node>
+    <node concept="2tJIrI" id="3qKzW8QEqTW" role="jymVt" />
     <node concept="2YIFZL" id="ncXQh4_bka" role="jymVt">
       <property role="TrG5h" value="nothingToDec" />
       <node concept="3clFbS" id="ncXQh4_bkb" role="3clF47">
-        <node concept="3clFbJ" id="ncXQh4_bkc" role="3cqZAp">
-          <node concept="3clFbS" id="ncXQh4_bkd" role="3clFbx">
-            <node concept="3cpWs6" id="ncXQh4_bke" role="3cqZAp">
-              <node concept="2ShNRf" id="5QDPRL$cWSq" role="3cqZAk">
-                <node concept="1pGfFk" id="5QDPRL$cYr$" role="2ShVmc">
-                  <ref role="37wK5l" to="xlxw:~BigDecimal.&lt;init&gt;(java.lang.String)" resolve="BigDecimal" />
-                  <node concept="2OqwBi" id="5QDPRL$cZ8B" role="37wK5m">
-                    <node concept="37vLTw" id="5QDPRL$cYOZ" role="2Oq$k0">
-                      <ref role="3cqZAo" node="ncXQh4_bkz" resolve="value" />
-                    </node>
-                    <node concept="liA8E" id="5QDPRL$cZ_J" role="2OqNvi">
-                      <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbC" id="ncXQh4_bki" role="3clFbw">
-            <node concept="10Nm6u" id="ncXQh4_bkj" role="3uHU7w" />
-            <node concept="37vLTw" id="ncXQh4_bkk" role="3uHU7B">
-              <ref role="3cqZAo" node="ncXQh4_bk_" resolve="nothingClass" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="ncXQh4_bkl" role="3cqZAp">
-          <node concept="3clFbS" id="ncXQh4_bkm" role="3clFbx">
-            <node concept="3cpWs6" id="ncXQh4_bkn" role="3cqZAp">
-              <node concept="2ShNRf" id="ncXQh4_bko" role="3cqZAk">
-                <node concept="1pGfFk" id="ncXQh4_bkp" role="2ShVmc">
-                  <ref role="37wK5l" to="xlxw:~BigDecimal.&lt;init&gt;(java.lang.String)" resolve="BigDecimal" />
-                  <node concept="Xl_RD" id="ncXQh4_bkq" role="37wK5m">
-                    <property role="Xl_RC" value="0" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="2OqwBi" id="ncXQh4_bkr" role="3clFbw">
-            <node concept="37vLTw" id="ncXQh4_bks" role="2Oq$k0">
-              <ref role="3cqZAo" node="ncXQh4_bk_" resolve="nothingClass" />
-            </node>
-            <node concept="liA8E" id="ncXQh4_bkt" role="2OqNvi">
-              <ref role="37wK5l" to="wyt6:~Class.isInstance(java.lang.Object)" resolve="isInstance" />
-              <node concept="37vLTw" id="ncXQh4_bku" role="37wK5m">
-                <ref role="3cqZAo" node="ncXQh4_bkz" resolve="value" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="ncXQh4LsrJ" role="3cqZAp">
-          <node concept="3clFbS" id="ncXQh4LsrL" role="3clFbx">
-            <node concept="3cpWs6" id="ncXQh4Lthv" role="3cqZAp">
-              <node concept="2ShNRf" id="ncXQh4Lt$i" role="3cqZAk">
-                <node concept="1pGfFk" id="ncXQh4Lu9S" role="2ShVmc">
-                  <ref role="37wK5l" to="xlxw:~BigDecimal.&lt;init&gt;(java.lang.String)" resolve="BigDecimal" />
-                  <node concept="Xl_RD" id="ncXQh4LuxO" role="37wK5m">
-                    <property role="Xl_RC" value="0" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="2ZW3vV" id="ncXQh4LsW9" role="3clFbw">
-            <node concept="3uibUv" id="ncXQh4Lt5k" role="2ZW6by">
-              <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
-            </node>
-            <node concept="37vLTw" id="ncXQh4LsLW" role="2ZW6bz">
+        <node concept="3clFbF" id="3qKzW8QEr5c" role="3cqZAp">
+          <node concept="2YIFZM" id="3qKzW8QEr6x" role="3clFbG">
+            <ref role="37wK5l" to="ppzb:ncXQh4_bka" resolve="nothingToDec" />
+            <ref role="1Pybhc" to="ppzb:1RwPUjziune" resolve="SharedMinMaxHelper" />
+            <node concept="37vLTw" id="3qKzW8QEr76" role="37wK5m">
               <ref role="3cqZAo" node="ncXQh4_bkz" resolve="value" />
             </node>
-          </node>
-        </node>
-        <node concept="3cpWs6" id="ncXQh4_bkv" role="3cqZAp">
-          <node concept="10QFUN" id="ncXQh4_bkw" role="3cqZAk">
-            <node concept="37vLTw" id="ncXQh4_bkx" role="10QFUP">
-              <ref role="3cqZAo" node="ncXQh4_bkz" resolve="value" />
-            </node>
-            <node concept="3uibUv" id="ncXQh4_dQ4" role="10QFUM">
-              <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+            <node concept="37vLTw" id="3qKzW8QEr8w" role="37wK5m">
+              <ref role="3cqZAo" node="ncXQh4_bk_" resolve="nothingClass" />
             </node>
           </node>
         </node>
@@ -2792,9 +1360,47 @@
         <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
       </node>
       <node concept="3Tm1VV" id="ncXQh4_bkC" role="1B3o_S" />
+      <node concept="2AHcQZ" id="3qKzW8QEqOQ" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+        <node concept="2B6LJw" id="3qKzW8QEqOR" role="2B76xF">
+          <ref role="2B6OnR" to="wyt6:~Deprecated.forRemoval()" resolve="forRemoval" />
+          <node concept="3clFbT" id="3qKzW8QEqOS" role="2B70Vg">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="1RwPUjziunU" role="jymVt" />
     <node concept="3Tm1VV" id="1RwPUjziunf" role="1B3o_S" />
+    <node concept="3UR2Jj" id="3qKzW8QEgCV" role="lGtFl">
+      <node concept="TZ5HI" id="3qKzW8QEgCW" role="3nqlJM">
+        <node concept="TZ5HA" id="3qKzW8QEgCX" role="3HnX3l">
+          <node concept="1dT_AC" id="3qKzW8QEha8" role="1dT_Ay">
+            <property role="1dT_AB" value="Use " />
+          </node>
+          <node concept="1dT_AA" id="3qKzW8QEhab" role="1dT_Ay">
+            <node concept="92FcH" id="3qKzW8QEhah" role="qph3F">
+              <node concept="TZ5HA" id="3qKzW8QEhaj" role="2XjZqd" />
+              <node concept="VXe08" id="3qKzW8QEkz2" role="92FcQ">
+                <ref role="VXe09" to="ppzb:1RwPUjziune" resolve="SharedMinMaxHelper" />
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="3qKzW8QEhaa" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2AHcQZ" id="3qKzW8QEgCY" role="2AJF6D">
+      <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+      <node concept="2B6LJw" id="3qKzW8QEh86" role="2B76xF">
+        <ref role="2B6OnR" to="wyt6:~Deprecated.forRemoval()" resolve="forRemoval" />
+        <node concept="3clFbT" id="3qKzW8QEha1" role="2B70Vg">
+          <property role="3clFbU" value="true" />
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="312cEu" id="6fmG8CYTWg1">
     <property role="TrG5h" value="IdentifierConfiguratorAccess" />
@@ -2972,7 +1578,7 @@
         <node concept="3cpWs6" id="26cjRABQfdt" role="3cqZAp">
           <node concept="2ZW3vV" id="26cjRABQfhs" role="3cqZAk">
             <node concept="3uibUv" id="26cjRABQfks" role="2ZW6by">
-              <ref role="3uigEE" node="3nVyItrYNyp" resolve="INixValue" />
+              <ref role="3uigEE" to="ppzb:3nVyItrYNyp" resolve="INixValue" />
             </node>
             <node concept="37vLTw" id="26cjRABQfdF" role="2ZW6bz">
               <ref role="3cqZAo" node="26cjRABQf94" resolve="other" />
@@ -2993,7 +1599,7 @@
     <node concept="2tJIrI" id="26cjRABQf4_" role="jymVt" />
     <node concept="3Tm1VV" id="3nVyItrYWd8" role="1B3o_S" />
     <node concept="3uibUv" id="3nVyItrYWdF" role="EKbjA">
-      <ref role="3uigEE" node="3nVyItrYNyp" resolve="INixValue" />
+      <ref role="3uigEE" to="ppzb:3nVyItrYNyp" resolve="INixValue" />
     </node>
   </node>
   <node concept="312cEu" id="3nVyItrYOkv">
@@ -3270,7 +1876,7 @@
         <node concept="3cpWs6" id="26cjRACBdBY" role="3cqZAp">
           <node concept="2ZW3vV" id="26cjRACBdHh" role="3cqZAk">
             <node concept="3uibUv" id="26cjRACBeK9" role="2ZW6by">
-              <ref role="3uigEE" node="3nVyItrYNyp" resolve="INixValue" />
+              <ref role="3uigEE" to="ppzb:3nVyItrYNyp" resolve="INixValue" />
             </node>
             <node concept="2OqwBi" id="26cjRACDdOK" role="2ZW6bz">
               <node concept="37vLTw" id="26cjRACDdOL" role="2Oq$k0">
@@ -3310,7 +1916,7 @@
                     <node concept="3fqX7Q" id="26cjRAD8YLX" role="3clFbG">
                       <node concept="2ZW3vV" id="26cjRAD8YLZ" role="3fr31v">
                         <node concept="3uibUv" id="26cjRAD8YM0" role="2ZW6by">
-                          <ref role="3uigEE" node="3nVyItrYNyp" resolve="INixValue" />
+                          <ref role="3uigEE" to="ppzb:3nVyItrYNyp" resolve="INixValue" />
                         </node>
                         <node concept="37vLTw" id="26cjRAD8YM1" role="2ZW6bz">
                           <ref role="3cqZAo" node="26cjRAD8RWp" resolve="it" />
@@ -3346,7 +1952,7 @@
                   <node concept="3clFbF" id="26cjRACFnDm" role="3cqZAp">
                     <node concept="2ZW3vV" id="26cjRACFog1" role="3clFbG">
                       <node concept="3uibUv" id="26cjRACFonE" role="2ZW6by">
-                        <ref role="3uigEE" node="3nVyItrYNyp" resolve="INixValue" />
+                        <ref role="3uigEE" to="ppzb:3nVyItrYNyp" resolve="INixValue" />
                       </node>
                       <node concept="37vLTw" id="26cjRACFnDl" role="2ZW6bz">
                         <ref role="3cqZAo" node="26cjRACFnx3" resolve="it" />
@@ -3381,7 +1987,7 @@
                   <node concept="3clFbF" id="26cjRADa0yb" role="3cqZAp">
                     <node concept="2ZW3vV" id="26cjRADa0yc" role="3clFbG">
                       <node concept="3uibUv" id="26cjRADa0yd" role="2ZW6by">
-                        <ref role="3uigEE" node="3nVyItrYNyp" resolve="INixValue" />
+                        <ref role="3uigEE" to="ppzb:3nVyItrYNyp" resolve="INixValue" />
                       </node>
                       <node concept="37vLTw" id="26cjRADa0ye" role="2ZW6bz">
                         <ref role="3cqZAo" node="26cjRADa0yf" resolve="it" />
@@ -4507,18 +3113,6 @@
     </node>
     <node concept="2tJIrI" id="26cjRACVUI9" role="jymVt" />
     <node concept="3Tm1VV" id="26cjRACVUN4" role="1B3o_S" />
-  </node>
-  <node concept="3HP615" id="3nVyItrYNyp">
-    <property role="3GE5qa" value="nix" />
-    <property role="TrG5h" value="INixValue" />
-    <node concept="3Tm1VV" id="3nVyItrYNyq" role="1B3o_S" />
-    <node concept="3UR2Jj" id="3iq6R$ZyUFV" role="lGtFl">
-      <node concept="TZ5HA" id="3iq6R$ZyUFW" role="TZ5H$">
-        <node concept="1dT_AC" id="3iq6R$ZyUFX" role="1dT_Ay">
-          <property role="1dT_AB" value="Represents general empty ('nothing') value for any value type." />
-        </node>
-      </node>
-    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.runtime/org.iets3.core.expr.base.runtime.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.runtime/org.iets3.core.expr.base.runtime.msd
@@ -14,6 +14,7 @@
   <dependencies>
     <dependency reexport="false">cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
@@ -63,6 +64,7 @@
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
     <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="3" />
     <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
+    <module reference="00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.shared.runtime/models/org.iets3.core.expr.base.shared.runtime.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.shared.runtime/models/org.iets3.core.expr.base.shared.runtime.mps
@@ -1,0 +1,1870 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:5db517a0-f62d-4841-a421-11bb7269799d(org.iets3.core.expr.base.shared.runtime)">
+  <persistence version="9" />
+  <languages>
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+  </languages>
+  <imports>
+    <import index="xlxw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.math(JDK/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
+        <child id="1076505808688" name="condition" index="2$JKZa" />
+      </concept>
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+        <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1164991038168" name="jetbrains.mps.baseLanguage.structure.ThrowStatement" flags="nn" index="YS8fn">
+        <child id="1164991057263" name="throwable" index="YScLw" />
+      </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <property id="1221565133444" name="isFinal" index="1EXbeo" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+        <child id="1206060520071" name="elsifClauses" index="3eNLev" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
+        <child id="1206060619838" name="condition" index="3eO9$A" />
+        <child id="1206060644605" name="statementList" index="3eOfB_" />
+      </concept>
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1107796713796" name="jetbrains.mps.baseLanguage.structure.Interface" flags="ig" index="3HP615" />
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+      <concept id="8064396509828172209" name="jetbrains.mps.baseLanguage.structure.UnaryMinus" flags="nn" index="1ZRNhn" />
+    </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="6832197706140896242" name="jetbrains.mps.baseLanguage.javadoc.structure.FieldDocComment" flags="ng" index="z59LJ" />
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
+      </concept>
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
+      </concept>
+      <concept id="2068944020170241612" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocComment" flags="ng" index="3UR2Jj" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="3HP615" id="3nVyItrYNyp">
+    <property role="3GE5qa" value="" />
+    <property role="TrG5h" value="INixValue" />
+    <node concept="3Tm1VV" id="3nVyItrYNyq" role="1B3o_S" />
+    <node concept="3UR2Jj" id="3iq6R$ZyUFV" role="lGtFl">
+      <node concept="TZ5HA" id="3iq6R$ZyUFW" role="TZ5H$">
+        <node concept="1dT_AC" id="3iq6R$ZyUFX" role="1dT_Ay">
+          <property role="1dT_AB" value="Represents general empty ('nothing') value for any value type." />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="3qKzW8QxL7h">
+    <property role="TrG5h" value="SharedInfHelper" />
+    <property role="1EXbeo" value="true" />
+    <node concept="3clFbW" id="3qKzW8QHIqT" role="jymVt">
+      <node concept="3cqZAl" id="3qKzW8QHIqU" role="3clF45" />
+      <node concept="3clFbS" id="3qKzW8QHIqW" role="3clF47" />
+      <node concept="3Tm6S6" id="3qKzW8QHIqG" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="3qKzW8QHIrd" role="jymVt" />
+    <node concept="Wx3nA" id="7Wa2sv3XRPP" role="jymVt">
+      <property role="3TUv4t" value="true" />
+      <property role="TrG5h" value="INF_PREC" />
+      <node concept="3Tm1VV" id="7kyIuXqewWi" role="1B3o_S" />
+      <node concept="10Oyi0" id="7Wa2sv3XRPN" role="1tU5fm" />
+      <node concept="3cmrfG" id="7Wa2sv3XRPO" role="33vP2m">
+        <property role="3cmrfH" value="16" />
+      </node>
+      <node concept="z59LJ" id="1VqmZU7jL_C" role="lGtFl">
+        <node concept="TZ5HA" id="1VqmZU7jL_D" role="TZ5H$">
+          <node concept="1dT_AC" id="1VqmZU7jL_E" role="1dT_Ay">
+            <property role="1dT_AB" value="Default infinite precision corresponds to the decimal digits number of the double-precision" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="Wx3nA" id="7Wa2sv3XSnr" role="jymVt">
+      <property role="3TUv4t" value="true" />
+      <property role="TrG5h" value="DEFAULT_ROUNDING" />
+      <node concept="3Tm1VV" id="7kyIuXqex5i" role="1B3o_S" />
+      <node concept="3uibUv" id="7Wa2sv3XSnp" role="1tU5fm">
+        <ref role="3uigEE" to="xlxw:~RoundingMode" resolve="RoundingMode" />
+      </node>
+      <node concept="Rm8GO" id="7Wa2sv3XSnq" role="33vP2m">
+        <ref role="1Px2BO" to="xlxw:~RoundingMode" resolve="RoundingMode" />
+        <ref role="Rm8GQ" to="xlxw:~RoundingMode.HALF_UP" resolve="HALF_UP" />
+      </node>
+      <node concept="z59LJ" id="6zU$Zuz6NV7" role="lGtFl">
+        <node concept="TZ5HA" id="6zU$Zuz6NV8" role="TZ5H$">
+          <node concept="1dT_AC" id="6zU$Zuz6NV9" role="1dT_Ay">
+            <property role="1dT_AB" value="Default rounding mode applied when converting decimals with infinite/undefined precision to decimals with INF_PREC" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3qKzW8QBgdp" role="jymVt" />
+    <node concept="3Tm1VV" id="3qKzW8QxL7i" role="1B3o_S" />
+    <node concept="3UR2Jj" id="3qKzW8QHIs2" role="lGtFl">
+      <node concept="TZ5HA" id="3qKzW8QHIs3" role="TZ5H$">
+        <node concept="1dT_AC" id="3qKzW8QHIs4" role="1dT_Ay">
+          <property role="1dT_AB" value="This class is shared between interpreter and generator, be careful when introducing extra dependencies." />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="1RwPUjziune">
+    <property role="TrG5h" value="SharedMinMaxHelper" />
+    <node concept="2tJIrI" id="1RwPUjziunM" role="jymVt" />
+    <node concept="2YIFZL" id="1RwPUjziwEu" role="jymVt">
+      <property role="TrG5h" value="max" />
+      <node concept="3uibUv" id="1RwPUjziTgX" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+      </node>
+      <node concept="3Tm1VV" id="1RwPUjziwEx" role="1B3o_S" />
+      <node concept="3clFbS" id="1RwPUjziwEy" role="3clF47">
+        <node concept="3clFbJ" id="4Q4DxjDbM3I" role="3cqZAp">
+          <node concept="37vLTw" id="1RwPUjziSd$" role="3clFbw">
+            <ref role="3cqZAo" node="1RwPUjziBhK" resolve="isReal" />
+          </node>
+          <node concept="3clFbS" id="4Q4DxjDbM3J" role="3clFbx">
+            <node concept="3cpWs8" id="4Q4DxjDbM3V" role="3cqZAp">
+              <node concept="3cpWsn" id="4Q4DxjDbM3W" role="3cpWs9">
+                <property role="TrG5h" value="iterator" />
+                <node concept="3uibUv" id="4Q4DxjDbM3X" role="1tU5fm">
+                  <ref role="3uigEE" to="33ny:~Iterator" resolve="Iterator" />
+                  <node concept="3uibUv" id="4Q4DxjDbM3Y" role="11_B2D">
+                    <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="4Q4DxjDbM3Z" role="33vP2m">
+                  <node concept="37vLTw" id="1RwPUjziSJF" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1RwPUjzi$ax" resolve="values" />
+                  </node>
+                  <node concept="liA8E" id="4Q4DxjDbM41" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Collection.iterator()" resolve="iterator" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="4Q4DxjDbM42" role="3cqZAp">
+              <node concept="3cpWsn" id="4Q4DxjDbM43" role="3cpWs9">
+                <property role="TrG5h" value="max" />
+                <node concept="3uibUv" id="ncXQh4_agi" role="1tU5fm">
+                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                </node>
+                <node concept="10Nm6u" id="3SMYSUUjsni" role="33vP2m" />
+              </node>
+            </node>
+            <node concept="2$JKZl" id="4Q4DxjDbM46" role="3cqZAp">
+              <node concept="3clFbS" id="4Q4DxjDbM47" role="2LFqv$">
+                <node concept="3cpWs8" id="4Q4DxjDbM48" role="3cqZAp">
+                  <node concept="3cpWsn" id="4Q4DxjDbM49" role="3cpWs9">
+                    <property role="TrG5h" value="next" />
+                    <node concept="3uibUv" id="4Q4DxjDbM4a" role="1tU5fm">
+                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                    </node>
+                    <node concept="2OqwBi" id="4Q4DxjDbM4b" role="33vP2m">
+                      <node concept="37vLTw" id="4Q4DxjDbM4c" role="2Oq$k0">
+                        <ref role="3cqZAo" node="4Q4DxjDbM3W" resolve="iterator" />
+                      </node>
+                      <node concept="liA8E" id="4Q4DxjDbM4d" role="2OqNvi">
+                        <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="3SMYSUUk50$" role="3cqZAp">
+                  <node concept="3cpWsn" id="3SMYSUUk50_" role="3cpWs9">
+                    <property role="TrG5h" value="element" />
+                    <node concept="3uibUv" id="ncXQh4_8Lb" role="1tU5fm">
+                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                    </node>
+                    <node concept="10Nm6u" id="3SMYSUUkcey" role="33vP2m" />
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="3SMYSUUk8tA" role="3cqZAp">
+                  <node concept="3clFbS" id="3SMYSUUk8tC" role="3clFbx">
+                    <node concept="3clFbF" id="3SMYSUUkapJ" role="3cqZAp">
+                      <node concept="37vLTI" id="3SMYSUUkbAq" role="3clFbG">
+                        <node concept="37vLTw" id="3SMYSUUkapH" role="37vLTJ">
+                          <ref role="3cqZAo" node="3SMYSUUk50_" resolve="element" />
+                        </node>
+                        <node concept="1eOMI4" id="3SMYSUUk50A" role="37vLTx">
+                          <node concept="10QFUN" id="3SMYSUUk50B" role="1eOMHV">
+                            <node concept="3uibUv" id="3SMYSUUkvcE" role="10QFUM">
+                              <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+                            </node>
+                            <node concept="37vLTw" id="3SMYSUUk50D" role="10QFUP">
+                              <ref role="3cqZAo" node="4Q4DxjDbM49" resolve="next" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2ZW3vV" id="3SMYSUUk7C9" role="3clFbw">
+                    <node concept="3uibUv" id="3SMYSUUkvDc" role="2ZW6by">
+                      <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+                    </node>
+                    <node concept="37vLTw" id="3SMYSUUk6lR" role="2ZW6bz">
+                      <ref role="3cqZAo" node="4Q4DxjDbM49" resolve="next" />
+                    </node>
+                  </node>
+                  <node concept="3eNFk2" id="3SMYSUUkcu1" role="3eNLev">
+                    <node concept="2ZW3vV" id="3SMYSUUkdm$" role="3eO9$A">
+                      <node concept="3uibUv" id="3SMYSUUkd$N" role="2ZW6by">
+                        <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
+                      </node>
+                      <node concept="37vLTw" id="3SMYSUUkc_Q" role="2ZW6bz">
+                        <ref role="3cqZAo" node="4Q4DxjDbM49" resolve="next" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="3SMYSUUkcu3" role="3eOfB_">
+                      <node concept="3clFbF" id="3SMYSUUkdOU" role="3cqZAp">
+                        <node concept="37vLTI" id="3SMYSUUkevP" role="3clFbG">
+                          <node concept="37vLTw" id="3SMYSUUkdOT" role="37vLTJ">
+                            <ref role="3cqZAo" node="3SMYSUUk50_" resolve="element" />
+                          </node>
+                          <node concept="2ShNRf" id="3SMYSUUkh2y" role="37vLTx">
+                            <node concept="1pGfFk" id="3SMYSUUkhPF" role="2ShVmc">
+                              <ref role="37wK5l" to="xlxw:~BigDecimal.&lt;init&gt;(java.lang.String)" resolve="BigDecimal" />
+                              <node concept="2OqwBi" id="3SMYSUUkfnB" role="37wK5m">
+                                <node concept="1eOMI4" id="3SMYSUUkeVF" role="2Oq$k0">
+                                  <node concept="10QFUN" id="3SMYSUUkeVC" role="1eOMHV">
+                                    <node concept="3uibUv" id="3SMYSUUkf9v" role="10QFUM">
+                                      <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
+                                    </node>
+                                    <node concept="37vLTw" id="3SMYSUUkeFE" role="10QFUP">
+                                      <ref role="3cqZAo" node="4Q4DxjDbM49" resolve="next" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="3SMYSUUkg6k" role="2OqNvi">
+                                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3eNFk2" id="ncXQh4_8hD" role="3eNLev">
+                    <node concept="1Wc70l" id="ncXQh4_8hE" role="3eO9$A">
+                      <node concept="2OqwBi" id="ncXQh4_8hF" role="3uHU7w">
+                        <node concept="37vLTw" id="ncXQh4_8hG" role="2Oq$k0">
+                          <ref role="3cqZAo" node="ncXQh4q5UR" resolve="nothingType" />
+                        </node>
+                        <node concept="liA8E" id="ncXQh4_8hH" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~Class.isInstance(java.lang.Object)" resolve="isInstance" />
+                          <node concept="37vLTw" id="ncXQh4_8hI" role="37wK5m">
+                            <ref role="3cqZAo" node="4Q4DxjDbM49" resolve="next" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3y3z36" id="ncXQh4_8hJ" role="3uHU7B">
+                        <node concept="37vLTw" id="ncXQh4_8hK" role="3uHU7B">
+                          <ref role="3cqZAo" node="ncXQh4q5UR" resolve="nothingType" />
+                        </node>
+                        <node concept="10Nm6u" id="ncXQh4_8hL" role="3uHU7w" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="ncXQh4_8hM" role="3eOfB_">
+                      <node concept="3clFbF" id="ncXQh4_8hN" role="3cqZAp">
+                        <node concept="37vLTI" id="ncXQh4_8hO" role="3clFbG">
+                          <node concept="37vLTw" id="ncXQh4_8hP" role="37vLTx">
+                            <ref role="3cqZAo" node="4Q4DxjDbM49" resolve="next" />
+                          </node>
+                          <node concept="37vLTw" id="ncXQh4_8hQ" role="37vLTJ">
+                            <ref role="3cqZAo" node="3SMYSUUk50_" resolve="element" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="9aQIb" id="3SMYSUUki9H" role="9aQIa">
+                    <node concept="3clFbS" id="3SMYSUUki9I" role="9aQI4">
+                      <node concept="YS8fn" id="3SMYSUUkivC" role="3cqZAp">
+                        <node concept="2ShNRf" id="3SMYSUUkiBe" role="YScLw">
+                          <node concept="1pGfFk" id="3SMYSUUkjme" role="2ShVmc">
+                            <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
+                            <node concept="3cpWs3" id="3SMYSUUknhu" role="37wK5m">
+                              <node concept="Xl_RD" id="3SMYSUUkow0" role="3uHU7w">
+                                <property role="Xl_RC" value=" to BigDecimal." />
+                              </node>
+                              <node concept="3cpWs3" id="3SMYSUUkl7o" role="3uHU7B">
+                                <node concept="Xl_RD" id="3SMYSUUkjv8" role="3uHU7B">
+                                  <property role="Xl_RC" value="Don't know how to cast element " />
+                                </node>
+                                <node concept="2OqwBi" id="3SMYSUUklx$" role="3uHU7w">
+                                  <node concept="37vLTw" id="3SMYSUUklgU" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="4Q4DxjDbM49" resolve="next" />
+                                  </node>
+                                  <node concept="liA8E" id="3SMYSUUklLA" role="2OqNvi">
+                                    <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="3SMYSUUpnLi" role="3cqZAp">
+                  <node concept="3clFbS" id="3SMYSUUpnLk" role="3clFbx">
+                    <node concept="3clFbF" id="3SMYSUUppE7" role="3cqZAp">
+                      <node concept="37vLTI" id="3SMYSUUppE8" role="3clFbG">
+                        <node concept="37vLTw" id="3SMYSUUppE9" role="37vLTJ">
+                          <ref role="3cqZAo" node="4Q4DxjDbM43" resolve="max" />
+                        </node>
+                        <node concept="37vLTw" id="3SMYSUUppEa" role="37vLTx">
+                          <ref role="3cqZAo" node="3SMYSUUk50_" resolve="element" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbC" id="3SMYSUUpoRC" role="3clFbw">
+                    <node concept="10Nm6u" id="3SMYSUUpp3y" role="3uHU7w" />
+                    <node concept="37vLTw" id="3SMYSUUpo8$" role="3uHU7B">
+                      <ref role="3cqZAo" node="4Q4DxjDbM43" resolve="max" />
+                    </node>
+                  </node>
+                  <node concept="9aQIb" id="3SMYSUUppeH" role="9aQIa">
+                    <node concept="3clFbS" id="3SMYSUUppeI" role="9aQI4">
+                      <node concept="3clFbJ" id="3SMYSUUjuQV" role="3cqZAp">
+                        <node concept="3clFbS" id="3SMYSUUjuQX" role="3clFbx">
+                          <node concept="3clFbF" id="3SMYSUUksLR" role="3cqZAp">
+                            <node concept="37vLTI" id="3SMYSUUktHB" role="3clFbG">
+                              <node concept="37vLTw" id="3SMYSUUksLP" role="37vLTJ">
+                                <ref role="3cqZAo" node="4Q4DxjDbM43" resolve="max" />
+                              </node>
+                              <node concept="37vLTw" id="3SMYSUUkucI" role="37vLTx">
+                                <ref role="3cqZAo" node="3SMYSUUk50_" resolve="element" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3eOSWO" id="3SMYSUUk3Nu" role="3clFbw">
+                          <node concept="3cmrfG" id="3SMYSUUk4la" role="3uHU7w">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="2OqwBi" id="3SMYSUUjZTO" role="3uHU7B">
+                            <node concept="1rXfSq" id="ncXQh4_fbQ" role="2Oq$k0">
+                              <ref role="37wK5l" node="ncXQh4_bka" resolve="nothingToDec" />
+                              <node concept="37vLTw" id="ncXQh4_fqs" role="37wK5m">
+                                <ref role="3cqZAo" node="3SMYSUUk50_" resolve="element" />
+                              </node>
+                              <node concept="37vLTw" id="ncXQh4_hIt" role="37wK5m">
+                                <ref role="3cqZAo" node="ncXQh4q5UR" resolve="nothingType" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="3SMYSUUk0pU" role="2OqNvi">
+                              <ref role="37wK5l" to="xlxw:~BigDecimal.compareTo(java.math.BigDecimal)" resolve="compareTo" />
+                              <node concept="1rXfSq" id="ncXQh4_fHo" role="37wK5m">
+                                <ref role="37wK5l" node="ncXQh4_bka" resolve="nothingToDec" />
+                                <node concept="37vLTw" id="ncXQh4_fWx" role="37wK5m">
+                                  <ref role="3cqZAo" node="4Q4DxjDbM43" resolve="max" />
+                                </node>
+                                <node concept="37vLTw" id="ncXQh4_i6M" role="37wK5m">
+                                  <ref role="3cqZAo" node="ncXQh4q5UR" resolve="nothingType" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4Q4DxjDbM4w" role="2$JKZa">
+                <node concept="37vLTw" id="4Q4DxjDbM4x" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4Q4DxjDbM3W" resolve="iterator" />
+                </node>
+                <node concept="liA8E" id="4Q4DxjDbM4y" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~Iterator.hasNext()" resolve="hasNext" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="3SMYSUUkyZp" role="3cqZAp">
+              <node concept="3clFbS" id="3SMYSUUkyZr" role="3clFbx">
+                <node concept="3cpWs6" id="4Q4DxjDbM4z" role="3cqZAp">
+                  <node concept="37vLTw" id="3SMYSUUkybf" role="3cqZAk">
+                    <ref role="3cqZAo" node="4Q4DxjDbM43" resolve="max" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3y3z36" id="3SMYSUUk$5o" role="3clFbw">
+                <node concept="10Nm6u" id="3SMYSUUk$da" role="3uHU7w" />
+                <node concept="37vLTw" id="3SMYSUUkzmn" role="3uHU7B">
+                  <ref role="3cqZAo" node="4Q4DxjDbM43" resolve="max" />
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="3SMYSUUkBZX" role="3cqZAp">
+              <node concept="1PaTwC" id="17Nm8oCo8Kh" role="1aUNEU">
+                <node concept="3oM_SD" id="17Nm8oCo8Ki" role="1PaTwD">
+                  <property role="3oM_SC" value="max" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8Kj" role="1PaTwD">
+                  <property role="3oM_SC" value="of" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8Kk" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8Kl" role="1PaTwD">
+                  <property role="3oM_SC" value="empty" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8Km" role="1PaTwD">
+                  <property role="3oM_SC" value="list" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8Kn" role="1PaTwD">
+                  <property role="3oM_SC" value="(arbitrarily" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8Ko" role="1PaTwD">
+                  <property role="3oM_SC" value="chosen" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8Kp" role="1PaTwD">
+                  <property role="3oM_SC" value="as" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8Kq" role="1PaTwD">
+                  <property role="3oM_SC" value="-Double.MAX_VALUE" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8Kr" role="1PaTwD">
+                  <property role="3oM_SC" value="since" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8Ks" role="1PaTwD">
+                  <property role="3oM_SC" value="there" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8Kt" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8Ku" role="1PaTwD">
+                  <property role="3oM_SC" value="no" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8Kv" role="1PaTwD">
+                  <property role="3oM_SC" value="-INF" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8Kw" role="1PaTwD">
+                  <property role="3oM_SC" value="in" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8Kx" role="1PaTwD">
+                  <property role="3oM_SC" value="type" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8Ky" role="1PaTwD">
+                  <property role="3oM_SC" value="BigDecimal)" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="3SMYSUUk_xj" role="3cqZAp">
+              <node concept="2YIFZM" id="3SMYSUUkAqv" role="3cqZAk">
+                <ref role="1Pybhc" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+                <ref role="37wK5l" to="xlxw:~BigDecimal.valueOf(double)" resolve="valueOf" />
+                <node concept="1ZRNhn" id="3SMYSUUkBhn" role="37wK5m">
+                  <node concept="10M0yZ" id="3SMYSUUkAYT" role="2$L3a6">
+                    <ref role="1PxDUh" to="wyt6:~Double" resolve="Double" />
+                    <ref role="3cqZAo" to="wyt6:~Double.MAX_VALUE" resolve="MAX_VALUE" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="1RwPUjziTDj" role="9aQIa">
+            <node concept="3clFbS" id="1RwPUjziTDk" role="9aQI4">
+              <node concept="3cpWs8" id="4Q4DxjDbJJf" role="3cqZAp">
+                <node concept="3cpWsn" id="4Q4DxjDbJJg" role="3cpWs9">
+                  <property role="TrG5h" value="iterator" />
+                  <node concept="3uibUv" id="4Q4DxjDbJJb" role="1tU5fm">
+                    <ref role="3uigEE" to="33ny:~Iterator" resolve="Iterator" />
+                    <node concept="3uibUv" id="4Q4DxjDbJJe" role="11_B2D">
+                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="4Q4DxjDbJJh" role="33vP2m">
+                    <node concept="37vLTw" id="1RwPUjziWys" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1RwPUjzi$ax" resolve="values" />
+                    </node>
+                    <node concept="liA8E" id="4Q4DxjDbJJj" role="2OqNvi">
+                      <ref role="37wK5l" to="33ny:~Collection.iterator()" resolve="iterator" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="4Q4DxjDbLbP" role="3cqZAp">
+                <node concept="3cpWsn" id="4Q4DxjDbLbS" role="3cpWs9">
+                  <property role="TrG5h" value="max" />
+                  <node concept="3uibUv" id="ncXQh4z0IV" role="1tU5fm">
+                    <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                  </node>
+                  <node concept="10Nm6u" id="3SMYSUUkOd$" role="33vP2m" />
+                </node>
+              </node>
+              <node concept="2$JKZl" id="4Q4DxjDbJWs" role="3cqZAp">
+                <node concept="3clFbS" id="4Q4DxjDbJWv" role="2LFqv$">
+                  <node concept="3cpWs8" id="4Q4DxjDbKiZ" role="3cqZAp">
+                    <node concept="3cpWsn" id="4Q4DxjDbKj0" role="3cpWs9">
+                      <property role="TrG5h" value="next" />
+                      <node concept="3uibUv" id="4Q4DxjDbKiY" role="1tU5fm">
+                        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                      </node>
+                      <node concept="2OqwBi" id="4Q4DxjDbKj1" role="33vP2m">
+                        <node concept="37vLTw" id="4Q4DxjDbKj2" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4Q4DxjDbJJg" resolve="iterator" />
+                        </node>
+                        <node concept="liA8E" id="4Q4DxjDbKj3" role="2OqNvi">
+                          <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="3SMYSUUkVke" role="3cqZAp">
+                    <node concept="3cpWsn" id="3SMYSUUkVkf" role="3cpWs9">
+                      <property role="TrG5h" value="element" />
+                      <node concept="3uibUv" id="ncXQh4zkYJ" role="1tU5fm">
+                        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                      </node>
+                      <node concept="10Nm6u" id="3SMYSUUkVOv" role="33vP2m" />
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="3SMYSUUkPo2" role="3cqZAp">
+                    <node concept="3clFbS" id="3SMYSUUkPo4" role="3clFbx">
+                      <node concept="3clFbF" id="3SMYSUUkWeJ" role="3cqZAp">
+                        <node concept="37vLTI" id="3SMYSUUkWTS" role="3clFbG">
+                          <node concept="37vLTw" id="3SMYSUUkWeH" role="37vLTJ">
+                            <ref role="3cqZAo" node="3SMYSUUkVkf" resolve="element" />
+                          </node>
+                          <node concept="10QFUN" id="3SMYSUUkSCD" role="37vLTx">
+                            <node concept="3uibUv" id="3SMYSUUkSQg" role="10QFUM">
+                              <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                            </node>
+                            <node concept="37vLTw" id="3SMYSUUkSmD" role="10QFUP">
+                              <ref role="3cqZAo" node="4Q4DxjDbKj0" resolve="next" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2ZW3vV" id="3SMYSUUkQvh" role="3clFbw">
+                      <node concept="3uibUv" id="3SMYSUUkQHz" role="2ZW6by">
+                        <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                      </node>
+                      <node concept="37vLTw" id="3SMYSUUkPLM" role="2ZW6bz">
+                        <ref role="3cqZAo" node="4Q4DxjDbKj0" resolve="next" />
+                      </node>
+                    </node>
+                    <node concept="3eNFk2" id="3SMYSUUkXAO" role="3eNLev">
+                      <node concept="2ZW3vV" id="3SMYSUUkYvv" role="3eO9$A">
+                        <node concept="3uibUv" id="3SMYSUUkYHM" role="2ZW6by">
+                          <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
+                        </node>
+                        <node concept="37vLTw" id="3SMYSUUkXIH" role="2ZW6bz">
+                          <ref role="3cqZAo" node="4Q4DxjDbKj0" resolve="next" />
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="3SMYSUUkXAQ" role="3eOfB_">
+                        <node concept="3clFbF" id="3SMYSUUl0il" role="3cqZAp">
+                          <node concept="37vLTI" id="3SMYSUUl11T" role="3clFbG">
+                            <node concept="2ShNRf" id="3SMYSUUl1iQ" role="37vLTx">
+                              <node concept="1pGfFk" id="3SMYSUUl263" role="2ShVmc">
+                                <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
+                                <node concept="2OqwBi" id="3SMYSUUkZ_s" role="37wK5m">
+                                  <node concept="37vLTw" id="3SMYSUUkYSR" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="4Q4DxjDbKj0" resolve="next" />
+                                  </node>
+                                  <node concept="liA8E" id="3SMYSUUkZPY" role="2OqNvi">
+                                    <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="37vLTw" id="3SMYSUUl0ij" role="37vLTJ">
+                              <ref role="3cqZAo" node="3SMYSUUkVkf" resolve="element" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3eNFk2" id="ncXQh4zW8S" role="3eNLev">
+                      <node concept="1Wc70l" id="ncXQh4zW8T" role="3eO9$A">
+                        <node concept="2OqwBi" id="ncXQh4zW8U" role="3uHU7w">
+                          <node concept="37vLTw" id="ncXQh4zW8V" role="2Oq$k0">
+                            <ref role="3cqZAo" node="ncXQh4q5UR" resolve="nothingType" />
+                          </node>
+                          <node concept="liA8E" id="ncXQh4zW8W" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~Class.isInstance(java.lang.Object)" resolve="isInstance" />
+                            <node concept="37vLTw" id="ncXQh4zW8X" role="37wK5m">
+                              <ref role="3cqZAo" node="4Q4DxjDbKj0" resolve="next" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3y3z36" id="ncXQh4zW8Y" role="3uHU7B">
+                          <node concept="37vLTw" id="ncXQh4zW8Z" role="3uHU7B">
+                            <ref role="3cqZAo" node="ncXQh4q5UR" resolve="nothingType" />
+                          </node>
+                          <node concept="10Nm6u" id="ncXQh4zW90" role="3uHU7w" />
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="ncXQh4zW91" role="3eOfB_">
+                        <node concept="3clFbF" id="ncXQh4zW92" role="3cqZAp">
+                          <node concept="37vLTI" id="ncXQh4zW93" role="3clFbG">
+                            <node concept="37vLTw" id="ncXQh4zW94" role="37vLTx">
+                              <ref role="3cqZAo" node="4Q4DxjDbKj0" resolve="next" />
+                            </node>
+                            <node concept="37vLTw" id="ncXQh4zW95" role="37vLTJ">
+                              <ref role="3cqZAo" node="3SMYSUUkVkf" resolve="element" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="9aQIb" id="3SMYSUUlazq" role="9aQIa">
+                      <node concept="3clFbS" id="3SMYSUUlazr" role="9aQI4">
+                        <node concept="YS8fn" id="3SMYSUUlaJ2" role="3cqZAp">
+                          <node concept="2ShNRf" id="3SMYSUUlaQG" role="YScLw">
+                            <node concept="1pGfFk" id="3SMYSUUlb_K" role="2ShVmc">
+                              <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
+                              <node concept="3cpWs3" id="3SMYSUUlfG8" role="37wK5m">
+                                <node concept="Xl_RD" id="3SMYSUUlgUH" role="3uHU7w">
+                                  <property role="Xl_RC" value=" to BigInteger." />
+                                </node>
+                                <node concept="3cpWs3" id="3SMYSUUldnr" role="3uHU7B">
+                                  <node concept="Xl_RD" id="3SMYSUUlbPW" role="3uHU7B">
+                                    <property role="Xl_RC" value="Don't know how to cast element " />
+                                  </node>
+                                  <node concept="2OqwBi" id="3SMYSUUldW7" role="3uHU7w">
+                                    <node concept="37vLTw" id="3SMYSUUldpg" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="4Q4DxjDbKj0" resolve="next" />
+                                    </node>
+                                    <node concept="liA8E" id="3SMYSUUlecc" role="2OqNvi">
+                                      <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="3SMYSUUpkfR" role="3cqZAp">
+                    <node concept="3clFbS" id="3SMYSUUpkfT" role="3clFbx">
+                      <node concept="3clFbF" id="3SMYSUUplOt" role="3cqZAp">
+                        <node concept="37vLTI" id="3SMYSUUpmvt" role="3clFbG">
+                          <node concept="37vLTw" id="3SMYSUUpmH3" role="37vLTx">
+                            <ref role="3cqZAo" node="3SMYSUUkVkf" resolve="element" />
+                          </node>
+                          <node concept="37vLTw" id="3SMYSUUplOr" role="37vLTJ">
+                            <ref role="3cqZAo" node="4Q4DxjDbLbS" resolve="max" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbC" id="3SMYSUUpl$4" role="3clFbw">
+                      <node concept="37vLTw" id="3SMYSUUpkAP" role="3uHU7B">
+                        <ref role="3cqZAo" node="4Q4DxjDbLbS" resolve="max" />
+                      </node>
+                      <node concept="10Nm6u" id="3SMYSUUpltI" role="3uHU7w" />
+                    </node>
+                    <node concept="9aQIb" id="3SMYSUUpmSd" role="9aQIa">
+                      <node concept="3clFbS" id="3SMYSUUpmSe" role="9aQI4">
+                        <node concept="3clFbJ" id="3SMYSUUl4gs" role="3cqZAp">
+                          <node concept="3clFbS" id="3SMYSUUl4gu" role="3clFbx">
+                            <node concept="3clFbF" id="3SMYSUUl9jz" role="3cqZAp">
+                              <node concept="37vLTI" id="3SMYSUUl9Y$" role="3clFbG">
+                                <node concept="37vLTw" id="3SMYSUUlacb" role="37vLTx">
+                                  <ref role="3cqZAo" node="3SMYSUUkVkf" resolve="element" />
+                                </node>
+                                <node concept="37vLTw" id="3SMYSUUl9jx" role="37vLTJ">
+                                  <ref role="3cqZAo" node="4Q4DxjDbLbS" resolve="max" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3eOSWO" id="3SMYSUUl8MY" role="3clFbw">
+                            <node concept="3cmrfG" id="3SMYSUUl8Zq" role="3uHU7w">
+                              <property role="3cmrfH" value="0" />
+                            </node>
+                            <node concept="2OqwBi" id="3SMYSUUl5ap" role="3uHU7B">
+                              <node concept="1rXfSq" id="ncXQh4zmpC" role="2Oq$k0">
+                                <ref role="37wK5l" node="ncXQh4z3V8" resolve="nothingToInt" />
+                                <node concept="37vLTw" id="ncXQh4zmNY" role="37wK5m">
+                                  <ref role="3cqZAo" node="3SMYSUUkVkf" resolve="element" />
+                                </node>
+                                <node concept="37vLTw" id="ncXQh4znfB" role="37wK5m">
+                                  <ref role="3cqZAo" node="ncXQh4q5UR" resolve="nothingType" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="3SMYSUUl63$" role="2OqNvi">
+                                <ref role="37wK5l" to="xlxw:~BigInteger.compareTo(java.math.BigInteger)" resolve="compareTo" />
+                                <node concept="1rXfSq" id="ncXQh4z5iv" role="37wK5m">
+                                  <ref role="37wK5l" node="ncXQh4z3V8" resolve="nothingToInt" />
+                                  <node concept="37vLTw" id="ncXQh4z5J2" role="37wK5m">
+                                    <ref role="3cqZAo" node="4Q4DxjDbLbS" resolve="max" />
+                                  </node>
+                                  <node concept="37vLTw" id="ncXQh4z6vc" role="37wK5m">
+                                    <ref role="3cqZAo" node="ncXQh4q5UR" resolve="nothingType" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="4Q4DxjDbK1R" role="2$JKZa">
+                  <node concept="37vLTw" id="4Q4DxjDbK0n" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4Q4DxjDbJJg" resolve="iterator" />
+                  </node>
+                  <node concept="liA8E" id="4Q4DxjDbK5j" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Iterator.hasNext()" resolve="hasNext" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="3SMYSUUkE9g" role="3cqZAp">
+                <node concept="3clFbS" id="3SMYSUUkE9i" role="3clFbx">
+                  <node concept="3cpWs6" id="3SMYSUUkInv" role="3cqZAp">
+                    <node concept="37vLTw" id="3SMYSUUkJ1d" role="3cqZAk">
+                      <ref role="3cqZAo" node="4Q4DxjDbLbS" resolve="max" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3y3z36" id="3SMYSUUkIav" role="3clFbw">
+                  <node concept="10Nm6u" id="3SMYSUUkIck" role="3uHU7w" />
+                  <node concept="37vLTw" id="3SMYSUUkELW" role="3uHU7B">
+                    <ref role="3cqZAo" node="4Q4DxjDbLbS" resolve="max" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3SKdUt" id="3SMYSUUkN4N" role="3cqZAp">
+                <node concept="1PaTwC" id="17Nm8oCo8Kz" role="1aUNEU">
+                  <node concept="3oM_SD" id="17Nm8oCo8K$" role="1PaTwD">
+                    <property role="3oM_SC" value="max" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8K_" role="1PaTwD">
+                    <property role="3oM_SC" value="of" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8KA" role="1PaTwD">
+                    <property role="3oM_SC" value="the" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8KB" role="1PaTwD">
+                    <property role="3oM_SC" value="empty" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8KC" role="1PaTwD">
+                    <property role="3oM_SC" value="list" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8KD" role="1PaTwD">
+                    <property role="3oM_SC" value="(arbitrarily" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8KE" role="1PaTwD">
+                    <property role="3oM_SC" value="chosen" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8KF" role="1PaTwD">
+                    <property role="3oM_SC" value="as" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8KG" role="1PaTwD">
+                    <property role="3oM_SC" value="Long.MIN_VALUE" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8KH" role="1PaTwD">
+                    <property role="3oM_SC" value="since" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8KI" role="1PaTwD">
+                    <property role="3oM_SC" value="there" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8KJ" role="1PaTwD">
+                    <property role="3oM_SC" value="is" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8KK" role="1PaTwD">
+                    <property role="3oM_SC" value="no" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8KL" role="1PaTwD">
+                    <property role="3oM_SC" value="-INF" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8KM" role="1PaTwD">
+                    <property role="3oM_SC" value="in" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8KN" role="1PaTwD">
+                    <property role="3oM_SC" value="type" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8KO" role="1PaTwD">
+                    <property role="3oM_SC" value="BigInteger)" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs6" id="1RwPUjzjmil" role="3cqZAp">
+                <node concept="2YIFZM" id="1RwPUjzjmim" role="3cqZAk">
+                  <ref role="1Pybhc" to="xlxw:~BigInteger" resolve="BigInteger" />
+                  <ref role="37wK5l" to="xlxw:~BigInteger.valueOf(long)" resolve="valueOf" />
+                  <node concept="10M0yZ" id="3SMYSUUkLkN" role="37wK5m">
+                    <ref role="1PxDUh" to="wyt6:~Long" resolve="Long" />
+                    <ref role="3cqZAo" to="wyt6:~Long.MIN_VALUE" resolve="MIN_VALUE" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="1RwPUjzi$ax" role="3clF46">
+        <property role="TrG5h" value="values" />
+        <node concept="3uibUv" id="1RwPUjzi$Dx" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1RwPUjziBhK" role="3clF46">
+        <property role="TrG5h" value="isReal" />
+        <node concept="10P_77" id="1RwPUjziBl_" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="ncXQh4q5UR" role="3clF46">
+        <property role="TrG5h" value="nothingType" />
+        <node concept="3uibUv" id="ncXQh4q6AX" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Class" resolve="Class" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="ncXQh4pyFZ" role="jymVt" />
+    <node concept="2tJIrI" id="ncXQh4pyTo" role="jymVt" />
+    <node concept="2YIFZL" id="1RwPUjzjkk_" role="jymVt">
+      <property role="TrG5h" value="min" />
+      <node concept="3uibUv" id="1RwPUjzjkkA" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+      </node>
+      <node concept="3Tm1VV" id="1RwPUjzjkkB" role="1B3o_S" />
+      <node concept="3clFbS" id="1RwPUjzjkkC" role="3clF47">
+        <node concept="3clFbJ" id="1RwPUjzjkkD" role="3cqZAp">
+          <node concept="37vLTw" id="1RwPUjzjkkE" role="3clFbw">
+            <ref role="3cqZAo" node="1RwPUjzjkm5" resolve="isReal" />
+          </node>
+          <node concept="3clFbS" id="1RwPUjzjkkF" role="3clFbx">
+            <node concept="3cpWs8" id="6HHp2WnvqX_" role="3cqZAp">
+              <node concept="3cpWsn" id="6HHp2WnvqXA" role="3cpWs9">
+                <property role="TrG5h" value="iterator" />
+                <node concept="3uibUv" id="6HHp2WnvqXB" role="1tU5fm">
+                  <ref role="3uigEE" to="33ny:~Iterator" resolve="Iterator" />
+                  <node concept="3uibUv" id="6HHp2WnvqXC" role="11_B2D">
+                    <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="6HHp2WnvqXD" role="33vP2m">
+                  <node concept="37vLTw" id="1RwPUjzjwhC" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1RwPUjzjkm3" resolve="values" />
+                  </node>
+                  <node concept="liA8E" id="6HHp2WnvqXF" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Collection.iterator()" resolve="iterator" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="6HHp2WnvqXG" role="3cqZAp">
+              <node concept="3cpWsn" id="6HHp2WnvqXH" role="3cpWs9">
+                <property role="TrG5h" value="min" />
+                <node concept="3uibUv" id="ncXQh4_iu4" role="1tU5fm">
+                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                </node>
+                <node concept="10Nm6u" id="3SMYSUUtxJx" role="33vP2m" />
+              </node>
+            </node>
+            <node concept="2$JKZl" id="6HHp2WnvqXK" role="3cqZAp">
+              <node concept="3clFbS" id="6HHp2WnvqXL" role="2LFqv$">
+                <node concept="3cpWs8" id="6HHp2WnvqXM" role="3cqZAp">
+                  <node concept="3cpWsn" id="6HHp2WnvqXN" role="3cpWs9">
+                    <property role="TrG5h" value="next" />
+                    <node concept="3uibUv" id="6HHp2WnvqXO" role="1tU5fm">
+                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                    </node>
+                    <node concept="2OqwBi" id="6HHp2WnvqXP" role="33vP2m">
+                      <node concept="37vLTw" id="6HHp2WnvqXQ" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6HHp2WnvqXA" resolve="iterator" />
+                      </node>
+                      <node concept="liA8E" id="6HHp2WnvqXR" role="2OqNvi">
+                        <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="3SMYSUUtzES" role="3cqZAp">
+                  <node concept="3cpWsn" id="3SMYSUUtzET" role="3cpWs9">
+                    <property role="TrG5h" value="element" />
+                    <node concept="3uibUv" id="ncXQh4_jv1" role="1tU5fm">
+                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                    </node>
+                    <node concept="10Nm6u" id="3SMYSUUtzEV" role="33vP2m" />
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="3SMYSUUtzEW" role="3cqZAp">
+                  <node concept="3clFbS" id="3SMYSUUtzEX" role="3clFbx">
+                    <node concept="3clFbF" id="3SMYSUUtzEY" role="3cqZAp">
+                      <node concept="37vLTI" id="3SMYSUUtzEZ" role="3clFbG">
+                        <node concept="37vLTw" id="3SMYSUUtzF0" role="37vLTJ">
+                          <ref role="3cqZAo" node="3SMYSUUtzET" resolve="element" />
+                        </node>
+                        <node concept="1eOMI4" id="3SMYSUUtzF1" role="37vLTx">
+                          <node concept="10QFUN" id="3SMYSUUtzF2" role="1eOMHV">
+                            <node concept="3uibUv" id="3SMYSUUtzF3" role="10QFUM">
+                              <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+                            </node>
+                            <node concept="37vLTw" id="3SMYSUUtzF4" role="10QFUP">
+                              <ref role="3cqZAo" node="6HHp2WnvqXN" resolve="next" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2ZW3vV" id="3SMYSUUtzF5" role="3clFbw">
+                    <node concept="3uibUv" id="3SMYSUUtzF6" role="2ZW6by">
+                      <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+                    </node>
+                    <node concept="37vLTw" id="3SMYSUUtzF7" role="2ZW6bz">
+                      <ref role="3cqZAo" node="6HHp2WnvqXN" resolve="next" />
+                    </node>
+                  </node>
+                  <node concept="3eNFk2" id="3SMYSUUtzF8" role="3eNLev">
+                    <node concept="2ZW3vV" id="3SMYSUUtzF9" role="3eO9$A">
+                      <node concept="3uibUv" id="3SMYSUUtzFa" role="2ZW6by">
+                        <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
+                      </node>
+                      <node concept="37vLTw" id="3SMYSUUtzFb" role="2ZW6bz">
+                        <ref role="3cqZAo" node="6HHp2WnvqXN" resolve="next" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="3SMYSUUtzFc" role="3eOfB_">
+                      <node concept="3clFbF" id="3SMYSUUtzFd" role="3cqZAp">
+                        <node concept="37vLTI" id="3SMYSUUtzFe" role="3clFbG">
+                          <node concept="37vLTw" id="3SMYSUUtzFf" role="37vLTJ">
+                            <ref role="3cqZAo" node="3SMYSUUtzET" resolve="element" />
+                          </node>
+                          <node concept="2ShNRf" id="3SMYSUUtzFg" role="37vLTx">
+                            <node concept="1pGfFk" id="3SMYSUUtzFh" role="2ShVmc">
+                              <ref role="37wK5l" to="xlxw:~BigDecimal.&lt;init&gt;(java.lang.String)" resolve="BigDecimal" />
+                              <node concept="2OqwBi" id="3SMYSUUtzFi" role="37wK5m">
+                                <node concept="1eOMI4" id="3SMYSUUtzFj" role="2Oq$k0">
+                                  <node concept="10QFUN" id="3SMYSUUtzFk" role="1eOMHV">
+                                    <node concept="3uibUv" id="3SMYSUUtzFl" role="10QFUM">
+                                      <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
+                                    </node>
+                                    <node concept="37vLTw" id="3SMYSUUtzFm" role="10QFUP">
+                                      <ref role="3cqZAo" node="6HHp2WnvqXN" resolve="next" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="3SMYSUUtzFn" role="2OqNvi">
+                                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3eNFk2" id="5QDPRL$feXr" role="3eNLev">
+                    <node concept="1Wc70l" id="5QDPRL$feXs" role="3eO9$A">
+                      <node concept="2OqwBi" id="5QDPRL$feXt" role="3uHU7w">
+                        <node concept="37vLTw" id="5QDPRL$feXu" role="2Oq$k0">
+                          <ref role="3cqZAo" node="ncXQh4qfxK" resolve="nothingType" />
+                        </node>
+                        <node concept="liA8E" id="5QDPRL$feXv" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~Class.isInstance(java.lang.Object)" resolve="isInstance" />
+                          <node concept="37vLTw" id="5QDPRL$feXw" role="37wK5m">
+                            <ref role="3cqZAo" node="6HHp2WnvqXN" resolve="next" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3y3z36" id="5QDPRL$feXx" role="3uHU7B">
+                        <node concept="37vLTw" id="5QDPRL$feXy" role="3uHU7B">
+                          <ref role="3cqZAo" node="ncXQh4qfxK" resolve="nothingType" />
+                        </node>
+                        <node concept="10Nm6u" id="5QDPRL$feXz" role="3uHU7w" />
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="5QDPRL$feX$" role="3eOfB_">
+                      <node concept="3clFbF" id="5QDPRL$feX_" role="3cqZAp">
+                        <node concept="37vLTI" id="5QDPRL$feXA" role="3clFbG">
+                          <node concept="37vLTw" id="5QDPRL$feXB" role="37vLTx">
+                            <ref role="3cqZAo" node="6HHp2WnvqXN" resolve="next" />
+                          </node>
+                          <node concept="37vLTw" id="5QDPRL$feXC" role="37vLTJ">
+                            <ref role="3cqZAo" node="3SMYSUUtzET" resolve="element" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="9aQIb" id="3SMYSUUtzFo" role="9aQIa">
+                    <node concept="3clFbS" id="3SMYSUUtzFp" role="9aQI4">
+                      <node concept="YS8fn" id="3SMYSUUtzFq" role="3cqZAp">
+                        <node concept="2ShNRf" id="3SMYSUUtzFr" role="YScLw">
+                          <node concept="1pGfFk" id="3SMYSUUtzFs" role="2ShVmc">
+                            <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
+                            <node concept="3cpWs3" id="3SMYSUUtzFt" role="37wK5m">
+                              <node concept="Xl_RD" id="3SMYSUUtzFu" role="3uHU7w">
+                                <property role="Xl_RC" value=" to BigDecimal." />
+                              </node>
+                              <node concept="3cpWs3" id="3SMYSUUtzFv" role="3uHU7B">
+                                <node concept="Xl_RD" id="3SMYSUUtzFw" role="3uHU7B">
+                                  <property role="Xl_RC" value="Don't know how to cast element " />
+                                </node>
+                                <node concept="2OqwBi" id="3SMYSUUtzFx" role="3uHU7w">
+                                  <node concept="37vLTw" id="3SMYSUUtzFy" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="6HHp2WnvqXN" resolve="next" />
+                                  </node>
+                                  <node concept="liA8E" id="3SMYSUUtzFz" role="2OqNvi">
+                                    <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbH" id="3SMYSUUtzm4" role="3cqZAp" />
+                <node concept="3clFbJ" id="3SMYSUUt_9X" role="3cqZAp">
+                  <node concept="3clFbS" id="3SMYSUUt_9Z" role="3clFbx">
+                    <node concept="3clFbF" id="3SMYSUUtAQe" role="3cqZAp">
+                      <node concept="37vLTI" id="3SMYSUUtBxd" role="3clFbG">
+                        <node concept="37vLTw" id="3SMYSUUtBIM" role="37vLTx">
+                          <ref role="3cqZAo" node="3SMYSUUtzET" resolve="element" />
+                        </node>
+                        <node concept="37vLTw" id="3SMYSUUtAQc" role="37vLTJ">
+                          <ref role="3cqZAo" node="6HHp2WnvqXH" resolve="min" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbC" id="3SMYSUUtAq8" role="3clFbw">
+                    <node concept="10Nm6u" id="3SMYSUUtAA1" role="3uHU7w" />
+                    <node concept="37vLTw" id="3SMYSUUt_F5" role="3uHU7B">
+                      <ref role="3cqZAo" node="6HHp2WnvqXH" resolve="min" />
+                    </node>
+                  </node>
+                  <node concept="9aQIb" id="3SMYSUUtBY0" role="9aQIa">
+                    <node concept="3clFbS" id="3SMYSUUtBY1" role="9aQI4">
+                      <node concept="3clFbJ" id="3SMYSUUtCeh" role="3cqZAp">
+                        <node concept="3eOVzh" id="3SMYSUUtGx$" role="3clFbw">
+                          <node concept="3cmrfG" id="3SMYSUUtGHy" role="3uHU7w">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="2OqwBi" id="3SMYSUUtCS9" role="3uHU7B">
+                            <node concept="liA8E" id="3SMYSUUtDLe" role="2OqNvi">
+                              <ref role="37wK5l" to="xlxw:~BigDecimal.compareTo(java.math.BigDecimal)" resolve="compareTo" />
+                              <node concept="1rXfSq" id="ncXQh4_kWc" role="37wK5m">
+                                <ref role="37wK5l" node="ncXQh4_bka" resolve="nothingToDec" />
+                                <node concept="37vLTw" id="ncXQh4_lev" role="37wK5m">
+                                  <ref role="3cqZAo" node="6HHp2WnvqXH" resolve="min" />
+                                </node>
+                                <node concept="37vLTw" id="ncXQh4_lz5" role="37wK5m">
+                                  <ref role="3cqZAo" node="ncXQh4qfxK" resolve="nothingType" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="1rXfSq" id="ncXQh4_khP" role="2Oq$k0">
+                              <ref role="37wK5l" node="ncXQh4_bka" resolve="nothingToDec" />
+                              <node concept="37vLTw" id="ncXQh4_khQ" role="37wK5m">
+                                <ref role="3cqZAo" node="3SMYSUUtzET" resolve="element" />
+                              </node>
+                              <node concept="37vLTw" id="ncXQh4_kI0" role="37wK5m">
+                                <ref role="3cqZAo" node="ncXQh4qfxK" resolve="nothingType" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbS" id="3SMYSUUtCej" role="3clFbx">
+                          <node concept="3clFbF" id="3SMYSUUtH1C" role="3cqZAp">
+                            <node concept="37vLTI" id="3SMYSUUtHGy" role="3clFbG">
+                              <node concept="37vLTw" id="3SMYSUUtHU7" role="37vLTx">
+                                <ref role="3cqZAo" node="3SMYSUUtzET" resolve="element" />
+                              </node>
+                              <node concept="37vLTw" id="3SMYSUUtH1B" role="37vLTJ">
+                                <ref role="3cqZAo" node="6HHp2WnvqXH" resolve="min" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="6HHp2WnvqYa" role="2$JKZa">
+                <node concept="37vLTw" id="6HHp2WnvqYb" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6HHp2WnvqXA" resolve="iterator" />
+                </node>
+                <node concept="liA8E" id="6HHp2WnvqYc" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~Iterator.hasNext()" resolve="hasNext" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="3SMYSUUts5J" role="3cqZAp">
+              <node concept="3clFbS" id="3SMYSUUts5L" role="3clFbx">
+                <node concept="3cpWs6" id="3SMYSUUtvhC" role="3cqZAp">
+                  <node concept="37vLTw" id="3SMYSUUtvN9" role="3cqZAk">
+                    <ref role="3cqZAo" node="6HHp2WnvqXH" resolve="min" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3y3z36" id="3SMYSUUtv6p" role="3clFbw">
+                <node concept="37vLTw" id="3SMYSUUtsyU" role="3uHU7B">
+                  <ref role="3cqZAo" node="6HHp2WnvqXH" resolve="min" />
+                </node>
+                <node concept="10Nm6u" id="3SMYSUUtv0q" role="3uHU7w" />
+              </node>
+            </node>
+            <node concept="3SKdUt" id="3SMYSUUtyy8" role="3cqZAp">
+              <node concept="1PaTwC" id="17Nm8oCo8KP" role="1aUNEU">
+                <node concept="3oM_SD" id="17Nm8oCo8KQ" role="1PaTwD">
+                  <property role="3oM_SC" value="min" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8KR" role="1PaTwD">
+                  <property role="3oM_SC" value="of" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8KS" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8KT" role="1PaTwD">
+                  <property role="3oM_SC" value="empty" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8KU" role="1PaTwD">
+                  <property role="3oM_SC" value="list" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8KV" role="1PaTwD">
+                  <property role="3oM_SC" value="(arbitrarily" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8KW" role="1PaTwD">
+                  <property role="3oM_SC" value="chosen" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8KX" role="1PaTwD">
+                  <property role="3oM_SC" value="as" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8KY" role="1PaTwD">
+                  <property role="3oM_SC" value="Double.MAX_VALUE" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8KZ" role="1PaTwD">
+                  <property role="3oM_SC" value="since" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8L0" role="1PaTwD">
+                  <property role="3oM_SC" value="there" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8L1" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8L2" role="1PaTwD">
+                  <property role="3oM_SC" value="no" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8L3" role="1PaTwD">
+                  <property role="3oM_SC" value="INF" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8L4" role="1PaTwD">
+                  <property role="3oM_SC" value="in" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8L5" role="1PaTwD">
+                  <property role="3oM_SC" value="type" />
+                </node>
+                <node concept="3oM_SD" id="17Nm8oCo8L6" role="1PaTwD">
+                  <property role="3oM_SC" value="BigDecimal)" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="6HHp2WnvqYd" role="3cqZAp">
+              <node concept="2YIFZM" id="s2V0$62ke1" role="3cqZAk">
+                <ref role="37wK5l" to="xlxw:~BigDecimal.valueOf(double)" resolve="valueOf" />
+                <ref role="1Pybhc" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+                <node concept="10M0yZ" id="oG0sI$C_Yh" role="37wK5m">
+                  <ref role="3cqZAo" to="wyt6:~Double.MAX_VALUE" resolve="MAX_VALUE" />
+                  <ref role="1PxDUh" to="wyt6:~Double" resolve="Double" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="1RwPUjzjkln" role="9aQIa">
+            <node concept="3clFbS" id="1RwPUjzjklo" role="9aQI4">
+              <node concept="3cpWs8" id="6HHp2WnvqWE" role="3cqZAp">
+                <node concept="3cpWsn" id="6HHp2WnvqWF" role="3cpWs9">
+                  <property role="TrG5h" value="iterator" />
+                  <node concept="3uibUv" id="6HHp2WnvqWG" role="1tU5fm">
+                    <ref role="3uigEE" to="33ny:~Iterator" resolve="Iterator" />
+                    <node concept="3uibUv" id="6HHp2WnvqWH" role="11_B2D">
+                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="6HHp2WnvqWI" role="33vP2m">
+                    <node concept="37vLTw" id="1RwPUjzjrG3" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1RwPUjzjkm3" resolve="values" />
+                    </node>
+                    <node concept="liA8E" id="6HHp2WnvqWK" role="2OqNvi">
+                      <ref role="37wK5l" to="33ny:~Collection.iterator()" resolve="iterator" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="6HHp2WnvqWL" role="3cqZAp">
+                <node concept="3cpWsn" id="6HHp2WnvqWM" role="3cpWs9">
+                  <property role="TrG5h" value="min" />
+                  <node concept="3uibUv" id="ncXQh4zfR2" role="1tU5fm">
+                    <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                  </node>
+                  <node concept="10Nm6u" id="3SMYSUUtQXX" role="33vP2m" />
+                </node>
+              </node>
+              <node concept="2$JKZl" id="6HHp2WnvqWP" role="3cqZAp">
+                <node concept="3clFbS" id="6HHp2WnvqWQ" role="2LFqv$">
+                  <node concept="3cpWs8" id="6HHp2WnvqWR" role="3cqZAp">
+                    <node concept="3cpWsn" id="6HHp2WnvqWS" role="3cpWs9">
+                      <property role="TrG5h" value="next" />
+                      <node concept="3uibUv" id="6HHp2WnvqWT" role="1tU5fm">
+                        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                      </node>
+                      <node concept="2OqwBi" id="6HHp2WnvqWU" role="33vP2m">
+                        <node concept="37vLTw" id="6HHp2WnvqWV" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6HHp2WnvqWF" resolve="iterator" />
+                        </node>
+                        <node concept="liA8E" id="6HHp2WnvqWW" role="2OqNvi">
+                          <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="3SMYSUUtT$I" role="3cqZAp">
+                    <node concept="3cpWsn" id="3SMYSUUtT$J" role="3cpWs9">
+                      <property role="TrG5h" value="element" />
+                      <node concept="3uibUv" id="ncXQh4ze7w" role="1tU5fm">
+                        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                      </node>
+                      <node concept="10Nm6u" id="3SMYSUUtT$L" role="33vP2m" />
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="3SMYSUUtT$M" role="3cqZAp">
+                    <node concept="3clFbS" id="3SMYSUUtT$N" role="3clFbx">
+                      <node concept="3clFbF" id="3SMYSUUtT$O" role="3cqZAp">
+                        <node concept="37vLTI" id="3SMYSUUtT$P" role="3clFbG">
+                          <node concept="37vLTw" id="3SMYSUUtT$Q" role="37vLTJ">
+                            <ref role="3cqZAo" node="3SMYSUUtT$J" resolve="element" />
+                          </node>
+                          <node concept="10QFUN" id="3SMYSUUtT$R" role="37vLTx">
+                            <node concept="3uibUv" id="3SMYSUUtT$S" role="10QFUM">
+                              <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                            </node>
+                            <node concept="37vLTw" id="3SMYSUUtT$T" role="10QFUP">
+                              <ref role="3cqZAo" node="6HHp2WnvqWS" resolve="next" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2ZW3vV" id="3SMYSUUtT$U" role="3clFbw">
+                      <node concept="3uibUv" id="3SMYSUUtT$V" role="2ZW6by">
+                        <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                      </node>
+                      <node concept="37vLTw" id="3SMYSUUtT$W" role="2ZW6bz">
+                        <ref role="3cqZAo" node="6HHp2WnvqWS" resolve="next" />
+                      </node>
+                    </node>
+                    <node concept="3eNFk2" id="3SMYSUUtT$X" role="3eNLev">
+                      <node concept="2ZW3vV" id="3SMYSUUtT$Y" role="3eO9$A">
+                        <node concept="3uibUv" id="3SMYSUUtT$Z" role="2ZW6by">
+                          <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
+                        </node>
+                        <node concept="37vLTw" id="3SMYSUUtT_0" role="2ZW6bz">
+                          <ref role="3cqZAo" node="6HHp2WnvqWS" resolve="next" />
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="3SMYSUUtT_1" role="3eOfB_">
+                        <node concept="3clFbF" id="3SMYSUUtT_2" role="3cqZAp">
+                          <node concept="37vLTI" id="3SMYSUUtT_3" role="3clFbG">
+                            <node concept="2ShNRf" id="3SMYSUUtT_4" role="37vLTx">
+                              <node concept="1pGfFk" id="3SMYSUUtT_5" role="2ShVmc">
+                                <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
+                                <node concept="2OqwBi" id="3SMYSUUtT_6" role="37wK5m">
+                                  <node concept="37vLTw" id="3SMYSUUtT_7" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="6HHp2WnvqWS" resolve="next" />
+                                  </node>
+                                  <node concept="liA8E" id="3SMYSUUtT_8" role="2OqNvi">
+                                    <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="37vLTw" id="3SMYSUUtT_9" role="37vLTJ">
+                              <ref role="3cqZAo" node="3SMYSUUtT$J" resolve="element" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3eNFk2" id="ncXQh4zRwQ" role="3eNLev">
+                      <node concept="1Wc70l" id="ncXQh4zTX0" role="3eO9$A">
+                        <node concept="2OqwBi" id="ncXQh4zUx3" role="3uHU7w">
+                          <node concept="37vLTw" id="ncXQh4zUae" role="2Oq$k0">
+                            <ref role="3cqZAo" node="ncXQh4qfxK" resolve="nothingType" />
+                          </node>
+                          <node concept="liA8E" id="ncXQh4zUZy" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~Class.isInstance(java.lang.Object)" resolve="isInstance" />
+                            <node concept="37vLTw" id="ncXQh4zVca" role="37wK5m">
+                              <ref role="3cqZAo" node="6HHp2WnvqWS" resolve="next" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3y3z36" id="ncXQh4zTGP" role="3uHU7B">
+                          <node concept="37vLTw" id="ncXQh4zTmf" role="3uHU7B">
+                            <ref role="3cqZAo" node="ncXQh4qfxK" resolve="nothingType" />
+                          </node>
+                          <node concept="10Nm6u" id="ncXQh4zTQG" role="3uHU7w" />
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="ncXQh4zRwS" role="3eOfB_">
+                        <node concept="3clFbF" id="ncXQh4zVrS" role="3cqZAp">
+                          <node concept="37vLTI" id="ncXQh4zV_c" role="3clFbG">
+                            <node concept="37vLTw" id="ncXQh4zVFj" role="37vLTx">
+                              <ref role="3cqZAo" node="6HHp2WnvqWS" resolve="next" />
+                            </node>
+                            <node concept="37vLTw" id="ncXQh4zVrR" role="37vLTJ">
+                              <ref role="3cqZAo" node="3SMYSUUtT$J" resolve="element" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="9aQIb" id="3SMYSUUtT_a" role="9aQIa">
+                      <node concept="3clFbS" id="3SMYSUUtT_b" role="9aQI4">
+                        <node concept="YS8fn" id="3SMYSUUtT_c" role="3cqZAp">
+                          <node concept="2ShNRf" id="3SMYSUUtT_d" role="YScLw">
+                            <node concept="1pGfFk" id="3SMYSUUtT_e" role="2ShVmc">
+                              <ref role="37wK5l" to="wyt6:~RuntimeException.&lt;init&gt;(java.lang.String)" resolve="RuntimeException" />
+                              <node concept="3cpWs3" id="3SMYSUUtT_f" role="37wK5m">
+                                <node concept="Xl_RD" id="3SMYSUUtT_g" role="3uHU7w">
+                                  <property role="Xl_RC" value=" to BigInteger." />
+                                </node>
+                                <node concept="3cpWs3" id="3SMYSUUtT_h" role="3uHU7B">
+                                  <node concept="Xl_RD" id="3SMYSUUtT_i" role="3uHU7B">
+                                    <property role="Xl_RC" value="Don't know how to cast element " />
+                                  </node>
+                                  <node concept="2OqwBi" id="3SMYSUUtT_j" role="3uHU7w">
+                                    <node concept="37vLTw" id="3SMYSUUtT_k" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="6HHp2WnvqWS" resolve="next" />
+                                    </node>
+                                    <node concept="liA8E" id="3SMYSUUtT_l" role="2OqNvi">
+                                      <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="3SMYSUUtTcS" role="3cqZAp" />
+                  <node concept="3clFbJ" id="3SMYSUUtV6$" role="3cqZAp">
+                    <node concept="3clFbS" id="3SMYSUUtV6A" role="3clFbx">
+                      <node concept="3clFbF" id="3SMYSUUtWPD" role="3cqZAp">
+                        <node concept="37vLTI" id="3SMYSUUtXwE" role="3clFbG">
+                          <node concept="37vLTw" id="3SMYSUUtXIc" role="37vLTx">
+                            <ref role="3cqZAo" node="3SMYSUUtT$J" resolve="element" />
+                          </node>
+                          <node concept="37vLTw" id="3SMYSUUtWPB" role="37vLTJ">
+                            <ref role="3cqZAo" node="6HHp2WnvqWM" resolve="min" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbC" id="3SMYSUUtWpv" role="3clFbw">
+                      <node concept="10Nm6u" id="3SMYSUUtW_q" role="3uHU7w" />
+                      <node concept="37vLTw" id="3SMYSUUtVEq" role="3uHU7B">
+                        <ref role="3cqZAo" node="6HHp2WnvqWM" resolve="min" />
+                      </node>
+                    </node>
+                    <node concept="9aQIb" id="3SMYSUUtXTp" role="9aQIa">
+                      <node concept="3clFbS" id="3SMYSUUtXTq" role="9aQI4">
+                        <node concept="3clFbJ" id="3SMYSUUtY9G" role="3cqZAp">
+                          <node concept="3eOVzh" id="3SMYSUUu2pb" role="3clFbw">
+                            <node concept="3cmrfG" id="3SMYSUUu2_b" role="3uHU7w">
+                              <property role="3cmrfH" value="0" />
+                            </node>
+                            <node concept="2OqwBi" id="3SMYSUUtYJ_" role="3uHU7B">
+                              <node concept="1rXfSq" id="ncXQh4zhMR" role="2Oq$k0">
+                                <ref role="37wK5l" node="ncXQh4z3V8" resolve="nothingToInt" />
+                                <node concept="37vLTw" id="ncXQh4zicr" role="37wK5m">
+                                  <ref role="3cqZAo" node="3SMYSUUtT$J" resolve="element" />
+                                </node>
+                                <node concept="37vLTw" id="ncXQh4ziBj" role="37wK5m">
+                                  <ref role="3cqZAo" node="ncXQh4qfxK" resolve="nothingType" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="3SMYSUUtZCG" role="2OqNvi">
+                                <ref role="37wK5l" to="xlxw:~BigInteger.compareTo(java.math.BigInteger)" resolve="compareTo" />
+                                <node concept="1rXfSq" id="ncXQh4zj9r" role="37wK5m">
+                                  <ref role="37wK5l" node="ncXQh4z3V8" resolve="nothingToInt" />
+                                  <node concept="37vLTw" id="ncXQh4zjyv" role="37wK5m">
+                                    <ref role="3cqZAo" node="6HHp2WnvqWM" resolve="min" />
+                                  </node>
+                                  <node concept="37vLTw" id="ncXQh4zkaX" role="37wK5m">
+                                    <ref role="3cqZAo" node="ncXQh4qfxK" resolve="nothingType" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbS" id="3SMYSUUtY9I" role="3clFbx">
+                            <node concept="3clFbF" id="3SMYSUUu2Tj" role="3cqZAp">
+                              <node concept="37vLTI" id="3SMYSUUu3$f" role="3clFbG">
+                                <node concept="37vLTw" id="3SMYSUUu3LQ" role="37vLTx">
+                                  <ref role="3cqZAo" node="3SMYSUUtT$J" resolve="element" />
+                                </node>
+                                <node concept="37vLTw" id="3SMYSUUu2Ti" role="37vLTJ">
+                                  <ref role="3cqZAo" node="6HHp2WnvqWM" resolve="min" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="6HHp2WnvqXf" role="2$JKZa">
+                  <node concept="37vLTw" id="6HHp2WnvqXg" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6HHp2WnvqWF" resolve="iterator" />
+                  </node>
+                  <node concept="liA8E" id="6HHp2WnvqXh" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Iterator.hasNext()" resolve="hasNext" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="3SMYSUUtJBp" role="3cqZAp">
+                <node concept="3clFbS" id="3SMYSUUtJBr" role="3clFbx">
+                  <node concept="3cpWs6" id="3SMYSUUtO8f" role="3cqZAp">
+                    <node concept="37vLTw" id="3SMYSUUtOLO" role="3cqZAk">
+                      <ref role="3cqZAo" node="6HHp2WnvqWM" resolve="min" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3y3z36" id="3SMYSUUtNPl" role="3clFbw">
+                  <node concept="10Nm6u" id="3SMYSUUtNX9" role="3uHU7w" />
+                  <node concept="37vLTw" id="3SMYSUUtKcA" role="3uHU7B">
+                    <ref role="3cqZAo" node="6HHp2WnvqWM" resolve="min" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3SKdUt" id="3SMYSUUtS4K" role="3cqZAp">
+                <node concept="1PaTwC" id="17Nm8oCo8L7" role="1aUNEU">
+                  <node concept="3oM_SD" id="17Nm8oCo8L8" role="1PaTwD">
+                    <property role="3oM_SC" value="min" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8L9" role="1PaTwD">
+                    <property role="3oM_SC" value="of" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8La" role="1PaTwD">
+                    <property role="3oM_SC" value="the" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8Lb" role="1PaTwD">
+                    <property role="3oM_SC" value="empty" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8Lc" role="1PaTwD">
+                    <property role="3oM_SC" value="list" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8Ld" role="1PaTwD">
+                    <property role="3oM_SC" value="(arbitrarily" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8Le" role="1PaTwD">
+                    <property role="3oM_SC" value="chosen" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8Lf" role="1PaTwD">
+                    <property role="3oM_SC" value="as" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8Lg" role="1PaTwD">
+                    <property role="3oM_SC" value="Long.MAX_VALUE" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8Lh" role="1PaTwD">
+                    <property role="3oM_SC" value="since" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8Li" role="1PaTwD">
+                    <property role="3oM_SC" value="there" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8Lj" role="1PaTwD">
+                    <property role="3oM_SC" value="is" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8Lk" role="1PaTwD">
+                    <property role="3oM_SC" value="no" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8Ll" role="1PaTwD">
+                    <property role="3oM_SC" value="INF" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8Lm" role="1PaTwD">
+                    <property role="3oM_SC" value="in" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8Ln" role="1PaTwD">
+                    <property role="3oM_SC" value="type" />
+                  </node>
+                  <node concept="3oM_SD" id="17Nm8oCo8Lo" role="1PaTwD">
+                    <property role="3oM_SC" value="BigInteger)" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs6" id="6HHp2WnvqXi" role="3cqZAp">
+                <node concept="2YIFZM" id="s2V0$62kcN" role="3cqZAk">
+                  <ref role="1Pybhc" to="xlxw:~BigInteger" resolve="BigInteger" />
+                  <ref role="37wK5l" to="xlxw:~BigInteger.valueOf(long)" resolve="valueOf" />
+                  <node concept="10M0yZ" id="6HHp2Wnvrjy" role="37wK5m">
+                    <ref role="3cqZAo" to="wyt6:~Long.MAX_VALUE" resolve="MAX_VALUE" />
+                    <ref role="1PxDUh" to="wyt6:~Long" resolve="Long" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="1RwPUjzjkm3" role="3clF46">
+        <property role="TrG5h" value="values" />
+        <node concept="3uibUv" id="1RwPUjzjkm4" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1RwPUjzjkm5" role="3clF46">
+        <property role="TrG5h" value="isReal" />
+        <node concept="10P_77" id="1RwPUjzjkm6" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="ncXQh4qfxK" role="3clF46">
+        <property role="TrG5h" value="nothingType" />
+        <node concept="3uibUv" id="ncXQh4qga5" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Class" resolve="Class" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="ncXQh4yF7B" role="jymVt" />
+    <node concept="2YIFZL" id="ncXQh4z3V8" role="jymVt">
+      <property role="TrG5h" value="nothingToInt" />
+      <node concept="3clFbS" id="ncXQh4yGlh" role="3clF47">
+        <node concept="3clFbJ" id="ncXQh4yOpz" role="3cqZAp">
+          <node concept="3clFbS" id="ncXQh4yOp_" role="3clFbx">
+            <node concept="3cpWs6" id="ncXQh4yOSw" role="3cqZAp">
+              <node concept="10QFUN" id="ncXQh4ySX4" role="3cqZAk">
+                <node concept="37vLTw" id="ncXQh4ySX3" role="10QFUP">
+                  <ref role="3cqZAo" node="ncXQh4yIPs" resolve="value" />
+                </node>
+                <node concept="3uibUv" id="ncXQh4z9Mv" role="10QFUM">
+                  <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="ncXQh4yONj" role="3clFbw">
+            <node concept="10Nm6u" id="ncXQh4yONA" role="3uHU7w" />
+            <node concept="37vLTw" id="ncXQh4yOq0" role="3uHU7B">
+              <ref role="3cqZAo" node="ncXQh4yJLG" resolve="nothingClass" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="ncXQh4yPG1" role="3cqZAp">
+          <node concept="3clFbS" id="ncXQh4yPG3" role="3clFbx">
+            <node concept="3cpWs6" id="ncXQh4yV8H" role="3cqZAp">
+              <node concept="2ShNRf" id="ncXQh4yVcu" role="3cqZAk">
+                <node concept="1pGfFk" id="ncXQh4yVcl" role="2ShVmc">
+                  <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
+                  <node concept="Xl_RD" id="ncXQh4yW8i" role="37wK5m">
+                    <property role="Xl_RC" value="0" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="ncXQh4yUxS" role="3clFbw">
+            <node concept="37vLTw" id="ncXQh4yUgY" role="2Oq$k0">
+              <ref role="3cqZAo" node="ncXQh4yJLG" resolve="nothingClass" />
+            </node>
+            <node concept="liA8E" id="ncXQh4yUVk" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~Class.isInstance(java.lang.Object)" resolve="isInstance" />
+              <node concept="37vLTw" id="ncXQh4yV2Y" role="37wK5m">
+                <ref role="3cqZAo" node="ncXQh4yIPs" resolve="value" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="ncXQh4yYtV" role="3cqZAp">
+          <node concept="10QFUN" id="ncXQh4yZqY" role="3cqZAk">
+            <node concept="37vLTw" id="ncXQh4yZqX" role="10QFUP">
+              <ref role="3cqZAo" node="ncXQh4yIPs" resolve="value" />
+            </node>
+            <node concept="3uibUv" id="ncXQh4zclf" role="10QFUM">
+              <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="ncXQh4yIPs" role="3clF46">
+        <property role="TrG5h" value="value" />
+        <node concept="3uibUv" id="ncXQh4yIPr" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="ncXQh4yJLG" role="3clF46">
+        <property role="TrG5h" value="nothingClass" />
+        <node concept="3uibUv" id="ncXQh4yOaD" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Class" resolve="Class" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="ncXQh4z8mz" role="3clF45">
+        <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+      </node>
+      <node concept="3Tm1VV" id="ncXQh4yGlg" role="1B3o_S" />
+    </node>
+    <node concept="2YIFZL" id="ncXQh4_bka" role="jymVt">
+      <property role="TrG5h" value="nothingToDec" />
+      <node concept="3clFbS" id="ncXQh4_bkb" role="3clF47">
+        <node concept="3clFbJ" id="ncXQh4_bkc" role="3cqZAp">
+          <node concept="3clFbS" id="ncXQh4_bkd" role="3clFbx">
+            <node concept="3cpWs6" id="ncXQh4_bke" role="3cqZAp">
+              <node concept="2ShNRf" id="5QDPRL$cWSq" role="3cqZAk">
+                <node concept="1pGfFk" id="5QDPRL$cYr$" role="2ShVmc">
+                  <ref role="37wK5l" to="xlxw:~BigDecimal.&lt;init&gt;(java.lang.String)" resolve="BigDecimal" />
+                  <node concept="2OqwBi" id="5QDPRL$cZ8B" role="37wK5m">
+                    <node concept="37vLTw" id="5QDPRL$cYOZ" role="2Oq$k0">
+                      <ref role="3cqZAo" node="ncXQh4_bkz" resolve="value" />
+                    </node>
+                    <node concept="liA8E" id="5QDPRL$cZ_J" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="ncXQh4_bki" role="3clFbw">
+            <node concept="10Nm6u" id="ncXQh4_bkj" role="3uHU7w" />
+            <node concept="37vLTw" id="ncXQh4_bkk" role="3uHU7B">
+              <ref role="3cqZAo" node="ncXQh4_bk_" resolve="nothingClass" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="ncXQh4_bkl" role="3cqZAp">
+          <node concept="3clFbS" id="ncXQh4_bkm" role="3clFbx">
+            <node concept="3cpWs6" id="ncXQh4_bkn" role="3cqZAp">
+              <node concept="2ShNRf" id="ncXQh4_bko" role="3cqZAk">
+                <node concept="1pGfFk" id="ncXQh4_bkp" role="2ShVmc">
+                  <ref role="37wK5l" to="xlxw:~BigDecimal.&lt;init&gt;(java.lang.String)" resolve="BigDecimal" />
+                  <node concept="Xl_RD" id="ncXQh4_bkq" role="37wK5m">
+                    <property role="Xl_RC" value="0" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="ncXQh4_bkr" role="3clFbw">
+            <node concept="37vLTw" id="ncXQh4_bks" role="2Oq$k0">
+              <ref role="3cqZAo" node="ncXQh4_bk_" resolve="nothingClass" />
+            </node>
+            <node concept="liA8E" id="ncXQh4_bkt" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~Class.isInstance(java.lang.Object)" resolve="isInstance" />
+              <node concept="37vLTw" id="ncXQh4_bku" role="37wK5m">
+                <ref role="3cqZAo" node="ncXQh4_bkz" resolve="value" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="ncXQh4LsrJ" role="3cqZAp">
+          <node concept="3clFbS" id="ncXQh4LsrL" role="3clFbx">
+            <node concept="3cpWs6" id="ncXQh4Lthv" role="3cqZAp">
+              <node concept="2ShNRf" id="ncXQh4Lt$i" role="3cqZAk">
+                <node concept="1pGfFk" id="ncXQh4Lu9S" role="2ShVmc">
+                  <ref role="37wK5l" to="xlxw:~BigDecimal.&lt;init&gt;(java.lang.String)" resolve="BigDecimal" />
+                  <node concept="Xl_RD" id="ncXQh4LuxO" role="37wK5m">
+                    <property role="Xl_RC" value="0" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2ZW3vV" id="ncXQh4LsW9" role="3clFbw">
+            <node concept="3uibUv" id="ncXQh4Lt5k" role="2ZW6by">
+              <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+            </node>
+            <node concept="37vLTw" id="ncXQh4LsLW" role="2ZW6bz">
+              <ref role="3cqZAo" node="ncXQh4_bkz" resolve="value" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="ncXQh4_bkv" role="3cqZAp">
+          <node concept="10QFUN" id="ncXQh4_bkw" role="3cqZAk">
+            <node concept="37vLTw" id="ncXQh4_bkx" role="10QFUP">
+              <ref role="3cqZAo" node="ncXQh4_bkz" resolve="value" />
+            </node>
+            <node concept="3uibUv" id="ncXQh4_dQ4" role="10QFUM">
+              <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="ncXQh4_bkz" role="3clF46">
+        <property role="TrG5h" value="value" />
+        <node concept="3uibUv" id="ncXQh4_bk$" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="ncXQh4_bk_" role="3clF46">
+        <property role="TrG5h" value="nothingClass" />
+        <node concept="3uibUv" id="ncXQh4_bkA" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Class" resolve="Class" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="ncXQh4_crF" role="3clF45">
+        <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+      </node>
+      <node concept="3Tm1VV" id="ncXQh4_bkC" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="1RwPUjziunU" role="jymVt" />
+    <node concept="3Tm1VV" id="1RwPUjziunf" role="1B3o_S" />
+    <node concept="3UR2Jj" id="3qKzW8QHIf8" role="lGtFl">
+      <node concept="TZ5HA" id="3qKzW8QHIf9" role="TZ5H$">
+        <node concept="1dT_AC" id="3qKzW8QHIfa" role="1dT_Ay">
+          <property role="1dT_AB" value="This class is shared between interpreter and generator, be careful when introducing extra dependencies." />
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.shared.runtime/org.iets3.core.expr.base.shared.runtime.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.shared.runtime/org.iets3.core.expr.base.shared.runtime.msd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="org.iets3.core.expr.datetime.runtime" uuid="957f018c-4561-4081-9ad3-b8618bf1160d" moduleVersion="0" compileInMPS="true">
+<solution name="org.iets3.core.expr.base.shared.runtime" uuid="00ca1323-762b-4f39-ab5a-6a6bd602dc4b" moduleVersion="0" compileInMPS="true">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
@@ -13,22 +13,16 @@
   <sourcePath />
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
-    <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
-    <dependency reexport="false">00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-    <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
     <module reference="00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)" version="0" />
-    <module reference="957f018c-4561-4081-9ad3-b8618bf1160d(org.iets3.core.expr.datetime.runtime)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.interpreter/models/plugin.mps
@@ -24,6 +24,7 @@
     <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="j10v" ref="b76a0f63-5959-456b-993a-c796cc0d0c13/java:org.pcollections(org.iets3.core.expr.base.collections.stubs/)" />
+    <import index="ppzb" ref="r:5db517a0-f62d-4841-a421-11bb7269799d(org.iets3.core.expr.base.shared.runtime)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -3416,8 +3417,8 @@
                     </node>
                     <node concept="3cpWs6" id="4Q4DxjDbLP9" role="3cqZAp">
                       <node concept="2YIFZM" id="5wDe8wDIecJ" role="3cqZAk">
-                        <ref role="37wK5l" to="xfg9:1RwPUjziwEu" resolve="max" />
-                        <ref role="1Pybhc" to="xfg9:1RwPUjziune" resolve="MinMaxHelper" />
+                        <ref role="1Pybhc" to="ppzb:1RwPUjziune" resolve="SharedMinMaxHelper" />
+                        <ref role="37wK5l" to="ppzb:1RwPUjziwEu" resolve="max" />
                         <node concept="37vLTw" id="1RwPUjzj2xF" role="37wK5m">
                           <ref role="3cqZAo" node="4Q4DxjDbGuQ" resolve="coll" />
                         </node>
@@ -3518,8 +3519,8 @@
                     </node>
                     <node concept="3cpWs6" id="4Q4DxjDbM4z" role="3cqZAp">
                       <node concept="2YIFZM" id="5wDe8wDIecK" role="3cqZAk">
-                        <ref role="37wK5l" to="xfg9:1RwPUjziwEu" resolve="max" />
-                        <ref role="1Pybhc" to="xfg9:1RwPUjziune" resolve="MinMaxHelper" />
+                        <ref role="1Pybhc" to="ppzb:1RwPUjziune" resolve="SharedMinMaxHelper" />
+                        <ref role="37wK5l" to="ppzb:1RwPUjziwEu" resolve="max" />
                         <node concept="37vLTw" id="1RwPUjzj3iP" role="37wK5m">
                           <ref role="3cqZAo" node="4Q4DxjDbM3L" resolve="coll" />
                         </node>
@@ -3683,8 +3684,8 @@
                     </node>
                     <node concept="3cpWs6" id="1RwPUjzjzYw" role="3cqZAp">
                       <node concept="2YIFZM" id="5wDe8wDIecN" role="3cqZAk">
-                        <ref role="37wK5l" to="xfg9:1RwPUjzjkk_" resolve="min" />
-                        <ref role="1Pybhc" to="xfg9:1RwPUjziune" resolve="MinMaxHelper" />
+                        <ref role="1Pybhc" to="ppzb:1RwPUjziune" resolve="SharedMinMaxHelper" />
+                        <ref role="37wK5l" to="ppzb:1RwPUjzjkk_" resolve="min" />
                         <node concept="37vLTw" id="1RwPUjzjzYy" role="37wK5m">
                           <ref role="3cqZAo" node="6HHp2WnvqWw" resolve="coll" />
                         </node>
@@ -3785,8 +3786,8 @@
                     </node>
                     <node concept="3cpWs6" id="6HHp2WnvqYd" role="3cqZAp">
                       <node concept="2YIFZM" id="5wDe8wDIecO" role="3cqZAk">
-                        <ref role="37wK5l" to="xfg9:1RwPUjzjkk_" resolve="min" />
-                        <ref role="1Pybhc" to="xfg9:1RwPUjziune" resolve="MinMaxHelper" />
+                        <ref role="1Pybhc" to="ppzb:1RwPUjziune" resolve="SharedMinMaxHelper" />
+                        <ref role="37wK5l" to="ppzb:1RwPUjzjkk_" resolve="min" />
                         <node concept="37vLTw" id="1RwPUjzjzEb" role="37wK5m">
                           <ref role="3cqZAo" node="6HHp2WnvqXr" resolve="coll" />
                         </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.interpreter/org.iets3.core.expr.collections.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.interpreter/org.iets3.core.expr.collections.interpreter.msd
@@ -20,6 +20,7 @@
     <dependency reexport="false">9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)</dependency>
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
     <dependency reexport="false">b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)</dependency>
+    <dependency reexport="false">00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:47f075a6-558e-4640-a606-7ce0236c8023:com.mbeddr.mpsutil.interpreter" version="1" />
@@ -72,6 +73,7 @@
     <module reference="b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)" version="0" />
     <module reference="cf90f965-8554-4a16-aa0b-6387f27474ab(org.iets3.core.expr.base.interpreter)" version="0" />
     <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
+    <module reference="00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)" version="0" />
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="5" />
     <module reference="07f696b4-29e7-4878-aefb-39cac5e8c6cc(org.iets3.core.expr.collections.interpreter)" version="0" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.datetime.runtime/models/org.iets3.core.expr.datetime.runtime.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.datetime.runtime/models/org.iets3.core.expr.datetime.runtime.mps
@@ -12,7 +12,6 @@
     <import index="28m1" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time(JDK/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="dzyv" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time.temporal(JDK/)" />
-    <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="ppzb" ref="r:5db517a0-f62d-4841-a421-11bb7269799d(org.iets3.core.expr.base.shared.runtime)" />
   </imports>
   <registry>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.datetime.runtime/models/org.iets3.core.expr.datetime.runtime.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.datetime.runtime/models/org.iets3.core.expr.datetime.runtime.mps
@@ -13,6 +13,7 @@
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="dzyv" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time.temporal(JDK/)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
+    <import index="ppzb" ref="r:5db517a0-f62d-4841-a421-11bb7269799d(org.iets3.core.expr.base.shared.runtime)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -4450,7 +4451,7 @@
       </node>
     </node>
     <node concept="3uibUv" id="5RpnrChOM$w" role="EKbjA">
-      <ref role="3uigEE" to="xfg9:3nVyItrYNyp" resolve="INixValue" />
+      <ref role="3uigEE" to="ppzb:3nVyItrYNyp" resolve="INixValue" />
     </node>
   </node>
   <node concept="312cEu" id="64dkh69UxBV">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.datetime.runtime/org.iets3.core.expr.datetime.runtime.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.datetime.runtime/org.iets3.core.expr.datetime.runtime.msd
@@ -13,7 +13,6 @@
   <sourcePath />
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
-    <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
     <dependency reexport="false">00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)</dependency>
   </dependencies>
   <languageVersions>
@@ -26,7 +25,6 @@
   </languageVersions>
   <dependencyVersions>
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-    <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
     <module reference="00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)" version="0" />
     <module reference="957f018c-4561-4081-9ad3-b8618bf1160d(org.iets3.core.expr.datetime.runtime)" version="0" />
   </dependencyVersions>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.math.interpreter/org.iets3.core.expr.math.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.math.interpreter/org.iets3.core.expr.math.interpreter.msd
@@ -20,6 +20,7 @@
     <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
     <dependency reexport="false">52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)</dependency>
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
+    <dependency reexport="false">00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:47f075a6-558e-4640-a606-7ce0236c8023:com.mbeddr.mpsutil.interpreter" version="1" />
@@ -73,6 +74,7 @@
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
     <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="3" />
     <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
+    <module reference="00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)" version="0" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="0" />
     <module reference="6fadc44e-69c2-4a4a-9d16-7ebf5f8d3ba0(org.iets3.core.expr.math)" version="0" />
     <module reference="b804a851-ecf0-4ad4-a0af-ae720b39191a(org.iets3.core.expr.math.interpreter)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.interpreter/models/plugin.mps
@@ -23,6 +23,7 @@
     <import index="9mim" ref="r:5bf19129-2710-45a6-906e-9ee2d0977853(org.iets3.core.expr.simpleTypes.plugin)" />
     <import index="dj6k" ref="r:59d52af6-663b-49dc-8980-30d79b8dffa1(org.iets3.core.expr.simpleTypes.runtime)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
+    <import index="ppzb" ref="r:5db517a0-f62d-4841-a421-11bb7269799d(org.iets3.core.expr.base.shared.runtime)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -2451,7 +2452,7 @@
               </node>
               <node concept="2ZW3vV" id="4EEJFuvbYy4" role="3clFbw">
                 <node concept="3uibUv" id="4EEJFuvbYy5" role="2ZW6by">
-                  <ref role="3uigEE" to="xfg9:3nVyItrYNyp" resolve="INixValue" />
+                  <ref role="3uigEE" to="ppzb:3nVyItrYNyp" resolve="INixValue" />
                 </node>
                 <node concept="37vLTw" id="4EEJFuvbYy6" role="2ZW6bz">
                   <ref role="3cqZAo" node="4EEJFuvbYxy" resolve="leftNixEvaluated" />
@@ -2684,7 +2685,7 @@
               </node>
               <node concept="2ZW3vV" id="4EEJFuvlB4h" role="3clFbw">
                 <node concept="3uibUv" id="4EEJFuvlB5n" role="2ZW6by">
-                  <ref role="3uigEE" to="xfg9:3nVyItrYNyp" resolve="INixValue" />
+                  <ref role="3uigEE" to="ppzb:3nVyItrYNyp" resolve="INixValue" />
                 </node>
                 <node concept="37vLTw" id="4EEJFuvlB0y" role="2ZW6bz">
                   <ref role="3cqZAo" node="4EEJFuvcs$P" resolve="leftNixEvaluated" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.interpreter/org.iets3.core.expr.simpleTypes.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.interpreter/org.iets3.core.expr.simpleTypes.interpreter.msd
@@ -19,6 +19,7 @@
     <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
     <dependency reexport="false">52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)</dependency>
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
+    <dependency reexport="false">00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="5" />
@@ -85,6 +86,7 @@
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
     <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="3" />
     <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
+    <module reference="00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="1" />
     <module reference="197e2a32-ff26-4358-af5c-731ae2b35f83(org.iets3.core.expr.simpleTypes.interpreter)" version="0" />
     <module reference="52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.runtime/models/org.iets3.core.expr.simpleTypes.runtime.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.runtime/models/org.iets3.core.expr.simpleTypes.runtime.mps
@@ -3,7 +3,6 @@
   <persistence version="9" />
   <languages>
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
-    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
   </languages>
   <imports>
@@ -144,6 +143,12 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
+      <concept id="1144226303539" name="jetbrains.mps.baseLanguage.structure.ForeachStatement" flags="nn" index="1DcWWT">
+        <child id="1144226360166" name="iterable" index="1DdaDG" />
+      </concept>
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
@@ -165,16 +170,6 @@
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
-      </concept>
-    </language>
-    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
-      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
-        <child id="1153944400369" name="variable" index="2Gsz3X" />
-        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
-      </concept>
-      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
-      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
-        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
     </language>
   </registry>
@@ -2879,13 +2874,7 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="6I2TeLIlqQh" role="3clF47">
-        <node concept="2Gpval" id="6I2TeLIlrsp" role="3cqZAp">
-          <node concept="2GrKxI" id="6I2TeLIlrsq" role="2Gsz3X">
-            <property role="TrG5h" value="v" />
-          </node>
-          <node concept="37vLTw" id="6I2TeLIlrtq" role="2GsD0m">
-            <ref role="3cqZAo" node="6I2TeLIlroe" resolve="values" />
-          </node>
+        <node concept="1DcWWT" id="3qKzW8QLe5N" role="3cqZAp">
           <node concept="3clFbS" id="6I2TeLIlrss" role="2LFqv$">
             <node concept="3clFbJ" id="6I2TeLIlruH" role="3cqZAp">
               <node concept="1rXfSq" id="6I2TeLIls6$" role="3clFbw">
@@ -2893,8 +2882,8 @@
                 <node concept="37vLTw" id="6I2TeLIls8p" role="37wK5m">
                   <ref role="3cqZAo" node="6I2TeLIlrm5" resolve="expr" />
                 </node>
-                <node concept="2GrUjf" id="6I2TeLIlsaD" role="37wK5m">
-                  <ref role="2Gs0qQ" node="6I2TeLIlrsq" resolve="v" />
+                <node concept="37vLTw" id="3qKzW8QLe6a" role="37wK5m">
+                  <ref role="3cqZAo" node="3qKzW8QLe66" resolve="v" />
                 </node>
               </node>
               <node concept="3clFbS" id="6I2TeLIlruJ" role="3clFbx">
@@ -2904,6 +2893,15 @@
                   </node>
                 </node>
               </node>
+            </node>
+          </node>
+          <node concept="37vLTw" id="6I2TeLIlrtq" role="1DdaDG">
+            <ref role="3cqZAo" node="6I2TeLIlroe" resolve="values" />
+          </node>
+          <node concept="3cpWsn" id="3qKzW8QLe66" role="1Duv9x">
+            <property role="TrG5h" value="v" />
+            <node concept="3uibUv" id="3qKzW8QLe5M" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.runtime/models/org.iets3.core.expr.simpleTypes.runtime.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.runtime/models/org.iets3.core.expr.simpleTypes.runtime.mps
@@ -3,8 +3,6 @@
   <persistence version="9" />
   <languages>
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
-    <use id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext" version="0" />
-    <use id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil" version="1" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
   </languages>
@@ -12,8 +10,7 @@
     <import index="xlxw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.math(JDK/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
-    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
-    <import index="oq0c" ref="r:6c6155f0-4bbe-4af5-8c26-244d570e21e4(org.iets3.core.expr.base.plugin)" />
+    <import index="ppzb" ref="r:5db517a0-f62d-4841-a421-11bb7269799d(org.iets3.core.expr.base.shared.runtime)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -1701,9 +1698,9 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="10M0yZ" id="2oQlmR7HfeW" role="37wK5m">
-                    <ref role="3cqZAo" to="oq0c:7Wa2sv3XRPP" resolve="INF_PREC" />
-                    <ref role="1PxDUh" to="oq0c:2NHHcg2EXna" resolve="InfHelper" />
+                  <node concept="10M0yZ" id="3qKzW8QCkFC" role="37wK5m">
+                    <ref role="3cqZAo" to="ppzb:7Wa2sv3XRPP" resolve="INF_PREC" />
+                    <ref role="1PxDUh" to="ppzb:3qKzW8QxL7h" resolve="SharedInfHelper" />
                   </node>
                   <node concept="Rm8GO" id="5azVK7Pl8BN" role="37wK5m">
                     <ref role="1Px2BO" to="xlxw:~RoundingMode" resolve="RoundingMode" />
@@ -1761,9 +1758,9 @@
                       <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
                     </node>
                   </node>
-                  <node concept="10M0yZ" id="2oQlmR7HfId" role="37wK5m">
-                    <ref role="1PxDUh" to="oq0c:2NHHcg2EXna" resolve="InfHelper" />
-                    <ref role="3cqZAo" to="oq0c:7Wa2sv3XRPP" resolve="INF_PREC" />
+                  <node concept="10M0yZ" id="3qKzW8QCkWz" role="37wK5m">
+                    <ref role="3cqZAo" to="ppzb:7Wa2sv3XRPP" resolve="INF_PREC" />
+                    <ref role="1PxDUh" to="ppzb:3qKzW8QxL7h" resolve="SharedInfHelper" />
                   </node>
                   <node concept="Rm8GO" id="1uB4LRlVPCe" role="37wK5m">
                     <ref role="Rm8GQ" to="xlxw:~RoundingMode.HALF_UP" resolve="HALF_UP" />
@@ -1826,9 +1823,9 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="10M0yZ" id="2oQlmR7HfY7" role="37wK5m">
-                    <ref role="3cqZAo" to="oq0c:7Wa2sv3XRPP" resolve="INF_PREC" />
-                    <ref role="1PxDUh" to="oq0c:2NHHcg2EXna" resolve="InfHelper" />
+                  <node concept="10M0yZ" id="3qKzW8QClH6" role="37wK5m">
+                    <ref role="3cqZAo" to="ppzb:7Wa2sv3XRPP" resolve="INF_PREC" />
+                    <ref role="1PxDUh" to="ppzb:3qKzW8QxL7h" resolve="SharedInfHelper" />
                   </node>
                   <node concept="Rm8GO" id="1uB4LRlVQo_" role="37wK5m">
                     <ref role="1Px2BO" to="xlxw:~RoundingMode" resolve="RoundingMode" />
@@ -1881,9 +1878,9 @@
                       <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
                     </node>
                   </node>
-                  <node concept="10M0yZ" id="2oQlmR7HgtZ" role="37wK5m">
-                    <ref role="3cqZAo" to="oq0c:7Wa2sv3XRPP" resolve="INF_PREC" />
-                    <ref role="1PxDUh" to="oq0c:2NHHcg2EXna" resolve="InfHelper" />
+                  <node concept="10M0yZ" id="3qKzW8QCmoB" role="37wK5m">
+                    <ref role="3cqZAo" to="ppzb:7Wa2sv3XRPP" resolve="INF_PREC" />
+                    <ref role="1PxDUh" to="ppzb:3qKzW8QxL7h" resolve="SharedInfHelper" />
                   </node>
                   <node concept="Rm8GO" id="1uB4LRlVR7Z" role="37wK5m">
                     <ref role="Rm8GQ" to="xlxw:~RoundingMode.HALF_UP" resolve="HALF_UP" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.runtime/org.iets3.core.expr.simpleTypes.runtime.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.runtime/org.iets3.core.expr.simpleTypes.runtime.msd
@@ -18,8 +18,6 @@
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
-    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
-    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.runtime/org.iets3.core.expr.simpleTypes.runtime.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.runtime/org.iets3.core.expr.simpleTypes.runtime.msd
@@ -14,10 +14,9 @@
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</dependency>
+    <dependency reexport="false">00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
-    <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
@@ -60,6 +59,7 @@
     <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="1" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
     <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="1" />
+    <module reference="00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)" version="0" />
     <module reference="52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.runtime/org.iets3.core.expr.simpleTypes.runtime.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.runtime/org.iets3.core.expr.simpleTypes.runtime.msd
@@ -13,7 +13,6 @@
   <sourcePath />
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
-    <dependency reexport="false">cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</dependency>
     <dependency reexport="false">00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)</dependency>
   </dependencies>
   <languageVersions>
@@ -23,40 +22,7 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
-    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
-    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
-    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
-    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
-    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
-    <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
-    <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
-    <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
-    <module reference="47f075a6-558e-4640-a606-7ce0236c8023(com.mbeddr.mpsutil.interpreter)" version="0" />
-    <module reference="735f86bc-17fb-4d1c-a664-82c2b8e8a34e(com.mbeddr.mpsutil.interpreter.rt)" version="0" />
-    <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />
-    <module reference="b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)" version="0" />
-    <module reference="726886d1-ef90-4249-a08f-1e3ec23a7113(com.mbeddr.mpsutil.traceExplorer)" version="0" />
-    <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
-    <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
-    <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
-    <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
-    <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
-    <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />
-    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
-    <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
-    <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
-    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
-    <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
-    <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
-    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
-    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
-    <module reference="9e98f4e2-decf-4e97-bf80-9109e8b759aa(jetbrains.mps.lang.feedback.context)" version="0" />
-    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
-    <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="1" />
-    <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
-    <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="1" />
     <module reference="00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)" version="0" />
     <module reference="52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)" version="0" />
   </dependencyVersions>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -5686,11 +5686,6 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="1g_RmdExG2u" role="3bR37C">
-          <node concept="3bR9La" id="1g_RmdExG2v" role="1SiIV1">
-            <ref role="3bR37D" node="4C_RnzfEE1P" resolve="org.iets3.core.expr.base.runtime" />
-          </node>
-        </node>
         <node concept="1SiIV0" id="3qKzW8QxKRE" role="3bR37C">
           <node concept="3bR9La" id="3qKzW8QxKRF" role="1SiIV1">
             <ref role="3bR37D" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
@@ -7415,11 +7410,6 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="2oQlmR7HvLL" role="3bR37C">
-          <node concept="3bR9La" id="2oQlmR7HvLM" role="1SiIV1">
-            <ref role="3bR37D" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
-          </node>
-        </node>
         <node concept="1SiIV0" id="3qKzW8QC_j$" role="3bR37C">
           <node concept="3bR9La" id="3qKzW8QC_j_" role="1SiIV1">
             <ref role="3bR37D" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
@@ -8053,68 +8043,41 @@
         <node concept="3LEz8M" id="kEKsc8qBa7" role="3LEz9a">
           <ref role="3LEz8N" node="2zpAVpC$xZc" resolve="org.iets3.core.expr.genjava.core.devkit" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Kc" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        <node concept="3LEDTy" id="3qKzW8QLlEW" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Kd" role="3LEDUa">
-          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+        <node concept="3LEDTy" id="3qKzW8QLlEX" role="3LEDUa">
+          <ref role="3LEDTV" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Ke" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
+        <node concept="3LEDTy" id="3qKzW8QLlEY" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Kf" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
+        <node concept="3LEDTy" id="3qKzW8QLlEZ" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRRB" resolve="org.iets3.core.base" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Kg" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+        <node concept="3LEDTy" id="3qKzW8QLlF0" role="3LEDUa">
+          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Kh" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+        <node concept="3LEDTy" id="3qKzW8QLlF1" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAaa" resolve="org.iets3.analysis.base" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Ki" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
+        <node concept="3LEDTy" id="3qKzW8QLlF2" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Kj" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        <node concept="3LEDTy" id="3qKzW8QLlF3" role="3LEDUa">
+          <ref role="3LEDTV" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Kk" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        <node concept="3LEDTy" id="3qKzW8QLlF4" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Kl" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
+        <node concept="3LEDTy" id="3qKzW8QLlF5" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Km" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
+        <node concept="3LEDTy" id="3qKzW8QLlF6" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Kn" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
-        </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Ko" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
-        </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Kp" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
-        </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Kq" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
-        </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Kr" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
-        </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Ks" role="3LEDUa">
-          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
-        </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Kt" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
-        </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Ku" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
-        </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Kv" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
-        </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Kw" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
+        <node concept="3LEDTy" id="3qKzW8QLlF7" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
         </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC_4Ut" role="2G$12L">
@@ -10295,15 +10258,6 @@
         <node concept="3LEDTM" id="3qKzW8QJ_Qf" role="3LEDUa">
           <ref role="3LEDTN" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qg" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
-        </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qh" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
-        </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qi" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
-        </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC$OJa" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10348,14 +10302,20 @@
         <node concept="3LEDTM" id="6wnckeEe9TH" role="3LEDUa">
           <ref role="3LEDTN" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qj" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        <node concept="3LEDTy" id="3qKzW8QLlKP" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qk" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        <node concept="3LEDTy" id="3qKzW8QLlKQ" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Ql" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        <node concept="3LEDTy" id="3qKzW8QLlKR" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
+        <node concept="3LEDTy" id="3qKzW8QLlKS" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="3qKzW8QLlKT" role="3LEDUa">
+          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
         </node>
       </node>
       <node concept="3LEwk6" id="j5CxBKa9ks" role="2G$12L">
@@ -10383,68 +10343,59 @@
         <node concept="3LEDTM" id="1RMC8GHEwZU" role="3LEDUa">
           <ref role="3LEDTN" node="2zpAVpC$IQf" resolve="org.iets3.core.expr.genjava.advanced.genplan" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qm" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        <node concept="3LEDTy" id="3qKzW8QLlKU" role="3LEDUa">
+          <ref role="3LEDTV" node="5Y0kZK1N637" resolve="org.iets3.core.expr.genjava.datetime" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qn" role="3LEDUa">
-          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+        <node concept="3LEDTy" id="3qKzW8QLlKV" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qo" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
+        <node concept="3LEDTy" id="3qKzW8QLlKW" role="3LEDUa">
+          <ref role="3LEDTV" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qp" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
+        <node concept="3LEDTy" id="3qKzW8QLlKX" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qq" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+        <node concept="3LEDTy" id="3qKzW8QLlKY" role="3LEDUa">
+          <ref role="3LEDTV" node="5zQvLw7dsP5" resolve="org.iets3.core.expr.temporal" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qr" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+        <node concept="3LEDTy" id="3qKzW8QLlKZ" role="3LEDUa">
+          <ref role="3LEDTV" node="6hYPZtwrWbD" resolve="org.iets3.core.expr.genjava.util" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qs" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
+        <node concept="3LEDTy" id="3qKzW8QLlL0" role="3LEDUa">
+          <ref role="3LEDTV" node="7sID8G9sQTG" resolve="org.iets3.core.expr.genjava.temporal" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qt" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        <node concept="3LEDTy" id="3qKzW8QLlL1" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRRB" resolve="org.iets3.core.base" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qu" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        <node concept="3LEDTy" id="3qKzW8QLlL2" role="3LEDUa">
+          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qv" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
+        <node concept="3LEDTy" id="3qKzW8QLlL3" role="3LEDUa">
+          <ref role="3LEDTV" node="5zQvLw7dx1X" resolve="org.iets3.core.expr.datetime" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qw" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
+        <node concept="3LEDTy" id="3qKzW8QLlL4" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAaa" resolve="org.iets3.analysis.base" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qx" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
+        <node concept="3LEDTy" id="3qKzW8QLlL5" role="3LEDUa">
+          <ref role="3LEDTV" node="23q4CrmMjzr" resolve="org.iets3.core.expr.genjava.messages" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qy" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
+        <node concept="3LEDTy" id="3qKzW8QLlL6" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Qz" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
+        <node concept="3LEDTy" id="3qKzW8QLlL7" role="3LEDUa">
+          <ref role="3LEDTV" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Q$" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
+        <node concept="3LEDTy" id="3qKzW8QLlL8" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_Q_" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
+        <node concept="3LEDTy" id="3qKzW8QLlL9" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_QA" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        <node concept="3LEDTy" id="3qKzW8QLlLa" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_QB" role="3LEDUa">
-          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
-        </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_QC" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
-        </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_QD" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
-        </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_QE" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
+        <node concept="3LEDTy" id="3qKzW8QLlLb" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
         </node>
       </node>
       <node concept="3LEwk6" id="26tZ$Z4sNNn" role="2G$12L">
@@ -10478,8 +10429,11 @@
         <node concept="3LEDTy" id="3vxfdxbuHow" role="3LEDUa">
           <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
         </node>
-        <node concept="3LEDTy" id="3qKzW8QJ_QF" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        <node concept="3LEDTy" id="3qKzW8QLlLc" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="3qKzW8QLlLd" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -1749,6 +1749,11 @@
             <ref role="3bR37D" node="2uR5X5azttH" resolve="org.iets3.core.expr.toplevel" />
           </node>
         </node>
+        <node concept="1SiIV0" id="2xddOZL76By" role="3bR37C">
+          <node concept="3bR9La" id="2xddOZL76Bz" role="1SiIV1">
+            <ref role="3bR37D" node="4C_RnzfEE1P" resolve="org.iets3.core.expr.base.runtime" />
+          </node>
+        </node>
         <node concept="1BupzO" id="1RMC8GHEw$8" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -1769,11 +1774,6 @@
             <node concept="3qWCbU" id="1RMC8GHEw$a" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2xddOZL76By" role="3bR37C">
-          <node concept="3bR9La" id="2xddOZL76Bz" role="1SiIV1">
-            <ref role="3bR37D" node="4C_RnzfEE1P" resolve="org.iets3.core.expr.base.runtime" />
           </node>
         </node>
       </node>
@@ -5818,6 +5818,11 @@
             <ref role="3bR37D" node="5khwDRKS378" resolve="org.iets3.core.expr.base.collections.stubs" />
           </node>
         </node>
+        <node concept="1SiIV0" id="2xddOZL76J_" role="3bR37C">
+          <node concept="3bR9La" id="2xddOZL76JA" role="1SiIV1">
+            <ref role="3bR37D" node="2xddOZL74Qf" resolve="org.iets3.core.expr.temporal.runtime" />
+          </node>
+        </node>
         <node concept="1BupzO" id="1RMC8GHEwKV" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -5838,11 +5843,6 @@
             <node concept="3qWCbU" id="1RMC8GHEwKX" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2xddOZL76J_" role="3bR37C">
-          <node concept="3bR9La" id="2xddOZL76JA" role="1SiIV1">
-            <ref role="3bR37D" node="2xddOZL74Qf" resolve="org.iets3.core.expr.temporal.runtime" />
           </node>
         </node>
         <node concept="1SiIV0" id="2xddOZL76JB" role="3bR37C">
@@ -5993,6 +5993,16 @@
             <ref role="3bR37D" node="5khwDRKS378" resolve="org.iets3.core.expr.base.collections.stubs" />
           </node>
         </node>
+        <node concept="1SiIV0" id="2xddOZL76JO" role="3bR37C">
+          <node concept="3bR9La" id="2xddOZL76JP" role="1SiIV1">
+            <ref role="3bR37D" node="2xddOZL74Qj" resolve="org.iets3.core.expr.datetime.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2xddOZL76JQ" role="3bR37C">
+          <node concept="3bR9La" id="2xddOZL76JR" role="1SiIV1">
+            <ref role="3bR37D" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
+          </node>
+        </node>
         <node concept="1BupzO" id="1RMC8GHEwLB" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -6013,16 +6023,6 @@
             <node concept="3qWCbU" id="1RMC8GHEwLD" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2xddOZL76JO" role="3bR37C">
-          <node concept="3bR9La" id="2xddOZL76JP" role="1SiIV1">
-            <ref role="3bR37D" node="2xddOZL74Qj" resolve="org.iets3.core.expr.datetime.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2xddOZL76JQ" role="3bR37C">
-          <node concept="3bR9La" id="2xddOZL76JR" role="1SiIV1">
-            <ref role="3bR37D" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
           </node>
         </node>
         <node concept="1SiIV0" id="2xddOZL76JS" role="3bR37C">
@@ -9822,6 +9822,11 @@
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
           </node>
         </node>
+        <node concept="1SiIV0" id="2xddOZL76SM" role="3bR37C">
+          <node concept="3bR9La" id="2xddOZL76SN" role="1SiIV1">
+            <ref role="3bR37D" node="2xddOZL74Qf" resolve="org.iets3.core.expr.temporal.runtime" />
+          </node>
+        </node>
         <node concept="1BupzO" id="1RMC8GHEwYJ" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -9858,11 +9863,6 @@
                 </node>
               </node>
             </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2xddOZL76SM" role="3bR37C">
-          <node concept="3bR9La" id="2xddOZL76SN" role="1SiIV1">
-            <ref role="3bR37D" node="2xddOZL74Qf" resolve="org.iets3.core.expr.temporal.runtime" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -1207,6 +1207,11 @@
             <ref role="3bR37D" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
           </node>
         </node>
+        <node concept="1SiIV0" id="3qKzW8QC_7e" role="3bR37C">
+          <node concept="3bR9La" id="3qKzW8QC_7f" role="1SiIV1">
+            <ref role="3bR37D" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="5Q45tqZzw3Y" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -2602,6 +2607,67 @@
           </node>
         </node>
       </node>
+      <node concept="1E1JtA" id="3qKzW8QxJyw" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="org.iets3.core.expr.base.shared.runtime" />
+        <property role="3LESm3" value="00ca1323-762b-4f39-ab5a-6a6bd602dc4b" />
+        <node concept="398BVA" id="3qKzW8QxKcp" role="3LF7KH">
+          <ref role="398BVh" node="5wLtKNeTaqD" resolve="iets3.lang.opensource" />
+          <node concept="2Ry0Ak" id="3qKzW8QxKgq" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="3qKzW8QxKhL" role="2Ry0An">
+              <property role="2Ry0Am" value="org.iets3.core.expr.base.shared.runtime" />
+              <node concept="2Ry0Ak" id="3qKzW8QyS0J" role="2Ry0An">
+                <property role="2Ry0Am" value="org.iets3.core.expr.base.shared.runtime.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1BupzO" id="3qKzW8QxKo3" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="3qKzW8QxKo4" role="1HemKq">
+            <node concept="398BVA" id="3qKzW8QxKnS" role="3LXTmr">
+              <ref role="398BVh" node="5wLtKNeTaqD" resolve="iets3.lang.opensource" />
+              <node concept="2Ry0Ak" id="3qKzW8QxKnT" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="3qKzW8QxKnU" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.iets3.core.expr.base.gen.runtime" />
+                  <node concept="2Ry0Ak" id="3qKzW8QxKnV" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="3qKzW8QxKo5" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+          <node concept="3LXTmp" id="3qKzW8QyS5E" role="1HemKq">
+            <node concept="398BVA" id="3qKzW8QyS5v" role="3LXTmr">
+              <ref role="398BVh" node="5wLtKNeTaqD" resolve="iets3.lang.opensource" />
+              <node concept="2Ry0Ak" id="3qKzW8QyS5w" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="3qKzW8QyS5x" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.iets3.core.expr.base.shared.runtime" />
+                  <node concept="2Ry0Ak" id="3qKzW8QyS5y" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="3qKzW8QyS5F" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3qKzW8QC_aB" role="3bR37C">
+          <node concept="3bR9La" id="3qKzW8QC_aC" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+      </node>
       <node concept="1E1JtA" id="4C_RnzfEE1P" role="2G$12L">
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="org.iets3.core.expr.base.runtime" />
@@ -2664,6 +2730,11 @@
         <node concept="1SiIV0" id="1g_RmdExFUd" role="3bR37C">
           <node concept="3bR9La" id="1g_RmdExFUe" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3qKzW8QxKM0" role="3bR37C">
+          <node concept="3bR9La" id="3qKzW8QxKM1" role="1SiIV1">
+            <ref role="3bR37D" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
           </node>
         </node>
       </node>
@@ -2869,6 +2940,11 @@
         <node concept="1SiIV0" id="cPLa7FuOOX" role="3bR37C">
           <node concept="3bR9La" id="cPLa7FuOOY" role="1SiIV1">
             <ref role="3bR37D" node="44TucI396gl" resolve="org.iets3.core.expr.lambda.interpreter" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3qKzW8QJ_Az" role="3bR37C">
+          <node concept="3bR9La" id="3qKzW8QJ_A$" role="1SiIV1">
+            <ref role="3bR37D" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
           </node>
         </node>
       </node>
@@ -5615,6 +5691,11 @@
             <ref role="3bR37D" node="4C_RnzfEE1P" resolve="org.iets3.core.expr.base.runtime" />
           </node>
         </node>
+        <node concept="1SiIV0" id="3qKzW8QxKRE" role="3bR37C">
+          <node concept="3bR9La" id="3qKzW8QxKRF" role="1SiIV1">
+            <ref role="3bR37D" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="6XrtUF5gcnV" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -6969,6 +7050,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="3qKzW8QySdK" role="3bR37C">
+          <node concept="3bR9La" id="3qKzW8QySdL" role="1SiIV1">
+            <ref role="3bR37D" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="44TucI396gt" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -7052,6 +7138,11 @@
             <node concept="3qWCbU" id="1RMC8GHEwP5" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3qKzW8QxKUj" role="3bR37C">
+          <node concept="3bR9La" id="3qKzW8QxKUk" role="1SiIV1">
+            <ref role="3bR37D" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
           </node>
         </node>
       </node>
@@ -7259,6 +7350,11 @@
             <ref role="3bR37D" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
           </node>
         </node>
+        <node concept="1SiIV0" id="3qKzW8QxKUF" role="3bR37C">
+          <node concept="3bR9La" id="3qKzW8QxKUG" role="1SiIV1">
+            <ref role="3bR37D" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="7jAOwAVRc2S" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -7322,6 +7418,11 @@
         <node concept="1SiIV0" id="2oQlmR7HvLL" role="3bR37C">
           <node concept="3bR9La" id="2oQlmR7HvLM" role="1SiIV1">
             <ref role="3bR37D" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3qKzW8QC_j$" role="3bR37C">
+          <node concept="3bR9La" id="3qKzW8QC_j_" role="1SiIV1">
+            <ref role="3bR37D" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
           </node>
         </node>
       </node>
@@ -7952,41 +8053,68 @@
         <node concept="3LEz8M" id="kEKsc8qBa7" role="3LEz9a">
           <ref role="3LEz8N" node="2zpAVpC$xZc" resolve="org.iets3.core.expr.genjava.core.devkit" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76N_" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Kc" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76NA" role="3LEDUa">
-          <ref role="3LEDTV" node="49WTic8jAaa" resolve="org.iets3.analysis.base" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Kd" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76NB" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Ke" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76NC" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Kf" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76ND" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Kg" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76NE" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Kh" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76NF" role="3LEDUa">
-          <ref role="3LEDTV" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Ki" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76NG" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRRB" resolve="org.iets3.core.base" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Kj" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76NH" role="3LEDUa">
-          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Kk" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76NI" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Kl" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76NJ" role="3LEDUa">
-          <ref role="3LEDTV" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Km" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76NK" role="3LEDUa">
-          <ref role="3LEDTV" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Kn" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
+        </node>
+        <node concept="3LEDTy" id="3qKzW8QJ_Ko" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
+        </node>
+        <node concept="3LEDTy" id="3qKzW8QJ_Kp" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
+        </node>
+        <node concept="3LEDTy" id="3qKzW8QJ_Kq" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
+        </node>
+        <node concept="3LEDTy" id="3qKzW8QJ_Kr" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="3qKzW8QJ_Ks" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
+        </node>
+        <node concept="3LEDTy" id="3qKzW8QJ_Kt" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
+        </node>
+        <node concept="3LEDTy" id="3qKzW8QJ_Ku" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
+        </node>
+        <node concept="3LEDTy" id="3qKzW8QJ_Kv" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
+        </node>
+        <node concept="3LEDTy" id="3qKzW8QJ_Kw" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
         </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC_4Ut" role="2G$12L">
@@ -8263,11 +8391,6 @@
         <node concept="1E0d5M" id="lH$Puj5DR8" role="1E1XAP">
           <ref role="1E0d5P" node="23q4CrmMjed" resolve="org.iets3.core.expr.genjava.messages.rt" />
         </node>
-        <node concept="1SiIV0" id="7pfuzNDFAym" role="3bR37C">
-          <node concept="3bR9La" id="7pfuzNDFAyn" role="1SiIV1">
-            <ref role="3bR37D" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
-          </node>
-        </node>
         <node concept="1BupzO" id="1RMC8GHEwSy" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -8289,6 +8412,9 @@
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
           </node>
+        </node>
+        <node concept="1E0d5M" id="3qKzW8QJ_KG" role="1E1XAP">
+          <ref role="1E0d5P" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
         </node>
       </node>
       <node concept="1E1JtD" id="lH$Puj5DFq" role="2G$12L">
@@ -10166,6 +10292,18 @@
         <node concept="3LEDTM" id="2xddOZL76TH" role="3LEDUa">
           <ref role="3LEDTN" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
         </node>
+        <node concept="3LEDTM" id="3qKzW8QJ_Qf" role="3LEDUa">
+          <ref role="3LEDTN" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
+        </node>
+        <node concept="3LEDTy" id="3qKzW8QJ_Qg" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="3qKzW8QJ_Qh" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="3qKzW8QJ_Qi" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC$OJa" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10210,20 +10348,14 @@
         <node concept="3LEDTM" id="6wnckeEe9TH" role="3LEDUa">
           <ref role="3LEDTN" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76TI" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Qj" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76TJ" role="3LEDUa">
-          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Qk" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76TK" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
-        </node>
-        <node concept="3LEDTy" id="2xddOZL76TL" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
-        </node>
-        <node concept="3LEDTy" id="2xddOZL76TM" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Ql" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
         </node>
       </node>
       <node concept="3LEwk6" id="j5CxBKa9ks" role="2G$12L">
@@ -10251,59 +10383,68 @@
         <node concept="3LEDTM" id="1RMC8GHEwZU" role="3LEDUa">
           <ref role="3LEDTN" node="2zpAVpC$IQf" resolve="org.iets3.core.expr.genjava.advanced.genplan" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76TN" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Qm" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76TO" role="3LEDUa">
-          <ref role="3LEDTV" node="49WTic8jAaa" resolve="org.iets3.analysis.base" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Qn" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76TP" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Qo" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76TQ" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Qp" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76TR" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Qq" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76TS" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Qr" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76TT" role="3LEDUa">
-          <ref role="3LEDTV" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Qs" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76TU" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRRB" resolve="org.iets3.core.base" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Qt" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76TV" role="3LEDUa">
-          <ref role="3LEDTV" node="7sID8G9sQTG" resolve="org.iets3.core.expr.genjava.temporal" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Qu" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76TW" role="3LEDUa">
-          <ref role="3LEDTV" node="5Y0kZK1N637" resolve="org.iets3.core.expr.genjava.datetime" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Qv" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76TX" role="3LEDUa">
-          <ref role="3LEDTV" node="5zQvLw7dsP5" resolve="org.iets3.core.expr.temporal" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Qw" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76TY" role="3LEDUa">
-          <ref role="3LEDTV" node="5zQvLw7dx1X" resolve="org.iets3.core.expr.datetime" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Qx" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76TZ" role="3LEDUa">
-          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Qy" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76U0" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Qz" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76U1" role="3LEDUa">
-          <ref role="3LEDTV" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Q$" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76U2" role="3LEDUa">
-          <ref role="3LEDTV" node="23q4CrmMjzr" resolve="org.iets3.core.expr.genjava.messages" />
+        <node concept="3LEDTy" id="3qKzW8QJ_Q_" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76U3" role="3LEDUa">
-          <ref role="3LEDTV" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
+        <node concept="3LEDTy" id="3qKzW8QJ_QA" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76U4" role="3LEDUa">
-          <ref role="3LEDTV" node="6hYPZtwrWbD" resolve="org.iets3.core.expr.genjava.util" />
+        <node concept="3LEDTy" id="3qKzW8QJ_QB" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
+        </node>
+        <node concept="3LEDTy" id="3qKzW8QJ_QC" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
+        </node>
+        <node concept="3LEDTy" id="3qKzW8QJ_QD" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
+        </node>
+        <node concept="3LEDTy" id="3qKzW8QJ_QE" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
         </node>
       </node>
       <node concept="3LEwk6" id="26tZ$Z4sNNn" role="2G$12L">
@@ -10337,11 +10478,8 @@
         <node concept="3LEDTy" id="3vxfdxbuHow" role="3LEDUa">
           <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
         </node>
-        <node concept="3LEDTy" id="2xddOZL76U5" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
-        </node>
-        <node concept="3LEDTy" id="2xddOZL76U6" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        <node concept="3LEDTy" id="3qKzW8QJ_QF" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -10493,44 +10493,6 @@
           <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
         </node>
       </node>
-      <node concept="3LEwk6" id="26tZ$Z4sNNn" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="org.iets3.core.expr.genjava.stateMachineExample.devkit" />
-        <property role="3LESm3" value="1c135998-5440-4972-9921-4d69b80567f1" />
-        <node concept="3LEz8M" id="74GOZd5kreX" role="3LEz9a">
-          <ref role="3LEz8N" node="2zpAVpC$OJa" resolve="org.iets3.core.expr.genjava.advanced.devkit" />
-        </node>
-        <node concept="398BVA" id="26tZ$Z4sPb1" role="3LF7KH">
-          <ref role="398BVh" node="5wLtKNeTaqD" resolve="iets3.lang.opensource" />
-          <node concept="2Ry0Ak" id="26tZ$Z4sRar" role="iGT6I">
-            <property role="2Ry0Am" value="devkits" />
-            <node concept="2Ry0Ak" id="26tZ$Z4sSOA" role="2Ry0An">
-              <property role="2Ry0Am" value="org.iets3.core.expr.genjava.stateMachineExample.devkit" />
-              <node concept="2Ry0Ak" id="26tZ$Z4sTv7" role="2Ry0An">
-                <property role="2Ry0Am" value="org.iets3.core.expr.genjava.stateMachineExample.devkit.devkit" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3LEDTy" id="26tZ$Z4t0sK" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qXja" resolve="org.iets3.core.expr.genjava.stateMachineExample" />
-        </node>
-        <node concept="3LEDTy" id="26tZ$Z4t0sL" role="3LEDUa">
-          <ref role="3LEDTV" node="6JPXQMQs0pX" resolve="org.iets3.core.expr.collections" />
-        </node>
-        <node concept="3LEDTM" id="26tZ$Z4t0sN" role="3LEDUa">
-          <ref role="3LEDTN" node="26tZ$Z4rsyt" resolve="org.iets3.core.expr.genjava.stateMachineExample.genplan" />
-        </node>
-        <node concept="3LEDTy" id="3vxfdxbuHow" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
-        </node>
-        <node concept="3LEDTy" id="2xddOZL76U5" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
-        </node>
-        <node concept="3LEDTy" id="2xddOZL76U6" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
-        </node>
-      </node>
     </node>
     <node concept="2G$12M" id="7$nPgK7yqIF" role="3989C9">
       <property role="TrG5h" value="iets3.comp.os" />


### PR DESCRIPTION
Terms used:
* _base runtime_: solution `org.iets3.core.expr.base.runtime`
* _shared runtime_: solution `org.iets3.core.expr.base.shared.runtime`

The new shared runtime contains classes that will be used both from the generated code and by the interpreter or in-MPS code.

Even though the individual classes used by the generated code do not depend on MPS-specific classes, extracting them from the base runtime means that the generated code no longer needs to depend on a module that contain MPS-specific code (e.g. NixSupport with its usage of the node<> type).

The base runtime was taken out of module dependencies of other runtimes.

Breaking change: class INixValue was moved from the base runtime to the shared one so references to it will need to be updated (Ctrl+R to import org.iets3.core.expr.base.shared.runtime model, then F5 to update
the reference).

Another potentially breaking change is that the generated code now uses the shared runtime and its classes instead of the base runtime (e.g. SharedMinMaxHelper rather than MinMaxHelper). After it is regenerated, it will need the shared runtime JAR to execute (and should no longer need the base runtime JAR).