### PR TITLE
[breaking?] Remove MPS dependency from the published POMs, add tests → opensource dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -279,14 +279,6 @@ publishing {
                     dependencyNode.appendNode('version', it.moduleVersion)
                     dependencyNode.appendNode('type', it.moduleArtifacts[0].type)
                 }
-                configurations.mps.resolvedConfiguration.firstLevelModuleDependencies.each{
-                    def dependencyNode = dependenciesNode.appendNode('dependency')
-                    dependencyNode.appendNode('groupId', it.moduleGroup)
-                    dependencyNode.appendNode('artifactId', it.moduleName)
-                    dependencyNode.appendNode('version', it.moduleVersion)
-                    dependencyNode.appendNode('type', it.moduleArtifacts[0].type)
-                    dependencyNode.appendNode('scope', 'provided')
-                }
             }
         }
         tests(MavenPublication) {
@@ -295,13 +287,11 @@ publishing {
             artifact packageTests
             pom.withXml {
                 def dependenciesNode = asNode().appendNode('dependencies')
-                configurations.mps.resolvedConfiguration.firstLevelModuleDependencies.each{
-                    def dependencyNode = dependenciesNode.appendNode('dependency')
-                    dependencyNode.appendNode('groupId', it.moduleGroup)
-                    dependencyNode.appendNode('artifactId', it.moduleName)
-                    dependencyNode.appendNode('version', it.moduleVersion)
-                    dependencyNode.appendNode('type', it.moduleArtifacts[0].type)
-                }
+                def dependencyNode = dependenciesNode.appendNode('dependency')
+                dependencyNode.appendNode('groupId', 'org.iets3')
+                dependencyNode.appendNode('artifactId', 'opensource')
+                dependencyNode.appendNode('version', version)
+                dependencyNode.appendNode('type', 'zip')
             }
         }
     }


### PR DESCRIPTION
While it's a good idea to know which version of MPS a given version
uses, this is currently solved by the version number. Having MPS in
dependencies causes problems when downstream projects want to use Maven
to unpack all their dependencies to use as project libraries in MPS.

A version of MPS would get unpacked among other dependencies such as
mbeddr, and the dependency on MPS would have to be manually excluded to
prevent this.

On the other hand, the tests artifact was missing the dependency on
the opensource artifact, this commit adds it.

BREAKING? This could potentially be a breaking change if downstream projects expect opensource and tests to have MPS as the dependency.