### PR TITLE
Make test execution preferences overridable in workspace settings

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -64,6 +64,7 @@
     <import index="kvq8" ref="r:2e938759-cfd0-47cd-9046-896d85204f59(de.slisson.mps.hacks.editor)" />
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
     <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
+    <import index="jpm3" ref="r:e3e5593b-dfcd-4a2e-b10f-f1ed4a43f093(org.iets3.core.expr.plugin.plugin)" />
     <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -484,12 +485,6 @@
       </concept>
       <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
         <child id="2535923850359271783" name="elements" index="1PaTwD" />
-      </concept>
-    </language>
-    <language id="c3bfea76-7bba-4f0e-b5a2-ff4e7a8d7cf1" name="com.mbeddr.mpsutil.spreferences">
-      <concept id="5615086488402953540" name="com.mbeddr.mpsutil.spreferences.structure.PreferencesRootExpression" flags="ng" index="9H$SH">
-        <reference id="5615086488402976569" name="preferencePage" index="9Hxhg" />
-        <child id="5615086488402986988" name="module" index="9HWM5" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
@@ -2411,21 +2406,21 @@
           </node>
         </node>
         <node concept="3clFbH" id="57VdFqPiDih" role="3cqZAp" />
-        <node concept="3clFbH" id="57VdFqPiDhq" role="3cqZAp" />
-        <node concept="3cpWs8" id="6VjyfUYekA1" role="3cqZAp">
-          <node concept="3cpWsn" id="6VjyfUYekA2" role="3cpWs9">
-            <property role="TrG5h" value="tec" />
-            <node concept="3Tqbb2" id="6VjyfUYek_Z" role="1tU5fm">
-              <ref role="ehGHo" to="6yn5:3SkjTN1LMyJ" resolve="TestExecutionConfig" />
+        <node concept="3cpWs8" id="5rUl2R7PPvf" role="3cqZAp">
+          <node concept="3cpWsn" id="5rUl2R7PPvg" role="3cpWs9">
+            <property role="TrG5h" value="mode" />
+            <node concept="3uibUv" id="5rUl2R7PPpe" role="1tU5fm">
+              <ref role="3uigEE" to="jpm3:5rUl2R7KDH5" resolve="ExecutionModePreference" />
             </node>
-            <node concept="9H$SH" id="6VjyfUYekA3" role="33vP2m">
-              <ref role="9Hxhg" to="w474:3SkjTN1M1kS" resolve="TestExecutionPreferences" />
-              <node concept="2OqwBi" id="57VdFqPlqll" role="9HWM5">
-                <node concept="liA8E" id="57VdFqPlqzy" role="2OqNvi">
+            <node concept="2YIFZM" id="5rUl2R7PPvh" role="33vP2m">
+              <ref role="37wK5l" to="jpm3:5rUl2R7POK$" resolve="getExecutionModePreference" />
+              <ref role="1Pybhc" to="jpm3:5rUl2R7OncF" resolve="TestExecutionSettings" />
+              <node concept="2OqwBi" id="5rUl2R7PPvi" role="37wK5m">
+                <node concept="liA8E" id="5rUl2R7PPvj" role="2OqNvi">
                   <ref role="37wK5l" to="mhbf:~SModel.getModule()" resolve="getModule" />
                 </node>
-                <node concept="2JrnkZ" id="57VdFqPlqlq" role="2Oq$k0">
-                  <node concept="37vLTw" id="57VdFqPkSll" role="2JrQYb">
+                <node concept="2JrnkZ" id="5rUl2R7PPvk" role="2Oq$k0">
+                  <node concept="37vLTw" id="5rUl2R7PPvl" role="2JrQYb">
                     <ref role="3cqZAo" node="57VdFqPiDib" resolve="m" />
                   </node>
                 </node>
@@ -2433,28 +2428,21 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="UYp_yFoiq2" role="3cqZAp" />
-        <node concept="3clFbJ" id="6VjyfUYehd4" role="3cqZAp">
-          <node concept="2OqwBi" id="6VjyfUYelqw" role="3clFbw">
-            <node concept="2OqwBi" id="6VjyfUYekMg" role="2Oq$k0">
-              <node concept="37vLTw" id="6VjyfUYekBO" role="2Oq$k0">
-                <ref role="3cqZAo" node="6VjyfUYekA2" resolve="tec" />
-              </node>
-              <node concept="3TrEf2" id="6VjyfUYel5T" role="2OqNvi">
-                <ref role="3Tt5mk" to="6yn5:3SkjTN1LTtQ" resolve="executionMode" />
-              </node>
-            </node>
-            <node concept="1mIQ4w" id="6VjyfUYelHv" role="2OqNvi">
-              <node concept="chp4Y" id="6VjyfUYelJJ" role="cj9EA">
-                <ref role="cht4Q" to="6yn5:3SkjTN1LTuE" resolve="GeneratorExecutionMode" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbS" id="6VjyfUYehd6" role="3clFbx">
+        <node concept="3clFbJ" id="5rUl2R7PPVT" role="3cqZAp">
+          <node concept="3clFbS" id="5rUl2R7PPVV" role="3clFbx">
             <node concept="3cpWs6" id="6VjyfUYelNW" role="3cqZAp">
               <node concept="BsUDl" id="6VjyfUYelOs" role="3cqZAk">
                 <ref role="37wK5l" node="6VjyfUYe5Ll" resolve="getSimpleClassNameForGenerator" />
               </node>
+            </node>
+          </node>
+          <node concept="17R0WA" id="5rUl2R7PRxG" role="3clFbw">
+            <node concept="Rm8GO" id="5rUl2R7PRDG" role="3uHU7w">
+              <ref role="Rm8GQ" to="jpm3:5rUl2R7KE3p" resolve="GENERATOR" />
+              <ref role="1Px2BO" to="jpm3:5rUl2R7KDH5" resolve="ExecutionModePreference" />
+            </node>
+            <node concept="37vLTw" id="5rUl2R7PPZ4" role="3uHU7B">
+              <ref role="3cqZAo" node="5rUl2R7PPvg" resolve="mode" />
             </node>
           </node>
         </node>
@@ -2578,21 +2566,22 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="57VdFqPkLxS" role="3cqZAp" />
-        <node concept="3cpWs8" id="ljKHDcIbRS" role="3cqZAp">
-          <node concept="3cpWsn" id="ljKHDcIbRT" role="3cpWs9">
-            <property role="TrG5h" value="tec" />
-            <node concept="3Tqbb2" id="ljKHDcIbRU" role="1tU5fm">
-              <ref role="ehGHo" to="6yn5:3SkjTN1LMyJ" resolve="TestExecutionConfig" />
+        <node concept="3clFbH" id="5rUl2R7PSuh" role="3cqZAp" />
+        <node concept="3cpWs8" id="5rUl2R7PSh1" role="3cqZAp">
+          <node concept="3cpWsn" id="5rUl2R7PSh2" role="3cpWs9">
+            <property role="TrG5h" value="mode" />
+            <node concept="3uibUv" id="5rUl2R7PSh3" role="1tU5fm">
+              <ref role="3uigEE" to="jpm3:5rUl2R7KDH5" resolve="ExecutionModePreference" />
             </node>
-            <node concept="9H$SH" id="ljKHDcIbRV" role="33vP2m">
-              <ref role="9Hxhg" to="w474:3SkjTN1M1kS" resolve="TestExecutionPreferences" />
-              <node concept="2OqwBi" id="57VdFqPlujP" role="9HWM5">
-                <node concept="liA8E" id="57VdFqPlx1b" role="2OqNvi">
+            <node concept="2YIFZM" id="5rUl2R7PSh4" role="33vP2m">
+              <ref role="1Pybhc" to="jpm3:5rUl2R7OncF" resolve="TestExecutionSettings" />
+              <ref role="37wK5l" to="jpm3:5rUl2R7POK$" resolve="getExecutionModePreference" />
+              <node concept="2OqwBi" id="5rUl2R7PSh5" role="37wK5m">
+                <node concept="liA8E" id="5rUl2R7PSh6" role="2OqNvi">
                   <ref role="37wK5l" to="mhbf:~SModel.getModule()" resolve="getModule" />
                 </node>
-                <node concept="2JrnkZ" id="57VdFqPlujU" role="2Oq$k0">
-                  <node concept="37vLTw" id="57VdFqPkPAU" role="2JrQYb">
+                <node concept="2JrnkZ" id="5rUl2R7PSh7" role="2Oq$k0">
+                  <node concept="37vLTw" id="5rUl2R7PSh8" role="2JrQYb">
                     <ref role="3cqZAo" node="57VdFqPfgDL" resolve="m" />
                   </node>
                 </node>
@@ -2600,78 +2589,63 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbJ" id="ljKHDcIbRX" role="3cqZAp">
-          <node concept="3clFbS" id="ljKHDcIbRY" role="3clFbx">
-            <node concept="3clFbJ" id="ljKHDcIbRZ" role="3cqZAp">
-              <node concept="2OqwBi" id="ljKHDcIbS0" role="3clFbw">
-                <node concept="2OqwBi" id="ljKHDcIbS1" role="2Oq$k0">
-                  <node concept="37vLTw" id="ljKHDcIbS2" role="2Oq$k0">
-                    <ref role="3cqZAo" node="ljKHDcIbRT" resolve="tec" />
-                  </node>
-                  <node concept="3TrEf2" id="ljKHDcIbS3" role="2OqNvi">
-                    <ref role="3Tt5mk" to="6yn5:3SkjTN1LTtQ" resolve="executionMode" />
-                  </node>
-                </node>
-                <node concept="1mIQ4w" id="ljKHDcIbS4" role="2OqNvi">
-                  <node concept="chp4Y" id="ljKHDcIbS5" role="cj9EA">
-                    <ref role="cht4Q" to="6yn5:3SkjTN1LTuE" resolve="GeneratorExecutionMode" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbS" id="ljKHDcIbS6" role="3clFbx">
-                <node concept="3clFbJ" id="ljKHDcIfN6" role="3cqZAp">
-                  <node concept="3clFbS" id="ljKHDcIfN7" role="3clFbx">
-                    <node concept="3cpWs6" id="ljKHDcIfN8" role="3cqZAp">
-                      <node concept="3cpWs3" id="ljKHDcIfN9" role="3cqZAk">
-                        <node concept="BsUDl" id="ljKHDcIh4e" role="3uHU7w">
-                          <ref role="37wK5l" node="6VjyfUYe5Ll" resolve="getSimpleClassNameForGenerator" />
-                        </node>
-                        <node concept="Xl_RD" id="ljKHDcIfNb" role="3uHU7B">
-                          <property role="Xl_RC" value="[null model ]" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbC" id="ljKHDcIfNc" role="3clFbw">
-                    <node concept="10Nm6u" id="ljKHDcIfNd" role="3uHU7w" />
-                    <node concept="37vLTw" id="ljKHDcIfNe" role="3uHU7B">
-                      <ref role="3cqZAo" node="2_tP28kjNF9" resolve="mo" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs6" id="ljKHDcIgfm" role="3cqZAp">
-                  <node concept="3cpWs3" id="ljKHDcIgfo" role="3cqZAk">
-                    <node concept="3cpWs3" id="ljKHDcIgfp" role="3uHU7B">
-                      <node concept="Xl_RD" id="ljKHDcIgfq" role="3uHU7w">
-                        <property role="Xl_RC" value="." />
-                      </node>
-                      <node concept="2OqwBi" id="ljKHDcIgfr" role="3uHU7B">
-                        <node concept="2OqwBi" id="ljKHDcIgfs" role="2Oq$k0">
-                          <node concept="37vLTw" id="ljKHDcIgft" role="2Oq$k0">
-                            <ref role="3cqZAo" node="2_tP28kjNF9" resolve="mo" />
-                          </node>
-                          <node concept="liA8E" id="ljKHDcIgfu" role="2OqNvi">
-                            <ref role="37wK5l" to="mhbf:~SModel.getName()" resolve="getName" />
-                          </node>
-                        </node>
-                        <node concept="liA8E" id="ljKHDcIgfv" role="2OqNvi">
-                          <ref role="37wK5l" to="mhbf:~SModelName.getLongName()" resolve="getLongName" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="BsUDl" id="ljKHDcIhkR" role="3uHU7w">
-                      <ref role="37wK5l" node="6VjyfUYe5Ll" resolve="getSimpleClassNameForGenerator" />
-                    </node>
-                  </node>
-                </node>
-              </node>
+        <node concept="3clFbH" id="57VdFqPkLxS" role="3cqZAp" />
+        <node concept="3clFbJ" id="ljKHDcIbRZ" role="3cqZAp">
+          <node concept="17R0WA" id="5rUl2R7PUwA" role="3clFbw">
+            <node concept="Rm8GO" id="5rUl2R7PUWI" role="3uHU7w">
+              <ref role="Rm8GQ" to="jpm3:5rUl2R7KE3p" resolve="GENERATOR" />
+              <ref role="1Px2BO" to="jpm3:5rUl2R7KDH5" resolve="ExecutionModePreference" />
+            </node>
+            <node concept="37vLTw" id="5rUl2R7PTiF" role="3uHU7B">
+              <ref role="3cqZAo" node="5rUl2R7PSh2" resolve="mode" />
             </node>
           </node>
-          <node concept="2OqwBi" id="ljKHDcIbSx" role="3clFbw">
-            <node concept="37vLTw" id="ljKHDcIbSy" role="2Oq$k0">
-              <ref role="3cqZAo" node="ljKHDcIbRT" resolve="tec" />
+          <node concept="3clFbS" id="ljKHDcIbS6" role="3clFbx">
+            <node concept="3clFbJ" id="ljKHDcIfN6" role="3cqZAp">
+              <node concept="3clFbS" id="ljKHDcIfN7" role="3clFbx">
+                <node concept="3cpWs6" id="ljKHDcIfN8" role="3cqZAp">
+                  <node concept="3cpWs3" id="ljKHDcIfN9" role="3cqZAk">
+                    <node concept="BsUDl" id="ljKHDcIh4e" role="3uHU7w">
+                      <ref role="37wK5l" node="6VjyfUYe5Ll" resolve="getSimpleClassNameForGenerator" />
+                    </node>
+                    <node concept="Xl_RD" id="ljKHDcIfNb" role="3uHU7B">
+                      <property role="Xl_RC" value="[null model ]" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbC" id="ljKHDcIfNc" role="3clFbw">
+                <node concept="10Nm6u" id="ljKHDcIfNd" role="3uHU7w" />
+                <node concept="37vLTw" id="ljKHDcIfNe" role="3uHU7B">
+                  <ref role="3cqZAo" node="2_tP28kjNF9" resolve="mo" />
+                </node>
+              </node>
             </node>
-            <node concept="3x8VRR" id="ljKHDcIbSz" role="2OqNvi" />
+            <node concept="3cpWs6" id="ljKHDcIgfm" role="3cqZAp">
+              <node concept="3cpWs3" id="ljKHDcIgfo" role="3cqZAk">
+                <node concept="3cpWs3" id="ljKHDcIgfp" role="3uHU7B">
+                  <node concept="Xl_RD" id="ljKHDcIgfq" role="3uHU7w">
+                    <property role="Xl_RC" value="." />
+                  </node>
+                  <node concept="2OqwBi" id="ljKHDcIgfr" role="3uHU7B">
+                    <node concept="2OqwBi" id="ljKHDcIgfs" role="2Oq$k0">
+                      <node concept="37vLTw" id="ljKHDcIgft" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2_tP28kjNF9" resolve="mo" />
+                      </node>
+                      <node concept="liA8E" id="ljKHDcIgfu" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SModel.getName()" resolve="getName" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="ljKHDcIgfv" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SModelName.getLongName()" resolve="getLongName" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="BsUDl" id="ljKHDcIhkR" role="3uHU7w">
+                  <ref role="37wK5l" node="6VjyfUYe5Ll" resolve="getSimpleClassNameForGenerator" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
         <node concept="3clFbJ" id="2_tP28kjNSM" role="3cqZAp">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/org.iets3.core.expr.tests.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/org.iets3.core.expr.tests.mpl
@@ -165,6 +165,7 @@
     <dependency reexport="false">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.libs)</dependency>
     <dependency reexport="false">9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)</dependency>
     <dependency reexport="false">f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)</dependency>
+    <dependency reexport="false">cbb71b24-470d-4374-b77c-ebd0d3b3bb27(org.iets3.core.expr.plugin)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3b3dc28-fee3-49e1-a46e-685e96389094:com.mbeddr.mpsutil.bldoc" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/models/plugin.mps
@@ -63,14 +63,10 @@
     <import index="6yn5" ref="r:2bfc35a4-8334-4342-8e2a-a54b7cda4a4c(org.iets3.core.expr.testExecution.structure)" />
     <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
     <import index="22ra" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.update(MPS.Editor/)" />
-    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
     <import index="buwp" ref="r:8405f486-53b5-4fe6-af3e-7f68358bd631(org.iets3.core.expr.base.editor)" />
-    <import index="itrz" ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)" />
-    <import index="r4b4" ref="r:1784e088-20fd-4fdb-96b8-bc57f0056d94(com.mbeddr.core.base.editor)" />
     <import index="461n" ref="r:3b46a963-6deb-4d82-bdc0-36b5d9297fcf(de.slisson.mps.conditionalEditor.hints.editor)" />
-    <import index="agn9" ref="e78f91af-08a8-4a7a-bed6-b22739ed069a/r:f9e42dff-7cc2-48de-b7f5-594a5da757ae(com.mbeddr.mpsutil.spreferences.runtime/com.mbeddr.mpsutil.spreferences.runtime)" />
-    <import index="tmud" ref="c3bfea76-7bba-4f0e-b5a2-ff4e7a8d7cf1/r:8d0fa52a-32d1-4359-892e-669a9b66600c(com.mbeddr.mpsutil.spreferences/com.mbeddr.mpsutil.spreferences.structure)" />
     <import index="g1qu" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util.ui(MPS.IDEA/)" />
+    <import index="jmi8" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ide.util(MPS.IDEA/)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="3673" ref="r:78633c85-d020-485e-aaa3-59e2daa3b826(com.mbeddr.mpsutil.interpreter.structure)" implicit="true" />
     <import index="kqnq" ref="r:7628c3bd-6988-4d33-9682-86b8cef4b8c0(com.mbeddr.mpsutil.interpreter.behavior)" implicit="true" />
@@ -182,6 +178,10 @@
       </concept>
       <concept id="1224500790866" name="jetbrains.mps.baseLanguage.structure.BitwiseOrExpression" flags="nn" index="pVOtf" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1224575136086" name="jetbrains.mps.baseLanguage.structure.EnumValueOfExpression" flags="nn" index="unr1b">
+        <reference id="1224575174120" name="enumClass" index="un$jP" />
+        <child id="1224575157853" name="value" index="unwt0" />
+      </concept>
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
@@ -200,6 +200,14 @@
       </concept>
       <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
         <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+      <concept id="1083245097125" name="jetbrains.mps.baseLanguage.structure.EnumClass" flags="ig" index="Qs71p">
+        <child id="1083245396908" name="enumConstant" index="Qtgdg" />
+      </concept>
+      <concept id="1083245299891" name="jetbrains.mps.baseLanguage.structure.EnumConstantDeclaration" flags="ig" index="QsSxf" />
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
       </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
@@ -259,6 +267,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -7851,6 +7860,33 @@
             </node>
           </node>
         </node>
+        <node concept="fuyK3" id="5rUl2R7LmtW" role="3cqZAp">
+          <node concept="2YIFZM" id="5rUl2R7LmtX" role="fuByb">
+            <ref role="37wK5l" to="qkt:~Separator.getInstance()" resolve="getInstance" />
+            <ref role="1Pybhc" to="qkt:~Separator" resolve="Separator" />
+          </node>
+        </node>
+        <node concept="fuyK3" id="5rUl2R7KMvl" role="3cqZAp">
+          <node concept="2ShNRf" id="5rUl2R7KMvm" role="fuByb">
+            <node concept="1pGfFk" id="5rUl2R7KMvn" role="2ShVmc">
+              <ref role="37wK5l" node="5rUl2R7JDDN" resolve="GeneratorWorkspace" />
+            </node>
+          </node>
+        </node>
+        <node concept="fuyK3" id="5rUl2R7KMw_" role="3cqZAp">
+          <node concept="2ShNRf" id="5rUl2R7KMwA" role="fuByb">
+            <node concept="1pGfFk" id="5rUl2R7KMwB" role="2ShVmc">
+              <ref role="37wK5l" node="5rUl2R7KIeu" resolve="InterpreterWorkspace" />
+            </node>
+          </node>
+        </node>
+        <node concept="fuyK3" id="5rUl2R7NOsi" role="3cqZAp">
+          <node concept="2ShNRf" id="5rUl2R7NOsj" role="fuByb">
+            <node concept="1pGfFk" id="5rUl2R7NOsk" role="2ShVmc">
+              <ref role="37wK5l" node="5rUl2R7NKQu" resolve="NoPreferenceWorkspace" />
+            </node>
+          </node>
+        </node>
         <node concept="fuyK3" id="C3ikp6Zlrs" role="3cqZAp">
           <node concept="2YIFZM" id="C3ikp6Zlrt" role="fuByb">
             <ref role="37wK5l" to="qkt:~Separator.getInstance()" resolve="getInstance" />
@@ -8817,6 +8853,530 @@
     <node concept="1QGGSu" id="2JfTTG8itUG" role="3Uehp1">
       <property role="1iqoE4" value="${module}/icons/traceShowOne.png" />
     </node>
+  </node>
+  <node concept="312cEu" id="5rUl2R7JDDM">
+    <property role="3GE5qa" value="testExecution" />
+    <property role="TrG5h" value="GeneratorWorkspace" />
+    <node concept="3clFbW" id="5rUl2R7JDDN" role="jymVt">
+      <node concept="3cqZAl" id="5rUl2R7JDDO" role="3clF45" />
+      <node concept="3Tm1VV" id="5rUl2R7JDDP" role="1B3o_S" />
+      <node concept="3clFbS" id="5rUl2R7JDDQ" role="3clF47">
+        <node concept="XkiVB" id="5rUl2R7JDDR" role="3cqZAp">
+          <ref role="37wK5l" to="qkt:~ToggleAction.&lt;init&gt;(java.lang.String)" resolve="ToggleAction" />
+          <node concept="Xl_RD" id="5rUl2R7JDDS" role="37wK5m">
+            <property role="Xl_RC" value="KernelF Tests: Generator (workspace)" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="5rUl2R7JDDT" role="1B3o_S" />
+    <node concept="3uibUv" id="5rUl2R7JDDU" role="1zkMxy">
+      <ref role="3uigEE" to="qkt:~ToggleAction" resolve="ToggleAction" />
+    </node>
+    <node concept="3clFb_" id="5rUl2R7JDDV" role="jymVt">
+      <property role="1EzhhJ" value="false" />
+      <property role="TrG5h" value="isSelected" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <node concept="3Tm1VV" id="5rUl2R7JDDW" role="1B3o_S" />
+      <node concept="10P_77" id="5rUl2R7JDDX" role="3clF45" />
+      <node concept="37vLTG" id="5rUl2R7JDDY" role="3clF46">
+        <property role="TrG5h" value="event" />
+        <node concept="3uibUv" id="5rUl2R7JDDZ" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5rUl2R7JDE0" role="3clF47">
+        <node concept="3cpWs8" id="5rUl2R7KnQD" role="3cqZAp">
+          <node concept="3cpWsn" id="5rUl2R7KnQE" role="3cpWs9">
+            <property role="TrG5h" value="mode" />
+            <node concept="3uibUv" id="5rUl2R7KGhX" role="1tU5fm">
+              <ref role="3uigEE" node="5rUl2R7KDH5" resolve="ExecutionModePreference" />
+            </node>
+            <node concept="2YIFZM" id="5rUl2R7KrpJ" role="33vP2m">
+              <ref role="37wK5l" node="5rUl2R7Ka3V" resolve="getExecutionMode" />
+              <ref role="1Pybhc" node="5rUl2R7JYML" resolve="TestExecutionWorkspaceSetting" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5rUl2R7KtJ4" role="3cqZAp">
+          <node concept="17R0WA" id="5rUl2R7KwIK" role="3clFbG">
+            <node concept="Rm8GO" id="5rUl2R7KGB2" role="3uHU7w">
+              <ref role="Rm8GQ" node="5rUl2R7KE3p" resolve="GENERATOR" />
+              <ref role="1Px2BO" node="5rUl2R7KDH5" resolve="ExecutionModePreference" />
+            </node>
+            <node concept="37vLTw" id="5rUl2R7KtJ2" role="3uHU7B">
+              <ref role="3cqZAo" node="5rUl2R7KnQE" resolve="mode" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5rUl2R7JDEK" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5rUl2R7JDEL" role="jymVt">
+      <property role="1EzhhJ" value="false" />
+      <property role="TrG5h" value="setSelected" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <node concept="3Tm1VV" id="5rUl2R7JDEM" role="1B3o_S" />
+      <node concept="3cqZAl" id="5rUl2R7JDEN" role="3clF45" />
+      <node concept="37vLTG" id="5rUl2R7JDEO" role="3clF46">
+        <property role="TrG5h" value="event" />
+        <node concept="3uibUv" id="5rUl2R7JDEP" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5rUl2R7JDEQ" role="3clF46">
+        <property role="TrG5h" value="b" />
+        <node concept="10P_77" id="5rUl2R7JDER" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="5rUl2R7JDES" role="3clF47">
+        <node concept="3clFbF" id="5rUl2R7KHfz" role="3cqZAp">
+          <node concept="2YIFZM" id="5rUl2R7KCfH" role="3clFbG">
+            <ref role="37wK5l" node="5rUl2R7KxIX" resolve="setExecutionMode" />
+            <ref role="1Pybhc" node="5rUl2R7JYML" resolve="TestExecutionWorkspaceSetting" />
+            <node concept="Rm8GO" id="5rUl2R7KHbk" role="37wK5m">
+              <ref role="Rm8GQ" node="5rUl2R7KE3p" resolve="GENERATOR" />
+              <ref role="1Px2BO" node="5rUl2R7KDH5" resolve="ExecutionModePreference" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5rUl2R7JDFv" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="5rUl2R7JYML">
+    <property role="3GE5qa" value="testExecution" />
+    <property role="TrG5h" value="TestExecutionWorkspaceSetting" />
+    <node concept="Wx3nA" id="5rUl2R7KcOJ" role="jymVt">
+      <property role="TrG5h" value="KEY" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="5rUl2R7Kctg" role="1B3o_S" />
+      <node concept="17QB3L" id="5rUl2R7KcLR" role="1tU5fm" />
+      <node concept="Xl_RD" id="5rUl2R7KcYW" role="33vP2m">
+        <property role="Xl_RC" value="org.iets3.core.expr.testExecution" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5rUl2R7KcM3" role="jymVt" />
+    <node concept="2tJIrI" id="5rUl2R7K8MW" role="jymVt" />
+    <node concept="2YIFZL" id="5rUl2R7Ka3V" role="jymVt">
+      <property role="TrG5h" value="getExecutionMode" />
+      <node concept="3clFbS" id="5rUl2R7Ka3Y" role="3clF47">
+        <node concept="3cpWs8" id="5rUl2R7KeqZ" role="3cqZAp">
+          <node concept="3cpWsn" id="5rUl2R7Ker0" role="3cpWs9">
+            <property role="TrG5h" value="value" />
+            <node concept="17QB3L" id="5rUl2R7KiPQ" role="1tU5fm" />
+            <node concept="2OqwBi" id="5rUl2R7Ker1" role="33vP2m">
+              <node concept="2YIFZM" id="5rUl2R7Ker2" role="2Oq$k0">
+                <ref role="1Pybhc" to="jmi8:~PropertiesComponent" resolve="PropertiesComponent" />
+                <ref role="37wK5l" to="jmi8:~PropertiesComponent.getInstance()" resolve="getInstance" />
+              </node>
+              <node concept="liA8E" id="5rUl2R7Ker4" role="2OqNvi">
+                <ref role="37wK5l" to="jmi8:~PropertiesComponent.getValue(java.lang.String)" resolve="getValue" />
+                <node concept="37vLTw" id="5rUl2R7Ker5" role="37wK5m">
+                  <ref role="3cqZAo" node="5rUl2R7KcOJ" resolve="KEY" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5rUl2R7Kf2D" role="3cqZAp">
+          <node concept="3clFbS" id="5rUl2R7Kf2F" role="3clFbx">
+            <node concept="3cpWs6" id="5rUl2R7Kg8j" role="3cqZAp">
+              <node concept="Rm8GO" id="5rUl2R7KF0m" role="3cqZAk">
+                <ref role="Rm8GQ" node="5rUl2R7KE90" resolve="NO_PREFERENCE" />
+                <ref role="1Px2BO" node="5rUl2R7KDH5" resolve="ExecutionModePreference" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="5rUl2R7KfG5" role="3clFbw">
+            <node concept="10Nm6u" id="5rUl2R7KfX3" role="3uHU7w" />
+            <node concept="37vLTw" id="5rUl2R7Kfhp" role="3uHU7B">
+              <ref role="3cqZAo" node="5rUl2R7Ker0" resolve="value" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5rUl2R7KgDa" role="3cqZAp" />
+        <node concept="3clFbF" id="5rUl2R7Khco" role="3cqZAp">
+          <node concept="unr1b" id="5rUl2R7KhRh" role="3clFbG">
+            <ref role="un$jP" node="5rUl2R7KDH5" resolve="ExecutionModePreference" />
+            <node concept="37vLTw" id="5rUl2R7KixT" role="unwt0">
+              <ref role="3cqZAo" node="5rUl2R7Ker0" resolve="value" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5rUl2R7K9oN" role="1B3o_S" />
+      <node concept="3uibUv" id="5rUl2R7KEEl" role="3clF45">
+        <ref role="3uigEE" node="5rUl2R7KDH5" resolve="ExecutionModePreference" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5rUl2R7KxkE" role="jymVt" />
+    <node concept="2YIFZL" id="5rUl2R7KxIX" role="jymVt">
+      <property role="TrG5h" value="setExecutionMode" />
+      <node concept="37vLTG" id="5rUl2R7KyQy" role="3clF46">
+        <property role="TrG5h" value="mode" />
+        <node concept="3uibUv" id="5rUl2R7KFws" role="1tU5fm">
+          <ref role="3uigEE" node="5rUl2R7KDH5" resolve="ExecutionModePreference" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5rUl2R7KxJ0" role="3clF47">
+        <node concept="3clFbF" id="5rUl2R7K$Xy" role="3cqZAp">
+          <node concept="2OqwBi" id="5rUl2R7Ky40" role="3clFbG">
+            <node concept="2YIFZM" id="5rUl2R7Ky41" role="2Oq$k0">
+              <ref role="1Pybhc" to="jmi8:~PropertiesComponent" resolve="PropertiesComponent" />
+              <ref role="37wK5l" to="jmi8:~PropertiesComponent.getInstance()" resolve="getInstance" />
+            </node>
+            <node concept="liA8E" id="5rUl2R7Ky43" role="2OqNvi">
+              <ref role="37wK5l" to="jmi8:~PropertiesComponent.setValue(java.lang.String,java.lang.String)" resolve="setValue" />
+              <node concept="37vLTw" id="5rUl2R7K$XA" role="37wK5m">
+                <ref role="3cqZAo" node="5rUl2R7KcOJ" resolve="KEY" />
+              </node>
+              <node concept="2OqwBi" id="5rUl2R7K$49" role="37wK5m">
+                <node concept="37vLTw" id="5rUl2R7KzuD" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5rUl2R7KyQy" resolve="mode" />
+                </node>
+                <node concept="liA8E" id="5rUl2R7K$KH" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Enum.name()" resolve="name" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5rUl2R7Kxva" role="1B3o_S" />
+      <node concept="3cqZAl" id="5rUl2R7KxIF" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="5rUl2R7K_nM" role="jymVt" />
+    <node concept="2YIFZL" id="5rUl2R7K_Rs" role="jymVt">
+      <property role="TrG5h" value="clearExecutionMode" />
+      <node concept="3clFbS" id="5rUl2R7K_Rv" role="3clF47">
+        <node concept="3clFbF" id="5rUl2R7KA0l" role="3cqZAp">
+          <node concept="2OqwBi" id="5rUl2R7KA0m" role="3clFbG">
+            <node concept="2YIFZM" id="5rUl2R7KA0n" role="2Oq$k0">
+              <ref role="1Pybhc" to="jmi8:~PropertiesComponent" resolve="PropertiesComponent" />
+              <ref role="37wK5l" to="jmi8:~PropertiesComponent.getInstance()" resolve="getInstance" />
+            </node>
+            <node concept="liA8E" id="5rUl2R7KA0p" role="2OqNvi">
+              <ref role="37wK5l" to="jmi8:~PropertiesComponent.setValue(java.lang.String,java.lang.String)" resolve="setValue" />
+              <node concept="37vLTw" id="5rUl2R7KA0v" role="37wK5m">
+                <ref role="3cqZAo" node="5rUl2R7KcOJ" resolve="KEY" />
+              </node>
+              <node concept="10Nm6u" id="5rUl2R7KArb" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5rUl2R7K__4" role="1B3o_S" />
+      <node concept="3cqZAl" id="5rUl2R7K_R6" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="5rUl2R7JYMM" role="1B3o_S" />
+  </node>
+  <node concept="Qs71p" id="5rUl2R7KDH5">
+    <property role="3GE5qa" value="testExecution" />
+    <property role="TrG5h" value="ExecutionModePreference" />
+    <node concept="QsSxf" id="5rUl2R7KDTl" role="Qtgdg">
+      <property role="TrG5h" value="INTERPRETER" />
+      <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+    </node>
+    <node concept="QsSxf" id="5rUl2R7KE3p" role="Qtgdg">
+      <property role="TrG5h" value="GENERATOR" />
+      <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+    </node>
+    <node concept="QsSxf" id="5rUl2R7KE90" role="Qtgdg">
+      <property role="TrG5h" value="NO_PREFERENCE" />
+      <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+    </node>
+    <node concept="3Tm1VV" id="5rUl2R7KDH6" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="5rUl2R7KIet">
+    <property role="3GE5qa" value="testExecution" />
+    <property role="TrG5h" value="InterpreterWorkspace" />
+    <node concept="3clFbW" id="5rUl2R7KIeu" role="jymVt">
+      <node concept="3cqZAl" id="5rUl2R7KIev" role="3clF45" />
+      <node concept="3Tm1VV" id="5rUl2R7KIew" role="1B3o_S" />
+      <node concept="3clFbS" id="5rUl2R7KIex" role="3clF47">
+        <node concept="XkiVB" id="5rUl2R7KIey" role="3cqZAp">
+          <ref role="37wK5l" to="qkt:~ToggleAction.&lt;init&gt;(java.lang.String)" resolve="ToggleAction" />
+          <node concept="Xl_RD" id="5rUl2R7KIez" role="37wK5m">
+            <property role="Xl_RC" value="KernelF Tests: Interpreter (workspace)" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="5rUl2R7KIe$" role="1B3o_S" />
+    <node concept="3uibUv" id="5rUl2R7KIe_" role="1zkMxy">
+      <ref role="3uigEE" to="qkt:~ToggleAction" resolve="ToggleAction" />
+    </node>
+    <node concept="3clFb_" id="5rUl2R7KIeA" role="jymVt">
+      <property role="1EzhhJ" value="false" />
+      <property role="TrG5h" value="isSelected" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <node concept="3Tm1VV" id="5rUl2R7KIeB" role="1B3o_S" />
+      <node concept="10P_77" id="5rUl2R7KIeC" role="3clF45" />
+      <node concept="37vLTG" id="5rUl2R7KIeD" role="3clF46">
+        <property role="TrG5h" value="event" />
+        <node concept="3uibUv" id="5rUl2R7KIeE" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5rUl2R7KIeF" role="3clF47">
+        <node concept="3cpWs8" id="5rUl2R7KIeG" role="3cqZAp">
+          <node concept="3cpWsn" id="5rUl2R7KIeH" role="3cpWs9">
+            <property role="TrG5h" value="mode" />
+            <node concept="3uibUv" id="5rUl2R7KIeI" role="1tU5fm">
+              <ref role="3uigEE" node="5rUl2R7KDH5" resolve="ExecutionModePreference" />
+            </node>
+            <node concept="2YIFZM" id="5rUl2R7KIeJ" role="33vP2m">
+              <ref role="1Pybhc" node="5rUl2R7JYML" resolve="TestExecutionWorkspaceSetting" />
+              <ref role="37wK5l" node="5rUl2R7Ka3V" resolve="getExecutionMode" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5rUl2R7KIeN" role="3cqZAp">
+          <node concept="17R0WA" id="5rUl2R7KIeO" role="3clFbG">
+            <node concept="Rm8GO" id="5rUl2R7KJm4" role="3uHU7w">
+              <ref role="Rm8GQ" node="5rUl2R7KDTl" resolve="INTERPRETER" />
+              <ref role="1Px2BO" node="5rUl2R7KDH5" resolve="ExecutionModePreference" />
+            </node>
+            <node concept="37vLTw" id="5rUl2R7KIeQ" role="3uHU7B">
+              <ref role="3cqZAo" node="5rUl2R7KIeH" resolve="mode" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5rUl2R7KIeR" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5rUl2R7KIeS" role="jymVt">
+      <property role="1EzhhJ" value="false" />
+      <property role="TrG5h" value="setSelected" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <node concept="3Tm1VV" id="5rUl2R7KIeT" role="1B3o_S" />
+      <node concept="3cqZAl" id="5rUl2R7KIeU" role="3clF45" />
+      <node concept="37vLTG" id="5rUl2R7KIeV" role="3clF46">
+        <property role="TrG5h" value="event" />
+        <node concept="3uibUv" id="5rUl2R7KIeW" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5rUl2R7KIeX" role="3clF46">
+        <property role="TrG5h" value="b" />
+        <node concept="10P_77" id="5rUl2R7KIeY" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="5rUl2R7KIeZ" role="3clF47">
+        <node concept="3clFbF" id="5rUl2R7KIf0" role="3cqZAp">
+          <node concept="2YIFZM" id="5rUl2R7KIf1" role="3clFbG">
+            <ref role="1Pybhc" node="5rUl2R7JYML" resolve="TestExecutionWorkspaceSetting" />
+            <ref role="37wK5l" node="5rUl2R7KxIX" resolve="setExecutionMode" />
+            <node concept="Rm8GO" id="5rUl2R7KLM2" role="37wK5m">
+              <ref role="Rm8GQ" node="5rUl2R7KDTl" resolve="INTERPRETER" />
+              <ref role="1Px2BO" node="5rUl2R7KDH5" resolve="ExecutionModePreference" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5rUl2R7KIf6" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="5rUl2R7NKQt">
+    <property role="3GE5qa" value="testExecution" />
+    <property role="TrG5h" value="NoPreferenceWorkspace" />
+    <node concept="3clFbW" id="5rUl2R7NKQu" role="jymVt">
+      <node concept="3cqZAl" id="5rUl2R7NKQv" role="3clF45" />
+      <node concept="3Tm1VV" id="5rUl2R7NKQw" role="1B3o_S" />
+      <node concept="3clFbS" id="5rUl2R7NKQx" role="3clF47">
+        <node concept="XkiVB" id="5rUl2R7NKQy" role="3cqZAp">
+          <ref role="37wK5l" to="qkt:~ToggleAction.&lt;init&gt;(java.lang.String)" resolve="ToggleAction" />
+          <node concept="Xl_RD" id="5rUl2R7NKQz" role="37wK5m">
+            <property role="Xl_RC" value="KernelF Tests: No preference (workspace overrides above settings)" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="5rUl2R7NKQ$" role="1B3o_S" />
+    <node concept="3uibUv" id="5rUl2R7NKQ_" role="1zkMxy">
+      <ref role="3uigEE" to="qkt:~ToggleAction" resolve="ToggleAction" />
+    </node>
+    <node concept="3clFb_" id="5rUl2R7NKQA" role="jymVt">
+      <property role="1EzhhJ" value="false" />
+      <property role="TrG5h" value="isSelected" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <node concept="3Tm1VV" id="5rUl2R7NKQB" role="1B3o_S" />
+      <node concept="10P_77" id="5rUl2R7NKQC" role="3clF45" />
+      <node concept="37vLTG" id="5rUl2R7NKQD" role="3clF46">
+        <property role="TrG5h" value="event" />
+        <node concept="3uibUv" id="5rUl2R7NKQE" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5rUl2R7NKQF" role="3clF47">
+        <node concept="3cpWs8" id="5rUl2R7NKQG" role="3cqZAp">
+          <node concept="3cpWsn" id="5rUl2R7NKQH" role="3cpWs9">
+            <property role="TrG5h" value="mode" />
+            <node concept="3uibUv" id="5rUl2R7NKQI" role="1tU5fm">
+              <ref role="3uigEE" node="5rUl2R7KDH5" resolve="ExecutionModePreference" />
+            </node>
+            <node concept="2YIFZM" id="5rUl2R7NKQJ" role="33vP2m">
+              <ref role="1Pybhc" node="5rUl2R7JYML" resolve="TestExecutionWorkspaceSetting" />
+              <ref role="37wK5l" node="5rUl2R7Ka3V" resolve="getExecutionMode" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5rUl2R7NKQN" role="3cqZAp">
+          <node concept="17R0WA" id="5rUl2R7NKQO" role="3clFbG">
+            <node concept="Rm8GO" id="5rUl2R7NMki" role="3uHU7w">
+              <ref role="Rm8GQ" node="5rUl2R7KE90" resolve="NO_PREFERENCE" />
+              <ref role="1Px2BO" node="5rUl2R7KDH5" resolve="ExecutionModePreference" />
+            </node>
+            <node concept="37vLTw" id="5rUl2R7NKQQ" role="3uHU7B">
+              <ref role="3cqZAo" node="5rUl2R7NKQH" resolve="mode" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5rUl2R7NKQR" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="5rUl2R7NKQS" role="jymVt">
+      <property role="1EzhhJ" value="false" />
+      <property role="TrG5h" value="setSelected" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <node concept="3Tm1VV" id="5rUl2R7NKQT" role="1B3o_S" />
+      <node concept="3cqZAl" id="5rUl2R7NKQU" role="3clF45" />
+      <node concept="37vLTG" id="5rUl2R7NKQV" role="3clF46">
+        <property role="TrG5h" value="event" />
+        <node concept="3uibUv" id="5rUl2R7NKQW" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5rUl2R7NKQX" role="3clF46">
+        <property role="TrG5h" value="b" />
+        <node concept="10P_77" id="5rUl2R7NKQY" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="5rUl2R7NKQZ" role="3clF47">
+        <node concept="3clFbF" id="5rUl2R7NKR0" role="3cqZAp">
+          <node concept="2YIFZM" id="5rUl2R7NMZH" role="3clFbG">
+            <ref role="37wK5l" node="5rUl2R7K_Rs" resolve="clearExecutionMode" />
+            <ref role="1Pybhc" node="5rUl2R7JYML" resolve="TestExecutionWorkspaceSetting" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5rUl2R7NKR6" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="5rUl2R7OncF">
+    <property role="3GE5qa" value="testExecution" />
+    <property role="TrG5h" value="TestExecutionSettings" />
+    <node concept="2YIFZL" id="5rUl2R7POK$" role="jymVt">
+      <property role="TrG5h" value="getExecutionModePreference" />
+      <node concept="3clFbS" id="5rUl2R7POKA" role="3clF47">
+        <node concept="3cpWs8" id="5rUl2R7POKB" role="3cqZAp">
+          <node concept="3cpWsn" id="5rUl2R7POKC" role="3cpWs9">
+            <property role="TrG5h" value="tec" />
+            <node concept="3Tqbb2" id="5rUl2R7POKD" role="1tU5fm">
+              <ref role="ehGHo" to="6yn5:3SkjTN1LMyJ" resolve="TestExecutionConfig" />
+            </node>
+            <node concept="9H$SH" id="5rUl2R7POKE" role="33vP2m">
+              <ref role="9Hxhg" to="w474:3SkjTN1M1kS" resolve="TestExecutionPreferences" />
+              <node concept="37vLTw" id="5rUl2R7POKF" role="9HWM5">
+                <ref role="3cqZAo" node="5rUl2R7POL7" resolve="module" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5rUl2R7POKG" role="3cqZAp">
+          <node concept="3cpWsn" id="5rUl2R7POKH" role="3cpWs9">
+            <property role="TrG5h" value="userPreference" />
+            <node concept="3uibUv" id="5rUl2R7POKI" role="1tU5fm">
+              <ref role="3uigEE" node="5rUl2R7KDH5" resolve="ExecutionModePreference" />
+            </node>
+            <node concept="2YIFZM" id="5rUl2R7POKJ" role="33vP2m">
+              <ref role="37wK5l" node="5rUl2R7Ka3V" resolve="getExecutionMode" />
+              <ref role="1Pybhc" node="5rUl2R7JYML" resolve="TestExecutionWorkspaceSetting" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5rUl2R7POKK" role="3cqZAp">
+          <node concept="3clFbS" id="5rUl2R7POKL" role="3clFbx">
+            <node concept="3cpWs6" id="5rUl2R7POKM" role="3cqZAp">
+              <node concept="37vLTw" id="5rUl2R7POKN" role="3cqZAk">
+                <ref role="3cqZAo" node="5rUl2R7POKH" resolve="userPreference" />
+              </node>
+            </node>
+          </node>
+          <node concept="17QLQc" id="5rUl2R7POKO" role="3clFbw">
+            <node concept="Rm8GO" id="5rUl2R7POKP" role="3uHU7w">
+              <ref role="Rm8GQ" node="5rUl2R7KE90" resolve="NO_PREFERENCE" />
+              <ref role="1Px2BO" node="5rUl2R7KDH5" resolve="ExecutionModePreference" />
+            </node>
+            <node concept="37vLTw" id="5rUl2R7POKQ" role="3uHU7B">
+              <ref role="3cqZAo" node="5rUl2R7POKH" resolve="userPreference" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5rUl2R7POKR" role="3cqZAp">
+          <node concept="3clFbS" id="5rUl2R7POKS" role="3clFbx">
+            <node concept="3cpWs6" id="5rUl2R7POKT" role="3cqZAp">
+              <node concept="Rm8GO" id="5rUl2R7POKU" role="3cqZAk">
+                <ref role="Rm8GQ" node="5rUl2R7KE3p" resolve="GENERATOR" />
+                <ref role="1Px2BO" node="5rUl2R7KDH5" resolve="ExecutionModePreference" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="5rUl2R7POKV" role="3clFbw">
+            <node concept="2OqwBi" id="5rUl2R7POKW" role="2Oq$k0">
+              <node concept="37vLTw" id="5rUl2R7POKX" role="2Oq$k0">
+                <ref role="3cqZAo" node="5rUl2R7POKC" resolve="tec" />
+              </node>
+              <node concept="3TrEf2" id="5rUl2R7POKY" role="2OqNvi">
+                <ref role="3Tt5mk" to="6yn5:3SkjTN1LTtQ" resolve="executionMode" />
+              </node>
+            </node>
+            <node concept="1mIQ4w" id="5rUl2R7POKZ" role="2OqNvi">
+              <node concept="chp4Y" id="5rUl2R7POL0" role="cj9EA">
+                <ref role="cht4Q" to="6yn5:3SkjTN1LTuE" resolve="GeneratorExecutionMode" />
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="5rUl2R7POL1" role="9aQIa">
+            <node concept="3clFbS" id="5rUl2R7POL2" role="9aQI4">
+              <node concept="3cpWs6" id="5rUl2R7POL3" role="3cqZAp">
+                <node concept="Rm8GO" id="5rUl2R7POL4" role="3cqZAk">
+                  <ref role="Rm8GQ" node="5rUl2R7KDTl" resolve="INTERPRETER" />
+                  <ref role="1Px2BO" node="5rUl2R7KDH5" resolve="ExecutionModePreference" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="5rUl2R7POL6" role="3clF45">
+        <ref role="3uigEE" node="5rUl2R7KDH5" resolve="ExecutionModePreference" />
+      </node>
+      <node concept="37vLTG" id="5rUl2R7POL7" role="3clF46">
+        <property role="TrG5h" value="module" />
+        <node concept="3uibUv" id="5rUl2R7POL8" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5rUl2R7POL5" role="1B3o_S" />
+    </node>
+    <node concept="3Tm1VV" id="5rUl2R7OncG" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/org.iets3.core.expr.plugin.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/org.iets3.core.expr.plugin.msd
@@ -34,6 +34,7 @@
     <dependency reexport="false">e78f91af-08a8-4a7a-bed6-b22739ed069a(com.mbeddr.mpsutil.spreferences.runtime)</dependency>
     <dependency reexport="false">c3bfea76-7bba-4f0e-b5a2-ff4e7a8d7cf1(com.mbeddr.mpsutil.spreferences)</dependency>
     <dependency reexport="false">5474e4cd-6621-4b33-a39a-75552543ba57(de.slisson.mps.conditionalEditor.hints)</dependency>
+    <dependency reexport="false">d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -8008,41 +8008,68 @@
         <node concept="3LEz8M" id="kEKsc8qBa7" role="3LEz9a">
           <ref role="3LEz8N" node="2zpAVpC$xZc" resolve="org.iets3.core.expr.genjava.core.devkit" />
         </node>
-        <node concept="3LEDTy" id="5rUl2R7R_QT" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+        <node concept="3LEDTy" id="3$hkYrGH8VL" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
         </node>
-        <node concept="3LEDTy" id="5rUl2R7R_QU" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
+        <node concept="3LEDTy" id="3$hkYrGH8VM" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
         </node>
-        <node concept="3LEDTy" id="5rUl2R7R_QV" role="3LEDUa">
-          <ref role="3LEDTV" node="49WTic8jAaa" resolve="org.iets3.analysis.base" />
+        <node concept="3LEDTy" id="3$hkYrGH8VN" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
         </node>
-        <node concept="3LEDTy" id="5rUl2R7R_QW" role="3LEDUa">
-          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
+        <node concept="3LEDTy" id="3$hkYrGH8VO" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
         </node>
-        <node concept="3LEDTy" id="5rUl2R7R_QX" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        <node concept="3LEDTy" id="3$hkYrGH8VP" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
         </node>
-        <node concept="3LEDTy" id="5rUl2R7R_QY" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
+        <node concept="3LEDTy" id="3$hkYrGH8VQ" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
         </node>
-        <node concept="3LEDTy" id="5rUl2R7R_QZ" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        <node concept="3LEDTy" id="3$hkYrGH8VR" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
         </node>
-        <node concept="3LEDTy" id="5rUl2R7R_R0" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRRB" resolve="org.iets3.core.base" />
+        <node concept="3LEDTy" id="3$hkYrGH8VS" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
         </node>
-        <node concept="3LEDTy" id="5rUl2R7R_R1" role="3LEDUa">
-          <ref role="3LEDTV" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
+        <node concept="3LEDTy" id="3$hkYrGH8VT" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
         </node>
-        <node concept="3LEDTy" id="5rUl2R7R_R2" role="3LEDUa">
-          <ref role="3LEDTV" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
+        <node concept="3LEDTy" id="3$hkYrGH8VU" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
         </node>
-        <node concept="3LEDTy" id="5rUl2R7R_R3" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
+        <node concept="3LEDTy" id="3$hkYrGH8VV" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
         </node>
-        <node concept="3LEDTy" id="5rUl2R7R_R4" role="3LEDUa">
-          <ref role="3LEDTV" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
+        <node concept="3LEDTy" id="3$hkYrGH8VW" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
+        </node>
+        <node concept="3LEDTy" id="3$hkYrGH8VX" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTy" id="3$hkYrGH8VY" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
+        </node>
+        <node concept="3LEDTy" id="3$hkYrGH8VZ" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
+        </node>
+        <node concept="3LEDTy" id="3$hkYrGH8W0" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        </node>
+        <node concept="3LEDTy" id="3$hkYrGH8W1" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
+        </node>
+        <node concept="3LEDTy" id="3$hkYrGH8W2" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
+        </node>
+        <node concept="3LEDTy" id="3$hkYrGH8W3" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
+        </node>
+        <node concept="3LEDTy" id="3$hkYrGH8W4" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+        </node>
+        <node concept="3LEDTy" id="3$hkYrGH8W5" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
         </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC_4Ut" role="2G$12L">
@@ -8443,6 +8470,18 @@
         </node>
         <node concept="3LEDTy" id="CZ7JsUXByc" role="3LEDUa">
           <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="3$hkYrGH8WQ" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
+        <node concept="3LEDTy" id="3$hkYrGH8WR" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        </node>
+        <node concept="3LEDTy" id="3$hkYrGH8WS" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="3$hkYrGH8WT" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
         </node>
       </node>
       <node concept="1E1JtA" id="4YDVTWrP3Qy" role="2G$12L">
@@ -10308,15 +10347,6 @@
         <node concept="3LEDTM" id="3qKzW8QJ_Qf" role="3LEDUa">
           <ref role="3LEDTN" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
         </node>
-        <node concept="3LEDTy" id="5rUl2R7R_WZ" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_X0" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_X1" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
-        </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC$OJa" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10361,30 +10391,6 @@
         <node concept="3LEDTM" id="6wnckeEe9TH" role="3LEDUa">
           <ref role="3LEDTN" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
         </node>
-        <node concept="3LEDTy" id="5rUl2R7R_X2" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_X3" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_X4" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_X5" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_X6" role="3LEDUa">
-          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_X7" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_X8" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_X9" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
-        </node>
       </node>
       <node concept="3LEwk6" id="j5CxBKa9ks" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10410,123 +10416,6 @@
         </node>
         <node concept="3LEDTM" id="1RMC8GHEwZU" role="3LEDUa">
           <ref role="3LEDTN" node="2zpAVpC$IQf" resolve="org.iets3.core.expr.genjava.advanced.genplan" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xa" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xb" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xc" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xd" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xe" role="3LEDUa">
-          <ref role="3LEDTV" node="7sID8G9sQTG" resolve="org.iets3.core.expr.genjava.temporal" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xf" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xg" role="3LEDUa">
-          <ref role="3LEDTV" node="5Y0kZK1N637" resolve="org.iets3.core.expr.genjava.datetime" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xh" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xi" role="3LEDUa">
-          <ref role="3LEDTV" node="23q4CrmMjzr" resolve="org.iets3.core.expr.genjava.messages" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xj" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xk" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xl" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xm" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xn" role="3LEDUa">
-          <ref role="3LEDTV" node="49WTic8jAaa" resolve="org.iets3.analysis.base" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xo" role="3LEDUa">
-          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xp" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xq" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xr" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xs" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xt" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xu" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xv" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xw" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xx" role="3LEDUa">
-          <ref role="3LEDTV" node="5wLtKNeSRRB" resolve="org.iets3.core.base" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xy" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_Xz" role="3LEDUa">
-          <ref role="3LEDTV" node="5zQvLw7dx1X" resolve="org.iets3.core.expr.datetime" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_X$" role="3LEDUa">
-          <ref role="3LEDTV" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_X_" role="3LEDUa">
-          <ref role="3LEDTV" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_XA" role="3LEDUa">
-          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_XB" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_XC" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_XD" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_XE" role="3LEDUa">
-          <ref role="3LEDTV" node="6hYPZtwrWbD" resolve="org.iets3.core.expr.genjava.util" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_XF" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_XG" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_XH" role="3LEDUa">
-          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_XI" role="3LEDUa">
-          <ref role="3LEDTV" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_XJ" role="3LEDUa">
-          <ref role="3LEDTV" node="5zQvLw7dsP5" resolve="org.iets3.core.expr.temporal" />
-        </node>
-        <node concept="3LEDTy" id="5rUl2R7R_XK" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -4881,6 +4881,11 @@
             <ref role="3bR37D" to="90a9:64TsoMQT2qP" resolve="de.slisson.mps.hacks.editor" />
           </node>
         </node>
+        <node concept="1SiIV0" id="5rUl2R7R_KK" role="3bR37C">
+          <node concept="3bR9La" id="5rUl2R7R_KL" role="1SiIV1">
+            <ref role="3bR37D" node="3FexrMiSOe$" resolve="org.iets3.core.expr.plugin" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="44TucI396fH" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -6215,6 +6220,11 @@
             <node concept="3qWCbU" id="1RMC8GHEwLR" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5rUl2R7R_Np" role="3bR37C">
+          <node concept="3bR9La" id="5rUl2R7R_Nq" role="1SiIV1">
+            <ref role="3bR37D" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
           </node>
         </node>
       </node>
@@ -7998,68 +8008,41 @@
         <node concept="3LEz8M" id="kEKsc8qBa7" role="3LEz9a">
           <ref role="3LEz8N" node="2zpAVpC$xZc" resolve="org.iets3.core.expr.genjava.core.devkit" />
         </node>
-        <node concept="3LEDTy" id="BuchFahljL" role="3LEDUa">
-          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+        <node concept="3LEDTy" id="5rUl2R7R_QT" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
         </node>
-        <node concept="3LEDTy" id="BuchFahljM" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
+        <node concept="3LEDTy" id="5rUl2R7R_QU" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
         </node>
-        <node concept="3LEDTy" id="BuchFahljN" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
+        <node concept="3LEDTy" id="5rUl2R7R_QV" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAaa" resolve="org.iets3.analysis.base" />
         </node>
-        <node concept="3LEDTy" id="BuchFahljO" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
+        <node concept="3LEDTy" id="5rUl2R7R_QW" role="3LEDUa">
+          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
         </node>
-        <node concept="3LEDTy" id="BuchFahljP" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        <node concept="3LEDTy" id="5rUl2R7R_QX" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
         </node>
-        <node concept="3LEDTy" id="BuchFahljQ" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
+        <node concept="3LEDTy" id="5rUl2R7R_QY" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
         </node>
-        <node concept="3LEDTy" id="BuchFahljR" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
+        <node concept="3LEDTy" id="5rUl2R7R_QZ" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
         </node>
-        <node concept="3LEDTy" id="BuchFahljS" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        <node concept="3LEDTy" id="5rUl2R7R_R0" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRRB" resolve="org.iets3.core.base" />
         </node>
-        <node concept="3LEDTy" id="BuchFahljT" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
+        <node concept="3LEDTy" id="5rUl2R7R_R1" role="3LEDUa">
+          <ref role="3LEDTV" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
         </node>
-        <node concept="3LEDTy" id="BuchFahljU" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
+        <node concept="3LEDTy" id="5rUl2R7R_R2" role="3LEDUa">
+          <ref role="3LEDTV" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
         </node>
-        <node concept="3LEDTy" id="BuchFahljV" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        <node concept="3LEDTy" id="5rUl2R7R_R3" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
         </node>
-        <node concept="3LEDTy" id="BuchFahljW" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
-        </node>
-        <node concept="3LEDTy" id="BuchFahljX" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
-        </node>
-        <node concept="3LEDTy" id="BuchFahljY" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
-        </node>
-        <node concept="3LEDTy" id="BuchFahljZ" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
-        </node>
-        <node concept="3LEDTy" id="BuchFahlk0" role="3LEDUa">
-          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
-        </node>
-        <node concept="3LEDTy" id="BuchFahlk1" role="3LEDUa">
-          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
-        </node>
-        <node concept="3LEDTy" id="BuchFahlk2" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
-        </node>
-        <node concept="3LEDTy" id="BuchFahlk3" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
-        </node>
-        <node concept="3LEDTy" id="BuchFahlk4" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
-        </node>
-        <node concept="3LEDTy" id="BuchFahlk5" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
+        <node concept="3LEDTy" id="5rUl2R7R_R4" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
         </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC_4Ut" role="2G$12L">
@@ -8460,18 +8443,6 @@
         </node>
         <node concept="3LEDTy" id="CZ7JsUXByc" role="3LEDUa">
           <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
-        </node>
-        <node concept="3LEDTy" id="BuchFahlkQ" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
-        </node>
-        <node concept="3LEDTy" id="BuchFahlkR" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-        </node>
-        <node concept="3LEDTy" id="BuchFahlkS" role="3LEDUa">
-          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
-        </node>
-        <node concept="3LEDTy" id="BuchFahlkT" role="3LEDUa">
-          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
         </node>
       </node>
       <node concept="1E1JtA" id="4YDVTWrP3Qy" role="2G$12L">
@@ -10337,6 +10308,15 @@
         <node concept="3LEDTM" id="3qKzW8QJ_Qf" role="3LEDUa">
           <ref role="3LEDTN" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
         </node>
+        <node concept="3LEDTy" id="5rUl2R7R_WZ" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_X0" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_X1" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC$OJa" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10381,6 +10361,30 @@
         <node concept="3LEDTM" id="6wnckeEe9TH" role="3LEDUa">
           <ref role="3LEDTN" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
         </node>
+        <node concept="3LEDTy" id="5rUl2R7R_X2" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_X3" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_X4" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_X5" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_X6" role="3LEDUa">
+          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_X7" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_X8" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_X9" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
       </node>
       <node concept="3LEwk6" id="j5CxBKa9ks" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -10406,6 +10410,123 @@
         </node>
         <node concept="3LEDTM" id="1RMC8GHEwZU" role="3LEDUa">
           <ref role="3LEDTN" node="2zpAVpC$IQf" resolve="org.iets3.core.expr.genjava.advanced.genplan" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xa" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xb" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWJe" resolve="org.iets3.core.expr.genjava.toplevel" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xc" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xd" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xe" role="3LEDUa">
+          <ref role="3LEDTV" node="7sID8G9sQTG" resolve="org.iets3.core.expr.genjava.temporal" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xf" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xg" role="3LEDUa">
+          <ref role="3LEDTV" node="5Y0kZK1N637" resolve="org.iets3.core.expr.genjava.datetime" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xh" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xi" role="3LEDUa">
+          <ref role="3LEDTV" node="23q4CrmMjzr" resolve="org.iets3.core.expr.genjava.messages" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xj" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xk" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xl" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xm" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xn" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAaa" resolve="org.iets3.analysis.base" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xo" role="3LEDUa">
+          <ref role="3LEDTV" node="lH$Puj5DFq" resolve="org.iets3.core.expr.genjava.contracts" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xp" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xq" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xr" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xs" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xt" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xu" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xv" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xw" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xx" role="3LEDUa">
+          <ref role="3LEDTV" node="5wLtKNeSRRB" resolve="org.iets3.core.base" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xy" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_Xz" role="3LEDUa">
+          <ref role="3LEDTV" node="5zQvLw7dx1X" resolve="org.iets3.core.expr.datetime" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_X$" role="3LEDUa">
+          <ref role="3LEDTV" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_X_" role="3LEDUa">
+          <ref role="3LEDTV" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_XA" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_XB" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_XC" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_XD" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qWbm" resolve="org.iets3.core.expr.genjava.tests" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_XE" role="3LEDUa">
+          <ref role="3LEDTV" node="6hYPZtwrWbD" resolve="org.iets3.core.expr.genjava.util" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_XF" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_XG" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_XH" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_XI" role="3LEDUa">
+          <ref role="3LEDTV" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_XJ" role="3LEDUa">
+          <ref role="3LEDTV" node="5zQvLw7dsP5" resolve="org.iets3.core.expr.temporal" />
+        </node>
+        <node concept="3LEDTy" id="5rUl2R7R_XK" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
         </node>
       </node>
     </node>


### PR DESCRIPTION
This PR adds new actions to the run menu that allows changing the test execution mode (interpreter, generator) also per workspace (persisted in workspace.xml instead of model).
Reason: The original TestExecutionConfig might be changed by a user and checked into version control. Now all other user get the new preference when they check out the project.

After this change the workspace setting is preferred over the TestExecutionConfig when it is set by the user.
The combined preference should then be queried by calling`TestExecutionSettings.getExecutionModePreference` (for example in TestSuites).