### PR TITLE
Fix EmptyValue editor, so specification of a type is possible again

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
@@ -6587,13 +6587,16 @@
     <property role="3GE5qa" value="nix" />
     <ref role="1XX52x" to="hm2y:3nVyItrZBN9" resolve="EmptyValue" />
     <node concept="3EZMnI" id="3nVyItrZBNG" role="2wV5jI">
-      <node concept="2iRfu4" id="3nVyItrZBNH" role="2iSdaV" />
       <node concept="3F0ifn" id="3nVyItrZBND" role="3EZMnx">
         <property role="3F0ifm" value="empty" />
         <node concept="11LMrY" id="3tcv7J0_Tob" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
+        <node concept="3CIbrd" id="1kEzTWVBIaM" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
       </node>
+      <node concept="2iRfu4" id="3nVyItrZBNH" role="2iSdaV" />
       <node concept="_tjkj" id="3tcv7J0yv9p" role="3EZMnx">
         <node concept="3EZMnI" id="3tcv7J0yv9A" role="_tjki">
           <node concept="3F0ifn" id="3nVyItrZBO4" role="3EZMnx">


### PR DESCRIPTION
Fix EmptyValue editor, so specification of a type for the EmptyValue is possible again

Bug: On creation of an EmptyValue instance the cursor is positioned at "empt|y" and cannot move to "empty|",
thus it's not possible to add a type to the EmptyValue. Going to the right results in a jump to the next cell