### PR TITLE
Fix exception in generated code when modulo is used with floatingpoint

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.simpleTypes/generator/template/org.iets3.core.expr.genjava.simpleTypes@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.simpleTypes/generator/template/org.iets3.core.expr.genjava.simpleTypes@generator.mps
@@ -3,6 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <use id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator" version="3" />
     <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
   </languages>
   <imports>
@@ -6220,26 +6221,26 @@
         </node>
       </node>
     </node>
-    <node concept="3aamgX" id="5wDe8w_p3Mk" role="3aUrZf">
+    <node concept="3aamgX" id="6xqpdoQwdCp" role="3aUrZf">
       <property role="36QftV" value="true" />
       <ref role="30HIoZ" to="hm2y:5fy$GmTPJXq" resolve="ModExpression" />
-      <node concept="gft3U" id="5wDe8w_pvoc" role="1lVwrX">
-        <node concept="2OqwBi" id="5wDe8w_qiwe" role="gfFT$">
-          <node concept="1eOMI4" id="5wDe8wFyotw" role="2Oq$k0">
-            <node concept="10QFUN" id="5wDe8wFyott" role="1eOMHV">
-              <node concept="3uibUv" id="5wDe8wFyoKg" role="10QFUM">
+      <node concept="gft3U" id="6xqpdoQwdCq" role="1lVwrX">
+        <node concept="2OqwBi" id="6xqpdoQwdCr" role="gfFT$">
+          <node concept="1eOMI4" id="6xqpdoQwdCs" role="2Oq$k0">
+            <node concept="10QFUN" id="6xqpdoQwdCt" role="1eOMHV">
+              <node concept="3uibUv" id="6xqpdoQwdCu" role="10QFUM">
                 <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
               </node>
-              <node concept="10M0yZ" id="5wDe8w_qi97" role="10QFUP">
+              <node concept="10M0yZ" id="6xqpdoQwdCv" role="10QFUP">
                 <ref role="3cqZAo" to="xlxw:~BigInteger.ZERO" resolve="ZERO" />
                 <ref role="1PxDUh" to="xlxw:~BigInteger" resolve="BigInteger" />
-                <node concept="29HgVG" id="5wDe8w_qjwA" role="lGtFl">
-                  <node concept="3NFfHV" id="5wDe8w_qjwX" role="3NFExx">
-                    <node concept="3clFbS" id="5wDe8w_qjwY" role="2VODD2">
-                      <node concept="3clFbF" id="5wDe8w_qj$O" role="3cqZAp">
-                        <node concept="2OqwBi" id="5wDe8w_qjPd" role="3clFbG">
-                          <node concept="30H73N" id="5wDe8w_qj$N" role="2Oq$k0" />
-                          <node concept="3TrEf2" id="5wDe8w_qkpA" role="2OqNvi">
+                <node concept="29HgVG" id="6xqpdoQwdCw" role="lGtFl">
+                  <node concept="3NFfHV" id="6xqpdoQwdCx" role="3NFExx">
+                    <node concept="3clFbS" id="6xqpdoQwdCy" role="2VODD2">
+                      <node concept="3clFbF" id="6xqpdoQwdCz" role="3cqZAp">
+                        <node concept="2OqwBi" id="6xqpdoQwdC$" role="3clFbG">
+                          <node concept="30H73N" id="6xqpdoQwdC_" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="6xqpdoQwdCA" role="2OqNvi">
                             <ref role="3Tt5mk" to="hm2y:4rZeNQ6MpKm" resolve="left" />
                           </node>
                         </node>
@@ -6250,28 +6251,134 @@
               </node>
             </node>
           </node>
-          <node concept="liA8E" id="5wDe8w_qji6" role="2OqNvi">
+          <node concept="liA8E" id="6xqpdoQwdCB" role="2OqNvi">
             <ref role="37wK5l" to="xlxw:~BigInteger.mod(java.math.BigInteger)" resolve="mod" />
-            <node concept="10QFUN" id="5wDe8wFyoYh" role="37wK5m">
-              <node concept="3uibUv" id="5wDe8wFyph9" role="10QFUM">
+            <node concept="10QFUN" id="6xqpdoQwdCC" role="37wK5m">
+              <node concept="3uibUv" id="6xqpdoQwdCD" role="10QFUM">
                 <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
               </node>
-              <node concept="10M0yZ" id="5wDe8w_qjpL" role="10QFUP">
+              <node concept="10M0yZ" id="6xqpdoQwdCE" role="10QFUP">
                 <ref role="3cqZAo" to="xlxw:~BigInteger.ZERO" resolve="ZERO" />
                 <ref role="1PxDUh" to="xlxw:~BigInteger" resolve="BigInteger" />
-                <node concept="29HgVG" id="5wDe8w_qpkV" role="lGtFl">
-                  <node concept="3NFfHV" id="5wDe8w_qpkW" role="3NFExx">
-                    <node concept="3clFbS" id="5wDe8w_qpkX" role="2VODD2">
-                      <node concept="3clFbF" id="5wDe8w_qpl3" role="3cqZAp">
-                        <node concept="2OqwBi" id="5wDe8w_qpkY" role="3clFbG">
-                          <node concept="3TrEf2" id="5wDe8w_qpl1" role="2OqNvi">
+                <node concept="29HgVG" id="6xqpdoQwdCF" role="lGtFl">
+                  <node concept="3NFfHV" id="6xqpdoQwdCG" role="3NFExx">
+                    <node concept="3clFbS" id="6xqpdoQwdCH" role="2VODD2">
+                      <node concept="3clFbF" id="6xqpdoQwdCI" role="3cqZAp">
+                        <node concept="2OqwBi" id="6xqpdoQwdCJ" role="3clFbG">
+                          <node concept="3TrEf2" id="6xqpdoQwdCK" role="2OqNvi">
                             <ref role="3Tt5mk" to="hm2y:4rZeNQ6MpKo" resolve="right" />
                           </node>
-                          <node concept="30H73N" id="5wDe8w_qpl2" role="2Oq$k0" />
+                          <node concept="30H73N" id="6xqpdoQwdCL" role="2Oq$k0" />
                         </node>
                       </node>
                     </node>
                   </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="6xqpdoQra22" role="30HLyM">
+        <node concept="3clFbS" id="6xqpdoQra23" role="2VODD2">
+          <node concept="3clFbF" id="6xqpdoQraCJ" role="3cqZAp">
+            <node concept="3fqX7Q" id="6xqpdoQraCK" role="3clFbG">
+              <node concept="2OqwBi" id="6xqpdoQraCL" role="3fr31v">
+                <node concept="2OqwBi" id="6xqpdoQraCM" role="2Oq$k0">
+                  <node concept="30H73N" id="6xqpdoQraCN" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="6xqpdoQraCO" role="2OqNvi">
+                    <ref role="3Tt5mk" to="hm2y:4rZeNQ6MpKm" resolve="left" />
+                  </node>
+                </node>
+                <node concept="1mIQ4w" id="6xqpdoQraCP" role="2OqNvi">
+                  <node concept="chp4Y" id="6xqpdoQraCQ" role="cj9EA">
+                    <ref role="cht4Q" to="5qo5:7DTWJ$8kg41" resolve="ConvertPrecisionNumberExpression" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="6xqpdoQtflK" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="hm2y:5fy$GmTPJXq" resolve="ModExpression" />
+      <node concept="gft3U" id="6xqpdoQtflL" role="1lVwrX">
+        <node concept="2OqwBi" id="6xqpdoQtflM" role="gfFT$">
+          <node concept="1eOMI4" id="6xqpdoQtZ$a" role="2Oq$k0">
+            <node concept="2OqwBi" id="6xqpdoQtZTg" role="1eOMHV">
+              <node concept="1eOMI4" id="6xqpdoQtZ$5" role="2Oq$k0">
+                <node concept="10QFUN" id="6xqpdoQu0on" role="1eOMHV">
+                  <node concept="3uibUv" id="6xqpdoQu0Lx" role="10QFUM">
+                    <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+                  </node>
+                  <node concept="10M0yZ" id="6xqpdoQtYQV" role="10QFUP">
+                    <ref role="1PxDUh" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+                    <ref role="3cqZAo" to="xlxw:~BigDecimal.ZERO" resolve="ZERO" />
+                    <node concept="29HgVG" id="6xqpdoQu1de" role="lGtFl">
+                      <node concept="3NFfHV" id="6xqpdoQu1jY" role="3NFExx">
+                        <node concept="3clFbS" id="6xqpdoQu1jZ" role="2VODD2">
+                          <node concept="3clFbF" id="6xqpdoQu1r3" role="3cqZAp">
+                            <node concept="2OqwBi" id="6xqpdoQu1FO" role="3clFbG">
+                              <node concept="30H73N" id="6xqpdoQu1r2" role="2Oq$k0" />
+                              <node concept="3TrEf2" id="6xqpdoQu27J" role="2OqNvi">
+                                <ref role="3Tt5mk" to="hm2y:4rZeNQ6MpKm" resolve="left" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="6xqpdoQu0hv" role="2OqNvi">
+                <ref role="37wK5l" to="xlxw:~BigDecimal.toBigInteger()" resolve="toBigInteger" />
+              </node>
+            </node>
+          </node>
+          <node concept="liA8E" id="6xqpdoQtflZ" role="2OqNvi">
+            <ref role="37wK5l" to="xlxw:~BigInteger.mod(java.math.BigInteger)" resolve="mod" />
+            <node concept="10QFUN" id="6xqpdoQtfm0" role="37wK5m">
+              <node concept="3uibUv" id="6xqpdoQtfm1" role="10QFUM">
+                <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+              </node>
+              <node concept="10M0yZ" id="6xqpdoQtfm2" role="10QFUP">
+                <ref role="1PxDUh" to="xlxw:~BigInteger" resolve="BigInteger" />
+                <ref role="3cqZAo" to="xlxw:~BigInteger.ZERO" resolve="ZERO" />
+                <node concept="29HgVG" id="6xqpdoQtfm3" role="lGtFl">
+                  <node concept="3NFfHV" id="6xqpdoQtfm4" role="3NFExx">
+                    <node concept="3clFbS" id="6xqpdoQtfm5" role="2VODD2">
+                      <node concept="3clFbF" id="6xqpdoQtfm6" role="3cqZAp">
+                        <node concept="2OqwBi" id="6xqpdoQtfm7" role="3clFbG">
+                          <node concept="3TrEf2" id="6xqpdoQtfm8" role="2OqNvi">
+                            <ref role="3Tt5mk" to="hm2y:4rZeNQ6MpKo" resolve="right" />
+                          </node>
+                          <node concept="30H73N" id="6xqpdoQtfm9" role="2Oq$k0" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="6xqpdoQtfma" role="30HLyM">
+        <node concept="3clFbS" id="6xqpdoQtfmb" role="2VODD2">
+          <node concept="3clFbF" id="6xqpdoQtfmc" role="3cqZAp">
+            <node concept="2OqwBi" id="6xqpdoQtfmd" role="3clFbG">
+              <node concept="2OqwBi" id="6xqpdoQtfme" role="2Oq$k0">
+                <node concept="30H73N" id="6xqpdoQtfmf" role="2Oq$k0" />
+                <node concept="3TrEf2" id="6xqpdoQtfmg" role="2OqNvi">
+                  <ref role="3Tt5mk" to="hm2y:4rZeNQ6MpKm" resolve="left" />
+                </node>
+              </node>
+              <node concept="1mIQ4w" id="6xqpdoQtfmh" role="2OqNvi">
+                <node concept="chp4Y" id="6xqpdoQtfmi" role="cj9EA">
+                  <ref role="cht4Q" to="5qo5:7DTWJ$8kg41" resolve="ConvertPrecisionNumberExpression" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.base@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.base@tests.mps
@@ -2,10 +2,10 @@
 <model ref="r:5c3f8be4-b275-4108-be9a-6a052d5b2428(test.in.expr.os.base@tests)">
   <persistence version="9" />
   <languages>
-    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
-    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base" version="6" />
-    <use id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext" version="0" />
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="-1" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="-1" />
+    <use id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base" version="-1" />
+    <use id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext" version="-1" />
     <devkit ref="ec967770-4707-442f-baaf-a8b7bb554717(org.iets3.core.expr.genall.core.devkit)" />
     <devkit ref="c4e521ab-b605-4ef9-a7c3-68075da058f0(org.iets3.core.expr.core.devkit)" />
   </languages>
@@ -154,6 +154,13 @@
       <concept id="5115872837157054169" name="org.iets3.core.expr.simpleTypes.structure.IntegerType" flags="ng" index="30bXR$" />
       <concept id="5115872837157054170" name="org.iets3.core.expr.simpleTypes.structure.NumberLiteral" flags="ng" index="30bXRB">
         <property id="5115872837157054173" name="value" index="30bXRw" />
+      </concept>
+      <concept id="8825352096210458329" name="org.iets3.core.expr.simpleTypes.structure.RoundUpRoundingMode" flags="ng" index="1M9Agw" />
+      <concept id="8825352096210456368" name="org.iets3.core.expr.simpleTypes.structure.RoundDownRoundingMode" flags="ng" index="1M9BR9" />
+      <concept id="8825352096209502465" name="org.iets3.core.expr.simpleTypes.structure.ConvertPrecisionNumberExpression" flags="ng" index="1MaffS">
+        <property id="8825352096209722453" name="targetPrecision" index="1MbqUG" />
+        <child id="8825352096209502752" name="rounding" index="1Maf3p" />
+        <child id="8825352096209502545" name="expr" index="1MafeC" />
       </concept>
     </language>
     <language id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel">
@@ -2102,6 +2109,42 @@
         </node>
         <node concept="30bXRB" id="620LAS5PSCe" role="_fkuS">
           <property role="30bXRw" value="3" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="6xqpdoQvk1a" role="_fkp5">
+        <node concept="_fku$" id="6xqpdoQvk1b" role="_fkur" />
+        <node concept="30bXRB" id="6xqpdoQvk7E" role="_fkuS">
+          <property role="30bXRw" value="0" />
+        </node>
+        <node concept="3Ed6Qv" id="6xqpdoQvk1X" role="_fkuY">
+          <node concept="1MaffS" id="6xqpdoQvk1Z" role="30dEsF">
+            <property role="1MbqUG" value="0" />
+            <node concept="1M9BR9" id="6xqpdoQvk20" role="1Maf3p" />
+            <node concept="30bXRB" id="6xqpdoQvk3w" role="1MafeC">
+              <property role="30bXRw" value="2.2" />
+            </node>
+          </node>
+          <node concept="30bXRB" id="6xqpdoQKA$T" role="30dEs_">
+            <property role="30bXRw" value="2" />
+          </node>
+        </node>
+      </node>
+      <node concept="_fkuZ" id="6xqpdoQvk7T" role="_fkp5">
+        <node concept="_fku$" id="6xqpdoQvk7U" role="_fkur" />
+        <node concept="3Ed6Qv" id="6xqpdoQvk7W" role="_fkuY">
+          <node concept="30bXRB" id="6xqpdoQKABp" role="30dEsF">
+            <property role="30bXRw" value="3" />
+          </node>
+          <node concept="1MaffS" id="6xqpdoQJNQM" role="30dEs_">
+            <property role="1MbqUG" value="0" />
+            <node concept="1M9Agw" id="6xqpdoQJNSV" role="1Maf3p" />
+            <node concept="30bXRB" id="6xqpdoQJNXE" role="1MafeC">
+              <property role="30bXRw" value="1.8" />
+            </node>
+          </node>
+        </node>
+        <node concept="30bXRB" id="6xqpdoQvkgs" role="_fkuS">
+          <property role="30bXRw" value="1" />
         </node>
       </node>
     </node>


### PR DESCRIPTION
Bug: When the modulo expression is used with a FloatingPoint, which is rounded, the generated code runs into an cast exception, trying to cast `BigDecimal` to `BigInteger`.
Solution: Handled the transformation from `BigDecimal` to `BigInteger` in the right way, instead of a simple cast.