### PR TITLE
Explicitly use node.getPresentation for string conversion

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/plugin.mps
@@ -42,7 +42,6 @@
     <import index="z1c3" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" />
     <import index="n70j" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.checking(MPS.Editor/)" />
     <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
-    <import index="j9xc" ref="r:6aee7d67-7b82-4d41-8ae4-450924f3612f(de.q60.mps.shadowmodels.modelcheck.runtime)" />
     <import index="z8iw" ref="r:dfdf3542-dbcf-43df-870a-3c3504b3c840(jetbrains.mps.baseLanguage.collections.custom)" implicit="true" />
   </imports>
   <registry>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/org.iets3.analysis.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/org.iets3.analysis.base.mpl
@@ -19,7 +19,6 @@
     <dependency reexport="false">cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</dependency>
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
     <dependency reexport="false">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.libs)</dependency>
-    <dependency reexport="false">b0c65e49-9d83-43ce-9e81-46c4fb70be71(de.q60.mps.shadowmodels.modelcheck.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
@@ -99,11 +98,7 @@
     <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
     <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
     <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
-    <module reference="95085166-3236-4dd7-bd8e-e753c8d20885(de.q60.mps.incremental.runtime)" version="0" />
     <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.libs)" version="0" />
-    <module reference="18463265-6d45-4514-82f1-cf7eb1222492(de.q60.mps.polymorphicfunctions.runtime)" version="0" />
-    <module reference="b0c65e49-9d83-43ce-9e81-46c4fb70be71(de.q60.mps.shadowmodels.modelcheck.runtime)" version="0" />
-    <module reference="e52a4835-844d-46a1-99f8-c06129db796f(de.q60.mps.shadowmodels.runtime)" version="0" />
     <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/typesystem.mps
@@ -10,6 +10,7 @@
     <import index="3eba" ref="r:be0c7a50-96d7-41ce-8522-0a6d4431fcc5(org.iets3.components.core.behavior)" />
     <import index="700h" ref="r:61b1de80-490d-4fee-8e95-b956503290e9(org.iets3.core.expr.collections.structure)" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
     <import index="yv47" ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" implicit="true" />
@@ -374,16 +375,26 @@
           </node>
           <node concept="2Mj0R9" id="6LfBX8Yll1h" role="3cqZAp">
             <node concept="3cpWs3" id="6LfBX8YlmDF" role="2MkJ7o">
-              <node concept="37vLTw" id="6LfBX8YlmFR" role="3uHU7w">
-                <ref role="3cqZAo" node="6LfBX8Ylmgj" resolve="contextKind" />
+              <node concept="2OqwBi" id="1br4Vy9oha" role="3uHU7w">
+                <node concept="37vLTw" id="1br4Vy9ohb" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6LfBX8Ylmgj" resolve="contextKind" />
+                </node>
+                <node concept="2qgKlT" id="1br4Vy9ohc" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                </node>
               </node>
               <node concept="3cpWs3" id="6LfBX8YlmrL" role="3uHU7B">
                 <node concept="3cpWs3" id="6LfBX8YlmmD" role="3uHU7B">
                   <node concept="Xl_RD" id="6LfBX8Ylm6p" role="3uHU7B">
                     <property role="Xl_RC" value="kind " />
                   </node>
-                  <node concept="37vLTw" id="6LfBX8YlmpQ" role="3uHU7w">
-                    <ref role="3cqZAo" node="6LfBX8Ylm9w" resolve="actualKind" />
+                  <node concept="2OqwBi" id="1br4Vy9ohH" role="3uHU7w">
+                    <node concept="37vLTw" id="1br4Vy9ohI" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6LfBX8Ylm9w" resolve="actualKind" />
+                    </node>
+                    <node concept="2qgKlT" id="1br4Vy9ohJ" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                    </node>
                   </node>
                 </node>
                 <node concept="Xl_RD" id="6LfBX8YlmrO" role="3uHU7w">
@@ -1109,12 +1120,17 @@
         <node concept="3clFbS" id="cJpacq1X9i" role="3clFbx">
           <node concept="2MkqsV" id="cJpacq1X9j" role="3cqZAp">
             <node concept="3cpWs3" id="7nsgDAXDIgc" role="2MkJ7o">
-              <node concept="2OqwBi" id="7nsgDAXDImI" role="3uHU7w">
-                <node concept="37vLTw" id="7nsgDAXDIgf" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7nsgDAXAPpv" resolve="g" />
+              <node concept="2OqwBi" id="1br4Vy9oge" role="3uHU7w">
+                <node concept="2OqwBi" id="1br4Vy9ogf" role="2Oq$k0">
+                  <node concept="37vLTw" id="1br4Vy9ogg" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7nsgDAXAPpv" resolve="g" />
+                  </node>
+                  <node concept="3TrEf2" id="1br4Vy9ogh" role="2OqNvi">
+                    <ref role="3Tt5mk" to="w9y2:6LfBX8YlAdM" resolve="type" />
+                  </node>
                 </node>
-                <node concept="3TrEf2" id="7nsgDAXDI_j" role="2OqNvi">
-                  <ref role="3Tt5mk" to="w9y2:6LfBX8YlAdM" resolve="type" />
+                <node concept="2qgKlT" id="1br4Vy9ogi" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                 </node>
               </node>
               <node concept="3cpWs3" id="7nsgDAXDHYj" role="3uHU7B">
@@ -1122,12 +1138,17 @@
                   <node concept="Xl_RD" id="cJpacq1X9l" role="3uHU7B">
                     <property role="Xl_RC" value="port " />
                   </node>
-                  <node concept="2OqwBi" id="7nsgDAXDHB5" role="3uHU7w">
-                    <node concept="37vLTw" id="7nsgDAXDHyc" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7nsgDAXAPzA" resolve="o" />
+                  <node concept="2OqwBi" id="1br4Vy9ogP" role="3uHU7w">
+                    <node concept="2OqwBi" id="1br4Vy9ogQ" role="2Oq$k0">
+                      <node concept="37vLTw" id="1br4Vy9ogR" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7nsgDAXAPzA" resolve="o" />
+                      </node>
+                      <node concept="3TrEf2" id="1br4Vy9ogS" role="2OqNvi">
+                        <ref role="3Tt5mk" to="w9y2:6LfBX8YlAdM" resolve="type" />
+                      </node>
                     </node>
-                    <node concept="3TrEf2" id="7nsgDAXDHLL" role="2OqNvi">
-                      <ref role="3Tt5mk" to="w9y2:6LfBX8YlAdM" resolve="type" />
+                    <node concept="2qgKlT" id="1br4Vy9ogT" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                     </node>
                   </node>
                 </node>
@@ -2119,12 +2140,17 @@
                       <node concept="3clFbS" id="6$fTUGAIeoU" role="3clFbx">
                         <node concept="2MkqsV" id="6$fTUGAImGI" role="3cqZAp">
                           <node concept="3cpWs3" id="6$fTUGAIDsX" role="2MkJ7o">
-                            <node concept="2OqwBi" id="6$fTUGAIE6P" role="3uHU7w">
-                              <node concept="1YBJjd" id="6$fTUGAIDKq" role="2Oq$k0">
-                                <ref role="1YBMHb" node="6$fTUGAI82f" resolve="component" />
+                            <node concept="2OqwBi" id="1br4Vy9oaN" role="3uHU7w">
+                              <node concept="2OqwBi" id="1br4Vy9oaO" role="2Oq$k0">
+                                <node concept="1YBJjd" id="1br4Vy9oaP" role="2Oq$k0">
+                                  <ref role="1YBMHb" node="6$fTUGAI82f" resolve="component" />
+                                </node>
+                                <node concept="3TrEf2" id="1br4Vy9oaQ" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
+                                </node>
                               </node>
-                              <node concept="3TrEf2" id="6$fTUGAIEHM" role="2OqNvi">
-                                <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
+                              <node concept="2qgKlT" id="1br4Vy9oaR" role="2OqNvi">
+                                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                               </node>
                             </node>
                             <node concept="3cpWs3" id="6$fTUGAIC0m" role="3uHU7B">
@@ -2134,12 +2160,17 @@
                                     <node concept="Xl_RD" id="6$fTUGAImT2" role="3uHU7B">
                                       <property role="Xl_RC" value="Component of kind " />
                                     </node>
-                                    <node concept="2OqwBi" id="6$fTUGAIxhR" role="3uHU7w">
-                                      <node concept="37vLTw" id="6$fTUGAIwLs" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="6$fTUGAIu$2" resolve="enrichingComponent" />
+                                    <node concept="2OqwBi" id="1br4Vy9ofS" role="3uHU7w">
+                                      <node concept="2OqwBi" id="1br4Vy9ofT" role="2Oq$k0">
+                                        <node concept="37vLTw" id="1br4Vy9ofU" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="6$fTUGAIu$2" resolve="enrichingComponent" />
+                                        </node>
+                                        <node concept="3TrEf2" id="1br4Vy9ofV" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
+                                        </node>
                                       </node>
-                                      <node concept="3TrEf2" id="6$fTUGAIxDp" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
+                                      <node concept="2qgKlT" id="1br4Vy9ofW" role="2OqNvi">
+                                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                                       </node>
                                     </node>
                                   </node>
@@ -2764,12 +2795,22 @@
             </node>
             <node concept="3cpWs6" id="3mxHOBiE_fx" role="3cqZAp">
               <node concept="3cpWs3" id="3mxHOBiEHgi" role="3cqZAk">
-                <node concept="37vLTw" id="3mxHOBiEHSt" role="3uHU7w">
-                  <ref role="3cqZAo" node="3mxHOBiEp8M" resolve="rightConfigType" />
+                <node concept="2OqwBi" id="1br4Vy9o22" role="3uHU7w">
+                  <node concept="37vLTw" id="1br4Vy9o23" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3mxHOBiEp8M" resolve="rightConfigType" />
+                  </node>
+                  <node concept="2qgKlT" id="1br4Vy9o24" role="2OqNvi">
+                    <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                  </node>
                 </node>
                 <node concept="3cpWs3" id="3mxHOBiEE7W" role="3uHU7B">
-                  <node concept="37vLTw" id="3mxHOBiEDrc" role="3uHU7B">
-                    <ref role="3cqZAo" node="3mxHOBiEoJC" resolve="leftConfigType" />
+                  <node concept="2OqwBi" id="1br4Vy9o6H" role="3uHU7B">
+                    <node concept="37vLTw" id="1br4Vy9o6I" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3mxHOBiEoJC" resolve="leftConfigType" />
+                    </node>
+                    <node concept="2qgKlT" id="1br4Vy9o6J" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                    </node>
                   </node>
                   <node concept="Xl_RD" id="3mxHOBiEED1" role="3uHU7w">
                     <property role="Xl_RC" value=" is incompatible with " />
@@ -2781,12 +2822,22 @@
         </node>
         <node concept="3cpWs6" id="3mxHOBiEIr5" role="3cqZAp">
           <node concept="3cpWs3" id="3mxHOBiEPBK" role="3cqZAk">
-            <node concept="37vLTw" id="3mxHOBiEPVZ" role="3uHU7w">
-              <ref role="3cqZAo" node="3mxHOBiEhqq" resolve="right" />
+            <node concept="2OqwBi" id="1br4Vy9o6S" role="3uHU7w">
+              <node concept="37vLTw" id="1br4Vy9o6T" role="2Oq$k0">
+                <ref role="3cqZAo" node="3mxHOBiEhqq" resolve="right" />
+              </node>
+              <node concept="2qgKlT" id="1br4Vy9o6U" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+              </node>
             </node>
             <node concept="3cpWs3" id="3mxHOBiELN9" role="3uHU7B">
-              <node concept="37vLTw" id="3mxHOBiELkr" role="3uHU7B">
-                <ref role="3cqZAo" node="3mxHOBiEhpW" resolve="left" />
+              <node concept="2OqwBi" id="1br4Vy9oaB" role="3uHU7B">
+                <node concept="37vLTw" id="1br4Vy9oaC" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3mxHOBiEhpW" resolve="left" />
+                </node>
+                <node concept="2qgKlT" id="1br4Vy9oaD" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                </node>
               </node>
               <node concept="Xl_RD" id="3mxHOBiEM4d" role="3uHU7w">
                 <property role="Xl_RC" value=" is incompatible with " />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/typesystem.mps
@@ -11,6 +11,7 @@
     <import index="juu2" ref="r:197c9a7f-bef3-4d38-a48a-51524151fecf(org.iets3.core.base.plugin)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -224,8 +225,13 @@
                         <node concept="Xl_RD" id="3q2wVepy$J3" role="3uHU7B">
                           <property role="Xl_RC" value="CHECKING RULE check_ICanRunCheckManually begin " />
                         </node>
-                        <node concept="1YBJjd" id="3q2wVepyTr6" role="3uHU7w">
-                          <ref role="1YBMHb" node="2BX$1355fco" resolve="icrm" />
+                        <node concept="2OqwBi" id="1br4Vy9oi1" role="3uHU7w">
+                          <node concept="1YBJjd" id="1br4Vy9oi2" role="2Oq$k0">
+                            <ref role="1YBMHb" node="2BX$1355fco" resolve="icrm" />
+                          </node>
+                          <node concept="2qgKlT" id="1br4Vy9oi3" role="2OqNvi">
+                            <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                          </node>
                         </node>
                       </node>
                       <node concept="Xl_RD" id="2NazPIlIyoG" role="3uHU7w">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -7107,10 +7107,15 @@
                         <property role="Xl_RC" value="try " />
                       </node>
                     </node>
-                    <node concept="2OqwBi" id="HywGhj856_" role="3uHU7w">
-                      <node concept="13iPFW" id="HywGhj856A" role="2Oq$k0" />
-                      <node concept="3TrEf2" id="HywGhj856B" role="2OqNvi">
-                        <ref role="3Tt5mk" to="hm2y:5BNZGjBvVh4" resolve="expr" />
+                    <node concept="2OqwBi" id="1br4Vy9oiF" role="3uHU7w">
+                      <node concept="2OqwBi" id="1br4Vy9oiG" role="2Oq$k0">
+                        <node concept="13iPFW" id="1br4Vy9oiH" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="1br4Vy9oiI" role="2OqNvi">
+                          <ref role="3Tt5mk" to="hm2y:5BNZGjBvVh4" resolve="expr" />
+                        </node>
+                      </node>
+                      <node concept="2qgKlT" id="1br4Vy9oiJ" role="2OqNvi">
+                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                       </node>
                     </node>
                   </node>
@@ -24286,10 +24291,15 @@
               <node concept="Xl_RD" id="mQGcCvPvsx" role="3uHU7B">
                 <property role="Xl_RC" value="fail(" />
               </node>
-              <node concept="2OqwBi" id="mQGcCvPvV2" role="3uHU7w">
-                <node concept="13iPFW" id="mQGcCvPvHV" role="2Oq$k0" />
-                <node concept="3TrEf2" id="mQGcCvPw5i" role="2OqNvi">
-                  <ref role="3Tt5mk" to="hm2y:mQGcCvPueY" resolve="message" />
+              <node concept="2OqwBi" id="1br4Vy9oil" role="3uHU7w">
+                <node concept="2OqwBi" id="1br4Vy9oim" role="2Oq$k0">
+                  <node concept="13iPFW" id="1br4Vy9oin" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="1br4Vy9oio" role="2OqNvi">
+                    <ref role="3Tt5mk" to="hm2y:mQGcCvPueY" resolve="message" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="1br4Vy9oip" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
@@ -1017,8 +1017,13 @@
                                 <node concept="3clFbS" id="6xvNSEj8gSZ" role="3clFbx">
                                   <node concept="2MkqsV" id="6xvNSEj8hpl" role="3cqZAp">
                                     <node concept="3cpWs3" id="6xvNSEj8hpm" role="2MkJ7o">
-                                      <node concept="37vLTw" id="6xvNSEj8hDf" role="3uHU7w">
-                                        <ref role="3cqZAo" node="5ya_dKpNDIj" resolve="rt" />
+                                      <node concept="2OqwBi" id="1br4Vy9okz" role="3uHU7w">
+                                        <node concept="37vLTw" id="1br4Vy9ok$" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="5ya_dKpNDIj" resolve="rt" />
+                                        </node>
+                                        <node concept="2qgKlT" id="1br4Vy9ok_" role="2OqNvi">
+                                          <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                                        </node>
                                       </node>
                                       <node concept="3cpWs3" id="6xvNSEj8hpo" role="3uHU7B">
                                         <node concept="3cpWs3" id="6xvNSEj8hpp" role="3uHU7B">
@@ -1036,8 +1041,13 @@
                                               <property role="Xl_RC" value=" cannot be applied to types " />
                                             </node>
                                           </node>
-                                          <node concept="37vLTw" id="6xvNSEj8hyD" role="3uHU7w">
-                                            <ref role="3cqZAo" node="5ya_dKpNDyr" resolve="lt" />
+                                          <node concept="2OqwBi" id="1br4Vy9olf" role="3uHU7w">
+                                            <node concept="37vLTw" id="1br4Vy9olg" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="5ya_dKpNDyr" resolve="lt" />
+                                            </node>
+                                            <node concept="2qgKlT" id="1br4Vy9olh" role="2OqNvi">
+                                              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                                            </node>
                                           </node>
                                         </node>
                                         <node concept="Xl_RD" id="6xvNSEj8hpy" role="3uHU7w">
@@ -1058,8 +1068,13 @@
                                             <ref role="2pJxcJ" to="tpd4:hfSilrU" resolve="errorText" />
                                             <node concept="WxPPo" id="6xvNSEj8hpD" role="28ntcv">
                                               <node concept="3cpWs3" id="6xvNSEj8hpE" role="WxPPp">
-                                                <node concept="37vLTw" id="6xvNSEj8hKJ" role="3uHU7w">
-                                                  <ref role="3cqZAo" node="5ya_dKpNDIj" resolve="rt" />
+                                                <node concept="2OqwBi" id="1br4Vy9olF" role="3uHU7w">
+                                                  <node concept="37vLTw" id="1br4Vy9olG" role="2Oq$k0">
+                                                    <ref role="3cqZAo" node="5ya_dKpNDIj" resolve="rt" />
+                                                  </node>
+                                                  <node concept="2qgKlT" id="1br4Vy9olH" role="2OqNvi">
+                                                    <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                                                  </node>
                                                 </node>
                                                 <node concept="3cpWs3" id="6xvNSEj8hpG" role="3uHU7B">
                                                   <node concept="3cpWs3" id="6xvNSEj8hpH" role="3uHU7B">
@@ -1077,8 +1092,13 @@
                                                         <node concept="3n3YKJ" id="6xvNSEj8hpO" role="2OqNvi" />
                                                       </node>
                                                     </node>
-                                                    <node concept="37vLTw" id="6xvNSEj8hEt" role="3uHU7w">
-                                                      <ref role="3cqZAo" node="5ya_dKpNDyr" resolve="lt" />
+                                                    <node concept="2OqwBi" id="1br4Vy9omn" role="3uHU7w">
+                                                      <node concept="37vLTw" id="1br4Vy9omo" role="2Oq$k0">
+                                                        <ref role="3cqZAo" node="5ya_dKpNDyr" resolve="lt" />
+                                                      </node>
+                                                      <node concept="2qgKlT" id="1br4Vy9omp" role="2OqNvi">
+                                                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                                                      </node>
                                                     </node>
                                                   </node>
                                                   <node concept="Xl_RD" id="6xvNSEj8hpQ" role="3uHU7w">
@@ -1392,16 +1412,26 @@
                                       <node concept="3clFbS" id="7KDVkAEtHhQ" role="1bW5cS">
                                         <node concept="2MkqsV" id="7KDVkAEtIWe" role="3cqZAp">
                                           <node concept="3cpWs3" id="7KDVkAEtNeX" role="2MkJ7o">
-                                            <node concept="37vLTw" id="7KDVkAEtNrl" role="3uHU7w">
-                                              <ref role="3cqZAo" node="7KDVkAEtI_F" resolve="right" />
+                                            <node concept="2OqwBi" id="1br4Vy9omN" role="3uHU7w">
+                                              <node concept="37vLTw" id="1br4Vy9omO" role="2Oq$k0">
+                                                <ref role="3cqZAo" node="7KDVkAEtI_F" resolve="right" />
+                                              </node>
+                                              <node concept="2qgKlT" id="1br4Vy9omP" role="2OqNvi">
+                                                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                                              </node>
                                             </node>
                                             <node concept="3cpWs3" id="7KDVkAEtM83" role="3uHU7B">
                                               <node concept="3cpWs3" id="7KDVkAEtKAp" role="3uHU7B">
                                                 <node concept="Xl_RD" id="7KDVkAEtJ3i" role="3uHU7B">
                                                   <property role="Xl_RC" value="incompatible types: " />
                                                 </node>
-                                                <node concept="37vLTw" id="7KDVkAEtKI5" role="3uHU7w">
-                                                  <ref role="3cqZAo" node="7KDVkAEtHpA" resolve="left" />
+                                                <node concept="2OqwBi" id="1br4Vy9onm" role="3uHU7w">
+                                                  <node concept="37vLTw" id="1br4Vy9onn" role="2Oq$k0">
+                                                    <ref role="3cqZAo" node="7KDVkAEtHpA" resolve="left" />
+                                                  </node>
+                                                  <node concept="2qgKlT" id="1br4Vy9ono" role="2OqNvi">
+                                                    <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                                                  </node>
                                                 </node>
                                               </node>
                                               <node concept="Xl_RD" id="7KDVkAEtMk9" role="3uHU7w">
@@ -1436,8 +1466,13 @@
                         <node concept="3clFbS" id="117BaR7EsSr" role="9aQI4">
                           <node concept="2MkqsV" id="2ck7OjOLa0b" role="3cqZAp">
                             <node concept="3cpWs3" id="2ck7OjOLcSO" role="2MkJ7o">
-                              <node concept="2X3wrD" id="2ck7OjOLcWq" role="3uHU7w">
-                                <ref role="2X3Bk0" node="4rZeNQ6PBb0" resolve="rightType" />
+                              <node concept="2OqwBi" id="1br4Vy9onH" role="3uHU7w">
+                                <node concept="2X3wrD" id="1br4Vy9onI" role="2Oq$k0">
+                                  <ref role="2X3Bk0" node="4rZeNQ6PBb0" resolve="rightType" />
+                                </node>
+                                <node concept="2qgKlT" id="1br4Vy9onJ" role="2OqNvi">
+                                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                                </node>
                               </node>
                               <node concept="3cpWs3" id="2ck7OjOLcHU" role="3uHU7B">
                                 <node concept="3cpWs3" id="2ck7OjOLc$e" role="3uHU7B">
@@ -1455,8 +1490,13 @@
                                       <property role="Xl_RC" value=" cannot be applied to types " />
                                     </node>
                                   </node>
-                                  <node concept="2X3wrD" id="2ck7OjOLcDV" role="3uHU7w">
-                                    <ref role="2X3Bk0" node="4rZeNQ6PB12" resolve="leftType" />
+                                  <node concept="2OqwBi" id="1br4Vy9ooy" role="3uHU7w">
+                                    <node concept="2X3wrD" id="1br4Vy9ooz" role="2Oq$k0">
+                                      <ref role="2X3Bk0" node="4rZeNQ6PB12" resolve="leftType" />
+                                    </node>
+                                    <node concept="2qgKlT" id="1br4Vy9oo$" role="2OqNvi">
+                                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                                    </node>
                                   </node>
                                 </node>
                                 <node concept="Xl_RD" id="2ck7OjOLcHX" role="3uHU7w">
@@ -1477,8 +1517,13 @@
                                     <ref role="2pJxcJ" to="tpd4:hfSilrU" resolve="errorText" />
                                     <node concept="WxPPo" id="uuJ7IpZtub" role="28ntcv">
                                       <node concept="3cpWs3" id="2xACJhqPMA$" role="WxPPp">
-                                        <node concept="2X3wrD" id="2xACJhqPMA_" role="3uHU7w">
-                                          <ref role="2X3Bk0" node="4rZeNQ6PBb0" resolve="rightType" />
+                                        <node concept="2OqwBi" id="1br4Vy9op2" role="3uHU7w">
+                                          <node concept="2X3wrD" id="1br4Vy9op3" role="2Oq$k0">
+                                            <ref role="2X3Bk0" node="4rZeNQ6PBb0" resolve="rightType" />
+                                          </node>
+                                          <node concept="2qgKlT" id="1br4Vy9op4" role="2OqNvi">
+                                            <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                                          </node>
                                         </node>
                                         <node concept="3cpWs3" id="2xACJhqPMAA" role="3uHU7B">
                                           <node concept="3cpWs3" id="2xACJhqPMAB" role="3uHU7B">
@@ -1496,8 +1541,13 @@
                                                 <node concept="3n3YKJ" id="2xACJhqUnT$" role="2OqNvi" />
                                               </node>
                                             </node>
-                                            <node concept="2X3wrD" id="2xACJhqPMAD" role="3uHU7w">
-                                              <ref role="2X3Bk0" node="4rZeNQ6PB12" resolve="leftType" />
+                                            <node concept="2OqwBi" id="1br4Vy9opR" role="3uHU7w">
+                                              <node concept="2X3wrD" id="1br4Vy9opS" role="2Oq$k0">
+                                                <ref role="2X3Bk0" node="4rZeNQ6PB12" resolve="leftType" />
+                                              </node>
+                                              <node concept="2qgKlT" id="1br4Vy9opT" role="2OqNvi">
+                                                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                                              </node>
                                             </node>
                                           </node>
                                           <node concept="Xl_RD" id="2xACJhqPMAE" role="3uHU7w">
@@ -2622,8 +2672,13 @@
         <node concept="3clFbS" id="5BNZGjBvVjo" role="3clFbx">
           <node concept="2MkqsV" id="5BNZGjBvZd0" role="3cqZAp">
             <node concept="3cpWs3" id="6iJ_gQBedW$" role="2MkJ7o">
-              <node concept="37vLTw" id="6iJ_gQBedWF" role="3uHU7w">
-                <ref role="3cqZAo" node="34FVxARm7cT" resolve="tt" />
+              <node concept="2OqwBi" id="1br4Vy9okg" role="3uHU7w">
+                <node concept="37vLTw" id="1br4Vy9okh" role="2Oq$k0">
+                  <ref role="3cqZAo" node="34FVxARm7cT" resolve="tt" />
+                </node>
+                <node concept="2qgKlT" id="1br4Vy9oki" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                </node>
               </node>
               <node concept="Xl_RD" id="5BNZGjBvZdf" role="3uHU7B">
                 <property role="Xl_RC" value="'try' can only be used with attempt[] types; it is " />
@@ -7694,8 +7749,13 @@
                     <node concept="Xl_RD" id="6JZACDWO9bX" role="3uHU7B">
                       <property role="Xl_RC" value="the type " />
                     </node>
-                    <node concept="37vLTw" id="6JZACDWO9bY" role="3uHU7w">
-                      <ref role="3cqZAo" node="6JZACDWO7jT" resolve="ctxType" />
+                    <node concept="2OqwBi" id="1br4Vy9ojE" role="3uHU7w">
+                      <node concept="37vLTw" id="1br4Vy9ojF" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6JZACDWO7jT" resolve="ctxType" />
+                      </node>
+                      <node concept="2qgKlT" id="1br4Vy9ojG" role="2OqNvi">
+                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -7722,8 +7782,13 @@
                   <node concept="Xl_RD" id="6JZACDWO466" role="3uHU7B">
                     <property role="Xl_RC" value="the type " />
                   </node>
-                  <node concept="37vLTw" id="6JZACDWO7k0" role="3uHU7w">
-                    <ref role="3cqZAo" node="6JZACDWO7jT" resolve="ctxType" />
+                  <node concept="2OqwBi" id="1br4Vy9ojX" role="3uHU7w">
+                    <node concept="37vLTw" id="1br4Vy9ojY" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6JZACDWO7jT" resolve="ctxType" />
+                    </node>
+                    <node concept="2qgKlT" id="1br4Vy9ojZ" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                    </node>
                   </node>
                 </node>
               </node>
@@ -8166,8 +8231,13 @@
                             <node concept="Xl_RD" id="ORfz$DScxd" role="3uHU7B">
                               <property role="Xl_RC" value="Effects " />
                             </node>
-                            <node concept="37vLTw" id="ORfz$DScMW" role="3uHU7w">
-                              <ref role="3cqZAo" node="ORfz$DSbF7" resolve="allower" />
+                            <node concept="2OqwBi" id="1br4Vy9ojn" role="3uHU7w">
+                              <node concept="37vLTw" id="1br4Vy9ojo" role="2Oq$k0">
+                                <ref role="3cqZAo" node="ORfz$DSbF7" resolve="allower" />
+                              </node>
+                              <node concept="2qgKlT" id="1br4Vy9ojp" role="2OqNvi">
+                                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                              </node>
                             </node>
                           </node>
                           <node concept="Xl_RD" id="ORfz$DSd30" role="3uHU7w">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/behavior.mps
@@ -3791,10 +3791,15 @@
                       <property role="Xl_RC" value="(" />
                     </node>
                   </node>
-                  <node concept="2OqwBi" id="4hLehKU0iWi" role="3uHU7w">
-                    <node concept="13iPFW" id="4hLehKU0iHV" role="2Oq$k0" />
-                    <node concept="3TrEf2" id="4hLehKU0jn8" role="2OqNvi">
-                      <ref role="3Tt5mk" to="700h:4hLehKU05d5" resolve="seed" />
+                  <node concept="2OqwBi" id="1br4Vy9or4" role="3uHU7w">
+                    <node concept="2OqwBi" id="1br4Vy9or5" role="2Oq$k0">
+                      <node concept="13iPFW" id="1br4Vy9or6" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="1br4Vy9or7" role="2OqNvi">
+                        <ref role="3Tt5mk" to="700h:4hLehKU05d5" resolve="seed" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="1br4Vy9or8" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                     </node>
                   </node>
                 </node>
@@ -3802,10 +3807,15 @@
                   <property role="Xl_RC" value=", " />
                 </node>
               </node>
-              <node concept="2OqwBi" id="4hLehKU0miy" role="3uHU7w">
-                <node concept="13iPFW" id="4hLehKU0m1p" role="2Oq$k0" />
-                <node concept="3TrEf2" id="4hLehKU0mJS" role="2OqNvi">
-                  <ref role="3Tt5mk" to="700h:4hLehKU05d8" resolve="combiner" />
+              <node concept="2OqwBi" id="1br4Vy9oqk" role="3uHU7w">
+                <node concept="2OqwBi" id="1br4Vy9oql" role="2Oq$k0">
+                  <node concept="13iPFW" id="1br4Vy9oqm" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="1br4Vy9oqn" role="2OqNvi">
+                    <ref role="3Tt5mk" to="700h:4hLehKU05d8" resolve="combiner" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="1br4Vy9oqo" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                 </node>
               </node>
             </node>
@@ -4563,10 +4573,15 @@
                   <node concept="Xl_RD" id="1yEri41sEK3" role="3uHU7B">
                     <property role="Xl_RC" value="insert(" />
                   </node>
-                  <node concept="2OqwBi" id="1yEri41sJjw" role="3uHU7w">
-                    <node concept="13iPFW" id="1yEri41sJ6r" role="2Oq$k0" />
-                    <node concept="3TrEf2" id="1yEri41sJHi" role="2OqNvi">
-                      <ref role="3Tt5mk" to="700h:1rPkY5wVdS6" resolve="index" />
+                  <node concept="2OqwBi" id="1br4Vy9orz" role="3uHU7w">
+                    <node concept="2OqwBi" id="1br4Vy9or$" role="2Oq$k0">
+                      <node concept="13iPFW" id="1br4Vy9or_" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="1br4Vy9orA" role="2OqNvi">
+                        <ref role="3Tt5mk" to="700h:1rPkY5wVdS6" resolve="index" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="1br4Vy9orB" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.dataflow/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.dataflow/models/typesystem.mps
@@ -9,6 +9,7 @@
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
     <import index="gx5r" ref="r:a9ed28db-11a2-453b-b8cd-4dbf2ae73280(org.iets3.core.expr.dataflow.structure)" />
     <import index="b4m9" ref="r:f73fffcc-e6a1-406e-b40b-65eaaa19bd69(org.iets3.core.expr.dataflow.behavior)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
@@ -315,8 +316,13 @@
                     <node concept="Xl_RD" id="5Q9FzcI57xl" role="3uHU7B">
                       <property role="Xl_RC" value="port " />
                     </node>
-                    <node concept="2GrUjf" id="5Q9FzcI59nd" role="3uHU7w">
-                      <ref role="2Gs0qQ" node="5Q9FzcI51Vf" resolve="op" />
+                    <node concept="2OqwBi" id="1br4Vy9osc" role="3uHU7w">
+                      <node concept="2GrUjf" id="1br4Vy9osd" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="5Q9FzcI51Vf" resolve="op" />
+                      </node>
+                      <node concept="2qgKlT" id="1br4Vy9ose" role="2OqNvi">
+                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                      </node>
                     </node>
                   </node>
                   <node concept="Xl_RD" id="5Q9FzcI5aor" role="3uHU7w">
@@ -460,8 +466,13 @@
         <node concept="3clFbS" id="2vkvJYSSd64" role="2LFqv$">
           <node concept="2MkqsV" id="2vkvJYSSdI0" role="3cqZAp">
             <node concept="3cpWs3" id="2vkvJYSSdZI" role="2MkJ7o">
-              <node concept="2GrUjf" id="2vkvJYSSe00" role="3uHU7w">
-                <ref role="2Gs0qQ" node="2vkvJYSSd60" resolve="p" />
+              <node concept="2OqwBi" id="1br4Vy9osW" role="3uHU7w">
+                <node concept="2GrUjf" id="1br4Vy9osX" role="2Oq$k0">
+                  <ref role="2Gs0qQ" node="2vkvJYSSd60" resolve="p" />
+                </node>
+                <node concept="2qgKlT" id="1br4Vy9osY" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                </node>
               </node>
               <node concept="Xl_RD" id="2vkvJYSSdIc" role="3uHU7B">
                 <property role="Xl_RC" value="missing parameter value for " />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
@@ -727,10 +727,15 @@
                   </node>
                 </node>
               </node>
-              <node concept="2OqwBi" id="6zmBjqUl7hC" role="3uHU7w">
-                <node concept="13iPFW" id="6zmBjqUl7eF" role="2Oq$k0" />
-                <node concept="3TrEf2" id="6zmBjqUl7nK" role="2OqNvi">
-                  <ref role="3Tt5mk" to="zzzn:6zmBjqUjGYT" resolve="returnType" />
+              <node concept="2OqwBi" id="1br4Vy9otg" role="3uHU7w">
+                <node concept="2OqwBi" id="1br4Vy9oth" role="2Oq$k0">
+                  <node concept="13iPFW" id="1br4Vy9oti" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="1br4Vy9otj" role="2OqNvi">
+                    <ref role="3Tt5mk" to="zzzn:6zmBjqUjGYT" resolve="returnType" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="1br4Vy9otk" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                 </node>
               </node>
             </node>
@@ -1121,10 +1126,15 @@
               <node concept="Xl_RD" id="HywGhj7QPo" role="3uHU7B">
                 <property role="Xl_RC" value="|" />
               </node>
-              <node concept="2OqwBi" id="HywGhj7SjM" role="3uHU7w">
-                <node concept="13iPFW" id="HywGhj7Sgw" role="2Oq$k0" />
-                <node concept="3TrEf2" id="HywGhj7Sqr" role="2OqNvi">
-                  <ref role="3Tt5mk" to="zzzn:6zmBjqUm7MR" resolve="expression" />
+              <node concept="2OqwBi" id="1br4Vy9oui" role="3uHU7w">
+                <node concept="2OqwBi" id="1br4Vy9ouj" role="2Oq$k0">
+                  <node concept="13iPFW" id="1br4Vy9ouk" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="1br4Vy9oul" role="2OqNvi">
+                    <ref role="3Tt5mk" to="zzzn:6zmBjqUm7MR" resolve="expression" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="1br4Vy9oum" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/typesystem.mps
@@ -17,6 +17,7 @@
     <import index="tpd4" ref="r:00000000-0000-4000-0000-011c895902b4(jetbrains.mps.lang.typesystem.structure)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -3175,16 +3176,26 @@
               <node concept="3clFbS" id="5Win3SAclEY" role="3clFbx">
                 <node concept="2MkqsV" id="5Win3SAcGML" role="3cqZAp">
                   <node concept="3cpWs3" id="5Win3SAcJGe" role="2MkJ7o">
-                    <node concept="37vLTw" id="5Win3SAcKob" role="3uHU7w">
-                      <ref role="3cqZAo" node="5Win3SAcJMb" resolve="leftInput" />
+                    <node concept="2OqwBi" id="1br4Vy9ouB" role="3uHU7w">
+                      <node concept="37vLTw" id="1br4Vy9ouC" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5Win3SAcJMb" resolve="leftInput" />
+                      </node>
+                      <node concept="2qgKlT" id="1br4Vy9ouD" role="2OqNvi">
+                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                      </node>
                     </node>
                     <node concept="3cpWs3" id="5Win3SAcIEq" role="3uHU7B">
                       <node concept="3cpWs3" id="5Win3SAcItD" role="3uHU7B">
                         <node concept="Xl_RD" id="5Win3SAcGN0" role="3uHU7B">
                           <property role="Xl_RC" value="return type of right function " />
                         </node>
-                        <node concept="37vLTw" id="5Win3SAcItV" role="3uHU7w">
-                          <ref role="3cqZAo" node="5Win3SAcH5Q" resolve="rightReturn" />
+                        <node concept="2OqwBi" id="1br4Vy9ova" role="3uHU7w">
+                          <node concept="37vLTw" id="1br4Vy9ovb" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5Win3SAcH5Q" resolve="rightReturn" />
+                          </node>
+                          <node concept="2qgKlT" id="1br4Vy9ovc" role="2OqNvi">
+                            <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                          </node>
                         </node>
                       </node>
                       <node concept="Xl_RD" id="5Win3SAcIEt" role="3uHU7w">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/behavior.mps
@@ -21,6 +21,7 @@
     <import index="3rlt" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.math3.analysis.integration(org.apache.commons/)" />
     <import index="e1fw" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.math3.analysis.polynomials(org.apache.commons/)" />
     <import index="zl0b" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.math3.analysis(org.apache.commons/)" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="b1h1" ref="r:ac5f749f-6179-4d4f-ad24-ad9edbd8077b(org.iets3.core.expr.simpleTypes.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -378,10 +379,15 @@
                   <node concept="Xl_RD" id="6kR0qIbHGp0" role="3uHU7B">
                     <property role="Xl_RC" value="(" />
                   </node>
-                  <node concept="2OqwBi" id="6kR0qIbHMfu" role="3uHU7w">
-                    <node concept="13iPFW" id="6kR0qIbHMdh" role="2Oq$k0" />
-                    <node concept="3TrEf2" id="6kR0qIbHMjd" role="2OqNvi">
-                      <ref role="3Tt5mk" to="1qv1:4iu6t1eAWP7" resolve="numerator" />
+                  <node concept="2OqwBi" id="1br4Vy9ow5" role="3uHU7w">
+                    <node concept="2OqwBi" id="1br4Vy9ow6" role="2Oq$k0">
+                      <node concept="13iPFW" id="1br4Vy9ow7" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="1br4Vy9ow8" role="2OqNvi">
+                        <ref role="3Tt5mk" to="1qv1:4iu6t1eAWP7" resolve="numerator" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="1br4Vy9ow9" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                     </node>
                   </node>
                 </node>
@@ -389,10 +395,15 @@
                   <property role="Xl_RC" value=" / " />
                 </node>
               </node>
-              <node concept="2OqwBi" id="6kR0qIbHMxK" role="3uHU7w">
-                <node concept="13iPFW" id="6kR0qIbHMva" role="2Oq$k0" />
-                <node concept="3TrEf2" id="6kR0qIbHMAO" role="2OqNvi">
-                  <ref role="3Tt5mk" to="1qv1:4iu6t1eAWPa" resolve="denominator" />
+              <node concept="2OqwBi" id="1br4Vy9ovu" role="3uHU7w">
+                <node concept="2OqwBi" id="1br4Vy9ovv" role="2Oq$k0">
+                  <node concept="13iPFW" id="1br4Vy9ovw" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="1br4Vy9ovx" role="2OqNvi">
+                    <ref role="3Tt5mk" to="1qv1:4iu6t1eAWPa" resolve="denominator" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="1br4Vy9ovy" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                 </node>
               </node>
             </node>
@@ -476,10 +487,15 @@
                   <node concept="Xl_RD" id="6kR0qIbHRV_" role="3uHU7B">
                     <property role="Xl_RC" value="log(" />
                   </node>
-                  <node concept="2OqwBi" id="6kR0qIbHS0v" role="3uHU7w">
-                    <node concept="13iPFW" id="6kR0qIbHRYi" role="2Oq$k0" />
-                    <node concept="3TrEf2" id="6kR0qIbHS4e" role="2OqNvi">
-                      <ref role="3Tt5mk" to="1qv1:4iu6t1eAXZS" resolve="logOf" />
+                  <node concept="2OqwBi" id="1br4Vy9ox2" role="3uHU7w">
+                    <node concept="2OqwBi" id="1br4Vy9ox3" role="2Oq$k0">
+                      <node concept="13iPFW" id="1br4Vy9ox4" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="1br4Vy9ox5" role="2OqNvi">
+                        <ref role="3Tt5mk" to="1qv1:4iu6t1eAXZS" resolve="logOf" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="1br4Vy9ox6" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                     </node>
                   </node>
                 </node>
@@ -487,10 +503,15 @@
                   <property role="Xl_RC" value=", " />
                 </node>
               </node>
-              <node concept="2OqwBi" id="6kR0qIbHSjh" role="3uHU7w">
-                <node concept="13iPFW" id="6kR0qIbHSgF" role="2Oq$k0" />
-                <node concept="3TrEf2" id="6kR0qIbHSol" role="2OqNvi">
-                  <ref role="3Tt5mk" to="1qv1:4iu6t1eB9_$" resolve="expr" />
+              <node concept="2OqwBi" id="1br4Vy9owr" role="3uHU7w">
+                <node concept="2OqwBi" id="1br4Vy9ows" role="2Oq$k0">
+                  <node concept="13iPFW" id="1br4Vy9owt" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="1br4Vy9owu" role="2OqNvi">
+                    <ref role="3Tt5mk" to="1qv1:4iu6t1eB9_$" resolve="expr" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="1br4Vy9owv" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                 </node>
               </node>
             </node>
@@ -813,10 +834,15 @@
                       <node concept="Xl_RD" id="6kR0qIbHSRt" role="3uHU7B">
                         <property role="Xl_RC" value="&lt;product&gt;(" />
                       </node>
-                      <node concept="2OqwBi" id="HywGhj7L1x" role="3uHU7w">
-                        <node concept="13iPFW" id="HywGhj7KX5" role="2Oq$k0" />
-                        <node concept="3TrEf2" id="HywGhj7Lbj" role="2OqNvi">
-                          <ref role="3Tt5mk" to="1qv1:PWcNB4W2v_" resolve="lower" />
+                      <node concept="2OqwBi" id="1br4Vy9oyR" role="3uHU7w">
+                        <node concept="2OqwBi" id="1br4Vy9oyS" role="2Oq$k0">
+                          <node concept="13iPFW" id="1br4Vy9oyT" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="1br4Vy9oyU" role="2OqNvi">
+                            <ref role="3Tt5mk" to="1qv1:PWcNB4W2v_" resolve="lower" />
+                          </node>
+                        </node>
+                        <node concept="2qgKlT" id="1br4Vy9oyV" role="2OqNvi">
+                          <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                         </node>
                       </node>
                     </node>
@@ -824,10 +850,15 @@
                       <property role="Xl_RC" value="; " />
                     </node>
                   </node>
-                  <node concept="2OqwBi" id="HywGhj7LzN" role="3uHU7w">
-                    <node concept="13iPFW" id="HywGhj7LuY" role="2Oq$k0" />
-                    <node concept="3TrEf2" id="HywGhj7LJq" role="2OqNvi">
-                      <ref role="3Tt5mk" to="1qv1:PWcNB4VG$Z" resolve="upper" />
+                  <node concept="2OqwBi" id="1br4Vy9oyg" role="3uHU7w">
+                    <node concept="2OqwBi" id="1br4Vy9oyh" role="2Oq$k0">
+                      <node concept="13iPFW" id="1br4Vy9oyi" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="1br4Vy9oyj" role="2OqNvi">
+                        <ref role="3Tt5mk" to="1qv1:PWcNB4VG$Z" resolve="upper" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="1br4Vy9oyk" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                     </node>
                   </node>
                 </node>
@@ -835,10 +866,15 @@
                   <property role="Xl_RC" value="; " />
                 </node>
               </node>
-              <node concept="2OqwBi" id="HywGhj7M99" role="3uHU7w">
-                <node concept="13iPFW" id="HywGhj7M3V" role="2Oq$k0" />
-                <node concept="3TrEf2" id="HywGhj7Ml8" role="2OqNvi">
-                  <ref role="3Tt5mk" to="1qv1:PWcNB4VG_6" resolve="body" />
+              <node concept="2OqwBi" id="1br4Vy9oxo" role="3uHU7w">
+                <node concept="2OqwBi" id="1br4Vy9oxp" role="2Oq$k0">
+                  <node concept="13iPFW" id="1br4Vy9oxq" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="1br4Vy9oxr" role="2OqNvi">
+                    <ref role="3Tt5mk" to="1qv1:PWcNB4VG_6" resolve="body" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="1br4Vy9oxs" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                 </node>
               </node>
             </node>
@@ -873,10 +909,15 @@
                       <node concept="Xl_RD" id="HywGhj7MCk" role="3uHU7B">
                         <property role="Xl_RC" value="&lt;sum&gt;" />
                       </node>
-                      <node concept="2OqwBi" id="HywGhj7MCl" role="3uHU7w">
-                        <node concept="13iPFW" id="HywGhj7MCm" role="2Oq$k0" />
-                        <node concept="3TrEf2" id="HywGhj7MCn" role="2OqNvi">
-                          <ref role="3Tt5mk" to="1qv1:PWcNB4W2v_" resolve="lower" />
+                      <node concept="2OqwBi" id="1br4Vy9o$G" role="3uHU7w">
+                        <node concept="2OqwBi" id="1br4Vy9o$H" role="2Oq$k0">
+                          <node concept="13iPFW" id="1br4Vy9o$I" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="1br4Vy9o$J" role="2OqNvi">
+                            <ref role="3Tt5mk" to="1qv1:PWcNB4W2v_" resolve="lower" />
+                          </node>
+                        </node>
+                        <node concept="2qgKlT" id="1br4Vy9o$K" role="2OqNvi">
+                          <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                         </node>
                       </node>
                     </node>
@@ -884,10 +925,15 @@
                       <property role="Xl_RC" value="; " />
                     </node>
                   </node>
-                  <node concept="2OqwBi" id="HywGhj7MCp" role="3uHU7w">
-                    <node concept="13iPFW" id="HywGhj7MCq" role="2Oq$k0" />
-                    <node concept="3TrEf2" id="HywGhj7MCr" role="2OqNvi">
-                      <ref role="3Tt5mk" to="1qv1:PWcNB4VG$Z" resolve="upper" />
+                  <node concept="2OqwBi" id="1br4Vy9o$5" role="3uHU7w">
+                    <node concept="2OqwBi" id="1br4Vy9o$6" role="2Oq$k0">
+                      <node concept="13iPFW" id="1br4Vy9o$7" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="1br4Vy9o$8" role="2OqNvi">
+                        <ref role="3Tt5mk" to="1qv1:PWcNB4VG$Z" resolve="upper" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="1br4Vy9o$9" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                     </node>
                   </node>
                 </node>
@@ -895,10 +941,15 @@
                   <property role="Xl_RC" value="; " />
                 </node>
               </node>
-              <node concept="2OqwBi" id="HywGhj7MCt" role="3uHU7w">
-                <node concept="13iPFW" id="HywGhj7MCu" role="2Oq$k0" />
-                <node concept="3TrEf2" id="HywGhj7MCv" role="2OqNvi">
-                  <ref role="3Tt5mk" to="1qv1:PWcNB4VG_6" resolve="body" />
+              <node concept="2OqwBi" id="1br4Vy9ozd" role="3uHU7w">
+                <node concept="2OqwBi" id="1br4Vy9oze" role="2Oq$k0">
+                  <node concept="13iPFW" id="1br4Vy9ozf" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="1br4Vy9ozg" role="2OqNvi">
+                    <ref role="3Tt5mk" to="1qv1:PWcNB4VG_6" resolve="body" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="1br4Vy9ozh" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/typesystem.mps
@@ -17,6 +17,7 @@
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="b1h1" ref="r:ac5f749f-6179-4d4f-ad24-ad9edbd8077b(org.iets3.core.expr.simpleTypes.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -1969,12 +1970,17 @@
         <node concept="3clFbS" id="3C0hCYbUea4" role="3clFbx">
           <node concept="2MkqsV" id="3C0hCYbRU40" role="3cqZAp">
             <node concept="3cpWs3" id="3C0hCYbRUvd" role="2MkJ7o">
-              <node concept="2OqwBi" id="3C0hCYbRUIo" role="3uHU7w">
-                <node concept="37vLTw" id="3C0hCYbRUvx" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3C0hCYbRTGm" resolve="malformedBaseInMathVarExpression" />
+              <node concept="2OqwBi" id="1br4Vy9o_2" role="3uHU7w">
+                <node concept="2OqwBi" id="1br4Vy9o_3" role="2Oq$k0">
+                  <node concept="37vLTw" id="1br4Vy9o_4" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3C0hCYbRTGm" resolve="malformedBaseInMathVarExpression" />
+                  </node>
+                  <node concept="3TrEf2" id="1br4Vy9o_5" role="2OqNvi">
+                    <ref role="3Tt5mk" to="1qv1:4iu6t1eBdVy" resolve="expr" />
+                  </node>
                 </node>
-                <node concept="3TrEf2" id="3C0hCYbRUX6" role="2OqNvi">
-                  <ref role="3Tt5mk" to="1qv1:4iu6t1eBdVy" resolve="expr" />
+                <node concept="2qgKlT" id="1br4Vy9o_6" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                 </node>
               </node>
               <node concept="Xl_RD" id="3C0hCYbRU7y" role="3uHU7B">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/editor.mps
@@ -4014,18 +4014,18 @@
                     <node concept="3TQlhw" id="5avmkTFpf$K" role="1Hhtcw">
                       <node concept="3clFbS" id="5avmkTFpf$M" role="2VODD2">
                         <node concept="3clFbF" id="5avmkTFwBcX" role="3cqZAp">
-                          <node concept="3cpWs3" id="5avmkTFr96P" role="3clFbG">
-                            <node concept="Xl_RD" id="5avmkTFr96V" role="3uHU7w">
-                              <property role="Xl_RC" value="" />
-                            </node>
-                            <node concept="2OqwBi" id="5avmkTFwCcB" role="3uHU7B">
-                              <node concept="2OqwBi" id="5avmkTFwZsm" role="2Oq$k0">
-                                <node concept="pncrf" id="5avmkTFwBY2" role="2Oq$k0" />
-                                <node concept="3TrEf2" id="5avmkTFwZTS" role="2OqNvi">
+                          <node concept="2OqwBi" id="1br4Vy9o_P" role="3clFbG">
+                            <node concept="2OqwBi" id="1br4Vy9o_Q" role="2Oq$k0">
+                              <node concept="2OqwBi" id="1br4Vy9o_R" role="2Oq$k0">
+                                <node concept="pncrf" id="1br4Vy9o_S" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="1br4Vy9o_T" role="2OqNvi">
                                   <ref role="3Tt5mk" to="wtll:5xEoEMrmiVo" resolve="expr" />
                                 </node>
                               </node>
-                              <node concept="3JvlWi" id="5avmkTFwCFK" role="2OqNvi" />
+                              <node concept="3JvlWi" id="1br4Vy9o_U" role="2OqNvi" />
+                            </node>
+                            <node concept="2qgKlT" id="1br4Vy9o_V" role="2OqNvi">
+                              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                             </node>
                           </node>
                         </node>
@@ -4131,18 +4131,18 @@
                   <node concept="3TQlhw" id="5avmkTFxQi8" role="1Hhtcw">
                     <node concept="3clFbS" id="5avmkTFxQi9" role="2VODD2">
                       <node concept="3clFbF" id="5avmkTFxQia" role="3cqZAp">
-                        <node concept="3cpWs3" id="5avmkTFxQib" role="3clFbG">
-                          <node concept="Xl_RD" id="5avmkTFxQic" role="3uHU7w">
-                            <property role="Xl_RC" value="" />
-                          </node>
-                          <node concept="2OqwBi" id="5avmkTFxQid" role="3uHU7B">
-                            <node concept="2OqwBi" id="5avmkTFxQie" role="2Oq$k0">
-                              <node concept="pncrf" id="5avmkTFxQif" role="2Oq$k0" />
-                              <node concept="3TrEf2" id="5avmkTFxQig" role="2OqNvi">
+                        <node concept="2OqwBi" id="1br4Vy9oAd" role="3clFbG">
+                          <node concept="2OqwBi" id="1br4Vy9oAe" role="2Oq$k0">
+                            <node concept="2OqwBi" id="1br4Vy9oAf" role="2Oq$k0">
+                              <node concept="pncrf" id="1br4Vy9oAg" role="2Oq$k0" />
+                              <node concept="3TrEf2" id="1br4Vy9oAh" role="2OqNvi">
                                 <ref role="3Tt5mk" to="wtll:5xEoEMrmiVo" resolve="expr" />
                               </node>
                             </node>
-                            <node concept="3JvlWi" id="5avmkTFxQih" role="2OqNvi" />
+                            <node concept="3JvlWi" id="1br4Vy9oAi" role="2OqNvi" />
+                          </node>
+                          <node concept="2qgKlT" id="1br4Vy9oAj" role="2OqNvi">
+                            <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                           </node>
                         </node>
                       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/typesystem.mps
@@ -22,6 +22,7 @@
     <import index="2ahs" ref="r:ea6cf71d-29d2-478d-8027-a9f4a4de53c4(com.mbeddr.mpsutil.interpreter.rt)" implicit="true" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="yv47" ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" implicit="true" />
     <import index="nu60" ref="r:cfd59c48-ecc8-4b0c-8ae8-6d876c46ebbb(org.iets3.core.expr.toplevel.behavior)" implicit="true" />
   </imports>
@@ -1751,8 +1752,13 @@
                       <node concept="Xl_RD" id="4YhD5cZpDGE" role="3uHU7B">
                         <property role="Xl_RC" value="expression " />
                       </node>
-                      <node concept="37vLTw" id="4YhD5cZpEob" role="3uHU7w">
-                        <ref role="3cqZAo" node="4YhD5cZpEhf" resolve="e" />
+                      <node concept="2OqwBi" id="1br4Vy9oAs" role="3uHU7w">
+                        <node concept="37vLTw" id="1br4Vy9oAt" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4YhD5cZpEhf" resolve="e" />
+                        </node>
+                        <node concept="2qgKlT" id="1br4Vy9oAu" role="2OqNvi">
+                          <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                        </node>
                       </node>
                     </node>
                     <node concept="Xl_RD" id="4YhD5cZpEyF" role="3uHU7w">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.statemachines/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.statemachines/models/editor.mps
@@ -591,39 +591,39 @@
                 <node concept="3clFbJ" id="k9boAtXxFf" role="3cqZAp">
                   <node concept="3clFbS" id="k9boAtXxFh" role="3clFbx">
                     <node concept="3cpWs6" id="k9boAtX_8A" role="3cqZAp">
-                      <node concept="3cpWs3" id="k9boAtX_8C" role="3cqZAk">
-                        <node concept="Xl_RD" id="k9boAtX_8D" role="3uHU7w">
-                          <property role="Xl_RC" value="" />
-                        </node>
-                        <node concept="2OqwBi" id="k9boAtX_8E" role="3uHU7B">
-                          <node concept="1PxgMI" id="k9boAtX_8F" role="2Oq$k0">
-                            <node concept="chp4Y" id="k9boAtX_8G" role="3oSUPX">
+                      <node concept="2OqwBi" id="1br4Vy9oAS" role="3cqZAk">
+                        <node concept="2OqwBi" id="1br4Vy9oAT" role="2Oq$k0">
+                          <node concept="1PxgMI" id="1br4Vy9oAU" role="2Oq$k0">
+                            <node concept="chp4Y" id="1br4Vy9oAV" role="3oSUPX">
                               <ref role="cht4Q" to="19m5:7$TgoCYa5Nn" resolve="State" />
                             </node>
-                            <node concept="2OqwBi" id="k9boAtX_8H" role="1m5AlR">
-                              <node concept="pncrf" id="k9boAtX_8I" role="2Oq$k0" />
-                              <node concept="1mfA1w" id="k9boAtX_8J" role="2OqNvi" />
+                            <node concept="2OqwBi" id="1br4Vy9oAW" role="1m5AlR">
+                              <node concept="pncrf" id="1br4Vy9oAX" role="2Oq$k0" />
+                              <node concept="1mfA1w" id="1br4Vy9oAY" role="2OqNvi" />
                             </node>
                           </node>
-                          <node concept="2qgKlT" id="k9boAtX_8K" role="2OqNvi">
+                          <node concept="2qgKlT" id="1br4Vy9oAZ" role="2OqNvi">
                             <ref role="37wK5l" to="w10o:k9boAtVIcE" resolve="leastCommonContainerWith" />
-                            <node concept="2OqwBi" id="k9boAtX_8L" role="37wK5m">
-                              <node concept="1PxgMI" id="k9boAtX_8M" role="2Oq$k0">
-                                <node concept="chp4Y" id="k9boAtX_8N" role="3oSUPX">
+                            <node concept="2OqwBi" id="1br4Vy9oB0" role="37wK5m">
+                              <node concept="1PxgMI" id="1br4Vy9oB1" role="2Oq$k0">
+                                <node concept="chp4Y" id="1br4Vy9oB2" role="3oSUPX">
                                   <ref role="cht4Q" to="19m5:7Z_fDCwfvKx" resolve="StateTarget" />
                                 </node>
-                                <node concept="2OqwBi" id="k9boAtX_8O" role="1m5AlR">
-                                  <node concept="pncrf" id="k9boAtX_8P" role="2Oq$k0" />
-                                  <node concept="3TrEf2" id="k9boAtX_8Q" role="2OqNvi">
+                                <node concept="2OqwBi" id="1br4Vy9oB3" role="1m5AlR">
+                                  <node concept="pncrf" id="1br4Vy9oB4" role="2Oq$k0" />
+                                  <node concept="3TrEf2" id="1br4Vy9oB5" role="2OqNvi">
                                     <ref role="3Tt5mk" to="19m5:7Z_fDCwfwnL" resolve="target" />
                                   </node>
                                 </node>
                               </node>
-                              <node concept="3TrEf2" id="k9boAtX_8R" role="2OqNvi">
+                              <node concept="3TrEf2" id="1br4Vy9oB6" role="2OqNvi">
                                 <ref role="3Tt5mk" to="19m5:7Z_fDCwfvKy" resolve="state" />
                               </node>
                             </node>
                           </node>
+                        </node>
+                        <node concept="2qgKlT" id="1br4Vy9oB7" role="2OqNvi">
+                          <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                         </node>
                       </node>
                     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
@@ -22,6 +22,7 @@
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
     <import index="x8ug" ref="r:761e0f2a-4ffc-4d74-83bd-c6255a04ca73(org.iets3.core.expr.temporal.behavior)" implicit="true" />
@@ -1415,16 +1416,26 @@
                   <node concept="3clFbS" id="117BaR7EsSr" role="9aQI4">
                     <node concept="2MkqsV" id="2ck7OjOLa0b" role="3cqZAp">
                       <node concept="3cpWs3" id="2ck7OjOLcSO" role="2MkJ7o">
-                        <node concept="2X3wrD" id="2ck7OjOLcWq" role="3uHU7w">
-                          <ref role="2X3Bk0" node="4rZeNQ6PBb0" resolve="rightType" />
+                        <node concept="2OqwBi" id="1br4Vy9oBk" role="3uHU7w">
+                          <node concept="2X3wrD" id="1br4Vy9oBl" role="2Oq$k0">
+                            <ref role="2X3Bk0" node="4rZeNQ6PBb0" resolve="rightType" />
+                          </node>
+                          <node concept="2qgKlT" id="1br4Vy9oBm" role="2OqNvi">
+                            <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                          </node>
                         </node>
                         <node concept="3cpWs3" id="2ck7OjOLcHU" role="3uHU7B">
                           <node concept="3cpWs3" id="2ck7OjOLc$e" role="3uHU7B">
                             <node concept="Xl_RD" id="2ck7OjOLa0z" role="3uHU7B">
                               <property role="Xl_RC" value="cannot be applied to types " />
                             </node>
-                            <node concept="2X3wrD" id="2ck7OjOLcDV" role="3uHU7w">
-                              <ref role="2X3Bk0" node="4rZeNQ6PB12" resolve="leftType" />
+                            <node concept="2OqwBi" id="1br4Vy9oC0" role="3uHU7w">
+                              <node concept="2X3wrD" id="1br4Vy9oC1" role="2Oq$k0">
+                                <ref role="2X3Bk0" node="4rZeNQ6PB12" resolve="leftType" />
+                              </node>
+                              <node concept="2qgKlT" id="1br4Vy9oC2" role="2OqNvi">
+                                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                              </node>
                             </node>
                           </node>
                           <node concept="Xl_RD" id="2ck7OjOLcHX" role="3uHU7w">
@@ -2139,16 +2150,26 @@
                   <node concept="3clFbS" id="6C2wkq6OV7E" role="9aQI4">
                     <node concept="2MkqsV" id="6C2wkq6OV7F" role="3cqZAp">
                       <node concept="3cpWs3" id="6C2wkq6OV7G" role="2MkJ7o">
-                        <node concept="2X3wrD" id="6C2wkq6OV7H" role="3uHU7w">
-                          <ref role="2X3Bk0" node="6C2wkq6OV60" resolve="rightType" />
+                        <node concept="2OqwBi" id="1br4Vy9oGH" role="3uHU7w">
+                          <node concept="2X3wrD" id="1br4Vy9oGI" role="2Oq$k0">
+                            <ref role="2X3Bk0" node="6C2wkq6OV60" resolve="rightType" />
+                          </node>
+                          <node concept="2qgKlT" id="1br4Vy9oGJ" role="2OqNvi">
+                            <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                          </node>
                         </node>
                         <node concept="3cpWs3" id="6C2wkq6OV7I" role="3uHU7B">
                           <node concept="3cpWs3" id="6C2wkq6OV7J" role="3uHU7B">
                             <node concept="Xl_RD" id="6C2wkq6OV7K" role="3uHU7B">
                               <property role="Xl_RC" value="cannot be applied to types " />
                             </node>
-                            <node concept="2X3wrD" id="6C2wkq6OV7L" role="3uHU7w">
-                              <ref role="2X3Bk0" node="6C2wkq6OV5W" resolve="leftType" />
+                            <node concept="2OqwBi" id="1br4Vy9oHp" role="3uHU7w">
+                              <node concept="2X3wrD" id="1br4Vy9oHq" role="2Oq$k0">
+                                <ref role="2X3Bk0" node="6C2wkq6OV5W" resolve="leftType" />
+                              </node>
+                              <node concept="2qgKlT" id="1br4Vy9oHr" role="2OqNvi">
+                                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                              </node>
                             </node>
                           </node>
                           <node concept="Xl_RD" id="6C2wkq6OV7M" role="3uHU7w">
@@ -3139,8 +3160,13 @@
                     <node concept="3clFbS" id="6xvNSEj8gSZ" role="3clFbx">
                       <node concept="2MkqsV" id="6xvNSEj8hpl" role="3cqZAp">
                         <node concept="3cpWs3" id="6xvNSEj8hpm" role="2MkJ7o">
-                          <node concept="37vLTw" id="6xvNSEj8hDf" role="3uHU7w">
-                            <ref role="3cqZAo" node="VFjlN5IH2b" resolve="rt" />
+                          <node concept="2OqwBi" id="1br4Vy9oDm" role="3uHU7w">
+                            <node concept="37vLTw" id="1br4Vy9oDn" role="2Oq$k0">
+                              <ref role="3cqZAo" node="VFjlN5IH2b" resolve="rt" />
+                            </node>
+                            <node concept="2qgKlT" id="1br4Vy9oDo" role="2OqNvi">
+                              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                            </node>
                           </node>
                           <node concept="3cpWs3" id="6xvNSEj8hpo" role="3uHU7B">
                             <node concept="3cpWs3" id="6xvNSEj8hpp" role="3uHU7B">
@@ -3158,8 +3184,13 @@
                                   <property role="Xl_RC" value=" cannot be applied to types " />
                                 </node>
                               </node>
-                              <node concept="37vLTw" id="6xvNSEj8hyD" role="3uHU7w">
-                                <ref role="3cqZAo" node="VFjlN5IH27" resolve="lt" />
+                              <node concept="2OqwBi" id="1br4Vy9oE2" role="3uHU7w">
+                                <node concept="37vLTw" id="1br4Vy9oE3" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="VFjlN5IH27" resolve="lt" />
+                                </node>
+                                <node concept="2qgKlT" id="1br4Vy9oE4" role="2OqNvi">
+                                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                                </node>
                               </node>
                             </node>
                             <node concept="Xl_RD" id="6xvNSEj8hpy" role="3uHU7w">
@@ -3180,8 +3211,13 @@
                                 <ref role="2pJxcJ" to="tpd4:hfSilrU" resolve="errorText" />
                                 <node concept="WxPPo" id="6xvNSEj8hpD" role="28ntcv">
                                   <node concept="3cpWs3" id="6xvNSEj8hpE" role="WxPPp">
-                                    <node concept="37vLTw" id="6xvNSEj8hKJ" role="3uHU7w">
-                                      <ref role="3cqZAo" node="VFjlN5IH2b" resolve="rt" />
+                                    <node concept="2OqwBi" id="1br4Vy9oEu" role="3uHU7w">
+                                      <node concept="37vLTw" id="1br4Vy9oEv" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="VFjlN5IH2b" resolve="rt" />
+                                      </node>
+                                      <node concept="2qgKlT" id="1br4Vy9oEw" role="2OqNvi">
+                                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                                      </node>
                                     </node>
                                     <node concept="3cpWs3" id="6xvNSEj8hpG" role="3uHU7B">
                                       <node concept="3cpWs3" id="6xvNSEj8hpH" role="3uHU7B">
@@ -3199,8 +3235,13 @@
                                             <node concept="3n3YKJ" id="6xvNSEj8hpO" role="2OqNvi" />
                                           </node>
                                         </node>
-                                        <node concept="37vLTw" id="6xvNSEj8hEt" role="3uHU7w">
-                                          <ref role="3cqZAo" node="VFjlN5IH27" resolve="lt" />
+                                        <node concept="2OqwBi" id="1br4Vy9oFa" role="3uHU7w">
+                                          <node concept="37vLTw" id="1br4Vy9oFb" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="VFjlN5IH27" resolve="lt" />
+                                          </node>
+                                          <node concept="2qgKlT" id="1br4Vy9oFc" role="2OqNvi">
+                                            <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                                          </node>
                                         </node>
                                       </node>
                                       <node concept="Xl_RD" id="6xvNSEj8hpQ" role="3uHU7w">
@@ -3406,16 +3447,26 @@
                   <property role="TrG5h" value="message" />
                   <node concept="17QB3L" id="$UzLJuXIic" role="1tU5fm" />
                   <node concept="3cpWs3" id="$UzLJuXIif" role="33vP2m">
-                    <node concept="2X3wrD" id="$UzLJuXIig" role="3uHU7w">
-                      <ref role="2X3Bk0" node="VFjlN5IH1S" resolve="rightType" />
+                    <node concept="2OqwBi" id="1br4Vy9oFE" role="3uHU7w">
+                      <node concept="2X3wrD" id="1br4Vy9oFF" role="2Oq$k0">
+                        <ref role="2X3Bk0" node="VFjlN5IH1S" resolve="rightType" />
+                      </node>
+                      <node concept="2qgKlT" id="1br4Vy9oFG" role="2OqNvi">
+                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                      </node>
                     </node>
                     <node concept="3cpWs3" id="$UzLJuXIih" role="3uHU7B">
                       <node concept="3cpWs3" id="$UzLJuXIii" role="3uHU7B">
                         <node concept="Xl_RD" id="$UzLJuXIij" role="3uHU7B">
                           <property role="Xl_RC" value="cannot be applied to types " />
                         </node>
-                        <node concept="2X3wrD" id="$UzLJuXIik" role="3uHU7w">
-                          <ref role="2X3Bk0" node="VFjlN5IH1O" resolve="leftType" />
+                        <node concept="2OqwBi" id="1br4Vy9oGm" role="3uHU7w">
+                          <node concept="2X3wrD" id="1br4Vy9oGn" role="2Oq$k0">
+                            <ref role="2X3Bk0" node="VFjlN5IH1O" resolve="leftType" />
+                          </node>
+                          <node concept="2qgKlT" id="1br4Vy9oGo" role="2OqNvi">
+                            <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                          </node>
                         </node>
                       </node>
                       <node concept="Xl_RD" id="$UzLJuXIil" role="3uHU7w">
@@ -3755,16 +3806,26 @@
                   <node concept="3clFbS" id="4MUSbESIC74" role="9aQI4">
                     <node concept="2MkqsV" id="4MUSbESIC75" role="3cqZAp">
                       <node concept="3cpWs3" id="4MUSbESIC76" role="2MkJ7o">
-                        <node concept="2X3wrD" id="4MUSbESIC77" role="3uHU7w">
-                          <ref role="2X3Bk0" node="4MUSbESIC5q" resolve="rightType" />
+                        <node concept="2OqwBi" id="1br4Vy9oCn" role="3uHU7w">
+                          <node concept="2X3wrD" id="1br4Vy9oCo" role="2Oq$k0">
+                            <ref role="2X3Bk0" node="4MUSbESIC5q" resolve="rightType" />
+                          </node>
+                          <node concept="2qgKlT" id="1br4Vy9oCp" role="2OqNvi">
+                            <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                          </node>
                         </node>
                         <node concept="3cpWs3" id="4MUSbESIC78" role="3uHU7B">
                           <node concept="3cpWs3" id="4MUSbESIC79" role="3uHU7B">
                             <node concept="Xl_RD" id="4MUSbESIC7a" role="3uHU7B">
                               <property role="Xl_RC" value="cannot be applied to types " />
                             </node>
-                            <node concept="2X3wrD" id="4MUSbESIC7b" role="3uHU7w">
-                              <ref role="2X3Bk0" node="4MUSbESIC5m" resolve="leftType" />
+                            <node concept="2OqwBi" id="1br4Vy9oD3" role="3uHU7w">
+                              <node concept="2X3wrD" id="1br4Vy9oD4" role="2Oq$k0">
+                                <ref role="2X3Bk0" node="4MUSbESIC5m" resolve="leftType" />
+                              </node>
+                              <node concept="2qgKlT" id="1br4Vy9oD5" role="2OqNvi">
+                                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                              </node>
                             </node>
                           </node>
                           <node concept="Xl_RD" id="4MUSbESIC7c" role="3uHU7w">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -1621,10 +1621,15 @@
                     <property role="Xl_RC" value=" " />
                   </node>
                 </node>
-                <node concept="2OqwBi" id="252QIDyrHLK" role="3uHU7w">
-                  <node concept="13iPFW" id="252QIDyrHGU" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="252QIDyrHYk" role="2OqNvi">
-                    <ref role="3Tt5mk" to="av4b:ub9nkyHAbI" resolve="op" />
+                <node concept="2OqwBi" id="1br4Vy9oHH" role="3uHU7w">
+                  <node concept="2OqwBi" id="1br4Vy9oHI" role="2Oq$k0">
+                    <node concept="13iPFW" id="1br4Vy9oHJ" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="1br4Vy9oHK" role="2OqNvi">
+                      <ref role="3Tt5mk" to="av4b:ub9nkyHAbI" resolve="op" />
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="1br4Vy9oHL" role="2OqNvi">
+                    <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                   </node>
                 </node>
               </node>
@@ -12213,10 +12218,15 @@
               <node concept="Xl_RD" id="3GdqffBS_Ks" role="3uHU7B">
                 <property role="Xl_RC" value="mute(" />
               </node>
-              <node concept="2OqwBi" id="7S4tmubD$45" role="3uHU7w">
-                <node concept="13iPFW" id="7S4tmubDzPG" role="2Oq$k0" />
-                <node concept="3TrEf2" id="7S4tmubD$gP" role="2OqNvi">
-                  <ref role="3Tt5mk" to="av4b:3GdqffBS$Mq" resolve="expr" />
+              <node concept="2OqwBi" id="1br4Vy9oIn" role="3uHU7w">
+                <node concept="2OqwBi" id="1br4Vy9oIo" role="2Oq$k0">
+                  <node concept="13iPFW" id="1br4Vy9oIp" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="1br4Vy9oIq" role="2OqNvi">
+                    <ref role="3Tt5mk" to="av4b:3GdqffBS$Mq" resolve="expr" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="1br4Vy9oIr" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/plugin.mps
@@ -22,6 +22,7 @@
     <import index="2ahs" ref="r:ea6cf71d-29d2-478d-8027-a9f4a4de53c4(com.mbeddr.mpsutil.interpreter.rt)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
   </imports>
   <registry>
@@ -183,6 +184,7 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
@@ -834,8 +836,13 @@
                 <node concept="liA8E" id="5Pgo_AScpCQ" role="2OqNvi">
                   <ref role="37wK5l" to="4k19:~Description.appendText(java.lang.String)" resolve="appendText" />
                   <node concept="3cpWs3" id="5Pgo_AScq22" role="37wK5m">
-                    <node concept="37vLTw" id="5Pgo_AScq4c" role="3uHU7w">
-                      <ref role="3cqZAo" node="5Pgo_AScl1V" resolve="type" />
+                    <node concept="2OqwBi" id="1br4Vy9oIG" role="3uHU7w">
+                      <node concept="37vLTw" id="1br4Vy9oIH" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5Pgo_AScl1V" resolve="type" />
+                      </node>
+                      <node concept="2qgKlT" id="1br4Vy9oII" role="2OqNvi">
+                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                      </node>
                     </node>
                     <node concept="Xl_RD" id="5Pgo_AScpEE" role="3uHU7B">
                       <property role="Xl_RC" value="was a record value with an invalid type " />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -4299,10 +4299,15 @@
                   <node concept="Xl_RD" id="2Q7faZZwpYC" role="3uHU7w">
                     <property role="Xl_RC" value=" inline record member" />
                   </node>
-                  <node concept="2OqwBi" id="2Q7faZZx7lA" role="3uHU7B">
-                    <node concept="2ZBlsa" id="2Q7faZZx7dq" role="2Oq$k0" />
-                    <node concept="2qgKlT" id="2Q7faZZx7mH" role="2OqNvi">
-                      <ref role="37wK5l" to="pbu6:4WLweXm3SW5" resolve="type" />
+                  <node concept="2OqwBi" id="1br4Vy9oJ8" role="3uHU7B">
+                    <node concept="2OqwBi" id="1br4Vy9oJ9" role="2Oq$k0">
+                      <node concept="2ZBlsa" id="1br4Vy9oJa" role="2Oq$k0" />
+                      <node concept="2qgKlT" id="1br4Vy9oJb" role="2OqNvi">
+                        <ref role="37wK5l" to="pbu6:4WLweXm3SW5" resolve="type" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="1br4Vy9oJc" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/plugin.mps
@@ -21,6 +21,7 @@
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="1ne1" ref="r:e9a49de8-6adf-4c2e-b5c2-32fc88189c93(com.mbeddr.mpsutil.contextactions.runtime)" />
     <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="nu60" ref="r:cfd59c48-ecc8-4b0c-8ae8-6d876c46ebbb(org.iets3.core.expr.toplevel.behavior)" implicit="true" />
     <import index="lmd" ref="r:a6074908-e483-4c8e-80b5-5dbf8b24df4c(org.iets3.core.expr.path.structure)" implicit="true" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" implicit="true" />
@@ -419,8 +420,13 @@
             </node>
             <node concept="3cpWs3" id="7D7uZV2wu9l" role="3uHU7B">
               <node concept="3cpWs3" id="7$ajNzj$0Yi" role="3uHU7B">
-                <node concept="37vLTw" id="7$ajNzj$19H" role="3uHU7w">
-                  <ref role="3cqZAo" node="7$ajNzjzZzN" resolve="recordDeclaration" />
+                <node concept="2OqwBi" id="1br4Vy9oJl" role="3uHU7w">
+                  <node concept="37vLTw" id="1br4Vy9oJm" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7$ajNzjzZzN" resolve="recordDeclaration" />
+                  </node>
+                  <node concept="2qgKlT" id="1br4Vy9oJn" role="2OqNvi">
+                    <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                  </node>
                 </node>
                 <node concept="Xl_RD" id="7D7uZV2wch4" role="3uHU7B">
                   <property role="Xl_RC" value="#" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/behavior.mps
@@ -3106,10 +3106,15 @@
                   <node concept="Xl_RD" id="6kR0qIbI0Qj" role="3uHU7B">
                     <property role="Xl_RC" value="convert&lt;" />
                   </node>
-                  <node concept="2OqwBi" id="6kR0qIbI0VR" role="3uHU7w">
-                    <node concept="13iPFW" id="6kR0qIbI0Tj" role="2Oq$k0" />
-                    <node concept="3TrEf2" id="6kR0qIbI10$" role="2OqNvi">
-                      <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                  <node concept="2OqwBi" id="1br4Vy9oKg" role="3uHU7w">
+                    <node concept="2OqwBi" id="1br4Vy9oKh" role="2Oq$k0">
+                      <node concept="13iPFW" id="1br4Vy9oKi" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="1br4Vy9oKj" role="2OqNvi">
+                        <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="1br4Vy9oKk" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                     </node>
                   </node>
                 </node>
@@ -3117,10 +3122,15 @@
                   <property role="Xl_RC" value=", " />
                 </node>
               </node>
-              <node concept="2OqwBi" id="6kR0qIbI1hF" role="3uHU7w">
-                <node concept="13iPFW" id="6kR0qIbI1eI" role="2Oq$k0" />
-                <node concept="3TrEf2" id="6kR0qIbI1nM" role="2OqNvi">
-                  <ref role="3Tt5mk" to="b0gq:3$KQaHc3HJG" resolve="targetUnit" />
+              <node concept="2OqwBi" id="1br4Vy9oJD" role="3uHU7w">
+                <node concept="2OqwBi" id="1br4Vy9oJE" role="2Oq$k0">
+                  <node concept="13iPFW" id="1br4Vy9oJF" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="1br4Vy9oJG" role="2OqNvi">
+                    <ref role="3Tt5mk" to="b0gq:3$KQaHc3HJG" resolve="targetUnit" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="1br4Vy9oJH" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/typesystem.mps
@@ -3340,17 +3340,22 @@
                               <property role="Xl_RC" value=" in " />
                             </node>
                           </node>
-                          <node concept="2OqwBi" id="52UOzzPpYS7" role="3uHU7w">
-                            <node concept="2GrUjf" id="52UOzzPpYK6" role="2Oq$k0">
-                              <ref role="2Gs0qQ" node="52UOzzPp302" resolve="specifier" />
-                            </node>
-                            <node concept="2Xjw5R" id="52UOzzPqSzq" role="2OqNvi">
-                              <node concept="1xMEDy" id="52UOzzPqSzs" role="1xVPHs">
-                                <node concept="chp4Y" id="52UOzzPqS_V" role="ri$Ld">
-                                  <ref role="cht4Q" to="vs0r:6clJcrJYOUA" resolve="Chunk" />
-                                </node>
+                          <node concept="2OqwBi" id="1br4Vy9oKB" role="3uHU7w">
+                            <node concept="2OqwBi" id="1br4Vy9oKC" role="2Oq$k0">
+                              <node concept="2GrUjf" id="1br4Vy9oKD" role="2Oq$k0">
+                                <ref role="2Gs0qQ" node="52UOzzPp302" resolve="specifier" />
                               </node>
-                              <node concept="1xIGOp" id="52UOzzPqSCS" role="1xVPHs" />
+                              <node concept="2Xjw5R" id="1br4Vy9oKE" role="2OqNvi">
+                                <node concept="1xMEDy" id="1br4Vy9oKF" role="1xVPHs">
+                                  <node concept="chp4Y" id="1br4Vy9oKG" role="ri$Ld">
+                                    <ref role="cht4Q" to="vs0r:6clJcrJYOUA" resolve="Chunk" />
+                                  </node>
+                                </node>
+                                <node concept="1xIGOp" id="1br4Vy9oKH" role="1xVPHs" />
+                              </node>
+                            </node>
+                            <node concept="2qgKlT" id="1br4Vy9oKI" role="2OqNvi">
+                              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                             </node>
                           </node>
                         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.opensource.build.gentests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.opensource.build.gentests/models/behavior.mps
@@ -635,7 +635,12 @@
                           <property role="Xl_RC" value=" in scope (this: " />
                         </node>
                       </node>
-                      <node concept="13iPFW" id="70Mo24wXXPd" role="3uHU7w" />
+                      <node concept="2OqwBi" id="1br4Vy9oLb" role="3uHU7w">
+                        <node concept="13iPFW" id="1br4Vy9oLc" role="2Oq$k0" />
+                        <node concept="2qgKlT" id="1br4Vy9oLd" role="2OqNvi">
+                          <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                        </node>
+                      </node>
                     </node>
                     <node concept="Xl_RD" id="70Mo24wXY2d" role="3uHU7w">
                       <property role="Xl_RC" value=", concept: " />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/editor.mps
@@ -3202,7 +3202,12 @@
                     <node concept="Xl_RD" id="7Ip2X68Ok40" role="3uHU7B">
                       <property role="Xl_RC" value="Move to State " />
                     </node>
-                    <node concept="2ZBlsa" id="73kHms33tnz" role="3uHU7w" />
+                    <node concept="2OqwBi" id="1br4Vy9oLH" role="3uHU7w">
+                      <node concept="2ZBlsa" id="1br4Vy9oLI" role="2Oq$k0" />
+                      <node concept="2qgKlT" id="1br4Vy9oLJ" role="2OqNvi">
+                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.plugin/models/org/iets3/req/plugin/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.plugin/models/org/iets3/req/plugin/plugin.mps
@@ -855,7 +855,12 @@
       </node>
       <node concept="geMak" id="7Ip2X68Oj8t" role="3_Xtdj">
         <node concept="3cpWs3" id="7Ip2X68Ok85" role="geMbG">
-          <node concept="geSxg" id="7Ip2X68Ok9k" role="3uHU7w" />
+          <node concept="2OqwBi" id="1br4Vy9oLZ" role="3uHU7w">
+            <node concept="geSxg" id="1br4Vy9oM0" role="2Oq$k0" />
+            <node concept="2qgKlT" id="1br4Vy9oM1" role="2OqNvi">
+              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+            </node>
+          </node>
           <node concept="Xl_RD" id="7Ip2X68Ok40" role="3uHU7B">
             <property role="Xl_RC" value="Move to State " />
           </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/models/plugin.mps
@@ -1134,10 +1134,15 @@
                 <ref role="37wK5l" to="jkm4:~Messages.showErrorDialog(java.lang.String,java.lang.String)" resolve="showErrorDialog" />
                 <ref role="1Pybhc" to="jkm4:~Messages" resolve="Messages" />
                 <node concept="3cpWs3" id="2g6f$bb2ABa" role="37wK5m">
-                  <node concept="2OqwBi" id="2g6f$bb2AEP" role="3uHU7w">
-                    <node concept="2WthIp" id="2g6f$bb2AES" role="2Oq$k0" />
-                    <node concept="3gHZIF" id="2g6f$bb2AEU" role="2OqNvi">
-                      <ref role="2WH_rO" node="5ipapt3lxen" resolve="someNode" />
+                  <node concept="2OqwBi" id="1br4Vy9o_n" role="3uHU7w">
+                    <node concept="2OqwBi" id="1br4Vy9o_o" role="2Oq$k0">
+                      <node concept="2WthIp" id="1br4Vy9o_p" role="2Oq$k0" />
+                      <node concept="3gHZIF" id="1br4Vy9o_q" role="2OqNvi">
+                        <ref role="2WH_rO" node="5ipapt3lxen" resolve="someNode" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="1br4Vy9o_r" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                     </node>
                   </node>
                   <node concept="Xl_RD" id="2g6f$bb2AfU" role="3uHU7B">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -2601,11 +2601,6 @@
             <ref role="3bR37D" to="90a9:6fQhGuklQWU" resolve="de.q60.mps.libs" />
           </node>
         </node>
-        <node concept="1SiIV0" id="616oath7Wnd" role="3bR37C">
-          <node concept="3bR9La" id="616oath7Wne" role="1SiIV1">
-            <ref role="3bR37D" to="90a9:763TrXRFx3C" resolve="de.q60.mps.shadowmodels.modelcheck.runtime" />
-          </node>
-        </node>
       </node>
       <node concept="1E1JtA" id="4C_RnzfEE1P" role="2G$12L">
         <property role="BnDLt" value="true" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
@@ -30,6 +30,7 @@
     <import index="63ih" ref="r:8b224ec5-7a3e-45b9-8341-eb73ff942246(org.iets3.core.expr.math.typesystem)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -491,6 +492,7 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
@@ -2318,8 +2320,13 @@
                 <node concept="Xl_RD" id="1JTgXSYNnv7" role="3uHU7B">
                   <property role="Xl_RC" value="Tag size of type " />
                 </node>
-                <node concept="37vLTw" id="1JTgXSYNnHw" role="3uHU7w">
-                  <ref role="3cqZAo" node="1JTgXSYMSaY" resolve="actualType" />
+                <node concept="2OqwBi" id="1br4Vy9oMi" role="3uHU7w">
+                  <node concept="37vLTw" id="1br4Vy9oMj" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1JTgXSYMSaY" resolve="actualType" />
+                  </node>
+                  <node concept="2qgKlT" id="1br4Vy9oMk" role="2OqNvi">
+                    <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -2950,11 +2957,16 @@
           </node>
           <node concept="3_1$Yv" id="1JTgXSYQGy_" role="3_9lra">
             <node concept="3cpWs3" id="1JTgXSYQGLy" role="3_1BAH">
-              <node concept="2OqwBi" id="1JTgXSYQH2r" role="3uHU7w">
-                <node concept="3xONca" id="1JTgXSYQGLO" role="2Oq$k0">
-                  <ref role="3xOPvv" node="1JTgXSYQEe5" resolve="sumWithoutUnit" />
+              <node concept="2OqwBi" id="1br4Vy9oMA" role="3uHU7w">
+                <node concept="2OqwBi" id="1br4Vy9oMB" role="2Oq$k0">
+                  <node concept="3xONca" id="1br4Vy9oMC" role="2Oq$k0">
+                    <ref role="3xOPvv" node="1JTgXSYQEe5" resolve="sumWithoutUnit" />
+                  </node>
+                  <node concept="3JvlWi" id="1br4Vy9oMD" role="2OqNvi" />
                 </node>
-                <node concept="3JvlWi" id="1JTgXSYQH_3" role="2OqNvi" />
+                <node concept="2qgKlT" id="1br4Vy9oME" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                </node>
               </node>
               <node concept="Xl_RD" id="1JTgXSYQGyD" role="3uHU7B">
                 <property role="Xl_RC" value="The type of the sum needs to be a number type, but was " />
@@ -3027,19 +3039,29 @@
                   <node concept="Xl_RD" id="6q$NxWeD2bi" role="3uHU7B">
                     <property role="Xl_RC" value="The type of " />
                   </node>
-                  <node concept="3xONca" id="6q$NxWeD2pv" role="3uHU7w">
-                    <ref role="3xOPvv" node="1JTgXSYTGiL" resolve="fracWithoutUnit" />
+                  <node concept="2OqwBi" id="1br4Vy9oNx" role="3uHU7w">
+                    <node concept="3xONca" id="1br4Vy9oNy" role="2Oq$k0">
+                      <ref role="3xOPvv" node="1JTgXSYTGiL" resolve="fracWithoutUnit" />
+                    </node>
+                    <node concept="2qgKlT" id="1br4Vy9oNz" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                    </node>
                   </node>
                 </node>
                 <node concept="Xl_RD" id="6q$NxWeD2C$" role="3uHU7w">
                   <property role="Xl_RC" value=" was expected to be a rational type, but was " />
                 </node>
               </node>
-              <node concept="2OqwBi" id="6q$NxWeD3vW" role="3uHU7w">
-                <node concept="3xONca" id="6q$NxWeD3cD" role="2Oq$k0">
-                  <ref role="3xOPvv" node="1JTgXSYTGiL" resolve="fracWithoutUnit" />
+              <node concept="2OqwBi" id="1br4Vy9oMW" role="3uHU7w">
+                <node concept="2OqwBi" id="1br4Vy9oMX" role="2Oq$k0">
+                  <node concept="3xONca" id="1br4Vy9oMY" role="2Oq$k0">
+                    <ref role="3xOPvv" node="1JTgXSYTGiL" resolve="fracWithoutUnit" />
+                  </node>
+                  <node concept="3JvlWi" id="1br4Vy9oMZ" role="2OqNvi" />
                 </node>
-                <node concept="3JvlWi" id="6q$NxWeD3VA" role="2OqNvi" />
+                <node concept="2qgKlT" id="1br4Vy9oN0" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                </node>
               </node>
             </node>
           </node>


### PR DESCRIPTION
In the last MPS version (2020.2) there was a change that impacted how nodes are converted to strings ([MPS-32042](https://youtrack.jetbrains.com/issue/MPS-32042)). Due to this change for some nodes the string+node concatenation could produce different result not readable from the user point of view (contains `(instance of <concept>)` instead of custom node presentation). To fix this, we need to always use node.getPresentation() explicitly in such cases. This PR adds required calls for all cases of previously implicit conversion of nodes to string.