### PR TITLE
Allow RunManually shortcut also if root node is a ICanRunCheckManually

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.plugin/models/org/iets3/core/plugin/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.plugin/models/org/iets3/core/plugin/plugin.mps
@@ -180,6 +180,9 @@
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -289,6 +292,9 @@
         <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
@@ -1086,26 +1092,43 @@
     <node concept="2ScWuX" id="4bmM0avMBSC" role="tmbBb">
       <node concept="3clFbS" id="4bmM0avMBSD" role="2VODD2">
         <node concept="3clFbF" id="4uMJoRGbn8y" role="3cqZAp">
-          <node concept="1Wc70l" id="4uMJoRGboyY" role="3clFbG">
-            <node concept="3y3z36" id="4uMJoRGbooG" role="3uHU7B">
-              <node concept="2OqwBi" id="4uMJoRGbnom" role="3uHU7B">
-                <node concept="2WthIp" id="4uMJoRGbn8w" role="2Oq$k0" />
-                <node concept="3gHZIF" id="4uMJoRGbnVl" role="2OqNvi">
-                  <ref role="2WH_rO" node="4bmM0avMBS$" resolve="root" />
-                </node>
-              </node>
-              <node concept="10Nm6u" id="4uMJoRGbopg" role="3uHU7w" />
-            </node>
-            <node concept="3clFbC" id="4bmM0avMGh1" role="3uHU7w">
-              <node concept="10Nm6u" id="4bmM0avMGil" role="3uHU7w" />
-              <node concept="2OqwBi" id="4bmM0avMFZz" role="3uHU7B">
-                <node concept="2OqwBi" id="4bmM0avMFPF" role="2Oq$k0">
-                  <node concept="2WthIp" id="4bmM0avMFNp" role="2Oq$k0" />
-                  <node concept="3gHZIF" id="4bmM0avMFU8" role="2OqNvi">
+          <node concept="1Wc70l" id="7PPxtDZ$ON" role="3clFbG">
+            <node concept="3fqX7Q" id="7PPxtDZ$We" role="3uHU7w">
+              <node concept="2OqwBi" id="7PPxtDZ_P6" role="3fr31v">
+                <node concept="2OqwBi" id="7PPxtDZ_dO" role="2Oq$k0">
+                  <node concept="2WthIp" id="7PPxtDZ$Wx" role="2Oq$k0" />
+                  <node concept="3gHZIF" id="7PPxtDZ_Bm" role="2OqNvi">
                     <ref role="2WH_rO" node="4bmM0avMBS$" resolve="root" />
                   </node>
                 </node>
-                <node concept="1mfA1w" id="4bmM0avMG3g" role="2OqNvi" />
+                <node concept="1mIQ4w" id="7PPxtDZA64" role="2OqNvi">
+                  <node concept="chp4Y" id="7PPxtDZAed" role="cj9EA">
+                    <ref role="cht4Q" to="4kwy:3R3AIvumrSU" resolve="ICanRunCheckManually" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1Wc70l" id="4uMJoRGboyY" role="3uHU7B">
+              <node concept="3y3z36" id="4uMJoRGbooG" role="3uHU7B">
+                <node concept="2OqwBi" id="4uMJoRGbnom" role="3uHU7B">
+                  <node concept="2WthIp" id="4uMJoRGbn8w" role="2Oq$k0" />
+                  <node concept="3gHZIF" id="4uMJoRGbnVl" role="2OqNvi">
+                    <ref role="2WH_rO" node="4bmM0avMBS$" resolve="root" />
+                  </node>
+                </node>
+                <node concept="10Nm6u" id="4uMJoRGbopg" role="3uHU7w" />
+              </node>
+              <node concept="3clFbC" id="4bmM0avMGh1" role="3uHU7w">
+                <node concept="2OqwBi" id="4bmM0avMFZz" role="3uHU7B">
+                  <node concept="2OqwBi" id="4bmM0avMFPF" role="2Oq$k0">
+                    <node concept="2WthIp" id="4bmM0avMFNp" role="2Oq$k0" />
+                    <node concept="3gHZIF" id="4bmM0avMFU8" role="2OqNvi">
+                      <ref role="2WH_rO" node="4bmM0avMBS$" resolve="root" />
+                    </node>
+                  </node>
+                  <node concept="1mfA1w" id="4bmM0avMG3g" role="2OqNvi" />
+                </node>
+                <node concept="10Nm6u" id="4bmM0avMGil" role="3uHU7w" />
               </node>
             </node>
           </node>


### PR DESCRIPTION
If a root node is a `ICanRunCheckManually`, the Cmd-Alt-Enter shortcut doesn't work currently (issue #480). This is because the `runAllManuallyOnRoot` action will grab the shortcut, but its `execute` will not handle it correctly. 

There are two possible options to solve this:
- option 1: fix `runAllManuallyOnRoot` so that it not only handles checks for the root's descendants, but also for itself
- option 2: fix the shortcut logic so that `runAllManuallyOnRoot` will not grab the shortcut, but leave it to `runManuallyOnNode`

This PR solves the problem by doing option 2. I chose to avoid option 1 because it seems so far it was perfectly fine if root nodes only check there children and not themselves, and I decided to stick with that behavior.