### PR TITLE
Bugfix/lambdas in tracer

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
@@ -32,6 +32,7 @@
     <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
+    <import index="sxpq" ref="r:51edfe99-0380-475c-a3e9-1d4425eac12f(org.iets3.core.expr.lambda.plugin)" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -1198,6 +1199,19 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbF" id="6ITtBskX_T6" role="3cqZAp">
+          <node concept="37vLTI" id="6ITtBskXCFm" role="3clFbG">
+            <node concept="37vLTw" id="6ITtBskXD1g" role="37vLTx">
+              <ref role="3cqZAo" node="49WTic8ey5D" resolve="le" />
+            </node>
+            <node concept="3EllGN" id="6ITtBskXCft" role="37vLTJ">
+              <node concept="13iPFW" id="6ITtBskXCwr" role="3ElVtu" />
+              <node concept="37vLTw" id="6ITtBskX_T4" role="3ElQJh">
+                <ref role="3cqZAo" node="dsAFRk6ftq" resolve="mapping" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="dsAFRk6g3s" role="3cqZAp">
           <node concept="37vLTI" id="dsAFRk6hBt" role="3clFbG">
             <node concept="1PxgMI" id="dsAFRk6jEb" role="37vLTx">
@@ -1506,23 +1520,20 @@
                         <node concept="3w_OXm" id="7cphKbKZT6H" role="2OqNvi" />
                       </node>
                       <node concept="3clFbC" id="7cphKbKZDbs" role="3uHU7B">
-                        <node concept="2OqwBi" id="7cphKbKZyNA" role="3uHU7B">
-                          <node concept="2OqwBi" id="7cphKbKZsxf" role="2Oq$k0">
-                            <node concept="37vLTw" id="7cphKbKZslz" role="2Oq$k0">
-                              <ref role="3cqZAo" node="49WTic8eCwS" resolve="it" />
-                            </node>
-                            <node concept="z$bX8" id="7cphKbKZt4m" role="2OqNvi">
-                              <node concept="1xMEDy" id="7cphKbKZvOA" role="1xVPHs">
-                                <node concept="chp4Y" id="7cphKbKZvRC" role="ri$Ld">
-                                  <ref role="cht4Q" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
-                                </node>
+                        <node concept="37vLTw" id="7cphKbKZDbJ" role="3uHU7w">
+                          <ref role="3cqZAo" node="49WTic8ey5D" resolve="le" />
+                        </node>
+                        <node concept="2OqwBi" id="6ITtBskTCMh" role="3uHU7B">
+                          <node concept="37vLTw" id="6ITtBskTCAp" role="2Oq$k0">
+                            <ref role="3cqZAo" node="49WTic8eCwS" resolve="it" />
+                          </node>
+                          <node concept="2Xjw5R" id="6ITtBskTDpX" role="2OqNvi">
+                            <node concept="1xMEDy" id="6ITtBskTDpZ" role="1xVPHs">
+                              <node concept="chp4Y" id="6ITtBskTDMY" role="ri$Ld">
+                                <ref role="cht4Q" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
                               </node>
                             </node>
                           </node>
-                          <node concept="1uHKPH" id="7cphKbKZATZ" role="2OqNvi" />
-                        </node>
-                        <node concept="37vLTw" id="7cphKbKZDbJ" role="3uHU7w">
-                          <ref role="3cqZAo" node="49WTic8ey5D" resolve="le" />
                         </node>
                       </node>
                     </node>
@@ -1545,8 +1556,9 @@
             </node>
             <node concept="liA8E" id="dsAFRk4vCP" role="2OqNvi">
               <ref role="37wK5l" to="mhbf:~SNode.putUserObject(java.lang.Object,java.lang.Object)" resolve="putUserObject" />
-              <node concept="Xl_RD" id="dsAFRk4vDs" role="37wK5m">
-                <property role="Xl_RC" value="shortLambdaMapping" />
+              <node concept="10M0yZ" id="6ITtBskT5VX" role="37wK5m">
+                <ref role="3cqZAo" to="sxpq:6ITtBskT0za" resolve="USER_OBJECT_KEY" />
+                <ref role="1PxDUh" to="sxpq:$yb$20f$a5" resolve="LambdaValue" />
               </node>
               <node concept="37vLTw" id="dsAFRk6mvt" role="37wK5m">
                 <ref role="3cqZAo" node="dsAFRk6ftq" resolve="mapping" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/plugin.mps
@@ -103,6 +103,7 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
@@ -154,6 +155,9 @@
       <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
         <child id="1144231399730" name="condition" index="1Dwp0S" />
         <child id="1144231408325" name="iteration" index="1Dwrff" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
@@ -235,6 +239,14 @@
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
@@ -295,12 +307,21 @@
   <node concept="312cEu" id="$yb$20f$a5">
     <property role="TrG5h" value="LambdaValue" />
     <node concept="2tJIrI" id="$yb$20f$ap" role="jymVt" />
+    <node concept="Wx3nA" id="6ITtBskT0za" role="jymVt">
+      <property role="TrG5h" value="USER_OBJECT_KEY" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm1VV" id="6ITtBskSWbF" role="1B3o_S" />
+      <node concept="17QB3L" id="6ITtBskT0bQ" role="1tU5fm" />
+      <node concept="Xl_RD" id="6ITtBskT2G0" role="33vP2m">
+        <property role="Xl_RC" value="shortLambdaMapping" />
+      </node>
+    </node>
     <node concept="312cEg" id="$yb$20fATA" role="jymVt">
       <property role="34CwA1" value="false" />
       <property role="eg7rD" value="false" />
       <property role="TrG5h" value="lambda" />
       <property role="3TUv4t" value="false" />
-      <node concept="3Tm1VV" id="$yb$20f$e5" role="1B3o_S" />
+      <node concept="3Tm6S6" id="6ITtBskUKs0" role="1B3o_S" />
       <node concept="3Tqbb2" id="$yb$20fATw" role="1tU5fm">
         <ref role="ehGHo" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
       </node>
@@ -308,7 +329,7 @@
     </node>
     <node concept="312cEg" id="dsAFRk0GB0" role="jymVt">
       <property role="TrG5h" value="mapping" />
-      <node concept="3Tm1VV" id="dsAFRk0CHd" role="1B3o_S" />
+      <node concept="3Tm6S6" id="6ITtBskUMs1" role="1B3o_S" />
       <node concept="3rvAFt" id="dsAFRk0Ggb" role="1tU5fm">
         <node concept="3Tqbb2" id="dsAFRk0GwE" role="3rvQeY" />
         <node concept="3Tqbb2" id="dsAFRk0GAX" role="3rvSg0" />
@@ -914,6 +935,81 @@
             </node>
           </node>
         </node>
+        <node concept="3SKdUt" id="7R7jyNngSfN" role="3cqZAp">
+          <node concept="1PaTwC" id="7R7jyNngSfO" role="1aUNEU">
+            <node concept="3oM_SD" id="7R7jyNngSfP" role="1PaTwD">
+              <property role="3oM_SC" value="get" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngUDm" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngUDy" role="1PaTwD">
+              <property role="3oM_SC" value="oginial" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngUEK" role="1PaTwD">
+              <property role="3oM_SC" value="LambdaExpression" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngUGg" role="1PaTwD">
+              <property role="3oM_SC" value="instead" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngUGv" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngUGA" role="1PaTwD">
+              <property role="3oM_SC" value="constructors" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngUHr" role="1PaTwD">
+              <property role="3oM_SC" value="copy" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6ITtBskYEkd" role="3cqZAp">
+          <node concept="3cpWsn" id="6ITtBskYEke" role="3cpWs9">
+            <property role="TrG5h" value="originalLE" />
+            <node concept="3Tqbb2" id="6ITtBskY_t$" role="1tU5fm">
+              <ref role="ehGHo" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
+            </node>
+            <node concept="1PxgMI" id="6ITtBskYOSy" role="33vP2m">
+              <property role="1BlNFB" value="true" />
+              <node concept="chp4Y" id="6ITtBskYRiJ" role="3oSUPX">
+                <ref role="cht4Q" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
+              </node>
+              <node concept="2OqwBi" id="6ITtBskYEkf" role="1m5AlR">
+                <node concept="2OqwBi" id="6ITtBskYEkg" role="2Oq$k0">
+                  <node concept="37vLTw" id="6ITtBskYEkh" role="2Oq$k0">
+                    <ref role="3cqZAo" node="dsAFRk0GB0" resolve="mapping" />
+                  </node>
+                  <node concept="3lbrtF" id="6ITtBskYEki" role="2OqNvi" />
+                </node>
+                <node concept="1z4cxt" id="6ITtBskYEkj" role="2OqNvi">
+                  <node concept="1bVj0M" id="6ITtBskYEkk" role="23t8la">
+                    <node concept="3clFbS" id="6ITtBskYEkl" role="1bW5cS">
+                      <node concept="3clFbF" id="6ITtBskYEkm" role="3cqZAp">
+                        <node concept="3clFbC" id="6ITtBskYEkn" role="3clFbG">
+                          <node concept="37vLTw" id="6ITtBskYEko" role="3uHU7w">
+                            <ref role="3cqZAo" node="$yb$20fATA" resolve="lambda" />
+                          </node>
+                          <node concept="3EllGN" id="6ITtBskYEkp" role="3uHU7B">
+                            <node concept="37vLTw" id="6ITtBskYEkq" role="3ElVtu">
+                              <ref role="3cqZAo" node="6ITtBskYEks" resolve="key" />
+                            </node>
+                            <node concept="37vLTw" id="6ITtBskYEkr" role="3ElQJh">
+                              <ref role="3cqZAo" node="dsAFRk0GB0" resolve="mapping" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="6ITtBskYEks" role="1bW2Oz">
+                      <property role="TrG5h" value="key" />
+                      <node concept="2jxLKc" id="6ITtBskYEkt" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="5d4Vabvgn7r" role="3cqZAp">
           <node concept="3cpWsn" id="5d4Vabvgn7s" role="3cpWs9">
             <property role="TrG5h" value="tt" />
@@ -923,8 +1019,8 @@
             <node concept="2ShNRf" id="5d4Vabvgn7t" role="33vP2m">
               <node concept="1pGfFk" id="5d4Vabvgn7u" role="2ShVmc">
                 <ref role="37wK5l" to="2ahs:5d4Vabvrrqt" resolve="ComputationTrace" />
-                <node concept="37vLTw" id="5IR_boHcVSo" role="37wK5m">
-                  <ref role="3cqZAo" node="$yb$20fATA" resolve="lambda" />
+                <node concept="37vLTw" id="6ITtBskYEku" role="37wK5m">
+                  <ref role="3cqZAo" node="6ITtBskYEke" resolve="originalLE" />
                 </node>
                 <node concept="3clFbT" id="5d4Vabvs8X9" role="37wK5m">
                   <property role="3clFbU" value="true" />
@@ -933,6 +1029,165 @@
             </node>
           </node>
         </node>
+        <node concept="3SKdUt" id="7R7jyNngXiz" role="3cqZAp">
+          <node concept="1PaTwC" id="7R7jyNngXi$" role="1aUNEU">
+            <node concept="3oM_SD" id="7R7jyNngXi_" role="1PaTwD">
+              <property role="3oM_SC" value="In" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngZIo" role="1PaTwD">
+              <property role="3oM_SC" value="case" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngZI$" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngZIL" role="1PaTwD">
+              <property role="3oM_SC" value="original" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngZIZ" role="1PaTwD">
+              <property role="3oM_SC" value="LambdaExpression" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngZJw" role="1PaTwD">
+              <property role="3oM_SC" value="was" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngZJK" role="1PaTwD">
+              <property role="3oM_SC" value="build" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngZJS" role="1PaTwD">
+              <property role="3oM_SC" value="from" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngZKa" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngZKt" role="1PaTwD">
+              <property role="3oM_SC" value="ShortLamdaExpression," />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngZOz" role="1PaTwD">
+              <property role="3oM_SC" value="use" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngZP1" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngZPn" role="1PaTwD">
+              <property role="3oM_SC" value="original" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngZPR" role="1PaTwD">
+              <property role="3oM_SC" value="ShortLambdaExpression" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngZRe" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngZRB" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="7R7jyNngZRS" role="1PaTwD">
+              <property role="3oM_SC" value="ComputationTrace" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="dsAFRk4B7u" role="3cqZAp">
+          <node concept="3cpWsn" id="dsAFRk4B7x" role="3cpWs9">
+            <property role="TrG5h" value="shortLambdaMapping" />
+            <node concept="10QFUN" id="dsAFRk6r$4" role="33vP2m">
+              <node concept="2OqwBi" id="dsAFRk4Foc" role="10QFUP">
+                <node concept="2JrnkZ" id="dsAFRk4EYb" role="2Oq$k0">
+                  <node concept="37vLTw" id="dsAFRk4CC7" role="2JrQYb">
+                    <ref role="3cqZAo" node="$yb$20fATA" resolve="lambda" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="dsAFRk4FYv" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SNode.getUserObject(java.lang.Object)" resolve="getUserObject" />
+                  <node concept="37vLTw" id="6ITtBskTmss" role="37wK5m">
+                    <ref role="3cqZAo" node="6ITtBskT0za" resolve="USER_OBJECT_KEY" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3rvAFt" id="dsAFRk6_pZ" role="10QFUM">
+                <node concept="3Tqbb2" id="dsAFRk6_Ro" role="3rvQeY" />
+                <node concept="3Tqbb2" id="dsAFRk6Axp" role="3rvSg0" />
+              </node>
+            </node>
+            <node concept="3rvAFt" id="dsAFRk6zt1" role="1tU5fm">
+              <node concept="3Tqbb2" id="dsAFRk6$3w" role="3rvQeY" />
+              <node concept="3Tqbb2" id="dsAFRk6$AJ" role="3rvSg0" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6ITtBskUXtD" role="3cqZAp">
+          <node concept="3clFbS" id="6ITtBskUXtF" role="3clFbx">
+            <node concept="3cpWs8" id="6ITtBskXoU1" role="3cqZAp">
+              <node concept="3cpWsn" id="6ITtBskXoU2" role="3cpWs9">
+                <property role="TrG5h" value="originalSLE" />
+                <node concept="3Tqbb2" id="6ITtBskXosv" role="1tU5fm">
+                  <ref role="ehGHo" to="zzzn:6zmBjqUm7MQ" resolve="ShortLambdaExpression" />
+                </node>
+                <node concept="1PxgMI" id="6ITtBskXrt9" role="33vP2m">
+                  <property role="1BlNFB" value="true" />
+                  <node concept="chp4Y" id="6ITtBskXs6X" role="3oSUPX">
+                    <ref role="cht4Q" to="zzzn:6zmBjqUm7MQ" resolve="ShortLambdaExpression" />
+                  </node>
+                  <node concept="2OqwBi" id="6ITtBskXoU3" role="1m5AlR">
+                    <node concept="2OqwBi" id="6ITtBskXoU4" role="2Oq$k0">
+                      <node concept="37vLTw" id="6ITtBskXoU5" role="2Oq$k0">
+                        <ref role="3cqZAo" node="dsAFRk4B7x" resolve="shortLambdaMapping" />
+                      </node>
+                      <node concept="3lbrtF" id="6ITtBskXoU6" role="2OqNvi" />
+                    </node>
+                    <node concept="1z4cxt" id="6ITtBskXoU7" role="2OqNvi">
+                      <node concept="1bVj0M" id="6ITtBskXoU8" role="23t8la">
+                        <node concept="3clFbS" id="6ITtBskXoU9" role="1bW5cS">
+                          <node concept="3clFbF" id="6ITtBskXoUa" role="3cqZAp">
+                            <node concept="3clFbC" id="6ITtBskXoUb" role="3clFbG">
+                              <node concept="37vLTw" id="6ITtBskXoUc" role="3uHU7w">
+                                <ref role="3cqZAo" node="6ITtBskYEke" resolve="originalLE" />
+                              </node>
+                              <node concept="3EllGN" id="6ITtBskXoUd" role="3uHU7B">
+                                <node concept="37vLTw" id="6ITtBskXoUe" role="3ElVtu">
+                                  <ref role="3cqZAo" node="6ITtBskXoUg" resolve="key" />
+                                </node>
+                                <node concept="37vLTw" id="6ITtBskXoUf" role="3ElQJh">
+                                  <ref role="3cqZAo" node="dsAFRk4B7x" resolve="shortLambdaMapping" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="6ITtBskXoUg" role="1bW2Oz">
+                          <property role="TrG5h" value="key" />
+                          <node concept="2jxLKc" id="6ITtBskXoUh" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="6ITtBskXsHY" role="3cqZAp">
+              <node concept="37vLTI" id="6ITtBskXtra" role="3clFbG">
+                <node concept="2ShNRf" id="6ITtBskXttH" role="37vLTx">
+                  <node concept="1pGfFk" id="6ITtBskXtS3" role="2ShVmc">
+                    <ref role="37wK5l" to="2ahs:5d4Vabvrrqt" resolve="ComputationTrace" />
+                    <node concept="37vLTw" id="6ITtBskXu01" role="37wK5m">
+                      <ref role="3cqZAo" node="6ITtBskXoU2" resolve="originalSLE" />
+                    </node>
+                    <node concept="3clFbT" id="6ITtBskXuea" role="37wK5m">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="6ITtBskXsHW" role="37vLTJ">
+                  <ref role="3cqZAo" node="5d4Vabvgn7s" resolve="tt" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="6ITtBskV7uJ" role="3clFbw">
+            <node concept="10Nm6u" id="6ITtBskV9Mn" role="3uHU7w" />
+            <node concept="37vLTw" id="6ITtBskUZ5h" role="3uHU7B">
+              <ref role="3cqZAo" node="dsAFRk4B7x" resolve="shortLambdaMapping" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6ITtBskV9O0" role="3cqZAp" />
         <node concept="3clFbF" id="5d4VabvgsFc" role="3cqZAp">
           <node concept="2OqwBi" id="5d4Vabvgv66" role="3clFbG">
             <node concept="37vLTw" id="5d4VabvgtY8" role="2Oq$k0">
@@ -1000,34 +1255,6 @@
             <node concept="2es0OD" id="dsAFRk19bn" role="2OqNvi">
               <node concept="1bVj0M" id="dsAFRk19bp" role="23t8la">
                 <node concept="3clFbS" id="dsAFRk19bq" role="1bW5cS">
-                  <node concept="3cpWs8" id="dsAFRk4B7u" role="3cqZAp">
-                    <node concept="3cpWsn" id="dsAFRk4B7x" role="3cpWs9">
-                      <property role="TrG5h" value="shortLambdaMapping" />
-                      <node concept="10QFUN" id="dsAFRk6r$4" role="33vP2m">
-                        <node concept="2OqwBi" id="dsAFRk4Foc" role="10QFUP">
-                          <node concept="2JrnkZ" id="dsAFRk4EYb" role="2Oq$k0">
-                            <node concept="37vLTw" id="dsAFRk4CC7" role="2JrQYb">
-                              <ref role="3cqZAo" node="$yb$20fATA" resolve="lambda" />
-                            </node>
-                          </node>
-                          <node concept="liA8E" id="dsAFRk4FYv" role="2OqNvi">
-                            <ref role="37wK5l" to="mhbf:~SNode.getUserObject(java.lang.Object)" resolve="getUserObject" />
-                            <node concept="Xl_RD" id="dsAFRk4Gc4" role="37wK5m">
-                              <property role="Xl_RC" value="shortLambdaMapping" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3rvAFt" id="dsAFRk6_pZ" role="10QFUM">
-                          <node concept="3Tqbb2" id="dsAFRk6_Ro" role="3rvQeY" />
-                          <node concept="3Tqbb2" id="dsAFRk6Axp" role="3rvSg0" />
-                        </node>
-                      </node>
-                      <node concept="3rvAFt" id="dsAFRk6zt1" role="1tU5fm">
-                        <node concept="3Tqbb2" id="dsAFRk6$3w" role="3rvQeY" />
-                        <node concept="3Tqbb2" id="dsAFRk6$AJ" role="3rvSg0" />
-                      </node>
-                    </node>
-                  </node>
                   <node concept="3clFbJ" id="dsAFRk6qdB" role="3cqZAp">
                     <node concept="3clFbS" id="dsAFRk6qdD" role="3clFbx">
                       <node concept="3clFbF" id="dsAFRk6Bi0" role="3cqZAp">
@@ -1044,7 +1271,7 @@
                                     <ref role="1Pybhc" to="pbu6:4_qY3E5IXRD" resolve="DefaultCoverageAnalyzer" />
                                     <node concept="2OqwBi" id="dsAFRk6FhD" role="37wK5m">
                                       <node concept="37vLTw" id="dsAFRk6ESX" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="dsAFRk6CI8" resolve="it" />
+                                        <ref role="3cqZAo" node="dsAFRk6CI8" resolve="mapping" />
                                       </node>
                                       <node concept="3AV6Ez" id="dsAFRka_Qp" role="2OqNvi" />
                                     </node>
@@ -1059,7 +1286,7 @@
                                           <ref role="37wK5l" to="2ahs:RaqQlV4lZg" resolve="coverValue" />
                                           <node concept="2OqwBi" id="dsAFRk6ImD" role="37wK5m">
                                             <node concept="37vLTw" id="dsAFRk6I05" role="2Oq$k0">
-                                              <ref role="3cqZAo" node="dsAFRk6CI8" resolve="it" />
+                                              <ref role="3cqZAo" node="dsAFRk6CI8" resolve="mapping" />
                                             </node>
                                             <node concept="3AY5_j" id="dsAFRkaAEM" role="2OqNvi" />
                                           </node>
@@ -1071,7 +1298,7 @@
                                 </node>
                               </node>
                               <node concept="Rh6nW" id="dsAFRk6CI8" role="1bW2Oz">
-                                <property role="TrG5h" value="it" />
+                                <property role="TrG5h" value="mapping" />
                                 <node concept="2jxLKc" id="dsAFRk6CI9" role="1tU5fm" />
                               </node>
                             </node>
@@ -1103,7 +1330,7 @@
                               <node concept="3clFbF" id="dsAFRk2nFu" role="3cqZAp">
                                 <node concept="3clFbC" id="dsAFRk2r8w" role="3clFbG">
                                   <node concept="37vLTw" id="dsAFRk2spL" role="3uHU7w">
-                                    <ref role="3cqZAo" node="dsAFRk19br" resolve="it" />
+                                    <ref role="3cqZAo" node="dsAFRk19br" resolve="descendant" />
                                   </node>
                                   <node concept="3EllGN" id="dsAFRk2q08" role="3uHU7B">
                                     <node concept="37vLTw" id="dsAFRk2qrp" role="3ElVtu">
@@ -1146,13 +1373,13 @@
                       <ref role="37wK5l" to="pbu6:1WlYLwX3McV" resolve="isNodeCovered" />
                       <ref role="1Pybhc" to="pbu6:4_qY3E5IXRD" resolve="DefaultCoverageAnalyzer" />
                       <node concept="37vLTw" id="230vOq3ig5J" role="37wK5m">
-                        <ref role="3cqZAo" node="dsAFRk19br" resolve="it" />
+                        <ref role="3cqZAo" node="dsAFRk19br" resolve="descendant" />
                       </node>
                     </node>
                   </node>
                 </node>
                 <node concept="Rh6nW" id="dsAFRk19br" role="1bW2Oz">
-                  <property role="TrG5h" value="it" />
+                  <property role="TrG5h" value="descendant" />
                   <node concept="2jxLKc" id="dsAFRk19bs" role="1tU5fm" />
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/models/plugin.mps
@@ -458,7 +458,6 @@
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
       <concept id="8866923313515890008" name="jetbrains.mps.lang.smodel.structure.AsNodeOperation" flags="nn" index="FGMqu" />
-      <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
@@ -1246,8 +1245,19 @@
               <node concept="1pGfFk" id="5Ch7I6mj5Tt" role="2ShVmc">
                 <ref role="37wK5l" to="pu3r:2jSY3BOb4yI" resolve="TraceRecordTreeCellRenderer" />
                 <node concept="2ShNRf" id="5Ch7I6mj5Tu" role="37wK5m">
-                  <node concept="HV5vD" id="1rUbSepkBE" role="2ShVmc">
-                    <ref role="HV5vE" node="1rUbSep6lZ" resolve="InterpreterRecordRenderer" />
+                  <node concept="1pGfFk" id="5mNjY0H5u20" role="2ShVmc">
+                    <ref role="37wK5l" node="5mNjY0H4H8o" resolve="InterpreterRecordRenderer" />
+                    <node concept="2OqwBi" id="5mNjY0H5vRQ" role="37wK5m">
+                      <node concept="2OqwBi" id="5mNjY0H5vRR" role="2Oq$k0">
+                        <node concept="2WthIp" id="5mNjY0H5vRS" role="2Oq$k0" />
+                        <node concept="1DTwFV" id="5mNjY0H5vRT" role="2OqNvi">
+                          <ref role="2WH_rO" node="1rUbSenB5_" resolve="mpsProject" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="5mNjY0H5vRU" role="2OqNvi">
+                        <ref role="37wK5l" to="z1c4:~Project.getRepository()" resolve="getRepository" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -2559,7 +2569,42 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="5mNjY0H4_4i" role="jymVt" />
+    <node concept="312cEg" id="5mNjY0H4DCX" role="jymVt">
+      <property role="TrG5h" value="repository" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="5mNjY0H4_wZ" role="1B3o_S" />
+      <node concept="3uibUv" id="5mNjY0H4Dz1" role="1tU5fm">
+        <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="4yQfyMjpiyg" role="jymVt" />
+    <node concept="3clFbW" id="5mNjY0H4H8o" role="jymVt">
+      <node concept="3cqZAl" id="5mNjY0H4H8p" role="3clF45" />
+      <node concept="3Tm1VV" id="5mNjY0H4H8q" role="1B3o_S" />
+      <node concept="3clFbS" id="5mNjY0H4H8s" role="3clF47">
+        <node concept="3clFbF" id="5mNjY0H4H8w" role="3cqZAp">
+          <node concept="37vLTI" id="5mNjY0H4H8y" role="3clFbG">
+            <node concept="2OqwBi" id="5mNjY0H4H8A" role="37vLTJ">
+              <node concept="Xjq3P" id="5mNjY0H4H8B" role="2Oq$k0" />
+              <node concept="2OwXpG" id="5mNjY0H4H8C" role="2OqNvi">
+                <ref role="2Oxat5" node="5mNjY0H4DCX" resolve="repository" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="5mNjY0H4H8D" role="37vLTx">
+              <ref role="3cqZAo" node="5mNjY0H4H8v" resolve="repository" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5mNjY0H4H8v" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <node concept="3uibUv" id="5mNjY0H4H8u" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5mNjY0H4IMo" role="jymVt" />
     <node concept="3clFb_" id="5U8d23PNiog" role="jymVt">
       <property role="1EzhhJ" value="false" />
       <property role="TrG5h" value="ta" />
@@ -2587,7 +2632,6 @@
           </node>
         </node>
       </node>
-      <node concept="3Tm6S6" id="5U8d23PNh01" role="1B3o_S" />
       <node concept="3uibUv" id="5U8d23PNil4" role="3clF45">
         <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
       </node>
@@ -2607,6 +2651,7 @@
         <property role="TrG5h" value="style" />
         <node concept="10Oyi0" id="5U8d23PNnnO" role="1tU5fm" />
       </node>
+      <node concept="3Tm6S6" id="4KxzaIKVipH" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="5U8d23PNfHb" role="jymVt" />
     <node concept="3clFb_" id="1rUbSep6th" role="jymVt">
@@ -2648,714 +2693,626 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbJ" id="2kKAjiTzuBL" role="3cqZAp">
-          <node concept="3clFbS" id="2kKAjiTzuBN" role="3clFbx">
-            <node concept="3clFbF" id="2kKAjiTzy9P" role="3cqZAp">
-              <node concept="2OqwBi" id="2kKAjiTzy9Q" role="3clFbG">
-                <node concept="37vLTw" id="2kKAjiTzy9R" role="2Oq$k0">
-                  <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
-                </node>
-                <node concept="liA8E" id="2kKAjiTzy9S" role="2OqNvi">
-                  <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
-                  <node concept="Xl_RD" id="2kKAjiTzy9T" role="37wK5m">
-                    <property role="Xl_RC" value="&lt;node.model == null&gt;" />
+        <node concept="1QHqEK" id="5d4VabwgQnC" role="3cqZAp">
+          <node concept="1QHqEC" id="5d4VabwgQnE" role="1QHqEI">
+            <node concept="3clFbS" id="5d4VabwgQnG" role="1bW5cS">
+              <node concept="3cpWs8" id="5U8d23PMIi4" role="3cqZAp">
+                <node concept="3cpWsn" id="5U8d23PMIi5" role="3cpWs9">
+                  <property role="TrG5h" value="bgColor" />
+                  <node concept="3uibUv" id="5U8d23PMIi6" role="1tU5fm">
+                    <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
                   </node>
-                  <node concept="1rXfSq" id="2kKAjiTzy9U" role="37wK5m">
+                  <node concept="2YIFZM" id="47M_Eqttnfs" role="33vP2m">
+                    <ref role="37wK5l" to="lzb2:~JBColor.background()" resolve="background" />
+                    <ref role="1Pybhc" to="lzb2:~JBColor" resolve="JBColor" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="5U8d23PMyi9" role="3cqZAp">
+                <node concept="3clFbS" id="5U8d23PMyib" role="3clFbx">
+                  <node concept="3clFbF" id="5U8d23PMR3c" role="3cqZAp">
+                    <node concept="37vLTI" id="5U8d23PMUH0" role="3clFbG">
+                      <node concept="10M0yZ" id="47M_Eqttw8v" role="37vLTx">
+                        <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      </node>
+                      <node concept="37vLTw" id="5U8d23PMR3b" role="37vLTJ">
+                        <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5U8d23PM$My" role="3clFbw">
+                  <node concept="37vLTw" id="5U8d23PMzFr" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
+                  </node>
+                  <node concept="1mIQ4w" id="5U8d23PMA1a" role="2OqNvi">
+                    <node concept="chp4Y" id="5U8d23PMAXT" role="cj9EA">
+                      <ref role="cht4Q" to="3673:7obiejCehKv" resolve="ITracerFrame" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="5U8d23PMw$V" role="3cqZAp" />
+              <node concept="3cpWs8" id="5U8d23PN054" role="3cqZAp">
+                <node concept="3cpWsn" id="5U8d23PN057" role="3cpWs9">
+                  <property role="TrG5h" value="effectStyle" />
+                  <property role="3TUv4t" value="false" />
+                  <node concept="3uibUv" id="5U8d23PN059" role="1tU5fm">
+                    <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                  </node>
+                  <node concept="1rXfSq" id="5U8d23PNpGQ" role="33vP2m">
                     <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
-                    <node concept="2YIFZM" id="47M_EqttfTp" role="37wK5m">
-                      <ref role="37wK5l" to="lzb2:~JBColor.background()" resolve="background" />
-                      <ref role="1Pybhc" to="lzb2:~JBColor" resolve="JBColor" />
+                    <node concept="37vLTw" id="5U8d23PNr3A" role="37wK5m">
+                      <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
                     </node>
-                    <node concept="10M0yZ" id="47M_Eqttldc" role="37wK5m">
-                      <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
-                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <node concept="2ShNRf" id="5U8d23PN24s" role="37wK5m">
+                      <node concept="1pGfFk" id="5U8d23PN24t" role="2ShVmc">
+                        <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                        <node concept="3cmrfG" id="5U8d23PN24u" role="37wK5m">
+                          <property role="3cmrfH" value="196" />
+                        </node>
+                        <node concept="3cmrfG" id="5U8d23PN24v" role="37wK5m">
+                          <property role="3cmrfH" value="107" />
+                        </node>
+                        <node concept="3cmrfG" id="5U8d23PN24w" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                      </node>
                     </node>
-                    <node concept="10M0yZ" id="2kKAjiTzy9X" role="37wK5m">
+                    <node concept="10M0yZ" id="5U8d23PNvv9" role="37wK5m">
                       <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_BOLD" resolve="STYLE_BOLD" />
                       <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
                     </node>
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="3clFbC" id="2kKAjiTzxRC" role="3clFbw">
-            <node concept="10Nm6u" id="2kKAjiTzy51" role="3uHU7w" />
-            <node concept="2OqwBi" id="2kKAjiTzwpc" role="3uHU7B">
-              <node concept="37vLTw" id="2kKAjiTzwpd" role="2Oq$k0">
-                <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
+              <node concept="3cpWs8" id="5U8d23PN05a" role="3cqZAp">
+                <node concept="3cpWsn" id="5U8d23PN05d" role="3cpWs9">
+                  <property role="TrG5h" value="revealStyle" />
+                  <property role="3TUv4t" value="false" />
+                  <node concept="3uibUv" id="5U8d23PN05f" role="1tU5fm">
+                    <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                  </node>
+                  <node concept="1rXfSq" id="5U8d23PNyO1" role="33vP2m">
+                    <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
+                    <node concept="37vLTw" id="5U8d23PN$bu" role="37wK5m">
+                      <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
+                    </node>
+                    <node concept="10M0yZ" id="47M_Eqtk7Y_" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    </node>
+                    <node concept="10M0yZ" id="5U8d23PND9H" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_BOLD" resolve="STYLE_BOLD" />
+                      <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                    </node>
+                  </node>
+                </node>
               </node>
-              <node concept="I4A8Y" id="2kKAjiTzwpe" role="2OqNvi" />
-            </node>
-          </node>
-          <node concept="9aQIb" id="2kKAjiTzCzn" role="9aQIa">
-            <node concept="3clFbS" id="2kKAjiTzCzo" role="9aQI4">
-              <node concept="1QHqEK" id="5d4VabwgQnC" role="3cqZAp">
-                <node concept="1QHqEC" id="5d4VabwgQnE" role="1QHqEI">
-                  <node concept="3clFbS" id="5d4VabwgQnG" role="1bW5cS">
-                    <node concept="3clFbH" id="5U8d23PMvuw" role="3cqZAp" />
-                    <node concept="3cpWs8" id="5U8d23PMIi4" role="3cqZAp">
-                      <node concept="3cpWsn" id="5U8d23PMIi5" role="3cpWs9">
-                        <property role="TrG5h" value="bgColor" />
-                        <node concept="3uibUv" id="5U8d23PMIi6" role="1tU5fm">
-                          <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
+              <node concept="3cpWs8" id="5U8d23PNOPd" role="3cqZAp">
+                <node concept="3cpWsn" id="5U8d23PNOPe" role="3cpWs9">
+                  <property role="TrG5h" value="regularBoldStyle" />
+                  <property role="3TUv4t" value="false" />
+                  <node concept="3uibUv" id="5U8d23PNOPf" role="1tU5fm">
+                    <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                  </node>
+                  <node concept="1rXfSq" id="5U8d23PNOPg" role="33vP2m">
+                    <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
+                    <node concept="37vLTw" id="5U8d23PNOPh" role="37wK5m">
+                      <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
+                    </node>
+                    <node concept="2YIFZM" id="47M_EqtkcdY" role="37wK5m">
+                      <ref role="37wK5l" to="lzb2:~JBColor.foreground()" resolve="foreground" />
+                      <ref role="1Pybhc" to="lzb2:~JBColor" resolve="JBColor" />
+                    </node>
+                    <node concept="10M0yZ" id="5U8d23PNTLq" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_BOLD" resolve="STYLE_BOLD" />
+                      <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="1J1iBrrdYG6" role="3cqZAp">
+                <node concept="3cpWsn" id="1J1iBrrdYG7" role="3cpWs9">
+                  <property role="TrG5h" value="regularStyle" />
+                  <property role="3TUv4t" value="false" />
+                  <node concept="3uibUv" id="1J1iBrrdYG8" role="1tU5fm">
+                    <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                  </node>
+                  <node concept="1rXfSq" id="1J1iBrrdYG9" role="33vP2m">
+                    <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
+                    <node concept="37vLTw" id="1J1iBrrdYGa" role="37wK5m">
+                      <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
+                    </node>
+                    <node concept="2YIFZM" id="47M_Eqtkf1f" role="37wK5m">
+                      <ref role="37wK5l" to="lzb2:~JBColor.foreground()" resolve="foreground" />
+                      <ref role="1Pybhc" to="lzb2:~JBColor" resolve="JBColor" />
+                    </node>
+                    <node concept="10M0yZ" id="1J1iBrre1Dr" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
+                      <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="5U8d23POwW2" role="3cqZAp">
+                <node concept="3cpWsn" id="5U8d23POwW3" role="3cpWs9">
+                  <property role="TrG5h" value="errorStyle" />
+                  <property role="3TUv4t" value="false" />
+                  <node concept="3uibUv" id="5U8d23POwW4" role="1tU5fm">
+                    <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                  </node>
+                  <node concept="1rXfSq" id="5U8d23POwW5" role="33vP2m">
+                    <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
+                    <node concept="37vLTw" id="5U8d23POwW6" role="37wK5m">
+                      <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
+                    </node>
+                    <node concept="10M0yZ" id="47M_EqtkhJm" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    </node>
+                    <node concept="10M0yZ" id="5U8d23POwW8" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_BOLD" resolve="STYLE_BOLD" />
+                      <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="3vcWfImf5qv" role="3cqZAp">
+                <node concept="3cpWsn" id="3vcWfImf5qw" role="3cpWs9">
+                  <property role="TrG5h" value="cachedStyle" />
+                  <property role="3TUv4t" value="false" />
+                  <node concept="3uibUv" id="3vcWfImf5qx" role="1tU5fm">
+                    <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                  </node>
+                  <node concept="1rXfSq" id="3vcWfImf5qy" role="33vP2m">
+                    <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
+                    <node concept="37vLTw" id="3vcWfImwaSo" role="37wK5m">
+                      <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
+                    </node>
+                    <node concept="2YIFZM" id="3vcWfImvuoG" role="37wK5m">
+                      <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                      <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                      <node concept="Xl_RD" id="3vcWfImvw0T" role="37wK5m">
+                        <property role="Xl_RC" value="#228A00" />
+                      </node>
+                    </node>
+                    <node concept="10M0yZ" id="3vcWfImf5q_" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_BOLD" resolve="STYLE_BOLD" />
+                      <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="47M_Eqtu4ih" role="3cqZAp">
+                <node concept="3cpWsn" id="47M_Eqtu4ii" role="3cpWs9">
+                  <property role="TrG5h" value="inactiveStyle" />
+                  <property role="3TUv4t" value="false" />
+                  <node concept="3uibUv" id="47M_Eqtu4ij" role="1tU5fm">
+                    <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                  </node>
+                  <node concept="1rXfSq" id="47M_Eqtu4ik" role="33vP2m">
+                    <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
+                    <node concept="37vLTw" id="47M_Eqtu4il" role="37wK5m">
+                      <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
+                    </node>
+                    <node concept="2YIFZM" id="47M_EqtuiUi" role="37wK5m">
+                      <ref role="37wK5l" to="g1qu:~UIUtil.getInactiveTextColor()" resolve="getInactiveTextColor" />
+                      <ref role="1Pybhc" to="g1qu:~UIUtil" resolve="UIUtil" />
+                    </node>
+                    <node concept="pVOtf" id="47M_Eqtu4in" role="37wK5m">
+                      <node concept="10M0yZ" id="47M_Eqtu4io" role="3uHU7B">
+                        <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
+                        <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                      </node>
+                      <node concept="10M0yZ" id="47M_Eqtu4ip" role="3uHU7w">
+                        <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_SMALLER" resolve="STYLE_SMALLER" />
+                        <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="5U8d23PMYXX" role="3cqZAp" />
+              <node concept="3clFbH" id="5U8d23PMZ38" role="3cqZAp" />
+              <node concept="3clFbJ" id="4yQfyMjkU66" role="3cqZAp">
+                <node concept="3clFbS" id="4yQfyMjkU68" role="3clFbx">
+                  <node concept="3clFbF" id="4yQfyMjl2Jj" role="3cqZAp">
+                    <node concept="2OqwBi" id="4yQfyMjl4dC" role="3clFbG">
+                      <node concept="37vLTw" id="4yQfyMjl2Jh" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
+                      </node>
+                      <node concept="liA8E" id="4yQfyMjl5gl" role="2OqNvi">
+                        <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
+                        <node concept="Xl_RD" id="4yQfyMjl6kH" role="37wK5m">
+                          <property role="Xl_RC" value="[R] " />
                         </node>
-                        <node concept="2YIFZM" id="47M_Eqttnfs" role="33vP2m">
-                          <ref role="37wK5l" to="lzb2:~JBColor.background()" resolve="background" />
-                          <ref role="1Pybhc" to="lzb2:~JBColor" resolve="JBColor" />
+                        <node concept="37vLTw" id="4yQfyMjprJn" role="37wK5m">
+                          <ref role="3cqZAo" node="5U8d23PN05d" resolve="revealStyle" />
                         </node>
                       </node>
                     </node>
-                    <node concept="3clFbJ" id="5U8d23PMyi9" role="3cqZAp">
-                      <node concept="3clFbS" id="5U8d23PMyib" role="3clFbx">
-                        <node concept="3clFbF" id="5U8d23PMR3c" role="3cqZAp">
-                          <node concept="37vLTI" id="5U8d23PMUH0" role="3clFbG">
-                            <node concept="10M0yZ" id="47M_Eqttw8v" role="37vLTx">
-                              <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
-                              <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
-                            </node>
-                            <node concept="37vLTw" id="5U8d23PMR3b" role="37vLTJ">
-                              <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
-                            </node>
-                          </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="4yQfyMjkXLQ" role="3clFbw">
+                  <node concept="37vLTw" id="4yQfyMjkWAu" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                  </node>
+                  <node concept="liA8E" id="4yQfyMjl1h6" role="2OqNvi">
+                    <ref role="37wK5l" to="2ahs:4yQfyMjibny" resolve="mustBeRevealed" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="3vcWfImfaK9" role="3cqZAp">
+                <node concept="3clFbS" id="3vcWfImfaKa" role="3clFbx">
+                  <node concept="3clFbF" id="3vcWfImfaKb" role="3cqZAp">
+                    <node concept="2OqwBi" id="3vcWfImfaKc" role="3clFbG">
+                      <node concept="37vLTw" id="3vcWfImfaKd" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
+                      </node>
+                      <node concept="liA8E" id="3vcWfImfaKe" role="2OqNvi">
+                        <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
+                        <node concept="Xl_RD" id="3vcWfImfaKf" role="37wK5m">
+                          <property role="Xl_RC" value="[C] " />
+                        </node>
+                        <node concept="37vLTw" id="3vcWfImfhhB" role="37wK5m">
+                          <ref role="3cqZAo" node="3vcWfImf5qw" resolve="cachedStyle" />
                         </node>
                       </node>
-                      <node concept="2OqwBi" id="5U8d23PM$My" role="3clFbw">
-                        <node concept="37vLTw" id="5U8d23PMzFr" role="2Oq$k0">
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="3vcWfImfaKh" role="3clFbw">
+                  <node concept="37vLTw" id="3vcWfImfaKi" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                  </node>
+                  <node concept="liA8E" id="3vcWfImfaKj" role="2OqNvi">
+                    <ref role="37wK5l" to="2ahs:3vcWfImeNK8" resolve="isCachedValue" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="4yQfyMjo9JO" role="3cqZAp">
+                <node concept="3clFbS" id="4yQfyMjo9JQ" role="3clFbx">
+                  <node concept="3clFbF" id="4yQfyMjom4F" role="3cqZAp">
+                    <node concept="2OqwBi" id="4yQfyMjom4G" role="3clFbG">
+                      <node concept="37vLTw" id="4yQfyMjom4H" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
+                      </node>
+                      <node concept="liA8E" id="4yQfyMjom4I" role="2OqNvi">
+                        <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
+                        <node concept="Xl_RD" id="4yQfyMjom4J" role="37wK5m">
+                          <property role="Xl_RC" value="[E] " />
+                        </node>
+                        <node concept="37vLTw" id="4yQfyMjpl0Q" role="37wK5m">
+                          <ref role="3cqZAo" node="5U8d23PN057" resolve="effectStyle" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1Wc70l" id="4yQfyMjoft2" role="3clFbw">
+                  <node concept="2OqwBi" id="6GySMNkxh$6" role="3uHU7w">
+                    <node concept="2ShNRf" id="6GySMNld7Lc" role="2Oq$k0">
+                      <node concept="1pGfFk" id="6GySMNldfwE" role="2ShVmc">
+                        <ref role="37wK5l" to="oq0c:3ni3WidV2MT" resolve="EffectHelper" />
+                        <node concept="37vLTw" id="6GySMNldk6a" role="37wK5m">
                           <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
                         </node>
-                        <node concept="1mIQ4w" id="5U8d23PMA1a" role="2OqNvi">
-                          <node concept="chp4Y" id="5U8d23PMAXT" role="cj9EA">
-                            <ref role="cht4Q" to="3673:7obiejCehKv" resolve="ITracerFrame" />
-                          </node>
-                        </node>
                       </node>
                     </node>
-                    <node concept="3clFbH" id="5U8d23PMw$V" role="3cqZAp" />
-                    <node concept="3cpWs8" id="5U8d23PN054" role="3cqZAp">
-                      <node concept="3cpWsn" id="5U8d23PN057" role="3cpWs9">
-                        <property role="TrG5h" value="effectStyle" />
-                        <property role="3TUv4t" value="false" />
-                        <node concept="3uibUv" id="5U8d23PN059" role="1tU5fm">
-                          <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                        </node>
-                        <node concept="1rXfSq" id="5U8d23PNpGQ" role="33vP2m">
-                          <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
-                          <node concept="37vLTw" id="5U8d23PNr3A" role="37wK5m">
-                            <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
-                          </node>
-                          <node concept="2ShNRf" id="5U8d23PN24s" role="37wK5m">
-                            <node concept="1pGfFk" id="5U8d23PN24t" role="2ShVmc">
-                              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                              <node concept="3cmrfG" id="5U8d23PN24u" role="37wK5m">
-                                <property role="3cmrfH" value="196" />
-                              </node>
-                              <node concept="3cmrfG" id="5U8d23PN24v" role="37wK5m">
-                                <property role="3cmrfH" value="107" />
-                              </node>
-                              <node concept="3cmrfG" id="5U8d23PN24w" role="37wK5m">
-                                <property role="3cmrfH" value="0" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="10M0yZ" id="5U8d23PNvv9" role="37wK5m">
-                            <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_BOLD" resolve="STYLE_BOLD" />
-                            <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                          </node>
-                        </node>
+                    <node concept="liA8E" id="6GySMNkxjaH" role="2OqNvi">
+                      <ref role="37wK5l" to="oq0c:6GySMNjNNTz" resolve="readsOrModifiesMutableState" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="4yQfyMjocez" role="3uHU7B">
+                    <node concept="37vLTw" id="4yQfyMjob8h" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
+                    </node>
+                    <node concept="1mIQ4w" id="4yQfyMjodoO" role="2OqNvi">
+                      <node concept="chp4Y" id="4yQfyMjoehf" role="cj9EA">
+                        <ref role="cht4Q" to="hm2y:6sdnDbSla17" resolve="Expression" />
                       </node>
                     </node>
-                    <node concept="3cpWs8" id="5U8d23PN05a" role="3cqZAp">
-                      <node concept="3cpWsn" id="5U8d23PN05d" role="3cpWs9">
-                        <property role="TrG5h" value="revealStyle" />
-                        <property role="3TUv4t" value="false" />
-                        <node concept="3uibUv" id="5U8d23PN05f" role="1tU5fm">
-                          <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                        </node>
-                        <node concept="1rXfSq" id="5U8d23PNyO1" role="33vP2m">
-                          <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
-                          <node concept="37vLTw" id="5U8d23PN$bu" role="37wK5m">
-                            <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="5syY_AL5s_X" role="3cqZAp">
+                <node concept="3clFbS" id="5syY_AL5s_Z" role="3clFbx">
+                  <node concept="3clFbJ" id="1J1iBrrdDmF" role="3cqZAp">
+                    <node concept="3clFbS" id="1J1iBrrdDmH" role="3clFbx">
+                      <node concept="3clFbF" id="1J1iBrrdNd1" role="3cqZAp">
+                        <node concept="2OqwBi" id="1J1iBrrdNd2" role="3clFbG">
+                          <node concept="37vLTw" id="1J1iBrrdNd3" role="2Oq$k0">
+                            <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
                           </node>
-                          <node concept="10M0yZ" id="47M_Eqtk7Y_" role="37wK5m">
-                            <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
-                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
-                          </node>
-                          <node concept="10M0yZ" id="5U8d23PND9H" role="37wK5m">
-                            <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_BOLD" resolve="STYLE_BOLD" />
-                            <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3cpWs8" id="5U8d23PNOPd" role="3cqZAp">
-                      <node concept="3cpWsn" id="5U8d23PNOPe" role="3cpWs9">
-                        <property role="TrG5h" value="regularBoldStyle" />
-                        <property role="3TUv4t" value="false" />
-                        <node concept="3uibUv" id="5U8d23PNOPf" role="1tU5fm">
-                          <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                        </node>
-                        <node concept="1rXfSq" id="5U8d23PNOPg" role="33vP2m">
-                          <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
-                          <node concept="37vLTw" id="5U8d23PNOPh" role="37wK5m">
-                            <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
-                          </node>
-                          <node concept="2YIFZM" id="47M_EqtkcdY" role="37wK5m">
-                            <ref role="37wK5l" to="lzb2:~JBColor.foreground()" resolve="foreground" />
-                            <ref role="1Pybhc" to="lzb2:~JBColor" resolve="JBColor" />
-                          </node>
-                          <node concept="10M0yZ" id="5U8d23PNTLq" role="37wK5m">
-                            <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_BOLD" resolve="STYLE_BOLD" />
-                            <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3cpWs8" id="1J1iBrrdYG6" role="3cqZAp">
-                      <node concept="3cpWsn" id="1J1iBrrdYG7" role="3cpWs9">
-                        <property role="TrG5h" value="regularStyle" />
-                        <property role="3TUv4t" value="false" />
-                        <node concept="3uibUv" id="1J1iBrrdYG8" role="1tU5fm">
-                          <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                        </node>
-                        <node concept="1rXfSq" id="1J1iBrrdYG9" role="33vP2m">
-                          <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
-                          <node concept="37vLTw" id="1J1iBrrdYGa" role="37wK5m">
-                            <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
-                          </node>
-                          <node concept="2YIFZM" id="47M_Eqtkf1f" role="37wK5m">
-                            <ref role="37wK5l" to="lzb2:~JBColor.foreground()" resolve="foreground" />
-                            <ref role="1Pybhc" to="lzb2:~JBColor" resolve="JBColor" />
-                          </node>
-                          <node concept="10M0yZ" id="1J1iBrre1Dr" role="37wK5m">
-                            <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
-                            <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3cpWs8" id="5U8d23POwW2" role="3cqZAp">
-                      <node concept="3cpWsn" id="5U8d23POwW3" role="3cpWs9">
-                        <property role="TrG5h" value="errorStyle" />
-                        <property role="3TUv4t" value="false" />
-                        <node concept="3uibUv" id="5U8d23POwW4" role="1tU5fm">
-                          <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                        </node>
-                        <node concept="1rXfSq" id="5U8d23POwW5" role="33vP2m">
-                          <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
-                          <node concept="37vLTw" id="5U8d23POwW6" role="37wK5m">
-                            <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
-                          </node>
-                          <node concept="10M0yZ" id="47M_EqtkhJm" role="37wK5m">
-                            <ref role="3cqZAo" to="lzb2:~JBColor.RED" resolve="RED" />
-                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
-                          </node>
-                          <node concept="10M0yZ" id="5U8d23POwW8" role="37wK5m">
-                            <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_BOLD" resolve="STYLE_BOLD" />
-                            <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3cpWs8" id="3vcWfImf5qv" role="3cqZAp">
-                      <node concept="3cpWsn" id="3vcWfImf5qw" role="3cpWs9">
-                        <property role="TrG5h" value="cachedStyle" />
-                        <property role="3TUv4t" value="false" />
-                        <node concept="3uibUv" id="3vcWfImf5qx" role="1tU5fm">
-                          <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                        </node>
-                        <node concept="1rXfSq" id="3vcWfImf5qy" role="33vP2m">
-                          <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
-                          <node concept="37vLTw" id="3vcWfImwaSo" role="37wK5m">
-                            <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
-                          </node>
-                          <node concept="2YIFZM" id="3vcWfImvuoG" role="37wK5m">
-                            <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                            <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                            <node concept="Xl_RD" id="3vcWfImvw0T" role="37wK5m">
-                              <property role="Xl_RC" value="#228A00" />
-                            </node>
-                          </node>
-                          <node concept="10M0yZ" id="3vcWfImf5q_" role="37wK5m">
-                            <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_BOLD" resolve="STYLE_BOLD" />
-                            <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3cpWs8" id="47M_Eqtu4ih" role="3cqZAp">
-                      <node concept="3cpWsn" id="47M_Eqtu4ii" role="3cpWs9">
-                        <property role="TrG5h" value="inactiveStyle" />
-                        <property role="3TUv4t" value="false" />
-                        <node concept="3uibUv" id="47M_Eqtu4ij" role="1tU5fm">
-                          <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                        </node>
-                        <node concept="1rXfSq" id="47M_Eqtu4ik" role="33vP2m">
-                          <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
-                          <node concept="37vLTw" id="47M_Eqtu4il" role="37wK5m">
-                            <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
-                          </node>
-                          <node concept="2YIFZM" id="47M_EqtuiUi" role="37wK5m">
-                            <ref role="37wK5l" to="g1qu:~UIUtil.getInactiveTextColor()" resolve="getInactiveTextColor" />
-                            <ref role="1Pybhc" to="g1qu:~UIUtil" resolve="UIUtil" />
-                          </node>
-                          <node concept="pVOtf" id="47M_Eqtu4in" role="37wK5m">
-                            <node concept="10M0yZ" id="47M_Eqtu4io" role="3uHU7B">
-                              <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
-                              <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                            </node>
-                            <node concept="10M0yZ" id="47M_Eqtu4ip" role="3uHU7w">
-                              <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_SMALLER" resolve="STYLE_SMALLER" />
-                              <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbH" id="5U8d23PMYXX" role="3cqZAp" />
-                    <node concept="3clFbH" id="5U8d23PMZ38" role="3cqZAp" />
-                    <node concept="3clFbJ" id="4yQfyMjkU66" role="3cqZAp">
-                      <node concept="3clFbS" id="4yQfyMjkU68" role="3clFbx">
-                        <node concept="3clFbF" id="4yQfyMjl2Jj" role="3cqZAp">
-                          <node concept="2OqwBi" id="4yQfyMjl4dC" role="3clFbG">
-                            <node concept="37vLTw" id="4yQfyMjl2Jh" role="2Oq$k0">
-                              <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
-                            </node>
-                            <node concept="liA8E" id="4yQfyMjl5gl" role="2OqNvi">
-                              <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
-                              <node concept="Xl_RD" id="4yQfyMjl6kH" role="37wK5m">
-                                <property role="Xl_RC" value="[R] " />
+                          <node concept="liA8E" id="1J1iBrrdNd4" role="2OqNvi">
+                            <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
+                            <node concept="3cpWs3" id="1J1iBrrdNd5" role="37wK5m">
+                              <node concept="Xl_RD" id="1J1iBrrdNd6" role="3uHU7w">
+                                <property role="Xl_RC" value=": " />
                               </node>
-                              <node concept="37vLTw" id="4yQfyMjprJn" role="37wK5m">
-                                <ref role="3cqZAo" node="5U8d23PN05d" resolve="revealStyle" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="4yQfyMjkXLQ" role="3clFbw">
-                        <node concept="37vLTw" id="4yQfyMjkWAu" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
-                        </node>
-                        <node concept="liA8E" id="4yQfyMjl1h6" role="2OqNvi">
-                          <ref role="37wK5l" to="2ahs:4yQfyMjibny" resolve="mustBeRevealed" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbJ" id="3vcWfImfaK9" role="3cqZAp">
-                      <node concept="3clFbS" id="3vcWfImfaKa" role="3clFbx">
-                        <node concept="3clFbF" id="3vcWfImfaKb" role="3cqZAp">
-                          <node concept="2OqwBi" id="3vcWfImfaKc" role="3clFbG">
-                            <node concept="37vLTw" id="3vcWfImfaKd" role="2Oq$k0">
-                              <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
-                            </node>
-                            <node concept="liA8E" id="3vcWfImfaKe" role="2OqNvi">
-                              <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
-                              <node concept="Xl_RD" id="3vcWfImfaKf" role="37wK5m">
-                                <property role="Xl_RC" value="[C] " />
-                              </node>
-                              <node concept="37vLTw" id="3vcWfImfhhB" role="37wK5m">
-                                <ref role="3cqZAo" node="3vcWfImf5qw" resolve="cachedStyle" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="3vcWfImfaKh" role="3clFbw">
-                        <node concept="37vLTw" id="3vcWfImfaKi" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
-                        </node>
-                        <node concept="liA8E" id="3vcWfImfaKj" role="2OqNvi">
-                          <ref role="37wK5l" to="2ahs:3vcWfImeNK8" resolve="isCachedValue" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbJ" id="4yQfyMjo9JO" role="3cqZAp">
-                      <node concept="3clFbS" id="4yQfyMjo9JQ" role="3clFbx">
-                        <node concept="3clFbF" id="4yQfyMjom4F" role="3cqZAp">
-                          <node concept="2OqwBi" id="4yQfyMjom4G" role="3clFbG">
-                            <node concept="37vLTw" id="4yQfyMjom4H" role="2Oq$k0">
-                              <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
-                            </node>
-                            <node concept="liA8E" id="4yQfyMjom4I" role="2OqNvi">
-                              <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
-                              <node concept="Xl_RD" id="4yQfyMjom4J" role="37wK5m">
-                                <property role="Xl_RC" value="[E] " />
-                              </node>
-                              <node concept="37vLTw" id="4yQfyMjpl0Q" role="37wK5m">
-                                <ref role="3cqZAo" node="5U8d23PN057" resolve="effectStyle" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="1Wc70l" id="4yQfyMjoft2" role="3clFbw">
-                        <node concept="2OqwBi" id="6GySMNkxh$6" role="3uHU7w">
-                          <node concept="2ShNRf" id="6GySMNld7Lc" role="2Oq$k0">
-                            <node concept="1pGfFk" id="6GySMNldfwE" role="2ShVmc">
-                              <ref role="37wK5l" to="oq0c:3ni3WidV2MT" resolve="EffectHelper" />
-                              <node concept="37vLTw" id="6GySMNldk6a" role="37wK5m">
-                                <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="liA8E" id="6GySMNkxjaH" role="2OqNvi">
-                            <ref role="37wK5l" to="oq0c:6GySMNjNNTz" resolve="readsOrModifiesMutableState" />
-                          </node>
-                        </node>
-                        <node concept="2OqwBi" id="4yQfyMjocez" role="3uHU7B">
-                          <node concept="37vLTw" id="4yQfyMjob8h" role="2Oq$k0">
-                            <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
-                          </node>
-                          <node concept="1mIQ4w" id="4yQfyMjodoO" role="2OqNvi">
-                            <node concept="chp4Y" id="4yQfyMjoehf" role="cj9EA">
-                              <ref role="cht4Q" to="hm2y:6sdnDbSla17" resolve="Expression" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbJ" id="5syY_AL5s_X" role="3cqZAp">
-                      <node concept="3clFbS" id="5syY_AL5s_Z" role="3clFbx">
-                        <node concept="3clFbJ" id="1J1iBrrdDmF" role="3cqZAp">
-                          <node concept="3clFbS" id="1J1iBrrdDmH" role="3clFbx">
-                            <node concept="3clFbF" id="1J1iBrrdNd1" role="3cqZAp">
-                              <node concept="2OqwBi" id="1J1iBrrdNd2" role="3clFbG">
-                                <node concept="37vLTw" id="1J1iBrrdNd3" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
-                                </node>
-                                <node concept="liA8E" id="1J1iBrrdNd4" role="2OqNvi">
-                                  <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
-                                  <node concept="3cpWs3" id="1J1iBrrdNd5" role="37wK5m">
-                                    <node concept="Xl_RD" id="1J1iBrrdNd6" role="3uHU7w">
-                                      <property role="Xl_RC" value=": " />
-                                    </node>
-                                    <node concept="2OqwBi" id="1J1iBrrdNd7" role="3uHU7B">
-                                      <node concept="37vLTw" id="1J1iBrrdNd8" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
-                                      </node>
-                                      <node concept="liA8E" id="1J1iBrrdNd9" role="2OqNvi">
-                                        <ref role="37wK5l" to="2ahs:5syY_AL4$F2" resolve="getCustomLabel" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="37vLTw" id="1J1iBrre3hR" role="37wK5m">
-                                    <ref role="3cqZAo" node="1J1iBrrdYG7" resolve="regularStyle" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="2OqwBi" id="1J1iBrrdGIw" role="3clFbw">
-                            <node concept="37vLTw" id="1J1iBrrdF7k" role="2Oq$k0">
-                              <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
-                            </node>
-                            <node concept="liA8E" id="1J1iBrrdIFJ" role="2OqNvi">
-                              <ref role="37wK5l" to="2ahs:P1znYOxiYP" resolve="isInfoNode" />
-                            </node>
-                          </node>
-                          <node concept="9aQIb" id="1J1iBrrdKo0" role="9aQIa">
-                            <node concept="3clFbS" id="1J1iBrrdKo1" role="9aQI4">
-                              <node concept="3clFbF" id="5syY_AL5xz7" role="3cqZAp">
-                                <node concept="2OqwBi" id="5syY_AL5xz8" role="3clFbG">
-                                  <node concept="37vLTw" id="5syY_AL5xz9" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
-                                  </node>
-                                  <node concept="liA8E" id="5syY_AL5xza" role="2OqNvi">
-                                    <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
-                                    <node concept="3cpWs3" id="5syY_AL5xzb" role="37wK5m">
-                                      <node concept="Xl_RD" id="5syY_AL5xzc" role="3uHU7w">
-                                        <property role="Xl_RC" value=": " />
-                                      </node>
-                                      <node concept="2OqwBi" id="5syY_AL5$fk" role="3uHU7B">
-                                        <node concept="37vLTw" id="5syY_AL5yWM" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
-                                        </node>
-                                        <node concept="liA8E" id="5syY_AL5_Kt" role="2OqNvi">
-                                          <ref role="37wK5l" to="2ahs:5syY_AL4$F2" resolve="getCustomLabel" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="37vLTw" id="5U8d23PO0Z6" role="37wK5m">
-                                      <ref role="3cqZAo" node="5U8d23PNOPe" resolve="regularBoldStyle" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="5syY_AL5vmP" role="3clFbw">
-                        <node concept="37vLTw" id="5syY_AL5u2L" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
-                        </node>
-                        <node concept="liA8E" id="5syY_AL5wA4" role="2OqNvi">
-                          <ref role="37wK5l" to="2ahs:5syY_AL4H_l" resolve="hasCustomLabel" />
-                        </node>
-                      </node>
-                      <node concept="9aQIb" id="1AvmZ19CBNJ" role="9aQIa">
-                        <node concept="3clFbS" id="1AvmZ19CBNK" role="9aQI4">
-                          <node concept="3clFbJ" id="5Beavy0KiKG" role="3cqZAp">
-                            <node concept="3clFbS" id="5Beavy0KiKI" role="3clFbx">
-                              <node concept="3cpWs8" id="2hAELMML8JE" role="3cqZAp">
-                                <node concept="3cpWsn" id="2hAELMML8JF" role="3cpWs9">
-                                  <property role="TrG5h" value="kind" />
-                                  <node concept="17QB3L" id="2hAELMML8JA" role="1tU5fm" />
-                                  <node concept="2OqwBi" id="2hAELMML8JG" role="33vP2m">
-                                    <node concept="37vLTw" id="2hAELMML8JH" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
-                                    </node>
-                                    <node concept="liA8E" id="2hAELMML8JI" role="2OqNvi">
-                                      <ref role="37wK5l" to="2ahs:6wNYzrU01Os" resolve="getKind" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3clFbJ" id="2hAELMMLevM" role="3cqZAp">
-                                <node concept="3clFbS" id="2hAELMMLevO" role="3clFbx">
-                                  <node concept="3clFbF" id="1rUbSep6E2" role="3cqZAp">
-                                    <node concept="2OqwBi" id="1rUbSep6NX" role="3clFbG">
-                                      <node concept="37vLTw" id="1rUbSep6Iu" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
-                                      </node>
-                                      <node concept="liA8E" id="1rUbSep6XD" role="2OqNvi">
-                                        <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
-                                        <node concept="3cpWs3" id="5Beavy0L6DH" role="37wK5m">
-                                          <node concept="Xl_RD" id="5Beavy0L6JG" role="3uHU7w">
-                                            <property role="Xl_RC" value=" " />
-                                          </node>
-                                          <node concept="37vLTw" id="2hAELMML8JJ" role="3uHU7B">
-                                            <ref role="3cqZAo" node="2hAELMML8JF" resolve="kind" />
-                                          </node>
-                                        </node>
-                                        <node concept="37vLTw" id="5U8d23PNYCL" role="37wK5m">
-                                          <ref role="3cqZAo" node="5U8d23PNOPe" resolve="regularBoldStyle" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="1Wc70l" id="5d4VabvTY3p" role="3clFbw">
-                                  <node concept="2OqwBi" id="5d4VabvTZyK" role="3uHU7w">
-                                    <node concept="37vLTw" id="4yQfyMjnCg7" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
-                                    </node>
-                                    <node concept="1mIQ4w" id="5d4VabvTZUa" role="2OqNvi">
-                                      <node concept="chp4Y" id="5d4VabvTZWN" role="cj9EA">
-                                        <ref role="cht4Q" to="tpck:h0TrEE$" resolve="INamedConcept" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="2OqwBi" id="2hAELMMLfhM" role="3uHU7B">
-                                    <node concept="37vLTw" id="2hAELMMLeLc" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="2hAELMML8JF" resolve="kind" />
-                                    </node>
-                                    <node concept="liA8E" id="2hAELMMLfFW" role="2OqNvi">
-                                      <ref role="37wK5l" to="wyt6:~String.matches(java.lang.String)" resolve="matches" />
-                                      <node concept="Xl_RD" id="2hAELMMLfTS" role="37wK5m">
-                                        <property role="Xl_RC" value="[a-z ]+" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3y3z36" id="5Beavy0Kk$8" role="3clFbw">
-                              <node concept="10Nm6u" id="5Beavy0KkEf" role="3uHU7w" />
-                              <node concept="2OqwBi" id="5Beavy0KjrC" role="3uHU7B">
-                                <node concept="37vLTw" id="5Beavy0Kj5K" role="2Oq$k0">
+                              <node concept="2OqwBi" id="1J1iBrrdNd7" role="3uHU7B">
+                                <node concept="37vLTw" id="1J1iBrrdNd8" role="2Oq$k0">
                                   <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
                                 </node>
-                                <node concept="liA8E" id="5Beavy0Kkiz" role="2OqNvi">
-                                  <ref role="37wK5l" to="2ahs:6wNYzrU01Os" resolve="getKind" />
+                                <node concept="liA8E" id="1J1iBrrdNd9" role="2OqNvi">
+                                  <ref role="37wK5l" to="2ahs:5syY_AL4$F2" resolve="getCustomLabel" />
                                 </node>
+                              </node>
+                            </node>
+                            <node concept="37vLTw" id="1J1iBrre3hR" role="37wK5m">
+                              <ref role="3cqZAo" node="1J1iBrrdYG7" resolve="regularStyle" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="1J1iBrrdGIw" role="3clFbw">
+                      <node concept="37vLTw" id="1J1iBrrdF7k" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                      </node>
+                      <node concept="liA8E" id="1J1iBrrdIFJ" role="2OqNvi">
+                        <ref role="37wK5l" to="2ahs:P1znYOxiYP" resolve="isInfoNode" />
+                      </node>
+                    </node>
+                    <node concept="9aQIb" id="1J1iBrrdKo0" role="9aQIa">
+                      <node concept="3clFbS" id="1J1iBrrdKo1" role="9aQI4">
+                        <node concept="3clFbF" id="5syY_AL5xz7" role="3cqZAp">
+                          <node concept="2OqwBi" id="5syY_AL5xz8" role="3clFbG">
+                            <node concept="37vLTw" id="5syY_AL5xz9" role="2Oq$k0">
+                              <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
+                            </node>
+                            <node concept="liA8E" id="5syY_AL5xza" role="2OqNvi">
+                              <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
+                              <node concept="3cpWs3" id="5syY_AL5xzb" role="37wK5m">
+                                <node concept="Xl_RD" id="5syY_AL5xzc" role="3uHU7w">
+                                  <property role="Xl_RC" value=": " />
+                                </node>
+                                <node concept="2OqwBi" id="5syY_AL5$fk" role="3uHU7B">
+                                  <node concept="37vLTw" id="5syY_AL5yWM" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                                  </node>
+                                  <node concept="liA8E" id="5syY_AL5_Kt" role="2OqNvi">
+                                    <ref role="37wK5l" to="2ahs:5syY_AL4$F2" resolve="getCustomLabel" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="37vLTw" id="5U8d23PO0Z6" role="37wK5m">
+                                <ref role="3cqZAo" node="5U8d23PNOPe" resolve="regularBoldStyle" />
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="3clFbH" id="5U8d23PO5aX" role="3cqZAp" />
-                    <node concept="3cpWs8" id="5U8d23PO1YQ" role="3cqZAp">
-                      <node concept="3cpWsn" id="5U8d23PO1YR" role="3cpWs9">
-                        <property role="TrG5h" value="syntaxStyle" />
-                        <property role="3TUv4t" value="false" />
-                        <node concept="3uibUv" id="5U8d23PO1YS" role="1tU5fm">
-                          <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5syY_AL5vmP" role="3clFbw">
+                  <node concept="37vLTw" id="5syY_AL5u2L" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                  </node>
+                  <node concept="liA8E" id="5syY_AL5wA4" role="2OqNvi">
+                    <ref role="37wK5l" to="2ahs:5syY_AL4H_l" resolve="hasCustomLabel" />
+                  </node>
+                </node>
+                <node concept="9aQIb" id="1AvmZ19CBNJ" role="9aQIa">
+                  <node concept="3clFbS" id="1AvmZ19CBNK" role="9aQI4">
+                    <node concept="3clFbJ" id="5Beavy0KiKG" role="3cqZAp">
+                      <node concept="3clFbS" id="5Beavy0KiKI" role="3clFbx">
+                        <node concept="3cpWs8" id="2hAELMML8JE" role="3cqZAp">
+                          <node concept="3cpWsn" id="2hAELMML8JF" role="3cpWs9">
+                            <property role="TrG5h" value="kind" />
+                            <node concept="17QB3L" id="2hAELMML8JA" role="1tU5fm" />
+                            <node concept="2OqwBi" id="2hAELMML8JG" role="33vP2m">
+                              <node concept="37vLTw" id="2hAELMML8JH" role="2Oq$k0">
+                                <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                              </node>
+                              <node concept="liA8E" id="2hAELMML8JI" role="2OqNvi">
+                                <ref role="37wK5l" to="2ahs:6wNYzrU01Os" resolve="getKind" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbJ" id="2hAELMMLevM" role="3cqZAp">
+                          <node concept="3clFbS" id="2hAELMMLevO" role="3clFbx">
+                            <node concept="3clFbF" id="1rUbSep6E2" role="3cqZAp">
+                              <node concept="2OqwBi" id="1rUbSep6NX" role="3clFbG">
+                                <node concept="37vLTw" id="1rUbSep6Iu" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
+                                </node>
+                                <node concept="liA8E" id="1rUbSep6XD" role="2OqNvi">
+                                  <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
+                                  <node concept="3cpWs3" id="5Beavy0L6DH" role="37wK5m">
+                                    <node concept="Xl_RD" id="5Beavy0L6JG" role="3uHU7w">
+                                      <property role="Xl_RC" value=" " />
+                                    </node>
+                                    <node concept="37vLTw" id="2hAELMML8JJ" role="3uHU7B">
+                                      <ref role="3cqZAo" node="2hAELMML8JF" resolve="kind" />
+                                    </node>
+                                  </node>
+                                  <node concept="37vLTw" id="5U8d23PNYCL" role="37wK5m">
+                                    <ref role="3cqZAo" node="5U8d23PNOPe" resolve="regularBoldStyle" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="1Wc70l" id="5d4VabvTY3p" role="3clFbw">
+                            <node concept="2OqwBi" id="5d4VabvTZyK" role="3uHU7w">
+                              <node concept="37vLTw" id="4yQfyMjnCg7" role="2Oq$k0">
+                                <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
+                              </node>
+                              <node concept="1mIQ4w" id="5d4VabvTZUa" role="2OqNvi">
+                                <node concept="chp4Y" id="5d4VabvTZWN" role="cj9EA">
+                                  <ref role="cht4Q" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="2OqwBi" id="2hAELMMLfhM" role="3uHU7B">
+                              <node concept="37vLTw" id="2hAELMMLeLc" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2hAELMML8JF" resolve="kind" />
+                              </node>
+                              <node concept="liA8E" id="2hAELMMLfFW" role="2OqNvi">
+                                <ref role="37wK5l" to="wyt6:~String.matches(java.lang.String)" resolve="matches" />
+                                <node concept="Xl_RD" id="2hAELMMLfTS" role="37wK5m">
+                                  <property role="Xl_RC" value="[a-z ]+" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3y3z36" id="5Beavy0Kk$8" role="3clFbw">
+                        <node concept="10Nm6u" id="5Beavy0KkEf" role="3uHU7w" />
+                        <node concept="2OqwBi" id="5Beavy0KjrC" role="3uHU7B">
+                          <node concept="37vLTw" id="5Beavy0Kj5K" role="2Oq$k0">
+                            <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                          </node>
+                          <node concept="liA8E" id="5Beavy0Kkiz" role="2OqNvi">
+                            <ref role="37wK5l" to="2ahs:6wNYzrU01Os" resolve="getKind" />
+                          </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="3cpWs8" id="5U8d23PO_6m" role="3cqZAp">
-                      <node concept="3cpWsn" id="5U8d23PO_6n" role="3cpWs9">
-                        <property role="TrG5h" value="valueStyleBold" />
-                        <property role="3TUv4t" value="false" />
-                        <node concept="3uibUv" id="5U8d23PO_6o" role="1tU5fm">
-                          <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="5U8d23PO5aX" role="3cqZAp" />
+              <node concept="3cpWs8" id="5U8d23PO1YQ" role="3cqZAp">
+                <node concept="3cpWsn" id="5U8d23PO1YR" role="3cpWs9">
+                  <property role="TrG5h" value="syntaxStyle" />
+                  <property role="3TUv4t" value="false" />
+                  <node concept="3uibUv" id="5U8d23PO1YS" role="1tU5fm">
+                    <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="5U8d23PO_6m" role="3cqZAp">
+                <node concept="3cpWsn" id="5U8d23PO_6n" role="3cpWs9">
+                  <property role="TrG5h" value="valueStyleBold" />
+                  <property role="3TUv4t" value="false" />
+                  <node concept="3uibUv" id="5U8d23PO_6o" role="1tU5fm">
+                    <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="5U8d23PP0Fl" role="3cqZAp">
+                <node concept="3cpWsn" id="5U8d23PP0Fm" role="3cpWs9">
+                  <property role="TrG5h" value="valueStyleRegular" />
+                  <property role="3TUv4t" value="false" />
+                  <node concept="3uibUv" id="5U8d23PP0Fn" role="1tU5fm">
+                    <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="5d4VabvUzPA" role="3cqZAp">
+                <node concept="3clFbS" id="5d4VabvUzPC" role="3clFbx">
+                  <node concept="3clFbJ" id="1J1iBrr9eSl" role="3cqZAp">
+                    <node concept="3clFbS" id="1J1iBrr9eSn" role="3clFbx">
+                      <node concept="3clFbF" id="1J1iBrr9lQ7" role="3cqZAp">
+                        <node concept="37vLTI" id="1J1iBrr9lQ9" role="3clFbG">
+                          <node concept="37vLTw" id="1J1iBrr9lQa" role="37vLTJ">
+                            <ref role="3cqZAo" node="5U8d23PO1YR" resolve="syntaxStyle" />
+                          </node>
+                          <node concept="1rXfSq" id="1J1iBrr9lQb" role="37vLTx">
+                            <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
+                            <node concept="37vLTw" id="1J1iBrr9lQc" role="37wK5m">
+                              <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
+                            </node>
+                            <node concept="2YIFZM" id="47M_EqttyWN" role="37wK5m">
+                              <ref role="37wK5l" to="lzb2:~JBColor.foreground()" resolve="foreground" />
+                              <ref role="1Pybhc" to="lzb2:~JBColor" resolve="JBColor" />
+                            </node>
+                            <node concept="10M0yZ" id="1J1iBrr9lQf" role="37wK5m">
+                              <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                              <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="3cpWs8" id="5U8d23PP0Fl" role="3cqZAp">
-                      <node concept="3cpWsn" id="5U8d23PP0Fm" role="3cpWs9">
-                        <property role="TrG5h" value="valueStyleRegular" />
-                        <property role="3TUv4t" value="false" />
-                        <node concept="3uibUv" id="5U8d23PP0Fn" role="1tU5fm">
-                          <ref role="3uigEE" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                        </node>
+                    <node concept="2OqwBi" id="1J1iBrr9idQ" role="3clFbw">
+                      <node concept="37vLTw" id="1J1iBrr9gC5" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                      </node>
+                      <node concept="liA8E" id="1J1iBrr9ktF" role="2OqNvi">
+                        <ref role="37wK5l" to="2ahs:P1znYOxiYP" resolve="isInfoNode" />
                       </node>
                     </node>
-                    <node concept="3clFbJ" id="5d4VabvUzPA" role="3cqZAp">
-                      <node concept="3clFbS" id="5d4VabvUzPC" role="3clFbx">
-                        <node concept="3clFbJ" id="1J1iBrr9eSl" role="3cqZAp">
-                          <node concept="3clFbS" id="1J1iBrr9eSn" role="3clFbx">
-                            <node concept="3clFbF" id="1J1iBrr9lQ7" role="3cqZAp">
-                              <node concept="37vLTI" id="1J1iBrr9lQ9" role="3clFbG">
-                                <node concept="37vLTw" id="1J1iBrr9lQa" role="37vLTJ">
-                                  <ref role="3cqZAo" node="5U8d23PO1YR" resolve="syntaxStyle" />
-                                </node>
-                                <node concept="1rXfSq" id="1J1iBrr9lQb" role="37vLTx">
-                                  <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
-                                  <node concept="37vLTw" id="1J1iBrr9lQc" role="37wK5m">
-                                    <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
-                                  </node>
-                                  <node concept="2YIFZM" id="47M_EqttyWN" role="37wK5m">
-                                    <ref role="37wK5l" to="lzb2:~JBColor.foreground()" resolve="foreground" />
-                                    <ref role="1Pybhc" to="lzb2:~JBColor" resolve="JBColor" />
-                                  </node>
-                                  <node concept="10M0yZ" id="1J1iBrr9lQf" role="37wK5m">
-                                    <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                                    <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
-                                  </node>
-                                </node>
-                              </node>
+                    <node concept="3eNFk2" id="1J1iBrr9qaK" role="3eNLev">
+                      <node concept="3clFbS" id="1J1iBrr9qaM" role="3eOfB_">
+                        <node concept="3clFbF" id="5U8d23PRHEq" role="3cqZAp">
+                          <node concept="37vLTI" id="5U8d23PRHEr" role="3clFbG">
+                            <node concept="37vLTw" id="5U8d23PRHEs" role="37vLTJ">
+                              <ref role="3cqZAo" node="5U8d23PO1YR" resolve="syntaxStyle" />
                             </node>
-                          </node>
-                          <node concept="2OqwBi" id="1J1iBrr9idQ" role="3clFbw">
-                            <node concept="37vLTw" id="1J1iBrr9gC5" role="2Oq$k0">
-                              <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
-                            </node>
-                            <node concept="liA8E" id="1J1iBrr9ktF" role="2OqNvi">
-                              <ref role="37wK5l" to="2ahs:P1znYOxiYP" resolve="isInfoNode" />
-                            </node>
-                          </node>
-                          <node concept="3eNFk2" id="1J1iBrr9qaK" role="3eNLev">
-                            <node concept="3clFbS" id="1J1iBrr9qaM" role="3eOfB_">
-                              <node concept="3clFbF" id="5U8d23PRHEq" role="3cqZAp">
-                                <node concept="37vLTI" id="5U8d23PRHEr" role="3clFbG">
-                                  <node concept="37vLTw" id="5U8d23PRHEs" role="37vLTJ">
-                                    <ref role="3cqZAo" node="5U8d23PO1YR" resolve="syntaxStyle" />
-                                  </node>
-                                  <node concept="1rXfSq" id="5U8d23PRHEt" role="37vLTx">
-                                    <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
-                                    <node concept="37vLTw" id="5U8d23PRHEu" role="37wK5m">
-                                      <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
-                                    </node>
-                                    <node concept="2YIFZM" id="47M_EqttA6u" role="37wK5m">
-                                      <ref role="37wK5l" to="lzb2:~JBColor.foreground()" resolve="foreground" />
-                                      <ref role="1Pybhc" to="lzb2:~JBColor" resolve="JBColor" />
-                                    </node>
-                                    <node concept="pVOtf" id="5U8d23PRHEw" role="37wK5m">
-                                      <node concept="10M0yZ" id="5U8d23PRHEx" role="3uHU7B">
-                                        <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
-                                        <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                                      </node>
-                                      <node concept="10M0yZ" id="5U8d23PRHEy" role="3uHU7w">
-                                        <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_UNDERLINE" resolve="STYLE_UNDERLINE" />
-                                        <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="1Wc70l" id="5U8d23PSBUo" role="3eO9$A">
-                              <node concept="2OqwBi" id="5U8d23PSHpS" role="3uHU7w">
-                                <node concept="1PxgMI" id="5U8d23PSEXX" role="2Oq$k0">
-                                  <node concept="chp4Y" id="5U8d23PSGeH" role="3oSUPX">
-                                    <ref role="cht4Q" to="3673:7obiejCehKv" resolve="ITracerFrame" />
-                                  </node>
-                                  <node concept="37vLTw" id="5U8d23PSDuQ" role="1m5AlR">
-                                    <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
-                                  </node>
-                                </node>
-                                <node concept="2qgKlT" id="5U8d23PSIKj" role="2OqNvi">
-                                  <ref role="37wK5l" to="kqnq:5U8d23PSzWx" resolve="isMajor" />
-                                </node>
-                              </node>
-                              <node concept="2OqwBi" id="5U8d23PRDUk" role="3uHU7B">
-                                <node concept="37vLTw" id="5U8d23PRCt0" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
-                                </node>
-                                <node concept="1mIQ4w" id="5U8d23PRFm9" role="2OqNvi">
-                                  <node concept="chp4Y" id="5U8d23PRGwh" role="cj9EA">
-                                    <ref role="cht4Q" to="3673:7obiejCehKv" resolve="ITracerFrame" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="9aQIb" id="1J1iBrr9u7A" role="9aQIa">
-                            <node concept="3clFbS" id="1J1iBrr9u7B" role="9aQI4">
-                              <node concept="3clFbF" id="5U8d23POdk$" role="3cqZAp">
-                                <node concept="37vLTI" id="5U8d23POe$k" role="3clFbG">
-                                  <node concept="37vLTw" id="5U8d23POdky" role="37vLTJ">
-                                    <ref role="3cqZAo" node="5U8d23PO1YR" resolve="syntaxStyle" />
-                                  </node>
-                                  <node concept="1rXfSq" id="5U8d23PO1YT" role="37vLTx">
-                                    <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
-                                    <node concept="37vLTw" id="5U8d23PO1YU" role="37wK5m">
-                                      <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
-                                    </node>
-                                    <node concept="2YIFZM" id="47M_EqttDwc" role="37wK5m">
-                                      <ref role="37wK5l" to="lzb2:~JBColor.foreground()" resolve="foreground" />
-                                      <ref role="1Pybhc" to="lzb2:~JBColor" resolve="JBColor" />
-                                    </node>
-                                    <node concept="10M0yZ" id="5U8d23PQ4dC" role="37wK5m">
-                                      <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
-                                      <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3clFbF" id="5U8d23POB9C" role="3cqZAp">
-                          <node concept="37vLTI" id="5U8d23POB9D" role="3clFbG">
-                            <node concept="37vLTw" id="5U8d23POCnP" role="37vLTJ">
-                              <ref role="3cqZAo" node="5U8d23PO_6n" resolve="valueStyleBold" />
-                            </node>
-                            <node concept="1rXfSq" id="5U8d23POB9F" role="37vLTx">
+                            <node concept="1rXfSq" id="5U8d23PRHEt" role="37vLTx">
                               <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
-                              <node concept="37vLTw" id="5U8d23POB9G" role="37wK5m">
+                              <node concept="37vLTw" id="5U8d23PRHEu" role="37wK5m">
                                 <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
                               </node>
-                              <node concept="10M0yZ" id="5U8d23POB9H" role="37wK5m">
-                                <ref role="3cqZAo" to="2gm9:1rUbSeoByS" resolve="DEBUGGER_COLOR" />
-                                <ref role="1PxDUh" to="2gm9:1rUbSeoBxI" resolve="TracingConstants" />
+                              <node concept="2YIFZM" id="47M_EqttA6u" role="37wK5m">
+                                <ref role="37wK5l" to="lzb2:~JBColor.foreground()" resolve="foreground" />
+                                <ref role="1Pybhc" to="lzb2:~JBColor" resolve="JBColor" />
                               </node>
-                              <node concept="10M0yZ" id="5U8d23POB9I" role="37wK5m">
-                                <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                                <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_BOLD" resolve="STYLE_BOLD" />
+                              <node concept="pVOtf" id="5U8d23PRHEw" role="37wK5m">
+                                <node concept="10M0yZ" id="5U8d23PRHEx" role="3uHU7B">
+                                  <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
+                                  <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                                </node>
+                                <node concept="10M0yZ" id="5U8d23PRHEy" role="3uHU7w">
+                                  <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_UNDERLINE" resolve="STYLE_UNDERLINE" />
+                                  <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                                </node>
                               </node>
                             </node>
                           </node>
                         </node>
-                        <node concept="3clFbF" id="5U8d23PPayV" role="3cqZAp">
-                          <node concept="37vLTI" id="5U8d23PPayW" role="3clFbG">
-                            <node concept="37vLTw" id="5U8d23PPkkY" role="37vLTJ">
-                              <ref role="3cqZAo" node="5U8d23PP0Fm" resolve="valueStyleRegular" />
+                      </node>
+                      <node concept="1Wc70l" id="5U8d23PSBUo" role="3eO9$A">
+                        <node concept="2OqwBi" id="5U8d23PSHpS" role="3uHU7w">
+                          <node concept="1PxgMI" id="5U8d23PSEXX" role="2Oq$k0">
+                            <node concept="chp4Y" id="5U8d23PSGeH" role="3oSUPX">
+                              <ref role="cht4Q" to="3673:7obiejCehKv" resolve="ITracerFrame" />
                             </node>
-                            <node concept="1rXfSq" id="5U8d23PPayY" role="37vLTx">
+                            <node concept="37vLTw" id="5U8d23PSDuQ" role="1m5AlR">
+                              <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
+                            </node>
+                          </node>
+                          <node concept="2qgKlT" id="5U8d23PSIKj" role="2OqNvi">
+                            <ref role="37wK5l" to="kqnq:5U8d23PSzWx" resolve="isMajor" />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="5U8d23PRDUk" role="3uHU7B">
+                          <node concept="37vLTw" id="5U8d23PRCt0" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
+                          </node>
+                          <node concept="1mIQ4w" id="5U8d23PRFm9" role="2OqNvi">
+                            <node concept="chp4Y" id="5U8d23PRGwh" role="cj9EA">
+                              <ref role="cht4Q" to="3673:7obiejCehKv" resolve="ITracerFrame" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="9aQIb" id="1J1iBrr9u7A" role="9aQIa">
+                      <node concept="3clFbS" id="1J1iBrr9u7B" role="9aQI4">
+                        <node concept="3clFbF" id="5U8d23POdk$" role="3cqZAp">
+                          <node concept="37vLTI" id="5U8d23POe$k" role="3clFbG">
+                            <node concept="37vLTw" id="5U8d23POdky" role="37vLTJ">
+                              <ref role="3cqZAo" node="5U8d23PO1YR" resolve="syntaxStyle" />
+                            </node>
+                            <node concept="1rXfSq" id="5U8d23PO1YT" role="37vLTx">
                               <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
-                              <node concept="37vLTw" id="5U8d23PPayZ" role="37wK5m">
+                              <node concept="37vLTw" id="5U8d23PO1YU" role="37wK5m">
                                 <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
                               </node>
-                              <node concept="10M0yZ" id="5U8d23PPaz0" role="37wK5m">
-                                <ref role="3cqZAo" to="2gm9:1rUbSeoByS" resolve="DEBUGGER_COLOR" />
-                                <ref role="1PxDUh" to="2gm9:1rUbSeoBxI" resolve="TracingConstants" />
+                              <node concept="2YIFZM" id="47M_EqttDwc" role="37wK5m">
+                                <ref role="37wK5l" to="lzb2:~JBColor.foreground()" resolve="foreground" />
+                                <ref role="1Pybhc" to="lzb2:~JBColor" resolve="JBColor" />
                               </node>
-                              <node concept="10M0yZ" id="5U8d23PPbEk" role="37wK5m">
+                              <node concept="10M0yZ" id="5U8d23PQ4dC" role="37wK5m">
                                 <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
                                 <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
                               </node>
@@ -3363,745 +3320,787 @@
                           </node>
                         </node>
                       </node>
-                      <node concept="2OqwBi" id="5d4VabvU$Z6" role="3clFbw">
-                        <node concept="37vLTw" id="5d4VabvU$BP" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="5U8d23POB9C" role="3cqZAp">
+                    <node concept="37vLTI" id="5U8d23POB9D" role="3clFbG">
+                      <node concept="37vLTw" id="5U8d23POCnP" role="37vLTJ">
+                        <ref role="3cqZAo" node="5U8d23PO_6n" resolve="valueStyleBold" />
+                      </node>
+                      <node concept="1rXfSq" id="5U8d23POB9F" role="37vLTx">
+                        <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
+                        <node concept="37vLTw" id="5U8d23POB9G" role="37wK5m">
+                          <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
                         </node>
-                        <node concept="liA8E" id="5d4VabvU_pc" role="2OqNvi">
-                          <ref role="37wK5l" to="2ahs:5d4VabvUiEx" resolve="isInAnEditor" />
+                        <node concept="10M0yZ" id="5U8d23POB9H" role="37wK5m">
+                          <ref role="3cqZAo" to="2gm9:1rUbSeoByS" resolve="DEBUGGER_COLOR" />
+                          <ref role="1PxDUh" to="2gm9:1rUbSeoBxI" resolve="TracingConstants" />
+                        </node>
+                        <node concept="10M0yZ" id="5U8d23POB9I" role="37wK5m">
+                          <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                          <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_BOLD" resolve="STYLE_BOLD" />
                         </node>
                       </node>
-                      <node concept="9aQIb" id="5d4VabvUAuf" role="9aQIa">
-                        <node concept="3clFbS" id="5d4VabvUAug" role="9aQI4">
-                          <node concept="3clFbJ" id="5U8d23PRQgY" role="3cqZAp">
-                            <node concept="3clFbS" id="5U8d23PRQgZ" role="3clFbx">
-                              <node concept="3clFbF" id="5U8d23PRQh0" role="3cqZAp">
-                                <node concept="37vLTI" id="5U8d23PRQh1" role="3clFbG">
-                                  <node concept="37vLTw" id="5U8d23PRQh2" role="37vLTJ">
-                                    <ref role="3cqZAo" node="5U8d23PO1YR" resolve="syntaxStyle" />
-                                  </node>
-                                  <node concept="1rXfSq" id="5U8d23PRQh3" role="37vLTx">
-                                    <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
-                                    <node concept="37vLTw" id="5U8d23PRQh4" role="37wK5m">
-                                      <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
-                                    </node>
-                                    <node concept="10M0yZ" id="47M_EqttGjf" role="37wK5m">
-                                      <ref role="3cqZAo" to="lzb2:~JBColor.GRAY" resolve="GRAY" />
-                                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
-                                    </node>
-                                    <node concept="pVOtf" id="5U8d23PRQh6" role="37wK5m">
-                                      <node concept="10M0yZ" id="5U8d23PRQh7" role="3uHU7B">
-                                        <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                                        <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
-                                      </node>
-                                      <node concept="10M0yZ" id="5U8d23PRQh8" role="3uHU7w">
-                                        <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                                        <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_UNDERLINE" resolve="STYLE_UNDERLINE" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="5U8d23PPayV" role="3cqZAp">
+                    <node concept="37vLTI" id="5U8d23PPayW" role="3clFbG">
+                      <node concept="37vLTw" id="5U8d23PPkkY" role="37vLTJ">
+                        <ref role="3cqZAo" node="5U8d23PP0Fm" resolve="valueStyleRegular" />
+                      </node>
+                      <node concept="1rXfSq" id="5U8d23PPayY" role="37vLTx">
+                        <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
+                        <node concept="37vLTw" id="5U8d23PPayZ" role="37wK5m">
+                          <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
+                        </node>
+                        <node concept="10M0yZ" id="5U8d23PPaz0" role="37wK5m">
+                          <ref role="3cqZAo" to="2gm9:1rUbSeoByS" resolve="DEBUGGER_COLOR" />
+                          <ref role="1PxDUh" to="2gm9:1rUbSeoBxI" resolve="TracingConstants" />
+                        </node>
+                        <node concept="10M0yZ" id="5U8d23PPbEk" role="37wK5m">
+                          <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
+                          <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="5d4VabvU$Z6" role="3clFbw">
+                  <node concept="37vLTw" id="5d4VabvU$BP" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                  </node>
+                  <node concept="liA8E" id="5d4VabvU_pc" role="2OqNvi">
+                    <ref role="37wK5l" to="2ahs:5d4VabvUiEx" resolve="isInAnEditor" />
+                  </node>
+                </node>
+                <node concept="9aQIb" id="5d4VabvUAuf" role="9aQIa">
+                  <node concept="3clFbS" id="5d4VabvUAug" role="9aQI4">
+                    <node concept="3clFbJ" id="5U8d23PRQgY" role="3cqZAp">
+                      <node concept="3clFbS" id="5U8d23PRQgZ" role="3clFbx">
+                        <node concept="3clFbF" id="5U8d23PRQh0" role="3cqZAp">
+                          <node concept="37vLTI" id="5U8d23PRQh1" role="3clFbG">
+                            <node concept="37vLTw" id="5U8d23PRQh2" role="37vLTJ">
+                              <ref role="3cqZAo" node="5U8d23PO1YR" resolve="syntaxStyle" />
                             </node>
-                            <node concept="9aQIb" id="5U8d23PRQhd" role="9aQIa">
-                              <node concept="3clFbS" id="5U8d23PRQhe" role="9aQI4">
-                                <node concept="3clFbF" id="5U8d23PRQhf" role="3cqZAp">
-                                  <node concept="37vLTI" id="5U8d23PRQhg" role="3clFbG">
-                                    <node concept="37vLTw" id="5U8d23PRQhh" role="37vLTJ">
-                                      <ref role="3cqZAo" node="5U8d23PO1YR" resolve="syntaxStyle" />
-                                    </node>
-                                    <node concept="1rXfSq" id="5U8d23PRQhi" role="37vLTx">
-                                      <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
-                                      <node concept="37vLTw" id="5U8d23PRQhj" role="37wK5m">
-                                        <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
-                                      </node>
-                                      <node concept="10M0yZ" id="47M_EqttJt7" role="37wK5m">
-                                        <ref role="3cqZAo" to="lzb2:~JBColor.GRAY" resolve="GRAY" />
-                                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
-                                      </node>
-                                      <node concept="10M0yZ" id="5U8d23PRQhm" role="37wK5m">
-                                        <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                                        <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
+                            <node concept="1rXfSq" id="5U8d23PRQh3" role="37vLTx">
+                              <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
+                              <node concept="37vLTw" id="5U8d23PRQh4" role="37wK5m">
+                                <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
                               </node>
-                            </node>
-                            <node concept="1Wc70l" id="5U8d23PSJZs" role="3clFbw">
-                              <node concept="2OqwBi" id="5U8d23PSJZt" role="3uHU7w">
-                                <node concept="1PxgMI" id="5U8d23PSJZu" role="2Oq$k0">
-                                  <node concept="chp4Y" id="5U8d23PSJZv" role="3oSUPX">
-                                    <ref role="cht4Q" to="3673:7obiejCehKv" resolve="ITracerFrame" />
-                                  </node>
-                                  <node concept="37vLTw" id="5U8d23PSJZw" role="1m5AlR">
-                                    <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
-                                  </node>
-                                </node>
-                                <node concept="2qgKlT" id="5U8d23PSJZx" role="2OqNvi">
-                                  <ref role="37wK5l" to="kqnq:5U8d23PSzWx" resolve="isMajor" />
-                                </node>
+                              <node concept="10M0yZ" id="47M_EqttGjf" role="37wK5m">
+                                <ref role="3cqZAo" to="lzb2:~JBColor.GRAY" resolve="GRAY" />
+                                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                               </node>
-                              <node concept="2OqwBi" id="5U8d23PSJZy" role="3uHU7B">
-                                <node concept="37vLTw" id="5U8d23PSJZz" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
+                              <node concept="pVOtf" id="5U8d23PRQh6" role="37wK5m">
+                                <node concept="10M0yZ" id="5U8d23PRQh7" role="3uHU7B">
+                                  <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                                  <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
                                 </node>
-                                <node concept="1mIQ4w" id="5U8d23PSJZ$" role="2OqNvi">
-                                  <node concept="chp4Y" id="5U8d23PSJZ_" role="cj9EA">
-                                    <ref role="cht4Q" to="3673:7obiejCehKv" resolve="ITracerFrame" />
-                                  </node>
+                                <node concept="10M0yZ" id="5U8d23PRQh8" role="3uHU7w">
+                                  <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                                  <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_UNDERLINE" resolve="STYLE_UNDERLINE" />
                                 </node>
                               </node>
                             </node>
                           </node>
-                          <node concept="3clFbF" id="5U8d23POocU" role="3cqZAp">
-                            <node concept="37vLTI" id="5U8d23POocV" role="3clFbG">
-                              <node concept="37vLTw" id="5U8d23POJZW" role="37vLTJ">
-                                <ref role="3cqZAo" node="5U8d23PO_6n" resolve="valueStyleBold" />
+                        </node>
+                      </node>
+                      <node concept="9aQIb" id="5U8d23PRQhd" role="9aQIa">
+                        <node concept="3clFbS" id="5U8d23PRQhe" role="9aQI4">
+                          <node concept="3clFbF" id="5U8d23PRQhf" role="3cqZAp">
+                            <node concept="37vLTI" id="5U8d23PRQhg" role="3clFbG">
+                              <node concept="37vLTw" id="5U8d23PRQhh" role="37vLTJ">
+                                <ref role="3cqZAo" node="5U8d23PO1YR" resolve="syntaxStyle" />
                               </node>
-                              <node concept="1rXfSq" id="5U8d23POocX" role="37vLTx">
+                              <node concept="1rXfSq" id="5U8d23PRQhi" role="37vLTx">
                                 <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
-                                <node concept="37vLTw" id="5U8d23POocY" role="37wK5m">
+                                <node concept="37vLTw" id="5U8d23PRQhj" role="37wK5m">
                                   <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
                                 </node>
-                                <node concept="10M0yZ" id="5U8d23POPid" role="37wK5m">
-                                  <ref role="3cqZAo" to="2gm9:5IR_boHb$0A" resolve="DEBUGGER_COLOR_LIGHT" />
-                                  <ref role="1PxDUh" to="2gm9:1rUbSeoBxI" resolve="TracingConstants" />
+                                <node concept="10M0yZ" id="47M_EqttJt7" role="37wK5m">
+                                  <ref role="3cqZAo" to="lzb2:~JBColor.GRAY" resolve="GRAY" />
+                                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                                 </node>
-                                <node concept="10M0yZ" id="5U8d23POqkQ" role="37wK5m">
-                                  <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
+                                <node concept="10M0yZ" id="5U8d23PRQhm" role="37wK5m">
                                   <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
+                                  <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
                                 </node>
                               </node>
                             </node>
                           </node>
-                          <node concept="3clFbF" id="5U8d23PPgUz" role="3cqZAp">
-                            <node concept="37vLTI" id="5U8d23PPgU$" role="3clFbG">
-                              <node concept="37vLTw" id="5U8d23PPlx2" role="37vLTJ">
-                                <ref role="3cqZAo" node="5U8d23PP0Fm" resolve="valueStyleRegular" />
-                              </node>
-                              <node concept="1rXfSq" id="5U8d23PPgUA" role="37vLTx">
-                                <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
-                                <node concept="37vLTw" id="5U8d23PPgUB" role="37wK5m">
-                                  <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
-                                </node>
-                                <node concept="10M0yZ" id="5U8d23PPgUC" role="37wK5m">
-                                  <ref role="3cqZAo" to="2gm9:5IR_boHb$0A" resolve="DEBUGGER_COLOR_LIGHT" />
-                                  <ref role="1PxDUh" to="2gm9:1rUbSeoBxI" resolve="TracingConstants" />
-                                </node>
-                                <node concept="10M0yZ" id="5U8d23PPgUD" role="37wK5m">
-                                  <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
-                                  <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
-                                </node>
-                              </node>
+                        </node>
+                      </node>
+                      <node concept="1Wc70l" id="5U8d23PSJZs" role="3clFbw">
+                        <node concept="2OqwBi" id="5U8d23PSJZt" role="3uHU7w">
+                          <node concept="1PxgMI" id="5U8d23PSJZu" role="2Oq$k0">
+                            <node concept="chp4Y" id="5U8d23PSJZv" role="3oSUPX">
+                              <ref role="cht4Q" to="3673:7obiejCehKv" resolve="ITracerFrame" />
+                            </node>
+                            <node concept="37vLTw" id="5U8d23PSJZw" role="1m5AlR">
+                              <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
+                            </node>
+                          </node>
+                          <node concept="2qgKlT" id="5U8d23PSJZx" role="2OqNvi">
+                            <ref role="37wK5l" to="kqnq:5U8d23PSzWx" resolve="isMajor" />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="5U8d23PSJZy" role="3uHU7B">
+                          <node concept="37vLTw" id="5U8d23PSJZz" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
+                          </node>
+                          <node concept="1mIQ4w" id="5U8d23PSJZ$" role="2OqNvi">
+                            <node concept="chp4Y" id="5U8d23PSJZ_" role="cj9EA">
+                              <ref role="cht4Q" to="3673:7obiejCehKv" resolve="ITracerFrame" />
                             </node>
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="3cpWs8" id="5U8d23Qm8PK" role="3cqZAp">
-                      <node concept="3cpWsn" id="5U8d23Qm8PL" role="3cpWs9">
-                        <property role="TrG5h" value="syntax" />
-                        <node concept="17QB3L" id="5U8d23Qm8PJ" role="1tU5fm" />
-                        <node concept="3K4zz7" id="1J1iBrrcI4w" role="33vP2m">
-                          <node concept="Xl_RD" id="1J1iBrrcJLC" role="3K4E3e">
-                            <property role="Xl_RC" value="" />
+                    <node concept="3clFbF" id="5U8d23POocU" role="3cqZAp">
+                      <node concept="37vLTI" id="5U8d23POocV" role="3clFbG">
+                        <node concept="37vLTw" id="5U8d23POJZW" role="37vLTJ">
+                          <ref role="3cqZAo" node="5U8d23PO_6n" resolve="valueStyleBold" />
+                        </node>
+                        <node concept="1rXfSq" id="5U8d23POocX" role="37vLTx">
+                          <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
+                          <node concept="37vLTw" id="5U8d23POocY" role="37wK5m">
+                            <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
                           </node>
-                          <node concept="2OqwBi" id="1J1iBrrcEtk" role="3K4Cdx">
-                            <node concept="37vLTw" id="1J1iBrrcCQQ" role="2Oq$k0">
-                              <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
-                            </node>
-                            <node concept="liA8E" id="1J1iBrrcGft" role="2OqNvi">
-                              <ref role="37wK5l" to="2ahs:P1znYOxiYP" resolve="isInfoNode" />
-                            </node>
+                          <node concept="10M0yZ" id="5U8d23POPid" role="37wK5m">
+                            <ref role="3cqZAo" to="2gm9:5IR_boHb$0A" resolve="DEBUGGER_COLOR_LIGHT" />
+                            <ref role="1PxDUh" to="2gm9:1rUbSeoBxI" resolve="TracingConstants" />
                           </node>
-                          <node concept="2OqwBi" id="5U8d23Qm8PM" role="3K4GZi">
-                            <node concept="37vLTw" id="5U8d23Qm8PN" role="2Oq$k0">
-                              <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
-                            </node>
-                            <node concept="liA8E" id="5U8d23Qm8PO" role="2OqNvi">
-                              <ref role="37wK5l" to="2ahs:5Beavy0Kfu9" resolve="getSyntax" />
-                            </node>
+                          <node concept="10M0yZ" id="5U8d23POqkQ" role="37wK5m">
+                            <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
+                            <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="3clFbJ" id="5U8d23QmeJq" role="3cqZAp">
-                      <node concept="3clFbS" id="5U8d23QmeJs" role="3clFbx">
-                        <node concept="3clFbF" id="5U8d23QmnP0" role="3cqZAp">
-                          <node concept="37vLTI" id="5U8d23Qmp9m" role="3clFbG">
-                            <node concept="3cpWs3" id="5U8d23Qm_nb" role="37vLTx">
-                              <node concept="Xl_RD" id="5U8d23Qm_z0" role="3uHU7w">
-                                <property role="Xl_RC" value="..." />
-                              </node>
-                              <node concept="2OqwBi" id="5U8d23QmssD" role="3uHU7B">
-                                <node concept="37vLTw" id="5U8d23QmqWv" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="5U8d23Qm8PL" resolve="syntax" />
-                                </node>
-                                <node concept="liA8E" id="5U8d23Qmubq" role="2OqNvi">
-                                  <ref role="37wK5l" to="wyt6:~String.substring(int,int)" resolve="substring" />
-                                  <node concept="3cmrfG" id="5U8d23Qmvt6" role="37wK5m">
-                                    <property role="3cmrfH" value="0" />
-                                  </node>
-                                  <node concept="37vLTw" id="6DRSV4d_aCR" role="37wK5m">
-                                    <ref role="3cqZAo" node="6DRSV4d_7AL" resolve="MAX_SYNTAX_LEN" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="37vLTw" id="5U8d23QmnOY" role="37vLTJ">
-                              <ref role="3cqZAo" node="5U8d23Qm8PL" resolve="syntax" />
-                            </node>
+                    <node concept="3clFbF" id="5U8d23PPgUz" role="3cqZAp">
+                      <node concept="37vLTI" id="5U8d23PPgU$" role="3clFbG">
+                        <node concept="37vLTw" id="5U8d23PPlx2" role="37vLTJ">
+                          <ref role="3cqZAo" node="5U8d23PP0Fm" resolve="valueStyleRegular" />
+                        </node>
+                        <node concept="1rXfSq" id="5U8d23PPgUA" role="37vLTx">
+                          <ref role="37wK5l" node="5U8d23PNiog" resolve="ta" />
+                          <node concept="37vLTw" id="5U8d23PPgUB" role="37wK5m">
+                            <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
+                          </node>
+                          <node concept="10M0yZ" id="5U8d23PPgUC" role="37wK5m">
+                            <ref role="3cqZAo" to="2gm9:5IR_boHb$0A" resolve="DEBUGGER_COLOR_LIGHT" />
+                            <ref role="1PxDUh" to="2gm9:1rUbSeoBxI" resolve="TracingConstants" />
+                          </node>
+                          <node concept="10M0yZ" id="5U8d23PPgUD" role="37wK5m">
+                            <ref role="3cqZAo" to="lzb2:~SimpleTextAttributes.STYLE_PLAIN" resolve="STYLE_PLAIN" />
+                            <ref role="1PxDUh" to="lzb2:~SimpleTextAttributes" resolve="SimpleTextAttributes" />
                           </node>
                         </node>
                       </node>
-                      <node concept="3eOSWO" id="5U8d23Qmm09" role="3clFbw">
-                        <node concept="37vLTw" id="6DRSV4d_7AP" role="3uHU7w">
-                          <ref role="3cqZAo" node="6DRSV4d_7AL" resolve="MAX_SYNTAX_LEN" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="5U8d23Qm8PK" role="3cqZAp">
+                <node concept="3cpWsn" id="5U8d23Qm8PL" role="3cpWs9">
+                  <property role="TrG5h" value="syntax" />
+                  <node concept="17QB3L" id="5U8d23Qm8PJ" role="1tU5fm" />
+                  <node concept="3K4zz7" id="1J1iBrrcI4w" role="33vP2m">
+                    <node concept="Xl_RD" id="1J1iBrrcJLC" role="3K4E3e">
+                      <property role="Xl_RC" value="" />
+                    </node>
+                    <node concept="2OqwBi" id="1J1iBrrcEtk" role="3K4Cdx">
+                      <node concept="37vLTw" id="1J1iBrrcCQQ" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                      </node>
+                      <node concept="liA8E" id="1J1iBrrcGft" role="2OqNvi">
+                        <ref role="37wK5l" to="2ahs:P1znYOxiYP" resolve="isInfoNode" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="5U8d23Qm8PM" role="3K4GZi">
+                      <node concept="37vLTw" id="5U8d23Qm8PN" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                      </node>
+                      <node concept="liA8E" id="5U8d23Qm8PO" role="2OqNvi">
+                        <ref role="37wK5l" to="2ahs:5Beavy0Kfu9" resolve="getSyntax" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="5U8d23QmeJq" role="3cqZAp">
+                <node concept="3clFbS" id="5U8d23QmeJs" role="3clFbx">
+                  <node concept="3clFbF" id="5U8d23QmnP0" role="3cqZAp">
+                    <node concept="37vLTI" id="5U8d23Qmp9m" role="3clFbG">
+                      <node concept="3cpWs3" id="5U8d23Qm_nb" role="37vLTx">
+                        <node concept="Xl_RD" id="5U8d23Qm_z0" role="3uHU7w">
+                          <property role="Xl_RC" value="..." />
                         </node>
-                        <node concept="2OqwBi" id="5U8d23Qmi9u" role="3uHU7B">
-                          <node concept="37vLTw" id="5U8d23Qmg_R" role="2Oq$k0">
+                        <node concept="2OqwBi" id="5U8d23QmssD" role="3uHU7B">
+                          <node concept="37vLTw" id="5U8d23QmqWv" role="2Oq$k0">
                             <ref role="3cqZAo" node="5U8d23Qm8PL" resolve="syntax" />
                           </node>
-                          <node concept="liA8E" id="5U8d23QmjZW" role="2OqNvi">
-                            <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                          <node concept="liA8E" id="5U8d23Qmubq" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~String.substring(int,int)" resolve="substring" />
+                            <node concept="3cmrfG" id="5U8d23Qmvt6" role="37wK5m">
+                              <property role="3cmrfH" value="0" />
+                            </node>
+                            <node concept="37vLTw" id="6DRSV4d_aCR" role="37wK5m">
+                              <ref role="3cqZAo" node="6DRSV4d_7AL" resolve="MAX_SYNTAX_LEN" />
+                            </node>
                           </node>
                         </node>
                       </node>
+                      <node concept="37vLTw" id="5U8d23QmnOY" role="37vLTJ">
+                        <ref role="3cqZAo" node="5U8d23Qm8PL" resolve="syntax" />
+                      </node>
                     </node>
-                    <node concept="3clFbF" id="5Beavy0KlLI" role="3cqZAp">
-                      <node concept="2OqwBi" id="5Beavy0Km8a" role="3clFbG">
-                        <node concept="37vLTw" id="5Beavy0KlLG" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
+                  </node>
+                </node>
+                <node concept="3eOSWO" id="5U8d23Qmm09" role="3clFbw">
+                  <node concept="37vLTw" id="6DRSV4d_7AP" role="3uHU7w">
+                    <ref role="3cqZAo" node="6DRSV4d_7AL" resolve="MAX_SYNTAX_LEN" />
+                  </node>
+                  <node concept="2OqwBi" id="5U8d23Qmi9u" role="3uHU7B">
+                    <node concept="37vLTw" id="5U8d23Qmg_R" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5U8d23Qm8PL" resolve="syntax" />
+                    </node>
+                    <node concept="liA8E" id="5U8d23QmjZW" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="5Beavy0KlLI" role="3cqZAp">
+                <node concept="2OqwBi" id="5Beavy0Km8a" role="3clFbG">
+                  <node concept="37vLTw" id="5Beavy0KlLG" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
+                  </node>
+                  <node concept="liA8E" id="5Beavy0Kmq5" role="2OqNvi">
+                    <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
+                    <node concept="37vLTw" id="5U8d23Qm8PP" role="37wK5m">
+                      <ref role="3cqZAo" node="5U8d23Qm8PL" resolve="syntax" />
+                    </node>
+                    <node concept="37vLTw" id="5U8d23POvVP" role="37wK5m">
+                      <ref role="3cqZAo" node="5U8d23PO1YR" resolve="syntaxStyle" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="5U8d23POl4r" role="3cqZAp" />
+              <node concept="3cpWs8" id="2CFPPn7nQl4" role="3cqZAp">
+                <node concept="3cpWsn" id="2CFPPn7nQl5" role="3cpWs9">
+                  <property role="TrG5h" value="value" />
+                  <node concept="3uibUv" id="2CFPPn7ogIr" role="1tU5fm">
+                    <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                  </node>
+                  <node concept="2OqwBi" id="2CFPPn7nQl6" role="33vP2m">
+                    <node concept="37vLTw" id="2CFPPn7nQl7" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                    </node>
+                    <node concept="liA8E" id="2CFPPn7nQl8" role="2OqNvi">
+                      <ref role="37wK5l" to="2ahs:2CFPPn7AGoH" resolve="getTracedValue" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="2jL$v5BW2XA" role="3cqZAp">
+                <node concept="3clFbS" id="2jL$v5BW2XC" role="3clFbx">
+                  <node concept="3clFbF" id="2jL$v5BWNKt" role="3cqZAp">
+                    <node concept="2OqwBi" id="2jL$v5BWNKu" role="3clFbG">
+                      <node concept="37vLTw" id="2jL$v5BWNKv" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
+                      </node>
+                      <node concept="liA8E" id="2jL$v5BWNKw" role="2OqNvi">
+                        <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
+                        <node concept="Xl_RD" id="2jL$v5BWNKx" role="37wK5m">
+                          <property role="Xl_RC" value="  \u21EA  " />
                         </node>
-                        <node concept="liA8E" id="5Beavy0Kmq5" role="2OqNvi">
-                          <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
-                          <node concept="37vLTw" id="5U8d23Qm8PP" role="37wK5m">
-                            <ref role="3cqZAo" node="5U8d23Qm8PL" resolve="syntax" />
-                          </node>
-                          <node concept="37vLTw" id="5U8d23POvVP" role="37wK5m">
-                            <ref role="3cqZAo" node="5U8d23PO1YR" resolve="syntaxStyle" />
-                          </node>
+                        <node concept="37vLTw" id="5U8d23PORzy" role="37wK5m">
+                          <ref role="3cqZAo" node="5U8d23POwW3" resolve="errorStyle" />
                         </node>
                       </node>
                     </node>
-                    <node concept="3clFbH" id="5U8d23POl4r" role="3cqZAp" />
-                    <node concept="3cpWs8" id="2CFPPn7nQl4" role="3cqZAp">
-                      <node concept="3cpWsn" id="2CFPPn7nQl5" role="3cpWs9">
-                        <property role="TrG5h" value="value" />
-                        <node concept="3uibUv" id="2CFPPn7ogIr" role="1tU5fm">
-                          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                        </node>
-                        <node concept="2OqwBi" id="2CFPPn7nQl6" role="33vP2m">
-                          <node concept="37vLTw" id="2CFPPn7nQl7" role="2Oq$k0">
+                  </node>
+                  <node concept="3clFbF" id="2jL$v5BWOPv" role="3cqZAp">
+                    <node concept="2OqwBi" id="2jL$v5BWOPw" role="3clFbG">
+                      <node concept="37vLTw" id="2jL$v5BWOPx" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
+                      </node>
+                      <node concept="liA8E" id="2jL$v5BWOPy" role="2OqNvi">
+                        <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
+                        <node concept="2OqwBi" id="2jL$v5BWTvg" role="37wK5m">
+                          <node concept="37vLTw" id="2jL$v5BWShW" role="2Oq$k0">
                             <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
                           </node>
-                          <node concept="liA8E" id="2CFPPn7nQl8" role="2OqNvi">
-                            <ref role="37wK5l" to="2ahs:2CFPPn7AGoH" resolve="getTracedValue" />
+                          <node concept="liA8E" id="2jL$v5BWUUL" role="2OqNvi">
+                            <ref role="37wK5l" to="2ahs:2jL$v5BWagj" resolve="getConstrainFailureMessage" />
                           </node>
+                        </node>
+                        <node concept="37vLTw" id="5U8d23POTPm" role="37wK5m">
+                          <ref role="3cqZAo" node="5U8d23POwW3" resolve="errorStyle" />
                         </node>
                       </node>
                     </node>
-                    <node concept="3clFbJ" id="2jL$v5BW2XA" role="3cqZAp">
-                      <node concept="3clFbS" id="2jL$v5BW2XC" role="3clFbx">
-                        <node concept="3clFbF" id="2jL$v5BWNKt" role="3cqZAp">
-                          <node concept="2OqwBi" id="2jL$v5BWNKu" role="3clFbG">
-                            <node concept="37vLTw" id="2jL$v5BWNKv" role="2Oq$k0">
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="2jL$v5BW5Gy" role="3clFbw">
+                  <node concept="37vLTw" id="2jL$v5BW4rC" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                  </node>
+                  <node concept="liA8E" id="2jL$v5BWIu5" role="2OqNvi">
+                    <ref role="37wK5l" to="2ahs:2jL$v5BWpOw" resolve="hasConstraintFailure" />
+                  </node>
+                </node>
+                <node concept="9aQIb" id="2jL$v5BWJK9" role="9aQIa">
+                  <node concept="3clFbS" id="2jL$v5BWJKa" role="9aQI4">
+                    <node concept="3clFbJ" id="6wNYzrU0ZRc" role="3cqZAp">
+                      <node concept="3clFbS" id="6wNYzrU0ZRe" role="3clFbx">
+                        <node concept="3clFbF" id="6wNYzrU0brI" role="3cqZAp">
+                          <node concept="2OqwBi" id="6wNYzrU0bBc" role="3clFbG">
+                            <node concept="37vLTw" id="6wNYzrU0brG" role="2Oq$k0">
                               <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
                             </node>
-                            <node concept="liA8E" id="2jL$v5BWNKw" role="2OqNvi">
+                            <node concept="liA8E" id="6wNYzrU0bSh" role="2OqNvi">
                               <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
-                              <node concept="Xl_RD" id="2jL$v5BWNKx" role="37wK5m">
-                                <property role="Xl_RC" value="  \u21EA  " />
+                              <node concept="Xl_RD" id="6wNYzrU0cAf" role="37wK5m">
+                                <property role="Xl_RC" value="  \u21D2  " />
                               </node>
-                              <node concept="37vLTw" id="5U8d23PORzy" role="37wK5m">
-                                <ref role="3cqZAo" node="5U8d23POwW3" resolve="errorStyle" />
+                              <node concept="37vLTw" id="5U8d23POXhs" role="37wK5m">
+                                <ref role="3cqZAo" node="5U8d23PO_6n" resolve="valueStyleBold" />
                               </node>
                             </node>
                           </node>
                         </node>
-                        <node concept="3clFbF" id="2jL$v5BWOPv" role="3cqZAp">
-                          <node concept="2OqwBi" id="2jL$v5BWOPw" role="3clFbG">
-                            <node concept="37vLTw" id="2jL$v5BWOPx" role="2Oq$k0">
-                              <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
-                            </node>
-                            <node concept="liA8E" id="2jL$v5BWOPy" role="2OqNvi">
-                              <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
-                              <node concept="2OqwBi" id="2jL$v5BWTvg" role="37wK5m">
-                                <node concept="37vLTw" id="2jL$v5BWShW" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
-                                </node>
-                                <node concept="liA8E" id="2jL$v5BWUUL" role="2OqNvi">
-                                  <ref role="37wK5l" to="2ahs:2jL$v5BWagj" resolve="getConstrainFailureMessage" />
-                                </node>
-                              </node>
-                              <node concept="37vLTw" id="5U8d23POTPm" role="37wK5m">
-                                <ref role="3cqZAo" node="5U8d23POwW3" resolve="errorStyle" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="2jL$v5BW5Gy" role="3clFbw">
-                        <node concept="37vLTw" id="2jL$v5BW4rC" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
-                        </node>
-                        <node concept="liA8E" id="2jL$v5BWIu5" role="2OqNvi">
-                          <ref role="37wK5l" to="2ahs:2jL$v5BWpOw" resolve="hasConstraintFailure" />
-                        </node>
-                      </node>
-                      <node concept="9aQIb" id="2jL$v5BWJK9" role="9aQIa">
-                        <node concept="3clFbS" id="2jL$v5BWJKa" role="9aQI4">
-                          <node concept="3clFbJ" id="6wNYzrU0ZRc" role="3cqZAp">
-                            <node concept="3clFbS" id="6wNYzrU0ZRe" role="3clFbx">
-                              <node concept="3clFbF" id="6wNYzrU0brI" role="3cqZAp">
-                                <node concept="2OqwBi" id="6wNYzrU0bBc" role="3clFbG">
-                                  <node concept="37vLTw" id="6wNYzrU0brG" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
-                                  </node>
-                                  <node concept="liA8E" id="6wNYzrU0bSh" role="2OqNvi">
-                                    <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
-                                    <node concept="Xl_RD" id="6wNYzrU0cAf" role="37wK5m">
-                                      <property role="Xl_RC" value="  \u21D2  " />
-                                    </node>
-                                    <node concept="37vLTw" id="5U8d23POXhs" role="37wK5m">
-                                      <ref role="3cqZAo" node="5U8d23PO_6n" resolve="valueStyleBold" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3cpWs8" id="5IR_boHOdf1" role="3cqZAp">
-                                <node concept="3cpWsn" id="5IR_boHOdf2" role="3cpWs9">
-                                  <property role="TrG5h" value="valString" />
-                                  <node concept="17QB3L" id="4yQfyMjptDo" role="1tU5fm" />
-                                  <node concept="2OqwBi" id="5IR_boHOdf3" role="33vP2m">
-                                    <node concept="37vLTw" id="5IR_boHOdf4" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="2CFPPn7nQl5" resolve="value" />
-                                    </node>
-                                    <node concept="liA8E" id="5IR_boHOdf5" role="2OqNvi">
-                                      <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3clFbJ" id="5IR_boHOgKg" role="3cqZAp">
-                                <node concept="3clFbS" id="5IR_boHOgKi" role="3clFbx">
-                                  <node concept="3clFbF" id="5IR_boHOnsl" role="3cqZAp">
-                                    <node concept="37vLTI" id="5IR_boHOoFk" role="3clFbG">
-                                      <node concept="3cpWs3" id="5IR_boHOxR5" role="37vLTx">
-                                        <node concept="Xl_RD" id="5IR_boHOy2O" role="3uHU7w">
-                                          <property role="Xl_RC" value=" ..." />
-                                        </node>
-                                        <node concept="2OqwBi" id="5IR_boHOr2Y" role="3uHU7B">
-                                          <node concept="37vLTw" id="5IR_boHOpTm" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="5IR_boHOdf2" resolve="valString" />
-                                          </node>
-                                          <node concept="liA8E" id="5IR_boHOsEc" role="2OqNvi">
-                                            <ref role="37wK5l" to="wyt6:~String.substring(int,int)" resolve="substring" />
-                                            <node concept="3cmrfG" id="5IR_boHOtEc" role="37wK5m">
-                                              <property role="3cmrfH" value="0" />
-                                            </node>
-                                            <node concept="37vLTw" id="6DRSV4d_zwP" role="37wK5m">
-                                              <ref role="3cqZAo" node="6DRSV4d_wdC" resolve="MAX_VAL_LEN" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="37vLTw" id="5IR_boHOnsj" role="37vLTJ">
-                                        <ref role="3cqZAo" node="5IR_boHOdf2" resolve="valString" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="3eOSWO" id="5IR_boHOlOJ" role="3clFbw">
-                                  <node concept="37vLTw" id="6DRSV4d_wdG" role="3uHU7w">
-                                    <ref role="3cqZAo" node="6DRSV4d_wdC" resolve="MAX_VAL_LEN" />
-                                  </node>
-                                  <node concept="2OqwBi" id="5IR_boHOj2S" role="3uHU7B">
-                                    <node concept="37vLTw" id="5IR_boHOhPN" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="5IR_boHOdf2" resolve="valString" />
-                                    </node>
-                                    <node concept="liA8E" id="5IR_boHOkdk" role="2OqNvi">
-                                      <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3clFbF" id="6wNYzrU0cJZ" role="3cqZAp">
-                                <node concept="2OqwBi" id="6wNYzrU0cK0" role="3clFbG">
-                                  <node concept="37vLTw" id="6wNYzrU0cK1" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
-                                  </node>
-                                  <node concept="liA8E" id="6wNYzrU0cK2" role="2OqNvi">
-                                    <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
-                                    <node concept="37vLTw" id="5IR_boHOdf6" role="37wK5m">
-                                      <ref role="3cqZAo" node="5IR_boHOdf2" resolve="valString" />
-                                    </node>
-                                    <node concept="37vLTw" id="5U8d23POZEn" role="37wK5m">
-                                      <ref role="3cqZAo" node="5U8d23PO_6n" resolve="valueStyleBold" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3cpWs8" id="5Odw3gwFnd9" role="3cqZAp">
-                                <node concept="3cpWsn" id="5Odw3gwFndc" role="3cpWs9">
-                                  <property role="TrG5h" value="nn" />
-                                  <node concept="17QB3L" id="5Odw3gwFndd" role="1tU5fm" />
-                                  <node concept="2OqwBi" id="2CFPPn7LAE$" role="33vP2m">
-                                    <node concept="2OqwBi" id="2CFPPn7LAE_" role="2Oq$k0">
-                                      <node concept="37vLTw" id="2CFPPn7LAEA" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="2CFPPn7nQl5" resolve="value" />
-                                      </node>
-                                      <node concept="liA8E" id="2CFPPn7LAEB" role="2OqNvi">
-                                        <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
-                                      </node>
-                                    </node>
-                                    <node concept="liA8E" id="2CFPPn7LAEC" role="2OqNvi">
-                                      <ref role="37wK5l" to="wyt6:~Class.getCanonicalName()" resolve="getCanonicalName" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3clFbJ" id="2CFPPn7LJFK" role="3cqZAp">
-                                <node concept="3clFbS" id="2CFPPn7LJFM" role="3clFbx">
-                                  <node concept="3clFbF" id="2CFPPn7LCoi" role="3cqZAp">
-                                    <node concept="37vLTI" id="2CFPPn7LCSA" role="3clFbG">
-                                      <node concept="2OqwBi" id="2CFPPn7LDBw" role="37vLTx">
-                                        <node concept="37vLTw" id="2CFPPn7LD9J" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="5Odw3gwFndc" resolve="nn" />
-                                        </node>
-                                        <node concept="liA8E" id="2CFPPn7LEBQ" role="2OqNvi">
-                                          <ref role="37wK5l" to="wyt6:~String.substring(int)" resolve="substring" />
-                                          <node concept="3cpWs3" id="2CFPPn7LYWQ" role="37wK5m">
-                                            <node concept="3cmrfG" id="2CFPPn7LZ4D" role="3uHU7w">
-                                              <property role="3cmrfH" value="1" />
-                                            </node>
-                                            <node concept="2OqwBi" id="2CFPPn7LFBI" role="3uHU7B">
-                                              <node concept="37vLTw" id="2CFPPn7LF5B" role="2Oq$k0">
-                                                <ref role="3cqZAo" node="5Odw3gwFndc" resolve="nn" />
-                                              </node>
-                                              <node concept="liA8E" id="2CFPPn7LGBu" role="2OqNvi">
-                                                <ref role="37wK5l" to="wyt6:~String.lastIndexOf(int)" resolve="lastIndexOf" />
-                                                <node concept="1Xhbcc" id="2CFPPn7LHVt" role="37wK5m">
-                                                  <property role="1XhdNS" value="." />
-                                                </node>
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="37vLTw" id="2CFPPn7LCog" role="37vLTJ">
-                                        <ref role="3cqZAo" node="5Odw3gwFndc" resolve="nn" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="1Wc70l" id="5Odw3gwGjz4" role="3clFbw">
-                                  <node concept="3y3z36" id="5Odw3gwGmzX" role="3uHU7B">
-                                    <node concept="10Nm6u" id="5Odw3gwGnUq" role="3uHU7w" />
-                                    <node concept="37vLTw" id="5Odw3gwGkTp" role="3uHU7B">
-                                      <ref role="3cqZAo" node="5Odw3gwFndc" resolve="nn" />
-                                    </node>
-                                  </node>
-                                  <node concept="2OqwBi" id="2CFPPn7LKzb" role="3uHU7w">
-                                    <node concept="37vLTw" id="2CFPPn7LK0H" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="5Odw3gwFndc" resolve="nn" />
-                                    </node>
-                                    <node concept="liA8E" id="2CFPPn7LLwf" role="2OqNvi">
-                                      <ref role="37wK5l" to="wyt6:~String.contains(java.lang.CharSequence)" resolve="contains" />
-                                      <node concept="Xl_RD" id="2CFPPn7LNJW" role="37wK5m">
-                                        <property role="Xl_RC" value="." />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3clFbF" id="2CFPPn7LhVz" role="3cqZAp">
-                                <node concept="2OqwBi" id="2CFPPn7LhV$" role="3clFbG">
-                                  <node concept="37vLTw" id="2CFPPn7LhV_" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
-                                  </node>
-                                  <node concept="liA8E" id="2CFPPn7LhVA" role="2OqNvi">
-                                    <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
-                                    <node concept="3cpWs3" id="2CFPPn7LlkI" role="37wK5m">
-                                      <node concept="Xl_RD" id="2CFPPn7Llsx" role="3uHU7B">
-                                        <property role="Xl_RC" value=" : " />
-                                      </node>
-                                      <node concept="37vLTw" id="2CFPPn7LAED" role="3uHU7w">
-                                        <ref role="3cqZAo" node="5Odw3gwFndc" resolve="nn" />
-                                      </node>
-                                    </node>
-                                    <node concept="37vLTw" id="5U8d23PPnVb" role="37wK5m">
-                                      <ref role="3cqZAo" node="5U8d23PP0Fm" resolve="valueStyleRegular" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3cpWs8" id="4HGbj9Til8y" role="3cqZAp">
-                                <node concept="3cpWsn" id="4HGbj9Til8z" role="3cpWs9">
-                                  <property role="TrG5h" value="ts" />
-                                  <node concept="17QB3L" id="4HGbj9Til8v" role="1tU5fm" />
-                                  <node concept="2OqwBi" id="4HGbj9Til8$" role="33vP2m">
-                                    <node concept="37vLTw" id="4HGbj9Til8_" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
-                                    </node>
-                                    <node concept="liA8E" id="4HGbj9Til8A" role="2OqNvi">
-                                      <ref role="37wK5l" to="2ahs:6wNYzrTZgHJ" resolve="getTimeAsString" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="3clFbJ" id="4HGbj9TifVt" role="3cqZAp">
-                                <node concept="3clFbS" id="4HGbj9TifVv" role="3clFbx">
-                                  <node concept="3clFbF" id="6wNYzrU0fnn" role="3cqZAp">
-                                    <node concept="2OqwBi" id="6wNYzrU0fno" role="3clFbG">
-                                      <node concept="37vLTw" id="6wNYzrU0fnp" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
-                                      </node>
-                                      <node concept="liA8E" id="6wNYzrU0fnq" role="2OqNvi">
-                                        <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
-                                        <node concept="3cpWs3" id="6wNYzrU0ghV" role="37wK5m">
-                                          <node concept="Xl_RD" id="6wNYzrU0gnU" role="3uHU7w">
-                                            <property role="Xl_RC" value=" ms)" />
-                                          </node>
-                                          <node concept="3cpWs3" id="6wNYzrU1csI" role="3uHU7B">
-                                            <node concept="Xl_RD" id="6wNYzrU1cyH" role="3uHU7B">
-                                              <property role="Xl_RC" value="   (" />
-                                            </node>
-                                            <node concept="37vLTw" id="4HGbj9Til8C" role="3uHU7w">
-                                              <ref role="3cqZAo" node="4HGbj9Til8z" resolve="ts" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                        <node concept="37vLTw" id="47M_EqtukZN" role="37wK5m">
-                                          <ref role="3cqZAo" node="47M_Eqtu4ii" resolve="inactiveStyle" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="3y3z36" id="4HGbj9TiiC2" role="3clFbw">
-                                  <node concept="10Nm6u" id="4HGbj9TiiO7" role="3uHU7w" />
-                                  <node concept="37vLTw" id="4HGbj9Til8B" role="3uHU7B">
-                                    <ref role="3cqZAo" node="4HGbj9Til8z" resolve="ts" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3y3z36" id="6wNYzrU12J6" role="3clFbw">
-                              <node concept="10Nm6u" id="6wNYzrU12Pd" role="3uHU7w" />
-                              <node concept="37vLTw" id="2CFPPn7nQla" role="3uHU7B">
+                        <node concept="3cpWs8" id="5IR_boHOdf1" role="3cqZAp">
+                          <node concept="3cpWsn" id="5IR_boHOdf2" role="3cpWs9">
+                            <property role="TrG5h" value="valString" />
+                            <node concept="17QB3L" id="4yQfyMjptDo" role="1tU5fm" />
+                            <node concept="2OqwBi" id="5IR_boHOdf3" role="33vP2m">
+                              <node concept="37vLTw" id="5IR_boHOdf4" role="2Oq$k0">
                                 <ref role="3cqZAo" node="2CFPPn7nQl5" resolve="value" />
                               </node>
+                              <node concept="liA8E" id="5IR_boHOdf5" role="2OqNvi">
+                                <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                              </node>
                             </node>
                           </node>
                         </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbH" id="5Beavy1mo1r" role="3cqZAp" />
-                    <node concept="3cpWs8" id="5Beavy1mebe" role="3cqZAp">
-                      <node concept="3cpWsn" id="5Beavy1mebf" role="3cpWs9">
-                        <property role="TrG5h" value="icon" />
-                        <node concept="3uibUv" id="5Beavy1meb8" role="1tU5fm">
-                          <ref role="3uigEE" to="dxuu:~Icon" resolve="Icon" />
-                        </node>
-                        <node concept="10Nm6u" id="5Beavy1moN_" role="33vP2m" />
-                      </node>
-                    </node>
-                    <node concept="3cpWs8" id="7GPsQwLRzZU" role="3cqZAp">
-                      <node concept="3cpWsn" id="7GPsQwLRzZV" role="3cpWs9">
-                        <property role="TrG5h" value="iconMng" />
-                        <node concept="3uibUv" id="7GPsQwLRzZT" role="1tU5fm">
-                          <ref role="3uigEE" to="sn11:192HKKPMXeL" resolve="GlobalIconManager" />
-                        </node>
-                        <node concept="2YIFZM" id="7GPsQwLRzZW" role="33vP2m">
-                          <ref role="37wK5l" to="sn11:5UC$YgehaLf" resolve="getInstance" />
-                          <ref role="1Pybhc" to="sn11:192HKKPMXeL" resolve="GlobalIconManager" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbJ" id="P1znYOxZhA" role="3cqZAp">
-                      <node concept="3clFbS" id="P1znYOxZhC" role="3clFbx">
-                        <node concept="3clFbF" id="P1znYOydxY" role="3cqZAp">
-                          <node concept="37vLTI" id="P1znYOyf11" role="3clFbG">
-                            <node concept="37vLTw" id="P1znYOydxW" role="37vLTJ">
-                              <ref role="3cqZAo" node="5Beavy1mebf" resolve="icon" />
-                            </node>
-                            <node concept="10M0yZ" id="P1znYOymhQ" role="37vLTx">
-                              <ref role="3cqZAo" to="z2i8:~AllIcons$General.Information" resolve="Information" />
-                              <ref role="1PxDUh" to="z2i8:~AllIcons$General" resolve="AllIcons.General" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="P1znYOy2Kk" role="3clFbw">
-                        <node concept="37vLTw" id="P1znYOy18S" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
-                        </node>
-                        <node concept="liA8E" id="P1znYOy4Ge" role="2OqNvi">
-                          <ref role="37wK5l" to="2ahs:P1znYOxiYP" resolve="isInfoNode" />
-                        </node>
-                      </node>
-                      <node concept="3eNFk2" id="P1znYOynXq" role="3eNLev">
-                        <node concept="3clFbS" id="P1znYOynXs" role="3eOfB_">
-                          <node concept="3clFbF" id="7GPsQwLRIQB" role="3cqZAp">
-                            <node concept="37vLTI" id="7GPsQwLRKrL" role="3clFbG">
-                              <node concept="2OqwBi" id="7GPsQwLROD$" role="37vLTx">
-                                <node concept="37vLTw" id="7GPsQwLRMxs" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="7GPsQwLRzZV" resolve="iconMng" />
-                                </node>
-                                <node concept="liA8E" id="7GPsQwLRQNt" role="2OqNvi">
-                                  <ref role="37wK5l" to="sn11:192HKKPOd3m" resolve="getIconFor" />
-                                  <node concept="2OqwBi" id="P1znYOvizE" role="37wK5m">
-                                    <node concept="37vLTw" id="P1znYOvgYW" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                        <node concept="3clFbJ" id="5IR_boHOgKg" role="3cqZAp">
+                          <node concept="3clFbS" id="5IR_boHOgKi" role="3clFbx">
+                            <node concept="3clFbF" id="5IR_boHOnsl" role="3cqZAp">
+                              <node concept="37vLTI" id="5IR_boHOoFk" role="3clFbG">
+                                <node concept="3cpWs3" id="5IR_boHOxR5" role="37vLTx">
+                                  <node concept="Xl_RD" id="5IR_boHOy2O" role="3uHU7w">
+                                    <property role="Xl_RC" value=" ..." />
+                                  </node>
+                                  <node concept="2OqwBi" id="5IR_boHOr2Y" role="3uHU7B">
+                                    <node concept="37vLTw" id="5IR_boHOpTm" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="5IR_boHOdf2" resolve="valString" />
                                     </node>
-                                    <node concept="liA8E" id="P1znYOvkhh" role="2OqNvi">
-                                      <ref role="37wK5l" to="2ahs:P1znYOt66X" resolve="getIconNode" />
+                                    <node concept="liA8E" id="5IR_boHOsEc" role="2OqNvi">
+                                      <ref role="37wK5l" to="wyt6:~String.substring(int,int)" resolve="substring" />
+                                      <node concept="3cmrfG" id="5IR_boHOtEc" role="37wK5m">
+                                        <property role="3cmrfH" value="0" />
+                                      </node>
+                                      <node concept="37vLTw" id="6DRSV4d_zwP" role="37wK5m">
+                                        <ref role="3cqZAo" node="6DRSV4d_wdC" resolve="MAX_VAL_LEN" />
+                                      </node>
                                     </node>
                                   </node>
                                 </node>
-                              </node>
-                              <node concept="37vLTw" id="7GPsQwLRIQ_" role="37vLTJ">
-                                <ref role="3cqZAo" node="5Beavy1mebf" resolve="icon" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3y3z36" id="P1znYOv6Yf" role="3eO9$A">
-                          <node concept="10Nm6u" id="P1znYOv8pm" role="3uHU7w" />
-                          <node concept="2OqwBi" id="P1znYOv3f_" role="3uHU7B">
-                            <node concept="37vLTw" id="P1znYOv1CX" role="2Oq$k0">
-                              <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
-                            </node>
-                            <node concept="liA8E" id="P1znYOv5uE" role="2OqNvi">
-                              <ref role="37wK5l" to="2ahs:P1znYOt66X" resolve="getIconNode" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="9aQIb" id="P1znYOytNu" role="9aQIa">
-                        <node concept="3clFbS" id="P1znYOytNv" role="9aQI4">
-                          <node concept="3cpWs8" id="5Beavy1n4np" role="3cqZAp">
-                            <node concept="3cpWsn" id="5Beavy1n4nq" role="3cpWs9">
-                              <property role="TrG5h" value="acd" />
-                              <node concept="3Tqbb2" id="5Beavy1n4nn" role="1tU5fm">
-                                <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
-                              </node>
-                              <node concept="2OqwBi" id="5Beavy1n4nr" role="33vP2m">
-                                <node concept="2OqwBi" id="5Beavy1n4ns" role="2Oq$k0">
-                                  <node concept="37vLTw" id="4yQfyMjnCg8" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
-                                  </node>
-                                  <node concept="2yIwOk" id="5Beavy1n4nw" role="2OqNvi" />
+                                <node concept="37vLTw" id="5IR_boHOnsj" role="37vLTJ">
+                                  <ref role="3cqZAo" node="5IR_boHOdf2" resolve="valString" />
                                 </node>
-                                <node concept="FGMqu" id="5Beavy1n4nx" role="2OqNvi" />
                               </node>
                             </node>
                           </node>
-                          <node concept="3clFbJ" id="5Beavy1n5f7" role="3cqZAp">
-                            <node concept="3clFbS" id="5Beavy1n5f9" role="3clFbx">
-                              <node concept="3clFbJ" id="5d4VabwgTGS" role="3cqZAp">
-                                <node concept="3clFbS" id="5d4VabwgTGU" role="3clFbx">
-                                  <node concept="3clFbF" id="7GPsQwLS07a" role="3cqZAp">
-                                    <node concept="37vLTI" id="7GPsQwLS5z0" role="3clFbG">
-                                      <node concept="2OqwBi" id="7GPsQwLS9ob" role="37vLTx">
-                                        <node concept="37vLTw" id="7GPsQwLS7Jr" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="7GPsQwLRzZV" resolve="iconMng" />
+                          <node concept="3eOSWO" id="5IR_boHOlOJ" role="3clFbw">
+                            <node concept="37vLTw" id="6DRSV4d_wdG" role="3uHU7w">
+                              <ref role="3cqZAo" node="6DRSV4d_wdC" resolve="MAX_VAL_LEN" />
+                            </node>
+                            <node concept="2OqwBi" id="5IR_boHOj2S" role="3uHU7B">
+                              <node concept="37vLTw" id="5IR_boHOhPN" role="2Oq$k0">
+                                <ref role="3cqZAo" node="5IR_boHOdf2" resolve="valString" />
+                              </node>
+                              <node concept="liA8E" id="5IR_boHOkdk" role="2OqNvi">
+                                <ref role="37wK5l" to="wyt6:~String.length()" resolve="length" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="6wNYzrU0cJZ" role="3cqZAp">
+                          <node concept="2OqwBi" id="6wNYzrU0cK0" role="3clFbG">
+                            <node concept="37vLTw" id="6wNYzrU0cK1" role="2Oq$k0">
+                              <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
+                            </node>
+                            <node concept="liA8E" id="6wNYzrU0cK2" role="2OqNvi">
+                              <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
+                              <node concept="37vLTw" id="5IR_boHOdf6" role="37wK5m">
+                                <ref role="3cqZAo" node="5IR_boHOdf2" resolve="valString" />
+                              </node>
+                              <node concept="37vLTw" id="5U8d23POZEn" role="37wK5m">
+                                <ref role="3cqZAo" node="5U8d23PO_6n" resolve="valueStyleBold" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="5Odw3gwFnd9" role="3cqZAp">
+                          <node concept="3cpWsn" id="5Odw3gwFndc" role="3cpWs9">
+                            <property role="TrG5h" value="nn" />
+                            <node concept="17QB3L" id="5Odw3gwFndd" role="1tU5fm" />
+                            <node concept="2OqwBi" id="2CFPPn7LAE$" role="33vP2m">
+                              <node concept="2OqwBi" id="2CFPPn7LAE_" role="2Oq$k0">
+                                <node concept="37vLTw" id="2CFPPn7LAEA" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="2CFPPn7nQl5" resolve="value" />
+                                </node>
+                                <node concept="liA8E" id="2CFPPn7LAEB" role="2OqNvi">
+                                  <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="2CFPPn7LAEC" role="2OqNvi">
+                                <ref role="37wK5l" to="wyt6:~Class.getCanonicalName()" resolve="getCanonicalName" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbJ" id="2CFPPn7LJFK" role="3cqZAp">
+                          <node concept="3clFbS" id="2CFPPn7LJFM" role="3clFbx">
+                            <node concept="3clFbF" id="2CFPPn7LCoi" role="3cqZAp">
+                              <node concept="37vLTI" id="2CFPPn7LCSA" role="3clFbG">
+                                <node concept="2OqwBi" id="2CFPPn7LDBw" role="37vLTx">
+                                  <node concept="37vLTw" id="2CFPPn7LD9J" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="5Odw3gwFndc" resolve="nn" />
+                                  </node>
+                                  <node concept="liA8E" id="2CFPPn7LEBQ" role="2OqNvi">
+                                    <ref role="37wK5l" to="wyt6:~String.substring(int)" resolve="substring" />
+                                    <node concept="3cpWs3" id="2CFPPn7LYWQ" role="37wK5m">
+                                      <node concept="3cmrfG" id="2CFPPn7LZ4D" role="3uHU7w">
+                                        <property role="3cmrfH" value="1" />
+                                      </node>
+                                      <node concept="2OqwBi" id="2CFPPn7LFBI" role="3uHU7B">
+                                        <node concept="37vLTw" id="2CFPPn7LF5B" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="5Odw3gwFndc" resolve="nn" />
                                         </node>
-                                        <node concept="liA8E" id="7GPsQwLSbzf" role="2OqNvi">
-                                          <ref role="37wK5l" to="sn11:192HKKPOd3m" resolve="getIconFor" />
-                                          <node concept="37vLTw" id="7GPsQwLSdDf" role="37wK5m">
-                                            <ref role="3cqZAo" node="5d4VabvUxVq" resolve="ghostIconNode" />
+                                        <node concept="liA8E" id="2CFPPn7LGBu" role="2OqNvi">
+                                          <ref role="37wK5l" to="wyt6:~String.lastIndexOf(int)" resolve="lastIndexOf" />
+                                          <node concept="1Xhbcc" id="2CFPPn7LHVt" role="37wK5m">
+                                            <property role="1XhdNS" value="." />
                                           </node>
                                         </node>
                                       </node>
-                                      <node concept="37vLTw" id="7GPsQwLS078" role="37vLTJ">
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="37vLTw" id="2CFPPn7LCog" role="37vLTJ">
+                                  <ref role="3cqZAo" node="5Odw3gwFndc" resolve="nn" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="1Wc70l" id="5Odw3gwGjz4" role="3clFbw">
+                            <node concept="3y3z36" id="5Odw3gwGmzX" role="3uHU7B">
+                              <node concept="10Nm6u" id="5Odw3gwGnUq" role="3uHU7w" />
+                              <node concept="37vLTw" id="5Odw3gwGkTp" role="3uHU7B">
+                                <ref role="3cqZAo" node="5Odw3gwFndc" resolve="nn" />
+                              </node>
+                            </node>
+                            <node concept="2OqwBi" id="2CFPPn7LKzb" role="3uHU7w">
+                              <node concept="37vLTw" id="2CFPPn7LK0H" role="2Oq$k0">
+                                <ref role="3cqZAo" node="5Odw3gwFndc" resolve="nn" />
+                              </node>
+                              <node concept="liA8E" id="2CFPPn7LLwf" role="2OqNvi">
+                                <ref role="37wK5l" to="wyt6:~String.contains(java.lang.CharSequence)" resolve="contains" />
+                                <node concept="Xl_RD" id="2CFPPn7LNJW" role="37wK5m">
+                                  <property role="Xl_RC" value="." />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="2CFPPn7LhVz" role="3cqZAp">
+                          <node concept="2OqwBi" id="2CFPPn7LhV$" role="3clFbG">
+                            <node concept="37vLTw" id="2CFPPn7LhV_" role="2Oq$k0">
+                              <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
+                            </node>
+                            <node concept="liA8E" id="2CFPPn7LhVA" role="2OqNvi">
+                              <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
+                              <node concept="3cpWs3" id="2CFPPn7LlkI" role="37wK5m">
+                                <node concept="Xl_RD" id="2CFPPn7Llsx" role="3uHU7B">
+                                  <property role="Xl_RC" value=" : " />
+                                </node>
+                                <node concept="37vLTw" id="2CFPPn7LAED" role="3uHU7w">
+                                  <ref role="3cqZAo" node="5Odw3gwFndc" resolve="nn" />
+                                </node>
+                              </node>
+                              <node concept="37vLTw" id="5U8d23PPnVb" role="37wK5m">
+                                <ref role="3cqZAo" node="5U8d23PP0Fm" resolve="valueStyleRegular" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs8" id="4HGbj9Til8y" role="3cqZAp">
+                          <node concept="3cpWsn" id="4HGbj9Til8z" role="3cpWs9">
+                            <property role="TrG5h" value="ts" />
+                            <node concept="17QB3L" id="4HGbj9Til8v" role="1tU5fm" />
+                            <node concept="2OqwBi" id="4HGbj9Til8$" role="33vP2m">
+                              <node concept="37vLTw" id="4HGbj9Til8_" role="2Oq$k0">
+                                <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                              </node>
+                              <node concept="liA8E" id="4HGbj9Til8A" role="2OqNvi">
+                                <ref role="37wK5l" to="2ahs:6wNYzrTZgHJ" resolve="getTimeAsString" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbJ" id="4HGbj9TifVt" role="3cqZAp">
+                          <node concept="3clFbS" id="4HGbj9TifVv" role="3clFbx">
+                            <node concept="3clFbF" id="6wNYzrU0fnn" role="3cqZAp">
+                              <node concept="2OqwBi" id="6wNYzrU0fno" role="3clFbG">
+                                <node concept="37vLTw" id="6wNYzrU0fnp" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
+                                </node>
+                                <node concept="liA8E" id="6wNYzrU0fnq" role="2OqNvi">
+                                  <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
+                                  <node concept="3cpWs3" id="6wNYzrU0ghV" role="37wK5m">
+                                    <node concept="Xl_RD" id="6wNYzrU0gnU" role="3uHU7w">
+                                      <property role="Xl_RC" value=" ms)" />
+                                    </node>
+                                    <node concept="3cpWs3" id="6wNYzrU1csI" role="3uHU7B">
+                                      <node concept="Xl_RD" id="6wNYzrU1cyH" role="3uHU7B">
+                                        <property role="Xl_RC" value="   (" />
+                                      </node>
+                                      <node concept="37vLTw" id="4HGbj9Til8C" role="3uHU7w">
+                                        <ref role="3cqZAo" node="4HGbj9Til8z" resolve="ts" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="37vLTw" id="47M_EqtukZN" role="37wK5m">
+                                    <ref role="3cqZAo" node="47M_Eqtu4ii" resolve="inactiveStyle" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3y3z36" id="4HGbj9TiiC2" role="3clFbw">
+                            <node concept="10Nm6u" id="4HGbj9TiiO7" role="3uHU7w" />
+                            <node concept="37vLTw" id="4HGbj9Til8B" role="3uHU7B">
+                              <ref role="3cqZAo" node="4HGbj9Til8z" resolve="ts" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3y3z36" id="6wNYzrU12J6" role="3clFbw">
+                        <node concept="10Nm6u" id="6wNYzrU12Pd" role="3uHU7w" />
+                        <node concept="37vLTw" id="2CFPPn7nQla" role="3uHU7B">
+                          <ref role="3cqZAo" node="2CFPPn7nQl5" resolve="value" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="5Beavy1mo1r" role="3cqZAp" />
+              <node concept="3cpWs8" id="5Beavy1mebe" role="3cqZAp">
+                <node concept="3cpWsn" id="5Beavy1mebf" role="3cpWs9">
+                  <property role="TrG5h" value="icon" />
+                  <node concept="3uibUv" id="5Beavy1meb8" role="1tU5fm">
+                    <ref role="3uigEE" to="dxuu:~Icon" resolve="Icon" />
+                  </node>
+                  <node concept="10Nm6u" id="5Beavy1moN_" role="33vP2m" />
+                </node>
+              </node>
+              <node concept="3cpWs8" id="7GPsQwLRzZU" role="3cqZAp">
+                <node concept="3cpWsn" id="7GPsQwLRzZV" role="3cpWs9">
+                  <property role="TrG5h" value="iconMng" />
+                  <node concept="3uibUv" id="7GPsQwLRzZT" role="1tU5fm">
+                    <ref role="3uigEE" to="sn11:192HKKPMXeL" resolve="GlobalIconManager" />
+                  </node>
+                  <node concept="2YIFZM" id="7GPsQwLRzZW" role="33vP2m">
+                    <ref role="37wK5l" to="sn11:5UC$YgehaLf" resolve="getInstance" />
+                    <ref role="1Pybhc" to="sn11:192HKKPMXeL" resolve="GlobalIconManager" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="P1znYOxZhA" role="3cqZAp">
+                <node concept="3clFbS" id="P1znYOxZhC" role="3clFbx">
+                  <node concept="3clFbF" id="P1znYOydxY" role="3cqZAp">
+                    <node concept="37vLTI" id="P1znYOyf11" role="3clFbG">
+                      <node concept="37vLTw" id="P1znYOydxW" role="37vLTJ">
+                        <ref role="3cqZAo" node="5Beavy1mebf" resolve="icon" />
+                      </node>
+                      <node concept="10M0yZ" id="P1znYOymhQ" role="37vLTx">
+                        <ref role="3cqZAo" to="z2i8:~AllIcons$General.Information" resolve="Information" />
+                        <ref role="1PxDUh" to="z2i8:~AllIcons$General" resolve="AllIcons.General" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="P1znYOy2Kk" role="3clFbw">
+                  <node concept="37vLTw" id="P1znYOy18S" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                  </node>
+                  <node concept="liA8E" id="P1znYOy4Ge" role="2OqNvi">
+                    <ref role="37wK5l" to="2ahs:P1znYOxiYP" resolve="isInfoNode" />
+                  </node>
+                </node>
+                <node concept="3eNFk2" id="P1znYOynXq" role="3eNLev">
+                  <node concept="3clFbS" id="P1znYOynXs" role="3eOfB_">
+                    <node concept="3clFbF" id="7GPsQwLRIQB" role="3cqZAp">
+                      <node concept="37vLTI" id="7GPsQwLRKrL" role="3clFbG">
+                        <node concept="2OqwBi" id="7GPsQwLROD$" role="37vLTx">
+                          <node concept="37vLTw" id="7GPsQwLRMxs" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7GPsQwLRzZV" resolve="iconMng" />
+                          </node>
+                          <node concept="liA8E" id="7GPsQwLRQNt" role="2OqNvi">
+                            <ref role="37wK5l" to="sn11:192HKKPOd3m" resolve="getIconFor" />
+                            <node concept="2OqwBi" id="P1znYOvizE" role="37wK5m">
+                              <node concept="37vLTw" id="P1znYOvgYW" role="2Oq$k0">
+                                <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                              </node>
+                              <node concept="liA8E" id="P1znYOvkhh" role="2OqNvi">
+                                <ref role="37wK5l" to="2ahs:P1znYOt66X" resolve="getIconNode" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="7GPsQwLRIQ_" role="37vLTJ">
+                          <ref role="3cqZAo" node="5Beavy1mebf" resolve="icon" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3y3z36" id="P1znYOv6Yf" role="3eO9$A">
+                    <node concept="10Nm6u" id="P1znYOv8pm" role="3uHU7w" />
+                    <node concept="2OqwBi" id="P1znYOv3f_" role="3uHU7B">
+                      <node concept="37vLTw" id="P1znYOv1CX" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                      </node>
+                      <node concept="liA8E" id="P1znYOv5uE" role="2OqNvi">
+                        <ref role="37wK5l" to="2ahs:P1znYOt66X" resolve="getIconNode" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="9aQIb" id="P1znYOytNu" role="9aQIa">
+                  <node concept="3clFbS" id="P1znYOytNv" role="9aQI4">
+                    <node concept="3cpWs8" id="5Beavy1n4np" role="3cqZAp">
+                      <node concept="3cpWsn" id="5Beavy1n4nq" role="3cpWs9">
+                        <property role="TrG5h" value="acd" />
+                        <node concept="3Tqbb2" id="5Beavy1n4nn" role="1tU5fm">
+                          <ref role="ehGHo" to="tpce:h0PkWnZ" resolve="AbstractConceptDeclaration" />
+                        </node>
+                        <node concept="2OqwBi" id="5Beavy1n4nr" role="33vP2m">
+                          <node concept="2OqwBi" id="5Beavy1n4ns" role="2Oq$k0">
+                            <node concept="37vLTw" id="4yQfyMjnCg8" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
+                            </node>
+                            <node concept="2yIwOk" id="5Beavy1n4nw" role="2OqNvi" />
+                          </node>
+                          <node concept="FGMqu" id="5Beavy1n4nx" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="5Beavy1n5f7" role="3cqZAp">
+                      <node concept="3clFbS" id="5Beavy1n5f9" role="3clFbx">
+                        <node concept="3clFbJ" id="5d4VabwgTGS" role="3cqZAp">
+                          <node concept="3clFbS" id="5d4VabwgTGU" role="3clFbx">
+                            <node concept="3clFbF" id="7GPsQwLS07a" role="3cqZAp">
+                              <node concept="37vLTI" id="7GPsQwLS5z0" role="3clFbG">
+                                <node concept="2OqwBi" id="7GPsQwLS9ob" role="37vLTx">
+                                  <node concept="37vLTw" id="7GPsQwLS7Jr" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="7GPsQwLRzZV" resolve="iconMng" />
+                                  </node>
+                                  <node concept="liA8E" id="7GPsQwLSbzf" role="2OqNvi">
+                                    <ref role="37wK5l" to="sn11:192HKKPOd3m" resolve="getIconFor" />
+                                    <node concept="37vLTw" id="7GPsQwLSdDf" role="37wK5m">
+                                      <ref role="3cqZAo" node="5d4VabvUxVq" resolve="ghostIconNode" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="37vLTw" id="7GPsQwLS078" role="37vLTJ">
+                                  <ref role="3cqZAo" node="5Beavy1mebf" resolve="icon" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3fqX7Q" id="5d4VabwgWzp" role="3clFbw">
+                            <node concept="2OqwBi" id="5d4VabwgWzr" role="3fr31v">
+                              <node concept="37vLTw" id="5d4VabwgWzs" role="2Oq$k0">
+                                <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                              </node>
+                              <node concept="liA8E" id="5d4VabwgWzt" role="2OqNvi">
+                                <ref role="37wK5l" to="2ahs:5d4VabvUiEx" resolve="isInAnEditor" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="9aQIb" id="5d4VabwgZ6R" role="9aQIa">
+                            <node concept="3clFbS" id="5d4VabwgZ6S" role="9aQI4">
+                              <node concept="3cpWs8" id="5Beavy1n8mR" role="3cqZAp">
+                                <node concept="3cpWsn" id="5Beavy1n8mS" role="3cpWs9">
+                                  <property role="TrG5h" value="conIcon" />
+                                  <node concept="3Tqbb2" id="5Beavy1n8mE" role="1tU5fm">
+                                    <ref role="ehGHo" to="1oap:2p1v3tOa9VI" resolve="Icon" />
+                                  </node>
+                                  <node concept="2OqwBi" id="5Beavy1n8mT" role="33vP2m">
+                                    <node concept="1PxgMI" id="5Beavy1n8mU" role="2Oq$k0">
+                                      <node concept="chp4Y" id="5Beavy1n8mV" role="3oSUPX">
+                                        <ref role="cht4Q" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
+                                      </node>
+                                      <node concept="37vLTw" id="5Beavy1n8mW" role="1m5AlR">
+                                        <ref role="3cqZAo" node="5Beavy1n4nq" resolve="acd" />
+                                      </node>
+                                    </node>
+                                    <node concept="3TrEf2" id="5Beavy1n8mX" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="tpce:5vfjF5cjTVP" resolve="icon" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="3clFbJ" id="5Beavy1n9u3" role="3cqZAp">
+                                <node concept="3clFbS" id="5Beavy1n9u5" role="3clFbx">
+                                  <node concept="3clFbF" id="7GPsQwLSjpJ" role="3cqZAp">
+                                    <node concept="37vLTI" id="7GPsQwLSkXa" role="3clFbG">
+                                      <node concept="2OqwBi" id="7GPsQwLSp6s" role="37vLTx">
+                                        <node concept="37vLTw" id="7GPsQwLSnb4" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="7GPsQwLRzZV" resolve="iconMng" />
+                                        </node>
+                                        <node concept="liA8E" id="7GPsQwLSrdq" role="2OqNvi">
+                                          <ref role="37wK5l" to="sn11:192HKKPOd3m" resolve="getIconFor" />
+                                          <node concept="37vLTw" id="7GPsQwLStqu" role="37wK5m">
+                                            <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="37vLTw" id="7GPsQwLSjpH" role="37vLTJ">
                                         <ref role="3cqZAo" node="5Beavy1mebf" resolve="icon" />
                                       </node>
                                     </node>
                                   </node>
                                 </node>
-                                <node concept="3fqX7Q" id="5d4VabwgWzp" role="3clFbw">
-                                  <node concept="2OqwBi" id="5d4VabwgWzr" role="3fr31v">
-                                    <node concept="37vLTw" id="5d4VabwgWzs" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
-                                    </node>
-                                    <node concept="liA8E" id="5d4VabwgWzt" role="2OqNvi">
-                                      <ref role="37wK5l" to="2ahs:5d4VabvUiEx" resolve="isInAnEditor" />
-                                    </node>
+                                <node concept="3y3z36" id="5Beavy1n9XY" role="3clFbw">
+                                  <node concept="10Nm6u" id="5Beavy1naf6" role="3uHU7w" />
+                                  <node concept="37vLTw" id="5Beavy1n9Jj" role="3uHU7B">
+                                    <ref role="3cqZAo" node="5Beavy1n8mS" resolve="conIcon" />
                                   </node>
                                 </node>
-                                <node concept="9aQIb" id="5d4VabwgZ6R" role="9aQIa">
-                                  <node concept="3clFbS" id="5d4VabwgZ6S" role="9aQI4">
-                                    <node concept="3cpWs8" id="5Beavy1n8mR" role="3cqZAp">
-                                      <node concept="3cpWsn" id="5Beavy1n8mS" role="3cpWs9">
-                                        <property role="TrG5h" value="conIcon" />
-                                        <node concept="3Tqbb2" id="5Beavy1n8mE" role="1tU5fm">
-                                          <ref role="ehGHo" to="1oap:2p1v3tOa9VI" resolve="Icon" />
-                                        </node>
-                                        <node concept="2OqwBi" id="5Beavy1n8mT" role="33vP2m">
-                                          <node concept="1PxgMI" id="5Beavy1n8mU" role="2Oq$k0">
-                                            <node concept="chp4Y" id="5Beavy1n8mV" role="3oSUPX">
-                                              <ref role="cht4Q" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-                                            </node>
-                                            <node concept="37vLTw" id="5Beavy1n8mW" role="1m5AlR">
-                                              <ref role="3cqZAo" node="5Beavy1n4nq" resolve="acd" />
-                                            </node>
+                                <node concept="9aQIb" id="5Beavy1nces" role="9aQIa">
+                                  <node concept="3clFbS" id="5Beavy1ncet" role="9aQI4">
+                                    <node concept="3clFbF" id="7GPsQwLSz8R" role="3cqZAp">
+                                      <node concept="37vLTI" id="7GPsQwLS$Ly" role="3clFbG">
+                                        <node concept="2OqwBi" id="7GPsQwLSC$i" role="37vLTx">
+                                          <node concept="37vLTw" id="7GPsQwLSAUz" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="7GPsQwLRzZV" resolve="iconMng" />
                                           </node>
-                                          <node concept="3TrEf2" id="5Beavy1n8mX" role="2OqNvi">
-                                            <ref role="3Tt5mk" to="tpce:5vfjF5cjTVP" resolve="icon" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="3clFbJ" id="5Beavy1n9u3" role="3cqZAp">
-                                      <node concept="3clFbS" id="5Beavy1n9u5" role="3clFbx">
-                                        <node concept="3clFbF" id="7GPsQwLSjpJ" role="3cqZAp">
-                                          <node concept="37vLTI" id="7GPsQwLSkXa" role="3clFbG">
-                                            <node concept="2OqwBi" id="7GPsQwLSp6s" role="37vLTx">
-                                              <node concept="37vLTw" id="7GPsQwLSnb4" role="2Oq$k0">
-                                                <ref role="3cqZAo" node="7GPsQwLRzZV" resolve="iconMng" />
-                                              </node>
-                                              <node concept="liA8E" id="7GPsQwLSrdq" role="2OqNvi">
-                                                <ref role="37wK5l" to="sn11:192HKKPOd3m" resolve="getIconFor" />
-                                                <node concept="37vLTw" id="7GPsQwLStqu" role="37wK5m">
-                                                  <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
-                                                </node>
-                                              </node>
-                                            </node>
-                                            <node concept="37vLTw" id="7GPsQwLSjpH" role="37vLTJ">
-                                              <ref role="3cqZAo" node="5Beavy1mebf" resolve="icon" />
+                                          <node concept="liA8E" id="7GPsQwLSELx" role="2OqNvi">
+                                            <ref role="37wK5l" to="sn11:192HKKPOd3m" resolve="getIconFor" />
+                                            <node concept="37vLTw" id="7GPsQwLSGTG" role="37wK5m">
+                                              <ref role="3cqZAo" node="5Beavy1mRW0" resolve="traceIconNode" />
                                             </node>
                                           </node>
                                         </node>
-                                      </node>
-                                      <node concept="3y3z36" id="5Beavy1n9XY" role="3clFbw">
-                                        <node concept="10Nm6u" id="5Beavy1naf6" role="3uHU7w" />
-                                        <node concept="37vLTw" id="5Beavy1n9Jj" role="3uHU7B">
-                                          <ref role="3cqZAo" node="5Beavy1n8mS" resolve="conIcon" />
-                                        </node>
-                                      </node>
-                                      <node concept="9aQIb" id="5Beavy1nces" role="9aQIa">
-                                        <node concept="3clFbS" id="5Beavy1ncet" role="9aQI4">
-                                          <node concept="3clFbF" id="7GPsQwLSz8R" role="3cqZAp">
-                                            <node concept="37vLTI" id="7GPsQwLS$Ly" role="3clFbG">
-                                              <node concept="2OqwBi" id="7GPsQwLSC$i" role="37vLTx">
-                                                <node concept="37vLTw" id="7GPsQwLSAUz" role="2Oq$k0">
-                                                  <ref role="3cqZAo" node="7GPsQwLRzZV" resolve="iconMng" />
-                                                </node>
-                                                <node concept="liA8E" id="7GPsQwLSELx" role="2OqNvi">
-                                                  <ref role="37wK5l" to="sn11:192HKKPOd3m" resolve="getIconFor" />
-                                                  <node concept="37vLTw" id="7GPsQwLSGTG" role="37wK5m">
-                                                    <ref role="3cqZAo" node="5Beavy1mRW0" resolve="traceIconNode" />
-                                                  </node>
-                                                </node>
-                                              </node>
-                                              <node concept="37vLTw" id="7GPsQwLSz8P" role="37vLTJ">
-                                                <ref role="3cqZAo" node="5Beavy1mebf" resolve="icon" />
-                                              </node>
-                                            </node>
-                                          </node>
+                                        <node concept="37vLTw" id="7GPsQwLSz8P" role="37vLTJ">
+                                          <ref role="3cqZAo" node="5Beavy1mebf" resolve="icon" />
                                         </node>
                                       </node>
                                     </node>
@@ -4109,99 +4108,89 @@
                                 </node>
                               </node>
                             </node>
-                            <node concept="2OqwBi" id="5Beavy1n5JG" role="3clFbw">
-                              <node concept="37vLTw" id="5Beavy1n5qM" role="2Oq$k0">
-                                <ref role="3cqZAo" node="5Beavy1n4nq" resolve="acd" />
-                              </node>
-                              <node concept="1mIQ4w" id="5Beavy1n6iF" role="2OqNvi">
-                                <node concept="chp4Y" id="5Beavy1n6pi" role="cj9EA">
-                                  <ref role="cht4Q" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
-                                </node>
-                              </node>
-                            </node>
                           </node>
                         </node>
                       </node>
-                    </node>
-                    <node concept="3clFbF" id="6wNYzrU1m7m" role="3cqZAp">
-                      <node concept="2OqwBi" id="6wNYzrU1mq3" role="3clFbG">
-                        <node concept="37vLTw" id="6wNYzrU1m7k" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
+                      <node concept="2OqwBi" id="5Beavy1n5JG" role="3clFbw">
+                        <node concept="37vLTw" id="5Beavy1n5qM" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5Beavy1n4nq" resolve="acd" />
                         </node>
-                        <node concept="liA8E" id="6wNYzrU1mFr" role="2OqNvi">
-                          <ref role="37wK5l" to="lzb2:~ColoredTextContainer.setIcon(javax.swing.Icon)" resolve="setIcon" />
-                          <node concept="37vLTw" id="5Beavy1mebm" role="37wK5m">
-                            <ref role="3cqZAo" node="5Beavy1mebf" resolve="icon" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="6wNYzrU1z2G" role="3cqZAp">
-                      <node concept="2OqwBi" id="6wNYzrU1zm7" role="3clFbG">
-                        <node concept="37vLTw" id="6wNYzrU1z2E" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
-                        </node>
-                        <node concept="liA8E" id="6wNYzrU1zC5" role="2OqNvi">
-                          <ref role="37wK5l" to="lzb2:~ColoredTextContainer.setToolTipText(java.lang.String)" resolve="setToolTipText" />
-                          <node concept="2OqwBi" id="6wNYzrU1zM1" role="37wK5m">
-                            <node concept="37vLTw" id="6wNYzrU1zM2" role="2Oq$k0">
-                              <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
-                            </node>
-                            <node concept="liA8E" id="6wNYzrU1zM3" role="2OqNvi">
-                              <ref role="37wK5l" to="2ahs:6wNYzrU06rm" resolve="getConceptName" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="6wNYzrU0aQu" role="3cqZAp">
-                      <node concept="2OqwBi" id="6wNYzrU0aQv" role="3clFbG">
-                        <node concept="37vLTw" id="6wNYzrU0aQw" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
-                        </node>
-                        <node concept="liA8E" id="6wNYzrU0aQx" role="2OqNvi">
-                          <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
-                          <node concept="3cpWs3" id="6wNYzrU1bYE" role="37wK5m">
-                            <node concept="Xl_RD" id="6wNYzrU1c4D" role="3uHU7w">
-                              <property role="Xl_RC" value="]" />
-                            </node>
-                            <node concept="3cpWs3" id="6wNYzrU1boT" role="3uHU7B">
-                              <node concept="Xl_RD" id="6wNYzrU1buS" role="3uHU7B">
-                                <property role="Xl_RC" value=" [" />
-                              </node>
-                              <node concept="2OqwBi" id="6wNYzrU0aQy" role="3uHU7w">
-                                <node concept="37vLTw" id="6wNYzrU0aQz" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
-                                </node>
-                                <node concept="liA8E" id="6wNYzrU0aQ$" role="2OqNvi">
-                                  <ref role="37wK5l" to="2ahs:6wNYzrU06rm" resolve="getConceptName" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="37vLTw" id="47M_EqtumXR" role="37wK5m">
-                            <ref role="3cqZAo" node="47M_Eqtu4ii" resolve="inactiveStyle" />
+                        <node concept="1mIQ4w" id="5Beavy1n6iF" role="2OqNvi">
+                          <node concept="chp4Y" id="5Beavy1n6pi" role="cj9EA">
+                            <ref role="cht4Q" to="tpce:f_TIwhg" resolve="ConceptDeclaration" />
                           </node>
                         </node>
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="2OqwBi" id="XlcHWd_iYh" role="ukAjM">
-                  <node concept="2JrnkZ" id="XlcHWd_gZD" role="2Oq$k0">
-                    <node concept="2OqwBi" id="XlcHWd_83Z" role="2JrQYb">
-                      <node concept="37vLTw" id="XlcHWd_5TZ" role="2Oq$k0">
-                        <ref role="3cqZAo" node="4yQfyMjnCg2" resolve="targetNode" />
-                      </node>
-                      <node concept="I4A8Y" id="XlcHWd_9k6" role="2OqNvi" />
+              </node>
+              <node concept="3clFbF" id="6wNYzrU1m7m" role="3cqZAp">
+                <node concept="2OqwBi" id="6wNYzrU1mq3" role="3clFbG">
+                  <node concept="37vLTw" id="6wNYzrU1m7k" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
+                  </node>
+                  <node concept="liA8E" id="6wNYzrU1mFr" role="2OqNvi">
+                    <ref role="37wK5l" to="lzb2:~ColoredTextContainer.setIcon(javax.swing.Icon)" resolve="setIcon" />
+                    <node concept="37vLTw" id="5Beavy1mebm" role="37wK5m">
+                      <ref role="3cqZAo" node="5Beavy1mebf" resolve="icon" />
                     </node>
                   </node>
-                  <node concept="liA8E" id="XlcHWd_mvi" role="2OqNvi">
-                    <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                </node>
+              </node>
+              <node concept="3clFbF" id="6wNYzrU1z2G" role="3cqZAp">
+                <node concept="2OqwBi" id="6wNYzrU1zm7" role="3clFbG">
+                  <node concept="37vLTw" id="6wNYzrU1z2E" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
+                  </node>
+                  <node concept="liA8E" id="6wNYzrU1zC5" role="2OqNvi">
+                    <ref role="37wK5l" to="lzb2:~ColoredTextContainer.setToolTipText(java.lang.String)" resolve="setToolTipText" />
+                    <node concept="2OqwBi" id="6wNYzrU1zM1" role="37wK5m">
+                      <node concept="37vLTw" id="6wNYzrU1zM2" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                      </node>
+                      <node concept="liA8E" id="6wNYzrU1zM3" role="2OqNvi">
+                        <ref role="37wK5l" to="2ahs:6wNYzrU06rm" resolve="getConceptName" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="6wNYzrU0aQu" role="3cqZAp">
+                <node concept="2OqwBi" id="6wNYzrU0aQv" role="3clFbG">
+                  <node concept="37vLTw" id="6wNYzrU0aQw" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1rUbSep6to" resolve="output" />
+                  </node>
+                  <node concept="liA8E" id="6wNYzrU0aQx" role="2OqNvi">
+                    <ref role="37wK5l" to="lzb2:~ColoredTextContainer.append(java.lang.String,com.intellij.ui.SimpleTextAttributes)" resolve="append" />
+                    <node concept="3cpWs3" id="6wNYzrU1bYE" role="37wK5m">
+                      <node concept="Xl_RD" id="6wNYzrU1c4D" role="3uHU7w">
+                        <property role="Xl_RC" value="]" />
+                      </node>
+                      <node concept="3cpWs3" id="6wNYzrU1boT" role="3uHU7B">
+                        <node concept="Xl_RD" id="6wNYzrU1buS" role="3uHU7B">
+                          <property role="Xl_RC" value=" [" />
+                        </node>
+                        <node concept="2OqwBi" id="6wNYzrU0aQy" role="3uHU7w">
+                          <node concept="37vLTw" id="6wNYzrU0aQz" role="2Oq$k0">
+                            <ref role="3cqZAo" node="1rUbSep6tl" resolve="record" />
+                          </node>
+                          <node concept="liA8E" id="6wNYzrU0aQ$" role="2OqNvi">
+                            <ref role="37wK5l" to="2ahs:6wNYzrU06rm" resolve="getConceptName" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="47M_EqtumXR" role="37wK5m">
+                      <ref role="3cqZAo" node="47M_Eqtu4ii" resolve="inactiveStyle" />
+                    </node>
                   </node>
                 </node>
               </node>
             </node>
+          </node>
+          <node concept="37vLTw" id="5mNjY0H4R_A" role="ukAjM">
+            <ref role="3cqZAo" node="5mNjY0H4DCX" resolve="repository" />
           </node>
         </node>
       </node>


### PR DESCRIPTION
Fix Tracer (Interpreter-Debugger) for (Short)LambdaExpressions

Problem: Traces for (Short)LambdaExpressions were shown broken and without links to the model, so clicking a trace to jump to the model wouldn't work.

Note: `LambdaValue.lambde` property changed from public to private
