### PR TITLE
Improve generator for sumOp to consider the collection base type

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.simpleTypes/generator/template/org.iets3.core.expr.genjava.simpleTypes@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.simpleTypes/generator/template/org.iets3.core.expr.genjava.simpleTypes@generator.mps
@@ -6,7 +6,6 @@
     <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
   </languages>
   <imports>
-    <import index="hxvb" ref="r:ebd1eee1-ef85-4edc-907f-bc08f2f6b482(org.iets3.core.expr.genjava.simpleTypes.structure)" />
     <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" />
     <import index="xlxw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.math(JDK/)" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
@@ -5013,7 +5012,7 @@
       <ref role="30HIoZ" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
       <node concept="gft3U" id="4lRNjFWThxS" role="1lVwrX">
         <node concept="2YIFZM" id="4lRNjFWTnjw" role="gfFT$">
-          <ref role="37wK5l" to="wfax:4lRNjFWSwEt" resolve="sum" />
+          <ref role="37wK5l" to="wfax:4lRNjFWSwEt" resolve="sumAsBigDecimal" />
           <ref role="1Pybhc" to="wfax:4lRNjFWGzDc" resolve="CollectionHelper" />
           <node concept="2YIFZM" id="4lRNjFWTnjx" role="37wK5m">
             <ref role="1Pybhc" to="j10v:~TreePVector" resolve="TreePVector" />
@@ -5044,20 +5043,124 @@
       </node>
       <node concept="30G5F_" id="4lRNjFWThy5" role="30HLyM">
         <node concept="3clFbS" id="4lRNjFWThy6" role="2VODD2">
-          <node concept="3clFbF" id="4lRNjFWThy7" role="3cqZAp">
-            <node concept="2OqwBi" id="4lRNjFWThy8" role="3clFbG">
-              <node concept="2OqwBi" id="4lRNjFWThy9" role="2Oq$k0">
-                <node concept="30H73N" id="4lRNjFWThya" role="2Oq$k0" />
-                <node concept="3TrEf2" id="4lRNjFWThyb" role="2OqNvi">
-                  <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
-                </node>
-              </node>
-              <node concept="1mIQ4w" id="4lRNjFWThyc" role="2OqNvi">
-                <node concept="chp4Y" id="4lRNjFWTmtx" role="cj9EA">
-                  <ref role="cht4Q" to="700h:4Q4DxjD$qtz" resolve="SumOp" />
+          <node concept="3clFbJ" id="7nYU6yJ3DIW" role="3cqZAp">
+            <node concept="3clFbS" id="7nYU6yJ3DIY" role="3clFbx">
+              <node concept="3cpWs6" id="7nYU6yJuhu6" role="3cqZAp">
+                <node concept="3clFbT" id="7nYU6yJuhDc" role="3cqZAk">
+                  <property role="3clFbU" value="true" />
                 </node>
               </node>
             </node>
+            <node concept="1Wc70l" id="7nYU6yJubP9" role="3clFbw">
+              <node concept="2YIFZM" id="7nYU6yJues5" role="3uHU7w">
+                <ref role="37wK5l" to="wfax:7nYU6yJucGT" resolve="isEligibleForBigDecimal" />
+                <ref role="1Pybhc" to="wfax:4lRNjFWGzDc" resolve="CollectionHelper" />
+                <node concept="2OqwBi" id="7nYU6yJug78" role="37wK5m">
+                  <node concept="2OqwBi" id="7nYU6yJuf9_" role="2Oq$k0">
+                    <node concept="30H73N" id="7nYU6yJueMc" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="7nYU6yJufCO" role="2OqNvi">
+                      <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                    </node>
+                  </node>
+                  <node concept="3JvlWi" id="7nYU6yJugBA" role="2OqNvi" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4lRNjFWThy8" role="3uHU7B">
+                <node concept="2OqwBi" id="4lRNjFWThy9" role="2Oq$k0">
+                  <node concept="30H73N" id="4lRNjFWThya" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4lRNjFWThyb" role="2OqNvi">
+                    <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                  </node>
+                </node>
+                <node concept="1mIQ4w" id="4lRNjFWThyc" role="2OqNvi">
+                  <node concept="chp4Y" id="4lRNjFWTmtx" role="cj9EA">
+                    <ref role="cht4Q" to="700h:4Q4DxjD$qtz" resolve="SumOp" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="7nYU6yJ3Ezz" role="3cqZAp">
+            <node concept="3clFbT" id="7nYU6yJ3ESG" role="3cqZAk" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="7nYU6yJ3FiX" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+      <node concept="gft3U" id="7nYU6yJ3FiY" role="1lVwrX">
+        <node concept="2YIFZM" id="7nYU6yJ3P4W" role="gfFT$">
+          <ref role="37wK5l" to="wfax:7nYU6yJ0$7s" resolve="sumAsBigInteger" />
+          <ref role="1Pybhc" to="wfax:4lRNjFWGzDc" resolve="CollectionHelper" />
+          <node concept="2YIFZM" id="7nYU6yJ3P4X" role="37wK5m">
+            <ref role="1Pybhc" to="j10v:~TreePVector" resolve="TreePVector" />
+            <ref role="37wK5l" to="j10v:~TreePVector.from(java.util.Collection)" resolve="from" />
+            <node concept="2ShNRf" id="7nYU6yJ3P4Y" role="37wK5m">
+              <node concept="Tc6Ow" id="7nYU6yJ3P4Z" role="2ShVmc">
+                <node concept="3uibUv" id="7nYU6yJ3P50" role="HW$YZ">
+                  <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
+                </node>
+              </node>
+            </node>
+            <node concept="29HgVG" id="7nYU6yJ3P51" role="lGtFl">
+              <node concept="3NFfHV" id="7nYU6yJ3P52" role="3NFExx">
+                <node concept="3clFbS" id="7nYU6yJ3P53" role="2VODD2">
+                  <node concept="3clFbF" id="7nYU6yJ3P54" role="3cqZAp">
+                    <node concept="2OqwBi" id="7nYU6yJ3P55" role="3clFbG">
+                      <node concept="3TrEf2" id="7nYU6yJ3P56" role="2OqNvi">
+                        <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                      </node>
+                      <node concept="30H73N" id="7nYU6yJ3P57" role="2Oq$k0" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="30G5F_" id="7nYU6yJ3Fjb" role="30HLyM">
+        <node concept="3clFbS" id="7nYU6yJ3Fjc" role="2VODD2">
+          <node concept="3clFbJ" id="7nYU6yJ3Fjd" role="3cqZAp">
+            <node concept="3clFbS" id="7nYU6yJ3Fje" role="3clFbx">
+              <node concept="3cpWs6" id="7nYU6yJAhox" role="3cqZAp">
+                <node concept="3clFbT" id="7nYU6yJAhES" role="3cqZAk">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="1Wc70l" id="7nYU6yJAeG0" role="3clFbw">
+              <node concept="2YIFZM" id="7nYU6yJAfg7" role="3uHU7w">
+                <ref role="37wK5l" to="wfax:7nYU6yJtgp2" resolve="isEligibleForBigInteger" />
+                <ref role="1Pybhc" to="wfax:4lRNjFWGzDc" resolve="CollectionHelper" />
+                <node concept="2OqwBi" id="7nYU6yJAgKS" role="37wK5m">
+                  <node concept="2OqwBi" id="7nYU6yJAfR4" role="2Oq$k0">
+                    <node concept="30H73N" id="7nYU6yJAfy1" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="7nYU6yJAgwX" role="2OqNvi">
+                      <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                    </node>
+                  </node>
+                  <node concept="3JvlWi" id="7nYU6yJAheS" role="2OqNvi" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7nYU6yJ3Fj$" role="3uHU7B">
+                <node concept="2OqwBi" id="7nYU6yJ3Fj_" role="2Oq$k0">
+                  <node concept="30H73N" id="7nYU6yJ3FjA" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="7nYU6yJ3FjB" role="2OqNvi">
+                    <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                  </node>
+                </node>
+                <node concept="1mIQ4w" id="7nYU6yJ3FjC" role="2OqNvi">
+                  <node concept="chp4Y" id="7nYU6yJ3FjD" role="cj9EA">
+                    <ref role="cht4Q" to="700h:4Q4DxjD$qtz" resolve="SumOp" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="7nYU6yJ3FjE" role="3cqZAp">
+            <node concept="3clFbT" id="7nYU6yJ3FjF" role="3cqZAk" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.genjava.simpleTypes.rt/models/org.iets3.core.expr.genjava.simpleTypes.rt.rt.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.genjava.simpleTypes.rt/models/org.iets3.core.expr.genjava.simpleTypes.rt.rt.mps
@@ -3,6 +3,8 @@
   <persistence version="9" />
   <attribute name="doNotGenerate" value="false" />
   <languages>
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -10,6 +12,8 @@
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="j10v" ref="b76a0f63-5959-456b-993a-c796cc0d0c13/java:org.pcollections(org.iets3.core.expr.base.collections.stubs/)" />
     <import index="dj6k" ref="r:59d52af6-663b-49dc-8980-30d79b8dffa1(org.iets3.core.expr.simpleTypes.runtime)" />
+    <import index="700h" ref="r:61b1de80-490d-4fee-8e95-b956503290e9(org.iets3.core.expr.collections.structure)" />
+    <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -18,6 +22,7 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
@@ -53,7 +58,9 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534760951" name="jetbrains.mps.baseLanguage.structure.ArrayType" flags="in" index="10Q1$e">
         <child id="1070534760952" name="componentType" index="10Q1$1" />
       </concept>
@@ -96,6 +103,9 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
@@ -108,6 +118,9 @@
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
@@ -127,19 +140,85 @@
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
         <child id="1201186121363" name="typeParameter" index="2Ghqu4" />
       </concept>
       <concept id="8064396509828172209" name="jetbrains.mps.baseLanguage.structure.UnaryMinus" flags="nn" index="1ZRNhn" />
     </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5858074156537516430" name="jetbrains.mps.baseLanguage.javadoc.structure.ReturnBlockDocTag" flags="ng" index="x79VA">
+        <property id="5858074156537516431" name="text" index="x79VB" />
+      </concept>
+      <concept id="6832197706140518104" name="jetbrains.mps.baseLanguage.javadoc.structure.DocMethodParameterReference" flags="ng" index="zr_55" />
+      <concept id="6832197706140518103" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseParameterReference" flags="ng" index="zr_5a">
+        <reference id="6832197706140518108" name="param" index="zr_51" />
+      </concept>
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
+        <child id="5383422241790532083" name="tags" index="3nqlJM" />
+      </concept>
+      <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690881930" name="jetbrains.mps.baseLanguage.javadoc.structure.ParameterBlockDocTag" flags="ng" index="TUZQ0">
+        <property id="8465538089690881934" name="text" index="TUZQ4" />
+        <child id="6832197706140518123" name="parameter" index="zr_5Q" />
+      </concept>
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
+      </concept>
+    </language>
+    <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1176543928247" name="jetbrains.mps.lang.typesystem.structure.IsSubtypeExpression" flags="nn" index="3JuTUA">
+        <child id="1176543945045" name="subtypeExpression" index="3JuY14" />
+        <child id="1176543950311" name="supertypeExpression" index="3JuZjQ" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+    </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
@@ -401,9 +480,153 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="7nYU6yJudre" role="jymVt" />
+    <node concept="2YIFZL" id="7nYU6yJucGT" role="jymVt">
+      <property role="TrG5h" value="isEligibleForBigDecimal" />
+      <node concept="3clFbS" id="7nYU6yJucGU" role="3clF47">
+        <node concept="Jncv_" id="7nYU6yJ0Xhx" role="3cqZAp">
+          <ref role="JncvD" to="700h:6zmBjqUily5" resolve="CollectionType" />
+          <node concept="37vLTw" id="7nYU6yJuich" role="JncvB">
+            <ref role="3cqZAo" node="7nYU6yJucGX" resolve="type" />
+          </node>
+          <node concept="3clFbS" id="7nYU6yJ0Xh_" role="Jncv$">
+            <node concept="3cpWs8" id="7nYU6yJt9Gm" role="3cqZAp">
+              <node concept="3cpWsn" id="7nYU6yJt9Gn" role="3cpWs9">
+                <property role="TrG5h" value="isIntSubtype" />
+                <node concept="10P_77" id="7nYU6yJt9vt" role="1tU5fm" />
+                <node concept="3JuTUA" id="7nYU6yJt9Go" role="33vP2m">
+                  <node concept="2OqwBi" id="7nYU6yJt9Gp" role="3JuY14">
+                    <node concept="Jnkvi" id="7nYU6yJt9Gq" role="2Oq$k0">
+                      <ref role="1M0zk5" node="7nYU6yJ0XhB" resolve="collectionType" />
+                    </node>
+                    <node concept="3TrEf2" id="7nYU6yJt9Gr" role="2OqNvi">
+                      <ref role="3Tt5mk" to="700h:6zmBjqUily6" resolve="baseType" />
+                    </node>
+                  </node>
+                  <node concept="2YIFZM" id="7nYU6yJt9Gw" role="3JuZjQ">
+                    <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+                    <ref role="37wK5l" to="xfg9:2Qbt$1tTQcM" resolve="createIntegerType" />
+                    <node concept="10Nm6u" id="7nYU6yJt9Gx" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="7nYU6yJtaNz" role="3cqZAp">
+              <node concept="3cpWsn" id="7nYU6yJtaN$" role="3cpWs9">
+                <property role="TrG5h" value="isRealSubtype" />
+                <node concept="10P_77" id="7nYU6yJtaN_" role="1tU5fm" />
+                <node concept="3JuTUA" id="7nYU6yJtaNA" role="33vP2m">
+                  <node concept="2OqwBi" id="7nYU6yJtaNB" role="3JuY14">
+                    <node concept="Jnkvi" id="7nYU6yJtaNC" role="2Oq$k0">
+                      <ref role="1M0zk5" node="7nYU6yJ0XhB" resolve="collectionType" />
+                    </node>
+                    <node concept="3TrEf2" id="7nYU6yJtaND" role="2OqNvi">
+                      <ref role="3Tt5mk" to="700h:6zmBjqUily6" resolve="baseType" />
+                    </node>
+                  </node>
+                  <node concept="2YIFZM" id="7nYU6yJtbvd" role="3JuZjQ">
+                    <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+                    <ref role="37wK5l" to="xfg9:2Qbt$1tTQdc" resolve="createRealType" />
+                    <node concept="10Nm6u" id="7nYU6yJtbve" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="1XDbtFtIRSi" role="3cqZAp">
+              <node concept="1PaTwC" id="1XDbtFtIRSj" role="1aUNEU">
+                <node concept="3oM_SD" id="1XDbtFtIRSk" role="1PaTwD">
+                  <property role="3oM_SC" value="IntegerType" />
+                </node>
+                <node concept="3oM_SD" id="1XDbtFtIRWt" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="1XDbtFtIRWC" role="1PaTwD">
+                  <property role="3oM_SC" value="a" />
+                </node>
+                <node concept="3oM_SD" id="1XDbtFtIRWG" role="1PaTwD">
+                  <property role="3oM_SC" value="subType" />
+                </node>
+                <node concept="3oM_SD" id="1XDbtFtIRXh" role="1PaTwD">
+                  <property role="3oM_SC" value="of" />
+                </node>
+                <node concept="3oM_SD" id="1XDbtFtIRXv" role="1PaTwD">
+                  <property role="3oM_SC" value="RealType," />
+                </node>
+                <node concept="3oM_SD" id="1XDbtFtIRYe" role="1PaTwD">
+                  <property role="3oM_SC" value="but" />
+                </node>
+                <node concept="3oM_SD" id="1XDbtFtIRYA" role="1PaTwD">
+                  <property role="3oM_SC" value="has" />
+                </node>
+                <node concept="3oM_SD" id="1XDbtFtIS0g" role="1PaTwD">
+                  <property role="3oM_SC" value="a" />
+                </node>
+                <node concept="3oM_SD" id="1XDbtFtIS0z" role="1PaTwD">
+                  <property role="3oM_SC" value="dedicated" />
+                </node>
+                <node concept="3oM_SD" id="1XDbtFtIS1Z" role="1PaTwD">
+                  <property role="3oM_SC" value="check:" />
+                </node>
+                <node concept="3oM_SD" id="1XDbtFtIS2C" role="1PaTwD">
+                  <property role="3oM_SC" value="isEligibleForBigInteger()" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="7nYU6yJtbWK" role="3cqZAp">
+              <node concept="3clFbS" id="7nYU6yJtbWM" role="3clFbx">
+                <node concept="3cpWs6" id="7nYU6yJtdc3" role="3cqZAp">
+                  <node concept="3clFbT" id="7nYU6yJtdub" role="3cqZAk">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1Wc70l" id="7nYU6yJtc$f" role="3clFbw">
+                <node concept="3fqX7Q" id="7nYU6yJtcQB" role="3uHU7w">
+                  <node concept="37vLTw" id="7nYU6yJtd92" role="3fr31v">
+                    <ref role="3cqZAo" node="7nYU6yJt9Gn" resolve="isIntSubtype" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="7nYU6yJtcf_" role="3uHU7B">
+                  <ref role="3cqZAo" node="7nYU6yJtaN$" resolve="isRealSubtype" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="7nYU6yJ0XhB" role="JncvA">
+            <property role="TrG5h" value="collectionType" />
+            <node concept="2jxLKc" id="7nYU6yJ0XhC" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7nYU6yJumO9" role="3cqZAp">
+          <node concept="3clFbT" id="7nYU6yJun2h" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7nYU6yJucGV" role="1B3o_S" />
+      <node concept="10P_77" id="7nYU6yJucGW" role="3clF45" />
+      <node concept="37vLTG" id="7nYU6yJucGX" role="3clF46">
+        <property role="TrG5h" value="type" />
+        <node concept="3Tqbb2" id="7nYU6yJucGY" role="1tU5fm" />
+      </node>
+      <node concept="P$JXv" id="1XDbtFtISlC" role="lGtFl">
+        <node concept="TZ5HA" id="1XDbtFtISlD" role="TZ5H$">
+          <node concept="1dT_AC" id="1XDbtFtISlE" role="1dT_Ay">
+            <property role="1dT_AB" value="Checks whether the provided type is a CollectionType and collection values can be represented with BigDecimals" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1XDbtFtISlF" role="3nqlJM">
+          <property role="TUZQ4" value="a collection type node" />
+          <node concept="zr_55" id="1XDbtFtISlH" role="zr_5Q">
+            <ref role="zr_51" node="7nYU6yJucGX" resolve="type" />
+          </node>
+        </node>
+        <node concept="x79VA" id="1XDbtFtISlI" role="3nqlJM">
+          <property role="x79VB" value="true, if collection values can be represented with BigDecimals" />
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="4lRNjFWSwAQ" role="jymVt" />
     <node concept="2YIFZL" id="4lRNjFWSwEt" role="jymVt">
-      <property role="TrG5h" value="sum" />
+      <property role="TrG5h" value="sumAsBigDecimal" />
       <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
@@ -451,9 +674,6 @@
         <node concept="3cpWs8" id="4lRNjFWSwEB" role="3cqZAp">
           <node concept="3cpWsn" id="4lRNjFWSwEC" role="3cpWs9">
             <property role="TrG5h" value="sum" />
-            <node concept="3uibUv" id="4lRNjFWSwED" role="1tU5fm">
-              <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
-            </node>
             <node concept="2ShNRf" id="4lRNjFWUfmY" role="33vP2m">
               <node concept="1pGfFk" id="4lRNjFWUfw$" role="2ShVmc">
                 <ref role="37wK5l" to="xlxw:~BigDecimal.&lt;init&gt;(java.lang.String)" resolve="BigDecimal" />
@@ -461,6 +681,9 @@
                   <property role="Xl_RC" value="0" />
                 </node>
               </node>
+            </node>
+            <node concept="3uibUv" id="4lRNjFWSwED" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
             </node>
           </node>
         </node>
@@ -530,6 +753,203 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="7nYU6yJteaR" role="jymVt" />
+    <node concept="2YIFZL" id="7nYU6yJtgp2" role="jymVt">
+      <property role="TrG5h" value="isEligibleForBigInteger" />
+      <node concept="3clFbS" id="7nYU6yJtgp5" role="3clF47">
+        <node concept="Jncv_" id="7nYU6yJ3Fjf" role="3cqZAp">
+          <ref role="JncvD" to="700h:6zmBjqUily5" resolve="CollectionType" />
+          <node concept="37vLTw" id="7nYU6yJAig4" role="JncvB">
+            <ref role="3cqZAo" node="7nYU6yJthdH" resolve="type" />
+          </node>
+          <node concept="3clFbS" id="7nYU6yJ3Fjl" role="Jncv$">
+            <node concept="3clFbJ" id="7nYU6yJoXmV" role="3cqZAp">
+              <node concept="3clFbS" id="7nYU6yJoXmX" role="3clFbx">
+                <node concept="3cpWs6" id="7nYU6yJt8fp" role="3cqZAp">
+                  <node concept="3clFbT" id="7nYU6yJt8wZ" role="3cqZAk">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3JuTUA" id="7nYU6yJp03Z" role="3clFbw">
+                <node concept="2OqwBi" id="7nYU6yJp0$B" role="3JuY14">
+                  <node concept="Jnkvi" id="7nYU6yJp060" role="2Oq$k0">
+                    <ref role="1M0zk5" node="7nYU6yJ3Fjy" resolve="collectionType" />
+                  </node>
+                  <node concept="3TrEf2" id="7nYU6yJp103" role="2OqNvi">
+                    <ref role="3Tt5mk" to="700h:6zmBjqUily6" resolve="baseType" />
+                  </node>
+                </node>
+                <node concept="2YIFZM" id="7nYU6yJp2FE" role="3JuZjQ">
+                  <ref role="37wK5l" to="xfg9:2Qbt$1tTQcM" resolve="createIntegerType" />
+                  <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+                  <node concept="10Nm6u" id="7nYU6yJp2FF" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="7nYU6yJ3Fjy" role="JncvA">
+            <property role="TrG5h" value="collectionType" />
+            <node concept="2jxLKc" id="7nYU6yJ3Fjz" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7nYU6yJAj8x" role="3cqZAp">
+          <node concept="3clFbT" id="7nYU6yJAjkS" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7nYU6yJtfxP" role="1B3o_S" />
+      <node concept="10P_77" id="7nYU6yJtgnA" role="3clF45" />
+      <node concept="37vLTG" id="7nYU6yJthdH" role="3clF46">
+        <property role="TrG5h" value="type" />
+        <node concept="3Tqbb2" id="7nYU6yJthdG" role="1tU5fm" />
+      </node>
+      <node concept="P$JXv" id="1XDbtFtISIn" role="lGtFl">
+        <node concept="TZ5HA" id="1XDbtFtISIo" role="TZ5H$">
+          <node concept="1dT_AC" id="1XDbtFtISIp" role="1dT_Ay">
+            <property role="1dT_AB" value="Checks whether the provided type is a CollectionType and collection values can be represented with BigInteger" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1XDbtFtISIq" role="3nqlJM">
+          <property role="TUZQ4" value="a collection type node" />
+          <node concept="zr_55" id="1XDbtFtISIs" role="zr_5Q">
+            <ref role="zr_51" node="7nYU6yJthdH" resolve="type" />
+          </node>
+        </node>
+        <node concept="x79VA" id="1XDbtFtISIt" role="3nqlJM">
+          <property role="x79VB" value="true, if collection values can be represented with BigIntegers" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7nYU6yJ0B6t" role="jymVt" />
+    <node concept="2YIFZL" id="7nYU6yJ0$7s" role="jymVt">
+      <property role="TrG5h" value="sumAsBigInteger" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="7nYU6yJ0$7t" role="3clF47">
+        <node concept="3clFbJ" id="7nYU6yJ0$7u" role="3cqZAp">
+          <node concept="3clFbS" id="7nYU6yJ0$7v" role="3clFbx">
+            <node concept="3cpWs6" id="7nYU6yJ0$7w" role="3cqZAp">
+              <node concept="2ShNRf" id="7nYU6yJ0$7x" role="3cqZAk">
+                <node concept="1pGfFk" id="7nYU6yJ0$7y" role="2ShVmc">
+                  <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
+                  <node concept="Xl_RD" id="7nYU6yJ0$7z" role="37wK5m">
+                    <property role="Xl_RC" value="0" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7nYU6yJ0$7$" role="3clFbw">
+            <node concept="37vLTw" id="7nYU6yJ0$7_" role="2Oq$k0">
+              <ref role="3cqZAo" node="7nYU6yJ0$8a" resolve="c" />
+            </node>
+            <node concept="liA8E" id="7nYU6yJ0$7A" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Collection.isEmpty()" resolve="isEmpty" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7nYU6yJ0$7B" role="3cqZAp">
+          <node concept="3cpWsn" id="7nYU6yJ0$7C" role="3cpWs9">
+            <property role="TrG5h" value="o" />
+            <node concept="10Q1$e" id="7nYU6yJ0$7D" role="1tU5fm">
+              <node concept="3uibUv" id="7nYU6yJ0$7E" role="10Q1$1">
+                <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7nYU6yJ0$7F" role="33vP2m">
+              <node concept="37vLTw" id="7nYU6yJ0$7G" role="2Oq$k0">
+                <ref role="3cqZAo" node="7nYU6yJ0$8a" resolve="c" />
+              </node>
+              <node concept="liA8E" id="7nYU6yJ0$7H" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~Collection.toArray()" resolve="toArray" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7nYU6yJ0$7I" role="3cqZAp">
+          <node concept="3cpWsn" id="7nYU6yJ0$7J" role="3cpWs9">
+            <property role="TrG5h" value="sum" />
+            <node concept="2ShNRf" id="7nYU6yJ0$7K" role="33vP2m">
+              <node concept="1pGfFk" id="7nYU6yJ0$7L" role="2ShVmc">
+                <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
+                <node concept="Xl_RD" id="7nYU6yJ0$7M" role="37wK5m">
+                  <property role="Xl_RC" value="0" />
+                </node>
+              </node>
+            </node>
+            <node concept="3uibUv" id="7nYU6yJ0$7N" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7nYU6yJ0$7O" role="3cqZAp" />
+        <node concept="2Gpval" id="7nYU6yJ0$7P" role="3cqZAp">
+          <node concept="2GrKxI" id="7nYU6yJ0$7Q" role="2Gsz3X">
+            <property role="TrG5h" value="i" />
+          </node>
+          <node concept="3clFbS" id="7nYU6yJ0$7R" role="2LFqv$">
+            <node concept="3cpWs8" id="7nYU6yJ0$7S" role="3cqZAp">
+              <node concept="3cpWsn" id="7nYU6yJ0$7T" role="3cpWs9">
+                <property role="TrG5h" value="j" />
+                <node concept="3uibUv" id="7nYU6yJ0$7U" role="1tU5fm">
+                  <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
+                </node>
+                <node concept="1eOMI4" id="7nYU6yJ0$7V" role="33vP2m">
+                  <node concept="10QFUN" id="7nYU6yJ0$7W" role="1eOMHV">
+                    <node concept="3uibUv" id="7nYU6yJ0$7X" role="10QFUM">
+                      <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
+                    </node>
+                    <node concept="2GrUjf" id="7nYU6yJ0$7Y" role="10QFUP">
+                      <ref role="2Gs0qQ" node="7nYU6yJ0$7Q" resolve="i" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7nYU6yJ0$7Z" role="3cqZAp">
+              <node concept="37vLTI" id="7nYU6yJ0$80" role="3clFbG">
+                <node concept="2YIFZM" id="7nYU6yJ0$81" role="37vLTx">
+                  <ref role="37wK5l" to="dj6k:5l4AfSwK2gq" resolve="add" />
+                  <ref role="1Pybhc" to="dj6k:6IxV2nShzcy" resolve="AH" />
+                  <node concept="37vLTw" id="7nYU6yJ0$82" role="37wK5m">
+                    <ref role="3cqZAo" node="7nYU6yJ0$7T" resolve="j" />
+                  </node>
+                  <node concept="37vLTw" id="7nYU6yJ0$83" role="37wK5m">
+                    <ref role="3cqZAo" node="7nYU6yJ0$7J" resolve="sum" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="7nYU6yJ0$84" role="37vLTJ">
+                  <ref role="3cqZAo" node="7nYU6yJ0$7J" resolve="sum" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="37vLTw" id="7nYU6yJ0$85" role="2GsD0m">
+            <ref role="3cqZAo" node="7nYU6yJ0$7C" resolve="o" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7nYU6yJ0$86" role="3cqZAp">
+          <node concept="37vLTw" id="7nYU6yJ0$87" role="3cqZAk">
+            <ref role="3cqZAo" node="7nYU6yJ0$7J" resolve="sum" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7nYU6yJ0$88" role="1B3o_S" />
+      <node concept="3uibUv" id="7nYU6yJ0$89" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
+      </node>
+      <node concept="37vLTG" id="7nYU6yJ0$8a" role="3clF46">
+        <property role="TrG5h" value="c" />
+        <node concept="3uibUv" id="7nYU6yJ0$8b" role="1tU5fm">
+          <ref role="3uigEE" to="j10v:~PCollection" resolve="PCollection" />
+          <node concept="3uibUv" id="7nYU6yJ0$8c" role="11_B2D">
+            <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6F$KudFDoQB" role="jymVt" />
     <node concept="2YIFZL" id="4lRNjFX1Yzx" role="jymVt">
       <property role="TrG5h" value="sortAsc" />
       <property role="od$2w" value="false" />
@@ -697,8 +1117,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="2xYnvNihLh6" role="jymVt" />
-    <node concept="2tJIrI" id="2xYnvNihLBM" role="jymVt" />
-    <node concept="2tJIrI" id="2xYnvNiibGl" role="jymVt" />
     <node concept="2YIFZL" id="2xYnvNiicEB" role="jymVt">
       <property role="TrG5h" value="sortDesc" />
       <property role="od$2w" value="false" />
@@ -868,9 +1286,6 @@
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="2xYnvNiicbt" role="jymVt" />
-    <node concept="2tJIrI" id="4lRNjFWSwCr" role="jymVt" />
-    <node concept="2tJIrI" id="4lRNjFWSwfR" role="jymVt" />
     <node concept="3Tm1VV" id="4lRNjFWGzDd" role="1B3o_S" />
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.genjava.simpleTypes.rt/org.iets3.core.expr.genjava.simpleTypes.rt.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.genjava.simpleTypes.rt/org.iets3.core.expr.genjava.simpleTypes.rt.msd
@@ -15,6 +15,9 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)</dependency>
     <dependency reexport="false">52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)</dependency>
+    <dependency reexport="false">2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)</dependency>
+    <dependency reexport="false">6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)</dependency>
+    <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -9822,6 +9822,21 @@
             <ref role="3bR37D" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
           </node>
         </node>
+        <node concept="1SiIV0" id="2WhI0V05JRv" role="3bR37C">
+          <node concept="3bR9La" id="2WhI0V05JRw" role="1SiIV1">
+            <ref role="3bR37D" node="4C_RnzfEE1P" resolve="org.iets3.core.expr.base.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2WhI0V05JRx" role="3bR37C">
+          <node concept="3bR9La" id="2WhI0V05JRy" role="1SiIV1">
+            <ref role="3bR37D" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2WhI0V05JRz" role="3bR37C">
+          <node concept="3bR9La" id="2WhI0V05JR$" role="1SiIV1">
+            <ref role="3bR37D" node="6JPXQMQs0pX" resolve="org.iets3.core.expr.collections" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="5v$Gz_MUO6K" role="2G$12L">
         <property role="BnDLt" value="true" />


### PR DESCRIPTION
Improve generator for sumOp to consider the collection base type

Problem: The generator of sumOp always returned the result as a BigDecimal,
which is not obvious and a different behaviour compared to the interpreter.

Solution: The generator considers the collection base type. In case it's a NumberType,
it depends on the numbers precision whether the result will be a BigInteger or BigDecimal.