### PR TITLE
Publish to artifacts.itemis.cloud

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -301,6 +301,18 @@ publishing {
                 }
             }
         }
+        maven {
+                name = "itemisCloud"
+                url = version.toString().endsWith("-SNAPSHOT")
+                        ? uri("https://artifacts.itemis.cloud/repository/maven-mps-snapshots/")
+                        : uri("https://artifacts.itemis.cloud/repository/maven-mps-releases/")
+                if (project.hasProperty("artifacts.itemis.cloud.user") && project.hasProperty("artifacts.itemis.cloud.pw")) {
+                    credentials {
+                        username = project.findProperty("artifacts.itemis.cloud.user")
+                        password = project.findProperty("artifacts.itemis.cloud.pw")
+                    }
+                }
+        }
     }
     repositories {
         if(currentBranch == "master" || currentBranch.startsWith("maintenance") || currentBranch.startsWith("mps")) {


### PR DESCRIPTION
Adds the new nexus as a publishing repository to the build.gradle ([example artifact]( https://artifacts.itemis.cloud/#browse/browse:maven-mps:org%2Fiets3%2Fopensource%2Ffeature-PublishItemisCloud.2021.1.5524.62a2b07%2Fopensource-feature-PublishItemisCloud.2021.1.5524.62a2b07.zip )).