### PR TITLE
Bugfix/temporal value equals alternative

### DIFF
--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.temporal.runtime/models/org.iets3.core.expr.temporal.runtime.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.temporal.runtime/models/org.iets3.core.expr.temporal.runtime.mps
@@ -3695,26 +3695,6 @@
                 </node>
               </node>
             </node>
-            <node concept="3clFbJ" id="50smQ1Vb0dh" role="3cqZAp">
-              <node concept="3clFbS" id="50smQ1Vb0dj" role="3clFbx">
-                <node concept="3cpWs6" id="50smQ1Vb5Jh" role="3cqZAp">
-                  <node concept="3clFbT" id="50smQ1Vb5JR" role="3cqZAk">
-                    <property role="3clFbU" value="false" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbC" id="7aRvJQF0xrL" role="3clFbw">
-                <node concept="10Nm6u" id="7aRvJQF0znC" role="3uHU7w" />
-                <node concept="2OqwBi" id="50smQ1VbN8r" role="3uHU7B">
-                  <node concept="37vLTw" id="4OwGieAyZvU" role="2Oq$k0">
-                    <ref role="3cqZAo" node="4OwGieAyZvO" resolve="s" />
-                  </node>
-                  <node concept="liA8E" id="50smQ1Vc07i" role="2OqNvi">
-                    <ref role="37wK5l" node="50smQ1VbR0B" resolve="value" />
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="3clFbJ" id="7aRvJQF0lZy" role="3cqZAp">
               <node concept="3clFbS" id="7aRvJQF0lZz" role="3clFbx">
                 <node concept="3cpWs6" id="7aRvJQF0lZ$" role="3cqZAp">
@@ -3724,24 +3704,23 @@
                 </node>
               </node>
               <node concept="3fqX7Q" id="7aRvJQF0lZA" role="3clFbw">
-                <node concept="2OqwBi" id="7aRvJQF0lZB" role="3fr31v">
-                  <node concept="2OqwBi" id="7aRvJQF0lZC" role="2Oq$k0">
-                    <node concept="37vLTw" id="4OwGieAyZvW" role="2Oq$k0">
+                <node concept="2YIFZM" id="2_olRhxz$1V" role="3fr31v">
+                  <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
+                  <ref role="37wK5l" to="33ny:~Objects.equals(java.lang.Object,java.lang.Object)" resolve="equals" />
+                  <node concept="2OqwBi" id="2_olRhxzGd$" role="37wK5m">
+                    <node concept="37vLTw" id="2_olRhxzG9D" role="2Oq$k0">
                       <ref role="3cqZAo" node="4OwGieAyZvO" resolve="s" />
                     </node>
-                    <node concept="liA8E" id="7aRvJQF0lZE" role="2OqNvi">
+                    <node concept="liA8E" id="2_olRhxzGkh" role="2OqNvi">
                       <ref role="37wK5l" node="50smQ1VbR0B" resolve="value" />
                     </node>
                   </node>
-                  <node concept="liA8E" id="7aRvJQF0lZF" role="2OqNvi">
-                    <ref role="37wK5l" to="wyt6:~Object.equals(java.lang.Object)" resolve="equals" />
-                    <node concept="2OqwBi" id="7aRvJQF0lZG" role="37wK5m">
-                      <node concept="37vLTw" id="7aRvJQF0lZH" role="2Oq$k0">
-                        <ref role="3cqZAo" node="50smQ1VaYe$" resolve="otherSlice" />
-                      </node>
-                      <node concept="liA8E" id="7aRvJQF0lZI" role="2OqNvi">
-                        <ref role="37wK5l" node="50smQ1VbR0B" resolve="value" />
-                      </node>
+                  <node concept="2OqwBi" id="2_olRhxzGyN" role="37wK5m">
+                    <node concept="37vLTw" id="2_olRhxzGtT" role="2Oq$k0">
+                      <ref role="3cqZAo" node="50smQ1VaYe$" resolve="otherSlice" />
+                    </node>
+                    <node concept="liA8E" id="2_olRhxzGA8" role="2OqNvi">
+                      <ref role="37wK5l" node="50smQ1VbR0B" resolve="value" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/temporal@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/temporal@tests.mps
@@ -466,52 +466,6 @@
         </node>
       </node>
     </node>
-    <node concept="2zPypq" id="VFjlN650gh" role="_iOnB">
-      <property role="TrG5h" value="v2b" />
-      <property role="0Rz4W" value="-1843236782" />
-      <node concept="FfN7I" id="VFjlN650gi" role="2zPyp_">
-        <node concept="FfN7L" id="VFjlN650gj" role="FfN64">
-          <node concept="30bXRB" id="VFjlN650gk" role="FfN7O">
-            <property role="30bXRw" value="100" />
-          </node>
-          <node concept="_emDc" id="VFjlN650gl" role="FfN7M">
-            <ref role="_emDf" node="7aRvJQErc4O" resolve="date0" />
-          </node>
-        </node>
-        <node concept="FfN7L" id="VFjlN650gm" role="FfN64">
-          <node concept="30bXRB" id="VFjlN650gn" role="FfN7O">
-            <property role="30bXRw" value="100" />
-          </node>
-          <node concept="_emDc" id="VFjlN650go" role="FfN7M">
-            <ref role="_emDf" node="7aRvJQErc4P" resolve="date05" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2zPypq" id="7aRvJQErc4Y" role="_iOnB">
-      <property role="TrG5h" value="v11" />
-      <property role="0Rz4W" value="1391826359" />
-      <node concept="FfN7I" id="7aRvJQErc5J" role="2zPyp_">
-        <node concept="FfN7L" id="7aRvJQErc6U" role="FfN64">
-          <node concept="30bXRB" id="7aRvJQErc9x" role="FfN7O">
-            <property role="30bXRw" value="100" />
-          </node>
-          <node concept="_emDc" id="7aRvJQErc9y" role="FfN7M">
-            <ref role="_emDf" node="7aRvJQErc4O" resolve="date0" />
-          </node>
-        </node>
-        <node concept="FfN7L" id="7aRvJQErc6V" role="FfN64">
-          <node concept="30bXRB" id="7aRvJQErc9z" role="FfN7O">
-            <property role="30bXRw" value="100" />
-          </node>
-          <node concept="_emDc" id="7aRvJQErc9$" role="FfN7M">
-            <ref role="_emDf" node="7aRvJQErc4P" resolve="date05" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="_ixoA" id="7aRvJQErc4Z" role="_iOnB" />
-    <node concept="_ixoA" id="7aRvJQEroak" role="_iOnB" />
     <node concept="2zPypq" id="VFjlN6eaAm" role="_iOnB">
       <property role="TrG5h" value="v5" />
       <property role="0Rz4W" value="34085867" />


### PR DESCRIPTION
Improve `TemporalValue.equals()` to compare values with null-value-slices, so it's returning `false` when a TemporalValue-slice has a null-value.

Problem: If two equal temporal values have a slice with a null-value, the equals() result is `false`