### PR TITLE
Merge datev-staging to 2020.1 maintenancne

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:8405f486-53b5-4fe6-af3e-7f68358bd631(org.iets3.core.expr.base.editor)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells" version="1" />
@@ -30,10 +31,13 @@
     <import index="5ueo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.style(MPS.Editor/)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
-    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
-    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
     <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="9eyi" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.lang.editor.menus.transformation(MPS.Editor/)" />
+    <import index="vndm" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.language(MPS.Core/)" />
+    <import index="6lvu" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellMenu(MPS.Editor/)" />
     <import index="gdgh" ref="r:e4d9478b-ae0e-416e-be60-73d136571015(org.iets3.core.base.behavior)" implicit="true" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" implicit="true" />
   </imports>
@@ -316,7 +320,7 @@
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
-      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="ng" index="2tJIrI" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
@@ -544,6 +548,9 @@
       </concept>
       <concept id="1145573345940" name="jetbrains.mps.lang.smodel.structure.Node_GetAllSiblingsOperation" flags="nn" index="2TvwIu" />
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="1182511038748" name="jetbrains.mps.lang.smodel.structure.Model_NodesIncludingImportedOperation" flags="nn" index="1j9C0f">
         <reference id="1182511038750" name="concept" index="1j9C0d" />
       </concept>
@@ -595,10 +602,10 @@
       </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
-      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="ng" index="3oM_SD">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
         <property id="155656958578482949" name="value" index="3oM_SC" />
       </concept>
-      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="ng" index="1PaTwC">
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
         <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
@@ -996,7 +1003,7 @@
                           <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
                         </node>
                         <node concept="37vLTG" id="3ijo1YRLIIa" role="3clF46">
-                          <property role="TrG5h" value="p1" />
+                          <property role="TrG5h" value="ec" />
                           <node concept="3uibUv" id="3ijo1YRLIIb" role="1tU5fm">
                             <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
                           </node>
@@ -1042,32 +1049,142 @@
                               </node>
                             </node>
                           </node>
-                          <node concept="3clFbF" id="3ijo1YRLJA$" role="3cqZAp">
-                            <node concept="2ShNRf" id="3ijo1YRLJAy" role="3clFbG">
-                              <node concept="1pGfFk" id="3ijo1YRLMxQ" role="2ShVmc">
-                                <ref role="37wK5l" to="g51k:~EditorCell_Error.&lt;init&gt;(jetbrains.mps.openapi.editor.EditorContext,org.jetbrains.mps.openapi.model.SNode,java.lang.String)" resolve="EditorCell_Error" />
-                                <node concept="1Q80Hx" id="3ijo1YRLMTH" role="37wK5m" />
-                                <node concept="pncrf" id="3ijo1YRLNxB" role="37wK5m" />
-                                <node concept="3cpWs3" id="3ijo1YRLQlI" role="37wK5m">
-                                  <node concept="Xl_RD" id="3ijo1YRLQs0" role="3uHU7w">
-                                    <property role="Xl_RC" value="&gt;" />
-                                  </node>
-                                  <node concept="3cpWs3" id="3ijo1YRLPzm" role="3uHU7B">
-                                    <node concept="Xl_RD" id="3ijo1YRLPXz" role="3uHU7B">
-                                      <property role="Xl_RC" value="&lt;" />
+                          <node concept="3cpWs8" id="3DWpd_K7xzL" role="3cqZAp">
+                            <node concept="3cpWsn" id="3DWpd_K7xzM" role="3cpWs9">
+                              <property role="TrG5h" value="errorCell" />
+                              <node concept="3uibUv" id="3DWpd_K7wrd" role="1tU5fm">
+                                <ref role="3uigEE" to="g51k:~EditorCell_Error" resolve="EditorCell_Error" />
+                              </node>
+                              <node concept="2ShNRf" id="3DWpd_K7xzN" role="33vP2m">
+                                <node concept="1pGfFk" id="3DWpd_K7xzO" role="2ShVmc">
+                                  <ref role="37wK5l" to="g51k:~EditorCell_Error.&lt;init&gt;(jetbrains.mps.openapi.editor.EditorContext,org.jetbrains.mps.openapi.model.SNode,java.lang.String)" resolve="EditorCell_Error" />
+                                  <node concept="1Q80Hx" id="3DWpd_K7xzP" role="37wK5m" />
+                                  <node concept="pncrf" id="3DWpd_K7xzQ" role="37wK5m" />
+                                  <node concept="3cpWs3" id="3DWpd_K7xzR" role="37wK5m">
+                                    <node concept="Xl_RD" id="3DWpd_K7xzS" role="3uHU7w">
+                                      <property role="Xl_RC" value="&gt;" />
                                     </node>
-                                    <node concept="2OqwBi" id="3ijo1YRLNOV" role="3uHU7w">
-                                      <node concept="2OqwBi" id="3ijo1YRLNOW" role="2Oq$k0">
-                                        <node concept="pncrf" id="3ijo1YRLNOX" role="2Oq$k0" />
-                                        <node concept="2NL2c5" id="3ijo1YRLNOY" role="2OqNvi" />
+                                    <node concept="3cpWs3" id="3DWpd_K7xzT" role="3uHU7B">
+                                      <node concept="Xl_RD" id="3DWpd_K7xzU" role="3uHU7B">
+                                        <property role="Xl_RC" value="&lt;" />
                                       </node>
-                                      <node concept="liA8E" id="3ijo1YRLNOZ" role="2OqNvi">
-                                        <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
+                                      <node concept="2OqwBi" id="3DWpd_K7xzV" role="3uHU7w">
+                                        <node concept="2OqwBi" id="3DWpd_K7xzW" role="2Oq$k0">
+                                          <node concept="pncrf" id="3DWpd_K7xzX" role="2Oq$k0" />
+                                          <node concept="2NL2c5" id="3DWpd_K7xzY" role="2OqNvi" />
+                                        </node>
+                                        <node concept="liA8E" id="3DWpd_K7xzZ" role="2OqNvi">
+                                          <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
+                                        </node>
                                       </node>
                                     </node>
                                   </node>
                                 </node>
                               </node>
+                            </node>
+                          </node>
+                          <node concept="3SKdUt" id="3DWpd_Kh65R" role="3cqZAp">
+                            <node concept="1PaTwC" id="3DWpd_Kh65S" role="1aUNEU">
+                              <node concept="3oM_SD" id="3DWpd_Kh65T" role="1PaTwD">
+                                <property role="3oM_SC" value="setting" />
+                              </node>
+                              <node concept="3oM_SD" id="3DWpd_Kh6aB" role="1PaTwD">
+                                <property role="3oM_SC" value="default" />
+                              </node>
+                              <node concept="3oM_SD" id="3DWpd_Kh6b6" role="1PaTwD">
+                                <property role="3oM_SC" value="transformation" />
+                              </node>
+                              <node concept="3oM_SD" id="3DWpd_Kh6cs" role="1PaTwD">
+                                <property role="3oM_SC" value="menu" />
+                              </node>
+                              <node concept="3oM_SD" id="3DWpd_Kh6cX" role="1PaTwD">
+                                <property role="3oM_SC" value="is" />
+                              </node>
+                              <node concept="3oM_SD" id="3DWpd_Kh6dv" role="1PaTwD">
+                                <property role="3oM_SC" value="required" />
+                              </node>
+                              <node concept="3oM_SD" id="3DWpd_Kh6e2" role="1PaTwD">
+                                <property role="3oM_SC" value="so" />
+                              </node>
+                              <node concept="3oM_SD" id="3DWpd_Kh6eA" role="1PaTwD">
+                                <property role="3oM_SC" value="that" />
+                              </node>
+                              <node concept="3oM_SD" id="3DWpd_Kh6gf" role="1PaTwD">
+                                <property role="3oM_SC" value="CC" />
+                              </node>
+                              <node concept="3oM_SD" id="3DWpd_Kh6qJ" role="1PaTwD">
+                                <property role="3oM_SC" value="menu" />
+                              </node>
+                              <node concept="3oM_SD" id="3DWpd_Kh6oK" role="1PaTwD">
+                                <property role="3oM_SC" value="works" />
+                              </node>
+                              <node concept="3oM_SD" id="3DWpd_Kh6qr" role="1PaTwD">
+                                <property role="3oM_SC" value="correctly" />
+                              </node>
+                              <node concept="3oM_SD" id="3DWpd_Kh6hR" role="1PaTwD">
+                                <property role="3oM_SC" value="on" />
+                              </node>
+                              <node concept="3oM_SD" id="3DWpd_Kh6iI" role="1PaTwD">
+                                <property role="3oM_SC" value="the" />
+                              </node>
+                              <node concept="3oM_SD" id="3DWpd_Kh6iX" role="1PaTwD">
+                                <property role="3oM_SC" value="error" />
+                              </node>
+                              <node concept="3oM_SD" id="3DWpd_Kh6k3" role="1PaTwD">
+                                <property role="3oM_SC" value="cell" />
+                              </node>
+                              <node concept="3oM_SD" id="3DWpd_Kh6mG" role="1PaTwD" />
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="3DWpd_K7xRa" role="3cqZAp">
+                            <node concept="2OqwBi" id="3DWpd_K7xRb" role="3clFbG">
+                              <node concept="37vLTw" id="3DWpd_K7xRc" role="2Oq$k0">
+                                <ref role="3cqZAo" node="3DWpd_K7xzM" resolve="errorCell" />
+                              </node>
+                              <node concept="liA8E" id="3DWpd_K7xRd" role="2OqNvi">
+                                <ref role="37wK5l" to="g51k:~EditorCell_Basic.setTransformationMenuLookup(jetbrains.mps.openapi.editor.menus.transformation.TransformationMenuLookup)" resolve="setTransformationMenuLookup" />
+                                <node concept="2ShNRf" id="3DWpd_K7xRe" role="37wK5m">
+                                  <node concept="1pGfFk" id="3DWpd_K7xRf" role="2ShVmc">
+                                    <ref role="37wK5l" to="9eyi:~DefaultTransformationMenuLookup.&lt;init&gt;(jetbrains.mps.smodel.language.LanguageRegistry,org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="DefaultTransformationMenuLookup" />
+                                    <node concept="2YIFZM" id="3DWpd_K7xRg" role="37wK5m">
+                                      <ref role="1Pybhc" to="vndm:~LanguageRegistry" resolve="LanguageRegistry" />
+                                      <ref role="37wK5l" to="vndm:~LanguageRegistry.getInstance(org.jetbrains.mps.openapi.module.SRepository)" resolve="getInstance" />
+                                      <node concept="2OqwBi" id="3DWpd_K7xRh" role="37wK5m">
+                                        <node concept="1Q80Hx" id="3DWpd_K7xRi" role="2Oq$k0" />
+                                        <node concept="liA8E" id="3DWpd_K7xRj" role="2OqNvi">
+                                          <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="35c_gC" id="3DWpd_K7xRk" role="37wK5m">
+                                      <ref role="35c_gD" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="3DWpd_KdRLF" role="3cqZAp">
+                            <node concept="2OqwBi" id="3DWpd_KdSlQ" role="3clFbG">
+                              <node concept="37vLTw" id="3DWpd_KdRLD" role="2Oq$k0">
+                                <ref role="3cqZAo" node="3DWpd_K7xzM" resolve="errorCell" />
+                              </node>
+                              <node concept="liA8E" id="3DWpd_KdThJ" role="2OqNvi">
+                                <ref role="37wK5l" to="g51k:~EditorCell_Basic.setSubstituteInfo(jetbrains.mps.openapi.editor.cells.SubstituteInfo)" resolve="setSubstituteInfo" />
+                                <node concept="2ShNRf" id="3DWpd_KdTWg" role="37wK5m">
+                                  <node concept="1pGfFk" id="3DWpd_KdTWr" role="2ShVmc">
+                                    <ref role="37wK5l" to="6lvu:~SChildSubstituteInfo.&lt;init&gt;(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="SChildSubstituteInfo" />
+                                    <node concept="37vLTw" id="3DWpd_KdUc2" role="37wK5m">
+                                      <ref role="3cqZAo" node="3DWpd_K7xzM" resolve="errorCell" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="3ijo1YRLJA$" role="3cqZAp">
+                            <node concept="37vLTw" id="3DWpd_K7x$0" role="3clFbG">
+                              <ref role="3cqZAo" node="3DWpd_K7xzM" resolve="errorCell" />
                             </node>
                           </node>
                         </node>
@@ -1107,7 +1224,7 @@
                         <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
                       </node>
                       <node concept="37vLTG" id="3ijo1YSEoe_" role="3clF46">
-                        <property role="TrG5h" value="p1" />
+                        <property role="TrG5h" value="ec" />
                         <node concept="3uibUv" id="3ijo1YSEoeA" role="1tU5fm">
                           <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
                         </node>
@@ -1153,32 +1270,89 @@
                             </node>
                           </node>
                         </node>
-                        <node concept="3clFbF" id="3ijo1YSEoeC" role="3cqZAp">
-                          <node concept="2ShNRf" id="3ijo1YSEoeD" role="3clFbG">
-                            <node concept="1pGfFk" id="3ijo1YSEoeE" role="2ShVmc">
-                              <ref role="37wK5l" to="g51k:~EditorCell_Error.&lt;init&gt;(jetbrains.mps.openapi.editor.EditorContext,org.jetbrains.mps.openapi.model.SNode,java.lang.String)" resolve="EditorCell_Error" />
-                              <node concept="1Q80Hx" id="3ijo1YSEoeF" role="37wK5m" />
-                              <node concept="pncrf" id="3ijo1YSEoeG" role="37wK5m" />
-                              <node concept="3cpWs3" id="3ijo1YSEoeH" role="37wK5m">
-                                <node concept="Xl_RD" id="3ijo1YSEoeI" role="3uHU7w">
-                                  <property role="Xl_RC" value="&gt;" />
-                                </node>
-                                <node concept="3cpWs3" id="3ijo1YSEoeJ" role="3uHU7B">
-                                  <node concept="Xl_RD" id="3ijo1YSEoeK" role="3uHU7B">
-                                    <property role="Xl_RC" value="&lt;" />
+                        <node concept="3cpWs8" id="3DWpd_K411G" role="3cqZAp">
+                          <node concept="3cpWsn" id="3DWpd_K411H" role="3cpWs9">
+                            <property role="TrG5h" value="errorCell" />
+                            <node concept="3uibUv" id="3DWpd_K410H" role="1tU5fm">
+                              <ref role="3uigEE" to="g51k:~EditorCell_Error" resolve="EditorCell_Error" />
+                            </node>
+                            <node concept="2ShNRf" id="3DWpd_K411I" role="33vP2m">
+                              <node concept="1pGfFk" id="3DWpd_K411J" role="2ShVmc">
+                                <ref role="37wK5l" to="g51k:~EditorCell_Error.&lt;init&gt;(jetbrains.mps.openapi.editor.EditorContext,org.jetbrains.mps.openapi.model.SNode,java.lang.String)" resolve="EditorCell_Error" />
+                                <node concept="1Q80Hx" id="3DWpd_K411K" role="37wK5m" />
+                                <node concept="pncrf" id="3DWpd_K411L" role="37wK5m" />
+                                <node concept="3cpWs3" id="3DWpd_K411M" role="37wK5m">
+                                  <node concept="Xl_RD" id="3DWpd_K411N" role="3uHU7w">
+                                    <property role="Xl_RC" value="&gt;" />
                                   </node>
-                                  <node concept="2OqwBi" id="3ijo1YSEoeL" role="3uHU7w">
-                                    <node concept="2OqwBi" id="3ijo1YSEoeM" role="2Oq$k0">
-                                      <node concept="pncrf" id="3ijo1YSEoeN" role="2Oq$k0" />
-                                      <node concept="2NL2c5" id="3ijo1YSEoeO" role="2OqNvi" />
+                                  <node concept="3cpWs3" id="3DWpd_K411O" role="3uHU7B">
+                                    <node concept="Xl_RD" id="3DWpd_K411P" role="3uHU7B">
+                                      <property role="Xl_RC" value="&lt;" />
                                     </node>
-                                    <node concept="liA8E" id="3ijo1YSEoeP" role="2OqNvi">
-                                      <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
+                                    <node concept="2OqwBi" id="3DWpd_K411Q" role="3uHU7w">
+                                      <node concept="2OqwBi" id="3DWpd_K411R" role="2Oq$k0">
+                                        <node concept="pncrf" id="3DWpd_K411S" role="2Oq$k0" />
+                                        <node concept="2NL2c5" id="3DWpd_K411T" role="2OqNvi" />
+                                      </node>
+                                      <node concept="liA8E" id="3DWpd_K411U" role="2OqNvi">
+                                        <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
+                                      </node>
                                     </node>
                                   </node>
                                 </node>
                               </node>
                             </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="3DWpd_K41KR" role="3cqZAp">
+                          <node concept="2OqwBi" id="3DWpd_K42jG" role="3clFbG">
+                            <node concept="37vLTw" id="3DWpd_K41KP" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3DWpd_K411H" resolve="errorCell" />
+                            </node>
+                            <node concept="liA8E" id="3DWpd_K43dP" role="2OqNvi">
+                              <ref role="37wK5l" to="g51k:~EditorCell_Basic.setTransformationMenuLookup(jetbrains.mps.openapi.editor.menus.transformation.TransformationMenuLookup)" resolve="setTransformationMenuLookup" />
+                              <node concept="2ShNRf" id="3DWpd_K43h1" role="37wK5m">
+                                <node concept="1pGfFk" id="3DWpd_K4kga" role="2ShVmc">
+                                  <ref role="37wK5l" to="9eyi:~DefaultTransformationMenuLookup.&lt;init&gt;(jetbrains.mps.smodel.language.LanguageRegistry,org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="DefaultTransformationMenuLookup" />
+                                  <node concept="2YIFZM" id="3DWpd_K4loP" role="37wK5m">
+                                    <ref role="1Pybhc" to="vndm:~LanguageRegistry" resolve="LanguageRegistry" />
+                                    <ref role="37wK5l" to="vndm:~LanguageRegistry.getInstance(org.jetbrains.mps.openapi.module.SRepository)" resolve="getInstance" />
+                                    <node concept="2OqwBi" id="3DWpd_K4lRF" role="37wK5m">
+                                      <node concept="1Q80Hx" id="3DWpd_K4l_q" role="2Oq$k0" />
+                                      <node concept="liA8E" id="3DWpd_K4m4Q" role="2OqNvi">
+                                        <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="35c_gC" id="3DWpd_K4mqi" role="37wK5m">
+                                    <ref role="35c_gD" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="3DWpd_Kh5nz" role="3cqZAp">
+                          <node concept="2OqwBi" id="3DWpd_Kh5n$" role="3clFbG">
+                            <node concept="37vLTw" id="3DWpd_Kh5n_" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3DWpd_K411H" resolve="errorCell" />
+                            </node>
+                            <node concept="liA8E" id="3DWpd_Kh5nA" role="2OqNvi">
+                              <ref role="37wK5l" to="g51k:~EditorCell_Basic.setSubstituteInfo(jetbrains.mps.openapi.editor.cells.SubstituteInfo)" resolve="setSubstituteInfo" />
+                              <node concept="2ShNRf" id="3DWpd_Kh5nB" role="37wK5m">
+                                <node concept="1pGfFk" id="3DWpd_Kh5nC" role="2ShVmc">
+                                  <ref role="37wK5l" to="6lvu:~SChildSubstituteInfo.&lt;init&gt;(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="SChildSubstituteInfo" />
+                                  <node concept="37vLTw" id="3DWpd_Kh5nD" role="37wK5m">
+                                    <ref role="3cqZAo" node="3DWpd_K411H" resolve="errorCell" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="3ijo1YSEoeC" role="3cqZAp">
+                          <node concept="37vLTw" id="3DWpd_K411V" role="3clFbG">
+                            <ref role="3cqZAo" node="3DWpd_K411H" resolve="errorCell" />
                           </node>
                         </node>
                       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
@@ -32,6 +32,7 @@
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
+      <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
@@ -73,6 +74,9 @@
         <property id="1140114345053" name="allowEmptyText" index="1O74Pk" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
+      <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
+        <child id="1142887637401" name="renderingCondition" index="pqm2j" />
+      </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
         <child id="1073389446424" name="childCellModel" index="3EZMnx" />
@@ -94,6 +98,12 @@
       </concept>
       <concept id="1225900081164" name="jetbrains.mps.lang.editor.structure.CellModel_ReadOnlyModelAccessor" flags="sg" stub="3708815482283559694" index="1HlG4h">
         <child id="1225900141900" name="modelAccessor" index="1HlULh" />
+      </concept>
+      <concept id="1088612959204" name="jetbrains.mps.lang.editor.structure.CellModel_Alternation" flags="sg" stub="8104358048506729361" index="1QoScp">
+        <property id="1088613081987" name="vertical" index="1QpmdY" />
+        <child id="1145918517974" name="alternationCondition" index="3e4ffs" />
+        <child id="1088612958265" name="ifTrueCellModel" index="1QoS34" />
+        <child id="1088612973955" name="ifFalseCellModel" index="1QoVPY" />
       </concept>
       <concept id="1176717841777" name="jetbrains.mps.lang.editor.structure.QueryFunction_ModelAccess_Getter" flags="in" index="3TQlhw" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
@@ -148,6 +158,7 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -331,6 +342,7 @@
       </concept>
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
   <node concept="24kQdi" id="cPLa7FpdIL">
@@ -981,8 +993,34 @@
     <ref role="1XX52x" to="e9k1:3y6PJwOpPmR" resolve="DataIsInTarget" />
     <node concept="3EZMnI" id="6WstIz8MK6C" role="2wV5jI">
       <node concept="l2Vlx" id="6WstIz8MK6D" role="2iSdaV" />
-      <node concept="3F0ifn" id="6WstIz8MK6E" role="3EZMnx">
-        <property role="3F0ifm" value="isIn" />
+      <node concept="1QoScp" id="3MDtzBr9V7" role="3EZMnx">
+        <property role="1QpmdY" value="true" />
+        <node concept="3F0ifn" id="3MDtzBr9V9" role="1QoS34">
+          <property role="3F0ifm" value="isIn" />
+        </node>
+        <node concept="pkWqt" id="3MDtzBr9Va" role="3e4ffs">
+          <node concept="3clFbS" id="3MDtzBr9Vc" role="2VODD2">
+            <node concept="3clFbF" id="3MDtzBrefN" role="3cqZAp">
+              <node concept="3eOSWO" id="3MDtzBrm6t" role="3clFbG">
+                <node concept="3cmrfG" id="3MDtzBrm6x" role="3uHU7w">
+                  <property role="3cmrfH" value="1" />
+                </node>
+                <node concept="2OqwBi" id="3MDtzBrmMr" role="3uHU7B">
+                  <node concept="2OqwBi" id="3MDtzBrev5" role="2Oq$k0">
+                    <node concept="pncrf" id="3MDtzBrefM" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="3MDtzBreNV" role="2OqNvi">
+                      <ref role="3TtcxE" to="e9k1:3y6PJwOpPmU" resolve="selectors" />
+                    </node>
+                  </node>
+                  <node concept="34oBXx" id="3MDtzBrpVo" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3F0ifn" id="3MDtzBrqex" role="1QoVPY">
+          <property role="3F0ifm" value="is" />
+        </node>
       </node>
       <node concept="3F0ifn" id="6WstIz8MK6F" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -1032,6 +1070,21 @@
                     <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
                   </node>
                 </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="pkWqt" id="3MDtzBsETN" role="pqm2j">
+          <node concept="3clFbS" id="3MDtzBsETO" role="2VODD2">
+            <node concept="3clFbF" id="3MDtzBsEUX" role="3cqZAp">
+              <node concept="2OqwBi" id="3MDtzBsH9B" role="3clFbG">
+                <node concept="2OqwBi" id="3MDtzBsFaf" role="2Oq$k0">
+                  <node concept="pncrf" id="3MDtzBsEUW" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="3MDtzBsFvp" role="2OqNvi">
+                    <ref role="3TtcxE" to="e9k1:3y6PJwOpPmU" resolve="selectors" />
+                  </node>
+                </node>
+                <node concept="3GX2aA" id="3MDtzBsKyA" role="2OqNvi" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.structure.mps
@@ -245,9 +245,9 @@
   <node concept="1TIwiD" id="3y6PJwOpPmR">
     <property role="EcuMT" value="4073179274522613175" />
     <property role="TrG5h" value="DataIsInTarget" />
-    <property role="34LRSv" value="isIn" />
+    <property role="34LRSv" value="is" />
     <property role="3GE5qa" value="expr" />
-    <property role="R4oN_" value="check data element against several rows" />
+    <property role="R4oN_" value="check data element against one or several rows" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="PrWs8" id="3y6PJwOpPmS" role="PzmwI">
       <ref role="PrY4T" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
@@ -256,7 +256,7 @@
       <property role="IQ2ns" value="4073179274522613178" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="selectors" />
-      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <property role="20lbJX" value="fLJekj6/_1__n" />
       <ref role="20lvS9" node="3y6PJwOpPmW" resolve="DataRowSelector" />
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -8078,6 +8078,22 @@
     <node concept="13hLZK" id="7cphKbL$4Ns" role="13h7CW">
       <node concept="3clFbS" id="7cphKbL$4Nt" role="2VODD2" />
     </node>
+    <node concept="13i0hz" id="1WTzGglLELu" role="13h7CS">
+      <property role="TrG5h" value="allowParagraph" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" to="gdgh:4ZH31cjGRan" resolve="allowParagraph" />
+      <node concept="3Tm1VV" id="1WTzGglLELv" role="1B3o_S" />
+      <node concept="3clFbS" id="1WTzGglLEL$" role="3clF47">
+        <node concept="3clFbF" id="1WTzGglLF93" role="3cqZAp">
+          <node concept="2YIFZM" id="1WTzGglLFaL" role="3clFbG">
+            <ref role="37wK5l" to="xfg9:3NUSEp5yd8T" resolve="allowParagraphsInIdentifiers" />
+            <ref role="1Pybhc" to="xfg9:6fmG8CYTWg1" resolve="IdentifierConfiguratorAccess" />
+            <node concept="1fM9EW" id="1WTzGglLFba" role="37wK5m" />
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="1WTzGglLEL_" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="5YygIlbmK_u" role="13h7CS">
       <property role="13i0iv" value="false" />
       <property role="13i0it" value="false" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -176,9 +176,13 @@
       <concept id="8998492695583125082" name="jetbrains.mps.lang.editor.structure.SubstituteFeature_MatchingText" flags="ng" index="16NfWO">
         <child id="8998492695583129244" name="query" index="16NeZM" />
       </concept>
+      <concept id="8998492695583129971" name="jetbrains.mps.lang.editor.structure.SubstituteFeature_DescriptionText" flags="ng" index="16NL0t">
+        <child id="8998492695583129972" name="query" index="16NL0q" />
+      </concept>
       <concept id="1220974635399" name="jetbrains.mps.lang.editor.structure.QueryFunction_FontStyle" flags="in" index="17KAyr" />
       <concept id="2115302367868116903" name="jetbrains.mps.lang.editor.structure.GeneratedSubstituteMenuAttribute" flags="ng" index="382kZG" />
       <concept id="3360401466585705291" name="jetbrains.mps.lang.editor.structure.CellModel_ContextAssistant" flags="ng" index="18a60v" />
+      <concept id="1154465273778" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_ParentNode" flags="nn" index="3bvxqY" />
       <concept id="1221057094638" name="jetbrains.mps.lang.editor.structure.QueryFunction_Integer" flags="in" index="1cFabM" />
       <concept id="2896773699153795590" name="jetbrains.mps.lang.editor.structure.TransformationLocation_SideTransform" flags="ng" index="3cWJ9i">
         <child id="3473224453637651919" name="placeInCell" index="CtIbM" />
@@ -328,7 +332,6 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
-      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -442,12 +445,19 @@
         <reference id="5455284157994012188" name="link" index="2pIpSl" />
         <child id="1595412875168045827" name="initValue" index="28nt2d" />
       </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
       <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
         <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
       </concept>
       <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
         <reference id="5455284157993910961" name="concept" index="2pJxaS" />
         <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
       </concept>
       <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
         <child id="8182547171709752112" name="expression" index="36biLW" />
@@ -551,21 +561,18 @@
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
-      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1224414427926" name="jetbrains.mps.baseLanguage.collections.structure.SequenceCreator" flags="nn" index="kMnCb">
+        <child id="1224414456414" name="elementType" index="kMuH3" />
+      </concept>
       <concept id="1235573135402" name="jetbrains.mps.baseLanguage.collections.structure.SingletonSequenceCreator" flags="nn" index="2HTt$P">
         <child id="1235573175711" name="elementType" index="2HTBi0" />
         <child id="1235573187520" name="singletonValue" index="2HTEbv" />
       </concept>
-      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
-        <child id="1237721435807" name="elementType" index="HW$YZ" />
-      </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
-      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
-      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
@@ -2896,110 +2903,8 @@
   <node concept="24kQdi" id="7cphKbLtLRz">
     <property role="3GE5qa" value="record.project" />
     <ref role="1XX52x" to="yv47:7cphKbLtLQW" resolve="InlineRecordMemberAccess" />
-    <node concept="1kIj98" id="7cphKbLy8g_" role="2wV5jI">
-      <node concept="3F0A7n" id="7cphKbLtLRI" role="1kIj9b">
-        <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
-        <node concept="OXEIz" id="7cphKbLwf$9" role="P5bDN">
-          <node concept="PvTIS" id="7cphKbLwf$b" role="OY2wv">
-            <node concept="MLZmj" id="7cphKbLwf$c" role="PvTIR">
-              <node concept="3clFbS" id="7cphKbLwf$d" role="2VODD2">
-                <node concept="3cpWs8" id="7cphKbLwqZq" role="3cqZAp">
-                  <node concept="3cpWsn" id="7cphKbLwqZr" role="3cpWs9">
-                    <property role="TrG5h" value="tt" />
-                    <node concept="3Tqbb2" id="7cphKbLwqZl" role="1tU5fm" />
-                    <node concept="2OqwBi" id="7cphKbLwqZs" role="33vP2m">
-                      <node concept="2OqwBi" id="7cphKbLwqZt" role="2Oq$k0">
-                        <node concept="1PxgMI" id="7cphKbLwqZu" role="2Oq$k0">
-                          <node concept="chp4Y" id="7cphKbLwqZv" role="3oSUPX">
-                            <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
-                          </node>
-                          <node concept="2OqwBi" id="7cphKbLwqZw" role="1m5AlR">
-                            <node concept="3GMtW1" id="7cphKbLwqZx" role="2Oq$k0" />
-                            <node concept="1mfA1w" id="7cphKbLwqZy" role="2OqNvi" />
-                          </node>
-                        </node>
-                        <node concept="3TrEf2" id="7cphKbLwqZz" role="2OqNvi">
-                          <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
-                        </node>
-                      </node>
-                      <node concept="3JvlWi" id="7cphKbLwqZ$" role="2OqNvi" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="7cphKbLwfOg" role="3cqZAp">
-                  <node concept="1Wc70l" id="4ptnK4iXuIh" role="3clFbw">
-                    <node concept="3y3z36" id="4ptnK4iXvUy" role="3uHU7B">
-                      <node concept="10Nm6u" id="4ptnK4iXwsV" role="3uHU7w" />
-                      <node concept="37vLTw" id="4ptnK4iXvgB" role="3uHU7B">
-                        <ref role="3cqZAo" node="7cphKbLwqZr" resolve="tt" />
-                      </node>
-                    </node>
-                    <node concept="2OqwBi" id="7cphKbLwhti" role="3uHU7w">
-                      <node concept="37vLTw" id="7cphKbLwqZ_" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7cphKbLwqZr" resolve="tt" />
-                      </node>
-                      <node concept="1mIQ4w" id="7cphKbLwhTP" role="2OqNvi">
-                        <node concept="chp4Y" id="7cphKbLwq6U" role="cj9EA">
-                          <ref role="cht4Q" to="yv47:7cphKbLawNf" resolve="InlineRecordType" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbS" id="7cphKbLwfOi" role="3clFbx">
-                    <node concept="3cpWs6" id="7cphKbLwqxP" role="3cqZAp">
-                      <node concept="2OqwBi" id="7cphKbLwPds" role="3cqZAk">
-                        <node concept="2OqwBi" id="7cphKbLwIzp" role="2Oq$k0">
-                          <node concept="2OqwBi" id="7cphKbLwxky" role="2Oq$k0">
-                            <node concept="1PxgMI" id="7cphKbLwuTO" role="2Oq$k0">
-                              <node concept="chp4Y" id="7cphKbLwvuN" role="3oSUPX">
-                                <ref role="cht4Q" to="yv47:7cphKbLawNf" resolve="InlineRecordType" />
-                              </node>
-                              <node concept="37vLTw" id="7cphKbLwrOI" role="1m5AlR">
-                                <ref role="3cqZAo" node="7cphKbLwqZr" resolve="tt" />
-                              </node>
-                            </node>
-                            <node concept="3Tsc0h" id="5ipapt3GmDs" role="2OqNvi">
-                              <ref role="3TtcxE" to="yv47:4ptnK4iZ$op" resolve="members" />
-                            </node>
-                          </node>
-                          <node concept="3$u5V9" id="7cphKbLwLy3" role="2OqNvi">
-                            <node concept="1bVj0M" id="7cphKbLwLy5" role="23t8la">
-                              <node concept="3clFbS" id="7cphKbLwLy6" role="1bW5cS">
-                                <node concept="3clFbF" id="7cphKbLwMCP" role="3cqZAp">
-                                  <node concept="2OqwBi" id="7cphKbLwNbD" role="3clFbG">
-                                    <node concept="37vLTw" id="7cphKbLwMCO" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="7cphKbLwLy7" resolve="it" />
-                                    </node>
-                                    <node concept="3TrcHB" id="7cphKbLwO2w" role="2OqNvi">
-                                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="Rh6nW" id="7cphKbLwLy7" role="1bW2Oz">
-                                <property role="TrG5h" value="it" />
-                                <node concept="2jxLKc" id="7cphKbLwLy8" role="1tU5fm" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="ANE8D" id="7cphKbLwQ8J" role="2OqNvi" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="7cphKbLwkTG" role="3cqZAp">
-                  <node concept="2ShNRf" id="7cphKbLwkTw" role="3clFbG">
-                    <node concept="Tc6Ow" id="7cphKbLwlyz" role="2ShVmc">
-                      <node concept="17QB3L" id="7cphKbLwmsd" role="HW$YZ" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
+    <node concept="3F0A7n" id="7cphKbLtLRI" role="2wV5jI">
+      <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
     </node>
   </node>
   <node concept="24kQdi" id="4ptnK4jbr0k">
@@ -4374,6 +4279,135 @@
     <ref role="1XX52x" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="3F0ifn" id="6dXnuBU76jV" role="2wV5jI">
       <property role="3F0ifm" value="Workaround to fix contributions to BaseConcept generated by grammarCells." />
+    </node>
+  </node>
+  <node concept="22mcaB" id="2Q7faZZqpyo">
+    <property role="3GE5qa" value="record.project" />
+    <ref role="aqKnT" to="yv47:7cphKbLtLQW" resolve="InlineRecordMemberAccess" />
+    <node concept="22hDWj" id="2Q7faZZqpyp" role="22hAXT" />
+    <node concept="2F$Pav" id="2Q7faZZqpyr" role="3ft7WO">
+      <node concept="3eGOop" id="2Q7faZZrL1w" role="2$S_pN">
+        <node concept="ucgPf" id="2Q7faZZrL1y" role="3aKz83">
+          <node concept="3clFbS" id="2Q7faZZrL1$" role="2VODD2">
+            <node concept="3clFbF" id="2Q7faZZrLgx" role="3cqZAp">
+              <node concept="2pJPEk" id="2Q7faZZrLgv" role="3clFbG">
+                <node concept="2pJPED" id="2Q7faZZrLmR" role="2pJPEn">
+                  <ref role="2pJxaS" to="yv47:7cphKbLtLQW" resolve="InlineRecordMemberAccess" />
+                  <node concept="2pJxcG" id="2Q7faZZrLt6" role="2pJxcM">
+                    <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                    <node concept="WxPPo" id="2Q7faZZx6Us" role="28ntcv">
+                      <node concept="2OqwBi" id="2Q7faZZx6Yq" role="WxPPp">
+                        <node concept="2ZBlsa" id="2Q7faZZx6Ur" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="2Q7faZZx75Y" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="16NfWO" id="2Q7faZZzsmM" role="upBLP">
+          <node concept="uGdhv" id="2Q7faZZzsoy" role="16NeZM">
+            <node concept="3clFbS" id="2Q7faZZzso$" role="2VODD2">
+              <node concept="3clFbF" id="2Q7faZZzsp0" role="3cqZAp">
+                <node concept="2OqwBi" id="2Q7faZZzsG1" role="3clFbG">
+                  <node concept="2ZBlsa" id="2Q7faZZzsoZ" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="2Q7faZZzteX" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="16NL0t" id="2Q7faZZwpfx" role="upBLP">
+          <node concept="uGdhv" id="2Q7faZZwpkc" role="16NL0q">
+            <node concept="3clFbS" id="2Q7faZZwpke" role="2VODD2">
+              <node concept="3clFbF" id="2Q7faZZwpYD" role="3cqZAp">
+                <node concept="3cpWs3" id="2Q7faZZztyH" role="3clFbG">
+                  <node concept="Xl_RD" id="2Q7faZZwpYC" role="3uHU7w">
+                    <property role="Xl_RC" value=" inline record member" />
+                  </node>
+                  <node concept="2OqwBi" id="2Q7faZZx7lA" role="3uHU7B">
+                    <node concept="2ZBlsa" id="2Q7faZZx7dq" role="2Oq$k0" />
+                    <node concept="2qgKlT" id="2Q7faZZx7mH" role="2OqNvi">
+                      <ref role="37wK5l" to="pbu6:4WLweXm3SW5" resolve="type" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="2Q7faZZwx_7" role="2ZBHrp">
+        <ref role="ehGHo" to="yv47:xu7xcKdQCB" resolve="IRecordMember" />
+      </node>
+      <node concept="2$S_p_" id="2Q7faZZqvd6" role="2$S_pT">
+        <node concept="3clFbS" id="2Q7faZZqvd7" role="2VODD2">
+          <node concept="3cpWs8" id="7cphKbLwqZq" role="3cqZAp">
+            <node concept="3cpWsn" id="7cphKbLwqZr" role="3cpWs9">
+              <property role="TrG5h" value="baseType" />
+              <node concept="3Tqbb2" id="7cphKbLwqZl" role="1tU5fm" />
+              <node concept="2OqwBi" id="7cphKbLwqZs" role="33vP2m">
+                <node concept="2OqwBi" id="7cphKbLwqZt" role="2Oq$k0">
+                  <node concept="1PxgMI" id="7cphKbLwqZu" role="2Oq$k0">
+                    <node concept="chp4Y" id="7cphKbLwqZv" role="3oSUPX">
+                      <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+                    </node>
+                    <node concept="3bvxqY" id="2Q7faZZqwBa" role="1m5AlR" />
+                  </node>
+                  <node concept="3TrEf2" id="7cphKbLwqZz" role="2OqNvi">
+                    <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                  </node>
+                </node>
+                <node concept="3JvlWi" id="7cphKbLwqZ$" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="7cphKbLwfOg" role="3cqZAp">
+            <node concept="2OqwBi" id="7cphKbLwhti" role="3clFbw">
+              <node concept="37vLTw" id="7cphKbLwqZ_" role="2Oq$k0">
+                <ref role="3cqZAo" node="7cphKbLwqZr" resolve="baseType" />
+              </node>
+              <node concept="1mIQ4w" id="7cphKbLwhTP" role="2OqNvi">
+                <node concept="chp4Y" id="7cphKbLwq6U" role="cj9EA">
+                  <ref role="cht4Q" to="yv47:7cphKbLawNf" resolve="InlineRecordType" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="7cphKbLwfOi" role="3clFbx">
+              <node concept="3cpWs6" id="7cphKbLwqxP" role="3cqZAp">
+                <node concept="2OqwBi" id="7cphKbLwxky" role="3cqZAk">
+                  <node concept="1PxgMI" id="7cphKbLwuTO" role="2Oq$k0">
+                    <node concept="chp4Y" id="7cphKbLwvuN" role="3oSUPX">
+                      <ref role="cht4Q" to="yv47:7cphKbLawNf" resolve="InlineRecordType" />
+                    </node>
+                    <node concept="37vLTw" id="7cphKbLwrOI" role="1m5AlR">
+                      <ref role="3cqZAo" node="7cphKbLwqZr" resolve="baseType" />
+                    </node>
+                  </node>
+                  <node concept="3Tsc0h" id="5ipapt3GmDs" role="2OqNvi">
+                    <ref role="3TtcxE" to="yv47:4ptnK4iZ$op" resolve="members" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="7cphKbLwkTG" role="3cqZAp">
+            <node concept="2ShNRf" id="7cphKbLwkTw" role="3clFbG">
+              <node concept="kMnCb" id="2Q7faZZx2qZ" role="2ShVmc">
+                <node concept="3Tqbb2" id="2Q7faZZx66x" role="kMuH3">
+                  <ref role="ehGHo" to="yv47:xu7xcKdQCB" resolve="IRecordMember" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.runtime/models/runtime.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.runtime/models/runtime.mps
@@ -195,6 +195,7 @@
       <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
         <reference id="1116615189566" name="classifier" index="3VsUkX" />
       </concept>
+      <concept id="1178893518978" name="jetbrains.mps.baseLanguage.structure.ThisConstructorInvocation" flags="nn" index="1VxSAg" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="8064396509828172209" name="jetbrains.mps.baseLanguage.structure.UnaryMinus" flags="nn" index="1ZRNhn" />
     </language>
@@ -3134,16 +3135,16 @@
       <node concept="3cqZAl" id="3nVyItrYQUA" role="3clF45" />
       <node concept="3Tm1VV" id="3nVyItrYQUB" role="1B3o_S" />
       <node concept="3clFbS" id="3nVyItrYQUC" role="3clF47">
-        <node concept="3clFbF" id="3nVyItrYQUD" role="3cqZAp">
-          <node concept="2OqwBi" id="3nVyItrYQUE" role="3clFbG">
-            <node concept="37vLTw" id="3nVyItrYQUF" role="2Oq$k0">
-              <ref role="3cqZAo" node="3nVyItrYPs9" resolve="values" />
-            </node>
-            <node concept="TSZUe" id="3nVyItrYQUG" role="2OqNvi">
-              <node concept="37vLTw" id="3nVyItrYQUH" role="25WWJ7">
-                <ref role="3cqZAo" node="3nVyItrYQUI" resolve="value1" />
-              </node>
-            </node>
+        <node concept="1VxSAg" id="6VQE9XR3qaJ" role="3cqZAp">
+          <ref role="37wK5l" node="3nVyItrYOln" resolve="NixSupport" />
+          <node concept="37vLTw" id="6VQE9XR3qgw" role="37wK5m">
+            <ref role="3cqZAo" node="3nVyItrYQUI" resolve="value1" />
+          </node>
+          <node concept="37vLTw" id="6VQE9XR3qhD" role="37wK5m">
+            <ref role="3cqZAo" node="3nVyItrZcQJ" resolve="node" />
+          </node>
+          <node concept="37vLTw" id="6VQE9XR3qiX" role="37wK5m">
+            <ref role="3cqZAo" node="26cjRABQVGa" resolve="calculator" />
           </node>
         </node>
         <node concept="3clFbF" id="3nVyItrYR9O" role="3cqZAp">
@@ -3155,32 +3156,6 @@
               <node concept="37vLTw" id="3nVyItrYRdA" role="25WWJ7">
                 <ref role="3cqZAo" node="3nVyItrYR2H" resolve="value2" />
               </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="3nVyItrZd3p" role="3cqZAp">
-          <node concept="37vLTI" id="3nVyItrZdrP" role="3clFbG">
-            <node concept="37vLTw" id="3nVyItrZdu7" role="37vLTx">
-              <ref role="3cqZAo" node="3nVyItrZcQJ" resolve="node" />
-            </node>
-            <node concept="2OqwBi" id="3nVyItrZddQ" role="37vLTJ">
-              <node concept="Xjq3P" id="3nVyItrZd3n" role="2Oq$k0" />
-              <node concept="2OwXpG" id="3nVyItrZdlv" role="2OqNvi">
-                <ref role="2Oxat5" node="3nVyItrZcrA" resolve="node" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="3nVyItrYSek" role="3cqZAp">
-          <node concept="37vLTI" id="26cjRABQX1a" role="3clFbG">
-            <node concept="2OqwBi" id="26cjRABQX1b" role="37vLTJ">
-              <node concept="Xjq3P" id="26cjRABQX1c" role="2Oq$k0" />
-              <node concept="2OwXpG" id="26cjRABQX1d" role="2OqNvi">
-                <ref role="2Oxat5" node="26cjRABQW0s" resolve="calculator" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="26cjRABQX1e" role="37vLTx">
-              <ref role="3cqZAo" node="26cjRABQVGa" resolve="calculator" />
             </node>
           </node>
         </node>
@@ -3208,6 +3183,73 @@
             <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
           </node>
           <node concept="3uibUv" id="26cjRABR7tS" role="1ajw0F">
+            <ref role="3uigEE" node="3nVyItrYOkv" resolve="NixSupport" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6VQE9XR3tXZ" role="jymVt" />
+    <node concept="3clFbW" id="6VQE9XR3srZ" role="jymVt">
+      <node concept="3cqZAl" id="6VQE9XR3ss0" role="3clF45" />
+      <node concept="3Tm1VV" id="6VQE9XR3ss1" role="1B3o_S" />
+      <node concept="3clFbS" id="6VQE9XR3ss2" role="3clF47">
+        <node concept="1VxSAg" id="6VQE9XR3ss3" role="3cqZAp">
+          <ref role="37wK5l" node="3nVyItrYQU_" resolve="NixSupport" />
+          <node concept="37vLTw" id="6VQE9XR3ss4" role="37wK5m">
+            <ref role="3cqZAo" node="6VQE9XR3ssc" resolve="value1" />
+          </node>
+          <node concept="37vLTw" id="6VQE9XR3wuH" role="37wK5m">
+            <ref role="3cqZAo" node="6VQE9XR3sse" resolve="value2" />
+          </node>
+          <node concept="37vLTw" id="6VQE9XR3ss5" role="37wK5m">
+            <ref role="3cqZAo" node="6VQE9XR3ssg" resolve="node" />
+          </node>
+          <node concept="37vLTw" id="6VQE9XR3ss6" role="37wK5m">
+            <ref role="3cqZAo" node="6VQE9XR3ssi" resolve="calculator" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="6VQE9XR3ss7" role="3cqZAp">
+          <node concept="2OqwBi" id="6VQE9XR3ss8" role="3clFbG">
+            <node concept="37vLTw" id="6VQE9XR3ss9" role="2Oq$k0">
+              <ref role="3cqZAo" node="3nVyItrYPs9" resolve="values" />
+            </node>
+            <node concept="TSZUe" id="6VQE9XR3ssa" role="2OqNvi">
+              <node concept="37vLTw" id="6VQE9XR3wvR" role="25WWJ7">
+                <ref role="3cqZAo" node="6VQE9XR3vXU" resolve="value3" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6VQE9XR3ssc" role="3clF46">
+        <property role="TrG5h" value="value1" />
+        <node concept="3uibUv" id="6VQE9XR3ssd" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6VQE9XR3sse" role="3clF46">
+        <property role="TrG5h" value="value2" />
+        <node concept="3uibUv" id="6VQE9XR3ssf" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6VQE9XR3vXU" role="3clF46">
+        <property role="TrG5h" value="value3" />
+        <node concept="3uibUv" id="6VQE9XR3vXV" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6VQE9XR3ssg" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="6VQE9XR3ssh" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6VQE9XR3ssi" role="3clF46">
+        <property role="TrG5h" value="calculator" />
+        <node concept="1ajhzC" id="6VQE9XR3ssj" role="1tU5fm">
+          <node concept="3uibUv" id="6VQE9XR3ssk" role="1ajl9A">
+            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+          </node>
+          <node concept="3uibUv" id="6VQE9XR3ssl" role="1ajw0F">
             <ref role="3uigEE" node="3nVyItrYOkv" resolve="NixSupport" />
           </node>
         </node>


### PR DESCRIPTION
This PR merges several minor adjustements/fixes for datev-steuer project to 2020.1 maintenance branch:
- proper substitute menu implemented for InlineRecords
- editor for DataIsInTarget adjusted for single argument case
- paragraph symbol allowed in record members
- NixSupport provides 3-arguments constructor
- fixed missing subst menu for custom error cell on abstract expressions