### PR TITLE
Temporal language: Fix NullPointer in reduce method by introducing a default constraint type

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/editor.mps
@@ -88,6 +88,7 @@
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -274,14 +275,25 @@
         <node concept="pkWqt" id="7SY$c$i5rRh" role="pqm2j">
           <node concept="3clFbS" id="7SY$c$i5rRi" role="2VODD2">
             <node concept="3clFbF" id="7SY$c$i5rRn" role="3cqZAp">
-              <node concept="2OqwBi" id="7SY$c$i5uKt" role="3clFbG">
-                <node concept="2OqwBi" id="7SY$c$i5s9D" role="2Oq$k0">
-                  <node concept="pncrf" id="7SY$c$i5rRm" role="2Oq$k0" />
-                  <node concept="3Tsc0h" id="7SY$c$i5t60" role="2OqNvi">
-                    <ref role="3TtcxE" to="l462:50smQ1V8QF$" resolve="slices" />
+              <node concept="22lmx$" id="2LepRDoQfT$" role="3clFbG">
+                <node concept="2OqwBi" id="2LepRDoQgWn" role="3uHU7w">
+                  <node concept="2OqwBi" id="2LepRDoQgjT" role="2Oq$k0">
+                    <node concept="pncrf" id="2LepRDoQg1l" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="2LepRDoQgLN" role="2OqNvi">
+                      <ref role="3Tt5mk" to="l462:7SY$c$i5rRe" resolve="typeConstraint" />
+                    </node>
                   </node>
+                  <node concept="3x8VRR" id="2LepRDoQhh7" role="2OqNvi" />
                 </node>
-                <node concept="1v1jN8" id="7SY$c$i5x75" role="2OqNvi" />
+                <node concept="2OqwBi" id="7SY$c$i5uKt" role="3uHU7B">
+                  <node concept="2OqwBi" id="7SY$c$i5s9D" role="2Oq$k0">
+                    <node concept="pncrf" id="7SY$c$i5rRm" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="7SY$c$i5t60" role="2OqNvi">
+                      <ref role="3TtcxE" to="l462:50smQ1V8QF$" resolve="slices" />
+                    </node>
+                  </node>
+                  <node concept="1v1jN8" id="7SY$c$i5x75" role="2OqNvi" />
+                </node>
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/editor.mps
@@ -56,6 +56,7 @@
       </concept>
       <concept id="1219226236603" name="jetbrains.mps.lang.editor.structure.DrawBracketsStyleClassItem" flags="ln" index="3vyZuw" />
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <property id="1139852716018" name="noTargetText" index="1$x2rV" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
@@ -167,6 +168,9 @@
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -175,6 +179,9 @@
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
     </language>
   </registry>
   <node concept="24kQdi" id="50smQ1V8i9n">
@@ -235,6 +242,49 @@
         <property role="3F0ifm" value="TT" />
         <node concept="Vb9p2" id="3wXkdMVKEtg" role="3F10Kt">
           <property role="Vbekb" value="g1_k_vY/BOLD" />
+        </node>
+      </node>
+      <node concept="3EZMnI" id="7yDflTqUNIW" role="3EZMnx">
+        <node concept="3F0ifn" id="7yDflTqUNJ3" role="3EZMnx">
+          <property role="3F0ifm" value="&lt;" />
+          <node concept="11L4FC" id="7yDflTqUNLs" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="11LMrY" id="7yDflTqUNNB" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F1sOY" id="7yDflTqUNJ9" role="3EZMnx">
+          <property role="1$x2rV" value="type" />
+          <ref role="1NtTu8" to="l462:7SY$c$i5rRe" resolve="typeConstraint" />
+        </node>
+        <node concept="3F0ifn" id="7yDflTqUNJh" role="3EZMnx">
+          <property role="3F0ifm" value="&gt;" />
+          <node concept="11L4FC" id="7yDflTqUNPL" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="2iRfu4" id="7yDflTqUNIZ" role="2iSdaV" />
+        <node concept="11L4FC" id="7yDflTqY$U8" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="11LMrY" id="7yDflTqY$XL" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pkWqt" id="7SY$c$i5rRh" role="pqm2j">
+          <node concept="3clFbS" id="7SY$c$i5rRi" role="2VODD2">
+            <node concept="3clFbF" id="7SY$c$i5rRn" role="3cqZAp">
+              <node concept="2OqwBi" id="7SY$c$i5uKt" role="3clFbG">
+                <node concept="2OqwBi" id="7SY$c$i5s9D" role="2Oq$k0">
+                  <node concept="pncrf" id="7SY$c$i5rRm" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="7SY$c$i5t60" role="2OqNvi">
+                    <ref role="3TtcxE" to="l462:50smQ1V8QF$" resolve="slices" />
+                  </node>
+                </node>
+                <node concept="1v1jN8" id="7SY$c$i5x75" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
         </node>
       </node>
       <node concept="3F2HdR" id="50smQ1V8QP8" role="3EZMnx">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/structure.mps
@@ -109,6 +109,12 @@
       <property role="20lbJX" value="fLJekj5/_0__n" />
       <ref role="20lvS9" node="50smQ1V8QEh" resolve="Slice" />
     </node>
+    <node concept="1TJgyj" id="7SY$c$i5rRe" role="1TKVEi">
+      <property role="IQ2ns" value="9096867490601221582" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="typeConstraint" />
+      <ref role="20lvS9" to="hm2y:60Qa1k_nI2f" resolve="ITypeSupportsDefaultValue" />
+    </node>
   </node>
   <node concept="1TIwiD" id="50smQ1V8QEh">
     <property role="EcuMT" value="5772589292323039889" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
@@ -127,6 +127,7 @@
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -240,6 +241,9 @@
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
+      <concept id="1145567426890" name="jetbrains.mps.lang.smodel.structure.SNodeListCreator" flags="nn" index="2T8Vx0">
+        <child id="1145567471833" name="createdType" index="2T96Bj" />
+      </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
@@ -282,6 +286,9 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
       <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
         <child id="1153944400369" name="variable" index="2Gsz3X" />
         <child id="1153944424730" name="inputSequence" index="2GsD0m" />
@@ -290,6 +297,8 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
@@ -334,17 +343,80 @@
   <node concept="1YbPZF" id="50smQ1V92UG">
     <property role="TrG5h" value="typeof_TemporalLiteral" />
     <node concept="3clFbS" id="50smQ1V92UH" role="18ibNy">
+      <node concept="3cpWs8" id="7SY$c$id_ww" role="3cqZAp">
+        <node concept="3cpWsn" id="7SY$c$id_wz" role="3cpWs9">
+          <property role="TrG5h" value="nodes" />
+          <node concept="2I9FWS" id="7SY$c$id_wu" role="1tU5fm" />
+          <node concept="2ShNRf" id="7SY$c$if1EK" role="33vP2m">
+            <node concept="2T8Vx0" id="7SY$c$if1WB" role="2ShVmc">
+              <node concept="2I9FWS" id="7SY$c$if1WD" role="2T96Bj" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbF" id="7SY$c$if2cg" role="3cqZAp">
+        <node concept="2OqwBi" id="7SY$c$if38f" role="3clFbG">
+          <node concept="37vLTw" id="7SY$c$if2ce" role="2Oq$k0">
+            <ref role="3cqZAo" node="7SY$c$id_wz" resolve="nodes" />
+          </node>
+          <node concept="X8dFx" id="7SY$c$if45e" role="2OqNvi">
+            <node concept="2OqwBi" id="7SY$c$idDzG" role="25WWJ7">
+              <node concept="1YBJjd" id="7SY$c$idDlB" role="2Oq$k0">
+                <ref role="1YBMHb" node="50smQ1V92UJ" resolve="tl" />
+              </node>
+              <node concept="3Tsc0h" id="7SY$c$idDWO" role="2OqNvi">
+                <ref role="3TtcxE" to="l462:50smQ1V8QF$" resolve="slices" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbJ" id="7SY$c$idE1A" role="3cqZAp">
+        <node concept="3clFbS" id="7SY$c$idE1C" role="3clFbx">
+          <node concept="3clFbF" id="7SY$c$idHtO" role="3cqZAp">
+            <node concept="2OqwBi" id="7SY$c$idIlL" role="3clFbG">
+              <node concept="37vLTw" id="7SY$c$idHtM" role="2Oq$k0">
+                <ref role="3cqZAo" node="7SY$c$id_wz" resolve="nodes" />
+              </node>
+              <node concept="TSZUe" id="7SY$c$idJhG" role="2OqNvi">
+                <node concept="2OqwBi" id="7SY$c$idJG1" role="25WWJ7">
+                  <node concept="1YBJjd" id="7SY$c$idJpY" role="2Oq$k0">
+                    <ref role="1YBMHb" node="50smQ1V92UJ" resolve="tl" />
+                  </node>
+                  <node concept="3TrEf2" id="7SY$c$idK8a" role="2OqNvi">
+                    <ref role="3Tt5mk" to="l462:7SY$c$i5rRe" resolve="typeConstraint" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1Wc70l" id="7SY$c$idGEJ" role="3clFbw">
+          <node concept="2OqwBi" id="7SY$c$idH3I" role="3uHU7w">
+            <node concept="2OqwBi" id="7SY$c$idGMc" role="2Oq$k0">
+              <node concept="1YBJjd" id="7SY$c$idGGD" role="2Oq$k0">
+                <ref role="1YBMHb" node="50smQ1V92UJ" resolve="tl" />
+              </node>
+              <node concept="3TrEf2" id="7SY$c$idGPU" role="2OqNvi">
+                <ref role="3Tt5mk" to="l462:7SY$c$i5rRe" resolve="typeConstraint" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="7SY$c$idHhG" role="2OqNvi" />
+          </node>
+          <node concept="2OqwBi" id="7SY$c$idF7k" role="3uHU7B">
+            <node concept="37vLTw" id="7SY$c$idE2j" role="2Oq$k0">
+              <ref role="3cqZAo" node="7SY$c$id_wz" resolve="nodes" />
+            </node>
+            <node concept="1v1jN8" id="7SY$c$idG3h" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
       <node concept="3clFbF" id="2NHHcg2KmZR" role="3cqZAp">
         <node concept="2YIFZM" id="2NHHcg2Kn2G" role="3clFbG">
           <ref role="37wK5l" to="t4jv:GQFmhcDvZa" resolve="doWithListOfTypes" />
           <ref role="1Pybhc" to="t4jv:12WRc28WG_m" resolve="TypingHelper" />
-          <node concept="2OqwBi" id="2NHHcg2KoQp" role="37wK5m">
-            <node concept="1YBJjd" id="50smQ1V945f" role="2Oq$k0">
-              <ref role="1YBMHb" node="50smQ1V92UJ" resolve="tl" />
-            </node>
-            <node concept="3Tsc0h" id="50smQ1V94NH" role="2OqNvi">
-              <ref role="3TtcxE" to="l462:50smQ1V8QF$" resolve="slices" />
-            </node>
+          <node concept="37vLTw" id="7SY$c$ie9VR" role="37wK5m">
+            <ref role="3cqZAo" node="7SY$c$id_wz" resolve="nodes" />
           </node>
           <node concept="1bVj0M" id="5aHkq2w3YsI" role="37wK5m">
             <node concept="3clFbS" id="5aHkq2w3YsK" role="1bW5cS">
@@ -523,22 +595,36 @@
   <node concept="18kY7G" id="50smQ1Va0Ew">
     <property role="TrG5h" value="check_TemporalLiteral" />
     <node concept="3clFbS" id="50smQ1Va0Ex" role="18ibNy">
+      <node concept="3clFbH" id="7SY$c$i76FJ" role="3cqZAp" />
       <node concept="3clFbJ" id="50smQ1Va0EH" role="3cqZAp">
-        <node concept="2OqwBi" id="50smQ1Va2Pl" role="3clFbw">
-          <node concept="2OqwBi" id="50smQ1Va0Rg" role="2Oq$k0">
-            <node concept="1YBJjd" id="50smQ1Va0EN" role="2Oq$k0">
-              <ref role="1YBMHb" node="50smQ1Va0Ez" resolve="tl" />
+        <node concept="1Wc70l" id="7SY$c$i9jtF" role="3clFbw">
+          <node concept="2OqwBi" id="7SY$c$i9kb5" role="3uHU7w">
+            <node concept="2OqwBi" id="7SY$c$i9jGP" role="2Oq$k0">
+              <node concept="1YBJjd" id="7SY$c$i9jtU" role="2Oq$k0">
+                <ref role="1YBMHb" node="50smQ1Va0Ez" resolve="tl" />
+              </node>
+              <node concept="3TrEf2" id="7SY$c$i9k06" role="2OqNvi">
+                <ref role="3Tt5mk" to="l462:7SY$c$i5rRe" resolve="typeConstraint" />
+              </node>
             </node>
-            <node concept="3Tsc0h" id="50smQ1Va13V" role="2OqNvi">
-              <ref role="3TtcxE" to="l462:50smQ1V8QF$" resolve="slices" />
-            </node>
+            <node concept="3w_OXm" id="7SY$c$i9km1" role="2OqNvi" />
           </node>
-          <node concept="1v1jN8" id="50smQ1Va56T" role="2OqNvi" />
+          <node concept="2OqwBi" id="50smQ1Va2Pl" role="3uHU7B">
+            <node concept="2OqwBi" id="50smQ1Va0Rg" role="2Oq$k0">
+              <node concept="1YBJjd" id="50smQ1Va0EN" role="2Oq$k0">
+                <ref role="1YBMHb" node="50smQ1Va0Ez" resolve="tl" />
+              </node>
+              <node concept="3Tsc0h" id="50smQ1Va13V" role="2OqNvi">
+                <ref role="3TtcxE" to="l462:50smQ1V8QF$" resolve="slices" />
+              </node>
+            </node>
+            <node concept="1v1jN8" id="50smQ1Va56T" role="2OqNvi" />
+          </node>
         </node>
         <node concept="3clFbS" id="50smQ1Va0EJ" role="3clFbx">
           <node concept="2MkqsV" id="50smQ1Va57y" role="3cqZAp">
             <node concept="Xl_RD" id="50smQ1Va57I" role="2MkJ7o">
-              <property role="Xl_RC" value="at least one slice must be defined" />
+              <property role="Xl_RC" value="at least one slice must be defined (alternatively the type constraint must be set)" />
             </node>
             <node concept="1YBJjd" id="50smQ1Va58l" role="1urrMF">
               <ref role="1YBMHb" node="50smQ1Va0Ez" resolve="tl" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
@@ -159,6 +159,9 @@
       </concept>
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1207055528241" name="jetbrains.mps.lang.typesystem.structure.WarningStatement" flags="nn" index="a7r0C">
+        <child id="1207055552304" name="warningText" index="a7wSD" />
+      </concept>
       <concept id="1766949807893567867" name="jetbrains.mps.lang.typesystem.structure.OverridesConceptFunction" flags="ig" index="bXqS6" />
       <concept id="1185788614172" name="jetbrains.mps.lang.typesystem.structure.NormalTypeClause" flags="ng" index="mw_s8">
         <child id="1185788644032" name="normalType" index="mwGJk" />
@@ -241,9 +244,6 @@
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
-      <concept id="1145567426890" name="jetbrains.mps.lang.smodel.structure.SNodeListCreator" flags="nn" index="2T8Vx0">
-        <child id="1145567471833" name="createdType" index="2T96Bj" />
-      </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
@@ -286,9 +286,6 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
-      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
-        <child id="540871147943773366" name="argument" index="25WWJ7" />
-      </concept>
       <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
         <child id="1153944400369" name="variable" index="2Gsz3X" />
         <child id="1153944424730" name="inputSequence" index="2GsD0m" />
@@ -297,11 +294,10 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
-      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
-      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
   <node concept="2sgARr" id="50smQ1V8pHj">
@@ -343,119 +339,154 @@
   <node concept="1YbPZF" id="50smQ1V92UG">
     <property role="TrG5h" value="typeof_TemporalLiteral" />
     <node concept="3clFbS" id="50smQ1V92UH" role="18ibNy">
-      <node concept="3cpWs8" id="7SY$c$id_ww" role="3cqZAp">
-        <node concept="3cpWsn" id="7SY$c$id_wz" role="3cpWs9">
-          <property role="TrG5h" value="nodes" />
-          <node concept="2I9FWS" id="7SY$c$id_wu" role="1tU5fm" />
-          <node concept="2ShNRf" id="7SY$c$if1EK" role="33vP2m">
-            <node concept="2T8Vx0" id="7SY$c$if1WB" role="2ShVmc">
-              <node concept="2I9FWS" id="7SY$c$if1WD" role="2T96Bj" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3clFbF" id="7SY$c$if2cg" role="3cqZAp">
-        <node concept="2OqwBi" id="7SY$c$if38f" role="3clFbG">
-          <node concept="37vLTw" id="7SY$c$if2ce" role="2Oq$k0">
-            <ref role="3cqZAo" node="7SY$c$id_wz" resolve="nodes" />
-          </node>
-          <node concept="X8dFx" id="7SY$c$if45e" role="2OqNvi">
-            <node concept="2OqwBi" id="7SY$c$idDzG" role="25WWJ7">
-              <node concept="1YBJjd" id="7SY$c$idDlB" role="2Oq$k0">
-                <ref role="1YBMHb" node="50smQ1V92UJ" resolve="tl" />
-              </node>
-              <node concept="3Tsc0h" id="7SY$c$idDWO" role="2OqNvi">
-                <ref role="3TtcxE" to="l462:50smQ1V8QF$" resolve="slices" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
       <node concept="3clFbJ" id="7SY$c$idE1A" role="3cqZAp">
         <node concept="3clFbS" id="7SY$c$idE1C" role="3clFbx">
-          <node concept="3clFbF" id="7SY$c$idHtO" role="3cqZAp">
-            <node concept="2OqwBi" id="7SY$c$idIlL" role="3clFbG">
-              <node concept="37vLTw" id="7SY$c$idHtM" role="2Oq$k0">
-                <ref role="3cqZAo" node="7SY$c$id_wz" resolve="nodes" />
-              </node>
-              <node concept="TSZUe" id="7SY$c$idJhG" role="2OqNvi">
-                <node concept="2OqwBi" id="7SY$c$idJG1" role="25WWJ7">
-                  <node concept="1YBJjd" id="7SY$c$idJpY" role="2Oq$k0">
-                    <ref role="1YBMHb" node="50smQ1V92UJ" resolve="tl" />
-                  </node>
-                  <node concept="3TrEf2" id="7SY$c$idK8a" role="2OqNvi">
-                    <ref role="3Tt5mk" to="l462:7SY$c$i5rRe" resolve="typeConstraint" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1Wc70l" id="7SY$c$idGEJ" role="3clFbw">
-          <node concept="2OqwBi" id="7SY$c$idH3I" role="3uHU7w">
-            <node concept="2OqwBi" id="7SY$c$idGMc" role="2Oq$k0">
-              <node concept="1YBJjd" id="7SY$c$idGGD" role="2Oq$k0">
-                <ref role="1YBMHb" node="50smQ1V92UJ" resolve="tl" />
-              </node>
-              <node concept="3TrEf2" id="7SY$c$idGPU" role="2OqNvi">
-                <ref role="3Tt5mk" to="l462:7SY$c$i5rRe" resolve="typeConstraint" />
-              </node>
-            </node>
-            <node concept="3x8VRR" id="7SY$c$idHhG" role="2OqNvi" />
-          </node>
-          <node concept="2OqwBi" id="7SY$c$idF7k" role="3uHU7B">
-            <node concept="37vLTw" id="7SY$c$idE2j" role="2Oq$k0">
-              <ref role="3cqZAo" node="7SY$c$id_wz" resolve="nodes" />
-            </node>
-            <node concept="1v1jN8" id="7SY$c$idG3h" role="2OqNvi" />
-          </node>
-        </node>
-      </node>
-      <node concept="3clFbF" id="2NHHcg2KmZR" role="3cqZAp">
-        <node concept="2YIFZM" id="2NHHcg2Kn2G" role="3clFbG">
-          <ref role="37wK5l" to="t4jv:GQFmhcDvZa" resolve="doWithListOfTypes" />
-          <ref role="1Pybhc" to="t4jv:12WRc28WG_m" resolve="TypingHelper" />
-          <node concept="37vLTw" id="7SY$c$ie9VR" role="37wK5m">
-            <ref role="3cqZAo" node="7SY$c$id_wz" resolve="nodes" />
-          </node>
-          <node concept="1bVj0M" id="5aHkq2w3YsI" role="37wK5m">
-            <node concept="3clFbS" id="5aHkq2w3YsK" role="1bW5cS">
-              <node concept="3cpWs8" id="2NHHcg2MxT5" role="3cqZAp">
-                <node concept="3cpWsn" id="2NHHcg2MxT6" role="3cpWs9">
-                  <property role="TrG5h" value="sliceSupertype" />
-                  <node concept="3Tqbb2" id="2NHHcg2MxT1" role="1tU5fm" />
-                  <node concept="2YIFZM" id="5wDe8wA6zsB" role="33vP2m">
-                    <ref role="37wK5l" to="xfg9:2NHHcg2KyAX" resolve="computeSupertype" />
-                    <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-                    <node concept="37vLTw" id="2NHHcg2MxT8" role="37wK5m">
-                      <ref role="3cqZAo" node="5aHkq2w3YD$" resolve="types" />
-                    </node>
-                    <node concept="3clFbT" id="2NHHcg2MxT9" role="37wK5m">
-                      <property role="3clFbU" value="false" />
-                    </node>
-                    <node concept="2OqwBi" id="2NHHcg2MxTa" role="37wK5m">
-                      <node concept="2QUAEa" id="2NHHcg2MxTb" role="2Oq$k0" />
-                      <node concept="liA8E" id="2NHHcg2MxTc" role="2OqNvi">
-                        <ref role="37wK5l" to="u78q:~TypeChecker.getSubtypingManager()" resolve="getSubtypingManager" />
+          <node concept="1Z5TYs" id="2LepRDoQ7Gv" role="3cqZAp">
+            <node concept="mw_s8" id="2LepRDoQ7Gw" role="1ZfhKB">
+              <node concept="2pJPEk" id="2LepRDoQ7Gx" role="mwGJk">
+                <node concept="2pJPED" id="2LepRDoQ7Gy" role="2pJPEn">
+                  <ref role="2pJxaS" to="l462:50smQ1V8i89" resolve="TemporalType" />
+                  <node concept="2pIpSj" id="2LepRDoQ7Gz" role="2pJxcM">
+                    <ref role="2pIpSl" to="l462:50smQ1V8i8a" resolve="baseType" />
+                    <node concept="36biLy" id="2LepRDoQ7G$" role="28nt2d">
+                      <node concept="1PxgMI" id="2LepRDoQa$X" role="36biLW">
+                        <node concept="chp4Y" id="2LepRDoQbrf" role="3oSUPX">
+                          <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                        </node>
+                        <node concept="2OqwBi" id="2LepRDoQ7Wn" role="1m5AlR">
+                          <node concept="1YBJjd" id="2LepRDoQ7HM" role="2Oq$k0">
+                            <ref role="1YBMHb" node="50smQ1V92UJ" resolve="tl" />
+                          </node>
+                          <node concept="3TrEf2" id="2LepRDoQ8QQ" role="2OqNvi">
+                            <ref role="3Tt5mk" to="l462:7SY$c$i5rRe" resolve="typeConstraint" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="1Z5TYs" id="7yDflTqX6Vd" role="3cqZAp">
-                <node concept="mw_s8" id="7yDflTqX71O" role="1ZfhKB">
-                  <node concept="2pJPEk" id="7yDflTqX71K" role="mwGJk">
-                    <node concept="2pJPED" id="7yDflTqX77K" role="2pJPEn">
-                      <ref role="2pJxaS" to="l462:50smQ1V8i89" resolve="TemporalType" />
-                      <node concept="2pIpSj" id="7yDflTqX7e2" role="2pJxcM">
-                        <ref role="2pIpSl" to="l462:50smQ1V8i8a" resolve="baseType" />
-                        <node concept="36biLy" id="7yDflTqX7e3" role="28nt2d">
-                          <node concept="1PxgMI" id="7yDflTqX7e4" role="36biLW">
-                            <node concept="chp4Y" id="6b_jefnKyol" role="3oSUPX">
-                              <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+            </node>
+            <node concept="mw_s8" id="2LepRDoQ7GC" role="1ZfhK$">
+              <node concept="1Z2H0r" id="2LepRDoQ7GD" role="mwGJk">
+                <node concept="1YBJjd" id="2LepRDoQ7GE" role="1Z2MuG">
+                  <ref role="1YBMHb" node="50smQ1V92UJ" resolve="tl" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2OqwBi" id="7SY$c$idH3I" role="3clFbw">
+          <node concept="2OqwBi" id="7SY$c$idGMc" role="2Oq$k0">
+            <node concept="1YBJjd" id="7SY$c$idGGD" role="2Oq$k0">
+              <ref role="1YBMHb" node="50smQ1V92UJ" resolve="tl" />
+            </node>
+            <node concept="3TrEf2" id="7SY$c$idGPU" role="2OqNvi">
+              <ref role="3Tt5mk" to="l462:7SY$c$i5rRe" resolve="typeConstraint" />
+            </node>
+          </node>
+          <node concept="3x8VRR" id="7SY$c$idHhG" role="2OqNvi" />
+        </node>
+      </node>
+      <node concept="3clFbJ" id="2LepRDoQnfM" role="3cqZAp">
+        <node concept="3clFbS" id="2LepRDoQnfO" role="3clFbx">
+          <node concept="3clFbF" id="2NHHcg2KmZR" role="3cqZAp">
+            <node concept="2YIFZM" id="2NHHcg2Kn2G" role="3clFbG">
+              <ref role="1Pybhc" to="t4jv:12WRc28WG_m" resolve="TypingHelper" />
+              <ref role="37wK5l" to="t4jv:GQFmhcDvZa" resolve="doWithListOfTypes" />
+              <node concept="2OqwBi" id="2LepRDoQcJT" role="37wK5m">
+                <node concept="1YBJjd" id="2LepRDoQcsy" role="2Oq$k0">
+                  <ref role="1YBMHb" node="50smQ1V92UJ" resolve="tl" />
+                </node>
+                <node concept="3Tsc0h" id="2LepRDoQdgk" role="2OqNvi">
+                  <ref role="3TtcxE" to="l462:50smQ1V8QF$" resolve="slices" />
+                </node>
+              </node>
+              <node concept="1bVj0M" id="5aHkq2w3YsI" role="37wK5m">
+                <node concept="3clFbS" id="5aHkq2w3YsK" role="1bW5cS">
+                  <node concept="3cpWs8" id="2NHHcg2MxT5" role="3cqZAp">
+                    <node concept="3cpWsn" id="2NHHcg2MxT6" role="3cpWs9">
+                      <property role="TrG5h" value="sliceSupertype" />
+                      <node concept="3Tqbb2" id="2NHHcg2MxT1" role="1tU5fm" />
+                      <node concept="2YIFZM" id="5wDe8wA6zsB" role="33vP2m">
+                        <ref role="37wK5l" to="xfg9:2NHHcg2KyAX" resolve="computeSupertype" />
+                        <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+                        <node concept="37vLTw" id="2NHHcg2MxT8" role="37wK5m">
+                          <ref role="3cqZAo" node="5aHkq2w3YD$" resolve="types" />
+                        </node>
+                        <node concept="3clFbT" id="2NHHcg2MxT9" role="37wK5m">
+                          <property role="3clFbU" value="false" />
+                        </node>
+                        <node concept="2OqwBi" id="2NHHcg2MxTa" role="37wK5m">
+                          <node concept="2QUAEa" id="2NHHcg2MxTb" role="2Oq$k0" />
+                          <node concept="liA8E" id="2NHHcg2MxTc" role="2OqNvi">
+                            <ref role="37wK5l" to="u78q:~TypeChecker.getSubtypingManager()" resolve="getSubtypingManager" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="2LepRDoQrkO" role="3cqZAp">
+                    <node concept="3clFbS" id="2LepRDoQrkQ" role="3clFbx">
+                      <node concept="1Z5TYs" id="7yDflTqX6Vd" role="3cqZAp">
+                        <node concept="mw_s8" id="7yDflTqX71O" role="1ZfhKB">
+                          <node concept="2pJPEk" id="7yDflTqX71K" role="mwGJk">
+                            <node concept="2pJPED" id="7yDflTqX77K" role="2pJPEn">
+                              <ref role="2pJxaS" to="l462:50smQ1V8i89" resolve="TemporalType" />
+                              <node concept="2pIpSj" id="7yDflTqX7e2" role="2pJxcM">
+                                <ref role="2pIpSl" to="l462:50smQ1V8i8a" resolve="baseType" />
+                                <node concept="36biLy" id="7yDflTqX7e3" role="28nt2d">
+                                  <node concept="1PxgMI" id="7yDflTqX7e4" role="36biLW">
+                                    <node concept="chp4Y" id="6b_jefnKyol" role="3oSUPX">
+                                      <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                                    </node>
+                                    <node concept="37vLTw" id="7yDflTqX7e5" role="1m5AlR">
+                                      <ref role="3cqZAo" node="2NHHcg2MxT6" resolve="sliceSupertype" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
                             </node>
-                            <node concept="37vLTw" id="7yDflTqX7e5" role="1m5AlR">
+                          </node>
+                        </node>
+                        <node concept="mw_s8" id="7yDflTqX6Vg" role="1ZfhK$">
+                          <node concept="1Z2H0r" id="7yDflTqX6$V" role="mwGJk">
+                            <node concept="1YBJjd" id="50smQ1V96QV" role="1Z2MuG">
+                              <ref role="1YBMHb" node="50smQ1V92UJ" resolve="tl" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="2LepRDoQsqD" role="3clFbw">
+                      <node concept="2OqwBi" id="2LepRDoQrI6" role="2Oq$k0">
+                        <node concept="1YBJjd" id="2LepRDoQrst" role="2Oq$k0">
+                          <ref role="1YBMHb" node="50smQ1V92UJ" resolve="tl" />
+                        </node>
+                        <node concept="3TrEf2" id="2LepRDoQsax" role="2OqNvi">
+                          <ref role="3Tt5mk" to="l462:7SY$c$i5rRe" resolve="typeConstraint" />
+                        </node>
+                      </node>
+                      <node concept="3w_OXm" id="2LepRDoQsEI" role="2OqNvi" />
+                    </node>
+                    <node concept="9aQIb" id="2LepRDoQsYG" role="9aQIa">
+                      <node concept="3clFbS" id="2LepRDoQsYH" role="9aQI4">
+                        <node concept="1ZoDhX" id="2LepRDoQlIf" role="3cqZAp">
+                          <node concept="mw_s8" id="2LepRDoQmJ2" role="1ZfhKB">
+                            <node concept="37vLTw" id="2LepRDoQmJ0" role="mwGJk">
                               <ref role="3cqZAo" node="2NHHcg2MxT6" resolve="sliceSupertype" />
+                            </node>
+                          </node>
+                          <node concept="mw_s8" id="2LepRDoQlIi" role="1ZfhK$">
+                            <node concept="1Z2H0r" id="2LepRDoQlbA" role="mwGJk">
+                              <node concept="2OqwBi" id="2LepRDoQloT" role="1Z2MuG">
+                                <node concept="1YBJjd" id="2LepRDoQldw" role="2Oq$k0">
+                                  <ref role="1YBMHb" node="50smQ1V92UJ" resolve="tl" />
+                                </node>
+                                <node concept="3TrEf2" id="2LepRDoQlwv" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="l462:7SY$c$i5rRe" resolve="typeConstraint" />
+                                </node>
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -463,22 +494,27 @@
                     </node>
                   </node>
                 </node>
-                <node concept="mw_s8" id="7yDflTqX6Vg" role="1ZfhK$">
-                  <node concept="1Z2H0r" id="7yDflTqX6$V" role="mwGJk">
-                    <node concept="1YBJjd" id="50smQ1V96QV" role="1Z2MuG">
-                      <ref role="1YBMHb" node="50smQ1V92UJ" resolve="tl" />
-                    </node>
+                <node concept="37vLTG" id="5aHkq2w3YD$" role="1bW2Oz">
+                  <property role="TrG5h" value="types" />
+                  <node concept="2I9FWS" id="5aHkq2w3Z2$" role="1tU5fm">
+                    <ref role="2I9WkF" to="hm2y:6sdnDbSlaok" resolve="Type" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="37vLTG" id="5aHkq2w3YD$" role="1bW2Oz">
-              <property role="TrG5h" value="types" />
-              <node concept="2I9FWS" id="5aHkq2w3Z2$" role="1tU5fm">
-                <ref role="2I9WkF" to="hm2y:6sdnDbSlaok" resolve="Type" />
-              </node>
+          </node>
+          <node concept="3clFbH" id="2LepRDoQnfN" role="3cqZAp" />
+        </node>
+        <node concept="2OqwBi" id="2LepRDoQpwl" role="3clFbw">
+          <node concept="2OqwBi" id="2LepRDoQnuN" role="2Oq$k0">
+            <node concept="1YBJjd" id="2LepRDoQngg" role="2Oq$k0">
+              <ref role="1YBMHb" node="50smQ1V92UJ" resolve="tl" />
+            </node>
+            <node concept="3Tsc0h" id="2LepRDoQnSG" role="2OqNvi">
+              <ref role="3TtcxE" to="l462:50smQ1V8QF$" resolve="slices" />
             </node>
           </node>
+          <node concept="3GX2aA" id="2LepRDoQqQB" role="2OqNvi" />
         </node>
       </node>
     </node>
@@ -628,6 +664,47 @@
             </node>
             <node concept="1YBJjd" id="50smQ1Va58l" role="1urrMF">
               <ref role="1YBMHb" node="50smQ1Va0Ez" resolve="tl" />
+            </node>
+          </node>
+        </node>
+        <node concept="3eNFk2" id="2LepRDoReMj" role="3eNLev">
+          <node concept="1Wc70l" id="2LepRDoRj8d" role="3eO9$A">
+            <node concept="2OqwBi" id="2LepRDoRjZS" role="3uHU7w">
+              <node concept="2OqwBi" id="2LepRDoRjqd" role="2Oq$k0">
+                <node concept="1YBJjd" id="2LepRDoRja_" role="2Oq$k0">
+                  <ref role="1YBMHb" node="50smQ1Va0Ez" resolve="tl" />
+                </node>
+                <node concept="3TrEf2" id="2LepRDoRjOP" role="2OqNvi">
+                  <ref role="3Tt5mk" to="l462:7SY$c$i5rRe" resolve="typeConstraint" />
+                </node>
+              </node>
+              <node concept="3x8VRR" id="2LepRDoRkbZ" role="2OqNvi" />
+            </node>
+            <node concept="2OqwBi" id="2LepRDoRh3R" role="3uHU7B">
+              <node concept="2OqwBi" id="2LepRDoRf5p" role="2Oq$k0">
+                <node concept="1YBJjd" id="2LepRDoReQQ" role="2Oq$k0">
+                  <ref role="1YBMHb" node="50smQ1Va0Ez" resolve="tl" />
+                </node>
+                <node concept="3Tsc0h" id="2LepRDoRfrQ" role="2OqNvi">
+                  <ref role="3TtcxE" to="l462:50smQ1V8QF$" resolve="slices" />
+                </node>
+              </node>
+              <node concept="3GX2aA" id="2LepRDoRiqx" role="2OqNvi" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="2LepRDoReMl" role="3eOfB_">
+            <node concept="a7r0C" id="2LepRDoRkej" role="3cqZAp">
+              <node concept="Xl_RD" id="2LepRDoRke_" role="a7wSD">
+                <property role="Xl_RC" value="The type constraint is used despite slices being present." />
+              </node>
+              <node concept="2OqwBi" id="2LepRDoTqnL" role="1urrMF">
+                <node concept="1YBJjd" id="2LepRDoTqbE" role="2Oq$k0">
+                  <ref role="1YBMHb" node="50smQ1Va0Ez" resolve="tl" />
+                </node>
+                <node concept="3TrEf2" id="2LepRDoTqMR" role="2OqNvi">
+                  <ref role="3Tt5mk" to="l462:7SY$c$i5rRe" resolve="typeConstraint" />
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.temporal.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.temporal.interpreter/models/plugin.mps
@@ -2465,6 +2465,42 @@
                 </node>
               </node>
             </node>
+            <node concept="3clFbJ" id="7SY$c$ihmZB" role="3cqZAp">
+              <node concept="3clFbS" id="7SY$c$ihmZD" role="3clFbx">
+                <node concept="3clFbF" id="7SY$c$ihmJc" role="3cqZAp">
+                  <node concept="2OqwBi" id="7SY$c$ihmPT" role="3clFbG">
+                    <node concept="37vLTw" id="7SY$c$ihmJa" role="2Oq$k0">
+                      <ref role="3cqZAo" node="50smQ1V9ZTU" resolve="value" />
+                    </node>
+                    <node concept="liA8E" id="7SY$c$ihmW3" role="2OqNvi">
+                      <ref role="37wK5l" to="8rdi:7SY$c$igwyp" resolve="setDefaultValue" />
+                      <node concept="qpA2v" id="7SY$c$ihoAJ" role="37wK5m">
+                        <node concept="2OqwBi" id="7SY$c$ihovO" role="3SLO0q">
+                          <node concept="2OqwBi" id="7SY$c$ihor8" role="2Oq$k0">
+                            <node concept="oxGPV" id="7SY$c$ihoeJ" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="7SY$c$ihotG" role="2OqNvi">
+                              <ref role="3Tt5mk" to="l462:7SY$c$i5rRe" resolve="typeConstraint" />
+                            </node>
+                          </node>
+                          <node concept="2qgKlT" id="7SY$c$ihoyF" role="2OqNvi">
+                            <ref role="37wK5l" to="pbu6:60Qa1k_nI2O" resolve="createDefaultVarExpr" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7SY$c$ihnST" role="3clFbw">
+                <node concept="2OqwBi" id="7SY$c$ihneu" role="2Oq$k0">
+                  <node concept="oxGPV" id="7SY$c$ihn2Q" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="7SY$c$ihnKX" role="2OqNvi">
+                    <ref role="3Tt5mk" to="l462:7SY$c$i5rRe" resolve="typeConstraint" />
+                  </node>
+                </node>
+                <node concept="3x8VRR" id="7SY$c$iho1y" role="2OqNvi" />
+              </node>
+            </node>
             <node concept="2Gpval" id="50smQ1Va03H" role="3cqZAp">
               <node concept="2GrKxI" id="50smQ1Va03J" role="2Gsz3X">
                 <property role="TrG5h" value="s" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.temporal.runtime/models/org.iets3.core.expr.temporal.runtime.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.temporal.runtime/models/org.iets3.core.expr.temporal.runtime.mps
@@ -3201,6 +3201,15 @@
       </node>
     </node>
     <node concept="2tJIrI" id="50smQ1V9OfN" role="jymVt" />
+    <node concept="312cEg" id="7SY$c$igh7w" role="jymVt">
+      <property role="TrG5h" value="defaultValue" />
+      <node concept="3Tm6S6" id="7SY$c$iga5$" role="1B3o_S" />
+      <node concept="3uibUv" id="7SY$c$igg0C" role="1tU5fm">
+        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+      </node>
+      <node concept="10Nm6u" id="7SY$c$ign2W" role="33vP2m" />
+    </node>
+    <node concept="2tJIrI" id="7SY$c$ig4az" role="jymVt" />
     <node concept="312cEg" id="50smQ1V9OxE" role="jymVt">
       <property role="TrG5h" value="slices" />
       <node concept="3Tm6S6" id="50smQ1V9OxF" role="1B3o_S" />
@@ -4807,6 +4816,28 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbJ" id="1ZlHRbjXGHs" role="3cqZAp">
+          <node concept="3clFbS" id="1ZlHRbjXGHu" role="3clFbx">
+            <node concept="3cpWs6" id="1ZlHRbk1quf" role="3cqZAp">
+              <node concept="37vLTw" id="7SY$c$ih49E" role="3cqZAk">
+                <ref role="3cqZAo" node="7SY$c$igh7w" resolve="defaultValue" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="1ZlHRbjXXjU" role="3clFbw">
+            <node concept="2OqwBi" id="1ZlHRbjXQkI" role="2Oq$k0">
+              <node concept="37vLTw" id="1ZlHRbjXMq1" role="2Oq$k0">
+                <ref role="3cqZAo" node="1Mp62pP1on0" resolve="between" />
+              </node>
+              <node concept="liA8E" id="1ZlHRbjXTDr" role="2OqNvi">
+                <ref role="37wK5l" node="4voqclTDifZ" resolve="slices" />
+              </node>
+            </node>
+            <node concept="liA8E" id="1ZlHRbjY2Tn" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~List.isEmpty()" resolve="isEmpty" />
+            </node>
+          </node>
+        </node>
         <node concept="3clFbJ" id="1Mp62pP1oDD" role="3cqZAp">
           <node concept="3clFbS" id="1Mp62pP1oDF" role="3clFbx">
             <node concept="3cpWs8" id="1Mp62pP3yBw" role="3cqZAp">
@@ -5321,6 +5352,33 @@
       <node concept="10P_77" id="j5CxBKlwM1" role="3clF45" />
     </node>
     <node concept="2tJIrI" id="50smQ1V9UiA" role="jymVt" />
+    <node concept="3clFb_" id="7SY$c$igwyp" role="jymVt">
+      <property role="TrG5h" value="setDefaultValue" />
+      <node concept="3clFbS" id="7SY$c$igwys" role="3clF47">
+        <node concept="3clFbF" id="7SY$c$igFh1" role="3cqZAp">
+          <node concept="37vLTI" id="7SY$c$igTBC" role="3clFbG">
+            <node concept="37vLTw" id="7SY$c$igZ1l" role="37vLTx">
+              <ref role="3cqZAo" node="7SY$c$igA9$" resolve="defaultValue" />
+            </node>
+            <node concept="2OqwBi" id="7SY$c$igJfi" role="37vLTJ">
+              <node concept="Xjq3P" id="7SY$c$igFh0" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7SY$c$igOF0" role="2OqNvi">
+                <ref role="2Oxat5" node="7SY$c$igh7w" resolve="defaultValue" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7SY$c$igsam" role="1B3o_S" />
+      <node concept="3cqZAl" id="7SY$c$igwfl" role="3clF45" />
+      <node concept="37vLTG" id="7SY$c$igA9$" role="3clF46">
+        <property role="TrG5h" value="defaultValue" />
+        <node concept="3uibUv" id="7SY$c$igA9z" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7SY$c$ignm5" role="jymVt" />
     <node concept="3Tm1VV" id="50smQ1V9Ofz" role="1B3o_S" />
   </node>
   <node concept="Qs71p" id="6AGD1sTq$nE">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/temporal@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/temporal@tests.mps
@@ -22,6 +22,9 @@
       </concept>
     </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
+      <concept id="8694548031077039769" name="org.iets3.core.expr.collections.structure.ElementTypeConstraintSingle" flags="ng" index="ygwf7">
+        <child id="8694548031077039770" name="typeConstraint" index="ygwf4" />
+      </concept>
       <concept id="5585772046594451299" name="org.iets3.core.expr.collections.structure.SumOp" flags="ng" index="2$5g5R" />
       <concept id="8872269265518788050" name="org.iets3.core.expr.collections.structure.AllOp" flags="ng" index="2TZ5KL" />
       <concept id="7554398283340715406" name="org.iets3.core.expr.collections.structure.WhereOp" flags="ng" index="3izCyS" />
@@ -29,9 +32,14 @@
         <child id="7554398283340020765" name="arg" index="3iAY4F" />
       </concept>
       <concept id="7554398283339796915" name="org.iets3.core.expr.collections.structure.SizeOp" flags="ng" index="3iB8M5" />
+      <concept id="7554398283339749509" name="org.iets3.core.expr.collections.structure.CollectionType" flags="ng" index="3iBWmN">
+        <child id="7554398283339749510" name="baseType" index="3iBWmK" />
+      </concept>
       <concept id="7554398283339759319" name="org.iets3.core.expr.collections.structure.ListLiteral" flags="ng" index="3iBYfx">
+        <child id="8694548031077041593" name="typeConstraint" index="ygBzB" />
         <child id="7554398283339759320" name="elements" index="3iBYfI" />
       </concept>
+      <concept id="7554398283339757344" name="org.iets3.core.expr.collections.structure.ListType" flags="ng" index="3iBYCm" />
     </language>
     <language id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base">
       <concept id="7831630342157089621" name="org.iets3.core.base.structure.IDetectNeedToRunManually" flags="ng" index="0Rz4o">
@@ -170,6 +178,7 @@
         <property id="5115872837157252555" name="value" index="30bdrQ" />
       </concept>
       <concept id="5115872837157054284" name="org.iets3.core.expr.simpleTypes.structure.RealType" flags="ng" index="30bXLL" />
+      <concept id="5115872837157054169" name="org.iets3.core.expr.simpleTypes.structure.IntegerType" flags="ng" index="30bXR$" />
       <concept id="5115872837157054170" name="org.iets3.core.expr.simpleTypes.structure.NumberLiteral" flags="ng" index="30bXRB">
         <property id="5115872837157054173" name="value" index="30bXRw" />
       </concept>
@@ -215,6 +224,7 @@
       </concept>
       <concept id="5772589292323039886" name="org.iets3.core.expr.temporal.structure.TemporalLiteral" flags="ng" index="FfN7I">
         <child id="5772589292323039972" name="slices" index="FfN64" />
+        <child id="9096867490601221582" name="typeConstraint" index="1GaMO7" />
       </concept>
       <concept id="5772589292323039889" name="org.iets3.core.expr.temporal.structure.Slice" flags="ng" index="FfN7L">
         <child id="5772589292323039890" name="pointInTime" index="FfN7M" />
@@ -3881,6 +3891,100 @@
         </node>
       </node>
       <node concept="3dYjL0" id="46fmv66pL1O" role="_fkp5" />
+    </node>
+    <node concept="_ixoA" id="7SY$c$iii7R" role="_iOnB" />
+    <node concept="2zPypq" id="7SY$c$iikdt" role="_iOnB">
+      <property role="TrG5h" value="toReduceWithoutSlices1" />
+      <property role="0Rz4W" value="1419291713" />
+      <node concept="FfN7I" id="7SY$c$iikdu" role="2zPyp_">
+        <node concept="30bXR$" id="7SY$c$iikXj" role="1GaMO7" />
+      </node>
+    </node>
+    <node concept="2zPypq" id="7SY$c$iikZU" role="_iOnB">
+      <property role="TrG5h" value="toReduceWithoutSlices2" />
+      <property role="0Rz4W" value="1419291713" />
+      <node concept="FfN7I" id="7SY$c$iikZV" role="2zPyp_">
+        <node concept="3iBYCm" id="7SY$c$iilky" role="1GaMO7">
+          <node concept="2vmvy5" id="7SY$c$iilln" role="3iBWmK" />
+        </node>
+      </node>
+    </node>
+    <node concept="_ixoA" id="7SY$c$iikdO" role="_iOnB" />
+    <node concept="2zPypq" id="7SY$c$iikdQ" role="_iOnB">
+      <property role="TrG5h" value="reduceFirstYearWithoutSlices1" />
+      <property role="0Rz4W" value="-1740576778" />
+      <node concept="1QScDb" id="7SY$c$iikdR" role="2zPyp_">
+        <node concept="1DAXCi" id="7SY$c$iikdS" role="1QScD9">
+          <node concept="1DAXD4" id="7SY$c$iikdT" role="1DAXD6" />
+          <node concept="1f6kyV" id="7SY$c$iikdU" role="1DAXD0">
+            <node concept="30bXRB" id="7SY$c$iikdV" role="1f6kyW">
+              <property role="30bXRw" value="2000" />
+            </node>
+          </node>
+        </node>
+        <node concept="_emDc" id="7SY$c$iikdW" role="30czhm">
+          <ref role="_emDf" node="7SY$c$iikdt" resolve="toReduceWithoutSlices1" />
+        </node>
+      </node>
+    </node>
+    <node concept="2zPypq" id="7SY$c$iilq1" role="_iOnB">
+      <property role="TrG5h" value="reduceFirstYearWithoutSlices2" />
+      <property role="0Rz4W" value="-1740576778" />
+      <node concept="1QScDb" id="7SY$c$iilq2" role="2zPyp_">
+        <node concept="1DAXCi" id="7SY$c$iilq3" role="1QScD9">
+          <node concept="1DAXD4" id="7SY$c$iilq4" role="1DAXD6" />
+          <node concept="1f6kyV" id="7SY$c$iilq5" role="1DAXD0">
+            <node concept="30bXRB" id="7SY$c$iilq6" role="1f6kyW">
+              <property role="30bXRw" value="2000" />
+            </node>
+          </node>
+        </node>
+        <node concept="_emDc" id="7SY$c$iilq7" role="30czhm">
+          <ref role="_emDf" node="7SY$c$iikZU" resolve="toReduceWithoutSlices2" />
+        </node>
+      </node>
+    </node>
+    <node concept="2zPypq" id="2Zbcfw$dM65" role="_iOnB">
+      <property role="TrG5h" value="reduceFirstYearWithoutSlices3" />
+      <property role="0Rz4W" value="-1740576778" />
+      <node concept="1QScDb" id="2Zbcfw$dM66" role="2zPyp_">
+        <node concept="1DAXCi" id="2Zbcfw$dM67" role="1QScD9">
+          <node concept="1DAXD4" id="2Zbcfw$dM68" role="1DAXD6" />
+          <node concept="1f6kyV" id="2Zbcfw$dM69" role="1DAXD0">
+            <node concept="30bXRB" id="2Zbcfw$dM6a" role="1f6kyW">
+              <property role="30bXRw" value="2000" />
+            </node>
+          </node>
+        </node>
+        <node concept="_emDc" id="2Zbcfw$dM6b" role="30czhm">
+          <ref role="_emDf" node="7SY$c$iikZU" resolve="toReduceWithoutSlices2" />
+        </node>
+      </node>
+    </node>
+    <node concept="_ixoA" id="7SY$c$iij_W" role="_iOnB" />
+    <node concept="_ixoA" id="7SY$c$iijTG" role="_iOnB" />
+    <node concept="_fkuM" id="7SY$c$iiiJa" role="_iOnB">
+      <property role="TrG5h" value="reduceWithoutSlices" />
+      <node concept="_fkuZ" id="7SY$c$iiiJb" role="_fkp5">
+        <node concept="_fku$" id="7SY$c$iiiJc" role="_fkur" />
+        <node concept="_emDc" id="7SY$c$iiiJd" role="_fkuY">
+          <ref role="_emDf" node="7SY$c$iikdQ" resolve="reduceFirstYearWithoutSlices1" />
+        </node>
+        <node concept="30bXRB" id="7SY$c$iiiJe" role="_fkuS">
+          <property role="30bXRw" value="0" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="7SY$c$iinPE" role="_fkp5">
+        <node concept="_fku$" id="7SY$c$iinPF" role="_fkur" />
+        <node concept="_emDc" id="7SY$c$iinPG" role="_fkuY">
+          <ref role="_emDf" node="7SY$c$iilq1" resolve="reduceFirstYearWithoutSlices2" />
+        </node>
+        <node concept="3iBYfx" id="7SY$c$iiozZ" role="_fkuS">
+          <node concept="ygwf7" id="7SY$c$ii_qm" role="ygBzB">
+            <node concept="2vmvy5" id="7SY$c$ii_qA" role="ygwf4" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="_ixoA" id="7X4dwX1dxh4" role="_iOnB" />
     <node concept="2zPypq" id="7X4dwX1bvgg" role="_iOnB">


### PR DESCRIPTION
Return an optional default value that is calculated from a type constraint on the temporal literal.
This constraint has to be set when no slices are provided. Previously, the reduce method returned null and failed with a `NullPointerException`.