### PR TITLE
Fix two inconsistencies with Nix-handling in interpreter

### DIFF
--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.interpreter/models/plugin.mps
@@ -2442,19 +2442,52 @@
                 </node>
               </node>
             </node>
-            <node concept="3clFbJ" id="4EEJFuvbYy0" role="3cqZAp">
-              <node concept="3clFbS" id="4EEJFuvbYy1" role="3clFbx">
-                <node concept="3cpWs6" id="4EEJFuvbYy2" role="3cqZAp">
-                  <node concept="37vLTw" id="4EEJFuvbYy3" role="3cqZAk">
-                    <ref role="3cqZAo" node="4EEJFuvbYxy" resolve="leftNixEvaluated" />
+            <node concept="3cpWs8" id="skNXYt0e7f" role="3cqZAp">
+              <node concept="3cpWsn" id="skNXYt0e7g" role="3cpWs9">
+                <property role="TrG5h" value="right" />
+                <node concept="3uibUv" id="skNXYt0e7h" role="1tU5fm">
+                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                </node>
+                <node concept="qpA2v" id="skNXYt0e7i" role="33vP2m">
+                  <node concept="2OqwBi" id="skNXYt0e7j" role="3SLO0q">
+                    <node concept="oxGPV" id="skNXYt0e7k" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="skNXYt0e7l" role="2OqNvi">
+                      <ref role="3Tt5mk" to="hm2y:4rZeNQ6MpKo" resolve="right" />
+                    </node>
                   </node>
                 </node>
               </node>
-              <node concept="2ZW3vV" id="4EEJFuvbYy4" role="3clFbw">
-                <node concept="3uibUv" id="4EEJFuvbYy5" role="2ZW6by">
+            </node>
+            <node concept="3clFbJ" id="skNXYt0e7m" role="3cqZAp">
+              <node concept="3clFbS" id="skNXYt0e7n" role="3clFbx">
+                <node concept="3cpWs6" id="skNXYt0e7o" role="3cqZAp">
+                  <node concept="2OqwBi" id="skNXYt0e7p" role="3cqZAk">
+                    <node concept="2ShNRf" id="skNXYt0e7q" role="2Oq$k0">
+                      <node concept="1pGfFk" id="skNXYt0e7r" role="2ShVmc">
+                        <ref role="37wK5l" to="xfg9:3nVyItrYQU_" resolve="NixSupport" />
+                        <node concept="3clFbT" id="skNXYt0e7s" role="37wK5m">
+                          <property role="3clFbU" value="true" />
+                        </node>
+                        <node concept="37vLTw" id="skNXYt0e7t" role="37wK5m">
+                          <ref role="3cqZAo" node="skNXYt0e7g" resolve="right" />
+                        </node>
+                        <node concept="oxGPV" id="skNXYt0e7u" role="37wK5m" />
+                        <node concept="37vLTw" id="skNXYt0f5w" role="37wK5m">
+                          <ref role="3cqZAo" node="2pRaEpcR5l_" resolve="andCalculator" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="skNXYt0e7w" role="2OqNvi">
+                      <ref role="37wK5l" to="xfg9:26cjRABQZG3" resolve="run" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2ZW3vV" id="skNXYt0e7x" role="3clFbw">
+                <node concept="3uibUv" id="skNXYt0e7y" role="2ZW6by">
                   <ref role="3uigEE" to="ppzb:3nVyItrYNyp" resolve="INixValue" />
                 </node>
-                <node concept="37vLTw" id="4EEJFuvbYy6" role="2ZW6bz">
+                <node concept="37vLTw" id="skNXYt0e7z" role="2ZW6bz">
                   <ref role="3cqZAo" node="4EEJFuvbYxy" resolve="leftNixEvaluated" />
                 </node>
               </node>
@@ -2468,13 +2501,8 @@
                     <node concept="37vLTw" id="4EEJFuvbZRP" role="37wK5m">
                       <ref role="3cqZAo" node="4EEJFuvbYxr" resolve="left" />
                     </node>
-                    <node concept="qpA2v" id="26cjRACQHvv" role="37wK5m">
-                      <node concept="2OqwBi" id="26cjRACQHvw" role="3SLO0q">
-                        <node concept="oxGPV" id="26cjRACQHvx" role="2Oq$k0" />
-                        <node concept="3TrEf2" id="26cjRACQHvy" role="2OqNvi">
-                          <ref role="3Tt5mk" to="hm2y:4rZeNQ6MpKo" resolve="right" />
-                        </node>
-                      </node>
+                    <node concept="37vLTw" id="skNXYt0fho" role="37wK5m">
+                      <ref role="3cqZAo" node="skNXYt0e7g" resolve="right" />
                     </node>
                     <node concept="oxGPV" id="26cjRACQHvz" role="37wK5m" />
                     <node concept="37vLTw" id="2pRaEpcR714" role="37wK5m">
@@ -3184,8 +3212,16 @@
                                   <node concept="3uibUv" id="26cjRACIbgA" role="1tU5fm">
                                     <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
                                   </node>
-                                  <node concept="rqRoa" id="26cjRACIbgB" role="33vP2m">
-                                    <ref role="rqRob" to="hm2y:4rZeNQ6MpKo" resolve="right" />
+                                  <node concept="2OqwBi" id="skNXYt0dcP" role="33vP2m">
+                                    <node concept="37vLTw" id="skNXYt0cXQ" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="26cjRACI9si" resolve="s" />
+                                    </node>
+                                    <node concept="liA8E" id="skNXYt0dSJ" role="2OqNvi">
+                                      <ref role="37wK5l" to="xfg9:3nVyIts6HwG" resolve="get" />
+                                      <node concept="3cmrfG" id="skNXYt0e0D" role="37wK5m">
+                                        <property role="3cmrfH" value="1" />
+                                      </node>
+                                    </node>
                                   </node>
                                 </node>
                               </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/operatorgroup@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/operatorgroup@tests.mps
@@ -182,7 +182,7 @@
             <ref role="_emDf" node="1Z72MIc6zOc" resolve="nix" />
           </node>
         </node>
-        <node concept="1I1voI" id="4EEJFuvb1T8" role="_fkuS" />
+        <node concept="2vmpn$" id="skNXYt2YZ2" role="_fkuS" />
       </node>
       <node concept="_fkuZ" id="1Z72MIc6xWE" role="_fkp5">
         <node concept="_fku$" id="1Z72MIc6xWF" role="_fkur" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.nix@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.nix@tests.mps
@@ -31,6 +31,8 @@
         <child id="5115872837156802411" name="expr" index="30czhm" />
       </concept>
       <concept id="5115872837156855227" name="org.iets3.core.expr.base.structure.UnaryMinusExpression" flags="ng" index="30cIq6" />
+      <concept id="5115872837156761033" name="org.iets3.core.expr.base.structure.EqualsExpression" flags="ng" index="30cPrO" />
+      <concept id="5115872837156761034" name="org.iets3.core.expr.base.structure.NotEqualsExpression" flags="ng" index="30cPrR" />
       <concept id="5115872837156578546" name="org.iets3.core.expr.base.structure.PlusExpression" flags="ng" index="30dDZf" />
       <concept id="5115872837156576277" name="org.iets3.core.expr.base.structure.BinaryExpression" flags="ng" index="30dEsC">
         <child id="5115872837156576280" name="right" index="30dEs_" />
@@ -98,7 +100,7 @@
     <property role="1XBH2A" value="true" />
     <node concept="2zPypq" id="3nVyIts6jOS" role="_iOnB">
       <property role="TrG5h" value="a1" />
-      <property role="0Rz4W" value="1551182782" />
+      <property role="0Rz4W" value="611402695" />
       <node concept="1I1voI" id="3nVyIts6jPi" role="2zPyp_" />
       <node concept="30bXR$" id="3nVyIts6jP4" role="2zM23F" />
     </node>
@@ -183,8 +185,8 @@
     </node>
     <node concept="_ixoA" id="26cjRABTkuN" role="_iOnB" />
     <node concept="2zPypq" id="26cjRABTkwo" role="_iOnB">
-      <property role="TrG5h" value="cond" />
-      <property role="0Rz4W" value="1563357530" />
+      <property role="TrG5h" value="nix" />
+      <property role="0Rz4W" value="614927467" />
       <node concept="1I1voI" id="26cjRABTkxt" role="2zPyp_">
         <node concept="2vmvy5" id="26cjRABTkxF" role="1I1voH" />
       </node>
@@ -201,7 +203,7 @@
             </node>
           </node>
           <node concept="_emDc" id="26cjRABTkAR" role="39w5ZE">
-            <ref role="_emDf" node="26cjRABTkwo" resolve="cond" />
+            <ref role="_emDf" node="26cjRABTkwo" resolve="nix" />
           </node>
           <node concept="30bXRB" id="26cjRABTkB6" role="39w5ZG">
             <property role="30bXRw" value="10" />
@@ -212,6 +214,119 @@
         </node>
       </node>
     </node>
+    <node concept="_ixoA" id="skNXYt4tKK" role="_iOnB" />
+    <node concept="_fkuM" id="skNXYt4tMD" role="_iOnB">
+      <property role="TrG5h" value="EqualityBoolean" />
+      <node concept="_fkuZ" id="4EEJFuvb1T3" role="_fkp5">
+        <node concept="_fku$" id="4EEJFuvb1T4" role="_fkur" />
+        <node concept="30cPrO" id="skNXYt4tPI" role="_fkuY">
+          <node concept="2vmpn$" id="4EEJFuvb1UW" role="30dEs_" />
+          <node concept="_emDc" id="skNXYt4uEg" role="30dEsF">
+            <ref role="_emDf" node="26cjRABTkwo" resolve="nix" />
+          </node>
+        </node>
+        <node concept="1I1voI" id="skNXYt4u6s" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="1Z72MIc6xWE" role="_fkp5">
+        <node concept="_fku$" id="1Z72MIc6xWF" role="_fkur" />
+        <node concept="1I1voI" id="skNXYt4u6H" role="_fkuS" />
+        <node concept="30cPrO" id="skNXYt4tQ$" role="_fkuY">
+          <node concept="2vmpn$" id="1Z72MIctSOG" role="30dEsF" />
+          <node concept="_emDc" id="skNXYt4uEw" role="30dEs_">
+            <ref role="_emDf" node="26cjRABTkwo" resolve="nix" />
+          </node>
+        </node>
+      </node>
+      <node concept="_fkuZ" id="skNXYt4u3g" role="_fkp5">
+        <node concept="_fku$" id="skNXYt4u3h" role="_fkur" />
+        <node concept="30cPrO" id="skNXYt4u3i" role="_fkuY">
+          <node concept="2vmpnb" id="skNXYt4u4g" role="30dEs_" />
+          <node concept="_emDc" id="skNXYt4uEs" role="30dEsF">
+            <ref role="_emDf" node="26cjRABTkwo" resolve="nix" />
+          </node>
+        </node>
+        <node concept="1I1voI" id="skNXYt4u3l" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="4EEJFuvaWda" role="_fkp5">
+        <node concept="_fku$" id="skNXYt4tTh" role="_fkur" />
+        <node concept="30cPrO" id="skNXYt4tSp" role="_fkuY">
+          <node concept="2vmpnb" id="4EEJFuvb91X" role="30dEsF" />
+          <node concept="_emDc" id="skNXYt4uE$" role="30dEs_">
+            <ref role="_emDf" node="26cjRABTkwo" resolve="nix" />
+          </node>
+        </node>
+        <node concept="1I1voI" id="4EEJFuvb1SV" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="skNXYt4u55" role="_fkp5">
+        <node concept="_fku$" id="skNXYt4u56" role="_fkur" />
+        <node concept="30cPrO" id="skNXYt4u57" role="_fkuY">
+          <node concept="_emDc" id="skNXYt4uEk" role="30dEsF">
+            <ref role="_emDf" node="26cjRABTkwo" resolve="nix" />
+          </node>
+          <node concept="_emDc" id="skNXYt4uEo" role="30dEs_">
+            <ref role="_emDf" node="26cjRABTkwo" resolve="nix" />
+          </node>
+        </node>
+        <node concept="1I1voI" id="skNXYt4u5a" role="_fkuS" />
+      </node>
+    </node>
+    <node concept="_ixoA" id="skNXYt4uiJ" role="_iOnB" />
+    <node concept="_fkuM" id="skNXYt4ulK" role="_iOnB">
+      <property role="TrG5h" value="InequalityBoolean" />
+      <node concept="_fkuZ" id="skNXYt4ulL" role="_fkp5">
+        <node concept="_fku$" id="skNXYt4ulM" role="_fkur" />
+        <node concept="30cPrR" id="skNXYt4upo" role="_fkuY">
+          <node concept="_emDc" id="skNXYt4uE8" role="30dEsF">
+            <ref role="_emDf" node="26cjRABTkwo" resolve="nix" />
+          </node>
+          <node concept="2vmpn$" id="skNXYt4ulO" role="30dEs_" />
+        </node>
+        <node concept="1I1voI" id="skNXYt4ulQ" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="skNXYt4ulR" role="_fkp5">
+        <node concept="_fku$" id="skNXYt4ulS" role="_fkur" />
+        <node concept="1I1voI" id="skNXYt4ulT" role="_fkuS" />
+        <node concept="30cPrR" id="skNXYt4urv" role="_fkuY">
+          <node concept="2vmpn$" id="skNXYt4ulV" role="30dEsF" />
+          <node concept="_emDc" id="skNXYt4uEC" role="30dEs_">
+            <ref role="_emDf" node="26cjRABTkwo" resolve="nix" />
+          </node>
+        </node>
+      </node>
+      <node concept="_fkuZ" id="skNXYt4ulX" role="_fkp5">
+        <node concept="_fku$" id="skNXYt4ulY" role="_fkur" />
+        <node concept="30cPrR" id="skNXYt4utA" role="_fkuY">
+          <node concept="_emDc" id="skNXYt4uE0" role="30dEsF">
+            <ref role="_emDf" node="26cjRABTkwo" resolve="nix" />
+          </node>
+          <node concept="2vmpnb" id="skNXYt4um0" role="30dEs_" />
+        </node>
+        <node concept="1I1voI" id="skNXYt4um2" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="skNXYt4um3" role="_fkp5">
+        <node concept="_fku$" id="skNXYt4um4" role="_fkur" />
+        <node concept="30cPrR" id="skNXYt4uvH" role="_fkuY">
+          <node concept="2vmpnb" id="skNXYt4um6" role="30dEsF" />
+          <node concept="_emDc" id="skNXYt4uEG" role="30dEs_">
+            <ref role="_emDf" node="26cjRABTkwo" resolve="nix" />
+          </node>
+        </node>
+        <node concept="1I1voI" id="skNXYt4um8" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="skNXYt4um9" role="_fkp5">
+        <node concept="_fku$" id="skNXYt4uma" role="_fkur" />
+        <node concept="30cPrR" id="skNXYt4uxO" role="_fkuY">
+          <node concept="_emDc" id="skNXYt4uEc" role="30dEsF">
+            <ref role="_emDf" node="26cjRABTkwo" resolve="nix" />
+          </node>
+          <node concept="_emDc" id="skNXYt4uE4" role="30dEs_">
+            <ref role="_emDf" node="26cjRABTkwo" resolve="nix" />
+          </node>
+        </node>
+        <node concept="1I1voI" id="skNXYt4ume" role="_fkuS" />
+      </node>
+    </node>
+    <node concept="_ixoA" id="skNXYt4ukf" role="_iOnB" />
   </node>
 </model>
 


### PR DESCRIPTION
This PR fixes two inconsistencies in the interpreter for the following binary operators:

- logical and (`&&`): the special logic for short-circuit-handling was non-symmetric and different from the interpreter for `||`, adapted it
- equality (`==`): the implemented logic was different from the one for non-equality, adapted it

Regarding the short-circuit-logic for `&&` and `||`: I am not sure if this is generic enough, I had some problems implementing ternary logic using this. But as I don't know how other NixHandlers (from customer projects) are using this, I couldn't come up with a better proposal. This is maybe something for a different PR.