### PR TITLE
Fix type calculation for ShortLambdaExpression

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/typesystem.mps
@@ -915,21 +915,24 @@
                           </node>
                         </node>
                         <node concept="TSZUe" id="kxHAhaUGnL" role="2OqNvi">
-                          <node concept="2OqwBi" id="4Uid4MjU6uG" role="25WWJ7">
-                            <node concept="1PxgMI" id="4Uid4MjU4Dy" role="2Oq$k0">
-                              <node concept="chp4Y" id="4Uid4MjU5jS" role="3oSUPX">
-                                <ref role="cht4Q" to="zzzn:6zmBjqUm7Mf" resolve="IShortLambdaContainer" />
-                              </node>
-                              <node concept="2OqwBi" id="4Uid4MjU2wn" role="1m5AlR">
-                                <node concept="1YBJjd" id="4Uid4MjU1op" role="2Oq$k0">
-                                  <ref role="1YBMHb" node="6zmBjqUm84F" resolve="sle" />
+                          <node concept="2OqwBi" id="3VarItJO3rW" role="25WWJ7">
+                            <node concept="2OqwBi" id="10RksdbPeCg" role="2Oq$k0">
+                              <node concept="1PxgMI" id="10RksdbPeCh" role="2Oq$k0">
+                                <node concept="chp4Y" id="10RksdbPeCi" role="3oSUPX">
+                                  <ref role="cht4Q" to="zzzn:6zmBjqUm7Mf" resolve="IShortLambdaContainer" />
                                 </node>
-                                <node concept="1mfA1w" id="4Uid4MjU3MJ" role="2OqNvi" />
+                                <node concept="2OqwBi" id="10RksdbPeCj" role="1m5AlR">
+                                  <node concept="1YBJjd" id="10RksdbPeCk" role="2Oq$k0">
+                                    <ref role="1YBMHb" node="6zmBjqUm84F" resolve="sle" />
+                                  </node>
+                                  <node concept="1mfA1w" id="10RksdbPeCl" role="2OqNvi" />
+                                </node>
+                              </node>
+                              <node concept="2qgKlT" id="10RksdbPeCm" role="2OqNvi">
+                                <ref role="37wK5l" to="5s8v:6zmBjqUm7MF" resolve="requiredType" />
                               </node>
                             </node>
-                            <node concept="2qgKlT" id="4Uid4MjU7p9" role="2OqNvi">
-                              <ref role="37wK5l" to="5s8v:6zmBjqUm7MF" resolve="requiredType" />
-                            </node>
+                            <node concept="1$rogu" id="3VarItJO4_E" role="2OqNvi" />
                           </node>
                         </node>
                       </node>


### PR DESCRIPTION
Fix type calculation for ShortLambdaExpression

Problem: When a ConstantRef of a TemporalValue is used, the constant type and the ref type are
calculated correctly. But when constantRef.mapEach() is used, the type of the constant and of the
ref breaks.