### PR TITLE
fix firstN/lastN semantics for N greater than list

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
@@ -5052,43 +5052,23 @@
               <node concept="2OqwBi" id="7Pk458DHiSe" role="3clFbG">
                 <node concept="1bVj0M" id="7Pk458DyYdI" role="2Oq$k0">
                   <node concept="3clFbS" id="7Pk458DyYdK" role="1bW5cS">
-                    <node concept="3clFbJ" id="7Pk458DzUTC" role="3cqZAp">
-                      <node concept="2OqwBi" id="7Pk458DzVUa" role="3clFbw">
-                        <node concept="37vLTw" id="7Pk458DzUUk" role="2Oq$k0">
+                    <node concept="3cpWs8" id="2YSwz9FBc8B" role="3cqZAp">
+                      <node concept="3cpWsn" id="2YSwz9FBc8C" role="3cpWs9">
+                        <property role="TrG5h" value="origList" />
+                        <node concept="3uibUv" id="2YSwz9FBc8D" role="1tU5fm">
+                          <ref role="3uigEE" to="j10v:~PVector" resolve="PVector" />
+                        </node>
+                        <node concept="37vLTw" id="2YSwz9FBfTp" role="33vP2m">
                           <ref role="3cqZAo" node="7Pk458DyXut" resolve="tpv" />
-                          <node concept="29HgVG" id="7Pk458DSmTL" role="lGtFl">
-                            <node concept="3NFfHV" id="7Pk458DSmTM" role="3NFExx">
-                              <node concept="3clFbS" id="7Pk458DSmTN" role="2VODD2">
-                                <node concept="3clFbF" id="7Pk458DSmTT" role="3cqZAp">
-                                  <node concept="2OqwBi" id="7Pk458DSmTO" role="3clFbG">
-                                    <node concept="3TrEf2" id="7Pk458DSmTR" role="2OqNvi">
+                          <node concept="29HgVG" id="2YSwz9FBfTq" role="lGtFl">
+                            <node concept="3NFfHV" id="2YSwz9FBfTr" role="3NFExx">
+                              <node concept="3clFbS" id="2YSwz9FBfTs" role="2VODD2">
+                                <node concept="3clFbF" id="2YSwz9FBfTt" role="3cqZAp">
+                                  <node concept="2OqwBi" id="2YSwz9FBfTu" role="3clFbG">
+                                    <node concept="3TrEf2" id="2YSwz9FBfTv" role="2OqNvi">
                                       <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
                                     </node>
-                                    <node concept="30H73N" id="7Pk458DSmTS" role="2Oq$k0" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="liA8E" id="7Pk458DzWRj" role="2OqNvi">
-                          <ref role="37wK5l" to="33ny:~Collection.isEmpty()" resolve="isEmpty" />
-                        </node>
-                      </node>
-                      <node concept="3clFbS" id="7Pk458DzUTE" role="3clFbx">
-                        <node concept="3cpWs6" id="7Pk458DzWZT" role="3cqZAp">
-                          <node concept="37vLTw" id="7Pk458DzX44" role="3cqZAk">
-                            <ref role="3cqZAo" node="7Pk458DyXut" resolve="tpv" />
-                            <node concept="29HgVG" id="7Pk458DSp_j" role="lGtFl">
-                              <node concept="3NFfHV" id="7Pk458DSp_k" role="3NFExx">
-                                <node concept="3clFbS" id="7Pk458DSp_l" role="2VODD2">
-                                  <node concept="3clFbF" id="7Pk458DSp_r" role="3cqZAp">
-                                    <node concept="2OqwBi" id="7Pk458DSp_m" role="3clFbG">
-                                      <node concept="3TrEf2" id="7Pk458DSp_p" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
-                                      </node>
-                                      <node concept="30H73N" id="7Pk458DSp_q" role="2Oq$k0" />
-                                    </node>
+                                    <node concept="30H73N" id="2YSwz9FBfTw" role="2Oq$k0" />
                                   </node>
                                 </node>
                               </node>
@@ -5097,66 +5077,83 @@
                         </node>
                       </node>
                     </node>
-                    <node concept="3cpWs6" id="7Pk458Eqr4h" role="3cqZAp">
-                      <node concept="2OqwBi" id="JK8zDWpaoq" role="3cqZAk">
-                        <node concept="37vLTw" id="JK8zDWpaor" role="2Oq$k0">
-                          <ref role="3cqZAo" node="7Pk458DyXut" resolve="tpv" />
-                          <node concept="29HgVG" id="JK8zDWpaos" role="lGtFl">
-                            <node concept="3NFfHV" id="JK8zDWpaot" role="3NFExx">
-                              <node concept="3clFbS" id="JK8zDWpaou" role="2VODD2">
-                                <node concept="3clFbF" id="JK8zDWpaov" role="3cqZAp">
-                                  <node concept="2OqwBi" id="JK8zDWpaow" role="3clFbG">
-                                    <node concept="3TrEf2" id="JK8zDWpaox" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
-                                    </node>
-                                    <node concept="30H73N" id="JK8zDWpaoy" role="2Oq$k0" />
-                                  </node>
-                                </node>
+                    <node concept="3cpWs8" id="2YSwz9FBL_a" role="3cqZAp">
+                      <node concept="3cpWsn" id="2YSwz9FBL_d" role="3cpWs9">
+                        <property role="TrG5h" value="noOfElements" />
+                        <node concept="10Oyi0" id="2YSwz9FBL_8" role="1tU5fm" />
+                        <node concept="2OqwBi" id="2YSwz9FBMkY" role="33vP2m">
+                          <node concept="2ShNRf" id="2YSwz9FBMkZ" role="2Oq$k0">
+                            <node concept="1pGfFk" id="2YSwz9FBMl0" role="2ShVmc">
+                              <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
+                              <node concept="Xl_RD" id="2YSwz9FBMl1" role="37wK5m">
+                                <property role="Xl_RC" value="5" />
                               </node>
                             </node>
-                          </node>
-                        </node>
-                        <node concept="liA8E" id="JK8zDWpaoz" role="2OqNvi">
-                          <ref role="37wK5l" to="j10v:~PVector.subList(int,int)" resolve="subList" />
-                          <node concept="3cmrfG" id="JK8zDWpao$" role="37wK5m">
-                            <property role="3cmrfH" value="0" />
-                          </node>
-                          <node concept="2OqwBi" id="JK8zDWpao_" role="37wK5m">
-                            <node concept="2ShNRf" id="JK8zDWpaoA" role="2Oq$k0">
-                              <node concept="1pGfFk" id="JK8zDWpaoB" role="2ShVmc">
-                                <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
-                                <node concept="Xl_RD" id="JK8zDWpaoC" role="37wK5m">
-                                  <property role="Xl_RC" value="5" />
-                                </node>
-                              </node>
-                              <node concept="29HgVG" id="JK8zDWpaoD" role="lGtFl">
-                                <node concept="3NFfHV" id="JK8zDWpaoE" role="3NFExx">
-                                  <node concept="3clFbS" id="JK8zDWpaoF" role="2VODD2">
-                                    <node concept="3clFbF" id="JK8zDWpaoG" role="3cqZAp">
-                                      <node concept="2OqwBi" id="JK8zDWpaoH" role="3clFbG">
-                                        <node concept="1PxgMI" id="JK8zDWpaoI" role="2Oq$k0">
-                                          <node concept="chp4Y" id="JK8zDWpaoJ" role="3oSUPX">
-                                            <ref role="cht4Q" to="700h:4Q4DxjDGLlO" resolve="FirstNOp" />
-                                          </node>
-                                          <node concept="2OqwBi" id="JK8zDWpaoK" role="1m5AlR">
-                                            <node concept="3TrEf2" id="JK8zDWpaoL" role="2OqNvi">
-                                              <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
-                                            </node>
-                                            <node concept="30H73N" id="JK8zDWpaoM" role="2Oq$k0" />
-                                          </node>
+                            <node concept="29HgVG" id="2YSwz9FBMl2" role="lGtFl">
+                              <node concept="3NFfHV" id="2YSwz9FBMl3" role="3NFExx">
+                                <node concept="3clFbS" id="2YSwz9FBMl4" role="2VODD2">
+                                  <node concept="3clFbF" id="2YSwz9FBMl5" role="3cqZAp">
+                                    <node concept="2OqwBi" id="2YSwz9FBMl6" role="3clFbG">
+                                      <node concept="1PxgMI" id="2YSwz9FBMl7" role="2Oq$k0">
+                                        <node concept="chp4Y" id="2YSwz9FBMl8" role="3oSUPX">
+                                          <ref role="cht4Q" to="700h:4Q4DxjDGLlO" resolve="FirstNOp" />
                                         </node>
-                                        <node concept="3TrEf2" id="JK8zDWpaoN" role="2OqNvi">
-                                          <ref role="3Tt5mk" to="700h:6zmBjqUjnKt" resolve="arg" />
+                                        <node concept="2OqwBi" id="2YSwz9FBMl9" role="1m5AlR">
+                                          <node concept="3TrEf2" id="2YSwz9FBMla" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                                          </node>
+                                          <node concept="30H73N" id="2YSwz9FBMlb" role="2Oq$k0" />
                                         </node>
+                                      </node>
+                                      <node concept="3TrEf2" id="2YSwz9FBMlc" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="700h:6zmBjqUjnKt" resolve="arg" />
                                       </node>
                                     </node>
                                   </node>
                                 </node>
                               </node>
                             </node>
-                            <node concept="liA8E" id="JK8zDWpaoO" role="2OqNvi">
-                              <ref role="37wK5l" to="xlxw:~BigInteger.intValue()" resolve="intValue" />
-                            </node>
+                          </node>
+                          <node concept="liA8E" id="2YSwz9FBMld" role="2OqNvi">
+                            <ref role="37wK5l" to="xlxw:~BigInteger.intValue()" resolve="intValue" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="7Pk458DzUTC" role="3cqZAp">
+                      <node concept="2dkUwp" id="2YSwz9FBPw_" role="3clFbw">
+                        <node concept="2OqwBi" id="7Pk458DzVUa" role="3uHU7B">
+                          <node concept="37vLTw" id="2YSwz9FBtOh" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2YSwz9FBc8C" resolve="origList" />
+                          </node>
+                          <node concept="liA8E" id="2YSwz9FBApw" role="2OqNvi">
+                            <ref role="37wK5l" to="33ny:~Collection.size()" resolve="size" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="2YSwz9FBPmC" role="3uHU7w">
+                          <ref role="3cqZAo" node="2YSwz9FBL_d" resolve="noOfElements" />
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="7Pk458DzUTE" role="3clFbx">
+                        <node concept="3cpWs6" id="7Pk458DzWZT" role="3cqZAp">
+                          <node concept="37vLTw" id="2YSwz9FBw$M" role="3cqZAk">
+                            <ref role="3cqZAo" node="2YSwz9FBc8C" resolve="origList" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs6" id="7Pk458Eqr4h" role="3cqZAp">
+                      <node concept="2OqwBi" id="JK8zDWpaoq" role="3cqZAk">
+                        <node concept="37vLTw" id="2YSwz9FBOb4" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2YSwz9FBc8C" resolve="origList" />
+                        </node>
+                        <node concept="liA8E" id="JK8zDWpaoz" role="2OqNvi">
+                          <ref role="37wK5l" to="j10v:~PVector.subList(int,int)" resolve="subList" />
+                          <node concept="3cmrfG" id="JK8zDWpao$" role="37wK5m">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="37vLTw" id="2YSwz9FBNBg" role="37wK5m">
+                            <ref role="3cqZAo" node="2YSwz9FBL_d" resolve="noOfElements" />
                           </node>
                         </node>
                       </node>
@@ -5219,43 +5216,23 @@
               <node concept="2OqwBi" id="7Pk458EOR9I" role="3clFbG">
                 <node concept="1bVj0M" id="7Pk458EOR9J" role="2Oq$k0">
                   <node concept="3clFbS" id="7Pk458EOR9K" role="1bW5cS">
-                    <node concept="3clFbJ" id="7Pk458EOR9L" role="3cqZAp">
-                      <node concept="2OqwBi" id="7Pk458EOR9M" role="3clFbw">
-                        <node concept="37vLTw" id="7Pk458EOR9N" role="2Oq$k0">
+                    <node concept="3cpWs8" id="2YSwz9FMPvZ" role="3cqZAp">
+                      <node concept="3cpWsn" id="2YSwz9FMPw0" role="3cpWs9">
+                        <property role="TrG5h" value="origList" />
+                        <node concept="3uibUv" id="2YSwz9FMPw1" role="1tU5fm">
+                          <ref role="3uigEE" to="j10v:~PVector" resolve="PVector" />
+                        </node>
+                        <node concept="37vLTw" id="2YSwz9FMPw2" role="33vP2m">
                           <ref role="3cqZAo" node="7Pk458EOR9D" resolve="tpv" />
-                          <node concept="29HgVG" id="7Pk458EOR9O" role="lGtFl">
-                            <node concept="3NFfHV" id="7Pk458EOR9P" role="3NFExx">
-                              <node concept="3clFbS" id="7Pk458EOR9Q" role="2VODD2">
-                                <node concept="3clFbF" id="7Pk458EOR9R" role="3cqZAp">
-                                  <node concept="2OqwBi" id="7Pk458EOR9S" role="3clFbG">
-                                    <node concept="3TrEf2" id="7Pk458EOR9T" role="2OqNvi">
+                          <node concept="29HgVG" id="2YSwz9FMPw3" role="lGtFl">
+                            <node concept="3NFfHV" id="2YSwz9FMPw4" role="3NFExx">
+                              <node concept="3clFbS" id="2YSwz9FMPw5" role="2VODD2">
+                                <node concept="3clFbF" id="2YSwz9FMPw6" role="3cqZAp">
+                                  <node concept="2OqwBi" id="2YSwz9FMPw7" role="3clFbG">
+                                    <node concept="3TrEf2" id="2YSwz9FQnMK" role="2OqNvi">
                                       <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
                                     </node>
-                                    <node concept="30H73N" id="7Pk458EOR9U" role="2Oq$k0" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="liA8E" id="7Pk458EOR9V" role="2OqNvi">
-                          <ref role="37wK5l" to="33ny:~Collection.isEmpty()" resolve="isEmpty" />
-                        </node>
-                      </node>
-                      <node concept="3clFbS" id="7Pk458EOR9W" role="3clFbx">
-                        <node concept="3cpWs6" id="7Pk458EOR9X" role="3cqZAp">
-                          <node concept="37vLTw" id="7Pk458EOR9Y" role="3cqZAk">
-                            <ref role="3cqZAo" node="7Pk458EOR9D" resolve="tpv" />
-                            <node concept="29HgVG" id="7Pk458EOR9Z" role="lGtFl">
-                              <node concept="3NFfHV" id="7Pk458EORa0" role="3NFExx">
-                                <node concept="3clFbS" id="7Pk458EORa1" role="2VODD2">
-                                  <node concept="3clFbF" id="7Pk458EORa2" role="3cqZAp">
-                                    <node concept="2OqwBi" id="7Pk458EORa3" role="3clFbG">
-                                      <node concept="3TrEf2" id="7Pk458EORa4" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
-                                      </node>
-                                      <node concept="30H73N" id="7Pk458EORa5" role="2Oq$k0" />
-                                    </node>
+                                    <node concept="30H73N" id="2YSwz9FQmIJ" role="2Oq$k0" />
                                   </node>
                                 </node>
                               </node>
@@ -5264,107 +5241,96 @@
                         </node>
                       </node>
                     </node>
-                    <node concept="3cpWs6" id="7Pk458EORa6" role="3cqZAp">
-                      <node concept="2OqwBi" id="JK8zDWpmB2" role="3cqZAk">
-                        <node concept="37vLTw" id="JK8zDWpmB3" role="2Oq$k0">
-                          <ref role="3cqZAo" node="7Pk458EOR9D" resolve="tpv" />
-                          <node concept="29HgVG" id="JK8zDWpmB4" role="lGtFl">
-                            <node concept="3NFfHV" id="JK8zDWpmB5" role="3NFExx">
-                              <node concept="3clFbS" id="JK8zDWpmB6" role="2VODD2">
-                                <node concept="3clFbF" id="JK8zDWpmB7" role="3cqZAp">
-                                  <node concept="2OqwBi" id="JK8zDWpmB8" role="3clFbG">
-                                    <node concept="3TrEf2" id="JK8zDWpmB9" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                    <node concept="3cpWs8" id="2YSwz9FMPwa" role="3cqZAp">
+                      <node concept="3cpWsn" id="2YSwz9FMPwb" role="3cpWs9">
+                        <property role="TrG5h" value="noOfElements" />
+                        <node concept="10Oyi0" id="2YSwz9FMPwc" role="1tU5fm" />
+                        <node concept="2OqwBi" id="2YSwz9FMPwd" role="33vP2m">
+                          <node concept="2ShNRf" id="2YSwz9FMPwe" role="2Oq$k0">
+                            <node concept="1pGfFk" id="2YSwz9FMPwf" role="2ShVmc">
+                              <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
+                              <node concept="Xl_RD" id="2YSwz9FMPwg" role="37wK5m">
+                                <property role="Xl_RC" value="5" />
+                              </node>
+                            </node>
+                            <node concept="29HgVG" id="2YSwz9FMPwh" role="lGtFl">
+                              <node concept="3NFfHV" id="2YSwz9FMPwi" role="3NFExx">
+                                <node concept="3clFbS" id="2YSwz9FMPwj" role="2VODD2">
+                                  <node concept="3clFbF" id="2YSwz9FMPwk" role="3cqZAp">
+                                    <node concept="2OqwBi" id="2YSwz9FMPwl" role="3clFbG">
+                                      <node concept="1PxgMI" id="2YSwz9FMPwm" role="2Oq$k0">
+                                        <node concept="chp4Y" id="2YSwz9FQpae" role="3oSUPX">
+                                          <ref role="cht4Q" to="700h:4Q4DxjDLg_t" resolve="LastNOp" />
+                                        </node>
+                                        <node concept="2OqwBi" id="2YSwz9FMPwo" role="1m5AlR">
+                                          <node concept="3TrEf2" id="2YSwz9FMPwp" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                                          </node>
+                                          <node concept="30H73N" id="2YSwz9FMPwq" role="2Oq$k0" />
+                                        </node>
+                                      </node>
+                                      <node concept="3TrEf2" id="2YSwz9FMPwr" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="700h:6zmBjqUjnKt" resolve="arg" />
+                                      </node>
                                     </node>
-                                    <node concept="30H73N" id="JK8zDWpmBa" role="2Oq$k0" />
                                   </node>
                                 </node>
                               </node>
                             </node>
                           </node>
+                          <node concept="liA8E" id="2YSwz9FMPws" role="2OqNvi">
+                            <ref role="37wK5l" to="xlxw:~BigInteger.intValue()" resolve="intValue" />
+                          </node>
                         </node>
-                        <node concept="liA8E" id="JK8zDWpmBb" role="2OqNvi">
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="2YSwz9FMPwt" role="3cqZAp">
+                      <node concept="2dkUwp" id="2YSwz9FMPwu" role="3clFbw">
+                        <node concept="2OqwBi" id="2YSwz9FMPwv" role="3uHU7B">
+                          <node concept="37vLTw" id="2YSwz9FMPww" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2YSwz9FMPw0" resolve="origList" />
+                          </node>
+                          <node concept="liA8E" id="2YSwz9FMPwx" role="2OqNvi">
+                            <ref role="37wK5l" to="33ny:~Collection.size()" resolve="size" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="2YSwz9FMPwy" role="3uHU7w">
+                          <ref role="3cqZAo" node="2YSwz9FMPwb" resolve="noOfElements" />
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="2YSwz9FMPwz" role="3clFbx">
+                        <node concept="3cpWs6" id="2YSwz9FMPw$" role="3cqZAp">
+                          <node concept="37vLTw" id="2YSwz9FMPw_" role="3cqZAk">
+                            <ref role="3cqZAo" node="2YSwz9FMPw0" resolve="origList" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs6" id="2YSwz9FMPwA" role="3cqZAp">
+                      <node concept="2OqwBi" id="2YSwz9FMPwB" role="3cqZAk">
+                        <node concept="37vLTw" id="2YSwz9FMPwC" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2YSwz9FMPw0" resolve="origList" />
+                        </node>
+                        <node concept="liA8E" id="2YSwz9FMPwD" role="2OqNvi">
                           <ref role="37wK5l" to="j10v:~PVector.subList(int,int)" resolve="subList" />
-                          <node concept="3cpWsd" id="JK8zDWpmBc" role="37wK5m">
-                            <node concept="2OqwBi" id="JK8zDWpmBd" role="3uHU7w">
-                              <node concept="2ShNRf" id="JK8zDWpmBe" role="2Oq$k0">
-                                <node concept="1pGfFk" id="JK8zDWpmBf" role="2ShVmc">
-                                  <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
-                                  <node concept="Xl_RD" id="JK8zDWpmBg" role="37wK5m">
-                                    <property role="Xl_RC" value="5" />
-                                  </node>
-                                </node>
-                                <node concept="29HgVG" id="JK8zDWpmBh" role="lGtFl">
-                                  <node concept="3NFfHV" id="JK8zDWpmBi" role="3NFExx">
-                                    <node concept="3clFbS" id="JK8zDWpmBj" role="2VODD2">
-                                      <node concept="3clFbF" id="JK8zDWpmBk" role="3cqZAp">
-                                        <node concept="2OqwBi" id="JK8zDWpmBl" role="3clFbG">
-                                          <node concept="1PxgMI" id="JK8zDWpmBm" role="2Oq$k0">
-                                            <node concept="chp4Y" id="JK8zDWpmBn" role="3oSUPX">
-                                              <ref role="cht4Q" to="700h:4Q4DxjDLg_t" resolve="LastNOp" />
-                                            </node>
-                                            <node concept="2OqwBi" id="JK8zDWpmBo" role="1m5AlR">
-                                              <node concept="3TrEf2" id="JK8zDWpmBp" role="2OqNvi">
-                                                <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
-                                              </node>
-                                              <node concept="30H73N" id="JK8zDWpmBq" role="2Oq$k0" />
-                                            </node>
-                                          </node>
-                                          <node concept="3TrEf2" id="JK8zDWpmBr" role="2OqNvi">
-                                            <ref role="3Tt5mk" to="700h:6zmBjqUjnKt" resolve="arg" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="liA8E" id="JK8zDWpmBs" role="2OqNvi">
-                                <ref role="37wK5l" to="xlxw:~BigInteger.intValue()" resolve="intValue" />
-                              </node>
+                          <node concept="3cpWsd" id="2YSwz9FN6pQ" role="37wK5m">
+                            <node concept="37vLTw" id="2YSwz9FNbPP" role="3uHU7w">
+                              <ref role="3cqZAo" node="2YSwz9FMPwb" resolve="noOfElements" />
                             </node>
-                            <node concept="2OqwBi" id="JK8zDWpmBt" role="3uHU7B">
-                              <node concept="37vLTw" id="JK8zDWpmBu" role="2Oq$k0">
-                                <ref role="3cqZAo" node="7Pk458EOR9D" resolve="tpv" />
-                                <node concept="29HgVG" id="JK8zDWpmBv" role="lGtFl">
-                                  <node concept="3NFfHV" id="JK8zDWpmBw" role="3NFExx">
-                                    <node concept="3clFbS" id="JK8zDWpmBx" role="2VODD2">
-                                      <node concept="3clFbF" id="JK8zDWpmBy" role="3cqZAp">
-                                        <node concept="2OqwBi" id="JK8zDWpmBz" role="3clFbG">
-                                          <node concept="3TrEf2" id="JK8zDWpmB$" role="2OqNvi">
-                                            <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
-                                          </node>
-                                          <node concept="30H73N" id="JK8zDWpmB_" role="2Oq$k0" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
+                            <node concept="2OqwBi" id="2YSwz9FMYJk" role="3uHU7B">
+                              <node concept="37vLTw" id="2YSwz9FMXwo" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2YSwz9FMPw0" resolve="origList" />
                               </node>
-                              <node concept="liA8E" id="JK8zDWpmBA" role="2OqNvi">
+                              <node concept="liA8E" id="2YSwz9FN0i9" role="2OqNvi">
                                 <ref role="37wK5l" to="33ny:~Collection.size()" resolve="size" />
                               </node>
                             </node>
                           </node>
-                          <node concept="2OqwBi" id="JK8zDWpmBB" role="37wK5m">
-                            <node concept="37vLTw" id="JK8zDWpmBC" role="2Oq$k0">
-                              <ref role="3cqZAo" node="7Pk458EOR9D" resolve="tpv" />
-                              <node concept="29HgVG" id="JK8zDWpmBD" role="lGtFl">
-                                <node concept="3NFfHV" id="JK8zDWpmBE" role="3NFExx">
-                                  <node concept="3clFbS" id="JK8zDWpmBF" role="2VODD2">
-                                    <node concept="3clFbF" id="JK8zDWpmBG" role="3cqZAp">
-                                      <node concept="2OqwBi" id="JK8zDWpmBH" role="3clFbG">
-                                        <node concept="3TrEf2" id="JK8zDWpmBI" role="2OqNvi">
-                                          <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
-                                        </node>
-                                        <node concept="30H73N" id="JK8zDWpmBJ" role="2Oq$k0" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
+                          <node concept="2OqwBi" id="2YSwz9FNd$d" role="37wK5m">
+                            <node concept="37vLTw" id="2YSwz9FNcnc" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2YSwz9FMPw0" resolve="origList" />
                             </node>
-                            <node concept="liA8E" id="JK8zDWpmBK" role="2OqNvi">
+                            <node concept="liA8E" id="2YSwz9FNfhC" role="2OqNvi">
                               <ref role="37wK5l" to="33ny:~Collection.size()" resolve="size" />
                             </node>
                           </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.collections@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.collections@tests.mps
@@ -2141,6 +2141,24 @@
           </node>
         </node>
       </node>
+      <node concept="_fkuZ" id="2YSwz9Fuk$g" role="_fkp5">
+        <node concept="_fku$" id="2YSwz9Fuk$h" role="_fkur" />
+        <node concept="1QScDb" id="2YSwz9Fuobj" role="_fkuY">
+          <node concept="2$dVdw" id="2YSwz9FupIl" role="1QScD9">
+            <node concept="30bXRB" id="2YSwz9FuqQZ" role="3iAY4F">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="1XGHHM" id="2YSwz9FuoaU" role="30czhm">
+            <ref role="1XGHHe" node="38v7GtLMP97" resolve="intList1" />
+          </node>
+        </node>
+        <node concept="3iBYfx" id="2YSwz9Fus24" role="_fkuS">
+          <node concept="30bXRB" id="2YSwz9Fus2c" role="3iBYfI">
+            <property role="30bXRw" value="1" />
+          </node>
+        </node>
+      </node>
       <node concept="3dYjL0" id="38v7GtPCOS$" role="_fkp5" />
       <node concept="_fkuZ" id="38v7GtPAIwq" role="_fkp5">
         <node concept="_fku$" id="38v7GtPAIwr" role="_fkur" />
@@ -2321,6 +2339,24 @@
           </node>
           <node concept="30bXRB" id="38v7GtPtwwf" role="3iBYfI">
             <property role="30bXRw" value="2" />
+          </node>
+        </node>
+      </node>
+      <node concept="_fkuZ" id="2YSwz9FLdpO" role="_fkp5">
+        <node concept="_fku$" id="2YSwz9FLdpP" role="_fkur" />
+        <node concept="1QScDb" id="2YSwz9FLdpQ" role="_fkuY">
+          <node concept="1XGHHM" id="2YSwz9FLdpT" role="30czhm">
+            <ref role="1XGHHe" node="38v7GtLMP97" resolve="intList1" />
+          </node>
+          <node concept="2$gqX9" id="2YSwz9FLiFk" role="1QScD9">
+            <node concept="30bXRB" id="2YSwz9FLjR1" role="3iAY4F">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+        </node>
+        <node concept="3iBYfx" id="2YSwz9FLdpU" role="_fkuS">
+          <node concept="30bXRB" id="2YSwz9FLdpV" role="3iBYfI">
+            <property role="30bXRw" value="1" />
           </node>
         </node>
       </node>


### PR DESCRIPTION
Resolves #402 

As mentioned in #394, the code generated for `list.firstN/lastN(n)` caused an IndexOutOfBoundsException when `n` was greater than the size of `list`.
With this change, the original list is returned instead in such cases, aligning the semantics of firstN/lastN in the generator with the semantics from the interpreter.

Also, this makes sure `list` is evaluated only once in the generated code for each firstN/lastN instead of up to 4 times, which might matter when `list` is a complex expression.
