### PR TITLE
Computation trace: Don't always show LambdaExpression

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/plugin.mps
@@ -1022,9 +1022,7 @@
                 <node concept="37vLTw" id="6ITtBskYEku" role="37wK5m">
                   <ref role="3cqZAo" node="6ITtBskYEke" resolve="originalLE" />
                 </node>
-                <node concept="3clFbT" id="5d4Vabvs8X9" role="37wK5m">
-                  <property role="3clFbU" value="true" />
-                </node>
+                <node concept="3clFbT" id="5d4Vabvs8X9" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -1169,9 +1167,7 @@
                     <node concept="37vLTw" id="6ITtBskXu01" role="37wK5m">
                       <ref role="3cqZAo" node="6ITtBskXoU2" resolve="originalSLE" />
                     </node>
-                    <node concept="3clFbT" id="6ITtBskXuea" role="37wK5m">
-                      <property role="3clFbU" value="true" />
-                    </node>
+                    <node concept="3clFbT" id="6ITtBskXuea" role="37wK5m" />
                   </node>
                 </node>
                 <node concept="37vLTw" id="6ITtBskXsHW" role="37vLTJ">


### PR DESCRIPTION
The lambda expression was shown as the child of every other node because the flag for also show was set. There was another fix in [mbeddr.core](https://github.com/mbeddr/mbeddr.core/pull/2216) to make this fix possible.

How to reproduce and check: Execute a test case with lambda expressions ([example](http://127.0.0.1:63320/node?ref=r%3Af6b93d14-1af1-4f84-a11b-cbe2d8c5efff%28test.in.expr.os.lambda%40tests%29%2F8293738266734930343)). Right click first assert statement -> Show trace and Click Expand All button. The ShortLambdaExpression shouldn't be displayed ~10 times anymore.

Screenshot from other project:

![withShortLambda](https://user-images.githubusercontent.com/88385944/165045152-f7ce2450-adae-4f00-8548-b335c924e5ec.png)
