### PR TITLE
Change layout of map literal(vertical editor)

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/editor.mps
@@ -34,6 +34,7 @@
       </concept>
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
+      <concept id="1237308012275" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineStyleClassItem" flags="ln" index="ljvvj" />
       <concept id="784421273959492578" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_IncludeMenu" flags="ng" index="mvV$s">
         <child id="784421273959492606" name="nodeFunction" index="mvV$0" />
       </concept>
@@ -769,6 +770,11 @@
         <node concept="3F0ifn" id="7kYh9Wszg3w" role="2czzBI">
           <property role="3F0ifm" value="" />
           <node concept="VPxyj" id="7kYh9Wszg4m" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="tppnM" id="1IYzzr$ldBF" role="sWeuL">
+          <node concept="ljvvj" id="1IYzzr$ldBH" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
         </node>


### PR DESCRIPTION
Original request: 
_Can the list of KeyValuePairs in the MapLiteral editor be changed from identical to VerticalGrid? A map is usually useful with many elements - and there the current editor with a line or non-flush vertical termination just does not look nice._

I changed the indent layout to look like a vertical layout. I didn't like the original request because the separators would all be on a separate lines which doesn't look good. @lhartl what do you think of this change in general?