### PR TITLE
Only allow backspace in some parts of SolverControl

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/editor.mps
@@ -28,6 +28,7 @@
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
+      <concept id="3547227755871693971" name="jetbrains.mps.lang.editor.structure.PredefinedSelector" flags="ng" index="2B6iha" />
       <concept id="1235728439575" name="jetbrains.mps.lang.editor.structure.BaseLineCell" flags="ln" index="2R9Tw8" />
       <concept id="1149850725784" name="jetbrains.mps.lang.editor.structure.CellModel_AttributedNodeCell" flags="ng" index="2SsqMj" />
       <concept id="1186403694788" name="jetbrains.mps.lang.editor.structure.ColorStyleClassItem" flags="ln" index="VaVBg">
@@ -72,6 +73,11 @@
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
+      <concept id="3647146066980922272" name="jetbrains.mps.lang.editor.structure.SelectInEditorOperation" flags="nn" index="1OKiuA">
+        <child id="1948540814633499358" name="editorContext" index="lBI5i" />
+        <child id="1948540814635895774" name="cellSelector" index="lGT1i" />
+      </concept>
+      <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
@@ -88,9 +94,19 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
@@ -100,6 +116,10 @@
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
@@ -112,6 +132,8 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
@@ -151,6 +173,7 @@
           </node>
         </node>
         <node concept="3EZMnI" id="2GQBRFCFw0y" role="3EZMnx">
+          <ref role="1ERwB7" node="7zJMcSxj$uX" resolve="preventDeletion" />
           <node concept="3F0ifn" id="2GQBRFCFw12" role="3EZMnx">
             <property role="3F0ifm" value="with timeout" />
             <node concept="VechU" id="2ZalWa8HPVn" role="3F10Kt">
@@ -184,14 +207,14 @@
             <node concept="3clFbS" id="2ZalWa8IziC" role="2VODD2">
               <node concept="3clFbF" id="2ZalWa8IzpN" role="3cqZAp">
                 <node concept="3eOSWO" id="2ZalWa8IAb0" role="3clFbG">
-                  <node concept="3cmrfG" id="2ZalWa8IAom" role="3uHU7w">
-                    <property role="3cmrfH" value="0" />
-                  </node>
                   <node concept="2OqwBi" id="2ZalWa8IzFd" role="3uHU7B">
                     <node concept="pncrf" id="2ZalWa8IzpM" role="2Oq$k0" />
                     <node concept="3TrcHB" id="2ZalWa8I$e6" role="2OqNvi">
                       <ref role="3TsBF5" to="l80j:2GQBRFCFk_3" resolve="timeout" />
                     </node>
+                  </node>
+                  <node concept="3cmrfG" id="2ZalWa8IAom" role="3uHU7w">
+                    <property role="3cmrfH" value="0" />
                   </node>
                 </node>
               </node>
@@ -214,10 +237,31 @@
       <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
       <node concept="1hAIg9" id="3DYDRw0XrNh" role="1hA7z_">
         <node concept="3clFbS" id="3DYDRw0XrNi" role="2VODD2">
-          <node concept="3clFbF" id="3DYDRw0XrNj" role="3cqZAp">
-            <node concept="2OqwBi" id="3DYDRw0XrNk" role="3clFbG">
-              <node concept="0IXxy" id="3DYDRw0XrNl" role="2Oq$k0" />
-              <node concept="3YRAZt" id="3DYDRw0XrNm" role="2OqNvi" />
+          <node concept="3cpWs8" id="6PYNGEsYwS4" role="3cqZAp">
+            <node concept="3cpWsn" id="6PYNGEsYwS5" role="3cpWs9">
+              <property role="TrG5h" value="p" />
+              <node concept="3Tqbb2" id="6PYNGEsYwS3" role="1tU5fm" />
+              <node concept="2OqwBi" id="6PYNGEsYwS6" role="33vP2m">
+                <node concept="0IXxy" id="6PYNGEsYwS7" role="2Oq$k0" />
+                <node concept="1mfA1w" id="6PYNGEsYwS8" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="8$8RMQUMIr" role="3cqZAp">
+            <node concept="2OqwBi" id="8$8RMQUMIL" role="3clFbG">
+              <node concept="0IXxy" id="8$8RMQUMIs" role="2Oq$k0" />
+              <node concept="3YRAZt" id="8$8RMQUMIR" role="2OqNvi" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="6PYNGEsYx0e" role="3cqZAp">
+            <node concept="2OqwBi" id="6PYNGEsYx6g" role="3clFbG">
+              <node concept="37vLTw" id="6PYNGEsYx0d" role="2Oq$k0">
+                <ref role="3cqZAo" node="6PYNGEsYwS5" resolve="p" />
+              </node>
+              <node concept="1OKiuA" id="6PYNGEsYxV_" role="2OqNvi">
+                <node concept="1Q80Hx" id="6PYNGEsYxW9" role="lBI5i" />
+                <node concept="2B6iha" id="k$AQtABI5G" role="lGT1i" />
+              </node>
             </node>
           </node>
         </node>
@@ -265,6 +309,30 @@
     <ref role="1XX52x" to="l80j:XhdFKvXSNr" resolve="ErrorMessage" />
     <node concept="3F0A7n" id="XhdFKvXSNV" role="2wV5jI">
       <ref role="1NtTu8" to="l80j:XhdFKvXSNs" resolve="msg" />
+    </node>
+  </node>
+  <node concept="1h_SRR" id="7zJMcSxj$uX">
+    <property role="3GE5qa" value="control" />
+    <property role="TrG5h" value="preventDeletion" />
+    <node concept="1hA7zw" id="7zJMcSxj$v2" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <node concept="1hAIg9" id="7zJMcSxj$v3" role="1hA7z_">
+        <node concept="3clFbS" id="7zJMcSxj$v4" role="2VODD2" />
+      </node>
+    </node>
+    <node concept="1hA7zw" id="7zJMcSxjEEE" role="1h_SK8">
+      <property role="1hAc7j" value="7P1WhNABBii/cut_action_id" />
+      <node concept="1hAIg9" id="7zJMcSxjEEF" role="1hA7z_">
+        <node concept="3clFbS" id="7zJMcSxjEEG" role="2VODD2" />
+      </node>
+    </node>
+    <node concept="1hA7zw" id="7zJMcSxj$uY" role="1h_SK8">
+      <property role="1hAc7j" value="7P1WhNABvta/backspace_action_id" />
+      <node concept="1hAIg9" id="7zJMcSxj$uZ" role="1hA7z_">
+        <node concept="3clFbS" id="7zJMcSxj$v0" role="2VODD2">
+          <node concept="3clFbH" id="7zJMcSxj$v1" role="3cqZAp" />
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/intentions.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/intentions.mps
@@ -83,9 +83,6 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
-      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
-        <child id="8356039341262087992" name="line" index="1aUNEU" />
-      </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="b92f861d-0184-446d-b88b-6dcf0e070241" name="com.mbeddr.mpsutil.intentions">
@@ -150,21 +147,6 @@
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
-      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
-        <property id="709746936026609031" name="linkId" index="3V$3ak" />
-        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
-      </concept>
-      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
-        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
-      </concept>
-    </language>
-    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
-      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
-        <property id="155656958578482949" name="value" index="3oM_SC" />
-      </concept>
-      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
-        <child id="2535923850359271783" name="elements" index="1PaTwD" />
-      </concept>
     </language>
   </registry>
   <node concept="2S6QgY" id="3DYDRw0WRwx">
@@ -173,103 +155,67 @@
     <ref role="2ZfgGC" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="2SaL7w" id="4FREEt6ybEn" role="2ZfVeh">
       <node concept="3clFbS" id="4FREEt6ybEo" role="2VODD2">
-        <node concept="3SKdUt" id="5QJ_0Lq6tsF" role="3cqZAp">
-          <node concept="1PaTwC" id="7759dYaYmHm" role="1aUNEU">
-            <node concept="3oM_SD" id="7759dYaYmHn" role="1PaTwD">
-              <property role="3oM_SC" value="disabled" />
-            </node>
-            <node concept="3oM_SD" id="7759dYaYmHo" role="1PaTwD">
-              <property role="3oM_SC" value="for" />
-            </node>
-            <node concept="3oM_SD" id="7759dYaYmHp" role="1PaTwD">
-              <property role="3oM_SC" value="now" />
-            </node>
-            <node concept="3oM_SD" id="7759dYaYmHq" role="1PaTwD">
-              <property role="3oM_SC" value="-" />
-            </node>
-            <node concept="3oM_SD" id="7759dYaYmHr" role="1PaTwD">
-              <property role="3oM_SC" value="will" />
-            </node>
-            <node concept="3oM_SD" id="7759dYaYmHs" role="1PaTwD">
-              <property role="3oM_SC" value="delete" />
-            </node>
-            <node concept="3oM_SD" id="7759dYaYmHt" role="1PaTwD">
-              <property role="3oM_SC" value="soon" />
+        <node concept="3clFbJ" id="2zI9HllFpbG" role="3cqZAp">
+          <node concept="3clFbS" id="2zI9HllFpbI" role="3clFbx">
+            <node concept="3cpWs6" id="2zI9HllFqjg" role="3cqZAp">
+              <node concept="3clFbT" id="2zI9HllFqBb" role="3cqZAk">
+                <property role="3clFbU" value="false" />
+              </node>
             </node>
           </node>
-        </node>
-        <node concept="3cpWs6" id="5QJ_0Lq6uaj" role="3cqZAp">
-          <node concept="3clFbT" id="5QJ_0Lq6ub2" role="3cqZAk" />
-        </node>
-        <node concept="1X3_iC" id="5QJ_0Lq6uwn" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbJ" id="2zI9HllFpbG" role="8Wnug">
-            <node concept="3clFbS" id="2zI9HllFpbI" role="3clFbx">
-              <node concept="3cpWs6" id="2zI9HllFqjg" role="3cqZAp">
-                <node concept="3clFbT" id="2zI9HllFqBb" role="3cqZAk">
-                  <property role="3clFbU" value="false" />
+          <node concept="22lmx$" id="2zI9HllFs8M" role="3clFbw">
+            <node concept="3fqX7Q" id="2zI9HllFqV$" role="3uHU7w">
+              <node concept="2OqwBi" id="2zI9HllFqVA" role="3fr31v">
+                <node concept="35c_gC" id="2zI9HllFqVB" role="2Oq$k0">
+                  <ref role="35c_gD" to="l80j:7QsdZDAwecO" resolve="IUseSolver" />
+                </node>
+                <node concept="2qgKlT" id="2zI9HllFqVC" role="2OqNvi">
+                  <ref role="37wK5l" to="1jcu:7QsdZDAweeW" resolve="isSolverEnabled" />
+                  <node concept="2Sf5sV" id="2zI9HllFqVD" role="37wK5m" />
                 </node>
               </node>
             </node>
-            <node concept="22lmx$" id="2zI9HllFs8M" role="3clFbw">
-              <node concept="3fqX7Q" id="2zI9HllFqV$" role="3uHU7w">
-                <node concept="2OqwBi" id="2zI9HllFqVA" role="3fr31v">
-                  <node concept="35c_gC" id="2zI9HllFqVB" role="2Oq$k0">
-                    <ref role="35c_gD" to="l80j:7QsdZDAwecO" resolve="IUseSolver" />
-                  </node>
-                  <node concept="2qgKlT" id="2zI9HllFqVC" role="2OqNvi">
-                    <ref role="37wK5l" to="1jcu:7QsdZDAweeW" resolve="isSolverEnabled" />
-                    <node concept="2Sf5sV" id="2zI9HllFqVD" role="37wK5m" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="2zI9HllEHpv" role="3uHU7B">
-                <node concept="2Sf5sV" id="2zI9HllEHpw" role="2Oq$k0" />
-                <node concept="1mIQ4w" id="2zI9HllEHpx" role="2OqNvi">
-                  <node concept="chp4Y" id="2zI9HllEHpy" role="cj9EA">
-                    <ref role="cht4Q" to="l80j:3DYDRw0WRrP" resolve="SolveControl" />
-                  </node>
+            <node concept="2OqwBi" id="2zI9HllEHpv" role="3uHU7B">
+              <node concept="2Sf5sV" id="2zI9HllEHpw" role="2Oq$k0" />
+              <node concept="1mIQ4w" id="2zI9HllEHpx" role="2OqNvi">
+                <node concept="chp4Y" id="2zI9HllEHpy" role="cj9EA">
+                  <ref role="cht4Q" to="l80j:3DYDRw0WRrP" resolve="SolveControl" />
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="1X3_iC" id="5QJ_0Lq6uwo" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="2zI9HllFlji" role="8Wnug">
-            <node concept="22lmx$" id="2zI9HllFuWd" role="3clFbG">
-              <node concept="2OqwBi" id="2zI9HllFmEK" role="3uHU7B">
-                <node concept="2OqwBi" id="2zI9HllFlxu" role="2Oq$k0">
-                  <node concept="2Sf5sV" id="2zI9HllFljg" role="2Oq$k0" />
-                  <node concept="3CFZ6_" id="2zI9HllFlV$" role="2OqNvi">
-                    <node concept="3CFYIy" id="2zI9HllFmeT" role="3CFYIz">
-                      <ref role="3CFYIx" to="l80j:3DYDRw0WRrP" resolve="SolveControl" />
-                    </node>
+        <node concept="3clFbF" id="2zI9HllFlji" role="3cqZAp">
+          <node concept="22lmx$" id="2zI9HllFuWd" role="3clFbG">
+            <node concept="2OqwBi" id="2zI9HllFmEK" role="3uHU7B">
+              <node concept="2OqwBi" id="2zI9HllFlxu" role="2Oq$k0">
+                <node concept="2Sf5sV" id="2zI9HllFljg" role="2Oq$k0" />
+                <node concept="3CFZ6_" id="2zI9HllFlV$" role="2OqNvi">
+                  <node concept="3CFYIy" id="2zI9HllFmeT" role="3CFYIz">
+                    <ref role="3CFYIx" to="l80j:3DYDRw0WRrP" resolve="SolveControl" />
                   </node>
                 </node>
-                <node concept="3w_OXm" id="2zI9HllFuCj" role="2OqNvi" />
               </node>
-              <node concept="3fqX7Q" id="2zI9HllFzR0" role="3uHU7w">
-                <node concept="2OqwBi" id="2zI9HllFzR2" role="3fr31v">
-                  <node concept="2OqwBi" id="2zI9HllFzR3" role="2Oq$k0">
-                    <node concept="2OqwBi" id="2zI9HllFzR4" role="2Oq$k0">
-                      <node concept="2Sf5sV" id="2zI9HllFzR5" role="2Oq$k0" />
-                      <node concept="3CFZ6_" id="2zI9HllFzR6" role="2OqNvi">
-                        <node concept="3CFYIy" id="2zI9HllFzR7" role="3CFYIz">
-                          <ref role="3CFYIx" to="l80j:3DYDRw0WRrP" resolve="SolveControl" />
-                        </node>
+              <node concept="3w_OXm" id="2zI9HllFuCj" role="2OqNvi" />
+            </node>
+            <node concept="3fqX7Q" id="2zI9HllFzR0" role="3uHU7w">
+              <node concept="2OqwBi" id="2zI9HllFzR2" role="3fr31v">
+                <node concept="2OqwBi" id="2zI9HllFzR3" role="2Oq$k0">
+                  <node concept="2OqwBi" id="2zI9HllFzR4" role="2Oq$k0">
+                    <node concept="2Sf5sV" id="2zI9HllFzR5" role="2Oq$k0" />
+                    <node concept="3CFZ6_" id="2zI9HllFzR6" role="2OqNvi">
+                      <node concept="3CFYIy" id="2zI9HllFzR7" role="3CFYIz">
+                        <ref role="3CFYIx" to="l80j:3DYDRw0WRrP" resolve="SolveControl" />
                       </node>
                     </node>
-                    <node concept="3TrcHB" id="2zI9HllFzR8" role="2OqNvi">
-                      <ref role="3TsBF5" to="l80j:17Nm8oCo8O2" resolve="mode" />
-                    </node>
                   </node>
-                  <node concept="21noJN" id="7759dYaYmK3" role="2OqNvi">
-                    <node concept="21nZrQ" id="7759dYaYmK4" role="21noJM">
-                      <ref role="21nZrZ" to="l80j:17Nm8oCo8NF" resolve="check" />
-                    </node>
+                  <node concept="3TrcHB" id="2zI9HllFzR8" role="2OqNvi">
+                    <ref role="3TsBF5" to="l80j:17Nm8oCo8O2" resolve="mode" />
+                  </node>
+                </node>
+                <node concept="21noJN" id="7759dYaYmK3" role="2OqNvi">
+                  <node concept="21nZrQ" id="7759dYaYmK4" role="21noJM">
+                    <ref role="21nZrZ" to="l80j:17Nm8oCo8NF" resolve="check" />
                   </node>
                 </node>
               </node>
@@ -351,103 +297,67 @@
     <ref role="2ZfgGC" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="2SaL7w" id="4FREEt6ydbo" role="2ZfVeh">
       <node concept="3clFbS" id="4FREEt6ydbp" role="2VODD2">
-        <node concept="3SKdUt" id="5QJ_0Lq6qbK" role="3cqZAp">
-          <node concept="1PaTwC" id="7759dYaYmHu" role="1aUNEU">
-            <node concept="3oM_SD" id="7759dYaYmHv" role="1PaTwD">
-              <property role="3oM_SC" value="disabled" />
-            </node>
-            <node concept="3oM_SD" id="7759dYaYmHw" role="1PaTwD">
-              <property role="3oM_SC" value="for" />
-            </node>
-            <node concept="3oM_SD" id="7759dYaYmHx" role="1PaTwD">
-              <property role="3oM_SC" value="now" />
-            </node>
-            <node concept="3oM_SD" id="7759dYaYmHy" role="1PaTwD">
-              <property role="3oM_SC" value="-" />
-            </node>
-            <node concept="3oM_SD" id="7759dYaYmHz" role="1PaTwD">
-              <property role="3oM_SC" value="will" />
-            </node>
-            <node concept="3oM_SD" id="7759dYaYmH$" role="1PaTwD">
-              <property role="3oM_SC" value="delete" />
-            </node>
-            <node concept="3oM_SD" id="7759dYaYmH_" role="1PaTwD">
-              <property role="3oM_SC" value="soon" />
+        <node concept="3clFbJ" id="2zI9HllF$sh" role="3cqZAp">
+          <node concept="3clFbS" id="2zI9HllF$si" role="3clFbx">
+            <node concept="3cpWs6" id="2zI9HllF$sj" role="3cqZAp">
+              <node concept="3clFbT" id="2zI9HllF$sk" role="3cqZAk">
+                <property role="3clFbU" value="false" />
+              </node>
             </node>
           </node>
-        </node>
-        <node concept="3cpWs6" id="5QJ_0Lq6qSO" role="3cqZAp">
-          <node concept="3clFbT" id="5QJ_0Lq6qTz" role="3cqZAk" />
-        </node>
-        <node concept="1X3_iC" id="5QJ_0Lq6reS" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbJ" id="2zI9HllF$sh" role="8Wnug">
-            <node concept="3clFbS" id="2zI9HllF$si" role="3clFbx">
-              <node concept="3cpWs6" id="2zI9HllF$sj" role="3cqZAp">
-                <node concept="3clFbT" id="2zI9HllF$sk" role="3cqZAk">
-                  <property role="3clFbU" value="false" />
+          <node concept="22lmx$" id="2zI9HllF$sl" role="3clFbw">
+            <node concept="3fqX7Q" id="2zI9HllF$sm" role="3uHU7w">
+              <node concept="2OqwBi" id="2zI9HllF$sn" role="3fr31v">
+                <node concept="35c_gC" id="2zI9HllF$so" role="2Oq$k0">
+                  <ref role="35c_gD" to="l80j:7QsdZDAwecO" resolve="IUseSolver" />
+                </node>
+                <node concept="2qgKlT" id="2zI9HllF$sp" role="2OqNvi">
+                  <ref role="37wK5l" to="1jcu:7QsdZDAweeW" resolve="isSolverEnabled" />
+                  <node concept="2Sf5sV" id="2zI9HllF$sq" role="37wK5m" />
                 </node>
               </node>
             </node>
-            <node concept="22lmx$" id="2zI9HllF$sl" role="3clFbw">
-              <node concept="3fqX7Q" id="2zI9HllF$sm" role="3uHU7w">
-                <node concept="2OqwBi" id="2zI9HllF$sn" role="3fr31v">
-                  <node concept="35c_gC" id="2zI9HllF$so" role="2Oq$k0">
-                    <ref role="35c_gD" to="l80j:7QsdZDAwecO" resolve="IUseSolver" />
-                  </node>
-                  <node concept="2qgKlT" id="2zI9HllF$sp" role="2OqNvi">
-                    <ref role="37wK5l" to="1jcu:7QsdZDAweeW" resolve="isSolverEnabled" />
-                    <node concept="2Sf5sV" id="2zI9HllF$sq" role="37wK5m" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="2zI9HllF$sr" role="3uHU7B">
-                <node concept="2Sf5sV" id="2zI9HllF$ss" role="2Oq$k0" />
-                <node concept="1mIQ4w" id="2zI9HllF$st" role="2OqNvi">
-                  <node concept="chp4Y" id="2zI9HllF$su" role="cj9EA">
-                    <ref role="cht4Q" to="l80j:3DYDRw0WRrP" resolve="SolveControl" />
-                  </node>
+            <node concept="2OqwBi" id="2zI9HllF$sr" role="3uHU7B">
+              <node concept="2Sf5sV" id="2zI9HllF$ss" role="2Oq$k0" />
+              <node concept="1mIQ4w" id="2zI9HllF$st" role="2OqNvi">
+                <node concept="chp4Y" id="2zI9HllF$su" role="cj9EA">
+                  <ref role="cht4Q" to="l80j:3DYDRw0WRrP" resolve="SolveControl" />
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="1X3_iC" id="5QJ_0Lq6reT" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="2zI9HllF$sv" role="8Wnug">
-            <node concept="22lmx$" id="2zI9HllF$sw" role="3clFbG">
-              <node concept="2OqwBi" id="2zI9HllF$sx" role="3uHU7B">
-                <node concept="2OqwBi" id="2zI9HllF$sy" role="2Oq$k0">
-                  <node concept="2Sf5sV" id="2zI9HllF$sz" role="2Oq$k0" />
-                  <node concept="3CFZ6_" id="2zI9HllF$s$" role="2OqNvi">
-                    <node concept="3CFYIy" id="2zI9HllF$s_" role="3CFYIz">
-                      <ref role="3CFYIx" to="l80j:3DYDRw0WRrP" resolve="SolveControl" />
-                    </node>
+        <node concept="3clFbF" id="2zI9HllF$sv" role="3cqZAp">
+          <node concept="22lmx$" id="4T6V$6cpFWY" role="3clFbG">
+            <node concept="2OqwBi" id="4T6V$6cpFWZ" role="3uHU7B">
+              <node concept="2OqwBi" id="4T6V$6cpFX0" role="2Oq$k0">
+                <node concept="2Sf5sV" id="4T6V$6cpFX1" role="2Oq$k0" />
+                <node concept="3CFZ6_" id="4T6V$6cpFX2" role="2OqNvi">
+                  <node concept="3CFYIy" id="4T6V$6cpFX3" role="3CFYIz">
+                    <ref role="3CFYIx" to="l80j:3DYDRw0WRrP" resolve="SolveControl" />
                   </node>
                 </node>
-                <node concept="3w_OXm" id="2zI9HllF$sA" role="2OqNvi" />
               </node>
-              <node concept="3fqX7Q" id="2zI9HllF$sB" role="3uHU7w">
-                <node concept="2OqwBi" id="2zI9HllF$sC" role="3fr31v">
-                  <node concept="2OqwBi" id="2zI9HllF$sD" role="2Oq$k0">
-                    <node concept="2OqwBi" id="2zI9HllF$sE" role="2Oq$k0">
-                      <node concept="2Sf5sV" id="2zI9HllF$sF" role="2Oq$k0" />
-                      <node concept="3CFZ6_" id="2zI9HllF$sG" role="2OqNvi">
-                        <node concept="3CFYIy" id="2zI9HllF$sH" role="3CFYIz">
-                          <ref role="3CFYIx" to="l80j:3DYDRw0WRrP" resolve="SolveControl" />
-                        </node>
+              <node concept="3w_OXm" id="4T6V$6cpFX4" role="2OqNvi" />
+            </node>
+            <node concept="3fqX7Q" id="4T6V$6cpFX5" role="3uHU7w">
+              <node concept="2OqwBi" id="4T6V$6cpFX6" role="3fr31v">
+                <node concept="2OqwBi" id="4T6V$6cpFX7" role="2Oq$k0">
+                  <node concept="2OqwBi" id="4T6V$6cpFX8" role="2Oq$k0">
+                    <node concept="2Sf5sV" id="4T6V$6cpFX9" role="2Oq$k0" />
+                    <node concept="3CFZ6_" id="4T6V$6cpFXa" role="2OqNvi">
+                      <node concept="3CFYIy" id="4T6V$6cpFXb" role="3CFYIz">
+                        <ref role="3CFYIx" to="l80j:3DYDRw0WRrP" resolve="SolveControl" />
                       </node>
                     </node>
-                    <node concept="3TrcHB" id="2zI9HllF$sI" role="2OqNvi">
-                      <ref role="3TsBF5" to="l80j:17Nm8oCo8O2" resolve="mode" />
-                    </node>
                   </node>
-                  <node concept="21noJN" id="7759dYaYmK5" role="2OqNvi">
-                    <node concept="21nZrQ" id="7759dYaYmK6" role="21noJM">
-                      <ref role="21nZrZ" to="l80j:17Nm8oCo8NG" resolve="ignore" />
-                    </node>
+                  <node concept="3TrcHB" id="4T6V$6cpFXc" role="2OqNvi">
+                    <ref role="3TsBF5" to="l80j:17Nm8oCo8O2" resolve="mode" />
+                  </node>
+                </node>
+                <node concept="21noJN" id="4T6V$6cpFXd" role="2OqNvi">
+                  <node concept="21nZrQ" id="4T6V$6cpFXe" role="21noJM">
+                    <ref role="21nZrZ" to="l80j:17Nm8oCo8NG" resolve="ignore" />
                   </node>
                 </node>
               </node>
@@ -670,95 +580,63 @@
     </node>
     <node concept="2SaL7w" id="1buLrYj9vh2" role="2ZfVeh">
       <node concept="3clFbS" id="1buLrYj9vh3" role="2VODD2">
-        <node concept="3SKdUt" id="5QJ_0Lq6wgg" role="3cqZAp">
-          <node concept="1PaTwC" id="7759dYaYmHA" role="1aUNEU">
-            <node concept="3oM_SD" id="7759dYaYmHB" role="1PaTwD">
-              <property role="3oM_SC" value="disabled" />
-            </node>
-            <node concept="3oM_SD" id="7759dYaYmHC" role="1PaTwD">
-              <property role="3oM_SC" value="for" />
-            </node>
-            <node concept="3oM_SD" id="7759dYaYmHD" role="1PaTwD">
-              <property role="3oM_SC" value="now" />
-            </node>
-            <node concept="3oM_SD" id="7759dYaYmHE" role="1PaTwD">
-              <property role="3oM_SC" value="-" />
-            </node>
-            <node concept="3oM_SD" id="7759dYaYmHF" role="1PaTwD">
-              <property role="3oM_SC" value="will" />
-            </node>
-            <node concept="3oM_SD" id="7759dYaYmHG" role="1PaTwD">
-              <property role="3oM_SC" value="delete" />
-            </node>
-            <node concept="3oM_SD" id="7759dYaYmHH" role="1PaTwD">
-              <property role="3oM_SC" value="later" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs6" id="5QJ_0Lq6wZx" role="3cqZAp">
-          <node concept="3clFbT" id="5QJ_0Lq6xmo" role="3cqZAk" />
-        </node>
-        <node concept="1X3_iC" id="5QJ_0Lq6ytF" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="7QsdZDAwiKW" role="8Wnug">
-            <node concept="1Wc70l" id="7QsdZDAwogW" role="3clFbG">
-              <node concept="1eOMI4" id="7QsdZDAwoTu" role="3uHU7w">
-                <node concept="22lmx$" id="1buLrYj9ybf" role="1eOMHV">
-                  <node concept="1eOMI4" id="1buLrYj9ynx" role="3uHU7w">
-                    <node concept="1Wc70l" id="1buLrYj9_pU" role="1eOMHV">
-                      <node concept="2dkUwp" id="1buLrYj9Dp1" role="3uHU7w">
-                        <node concept="3cmrfG" id="1buLrYj9DDh" role="3uHU7w">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                        <node concept="2OqwBi" id="1buLrYj9ATY" role="3uHU7B">
-                          <node concept="2OqwBi" id="1buLrYj9_Pu" role="2Oq$k0">
-                            <node concept="2Sf5sV" id="1buLrYj9_Ay" role="2Oq$k0" />
-                            <node concept="3CFZ6_" id="1buLrYj9Air" role="2OqNvi">
-                              <node concept="3CFYIy" id="1buLrYj9Awj" role="3CFYIz">
-                                <ref role="3CFYIx" to="l80j:3DYDRw0WRrP" resolve="SolveControl" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="3TrcHB" id="1buLrYj9B$X" role="2OqNvi">
-                            <ref role="3TsBF5" to="l80j:2GQBRFCFk_3" resolve="timeout" />
-                          </node>
-                        </node>
+        <node concept="3clFbF" id="7QsdZDAwiKW" role="3cqZAp">
+          <node concept="1Wc70l" id="7QsdZDAwogW" role="3clFbG">
+            <node concept="1eOMI4" id="7QsdZDAwoTu" role="3uHU7w">
+              <node concept="22lmx$" id="1buLrYj9ybf" role="1eOMHV">
+                <node concept="1eOMI4" id="1buLrYj9ynx" role="3uHU7w">
+                  <node concept="1Wc70l" id="1buLrYj9_pU" role="1eOMHV">
+                    <node concept="2dkUwp" id="1buLrYj9Dp1" role="3uHU7w">
+                      <node concept="3cmrfG" id="1buLrYj9DDh" role="3uHU7w">
+                        <property role="3cmrfH" value="0" />
                       </node>
-                      <node concept="2OqwBi" id="1buLrYj9zT1" role="3uHU7B">
-                        <node concept="2OqwBi" id="1buLrYj9yPt" role="2Oq$k0">
-                          <node concept="2Sf5sV" id="1buLrYj9yAL" role="2Oq$k0" />
-                          <node concept="3CFZ6_" id="1buLrYj9zeF" role="2OqNvi">
-                            <node concept="3CFYIy" id="1buLrYj9zvE" role="3CFYIz">
+                      <node concept="2OqwBi" id="1buLrYj9ATY" role="3uHU7B">
+                        <node concept="2OqwBi" id="1buLrYj9_Pu" role="2Oq$k0">
+                          <node concept="2Sf5sV" id="1buLrYj9_Ay" role="2Oq$k0" />
+                          <node concept="3CFZ6_" id="1buLrYj9Air" role="2OqNvi">
+                            <node concept="3CFYIy" id="1buLrYj9Awj" role="3CFYIz">
                               <ref role="3CFYIx" to="l80j:3DYDRw0WRrP" resolve="SolveControl" />
                             </node>
                           </node>
                         </node>
-                        <node concept="3x8VRR" id="1buLrYj9$zG" role="2OqNvi" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="1buLrYj9wK$" role="3uHU7B">
-                    <node concept="2OqwBi" id="1buLrYj9vGs" role="2Oq$k0">
-                      <node concept="2Sf5sV" id="1buLrYj9vom" role="2Oq$k0" />
-                      <node concept="3CFZ6_" id="1buLrYj9weg" role="2OqNvi">
-                        <node concept="3CFYIy" id="1buLrYj9wr6" role="3CFYIz">
-                          <ref role="3CFYIx" to="l80j:3DYDRw0WRrP" resolve="SolveControl" />
+                        <node concept="3TrcHB" id="1buLrYj9B$X" role="2OqNvi">
+                          <ref role="3TsBF5" to="l80j:2GQBRFCFk_3" resolve="timeout" />
                         </node>
                       </node>
                     </node>
-                    <node concept="3w_OXm" id="1buLrYj9xlo" role="2OqNvi" />
+                    <node concept="2OqwBi" id="1buLrYj9zT1" role="3uHU7B">
+                      <node concept="2OqwBi" id="1buLrYj9yPt" role="2Oq$k0">
+                        <node concept="2Sf5sV" id="1buLrYj9yAL" role="2Oq$k0" />
+                        <node concept="3CFZ6_" id="1buLrYj9zeF" role="2OqNvi">
+                          <node concept="3CFYIy" id="1buLrYj9zvE" role="3CFYIz">
+                            <ref role="3CFYIx" to="l80j:3DYDRw0WRrP" resolve="SolveControl" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3x8VRR" id="1buLrYj9$zG" role="2OqNvi" />
+                    </node>
                   </node>
                 </node>
+                <node concept="2OqwBi" id="1buLrYj9wK$" role="3uHU7B">
+                  <node concept="2OqwBi" id="1buLrYj9vGs" role="2Oq$k0">
+                    <node concept="2Sf5sV" id="1buLrYj9vom" role="2Oq$k0" />
+                    <node concept="3CFZ6_" id="1buLrYj9weg" role="2OqNvi">
+                      <node concept="3CFYIy" id="1buLrYj9wr6" role="3CFYIz">
+                        <ref role="3CFYIx" to="l80j:3DYDRw0WRrP" resolve="SolveControl" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3w_OXm" id="1buLrYj9xlo" role="2OqNvi" />
+                </node>
               </node>
-              <node concept="2OqwBi" id="7QsdZDAwjvt" role="3uHU7B">
-                <node concept="35c_gC" id="7QsdZDAwiKU" role="2Oq$k0">
-                  <ref role="35c_gD" to="l80j:7QsdZDAwecO" resolve="IUseSolver" />
-                </node>
-                <node concept="2qgKlT" id="7QsdZDAwk0z" role="2OqNvi">
-                  <ref role="37wK5l" to="1jcu:7QsdZDAweeW" resolve="isSolverEnabled" />
-                  <node concept="2Sf5sV" id="7QsdZDAwmXz" role="37wK5m" />
-                </node>
+            </node>
+            <node concept="2OqwBi" id="7QsdZDAwjvt" role="3uHU7B">
+              <node concept="35c_gC" id="7QsdZDAwiKU" role="2Oq$k0">
+                <ref role="35c_gD" to="l80j:7QsdZDAwecO" resolve="IUseSolver" />
+              </node>
+              <node concept="2qgKlT" id="7QsdZDAwk0z" role="2OqNvi">
+                <ref role="37wK5l" to="1jcu:7QsdZDAweeW" resolve="isSolverEnabled" />
+                <node concept="2Sf5sV" id="7QsdZDAwmXz" role="37wK5m" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/org.iets3.analysis.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/org.iets3.analysis.base.mpl
@@ -18,7 +18,7 @@
     <dependency reexport="false">7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)</dependency>
     <dependency reexport="false">cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</dependency>
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
-    <dependency reexport="false">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)</dependency>
+    <dependency reexport="false">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.libs)</dependency>
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
     <dependency reexport="false">742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)</dependency>
     <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
@@ -97,7 +97,7 @@
     <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
     <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
     <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
-    <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)" version="0" />
+    <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.libs)" version="0" />
     <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/org.iets3.core.expr.math.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/org.iets3.core.expr.math.mpl
@@ -92,7 +92,7 @@
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
     <dependency reexport="false">9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)</dependency>
     <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
-    <dependency reexport="false">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)</dependency>
+    <dependency reexport="false">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.libs)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:677f00fb-4488-405e-9885-abb75d472fd1:com.mbeddr.mpsutil.contextactions" version="0" />
@@ -166,7 +166,7 @@
     <module reference="a9a7bf57-15e6-4d28-adc1-be146e415fe5(de.itemis.mps.editor.math.runtime)" version="0" />
     <module reference="0fcee1cf-8f59-441b-b9c7-7ff7bdd6bc97(de.itemis.mps.editor.math.symbols)" version="0" />
     <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
-    <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)" version="0" />
+    <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.libs)" version="0" />
     <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/org.iets3.core.expr.tests.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/org.iets3.core.expr.tests.mpl
@@ -159,7 +159,7 @@
     <dependency reexport="false">2022a471-10ba-4431-ba5d-622df898f3c6(org.iets3.core.expr.testExecution)</dependency>
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
     <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
-    <dependency reexport="false">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)</dependency>
+    <dependency reexport="false">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.libs)</dependency>
     <dependency reexport="false">9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)</dependency>
   </dependencies>
   <languageVersions>
@@ -252,7 +252,7 @@
     <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
     <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
     <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
-    <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)" version="0" />
+    <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.libs)" version="0" />
     <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/org.iets3.core.expr.typetags.units.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/org.iets3.core.expr.typetags.units.mpl
@@ -21,7 +21,7 @@
     <dependency reexport="true">6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)</dependency>
     <dependency reexport="false">7a5dda62-9140-4668-ab76-d5ed1746f2b2(jetbrains.mps.lang.typesystem)</dependency>
     <dependency reexport="false">20c6e580-bdc5-4067-8049-d7e3265a86de(jetbrains.mps.typesystemEngine)</dependency>
-    <dependency reexport="false">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)</dependency>
+    <dependency reexport="false">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.libs)</dependency>
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
   </dependencies>
   <languageVersions>
@@ -102,7 +102,7 @@
     <module reference="766348f7-6a67-4b85-9323-384840132299(de.itemis.mps.editor.math)" version="0" />
     <module reference="a9a7bf57-15e6-4d28-adc1-be146e415fe5(de.itemis.mps.editor.math.runtime)" version="0" />
     <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
-    <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)" version="0" />
+    <module reference="ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.libs)" version="0" />
     <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />


### PR DESCRIPTION
Pressing backspace in solver timeout removes the whole timeout part of the editor. This commit fixes this issue.