### PR TITLE
Override baseType() in CollectionType

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/behavior.mps
@@ -1291,6 +1291,24 @@
         <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
       </node>
     </node>
+    <node concept="13i0hz" id="1IYzzr$ULqk" role="13h7CS">
+      <property role="TrG5h" value="baseType" />
+      <ref role="13i0hy" to="pbu6:XhdFKv3UAU" resolve="baseType" />
+      <node concept="3Tm1VV" id="1IYzzr$ULql" role="1B3o_S" />
+      <node concept="3clFbS" id="1IYzzr$ULqq" role="3clF47">
+        <node concept="3clFbF" id="1IYzzr$UMts" role="3cqZAp">
+          <node concept="2OqwBi" id="1IYzzr$UNcd" role="3clFbG">
+            <node concept="13iPFW" id="1IYzzr$UMZ9" role="2Oq$k0" />
+            <node concept="2qgKlT" id="1IYzzr$UNwx" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:3oWFox95OZf" resolve="getBaseType" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="1IYzzr$ULqr" role="3clF45">
+        <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+      </node>
+    </node>
     <node concept="13i0hz" id="5L2mTKm_pxP" role="13h7CS">
       <property role="TrG5h" value="isSameAs" />
       <property role="13i0it" value="false" />


### PR DESCRIPTION
The original request was for implementing baseType() In ListType, but it seems to make sense to implement in CollectionType. There are two different baseType() methods, only one was implemented through inheritance.