### PR TITLE
[breaking] publication: cleanup artifact publications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -279,7 +279,7 @@ publishing {
     publications {
         allScripts(MavenPublication) {
             groupId 'org.iets3.opensource'
-            artifactId 'allScripts'
+            artifactId 'allscripts'
             artifact packageAllScripts
         }
         openSource(MavenPublication) {

--- a/build.gradle
+++ b/build.gradle
@@ -218,12 +218,6 @@ task buildAndRunTests(type: TestLanguages, dependsOn: buildLanguages) {
 
 check.dependsOn buildAndRunTests
 
-task packageAllScripts(type: Zip, dependsOn: buildAllScripts) {
-    archiveBaseName = 'org.iets3.opensource.allScripts'
-    from artifactsDir
-    include 'org.iets3.opensource.allScripts.build/**'
-}
-
 task packageLanguages(type: Zip, dependsOn: buildLanguages) {
     archiveBaseName = 'org.iets3.opensource'
     from artifactsDir
@@ -247,7 +241,7 @@ task packageDistroWithDependencies(type: Zip, dependsOn: buildDistroWithDependen
     include 'org.iets3.opensource.distro/**'
 }
 
-assemble.dependsOn packageAllScripts, packageLanguages, packageTests
+assemble.dependsOn packageLanguages, packageTests
 
 publishing {
     repositories {
@@ -277,11 +271,6 @@ publishing {
         }
         
     publications {
-        allScripts(MavenPublication) {
-            groupId 'org.iets3.opensource'
-            artifactId 'allscripts'
-            artifact packageAllScripts
-        }
         openSource(MavenPublication) {
             groupId 'org.iets3'
             artifactId 'opensource'


### PR DESCRIPTION
It seems like TC is not able to deploy our artifacts to github packages. 
The reason for this might be the artifactID of our `allScripts` artifact. It seems like the maven repositories on ghp do not support upper case IDs.

This PR removes the publication for the `allScript` artefact. This artefact is not really required, because all of its content is already part of the overall [org.iets3.opensource](https://projects.itemis.de/nexus/content/repositories/mbeddr/org/iets3/opensource/) artefact.
~~This PR sets the corresponding IDs to lower case.~~

~~However I am not etirely sure if this will somehow break the backwards compatibility, in case users rely on the initiall artifact ID. 
Maybe @sergej-koscejev might know?~~

FIxes #493