### PR TITLE
Fix makeRecord interpreter off-by-one error

### DIFF
--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.repl.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.repl.interpreter/models/plugin.mps
@@ -567,13 +567,6 @@
                 </node>
               </node>
               <node concept="3clFbS" id="4YhD5cZq4w4" role="2LFqv$">
-                <node concept="3clFbF" id="6TK5sRjKoYP" role="3cqZAp">
-                  <node concept="3uNrnE" id="6TK5sRjKp$x" role="3clFbG">
-                    <node concept="37vLTw" id="6TK5sRjKp$z" role="2$L3a6">
-                      <ref role="3cqZAo" node="6TK5sRjKot$" resolve="idx" />
-                    </node>
-                  </node>
-                </node>
                 <node concept="3clFbF" id="4YhD5cZq7Bt" role="3cqZAp">
                   <node concept="2OqwBi" id="4YhD5cZq7HN" role="3clFbG">
                     <node concept="37vLTw" id="4YhD5cZq7Bs" role="2Oq$k0">
@@ -601,6 +594,13 @@
                           </node>
                         </node>
                       </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="6TK5sRjKoYP" role="3cqZAp">
+                  <node concept="3uNrnE" id="6TK5sRjKp$x" role="3clFbG">
+                    <node concept="37vLTw" id="6TK5sRjKp$z" role="2$L3a6">
+                      <ref role="3cqZAo" node="6TK5sRjKot$" resolve="idx" />
                     </node>
                   </node>
                 </node>


### PR DESCRIPTION
There's an off-by-one error in the interpreter for makeRecord caused by incrementing an index too early.