### PR TITLE
Don't use generic Object type for result of collection operations

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
@@ -5057,6 +5057,36 @@
                         <property role="TrG5h" value="origList" />
                         <node concept="3uibUv" id="2YSwz9FBc8D" role="1tU5fm">
                           <ref role="3uigEE" to="j10v:~PVector" resolve="PVector" />
+                          <node concept="3uibUv" id="ZMCvctH8f8" role="11_B2D">
+                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                            <node concept="29HgVG" id="ZMCvctHkIs" role="lGtFl">
+                              <node concept="3NFfHV" id="ZMCvctHkIt" role="3NFExx">
+                                <node concept="3clFbS" id="ZMCvctHkIu" role="2VODD2">
+                                  <node concept="3clFbF" id="ZMCvctHmtb" role="3cqZAp">
+                                    <node concept="2OqwBi" id="ZMCvctHmtc" role="3clFbG">
+                                      <node concept="1PxgMI" id="ZMCvctHmtd" role="2Oq$k0">
+                                        <node concept="chp4Y" id="ZMCvctHmte" role="3oSUPX">
+                                          <ref role="cht4Q" to="700h:6zmBjqUily5" resolve="CollectionType" />
+                                        </node>
+                                        <node concept="2OqwBi" id="ZMCvctHmtf" role="1m5AlR">
+                                          <node concept="2OqwBi" id="ZMCvctHmtg" role="2Oq$k0">
+                                            <node concept="3TrEf2" id="ZMCvctHmth" role="2OqNvi">
+                                              <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                                            </node>
+                                            <node concept="30H73N" id="ZMCvctHmti" role="2Oq$k0" />
+                                          </node>
+                                          <node concept="3JvlWi" id="ZMCvctHmtj" role="2OqNvi" />
+                                        </node>
+                                      </node>
+                                      <node concept="3TrEf2" id="ZMCvctHmtk" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="700h:6zmBjqUily6" resolve="baseType" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
                         </node>
                         <node concept="37vLTw" id="2YSwz9FBfTp" role="33vP2m">
                           <ref role="3cqZAo" node="7Pk458DyXut" resolve="tpv" />
@@ -5410,6 +5440,36 @@
                         <property role="TrG5h" value="origList" />
                         <node concept="3uibUv" id="2YSwz9FMPw1" role="1tU5fm">
                           <ref role="3uigEE" to="j10v:~PVector" resolve="PVector" />
+                          <node concept="3uibUv" id="ZMCvctHKl$" role="11_B2D">
+                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                            <node concept="29HgVG" id="ZMCvctHSjc" role="lGtFl">
+                              <node concept="3NFfHV" id="ZMCvctHSjd" role="3NFExx">
+                                <node concept="3clFbS" id="ZMCvctHSje" role="2VODD2">
+                                  <node concept="3clFbF" id="ZMCvctHYJx" role="3cqZAp">
+                                    <node concept="2OqwBi" id="ZMCvctHYJy" role="3clFbG">
+                                      <node concept="1PxgMI" id="ZMCvctHYJz" role="2Oq$k0">
+                                        <node concept="chp4Y" id="ZMCvctHYJ$" role="3oSUPX">
+                                          <ref role="cht4Q" to="700h:6zmBjqUily5" resolve="CollectionType" />
+                                        </node>
+                                        <node concept="2OqwBi" id="ZMCvctHYJ_" role="1m5AlR">
+                                          <node concept="2OqwBi" id="ZMCvctHYJA" role="2Oq$k0">
+                                            <node concept="3TrEf2" id="ZMCvctHYJB" role="2OqNvi">
+                                              <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                                            </node>
+                                            <node concept="30H73N" id="ZMCvctHYJC" role="2Oq$k0" />
+                                          </node>
+                                          <node concept="3JvlWi" id="ZMCvctHYJD" role="2OqNvi" />
+                                        </node>
+                                      </node>
+                                      <node concept="3TrEf2" id="ZMCvctHYJE" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="700h:6zmBjqUily6" resolve="baseType" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
                         </node>
                         <node concept="37vLTw" id="2YSwz9FMPw2" role="33vP2m">
                           <ref role="3cqZAo" node="7Pk458EOR9D" resolve="tpv" />
@@ -5673,6 +5733,36 @@
                   <property role="TrG5h" value="rev" />
                   <node concept="3uibUv" id="4F_NhVzDBJh" role="1tU5fm">
                     <ref role="3uigEE" to="j10v:~PVector" resolve="PVector" />
+                    <node concept="3uibUv" id="ZMCvctIHUJ" role="11_B2D">
+                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                      <node concept="29HgVG" id="ZMCvctIIrB" role="lGtFl">
+                        <node concept="3NFfHV" id="ZMCvctIIrC" role="3NFExx">
+                          <node concept="3clFbS" id="ZMCvctIIrD" role="2VODD2">
+                            <node concept="3clFbF" id="ZMCvctIVnF" role="3cqZAp">
+                              <node concept="2OqwBi" id="ZMCvctIVnG" role="3clFbG">
+                                <node concept="1PxgMI" id="ZMCvctIVnH" role="2Oq$k0">
+                                  <node concept="chp4Y" id="ZMCvctIVnI" role="3oSUPX">
+                                    <ref role="cht4Q" to="700h:6zmBjqUily5" resolve="CollectionType" />
+                                  </node>
+                                  <node concept="2OqwBi" id="ZMCvctIVnJ" role="1m5AlR">
+                                    <node concept="2OqwBi" id="ZMCvctIVnK" role="2Oq$k0">
+                                      <node concept="3TrEf2" id="ZMCvctIVnL" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                                      </node>
+                                      <node concept="30H73N" id="ZMCvctIVnM" role="2Oq$k0" />
+                                    </node>
+                                    <node concept="3JvlWi" id="ZMCvctIVnN" role="2OqNvi" />
+                                  </node>
+                                </node>
+                                <node concept="3TrEf2" id="ZMCvctIVnO" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="700h:6zmBjqUily6" resolve="baseType" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
                   </node>
                   <node concept="2YIFZM" id="4F_NhVzk$OA" role="33vP2m">
                     <ref role="1Pybhc" to="j10v:~Empty" resolve="Empty" />
@@ -6112,6 +6202,36 @@
                     <node concept="2YIFZM" id="3pkOvRwPnOe" role="37wK5m">
                       <ref role="37wK5l" to="1ctc:~Collectors.toList()" resolve="toList" />
                       <ref role="1Pybhc" to="1ctc:~Collectors" resolve="Collectors" />
+                      <node concept="3uibUv" id="ZMCvctwRIx" role="3PaCim">
+                        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                        <node concept="29HgVG" id="ZMCvctwVwQ" role="lGtFl">
+                          <node concept="3NFfHV" id="ZMCvctwVwR" role="3NFExx">
+                            <node concept="3clFbS" id="ZMCvctwVwS" role="2VODD2">
+                              <node concept="3clFbF" id="ZMCvctx5dp" role="3cqZAp">
+                                <node concept="2OqwBi" id="ZMCvctx5dr" role="3clFbG">
+                                  <node concept="1PxgMI" id="ZMCvctx5ds" role="2Oq$k0">
+                                    <node concept="chp4Y" id="ZMCvctx5dt" role="3oSUPX">
+                                      <ref role="cht4Q" to="700h:6zmBjqUily5" resolve="CollectionType" />
+                                    </node>
+                                    <node concept="2OqwBi" id="ZMCvctx5du" role="1m5AlR">
+                                      <node concept="2OqwBi" id="ZMCvctx5dv" role="2Oq$k0">
+                                        <node concept="3TrEf2" id="ZMCvctx5dw" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                                        </node>
+                                        <node concept="30H73N" id="ZMCvctx5dx" role="2Oq$k0" />
+                                      </node>
+                                      <node concept="3JvlWi" id="ZMCvctx5dy" role="2OqNvi" />
+                                    </node>
+                                  </node>
+                                  <node concept="3TrEf2" id="ZMCvctx5dz" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="700h:6zmBjqUily6" resolve="baseType" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -6847,6 +6967,36 @@
                     <node concept="2YIFZM" id="3pkOvRwoJMN" role="37wK5m">
                       <ref role="37wK5l" to="1ctc:~Collectors.toList()" resolve="toList" />
                       <ref role="1Pybhc" to="1ctc:~Collectors" resolve="Collectors" />
+                      <node concept="3uibUv" id="ZMCvctxulU" role="3PaCim">
+                        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                        <node concept="29HgVG" id="ZMCvctxGun" role="lGtFl">
+                          <node concept="3NFfHV" id="ZMCvctxGuo" role="3NFExx">
+                            <node concept="3clFbS" id="ZMCvctxGup" role="2VODD2">
+                              <node concept="3clFbF" id="DoUHVQS6N1" role="3cqZAp">
+                                <node concept="2OqwBi" id="DoUHVQS6N3" role="3clFbG">
+                                  <node concept="1PxgMI" id="DoUHVQS6N4" role="2Oq$k0">
+                                    <node concept="chp4Y" id="DoUHVQS6N5" role="3oSUPX">
+                                      <ref role="cht4Q" to="700h:6zmBjqUily5" resolve="CollectionType" />
+                                    </node>
+                                    <node concept="2OqwBi" id="DoUHVQS6N6" role="1m5AlR">
+                                      <node concept="2OqwBi" id="DoUHVQS6N7" role="2Oq$k0">
+                                        <node concept="3TrEf2" id="DoUHVQS6N8" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                                        </node>
+                                        <node concept="30H73N" id="DoUHVQS6N9" role="2Oq$k0" />
+                                      </node>
+                                      <node concept="3JvlWi" id="DoUHVQS6Na" role="2OqNvi" />
+                                    </node>
+                                  </node>
+                                  <node concept="3TrEf2" id="DoUHVQS6Nb" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="700h:6zmBjqUily6" resolve="baseType" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -7058,6 +7208,36 @@
                     <node concept="2YIFZM" id="27xhIwg4nyK" role="37wK5m">
                       <ref role="37wK5l" to="1ctc:~Collectors.toList()" resolve="toList" />
                       <ref role="1Pybhc" to="1ctc:~Collectors" resolve="Collectors" />
+                      <node concept="3uibUv" id="ZMCvctxVAS" role="3PaCim">
+                        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                        <node concept="29HgVG" id="ZMCvcty95d" role="lGtFl">
+                          <node concept="3NFfHV" id="ZMCvcty95e" role="3NFExx">
+                            <node concept="3clFbS" id="ZMCvcty95f" role="2VODD2">
+                              <node concept="3clFbF" id="ZMCvctybKL" role="3cqZAp">
+                                <node concept="2OqwBi" id="ZMCvctybKN" role="3clFbG">
+                                  <node concept="1PxgMI" id="ZMCvctybKO" role="2Oq$k0">
+                                    <node concept="chp4Y" id="ZMCvctybKP" role="3oSUPX">
+                                      <ref role="cht4Q" to="700h:6zmBjqUily5" resolve="CollectionType" />
+                                    </node>
+                                    <node concept="2OqwBi" id="ZMCvctybKQ" role="1m5AlR">
+                                      <node concept="2OqwBi" id="ZMCvctybKR" role="2Oq$k0">
+                                        <node concept="3TrEf2" id="ZMCvctybKS" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                                        </node>
+                                        <node concept="30H73N" id="ZMCvctybKT" role="2Oq$k0" />
+                                      </node>
+                                      <node concept="3JvlWi" id="ZMCvctybKU" role="2OqNvi" />
+                                    </node>
+                                  </node>
+                                  <node concept="3TrEf2" id="ZMCvctybKV" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="700h:6zmBjqUily6" resolve="baseType" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -8404,6 +8584,36 @@
                             <node concept="2YIFZM" id="7q4cgljJ7l$" role="37wK5m">
                               <ref role="37wK5l" to="1ctc:~Collectors.toList()" resolve="toList" />
                               <ref role="1Pybhc" to="1ctc:~Collectors" resolve="Collectors" />
+                              <node concept="3uibUv" id="ZMCvctzQPs" role="3PaCim">
+                                <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                                <node concept="29HgVG" id="ZMCvct$3ZB" role="lGtFl">
+                                  <node concept="3NFfHV" id="ZMCvct$3ZC" role="3NFExx">
+                                    <node concept="3clFbS" id="ZMCvct$3ZD" role="2VODD2">
+                                      <node concept="3clFbF" id="ZMCvct$6ER" role="3cqZAp">
+                                        <node concept="2OqwBi" id="ZMCvct$6ET" role="3clFbG">
+                                          <node concept="1PxgMI" id="ZMCvct$6EU" role="2Oq$k0">
+                                            <node concept="chp4Y" id="ZMCvct$6EV" role="3oSUPX">
+                                              <ref role="cht4Q" to="700h:6zmBjqUily5" resolve="CollectionType" />
+                                            </node>
+                                            <node concept="2OqwBi" id="ZMCvct$6EW" role="1m5AlR">
+                                              <node concept="2OqwBi" id="ZMCvct$6EX" role="2Oq$k0">
+                                                <node concept="3TrEf2" id="ZMCvct$6EY" role="2OqNvi">
+                                                  <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                                                </node>
+                                                <node concept="30H73N" id="ZMCvct$6EZ" role="2Oq$k0" />
+                                              </node>
+                                              <node concept="3JvlWi" id="ZMCvct$6F0" role="2OqNvi" />
+                                            </node>
+                                          </node>
+                                          <node concept="3TrEf2" id="ZMCvct$6F1" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="700h:6zmBjqUily6" resolve="baseType" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
                             </node>
                           </node>
                         </node>


### PR DESCRIPTION
This pull request fixes cases where collection operations fall back to the Object type when calling collect(Collectors.toList()) in the generator and the original type is not available.

Example: Some operations (distinct, lastN) return list&lt;Object&gt; instead of list&lt;Days&gt; and cast errors occur.
```
qualified enum Days { A, B, C }                                                                                                                                                                 
                                                                                                                                                                                                
fun days() : list<Days> { 
  val ds = list(Days:A) 
  ds.distinct.distinct.lastN(10).firstN(10).reverse.withAll(ds.lastN(1)).with(Days:A).without(Days:B).pick[list(1)].where(|it == Days:A|) 
}
```