### PR TITLE
Improve expression and temporal op editors

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
@@ -127,11 +127,15 @@
       <concept id="1164833692343" name="jetbrains.mps.lang.editor.structure.CellMenuPart_PropertyValues" flags="ng" index="PvTIS">
         <child id="1164833692344" name="valuesFunction" index="PvTIR" />
       </concept>
+      <concept id="1078938745671" name="jetbrains.mps.lang.editor.structure.EditorComponentDeclaration" flags="ig" index="PKFIW" />
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
         <reference id="1078939183255" name="editorComponent" index="PMmxG" />
       </concept>
       <concept id="1235728439575" name="jetbrains.mps.lang.editor.structure.BaseLineCell" flags="ln" index="2R9Tw8" />
       <concept id="1149850725784" name="jetbrains.mps.lang.editor.structure.CellModel_AttributedNodeCell" flags="ng" index="2SsqMj" />
+      <concept id="1164914519156" name="jetbrains.mps.lang.editor.structure.CellMenuPart_ReplaceNode_CustomNodeConcept" flags="ng" index="UkePV">
+        <reference id="1164914727930" name="replacementConcept" index="Ul1FP" />
+      </concept>
       <concept id="1186402211651" name="jetbrains.mps.lang.editor.structure.StyleSheet" flags="ng" index="V5hpn">
         <child id="1186402402630" name="styles" index="V601i" />
       </concept>
@@ -2659,8 +2663,8 @@
     <ref role="1XX52x" to="hm2y:2U5Q01UkDMQ" resolve="OneOfTarget" />
     <node concept="3EZMnI" id="2U5Q01UkDNw" role="2wV5jI">
       <node concept="2iRfu4" id="2U5Q01UkDNx" role="2iSdaV" />
-      <node concept="3F0ifn" id="2U5Q01UkDNs" role="3EZMnx">
-        <property role="3F0ifm" value="oneOf" />
+      <node concept="PMmxH" id="12bsjhgd0e2" role="3EZMnx">
+        <ref role="PMmxG" node="12bsjhgd0dR" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="2U5Q01UkDNJ" role="3EZMnx">
         <property role="3F0ifm" value="[" />
@@ -6574,6 +6578,18 @@
     <ref role="1XX52x" to="hm2y:3tcv7J0pmjC" resolve="EmptyType" />
     <node concept="PMmxH" id="3tcv7J0v6Vw" role="2wV5jI">
       <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+    </node>
+  </node>
+  <node concept="PKFIW" id="12bsjhgd0dR">
+    <property role="TrG5h" value="OpAlias" />
+    <ref role="1XX52x" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
+    <node concept="PMmxH" id="12bsjhgd0dT" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      <node concept="OXEIz" id="12bsjhgd0dW" role="P5bDN">
+        <node concept="UkePV" id="12bsjhgd0dZ" role="OY2wv">
+          <ref role="Ul1FP" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
@@ -2663,8 +2663,13 @@
     <ref role="1XX52x" to="hm2y:2U5Q01UkDMQ" resolve="OneOfTarget" />
     <node concept="3EZMnI" id="2U5Q01UkDNw" role="2wV5jI">
       <node concept="2iRfu4" id="2U5Q01UkDNx" role="2iSdaV" />
-      <node concept="PMmxH" id="12bsjhgd0e2" role="3EZMnx">
-        <ref role="PMmxG" node="12bsjhgd0dR" resolve="OpAlias" />
+      <node concept="PMmxH" id="2ovg8939xRZ" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+        <node concept="OXEIz" id="2ovg8939xSa" role="P5bDN">
+          <node concept="UkePV" id="2ovg8939xSc" role="OY2wv">
+            <ref role="Ul1FP" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
+          </node>
+        </node>
       </node>
       <node concept="3F0ifn" id="2U5Q01UkDNJ" role="3EZMnx">
         <property role="3F0ifm" value="[" />
@@ -2699,11 +2704,8 @@
     <ref role="1XX52x" to="hm2y:1WCh2thoP2K" resolve="RangeTarget" />
     <node concept="3EZMnI" id="1WCh2thoP47" role="2wV5jI">
       <node concept="l2Vlx" id="1WCh2thoP48" role="2iSdaV" />
-      <node concept="3F0ifn" id="1WCh2thoP49" role="3EZMnx">
-        <property role="3F0ifm" value="inRange" />
-        <node concept="11L4FC" id="1WCh2thoP69" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
+      <node concept="PMmxH" id="2ovg893icCL" role="3EZMnx">
+        <ref role="PMmxG" node="12bsjhgd0dR" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="1WCh2thoP4a" role="3EZMnx">
         <property role="3F0ifm" value="[" />
@@ -6583,11 +6585,17 @@
   <node concept="PKFIW" id="12bsjhgd0dR">
     <property role="TrG5h" value="OpAlias" />
     <ref role="1XX52x" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
-    <node concept="PMmxH" id="12bsjhgd0dT" role="2wV5jI">
-      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
-      <node concept="OXEIz" id="12bsjhgd0dW" role="P5bDN">
-        <node concept="UkePV" id="12bsjhgd0dZ" role="OY2wv">
-          <ref role="Ul1FP" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
+    <node concept="yw3OH" id="4BCdpRyUAx" role="2wV5jI">
+      <node concept="1Lj6DL" id="4BCdpRyUAB" role="yw3OG">
+        <node concept="1Lj6DC" id="4BCdpRyUAD" role="1Lj8FM">
+          <node concept="3clFbS" id="4BCdpRyUAF" role="2VODD2">
+            <node concept="3clFbF" id="4BCdpRz5vp" role="3cqZAp">
+              <node concept="2OqwBi" id="4BCdpRz5JT" role="3clFbG">
+                <node concept="1Lj6YZ" id="4BCdpRz5vo" role="2Oq$k0" />
+                <node concept="3n3YKJ" id="4BCdpRz686" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
@@ -2663,13 +2663,8 @@
     <ref role="1XX52x" to="hm2y:2U5Q01UkDMQ" resolve="OneOfTarget" />
     <node concept="3EZMnI" id="2U5Q01UkDNw" role="2wV5jI">
       <node concept="2iRfu4" id="2U5Q01UkDNx" role="2iSdaV" />
-      <node concept="PMmxH" id="2ovg8939xRZ" role="3EZMnx">
-        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
-        <node concept="OXEIz" id="2ovg8939xSa" role="P5bDN">
-          <node concept="UkePV" id="2ovg8939xSc" role="OY2wv">
-            <ref role="Ul1FP" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
-          </node>
-        </node>
+      <node concept="PMmxH" id="12bsjhgd0e2" role="3EZMnx">
+        <ref role="PMmxG" node="12bsjhgd0dR" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="2U5Q01UkDNJ" role="3EZMnx">
         <property role="3F0ifm" value="[" />
@@ -2704,8 +2699,11 @@
     <ref role="1XX52x" to="hm2y:1WCh2thoP2K" resolve="RangeTarget" />
     <node concept="3EZMnI" id="1WCh2thoP47" role="2wV5jI">
       <node concept="l2Vlx" id="1WCh2thoP48" role="2iSdaV" />
-      <node concept="PMmxH" id="2ovg893icCL" role="3EZMnx">
-        <ref role="PMmxG" node="12bsjhgd0dR" resolve="OpAlias" />
+      <node concept="3F0ifn" id="1WCh2thoP49" role="3EZMnx">
+        <property role="3F0ifm" value="inRange" />
+        <node concept="11L4FC" id="1WCh2thoP69" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
       </node>
       <node concept="3F0ifn" id="1WCh2thoP4a" role="3EZMnx">
         <property role="3F0ifm" value="[" />
@@ -6585,17 +6583,11 @@
   <node concept="PKFIW" id="12bsjhgd0dR">
     <property role="TrG5h" value="OpAlias" />
     <ref role="1XX52x" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
-    <node concept="yw3OH" id="4BCdpRyUAx" role="2wV5jI">
-      <node concept="1Lj6DL" id="4BCdpRyUAB" role="yw3OG">
-        <node concept="1Lj6DC" id="4BCdpRyUAD" role="1Lj8FM">
-          <node concept="3clFbS" id="4BCdpRyUAF" role="2VODD2">
-            <node concept="3clFbF" id="4BCdpRz5vp" role="3cqZAp">
-              <node concept="2OqwBi" id="4BCdpRz5JT" role="3clFbG">
-                <node concept="1Lj6YZ" id="4BCdpRz5vo" role="2Oq$k0" />
-                <node concept="3n3YKJ" id="4BCdpRz686" role="2OqNvi" />
-              </node>
-            </node>
-          </node>
+    <node concept="PMmxH" id="12bsjhgd0dT" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      <node concept="OXEIz" id="12bsjhgd0dW" role="P5bDN">
+        <node concept="UkePV" id="12bsjhgd0dZ" role="OY2wv">
+          <ref role="Ul1FP" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/actions.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/actions.mps
@@ -20,6 +20,7 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -51,10 +52,14 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6" />
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
@@ -97,6 +102,7 @@
       <concept id="1158701162220" name="jetbrains.mps.lang.actions.structure.NodeSetupFunction" flags="in" index="37Y9Zx" />
       <concept id="5584396657084912703" name="jetbrains.mps.lang.actions.structure.NodeSetupFunction_NewNode" flags="nn" index="1r4Lsj" />
       <concept id="5584396657084920670" name="jetbrains.mps.lang.actions.structure.NodeSetupFunction_EnclosingNode" flags="nn" index="1r4N1M" />
+      <concept id="5584396657084920413" name="jetbrains.mps.lang.actions.structure.NodeSetupFunction_SampleNode" flags="nn" index="1r4N5L" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
@@ -109,6 +115,14 @@
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
@@ -415,6 +429,54 @@
                   </node>
                 </node>
               </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="37WvkG" id="4l_LUjibjsh" role="37WGs$">
+      <ref role="37XkoT" to="700h:6zmBjqUjnKs" resolve="OneArgCollectionOp" />
+      <node concept="37Y9Zx" id="4l_LUjibjsi" role="37ZfLb">
+        <node concept="3clFbS" id="4l_LUjibjsj" role="2VODD2">
+          <node concept="3clFbJ" id="4l_LUjibEwm" role="3cqZAp">
+            <node concept="3clFbS" id="4l_LUjibEwo" role="3clFbx">
+              <node concept="3cpWs6" id="4l_LUjibELa" role="3cqZAp" />
+            </node>
+            <node concept="2OqwBi" id="4l_LUjibEC3" role="3clFbw">
+              <node concept="1r4Lsj" id="4l_LUjickKD" role="2Oq$k0" />
+              <node concept="1mIQ4w" id="4l_LUjibEIz" role="2OqNvi">
+                <node concept="chp4Y" id="4l_LUjibEIV" role="cj9EA">
+                  <ref role="cht4Q" to="700h:oG0sI$GQkF" resolve="TwoArgPredicateCollectionOp" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="Jncv_" id="4l_LUjibjut" role="3cqZAp">
+            <ref role="JncvD" to="700h:6zmBjqUjnKs" resolve="OneArgCollectionOp" />
+            <node concept="1r4N5L" id="4l_LUjibjuM" role="JncvB" />
+            <node concept="3clFbS" id="4l_LUjibjuv" role="Jncv$">
+              <node concept="3clFbF" id="4l_LUjibjvx" role="3cqZAp">
+                <node concept="37vLTI" id="4l_LUjibke4" role="3clFbG">
+                  <node concept="2OqwBi" id="4l_LUjibksF" role="37vLTx">
+                    <node concept="Jnkvi" id="4l_LUjibkeC" role="2Oq$k0">
+                      <ref role="1M0zk5" node="4l_LUjibjuw" resolve="oneArgOp" />
+                    </node>
+                    <node concept="3TrEf2" id="4l_LUjibkOP" role="2OqNvi">
+                      <ref role="3Tt5mk" to="700h:6zmBjqUjnKt" resolve="arg" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="4l_LUjibjFr" role="37vLTJ">
+                    <node concept="1r4Lsj" id="4l_LUjibjvQ" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="4l_LUjibk2J" role="2OqNvi">
+                      <ref role="3Tt5mk" to="700h:6zmBjqUjnKt" resolve="arg" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="JncvC" id="4l_LUjibjuw" role="JncvA">
+              <property role="TrG5h" value="oneArgOp" />
+              <node concept="2jxLKc" id="4l_LUjibjux" role="1tU5fm" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/editor.mps
@@ -13,6 +13,7 @@
     <import index="oq0c" ref="r:6c6155f0-4bbe-4af5-8c26-244d570e21e4(org.iets3.core.expr.base.plugin)" />
     <import index="700h" ref="r:61b1de80-490d-4fee-8e95-b956503290e9(org.iets3.core.expr.collections.structure)" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
+    <import index="buwp" ref="r:8405f486-53b5-4fe6-af3e-7f68358bd631(org.iets3.core.expr.base.editor)" implicit="true" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
@@ -423,11 +424,8 @@
     <property role="3GE5qa" value="" />
     <ref role="1XX52x" to="700h:6zmBjqUjnKs" resolve="OneArgCollectionOp" />
     <node concept="3EZMnI" id="6zmBjqUjnOV" role="2wV5jI">
-      <node concept="PMmxH" id="6zmBjqUjnOW" role="3EZMnx">
-        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
-        <node concept="11LMrY" id="49WTic8ec1k" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
+      <node concept="PMmxH" id="4l_LUjie3jr" role="3EZMnx">
+        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="6zmBjqUjnOX" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -817,8 +815,8 @@
     <ref role="1XX52x" to="700h:6IBT1wT$hPp" resolve="IMapOneArgOp" />
     <node concept="3EZMnI" id="7kYh9Ws$z$o" role="2wV5jI">
       <node concept="2iRfu4" id="7kYh9Ws$z$p" role="2iSdaV" />
-      <node concept="PMmxH" id="7kYh9Ws$z$m" role="3EZMnx">
-        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      <node concept="PMmxH" id="4l_LUjie3iJ" role="3EZMnx">
+        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="7kYh9Ws$z$x" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -887,8 +885,8 @@
     <ref role="1XX52x" to="700h:4_KMC82H1yT" resolve="IListOneArgOp" />
     <node concept="3EZMnI" id="1RHynufnBTp" role="2wV5jI">
       <node concept="l2Vlx" id="NE1gl4Nw13" role="2iSdaV" />
-      <node concept="PMmxH" id="1RHynufnBTr" role="3EZMnx">
-        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      <node concept="PMmxH" id="4l_LUjie3hU" role="3EZMnx">
+        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="1RHynufnBTs" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -1065,9 +1063,15 @@
   <node concept="24kQdi" id="3tudP_AOMNH">
     <ref role="1XX52x" to="700h:3tudP_AOMNf" resolve="UpToTarget" />
     <node concept="3EZMnI" id="3tudP_AOMNJ" role="2wV5jI">
-      <node concept="3F0ifn" id="3tudP_AOMNQ" role="3EZMnx">
-        <property role="3F0ifm" value="upto(" />
-        <node concept="11LMrY" id="3tudP_AOMSn" role="3F10Kt">
+      <node concept="PMmxH" id="4l_LUjie3jL" role="3EZMnx">
+        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
+      </node>
+      <node concept="3F0ifn" id="4l_LUjib1e6" role="3EZMnx">
+        <property role="3F0ifm" value="(" />
+        <node concept="11L4FC" id="4l_LUjib1ee" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="11LMrY" id="4l_LUjib1ej" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
       </node>
@@ -1101,8 +1105,8 @@
     <ref role="1XX52x" to="700h:4hLehKTZXcg" resolve="FoldOp" />
     <node concept="3EZMnI" id="4hLehKU05ea" role="2wV5jI">
       <node concept="l2Vlx" id="6vzDuv94evh" role="2iSdaV" />
-      <node concept="PMmxH" id="4hLehKU05e7" role="3EZMnx">
-        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      <node concept="PMmxH" id="4l_LUjie49l" role="3EZMnx">
+        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="4hLehKU05ep" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -1152,8 +1156,8 @@
     <ref role="1XX52x" to="700h:thkha3aNEl" resolve="ISetOneArgOp" />
     <node concept="3EZMnI" id="thkha3aNE$" role="2wV5jI">
       <node concept="2iRfu4" id="thkha3aNE_" role="2iSdaV" />
-      <node concept="PMmxH" id="thkha3aNEA" role="3EZMnx">
-        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      <node concept="PMmxH" id="4l_LUjie3j5" role="3EZMnx">
+        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="thkha3aNEB" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -1187,8 +1191,8 @@
     <ref role="1XX52x" to="700h:LrvgQhjFyf" resolve="ListInsertOp" />
     <node concept="3EZMnI" id="LrvgQhkLIP" role="2wV5jI">
       <node concept="2iRfu4" id="LrvgQhkLIQ" role="2iSdaV" />
-      <node concept="PMmxH" id="LrvgQhkLIR" role="3EZMnx">
-        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      <node concept="PMmxH" id="4l_LUjie3im" role="3EZMnx">
+        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="LrvgQhkLIS" role="3EZMnx">
         <property role="3F0ifm" value="(" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/editor.mps
@@ -10,6 +10,7 @@
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" />
     <import index="l462" ref="r:d6904536-4de8-40ba-b54e-09fcdfe1b62a(org.iets3.core.expr.temporal.structure)" implicit="true" />
+    <import index="buwp" ref="r:8405f486-53b5-4fe6-af3e-7f68358bd631(org.iets3.core.expr.base.editor)" implicit="true" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
     <import index="mi3w" ref="r:9ec53fca-e669-4a18-ba8b-6c9f4f1cb361(org.iets3.core.expr.datetime.structure)" implicit="true" />
     <import index="itrz" ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)" implicit="true" />
@@ -32,15 +33,9 @@
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
       <concept id="1239814640496" name="jetbrains.mps.lang.editor.structure.CellLayout_VerticalGrid" flags="nn" index="2EHx9g" />
-      <concept id="1164824717996" name="jetbrains.mps.lang.editor.structure.CellMenuDescriptor" flags="ng" index="OXEIz">
-        <child id="1164824815888" name="cellMenuPart" index="OY2wv" />
-      </concept>
       <concept id="1078938745671" name="jetbrains.mps.lang.editor.structure.EditorComponentDeclaration" flags="ig" index="PKFIW" />
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
         <reference id="1078939183255" name="editorComponent" index="PMmxG" />
-      </concept>
-      <concept id="1164914519156" name="jetbrains.mps.lang.editor.structure.CellMenuPart_ReplaceNode_CustomNodeConcept" flags="ng" index="UkePV">
-        <reference id="1164914727930" name="replacementConcept" index="Ul1FP" />
       </concept>
       <concept id="1186403694788" name="jetbrains.mps.lang.editor.structure.ColorStyleClassItem" flags="ln" index="VaVBg">
         <property id="1186403713874" name="color" index="Vb096" />
@@ -66,7 +61,6 @@
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
         <property id="1130859485024" name="attractsFocus" index="1cu_pB" />
         <child id="1142887637401" name="renderingCondition" index="pqm2j" />
-        <child id="1164826688380" name="menuDescriptor" index="P5bDN" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
@@ -279,7 +273,7 @@
     <node concept="3EZMnI" id="50smQ1VexWp" role="2wV5jI">
       <node concept="2iRfu4" id="50smQ1VexWq" role="2iSdaV" />
       <node concept="PMmxH" id="12bsjhgbOoz" role="3EZMnx">
-        <ref role="PMmxG" node="12bsjhgbNQu" resolve="OpAlias" />
+        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="50smQ1VexWy" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -351,7 +345,7 @@
     <ref role="1XX52x" to="l462:3nGzaxUtzZN" resolve="SpreadValuesOp" />
     <node concept="3EZMnI" id="3nGzaxUt$0K" role="2wV5jI">
       <node concept="PMmxH" id="12bsjhgcAoh" role="3EZMnx">
-        <ref role="PMmxG" node="12bsjhgbNQu" resolve="OpAlias" />
+        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="12bsjhgc_VQ" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -480,7 +474,7 @@
     <node concept="3EZMnI" id="12bsjhg8w8f" role="2wV5jI">
       <node concept="2iRfu4" id="12bsjhg8w8g" role="2iSdaV" />
       <node concept="PMmxH" id="12bsjhgc$I8" role="3EZMnx">
-        <ref role="PMmxG" node="12bsjhgbNQu" resolve="OpAlias" />
+        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="12bsjhg8w8i" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -554,7 +548,7 @@
     <node concept="3EZMnI" id="12bsjhg8wq8" role="2wV5jI">
       <node concept="2iRfu4" id="12bsjhg8wq9" role="2iSdaV" />
       <node concept="PMmxH" id="12bsjhgc$X7" role="3EZMnx">
-        <ref role="PMmxG" node="12bsjhgbNQu" resolve="OpAlias" />
+        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="12bsjhg8wqb" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -628,7 +622,7 @@
     <node concept="3EZMnI" id="3nGzaxUzMEr" role="2wV5jI">
       <node concept="2iRfu4" id="3nGzaxUzMEs" role="2iSdaV" />
       <node concept="PMmxH" id="12bsjhgc_43" role="3EZMnx">
-        <ref role="PMmxG" node="12bsjhgbNQu" resolve="OpAlias" />
+        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="3nGzaxUzMEu" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -741,7 +735,7 @@
     <ref role="1XX52x" to="l462:1Mp62pP0G8O" resolve="ReduceOp" />
     <node concept="3EZMnI" id="1Mp62pP0GaA" role="2wV5jI">
       <node concept="PMmxH" id="12bsjhgc$Ch" role="3EZMnx">
-        <ref role="PMmxG" node="12bsjhgbNQu" resolve="OpAlias" />
+        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="12bsjhgc$rr" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -939,7 +933,7 @@
     <ref role="1XX52x" to="l462:6C2wkq7f3JQ" resolve="MaskOp" />
     <node concept="3EZMnI" id="6C2wkq7f3Ky" role="2wV5jI">
       <node concept="PMmxH" id="12bsjhgc_aM" role="3EZMnx">
-        <ref role="PMmxG" node="12bsjhgbNQu" resolve="OpAlias" />
+        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="12bsjhgc_aq" role="3EZMnx">
         <property role="3F0ifm" value="[" />
@@ -973,7 +967,7 @@
     <node concept="3EZMnI" id="6C2wkq7iPtA" role="2wV5jI">
       <node concept="2iRfu4" id="6C2wkq7iPtB" role="2iSdaV" />
       <node concept="PMmxH" id="12bsjhgcAys" role="3EZMnx">
-        <ref role="PMmxG" node="12bsjhgbNQu" resolve="OpAlias" />
+        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="6C2wkq7iPtD" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -999,7 +993,7 @@
     <ref role="1XX52x" to="l462:6C2wkq7lrza" resolve="MapSlicesOp" />
     <node concept="3EZMnI" id="6zmBjqUjnOV" role="2wV5jI">
       <node concept="PMmxH" id="12bsjhgcZGu" role="3EZMnx">
-        <ref role="PMmxG" node="12bsjhgbNQu" resolve="OpAlias" />
+        <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="6zmBjqUjnOX" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -1034,18 +1028,6 @@
     <ref role="1XX52x" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="3F0ifn" id="6dXnuBU76jR" role="2wV5jI">
       <property role="3F0ifm" value="Workaround to fix contributions to BaseConcept generated by grammarCells." />
-    </node>
-  </node>
-  <node concept="PKFIW" id="12bsjhgbNQu">
-    <property role="TrG5h" value="OpAlias" />
-    <ref role="1XX52x" to="l462:50smQ1Vcw3K" resolve="AbstractTemporalOp" />
-    <node concept="PMmxH" id="12bsjhgbO9S" role="2wV5jI">
-      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
-      <node concept="OXEIz" id="12bsjhgbrPp" role="P5bDN">
-        <node concept="UkePV" id="12bsjhgbrPs" role="OY2wv">
-          <ref role="Ul1FP" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
-        </node>
-      </node>
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/editor.mps
@@ -10,6 +10,7 @@
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" />
     <import index="l462" ref="r:d6904536-4de8-40ba-b54e-09fcdfe1b62a(org.iets3.core.expr.temporal.structure)" implicit="true" />
+    <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
     <import index="mi3w" ref="r:9ec53fca-e669-4a18-ba8b-6c9f4f1cb361(org.iets3.core.expr.datetime.structure)" implicit="true" />
     <import index="itrz" ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)" implicit="true" />
     <import index="x8ug" ref="r:761e0f2a-4ffc-4d74-83bd-c6255a04ca73(org.iets3.core.expr.temporal.behavior)" implicit="true" />
@@ -31,9 +32,15 @@
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
       <concept id="1239814640496" name="jetbrains.mps.lang.editor.structure.CellLayout_VerticalGrid" flags="nn" index="2EHx9g" />
+      <concept id="1164824717996" name="jetbrains.mps.lang.editor.structure.CellMenuDescriptor" flags="ng" index="OXEIz">
+        <child id="1164824815888" name="cellMenuPart" index="OY2wv" />
+      </concept>
       <concept id="1078938745671" name="jetbrains.mps.lang.editor.structure.EditorComponentDeclaration" flags="ig" index="PKFIW" />
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
         <reference id="1078939183255" name="editorComponent" index="PMmxG" />
+      </concept>
+      <concept id="1164914519156" name="jetbrains.mps.lang.editor.structure.CellMenuPart_ReplaceNode_CustomNodeConcept" flags="ng" index="UkePV">
+        <reference id="1164914727930" name="replacementConcept" index="Ul1FP" />
       </concept>
       <concept id="1186403694788" name="jetbrains.mps.lang.editor.structure.ColorStyleClassItem" flags="ln" index="VaVBg">
         <property id="1186403713874" name="color" index="Vb096" />
@@ -59,6 +66,7 @@
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
         <property id="1130859485024" name="attractsFocus" index="1cu_pB" />
         <child id="1142887637401" name="renderingCondition" index="pqm2j" />
+        <child id="1164826688380" name="menuDescriptor" index="P5bDN" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
@@ -85,14 +93,22 @@
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -112,6 +128,16 @@
     <language id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells">
       <concept id="5083944728298846680" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell" flags="ng" index="_tjkj">
         <child id="5083944728298846681" name="option" index="_tjki" />
+      </concept>
+      <concept id="6856661361479784881" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem_Param_node" flags="ng" index="130tyv" />
+      <concept id="6856661361479784527" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem" flags="ng" index="130t_x">
+        <property id="1139535298778" name="actionId" index="1hAc7j" />
+        <child id="6856661361479798753" name="execute" index="130oVf" />
+      </concept>
+      <concept id="6856661361479784534" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem_ExecuteFunction" flags="ig" index="130t_S" />
+      <concept id="6856661361479732075" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapCell" flags="ng" index="130CD5">
+        <child id="6856661361479798957" name="actions" index="130p63" />
+        <child id="6856661361479732085" name="cell" index="130CDr" />
       </concept>
       <concept id="7363578995839435357" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell" flags="ng" index="1kIj98">
         <child id="7363578995839435358" name="wrapped" index="1kIj9b" />
@@ -137,6 +163,12 @@
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
+      <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
+        <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
@@ -246,8 +278,8 @@
     <ref role="1XX52x" to="l462:50smQ1VexVM" resolve="ValueAtOp" />
     <node concept="3EZMnI" id="50smQ1VexWp" role="2wV5jI">
       <node concept="2iRfu4" id="50smQ1VexWq" role="2iSdaV" />
-      <node concept="3F0ifn" id="50smQ1VexWm" role="3EZMnx">
-        <property role="3F0ifm" value="valueAt" />
+      <node concept="PMmxH" id="12bsjhgbOoz" role="3EZMnx">
+        <ref role="PMmxG" node="12bsjhgbNQu" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="50smQ1VexWy" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -258,27 +290,53 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="PMmxH" id="4t4tOuDdk5p" role="3EZMnx">
-        <ref role="PMmxG" node="4t4tOuDd4ex" resolve="PresentContext" />
-        <node concept="pkWqt" id="4t4tOuDdk5z" role="pqm2j">
-          <node concept="3clFbS" id="4t4tOuDdk5$" role="2VODD2">
-            <node concept="3clFbF" id="4t4tOuDdkcH" role="3cqZAp">
-              <node concept="2OqwBi" id="4t4tOuDdlkl" role="3clFbG">
-                <node concept="2OqwBi" id="4t4tOuDdks2" role="2Oq$k0">
-                  <node concept="pncrf" id="4t4tOuDdkcG" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="4t4tOuDdkQN" role="2OqNvi">
-                    <ref role="3Tt5mk" to="l462:50smQ1VexVQ" resolve="time" />
+      <node concept="_tjkj" id="4t4tOuDdk50" role="3EZMnx">
+        <node concept="3F1sOY" id="4t4tOuDdk5c" role="_tjki">
+          <ref role="1NtTu8" to="l462:50smQ1VexVQ" resolve="time" />
+        </node>
+      </node>
+      <node concept="130CD5" id="12bsjhgb3wr" role="3EZMnx">
+        <node concept="130t_x" id="12bsjhgb3ws" role="130p63">
+          <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+          <node concept="130t_S" id="12bsjhgb3wt" role="130oVf">
+            <node concept="3clFbS" id="12bsjhgb3wu" role="2VODD2">
+              <node concept="3clFbF" id="12bsjhgb3wv" role="3cqZAp">
+                <node concept="37vLTI" id="12bsjhgb3ww" role="3clFbG">
+                  <node concept="2ShNRf" id="12bsjhgb3wx" role="37vLTx">
+                    <node concept="3zrR0B" id="12bsjhgb3wy" role="2ShVmc">
+                      <node concept="3Tqbb2" id="12bsjhgb3wz" role="3zrR0E">
+                        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="12bsjhgb3w$" role="37vLTJ">
+                    <node concept="130tyv" id="12bsjhgb3w_" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="12bsjhgb3wA" role="2OqNvi">
+                      <ref role="3Tt5mk" to="l462:50smQ1VexVQ" resolve="time" />
+                    </node>
                   </node>
                 </node>
-                <node concept="3w_OXm" id="2OjHwrkf4iY" role="2OqNvi" />
               </node>
             </node>
           </node>
         </node>
-      </node>
-      <node concept="_tjkj" id="4t4tOuDdk50" role="3EZMnx">
-        <node concept="3F1sOY" id="4t4tOuDdk5c" role="_tjki">
-          <ref role="1NtTu8" to="l462:50smQ1VexVQ" resolve="time" />
+        <node concept="PMmxH" id="12bsjhgb3wB" role="130CDr">
+          <ref role="PMmxG" node="4t4tOuDd4ex" resolve="PresentContext" />
+          <node concept="pkWqt" id="12bsjhgb3wC" role="pqm2j">
+            <node concept="3clFbS" id="12bsjhgb3wD" role="2VODD2">
+              <node concept="3clFbF" id="12bsjhgb3wE" role="3cqZAp">
+                <node concept="2OqwBi" id="12bsjhgb3wF" role="3clFbG">
+                  <node concept="2OqwBi" id="12bsjhgb3wG" role="2Oq$k0">
+                    <node concept="pncrf" id="12bsjhgb3wH" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="12bsjhgb3wI" role="2OqNvi">
+                      <ref role="3Tt5mk" to="l462:50smQ1VexVQ" resolve="time" />
+                    </node>
+                  </node>
+                  <node concept="3w_OXm" id="12bsjhgb3wJ" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
       </node>
       <node concept="3F0ifn" id="50smQ1VexWE" role="3EZMnx">
@@ -292,9 +350,15 @@
   <node concept="24kQdi" id="3nGzaxUt$0I">
     <ref role="1XX52x" to="l462:3nGzaxUtzZN" resolve="SpreadValuesOp" />
     <node concept="3EZMnI" id="3nGzaxUt$0K" role="2wV5jI">
-      <node concept="3F0ifn" id="3nGzaxUt$0R" role="3EZMnx">
-        <property role="3F0ifm" value="spreadValues(" />
-        <node concept="11LMrY" id="3nGzaxUt$1L" role="3F10Kt">
+      <node concept="PMmxH" id="12bsjhgcAoh" role="3EZMnx">
+        <ref role="PMmxG" node="12bsjhgbNQu" resolve="OpAlias" />
+      </node>
+      <node concept="3F0ifn" id="12bsjhgc_VQ" role="3EZMnx">
+        <property role="3F0ifm" value="(" />
+        <node concept="11L4FC" id="12bsjhgcA2j" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="11LMrY" id="12bsjhgcA2k" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
       </node>
@@ -307,27 +371,53 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="PMmxH" id="4t4tOuDd9$a" role="3EZMnx">
-        <ref role="PMmxG" node="4t4tOuDd4ex" resolve="PresentContext" />
-        <node concept="pkWqt" id="4t4tOuDdasx" role="pqm2j">
-          <node concept="3clFbS" id="4t4tOuDdasy" role="2VODD2">
-            <node concept="3clFbF" id="4t4tOuDdazF" role="3cqZAp">
-              <node concept="2OqwBi" id="4t4tOuDdc3E" role="3clFbG">
-                <node concept="2OqwBi" id="4t4tOuDdaN0" role="2Oq$k0">
-                  <node concept="pncrf" id="4t4tOuDdazE" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="4t4tOuDdbwg" role="2OqNvi">
-                    <ref role="3Tt5mk" to="l462:3nGzaxUBq4G" resolve="fromTime" />
+      <node concept="_tjkj" id="4t4tOuDdaem" role="3EZMnx">
+        <node concept="3F1sOY" id="4t4tOuDdasu" role="_tjki">
+          <ref role="1NtTu8" to="l462:3nGzaxUBq4G" resolve="fromTime" />
+        </node>
+      </node>
+      <node concept="130CD5" id="12bsjhgaDJc" role="3EZMnx">
+        <node concept="130t_x" id="12bsjhgaDJd" role="130p63">
+          <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+          <node concept="130t_S" id="12bsjhgaDJe" role="130oVf">
+            <node concept="3clFbS" id="12bsjhgaDJf" role="2VODD2">
+              <node concept="3clFbF" id="12bsjhgaDJg" role="3cqZAp">
+                <node concept="37vLTI" id="12bsjhgaDJh" role="3clFbG">
+                  <node concept="2ShNRf" id="12bsjhgaDJi" role="37vLTx">
+                    <node concept="3zrR0B" id="12bsjhgaDJj" role="2ShVmc">
+                      <node concept="3Tqbb2" id="12bsjhgaDJk" role="3zrR0E">
+                        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="12bsjhgaDJl" role="37vLTJ">
+                    <node concept="130tyv" id="12bsjhgaDJm" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="12bsjhgaDJn" role="2OqNvi">
+                      <ref role="3Tt5mk" to="l462:3nGzaxUBq4G" resolve="fromTime" />
+                    </node>
                   </node>
                 </node>
-                <node concept="3w_OXm" id="4t4tOuDdcHi" role="2OqNvi" />
               </node>
             </node>
           </node>
         </node>
-      </node>
-      <node concept="_tjkj" id="4t4tOuDdaem" role="3EZMnx">
-        <node concept="3F1sOY" id="4t4tOuDdasu" role="_tjki">
-          <ref role="1NtTu8" to="l462:3nGzaxUBq4G" resolve="fromTime" />
+        <node concept="PMmxH" id="12bsjhgaDJo" role="130CDr">
+          <ref role="PMmxG" node="4t4tOuDd4ex" resolve="PresentContext" />
+          <node concept="pkWqt" id="12bsjhgaDJp" role="pqm2j">
+            <node concept="3clFbS" id="12bsjhgaDJq" role="2VODD2">
+              <node concept="3clFbF" id="12bsjhgaDJr" role="3cqZAp">
+                <node concept="2OqwBi" id="12bsjhgaDJs" role="3clFbG">
+                  <node concept="2OqwBi" id="12bsjhgaDJt" role="2Oq$k0">
+                    <node concept="pncrf" id="12bsjhgaDJu" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="12bsjhgaDJv" role="2OqNvi">
+                      <ref role="3Tt5mk" to="l462:3nGzaxUBq4G" resolve="fromTime" />
+                    </node>
+                  </node>
+                  <node concept="3w_OXm" id="12bsjhgaDJw" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
       </node>
       <node concept="3EZMnI" id="4voqclT$0A4" role="3EZMnx">
@@ -387,46 +477,72 @@
   <node concept="24kQdi" id="3nGzaxUt$2Y">
     <property role="3GE5qa" value="reslice" />
     <ref role="1XX52x" to="l462:3nGzaxUt$2z" resolve="AfterOp" />
-    <node concept="3EZMnI" id="3nGzaxUt$30" role="2wV5jI">
-      <node concept="2iRfu4" id="3nGzaxUt$31" role="2iSdaV" />
-      <node concept="3F0ifn" id="3nGzaxUt$32" role="3EZMnx">
-        <property role="3F0ifm" value="after" />
+    <node concept="3EZMnI" id="12bsjhg8w8f" role="2wV5jI">
+      <node concept="2iRfu4" id="12bsjhg8w8g" role="2iSdaV" />
+      <node concept="PMmxH" id="12bsjhgc$I8" role="3EZMnx">
+        <ref role="PMmxG" node="12bsjhgbNQu" resolve="OpAlias" />
       </node>
-      <node concept="3F0ifn" id="3nGzaxUt$33" role="3EZMnx">
+      <node concept="3F0ifn" id="12bsjhg8w8i" role="3EZMnx">
         <property role="3F0ifm" value="(" />
-        <node concept="11L4FC" id="3nGzaxUt$34" role="3F10Kt">
+        <node concept="11L4FC" id="12bsjhg8w8j" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
-        <node concept="11LMrY" id="3nGzaxUt$35" role="3F10Kt">
+        <node concept="11LMrY" id="12bsjhg8w8k" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="PMmxH" id="4t4tOuDd8RC" role="3EZMnx">
-        <ref role="PMmxG" node="4t4tOuDd4ex" resolve="PresentContext" />
-        <node concept="pkWqt" id="4t4tOuDdhTt" role="pqm2j">
-          <node concept="3clFbS" id="4t4tOuDdhTu" role="2VODD2">
-            <node concept="3clFbF" id="4t4tOuDdi0B" role="3cqZAp">
-              <node concept="2OqwBi" id="4t4tOuDdje7" role="3clFbG">
-                <node concept="2OqwBi" id="4t4tOuDdifW" role="2Oq$k0">
-                  <node concept="pncrf" id="4t4tOuDdi0A" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="4t4tOuDdiEH" role="2OqNvi">
-                    <ref role="3Tt5mk" to="l462:3nGzaxUt$2$" resolve="time" />
+      <node concept="_tjkj" id="12bsjhg8w8l" role="3EZMnx">
+        <node concept="3F1sOY" id="12bsjhg8w8m" role="_tjki">
+          <ref role="1NtTu8" to="l462:3nGzaxUt$2$" resolve="time" />
+        </node>
+      </node>
+      <node concept="130CD5" id="12bsjhg8w8n" role="3EZMnx">
+        <node concept="130t_x" id="12bsjhg8w8o" role="130p63">
+          <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+          <node concept="130t_S" id="12bsjhg8w8p" role="130oVf">
+            <node concept="3clFbS" id="12bsjhg8w8q" role="2VODD2">
+              <node concept="3clFbF" id="12bsjhg8w8r" role="3cqZAp">
+                <node concept="37vLTI" id="12bsjhg8w8s" role="3clFbG">
+                  <node concept="2ShNRf" id="12bsjhg8w8t" role="37vLTx">
+                    <node concept="3zrR0B" id="12bsjhg8w8u" role="2ShVmc">
+                      <node concept="3Tqbb2" id="12bsjhg8w8v" role="3zrR0E">
+                        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="12bsjhg8w8w" role="37vLTJ">
+                    <node concept="130tyv" id="12bsjhg8w8x" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="12bsjhg8w8y" role="2OqNvi">
+                      <ref role="3Tt5mk" to="l462:3nGzaxUt$2$" resolve="time" />
+                    </node>
                   </node>
                 </node>
-                <node concept="3w_OXm" id="4t4tOuDdjDI" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="PMmxH" id="12bsjhg8w8z" role="130CDr">
+          <ref role="PMmxG" node="4t4tOuDd4ex" resolve="PresentContext" />
+          <node concept="pkWqt" id="12bsjhg8w8$" role="pqm2j">
+            <node concept="3clFbS" id="12bsjhg8w8_" role="2VODD2">
+              <node concept="3clFbF" id="12bsjhg8w8A" role="3cqZAp">
+                <node concept="2OqwBi" id="12bsjhg8w8B" role="3clFbG">
+                  <node concept="2OqwBi" id="12bsjhg8w8C" role="2Oq$k0">
+                    <node concept="pncrf" id="12bsjhg8w8D" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="12bsjhg8w8E" role="2OqNvi">
+                      <ref role="3Tt5mk" to="l462:3nGzaxUt$2$" resolve="time" />
+                    </node>
+                  </node>
+                  <node concept="3w_OXm" id="12bsjhg8w8F" role="2OqNvi" />
+                </node>
               </node>
             </node>
           </node>
         </node>
       </node>
-      <node concept="_tjkj" id="4t4tOuDd1K3" role="3EZMnx">
-        <node concept="3F1sOY" id="4t4tOuDd1Kf" role="_tjki">
-          <ref role="1NtTu8" to="l462:3nGzaxUt$2$" resolve="time" />
-        </node>
-      </node>
-      <node concept="3F0ifn" id="3nGzaxUt$37" role="3EZMnx">
+      <node concept="3F0ifn" id="12bsjhg8w8G" role="3EZMnx">
         <property role="3F0ifm" value=")" />
-        <node concept="11L4FC" id="3nGzaxUt$38" role="3F10Kt">
+        <node concept="11L4FC" id="12bsjhg8w8H" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
       </node>
@@ -435,46 +551,72 @@
   <node concept="24kQdi" id="3nGzaxUyXFD">
     <property role="3GE5qa" value="reslice" />
     <ref role="1XX52x" to="l462:3nGzaxUyXFe" resolve="BeforeOp" />
-    <node concept="3EZMnI" id="3nGzaxUyXFF" role="2wV5jI">
-      <node concept="2iRfu4" id="3nGzaxUyXFG" role="2iSdaV" />
-      <node concept="3F0ifn" id="3nGzaxUyXFH" role="3EZMnx">
-        <property role="3F0ifm" value="before" />
+    <node concept="3EZMnI" id="12bsjhg8wq8" role="2wV5jI">
+      <node concept="2iRfu4" id="12bsjhg8wq9" role="2iSdaV" />
+      <node concept="PMmxH" id="12bsjhgc$X7" role="3EZMnx">
+        <ref role="PMmxG" node="12bsjhgbNQu" resolve="OpAlias" />
       </node>
-      <node concept="3F0ifn" id="3nGzaxUyXFI" role="3EZMnx">
+      <node concept="3F0ifn" id="12bsjhg8wqb" role="3EZMnx">
         <property role="3F0ifm" value="(" />
-        <node concept="11L4FC" id="3nGzaxUyXFJ" role="3F10Kt">
+        <node concept="11L4FC" id="12bsjhg8wqc" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
-        <node concept="11LMrY" id="3nGzaxUyXFK" role="3F10Kt">
+        <node concept="11LMrY" id="12bsjhg8wqd" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="PMmxH" id="4t4tOuDd8SK" role="3EZMnx">
-        <ref role="PMmxG" node="4t4tOuDd4ex" resolve="PresentContext" />
-        <node concept="pkWqt" id="4t4tOuDdfKb" role="pqm2j">
-          <node concept="3clFbS" id="4t4tOuDdfKc" role="2VODD2">
-            <node concept="3clFbF" id="4t4tOuDdfRl" role="3cqZAp">
-              <node concept="2OqwBi" id="4t4tOuDdhi6" role="3clFbG">
-                <node concept="2OqwBi" id="4t4tOuDdg6E" role="2Oq$k0">
-                  <node concept="pncrf" id="4t4tOuDdfRk" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="4t4tOuDdgxr" role="2OqNvi">
-                    <ref role="3Tt5mk" to="l462:3nGzaxUyXFf" resolve="time" />
+      <node concept="_tjkj" id="12bsjhg8wqe" role="3EZMnx">
+        <node concept="3F1sOY" id="12bsjhg8wqf" role="_tjki">
+          <ref role="1NtTu8" to="l462:3nGzaxUyXFf" resolve="time" />
+        </node>
+      </node>
+      <node concept="130CD5" id="12bsjhg8wqg" role="3EZMnx">
+        <node concept="130t_x" id="12bsjhg8wqh" role="130p63">
+          <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+          <node concept="130t_S" id="12bsjhg8wqi" role="130oVf">
+            <node concept="3clFbS" id="12bsjhg8wqj" role="2VODD2">
+              <node concept="3clFbF" id="12bsjhg8wqk" role="3cqZAp">
+                <node concept="37vLTI" id="12bsjhg8wql" role="3clFbG">
+                  <node concept="2ShNRf" id="12bsjhg8wqm" role="37vLTx">
+                    <node concept="3zrR0B" id="12bsjhg8wqn" role="2ShVmc">
+                      <node concept="3Tqbb2" id="12bsjhg8wqo" role="3zrR0E">
+                        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="12bsjhg8wqp" role="37vLTJ">
+                    <node concept="130tyv" id="12bsjhg8wqq" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="12bsjhg8wqr" role="2OqNvi">
+                      <ref role="3Tt5mk" to="l462:3nGzaxUyXFf" resolve="time" />
+                    </node>
                   </node>
                 </node>
-                <node concept="3w_OXm" id="4t4tOuDdhHH" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="PMmxH" id="12bsjhg8wqs" role="130CDr">
+          <ref role="PMmxG" node="4t4tOuDd4ex" resolve="PresentContext" />
+          <node concept="pkWqt" id="12bsjhg8wqt" role="pqm2j">
+            <node concept="3clFbS" id="12bsjhg8wqu" role="2VODD2">
+              <node concept="3clFbF" id="12bsjhg8wqv" role="3cqZAp">
+                <node concept="2OqwBi" id="12bsjhg8wqw" role="3clFbG">
+                  <node concept="2OqwBi" id="12bsjhg8wqx" role="2Oq$k0">
+                    <node concept="pncrf" id="12bsjhg8wqy" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="12bsjhg8wqz" role="2OqNvi">
+                      <ref role="3Tt5mk" to="l462:3nGzaxUyXFf" resolve="time" />
+                    </node>
+                  </node>
+                  <node concept="3w_OXm" id="12bsjhg8wq$" role="2OqNvi" />
+                </node>
               </node>
             </node>
           </node>
         </node>
       </node>
-      <node concept="_tjkj" id="4t4tOuDd8Si" role="3EZMnx">
-        <node concept="3F1sOY" id="4t4tOuDd8Sy" role="_tjki">
-          <ref role="1NtTu8" to="l462:3nGzaxUyXFf" resolve="time" />
-        </node>
-      </node>
-      <node concept="3F0ifn" id="3nGzaxUyXFM" role="3EZMnx">
+      <node concept="3F0ifn" id="12bsjhg8wq_" role="3EZMnx">
         <property role="3F0ifm" value=")" />
-        <node concept="11L4FC" id="3nGzaxUyXFN" role="3F10Kt">
+        <node concept="11L4FC" id="12bsjhg8wqA" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
       </node>
@@ -485,8 +627,8 @@
     <ref role="1XX52x" to="l462:3nGzaxUzMDV" resolve="BetweenOp" />
     <node concept="3EZMnI" id="3nGzaxUzMEr" role="2wV5jI">
       <node concept="2iRfu4" id="3nGzaxUzMEs" role="2iSdaV" />
-      <node concept="3F0ifn" id="3nGzaxUzMEt" role="3EZMnx">
-        <property role="3F0ifm" value="between" />
+      <node concept="PMmxH" id="12bsjhgc_43" role="3EZMnx">
+        <ref role="PMmxG" node="12bsjhgbNQu" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="3nGzaxUzMEu" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -497,27 +639,53 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="PMmxH" id="4t4tOuDd8U1" role="3EZMnx">
-        <ref role="PMmxG" node="4t4tOuDd4ex" resolve="PresentContext" />
-        <node concept="pkWqt" id="4t4tOuDdd0c" role="pqm2j">
-          <node concept="3clFbS" id="4t4tOuDdd0d" role="2VODD2">
-            <node concept="3clFbF" id="4t4tOuDdd7m" role="3cqZAp">
-              <node concept="2OqwBi" id="4t4tOuDdf1E" role="3clFbG">
-                <node concept="2OqwBi" id="4t4tOuDddFA" role="2Oq$k0">
-                  <node concept="pncrf" id="4t4tOuDdd7l" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="4t4tOuDde6j" role="2OqNvi">
-                    <ref role="3Tt5mk" to="l462:3nGzaxUzMDW" resolve="from" />
+      <node concept="_tjkj" id="4t4tOuDd8Tx" role="3EZMnx">
+        <node concept="3F1sOY" id="4t4tOuDd8TM" role="_tjki">
+          <ref role="1NtTu8" to="l462:3nGzaxUzMDW" resolve="from" />
+        </node>
+      </node>
+      <node concept="130CD5" id="12bsjhg9qAN" role="3EZMnx">
+        <node concept="130t_x" id="12bsjhg9qAO" role="130p63">
+          <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+          <node concept="130t_S" id="12bsjhg9qAP" role="130oVf">
+            <node concept="3clFbS" id="12bsjhg9qAQ" role="2VODD2">
+              <node concept="3clFbF" id="12bsjhg9qAR" role="3cqZAp">
+                <node concept="37vLTI" id="12bsjhg9qAS" role="3clFbG">
+                  <node concept="2ShNRf" id="12bsjhg9qAT" role="37vLTx">
+                    <node concept="3zrR0B" id="12bsjhg9qAU" role="2ShVmc">
+                      <node concept="3Tqbb2" id="12bsjhg9qAV" role="3zrR0E">
+                        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="12bsjhg9qAW" role="37vLTJ">
+                    <node concept="130tyv" id="12bsjhg9qAX" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="12bsjhg9qAY" role="2OqNvi">
+                      <ref role="3Tt5mk" to="l462:3nGzaxUzMDW" resolve="from" />
+                    </node>
                   </node>
                 </node>
-                <node concept="3w_OXm" id="4t4tOuDdfth" role="2OqNvi" />
               </node>
             </node>
           </node>
         </node>
-      </node>
-      <node concept="_tjkj" id="4t4tOuDd8Tx" role="3EZMnx">
-        <node concept="3F1sOY" id="4t4tOuDd8TM" role="_tjki">
-          <ref role="1NtTu8" to="l462:3nGzaxUzMDW" resolve="from" />
+        <node concept="PMmxH" id="12bsjhg9qAZ" role="130CDr">
+          <ref role="PMmxG" node="4t4tOuDd4ex" resolve="PresentContext" />
+          <node concept="pkWqt" id="12bsjhg9qB0" role="pqm2j">
+            <node concept="3clFbS" id="12bsjhg9qB1" role="2VODD2">
+              <node concept="3clFbF" id="12bsjhg9qB2" role="3cqZAp">
+                <node concept="2OqwBi" id="12bsjhg9qB3" role="3clFbG">
+                  <node concept="2OqwBi" id="12bsjhg9qB4" role="2Oq$k0">
+                    <node concept="pncrf" id="12bsjhg9qB5" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="12bsjhg9qB6" role="2OqNvi">
+                      <ref role="3Tt5mk" to="l462:3nGzaxUzMDW" resolve="from" />
+                    </node>
+                  </node>
+                  <node concept="3w_OXm" id="12bsjhg9qB7" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
       </node>
       <node concept="3F0ifn" id="3nGzaxUzMEQ" role="3EZMnx">
@@ -572,9 +740,15 @@
     <property role="3GE5qa" value="reduce" />
     <ref role="1XX52x" to="l462:1Mp62pP0G8O" resolve="ReduceOp" />
     <node concept="3EZMnI" id="1Mp62pP0GaA" role="2wV5jI">
-      <node concept="3F0ifn" id="1Mp62pP0GaB" role="3EZMnx">
-        <property role="3F0ifm" value="reduce(" />
-        <node concept="11LMrY" id="1Mp62pP0GaC" role="3F10Kt">
+      <node concept="PMmxH" id="12bsjhgc$Ch" role="3EZMnx">
+        <ref role="PMmxG" node="12bsjhgbNQu" resolve="OpAlias" />
+      </node>
+      <node concept="3F0ifn" id="12bsjhgc$rr" role="3EZMnx">
+        <property role="3F0ifm" value="(" />
+        <node concept="11L4FC" id="12bsjhgc$Cb" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="11LMrY" id="12bsjhgc$Cc" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
       </node>
@@ -584,27 +758,53 @@
       <node concept="3F0ifn" id="1Mp62pP0GaE" role="3EZMnx">
         <property role="3F0ifm" value="in" />
       </node>
-      <node concept="PMmxH" id="2OjHwrkiIgz" role="3EZMnx">
-        <ref role="PMmxG" node="4t4tOuDd4ex" resolve="PresentContext" />
-        <node concept="pkWqt" id="2OjHwrkiIgG" role="pqm2j">
-          <node concept="3clFbS" id="2OjHwrkiIgH" role="2VODD2">
-            <node concept="3clFbF" id="2OjHwrkiInQ" role="3cqZAp">
-              <node concept="2OqwBi" id="2OjHwrkiK0O" role="3clFbG">
-                <node concept="2OqwBi" id="2OjHwrkiIEO" role="2Oq$k0">
-                  <node concept="pncrf" id="2OjHwrkiInP" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="2OjHwrkiJ5x" role="2OqNvi">
-                    <ref role="3Tt5mk" to="l462:1Mp62pP0G9A" resolve="daterange" />
+      <node concept="_tjkj" id="2OjHwrkiLG9" role="3EZMnx">
+        <node concept="3F1sOY" id="1Mp62pP0HBq" role="_tjki">
+          <ref role="1NtTu8" to="l462:1Mp62pP0G9A" resolve="daterange" />
+        </node>
+      </node>
+      <node concept="130CD5" id="12bsjhg8x1J" role="3EZMnx">
+        <node concept="130t_x" id="12bsjhg8x1K" role="130p63">
+          <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+          <node concept="130t_S" id="12bsjhg8x1L" role="130oVf">
+            <node concept="3clFbS" id="12bsjhg8x1M" role="2VODD2">
+              <node concept="3clFbF" id="12bsjhg8x1N" role="3cqZAp">
+                <node concept="37vLTI" id="12bsjhg8x1O" role="3clFbG">
+                  <node concept="2ShNRf" id="12bsjhg8x1P" role="37vLTx">
+                    <node concept="3zrR0B" id="12bsjhg8x1Q" role="2ShVmc">
+                      <node concept="3Tqbb2" id="12bsjhg8x1R" role="3zrR0E">
+                        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="12bsjhg8x1S" role="37vLTJ">
+                    <node concept="130tyv" id="12bsjhg8x1T" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="12bsjhg8x1U" role="2OqNvi">
+                      <ref role="3Tt5mk" to="l462:1Mp62pP0G9A" resolve="daterange" />
+                    </node>
                   </node>
                 </node>
-                <node concept="3w_OXm" id="2OjHwrkiKEo" role="2OqNvi" />
               </node>
             </node>
           </node>
         </node>
-      </node>
-      <node concept="_tjkj" id="2OjHwrkiLG9" role="3EZMnx">
-        <node concept="3F1sOY" id="1Mp62pP0HBq" role="_tjki">
-          <ref role="1NtTu8" to="l462:1Mp62pP0G9A" resolve="daterange" />
+        <node concept="PMmxH" id="12bsjhg8x1V" role="130CDr">
+          <ref role="PMmxG" node="4t4tOuDd4ex" resolve="PresentContext" />
+          <node concept="pkWqt" id="12bsjhg8x1W" role="pqm2j">
+            <node concept="3clFbS" id="12bsjhg8x1X" role="2VODD2">
+              <node concept="3clFbF" id="12bsjhg8x1Y" role="3cqZAp">
+                <node concept="2OqwBi" id="12bsjhg8x1Z" role="3clFbG">
+                  <node concept="2OqwBi" id="12bsjhg8x20" role="2Oq$k0">
+                    <node concept="pncrf" id="12bsjhg8x21" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="12bsjhg8x22" role="2OqNvi">
+                      <ref role="3Tt5mk" to="l462:1Mp62pP0G9A" resolve="daterange" />
+                    </node>
+                  </node>
+                  <node concept="3w_OXm" id="12bsjhg8x23" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
       </node>
       <node concept="3F0ifn" id="1Mp62pP0Gb3" role="3EZMnx">
@@ -738,9 +938,15 @@
   <node concept="24kQdi" id="6C2wkq7f3Kq">
     <ref role="1XX52x" to="l462:6C2wkq7f3JQ" resolve="MaskOp" />
     <node concept="3EZMnI" id="6C2wkq7f3Ky" role="2wV5jI">
-      <node concept="3F0ifn" id="6C2wkq7f3Kz" role="3EZMnx">
-        <property role="3F0ifm" value="mask[" />
-        <node concept="11LMrY" id="6C2wkq7f3K$" role="3F10Kt">
+      <node concept="PMmxH" id="12bsjhgc_aM" role="3EZMnx">
+        <ref role="PMmxG" node="12bsjhgbNQu" resolve="OpAlias" />
+      </node>
+      <node concept="3F0ifn" id="12bsjhgc_aq" role="3EZMnx">
+        <property role="3F0ifm" value="[" />
+        <node concept="11L4FC" id="12bsjhgc_aG" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="11LMrY" id="12bsjhgc_aH" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
       </node>
@@ -766,8 +972,8 @@
     <ref role="1XX52x" to="l462:6C2wkq7iPsz" resolve="WithSliceOp" />
     <node concept="3EZMnI" id="6C2wkq7iPtA" role="2wV5jI">
       <node concept="2iRfu4" id="6C2wkq7iPtB" role="2iSdaV" />
-      <node concept="3F0ifn" id="6C2wkq7iPtC" role="3EZMnx">
-        <property role="3F0ifm" value="with" />
+      <node concept="PMmxH" id="12bsjhgcAys" role="3EZMnx">
+        <ref role="PMmxG" node="12bsjhgbNQu" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="6C2wkq7iPtD" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -792,11 +998,8 @@
   <node concept="24kQdi" id="6C2wkq7lrzD">
     <ref role="1XX52x" to="l462:6C2wkq7lrza" resolve="MapSlicesOp" />
     <node concept="3EZMnI" id="6zmBjqUjnOV" role="2wV5jI">
-      <node concept="PMmxH" id="6zmBjqUjnOW" role="3EZMnx">
-        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
-        <node concept="11LMrY" id="49WTic8ec1k" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
+      <node concept="PMmxH" id="12bsjhgcZGu" role="3EZMnx">
+        <ref role="PMmxG" node="12bsjhgbNQu" resolve="OpAlias" />
       </node>
       <node concept="3F0ifn" id="6zmBjqUjnOX" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -831,6 +1034,18 @@
     <ref role="1XX52x" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="3F0ifn" id="6dXnuBU76jR" role="2wV5jI">
       <property role="3F0ifm" value="Workaround to fix contributions to BaseConcept generated by grammarCells." />
+    </node>
+  </node>
+  <node concept="PKFIW" id="12bsjhgbNQu">
+    <property role="TrG5h" value="OpAlias" />
+    <ref role="1XX52x" to="l462:50smQ1Vcw3K" resolve="AbstractTemporalOp" />
+    <node concept="PMmxH" id="12bsjhgbO9S" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      <node concept="OXEIz" id="12bsjhgbrPp" role="P5bDN">
+        <node concept="UkePV" id="12bsjhgbrPs" role="OY2wv">
+          <ref role="Ul1FP" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -15960,46 +15960,6 @@
             </node>
           </node>
         </node>
-        <node concept="_ixoA" id="1CsE99tsrUs" role="_iOnC" />
-        <node concept="2zPypq" id="1CsE99tsoHp" role="_iOnC">
-          <property role="TrG5h" value="t8_no_error" />
-          <node concept="3iBYfx" id="1CsE99tsoHq" role="2zPyp_">
-            <node concept="m5g4o" id="1CsE99tsoHr" role="3iBYfI">
-              <node concept="30bXRB" id="1CsE99tsoHs" role="m5g4p">
-                <property role="30bXRw" value="100.1" />
-              </node>
-              <node concept="30bdrP" id="1CsE99tsoHt" role="m5g4p">
-                <property role="30bdrQ" value="test" />
-              </node>
-              <node concept="2vmpnb" id="1CsE99tsoHu" role="m5g4p" />
-            </node>
-            <node concept="m5g4o" id="1CsE99tsoHv" role="3iBYfI">
-              <node concept="30bXRB" id="1CsE99tsoHw" role="m5g4p">
-                <property role="30bXRw" value="100" />
-              </node>
-              <node concept="30bdrP" id="1CsE99tsoHx" role="m5g4p">
-                <property role="30bdrQ" value="test" />
-              </node>
-              <node concept="2vmpnb" id="1CsE99tsoHy" role="m5g4p" />
-            </node>
-          </node>
-          <node concept="3iBYCm" id="1CsE99tsplf" role="2zM23F">
-            <node concept="m5gfS" id="1CsE99tsplg" role="3iBWmK">
-              <node concept="mLuIC" id="1CsE99tspED" role="m5gfT">
-                <node concept="2gteS_" id="1CsE99tspLW" role="2gteVg">
-                  <property role="2gteVv" value="1" />
-                </node>
-              </node>
-              <node concept="30bdrU" id="1CsE99tspli" role="m5gfT" />
-              <node concept="2vmvy5" id="1CsE99tsplj" role="m5gfT" />
-            </node>
-          </node>
-          <node concept="7CXmI" id="1CsE99tt0wR" role="lGtFl">
-            <node concept="7OXhh" id="1CsE99tt0C1" role="7EUXB">
-              <property role="GvXf4" value="true" />
-            </node>
-          </node>
-        </node>
         <node concept="_ixoA" id="1CsE99tswIw" role="_iOnC" />
       </node>
     </node>


### PR DESCRIPTION
This PR adds autocompletion support for operation expression in the core, collections and temporal language and fixes and issue with optional cell in the temporal language. 

I've changed the editors of the temporal language so that the operation context can be overriden by the optional expression (e.g. time) and also deleted when the cursor is at the end of the context. The ability to override the context was lost after a change in the optional cell in  grammar cells where we fixed a bug where side transformations where erroneously added to neighboring cells that shouldn't have a transformation (in this case a transformation to the right and **left** side of the context cell).

There are other languages that also have the problem that the alias doesn't support code completion. Please let me know if my approach is the right one before I fix all instances.