### PR TITLE
Fix transform explicit lambdas into short lambdas

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
@@ -70,6 +70,9 @@
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
+      <concept id="1177666668936" name="jetbrains.mps.baseLanguage.structure.DoWhileStatement" flags="nn" index="MpOyq">
+        <child id="1177666688034" name="condition" index="MpTkK" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -110,6 +113,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -276,7 +280,7 @@
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
-      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
@@ -1395,67 +1399,86 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbJ" id="7cphKbKZslh" role="3cqZAp">
-                    <node concept="3clFbS" id="7cphKbKZslj" role="3clFbx">
-                      <node concept="3clFbF" id="49WTic8eCyZ" role="3cqZAp">
-                        <node concept="2OqwBi" id="49WTic8eCA1" role="3clFbG">
-                          <node concept="37vLTw" id="49WTic8eCyY" role="2Oq$k0">
-                            <ref role="3cqZAo" node="49WTic8eCwS" resolve="it" />
+                  <node concept="3cpWs8" id="2O0w_v2Ikd2" role="3cqZAp">
+                    <node concept="3cpWsn" id="2O0w_v2Ikd5" role="3cpWs9">
+                      <property role="TrG5h" value="currentNode" />
+                      <node concept="3Tqbb2" id="2O0w_v2Ikd0" role="1tU5fm" />
+                      <node concept="37vLTw" id="7C7MSq_8OcI" role="33vP2m">
+                        <ref role="3cqZAo" node="49WTic8eCwS" resolve="it" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="MpOyq" id="2O0w_v2InZD" role="3cqZAp">
+                    <node concept="3clFbS" id="2O0w_v2InZF" role="2LFqv$">
+                      <node concept="3clFbF" id="2O0w_v2IpWK" role="3cqZAp">
+                        <node concept="37vLTI" id="2O0w_v2Iq80" role="3clFbG">
+                          <node concept="2OqwBi" id="2O0w_v2IqnD" role="37vLTx">
+                            <node concept="37vLTw" id="7C7MSq_8OqX" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2O0w_v2Ikd5" resolve="currentNode" />
+                            </node>
+                            <node concept="1mfA1w" id="2O0w_v2Ir4a" role="2OqNvi" />
                           </node>
-                          <node concept="1P9Npp" id="49WTic8eCFh" role="2OqNvi">
-                            <node concept="2pJPEk" id="49WTic8eCHY" role="1P9ThW">
-                              <node concept="2pJPED" id="49WTic8eCKF" role="2pJPEn">
-                                <ref role="2pJxaS" to="zzzn:6zmBjqUkHal" resolve="LambdaArgRef" />
-                                <node concept="2pIpSj" id="49WTic8eCQh" role="2pJxcM">
-                                  <ref role="2pIpSl" to="zzzn:6zmBjqUkHam" resolve="arg" />
-                                  <node concept="36biLy" id="49WTic8eDst" role="28nt2d">
-                                    <node concept="37vLTw" id="49WTic8eDuU" role="36biLW">
-                                      <ref role="3cqZAo" node="49WTic8eCUf" resolve="arg" />
+                          <node concept="37vLTw" id="2O0w_v2IpWJ" role="37vLTJ">
+                            <ref role="3cqZAo" node="2O0w_v2Ikd5" resolve="currentNode" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbJ" id="2O0w_v2IrGw" role="3cqZAp">
+                        <node concept="3clFbS" id="2O0w_v2IrGy" role="3clFbx">
+                          <node concept="3cpWs6" id="2O0w_v2Itvr" role="3cqZAp" />
+                        </node>
+                        <node concept="2OqwBi" id="2O0w_v2IsdM" role="3clFbw">
+                          <node concept="37vLTw" id="2O0w_v2Is2F" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2O0w_v2Ikd5" resolve="currentNode" />
+                          </node>
+                          <node concept="1mIQ4w" id="2O0w_v2IsKe" role="2OqNvi">
+                            <node concept="chp4Y" id="2O0w_v2It1d" role="cj9EA">
+                              <ref role="cht4Q" to="zzzn:6zmBjqUm7MQ" resolve="ShortLambdaExpression" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbJ" id="2O0w_v2Iu2Q" role="3cqZAp">
+                        <node concept="3clFbS" id="2O0w_v2Iu2S" role="3clFbx">
+                          <node concept="3clFbF" id="49WTic8eCyZ" role="3cqZAp">
+                            <node concept="2OqwBi" id="49WTic8eCA1" role="3clFbG">
+                              <node concept="37vLTw" id="49WTic8eCyY" role="2Oq$k0">
+                                <ref role="3cqZAo" node="49WTic8eCwS" resolve="it" />
+                              </node>
+                              <node concept="1P9Npp" id="49WTic8eCFh" role="2OqNvi">
+                                <node concept="2pJPEk" id="49WTic8eCHY" role="1P9ThW">
+                                  <node concept="2pJPED" id="49WTic8eCKF" role="2pJPEn">
+                                    <ref role="2pJxaS" to="zzzn:6zmBjqUkHal" resolve="LambdaArgRef" />
+                                    <node concept="2pIpSj" id="49WTic8eCQh" role="2pJxcM">
+                                      <ref role="2pIpSl" to="zzzn:6zmBjqUkHam" resolve="arg" />
+                                      <node concept="36biLy" id="49WTic8eDst" role="28nt2d">
+                                        <node concept="37vLTw" id="49WTic8eDuU" role="36biLW">
+                                          <ref role="3cqZAo" node="49WTic8eCUf" resolve="arg" />
+                                        </node>
+                                      </node>
                                     </node>
                                   </node>
                                 </node>
                               </node>
                             </node>
                           </node>
+                          <node concept="3cpWs6" id="2O0w_v2IxAL" role="3cqZAp" />
+                        </node>
+                        <node concept="17R0WA" id="2O0w_v2IvUw" role="3clFbw">
+                          <node concept="37vLTw" id="2O0w_v2Iwp0" role="3uHU7w">
+                            <ref role="3cqZAo" node="49WTic8ey5D" resolve="le" />
+                          </node>
+                          <node concept="37vLTw" id="2O0w_v2Iurt" role="3uHU7B">
+                            <ref role="3cqZAo" node="2O0w_v2Ikd5" resolve="currentNode" />
+                          </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="1Wc70l" id="7cphKbKZQYW" role="3clFbw">
-                      <node concept="2OqwBi" id="7cphKbKZSbM" role="3uHU7w">
-                        <node concept="2OqwBi" id="7cphKbKZRrI" role="2Oq$k0">
-                          <node concept="37vLTw" id="7cphKbKZR93" role="2Oq$k0">
-                            <ref role="3cqZAo" node="49WTic8eCwS" resolve="it" />
-                          </node>
-                          <node concept="2Xjw5R" id="7cphKbKZRGP" role="2OqNvi">
-                            <node concept="1xMEDy" id="7cphKbKZRGR" role="1xVPHs">
-                              <node concept="chp4Y" id="7cphKbKZRRm" role="ri$Ld">
-                                <ref role="cht4Q" to="zzzn:6zmBjqUm7MQ" resolve="ShortLambdaExpression" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3w_OXm" id="7cphKbKZT6H" role="2OqNvi" />
+                    <node concept="2OqwBi" id="2O0w_v2Ioul" role="MpTkK">
+                      <node concept="37vLTw" id="2O0w_v2Iojr" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2O0w_v2Ikd5" resolve="currentNode" />
                       </node>
-                      <node concept="3clFbC" id="7cphKbKZDbs" role="3uHU7B">
-                        <node concept="2OqwBi" id="7cphKbKZyNA" role="3uHU7B">
-                          <node concept="2OqwBi" id="7cphKbKZsxf" role="2Oq$k0">
-                            <node concept="37vLTw" id="7cphKbKZslz" role="2Oq$k0">
-                              <ref role="3cqZAo" node="49WTic8eCwS" resolve="it" />
-                            </node>
-                            <node concept="z$bX8" id="7cphKbKZt4m" role="2OqNvi">
-                              <node concept="1xMEDy" id="7cphKbKZvOA" role="1xVPHs">
-                                <node concept="chp4Y" id="7cphKbKZvRC" role="ri$Ld">
-                                  <ref role="cht4Q" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="1uHKPH" id="7cphKbKZATZ" role="2OqNvi" />
-                        </node>
-                        <node concept="37vLTw" id="7cphKbKZDbJ" role="3uHU7w">
-                          <ref role="3cqZAo" node="49WTic8ey5D" resolve="le" />
-                        </node>
-                      </node>
+                      <node concept="3x8VRR" id="2O0w_v2IoX_" role="2OqNvi" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/editor.mps
@@ -622,8 +622,8 @@
                 <node concept="pncrf" id="6vzDuv93rXy" role="2Oq$k0" />
                 <node concept="2Xjw5R" id="6vzDuv93so5" role="2OqNvi">
                   <node concept="1xMEDy" id="6vzDuv93so7" role="1xVPHs">
-                    <node concept="chp4Y" id="6vzDuv93sve" role="ri$Ld">
-                      <ref role="cht4Q" to="zzzn:6zmBjqUm7Mf" resolve="IShortLambdaContainer" />
+                    <node concept="chp4Y" id="7C7MSq_b4wb" role="ri$Ld">
+                      <ref role="cht4Q" to="zzzn:6zmBjqUm7MQ" resolve="ShortLambdaExpression" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/intentions.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/intentions.mps
@@ -173,11 +173,12 @@
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
-      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
   <node concept="2S6QgY" id="49WTic8ewUk">
@@ -387,23 +388,84 @@
                 </node>
               </node>
             </node>
-            <node concept="2OqwBi" id="1iunvDRYEnM" role="3uHU7w">
-              <node concept="2OqwBi" id="1iunvDRY_qH" role="2Oq$k0">
-                <node concept="2OqwBi" id="1iunvDRYznp" role="2Oq$k0">
-                  <node concept="2Sf5sV" id="1iunvDRYyX6" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="1iunvDRY$$F" role="2OqNvi">
-                    <ref role="3Tt5mk" to="zzzn:6zmBjqUkwH3" resolve="expression" />
+            <node concept="3fqX7Q" id="4hUtPTIY8QE" role="3uHU7w">
+              <node concept="2OqwBi" id="4hUtPTIY8QG" role="3fr31v">
+                <node concept="2OqwBi" id="4hUtPTIY8QH" role="2Oq$k0">
+                  <node concept="2OqwBi" id="4hUtPTIY8QI" role="2Oq$k0">
+                    <node concept="2Sf5sV" id="4hUtPTIY8QJ" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="4hUtPTIY8QK" role="2OqNvi">
+                      <ref role="3Tt5mk" to="zzzn:6zmBjqUkwH3" resolve="expression" />
+                    </node>
+                  </node>
+                  <node concept="2Rf3mk" id="4hUtPTIY8QL" role="2OqNvi">
+                    <node concept="1xMEDy" id="4hUtPTIY8QM" role="1xVPHs">
+                      <node concept="chp4Y" id="4hUtPTIY8QN" role="ri$Ld">
+                        <ref role="cht4Q" to="zzzn:6zmBjqUm7MQ" resolve="ShortLambdaExpression" />
+                      </node>
+                    </node>
                   </node>
                 </node>
-                <node concept="2Rf3mk" id="1iunvDRY_Rf" role="2OqNvi">
-                  <node concept="1xMEDy" id="1iunvDRY_Rh" role="1xVPHs">
-                    <node concept="chp4Y" id="1iunvDRYAw3" role="ri$Ld">
-                      <ref role="cht4Q" to="zzzn:6zmBjqUm7MQ" resolve="ShortLambdaExpression" />
+                <node concept="2HwmR7" id="4hUtPTIY8QO" role="2OqNvi">
+                  <node concept="1bVj0M" id="4hUtPTIY8QP" role="23t8la">
+                    <node concept="3clFbS" id="4hUtPTIY8QQ" role="1bW5cS">
+                      <node concept="3clFbF" id="4hUtPTIY8QR" role="3cqZAp">
+                        <node concept="2OqwBi" id="4hUtPTIY8QS" role="3clFbG">
+                          <node concept="2OqwBi" id="4hUtPTIY8QT" role="2Oq$k0">
+                            <node concept="2OqwBi" id="4hUtPTIY8QU" role="2Oq$k0">
+                              <node concept="37vLTw" id="4hUtPTIY8QV" role="2Oq$k0">
+                                <ref role="3cqZAo" node="4hUtPTIY8Rf" resolve="shortLambda" />
+                              </node>
+                              <node concept="2Rf3mk" id="4hUtPTIY8QW" role="2OqNvi">
+                                <node concept="1xMEDy" id="4hUtPTIY8QX" role="1xVPHs">
+                                  <node concept="chp4Y" id="4hUtPTIY8QY" role="ri$Ld">
+                                    <ref role="cht4Q" to="zzzn:6zmBjqUkHal" resolve="LambdaArgRef" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3zZkjj" id="4hUtPTIY8QZ" role="2OqNvi">
+                              <node concept="1bVj0M" id="4hUtPTIY8R0" role="23t8la">
+                                <node concept="3clFbS" id="4hUtPTIY8R1" role="1bW5cS">
+                                  <node concept="3clFbF" id="4hUtPTIY8R2" role="3cqZAp">
+                                    <node concept="17R0WA" id="4hUtPTIY8R3" role="3clFbG">
+                                      <node concept="2OqwBi" id="4hUtPTIY8R4" role="3uHU7w">
+                                        <node concept="2OqwBi" id="4hUtPTIY8R5" role="2Oq$k0">
+                                          <node concept="2Sf5sV" id="4hUtPTIY8R6" role="2Oq$k0" />
+                                          <node concept="3Tsc0h" id="4hUtPTIY8R7" role="2OqNvi">
+                                            <ref role="3TtcxE" to="zzzn:6zmBjqUkws7" resolve="args" />
+                                          </node>
+                                        </node>
+                                        <node concept="1uHKPH" id="4hUtPTIY8R8" role="2OqNvi" />
+                                      </node>
+                                      <node concept="2OqwBi" id="4hUtPTIY8R9" role="3uHU7B">
+                                        <node concept="37vLTw" id="4hUtPTIY8Ra" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="4hUtPTIY8Rc" resolve="it" />
+                                        </node>
+                                        <node concept="3TrEf2" id="4hUtPTIY8Rb" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="zzzn:6zmBjqUkHam" resolve="arg" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="Rh6nW" id="4hUtPTIY8Rc" role="1bW2Oz">
+                                  <property role="TrG5h" value="it" />
+                                  <node concept="2jxLKc" id="4hUtPTIY8Rd" role="1tU5fm" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3GX2aA" id="4hUtPTIY9W1" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="4hUtPTIY8Rf" role="1bW2Oz">
+                      <property role="TrG5h" value="shortLambda" />
+                      <node concept="2jxLKc" id="4hUtPTIY8Rg" role="1tU5fm" />
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="1v1jN8" id="1iunvDRYHq3" role="2OqNvi" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/intentions.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/intentions.mps
@@ -173,10 +173,10 @@
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
-      <concept id="1235566831861" name="jetbrains.mps.baseLanguage.collections.structure.AllOperation" flags="nn" index="2HxqBE" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
     </language>
   </registry>
@@ -360,99 +360,6 @@
       <node concept="3clFbS" id="49WTic8eHbt" role="2VODD2">
         <node concept="3clFbF" id="49WTic8eHc_" role="3cqZAp">
           <node concept="1Wc70l" id="8xLOUt08m5" role="3clFbG">
-            <node concept="2OqwBi" id="8xLOUt0vDi" role="3uHU7w">
-              <node concept="2OqwBi" id="8xLOUt0fWy" role="2Oq$k0">
-                <node concept="2OqwBi" id="8xLOUt0b5x" role="2Oq$k0">
-                  <node concept="2OqwBi" id="8xLOUt09i1" role="2Oq$k0">
-                    <node concept="2Sf5sV" id="8xLOUt08V_" role="2Oq$k0" />
-                    <node concept="3TrEf2" id="8xLOUt09Sn" role="2OqNvi">
-                      <ref role="3Tt5mk" to="zzzn:6zmBjqUkwH3" resolve="expression" />
-                    </node>
-                  </node>
-                  <node concept="2Rf3mk" id="8xLOUt0bwb" role="2OqNvi">
-                    <node concept="1xMEDy" id="8xLOUt0bwd" role="1xVPHs">
-                      <node concept="chp4Y" id="8xLOUt0c0v" role="ri$Ld">
-                        <ref role="cht4Q" to="zzzn:6zmBjqUkHal" resolve="LambdaArgRef" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3zZkjj" id="8xLOUt0j5j" role="2OqNvi">
-                  <node concept="1bVj0M" id="8xLOUt0j5l" role="23t8la">
-                    <node concept="3clFbS" id="8xLOUt0j5m" role="1bW5cS">
-                      <node concept="3clFbF" id="8xLOUt0jnu" role="3cqZAp">
-                        <node concept="17R0WA" id="8xLOUt0lqz" role="3clFbG">
-                          <node concept="2OqwBi" id="8xLOUt0qZD" role="3uHU7w">
-                            <node concept="2OqwBi" id="8xLOUt0mEj" role="2Oq$k0">
-                              <node concept="2Sf5sV" id="8xLOUt0mdg" role="2Oq$k0" />
-                              <node concept="3Tsc0h" id="8xLOUt0no2" role="2OqNvi">
-                                <ref role="3TtcxE" to="zzzn:6zmBjqUkws7" resolve="args" />
-                              </node>
-                            </node>
-                            <node concept="1uHKPH" id="8xLOUt0u3b" role="2OqNvi" />
-                          </node>
-                          <node concept="2OqwBi" id="8xLOUt0jLd" role="3uHU7B">
-                            <node concept="37vLTw" id="8xLOUt0jnt" role="2Oq$k0">
-                              <ref role="3cqZAo" node="8xLOUt0j5n" resolve="it" />
-                            </node>
-                            <node concept="3TrEf2" id="8xLOUt0kSb" role="2OqNvi">
-                              <ref role="3Tt5mk" to="zzzn:6zmBjqUkHam" resolve="arg" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="Rh6nW" id="8xLOUt0j5n" role="1bW2Oz">
-                      <property role="TrG5h" value="it" />
-                      <node concept="2jxLKc" id="8xLOUt0j5o" role="1tU5fm" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2HxqBE" id="8xLOUt0w3K" role="2OqNvi">
-                <node concept="1bVj0M" id="8xLOUt0w3M" role="23t8la">
-                  <node concept="3clFbS" id="8xLOUt0w3N" role="1bW5cS">
-                    <node concept="3clFbF" id="8xLOUt0wVB" role="3cqZAp">
-                      <node concept="17R0WA" id="8xLOUt8Odh" role="3clFbG">
-                        <node concept="2OqwBi" id="8xLOUt8Pfg" role="3uHU7w">
-                          <node concept="37vLTw" id="8xLOUt8P4A" role="2Oq$k0">
-                            <ref role="3cqZAo" node="8xLOUt0w3O" resolve="it" />
-                          </node>
-                          <node concept="2Xjw5R" id="8xLOUt8Qai" role="2OqNvi">
-                            <node concept="1xMEDy" id="8xLOUt8Qak" role="1xVPHs">
-                              <node concept="chp4Y" id="8xLOUt8Qs3" role="ri$Ld">
-                                <ref role="cht4Q" to="zzzn:2D48zR6a1ez" resolve="ILambdaLike" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="2OqwBi" id="8xLOUt0ziz" role="3uHU7B">
-                          <node concept="2OqwBi" id="8xLOUt0xl0" role="2Oq$k0">
-                            <node concept="37vLTw" id="8xLOUt0wVA" role="2Oq$k0">
-                              <ref role="3cqZAo" node="8xLOUt0w3O" resolve="it" />
-                            </node>
-                            <node concept="3TrEf2" id="8xLOUt0xTQ" role="2OqNvi">
-                              <ref role="3Tt5mk" to="zzzn:6zmBjqUkHam" resolve="arg" />
-                            </node>
-                          </node>
-                          <node concept="2Xjw5R" id="8xLOUt8MJf" role="2OqNvi">
-                            <node concept="1xMEDy" id="8xLOUt8MJh" role="1xVPHs">
-                              <node concept="chp4Y" id="8xLOUt8NFL" role="ri$Ld">
-                                <ref role="cht4Q" to="zzzn:2D48zR6a1ez" resolve="ILambdaLike" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="Rh6nW" id="8xLOUt0w3O" role="1bW2Oz">
-                    <property role="TrG5h" value="it" />
-                    <node concept="2jxLKc" id="8xLOUt0w3P" role="1tU5fm" />
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="1Wc70l" id="49WTic8eIOc" role="3uHU7B">
               <node concept="2OqwBi" id="49WTic8eHry" role="3uHU7B">
                 <node concept="2OqwBi" id="49WTic8eHfC" role="2Oq$k0">
@@ -479,6 +386,24 @@
                   <property role="3cmrfH" value="1" />
                 </node>
               </node>
+            </node>
+            <node concept="2OqwBi" id="1iunvDRYEnM" role="3uHU7w">
+              <node concept="2OqwBi" id="1iunvDRY_qH" role="2Oq$k0">
+                <node concept="2OqwBi" id="1iunvDRYznp" role="2Oq$k0">
+                  <node concept="2Sf5sV" id="1iunvDRYyX6" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="1iunvDRY$$F" role="2OqNvi">
+                    <ref role="3Tt5mk" to="zzzn:6zmBjqUkwH3" resolve="expression" />
+                  </node>
+                </node>
+                <node concept="2Rf3mk" id="1iunvDRY_Rf" role="2OqNvi">
+                  <node concept="1xMEDy" id="1iunvDRY_Rh" role="1xVPHs">
+                    <node concept="chp4Y" id="1iunvDRYAw3" role="ri$Ld">
+                      <ref role="cht4Q" to="zzzn:6zmBjqUm7MQ" resolve="ShortLambdaExpression" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1v1jN8" id="1iunvDRYHq3" role="2OqNvi" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/intentions.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/intentions.mps
@@ -43,6 +43,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -172,8 +173,11 @@
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1235566831861" name="jetbrains.mps.baseLanguage.collections.structure.AllOperation" flags="nn" index="2HxqBE" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
     </language>
   </registry>
   <node concept="2S6QgY" id="49WTic8ewUk">
@@ -264,19 +268,52 @@
         </node>
         <node concept="3clFbF" id="49WTic8eIvM" role="3cqZAp">
           <node concept="2OqwBi" id="49WTic8eMSy" role="3clFbG">
-            <node concept="2OqwBi" id="49WTic8eIGg" role="2Oq$k0">
-              <node concept="2OqwBi" id="49WTic8eIyr" role="2Oq$k0">
-                <node concept="37vLTw" id="49WTic8eIvK" role="2Oq$k0">
-                  <ref role="3cqZAo" node="49WTic8eHNn" resolve="sle" />
+            <node concept="2OqwBi" id="8xLOUtapU_" role="2Oq$k0">
+              <node concept="2OqwBi" id="49WTic8eIGg" role="2Oq$k0">
+                <node concept="2OqwBi" id="49WTic8eIyr" role="2Oq$k0">
+                  <node concept="3TrEf2" id="49WTic8eIBz" role="2OqNvi">
+                    <ref role="3Tt5mk" to="zzzn:6zmBjqUm7MR" resolve="expression" />
+                  </node>
+                  <node concept="37vLTw" id="49WTic8eIvK" role="2Oq$k0">
+                    <ref role="3cqZAo" node="49WTic8eHNn" resolve="sle" />
+                  </node>
                 </node>
-                <node concept="3TrEf2" id="49WTic8eIBz" role="2OqNvi">
-                  <ref role="3Tt5mk" to="zzzn:6zmBjqUm7MR" resolve="expression" />
+                <node concept="2Rf3mk" id="49WTic8eMt6" role="2OqNvi">
+                  <node concept="1xMEDy" id="49WTic8eMt8" role="1xVPHs">
+                    <node concept="chp4Y" id="49WTic8eMvj" role="ri$Ld">
+                      <ref role="cht4Q" to="zzzn:6zmBjqUkHal" resolve="LambdaArgRef" />
+                    </node>
+                  </node>
                 </node>
               </node>
-              <node concept="2Rf3mk" id="49WTic8eMt6" role="2OqNvi">
-                <node concept="1xMEDy" id="49WTic8eMt8" role="1xVPHs">
-                  <node concept="chp4Y" id="49WTic8eMvj" role="ri$Ld">
-                    <ref role="cht4Q" to="zzzn:6zmBjqUkHal" resolve="LambdaArgRef" />
+              <node concept="3zZkjj" id="8xLOUtaswk" role="2OqNvi">
+                <node concept="1bVj0M" id="8xLOUtaswm" role="23t8la">
+                  <node concept="3clFbS" id="8xLOUtaswn" role="1bW5cS">
+                    <node concept="3clFbF" id="8xLOUtasGo" role="3cqZAp">
+                      <node concept="17R0WA" id="8xLOUtaty7" role="3clFbG">
+                        <node concept="2OqwBi" id="8xLOUtaxSl" role="3uHU7w">
+                          <node concept="2OqwBi" id="8xLOUtau3_" role="2Oq$k0">
+                            <node concept="2Sf5sV" id="8xLOUtatGQ" role="2Oq$k0" />
+                            <node concept="3Tsc0h" id="8xLOUtauHN" role="2OqNvi">
+                              <ref role="3TtcxE" to="zzzn:6zmBjqUkws7" resolve="args" />
+                            </node>
+                          </node>
+                          <node concept="1uHKPH" id="8xLOUta$y4" role="2OqNvi" />
+                        </node>
+                        <node concept="2OqwBi" id="8xLOUtasQp" role="3uHU7B">
+                          <node concept="37vLTw" id="8xLOUtasGn" role="2Oq$k0">
+                            <ref role="3cqZAo" node="8xLOUtaswo" resolve="it" />
+                          </node>
+                          <node concept="3TrEf2" id="8xLOUtat2K" role="2OqNvi">
+                            <ref role="3Tt5mk" to="zzzn:6zmBjqUkHam" resolve="arg" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="8xLOUtaswo" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="8xLOUtaswp" role="1tU5fm" />
                   </node>
                 </node>
               </node>
@@ -322,29 +359,124 @@
     <node concept="2SaL7w" id="49WTic8eHbs" role="2ZfVeh">
       <node concept="3clFbS" id="49WTic8eHbt" role="2VODD2">
         <node concept="3clFbF" id="49WTic8eHc_" role="3cqZAp">
-          <node concept="1Wc70l" id="49WTic8eIOc" role="3clFbG">
-            <node concept="3clFbC" id="49WTic8eMl9" role="3uHU7w">
-              <node concept="3cmrfG" id="49WTic8eMn0" role="3uHU7w">
-                <property role="3cmrfH" value="1" />
-              </node>
-              <node concept="2OqwBi" id="49WTic8eJO0" role="3uHU7B">
-                <node concept="2OqwBi" id="49WTic8eIUe" role="2Oq$k0">
-                  <node concept="2Sf5sV" id="49WTic8eIQE" role="2Oq$k0" />
-                  <node concept="3Tsc0h" id="49WTic8eJ0Y" role="2OqNvi">
-                    <ref role="3TtcxE" to="zzzn:6zmBjqUkws7" resolve="args" />
+          <node concept="1Wc70l" id="8xLOUt08m5" role="3clFbG">
+            <node concept="2OqwBi" id="8xLOUt0vDi" role="3uHU7w">
+              <node concept="2OqwBi" id="8xLOUt0fWy" role="2Oq$k0">
+                <node concept="2OqwBi" id="8xLOUt0b5x" role="2Oq$k0">
+                  <node concept="2OqwBi" id="8xLOUt09i1" role="2Oq$k0">
+                    <node concept="2Sf5sV" id="8xLOUt08V_" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="8xLOUt09Sn" role="2OqNvi">
+                      <ref role="3Tt5mk" to="zzzn:6zmBjqUkwH3" resolve="expression" />
+                    </node>
+                  </node>
+                  <node concept="2Rf3mk" id="8xLOUt0bwb" role="2OqNvi">
+                    <node concept="1xMEDy" id="8xLOUt0bwd" role="1xVPHs">
+                      <node concept="chp4Y" id="8xLOUt0c0v" role="ri$Ld">
+                        <ref role="cht4Q" to="zzzn:6zmBjqUkHal" resolve="LambdaArgRef" />
+                      </node>
+                    </node>
                   </node>
                 </node>
-                <node concept="34oBXx" id="49WTic8eL2b" role="2OqNvi" />
+                <node concept="3zZkjj" id="8xLOUt0j5j" role="2OqNvi">
+                  <node concept="1bVj0M" id="8xLOUt0j5l" role="23t8la">
+                    <node concept="3clFbS" id="8xLOUt0j5m" role="1bW5cS">
+                      <node concept="3clFbF" id="8xLOUt0jnu" role="3cqZAp">
+                        <node concept="17R0WA" id="8xLOUt0lqz" role="3clFbG">
+                          <node concept="2OqwBi" id="8xLOUt0qZD" role="3uHU7w">
+                            <node concept="2OqwBi" id="8xLOUt0mEj" role="2Oq$k0">
+                              <node concept="2Sf5sV" id="8xLOUt0mdg" role="2Oq$k0" />
+                              <node concept="3Tsc0h" id="8xLOUt0no2" role="2OqNvi">
+                                <ref role="3TtcxE" to="zzzn:6zmBjqUkws7" resolve="args" />
+                              </node>
+                            </node>
+                            <node concept="1uHKPH" id="8xLOUt0u3b" role="2OqNvi" />
+                          </node>
+                          <node concept="2OqwBi" id="8xLOUt0jLd" role="3uHU7B">
+                            <node concept="37vLTw" id="8xLOUt0jnt" role="2Oq$k0">
+                              <ref role="3cqZAo" node="8xLOUt0j5n" resolve="it" />
+                            </node>
+                            <node concept="3TrEf2" id="8xLOUt0kSb" role="2OqNvi">
+                              <ref role="3Tt5mk" to="zzzn:6zmBjqUkHam" resolve="arg" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="8xLOUt0j5n" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="8xLOUt0j5o" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2HxqBE" id="8xLOUt0w3K" role="2OqNvi">
+                <node concept="1bVj0M" id="8xLOUt0w3M" role="23t8la">
+                  <node concept="3clFbS" id="8xLOUt0w3N" role="1bW5cS">
+                    <node concept="3clFbF" id="8xLOUt0wVB" role="3cqZAp">
+                      <node concept="17R0WA" id="8xLOUt8Odh" role="3clFbG">
+                        <node concept="2OqwBi" id="8xLOUt8Pfg" role="3uHU7w">
+                          <node concept="37vLTw" id="8xLOUt8P4A" role="2Oq$k0">
+                            <ref role="3cqZAo" node="8xLOUt0w3O" resolve="it" />
+                          </node>
+                          <node concept="2Xjw5R" id="8xLOUt8Qai" role="2OqNvi">
+                            <node concept="1xMEDy" id="8xLOUt8Qak" role="1xVPHs">
+                              <node concept="chp4Y" id="8xLOUt8Qs3" role="ri$Ld">
+                                <ref role="cht4Q" to="zzzn:2D48zR6a1ez" resolve="ILambdaLike" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="8xLOUt0ziz" role="3uHU7B">
+                          <node concept="2OqwBi" id="8xLOUt0xl0" role="2Oq$k0">
+                            <node concept="37vLTw" id="8xLOUt0wVA" role="2Oq$k0">
+                              <ref role="3cqZAo" node="8xLOUt0w3O" resolve="it" />
+                            </node>
+                            <node concept="3TrEf2" id="8xLOUt0xTQ" role="2OqNvi">
+                              <ref role="3Tt5mk" to="zzzn:6zmBjqUkHam" resolve="arg" />
+                            </node>
+                          </node>
+                          <node concept="2Xjw5R" id="8xLOUt8MJf" role="2OqNvi">
+                            <node concept="1xMEDy" id="8xLOUt8MJh" role="1xVPHs">
+                              <node concept="chp4Y" id="8xLOUt8NFL" role="ri$Ld">
+                                <ref role="cht4Q" to="zzzn:2D48zR6a1ez" resolve="ILambdaLike" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="8xLOUt0w3O" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="8xLOUt0w3P" role="1tU5fm" />
+                  </node>
+                </node>
               </node>
             </node>
-            <node concept="2OqwBi" id="49WTic8eHry" role="3uHU7B">
-              <node concept="2OqwBi" id="49WTic8eHfC" role="2Oq$k0">
-                <node concept="2Sf5sV" id="49WTic8eHc$" role="2Oq$k0" />
-                <node concept="1mfA1w" id="49WTic8eHlo" role="2OqNvi" />
+            <node concept="1Wc70l" id="49WTic8eIOc" role="3uHU7B">
+              <node concept="2OqwBi" id="49WTic8eHry" role="3uHU7B">
+                <node concept="2OqwBi" id="49WTic8eHfC" role="2Oq$k0">
+                  <node concept="2Sf5sV" id="49WTic8eHc$" role="2Oq$k0" />
+                  <node concept="1mfA1w" id="49WTic8eHlo" role="2OqNvi" />
+                </node>
+                <node concept="1mIQ4w" id="49WTic8eHCm" role="2OqNvi">
+                  <node concept="chp4Y" id="49WTic8eHEF" role="cj9EA">
+                    <ref role="cht4Q" to="zzzn:6zmBjqUm7Mf" resolve="IShortLambdaContainer" />
+                  </node>
+                </node>
               </node>
-              <node concept="1mIQ4w" id="49WTic8eHCm" role="2OqNvi">
-                <node concept="chp4Y" id="49WTic8eHEF" role="cj9EA">
-                  <ref role="cht4Q" to="zzzn:6zmBjqUm7Mf" resolve="IShortLambdaContainer" />
+              <node concept="3clFbC" id="49WTic8eMl9" role="3uHU7w">
+                <node concept="2OqwBi" id="49WTic8eJO0" role="3uHU7B">
+                  <node concept="2OqwBi" id="49WTic8eIUe" role="2Oq$k0">
+                    <node concept="2Sf5sV" id="49WTic8eIQE" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="49WTic8eJ0Y" role="2OqNvi">
+                      <ref role="3TtcxE" to="zzzn:6zmBjqUkws7" resolve="args" />
+                    </node>
+                  </node>
+                  <node concept="34oBXx" id="49WTic8eL2b" role="2OqNvi" />
+                </node>
+                <node concept="3cmrfG" id="49WTic8eMn0" role="3uHU7w">
+                  <property role="3cmrfH" value="1" />
                 </node>
               </node>
             </node>


### PR DESCRIPTION
- replace only references to the original parameter
- disallow this intention for nested short lambda expressions because the **it** expression would be ambiguous
- fixes usage of **it** expression in nested lambda expressions
- let **it** parameter navigate to corresponding short lambda expression. It doesn't make sense to navigate to next Container (e.g. map) because it might refer to a different lambda expression (e.g. an outer short lambda expression)
