### PR TITLE
Improve type of box expression

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.mutable/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.mutable/models/typesystem.mps
@@ -124,6 +124,9 @@
       </concept>
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1207055528241" name="jetbrains.mps.lang.typesystem.structure.WarningStatement" flags="nn" index="a7r0C">
+        <child id="1207055552304" name="warningText" index="a7wSD" />
+      </concept>
       <concept id="1766949807893567867" name="jetbrains.mps.lang.typesystem.structure.OverridesConceptFunction" flags="ig" index="bXqS6" />
       <concept id="1185788614172" name="jetbrains.mps.lang.typesystem.structure.NormalTypeClause" flags="ng" index="mw_s8">
         <child id="1185788644032" name="normalType" index="mwGJk" />
@@ -154,6 +157,10 @@
       <concept id="1195214364922" name="jetbrains.mps.lang.typesystem.structure.NonTypesystemRule" flags="ig" index="18kY7G" />
       <concept id="3937244445246642777" name="jetbrains.mps.lang.typesystem.structure.AbstractReportStatement" flags="ng" index="1urrMJ">
         <child id="3937244445246642781" name="nodeToReport" index="1urrMF" />
+      </concept>
+      <concept id="1176543928247" name="jetbrains.mps.lang.typesystem.structure.IsSubtypeExpression" flags="nn" index="3JuTUA">
+        <child id="1176543945045" name="subtypeExpression" index="3JuY14" />
+        <child id="1176543950311" name="supertypeExpression" index="3JuZjQ" />
       </concept>
       <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
       <concept id="1174642788531" name="jetbrains.mps.lang.typesystem.structure.ConceptReference" flags="ig" index="1YaCAy">
@@ -401,6 +408,53 @@
                       </node>
                       <node concept="3TrEf2" id="3GdqffBR63g" role="2OqNvi">
                         <ref role="3Tt5mk" to="8lgj:3GdqffBQYFA" resolve="value" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="69ODpXSSzdg" role="3cqZAp">
+                <node concept="3clFbS" id="69ODpXSSzdi" role="3clFbx">
+                  <node concept="a7r0C" id="69ODpXSSoqa" role="3cqZAp">
+                    <node concept="Xl_RD" id="69ODpXSSoqT" role="a7wSD">
+                      <property role="Xl_RC" value="The expression is using an invalid subtype. Add an explicit type to the box declaration to fix it." />
+                    </node>
+                    <node concept="2OqwBi" id="69ODpXSSHu_" role="1urrMF">
+                      <node concept="1YBJjd" id="69ODpXSSoqx" role="2Oq$k0">
+                        <ref role="1YBMHb" node="3GdqffBQYQb" resolve="ut" />
+                      </node>
+                      <node concept="3TrEf2" id="69ODpXSSI36" role="2OqNvi">
+                        <ref role="3Tt5mk" to="8lgj:3GdqffBQYFA" resolve="value" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbH" id="69ODpXSSzdh" role="3cqZAp" />
+                </node>
+                <node concept="3fqX7Q" id="69ODpXSSDkQ" role="3clFbw">
+                  <node concept="3JuTUA" id="69ODpXSSDkS" role="3fr31v">
+                    <node concept="1Z2H0r" id="69ODpXSSDkT" role="3JuY14">
+                      <node concept="2OqwBi" id="69ODpXSSDkU" role="1Z2MuG">
+                        <node concept="1YBJjd" id="69ODpXSSDkV" role="2Oq$k0">
+                          <ref role="1YBMHb" node="3GdqffBQYQb" resolve="ut" />
+                        </node>
+                        <node concept="3TrEf2" id="69ODpXSSDkW" role="2OqNvi">
+                          <ref role="3Tt5mk" to="8lgj:3GdqffBQYFA" resolve="value" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1Z2H0r" id="69ODpXSSDkX" role="3JuZjQ">
+                      <node concept="2OqwBi" id="69ODpXSSDkY" role="1Z2MuG">
+                        <node concept="1PxgMI" id="69ODpXSSDkZ" role="2Oq$k0">
+                          <node concept="chp4Y" id="69ODpXSSDl0" role="3oSUPX">
+                            <ref role="cht4Q" to="8lgj:3GdqffBKoAm" resolve="BoxType" />
+                          </node>
+                          <node concept="2X3wrD" id="69ODpXSSDl1" role="1m5AlR">
+                            <ref role="2X3Bk0" node="3GdqffBR78c" resolve="contextType" />
+                          </node>
+                        </node>
+                        <node concept="3TrEf2" id="69ODpXSSDl2" role="2OqNvi">
+                          <ref role="3Tt5mk" to="8lgj:3GdqffBKoAn" resolve="baseType" />
+                        </node>
                       </node>
                     </node>
                   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.mutable/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.mutable/models/typesystem.mps
@@ -375,7 +375,7 @@
     </node>
   </node>
   <node concept="1YbPZF" id="3GdqffBQYQ8">
-    <property role="TrG5h" value="typeof_UdpateTarget" />
+    <property role="TrG5h" value="typeof_UptateTarget" />
     <property role="3GE5qa" value="box" />
     <node concept="3clFbS" id="3GdqffBQYQ9" role="18ibNy">
       <node concept="nvevp" id="3GdqffBR77P" role="3cqZAp">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -12992,6 +12992,11 @@
           <ref role="3bR37D" node="2utoDiy1iVD" resolve="org.iets3.core.expr.typetags.bindingtime" />
         </node>
       </node>
+      <node concept="1SiIV0" id="3i3CWWtzXDq" role="3bR37C">
+        <node concept="3bR9La" id="3i3CWWtzXDr" role="1SiIV1">
+          <ref role="3bR37D" node="3ni3WidJ1j3" resolve="org.iets3.core.expr.mutable" />
+        </node>
+      </node>
     </node>
     <node concept="1E1JtA" id="OJuIQp$d7j" role="3989C9">
       <property role="BnDLt" value="true" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -32,6 +32,7 @@
     <import index="yjde" ref="r:8023e40c-26d4-4543-bd46-2ec2c03f861f(org.iets3.core.expr.toplevel.typesystem)" />
     <import index="b1h1" ref="r:ac5f749f-6179-4d4f-ad24-ad9edbd8077b(org.iets3.core.expr.simpleTypes.behavior)" />
     <import index="mi3w" ref="r:9ec53fca-e669-4a18-ba8b-6c9f4f1cb361(org.iets3.core.expr.datetime.structure)" />
+    <import index="bg10" ref="r:a71eb8ca-1a88-4b3c-85ef-63f23e5a12e0(org.iets3.core.expr.mutable.typesystem)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
     <import index="xlxw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.math(JDK/)" implicit="true" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
@@ -41,7 +42,9 @@
       <concept id="1215507671101" name="jetbrains.mps.lang.test.structure.NodeErrorCheckOperation" flags="ng" index="1TM$A">
         <child id="8489045168660938517" name="errorRef" index="3lydEf" />
       </concept>
-      <concept id="1215511704609" name="jetbrains.mps.lang.test.structure.NodeWarningCheckOperation" flags="ng" index="29bkU" />
+      <concept id="1215511704609" name="jetbrains.mps.lang.test.structure.NodeWarningCheckOperation" flags="ng" index="29bkU">
+        <child id="8489045168660938635" name="warningRef" index="3lydCh" />
+      </concept>
       <concept id="1215526290564" name="jetbrains.mps.lang.test.structure.NodeTypeCheckOperation" flags="ng" index="30Omv">
         <child id="1215526393912" name="type" index="31d$z" />
       </concept>
@@ -61,7 +64,11 @@
       <concept id="7691029917083872157" name="jetbrains.mps.lang.test.structure.IRuleReference" flags="ng" index="2u4UPC">
         <reference id="8333855927540250453" name="declaration" index="39XzEq" />
       </concept>
-      <concept id="428590876651279930" name="jetbrains.mps.lang.test.structure.NodeTypeSystemErrorCheckOperation" flags="ng" index="2DdRWr" />
+      <concept id="428590876651279930" name="jetbrains.mps.lang.test.structure.NodeTypeSystemErrorCheckOperation" flags="ng" index="2DdRWr">
+        <child id="4649457259824818099" name="equationRef" index="MJxsd" />
+      </concept>
+      <concept id="4649457259824807647" name="jetbrains.mps.lang.test.structure.TypesystemEquationReference" flags="ng" index="MGsTx" />
+      <concept id="4531408400486526326" name="jetbrains.mps.lang.test.structure.WarningStatementReference" flags="ng" index="2PQEqo" />
       <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
       <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
@@ -8260,6 +8267,44 @@
     <node concept="1qefOq" id="3ni3Wiec5Qt" role="1SKRRt">
       <node concept="_iOnV" id="3ni3Wiec5Qu" role="1qenE9">
         <property role="TrG5h" value="effects2" />
+        <node concept="2zPypq" id="3i3CWWtziew" role="_iOnC">
+          <property role="TrG5h" value="globalcounter" />
+          <node concept="3sRH3H" id="3i3CWWtziiO" role="2zPyp_">
+            <node concept="30bXRB" id="3i3CWWtzij3" role="3sRH3h">
+              <property role="30bXRw" value="10" />
+            </node>
+          </node>
+        </node>
+        <node concept="1aga60" id="3i3CWWtzjX9" role="_iOnC">
+          <property role="TrG5h" value="update" />
+          <node concept="2lgajX" id="3i3CWWtzk1A" role="28QfE6" />
+          <node concept="1QScDb" id="3i3CWWtziy_" role="1ahQXP">
+            <node concept="3sPC8h" id="3i3CWWtzi$k" role="1QScD9">
+              <node concept="30dDZf" id="3i3CWWtziGm" role="3sPC8l">
+                <node concept="30bXRB" id="3i3CWWtziKM" role="30dEs_">
+                  <property role="30bXRw" value="1" />
+                </node>
+                <node concept="3j5BQN" id="3i3CWWtziC9" role="30dEsF" />
+                <node concept="7CXmI" id="3i3CWWtzQCq" role="lGtFl">
+                  <node concept="29bkU" id="3i3CWWtzSBZ" role="7EUXB">
+                    <node concept="2PQEqo" id="3i3CWWtzSC0" role="3lydCh">
+                      <ref role="39XzEq" to="bg10:69ODpXSSoqa" />
+                    </node>
+                  </node>
+                  <node concept="2DdRWr" id="3i3CWWtzSC1" role="7EUXB">
+                    <node concept="MGsTx" id="3i3CWWtzSC2" role="MJxsd">
+                      <ref role="39XzEq" to="bg10:3GdqffBR6kN" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="_emDc" id="3i3CWWtzixM" role="30czhm">
+              <ref role="_emDf" node="3i3CWWtziew" resolve="globalcounter" />
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="3i3CWWtziar" role="_iOnC" />
         <node concept="2zPypq" id="3ni3WiedEDe" role="_iOnC">
           <property role="TrG5h" value="x" />
           <node concept="30bXRB" id="3ni3WiedEDE" role="2zPyp_">

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
@@ -30,6 +30,7 @@
     <dependency reexport="false">4621d3e3-b8a3-4bbe-b7ac-234b6e2d1d68(org.iets3.core.expr.temporal)</dependency>
     <dependency reexport="false">289fb12b-7f53-4ef7-bc2e-1ed2c6a7c998(org.iets3.core.expr.datetime)</dependency>
     <dependency reexport="false">9c3cc6fb-ae5e-46d1-ace2-1e08bb47d03d(org.iets3.core.expr.typetags.bindingtime)</dependency>
+    <dependency reexport="false">fbba5118-5fc6-49ff-9c3b-0b4469830440(org.iets3.core.expr.mutable)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
@@ -135,7 +136,9 @@
     <module reference="8ba65567-1c8a-4983-beb8-0482324d7e44(org.iets3.core.expr.lambda.interpreter)" version="0" />
     <module reference="0495221f-9fd1-41d6-bf26-b3b8aeb7eb7b(org.iets3.core.expr.lambda.plugin)" version="0" />
     <module reference="6fadc44e-69c2-4a4a-9d16-7ebf5f8d3ba0(org.iets3.core.expr.math)" version="0" />
+    <module reference="711a16d7-99e8-4e1d-b20c-99c0b7309cd8(org.iets3.core.expr.metafunction)" version="0" />
     <module reference="dff61827-7f11-4bfe-aeb1-6491ed8a49b2(org.iets3.core.expr.metafunction.interpreter)" version="0" />
+    <module reference="fbba5118-5fc6-49ff-9c3b-0b4469830440(org.iets3.core.expr.mutable)" version="1" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="c008c84a-6d05-4b6f-82f0-5cb6c0231a11(org.iets3.core.expr.path.interpreter)" version="0" />
     <module reference="cbb71b24-470d-4374-b77c-ebd0d3b3bb27(org.iets3.core.expr.plugin)" version="0" />


### PR DESCRIPTION
When the expression in the box expression has a specific number type, a generic integer type is used instead. Fixes #170 
An example can be seen in #170. Let me know if you see any additional problems.