### PR TITLE
Improve IRunManuallyWithUIUpdate logic

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/behavior.mps
@@ -179,6 +179,7 @@
       <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
         <property id="8355037393041754995" name="isNative" index="2aFKle" />
       </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
@@ -205,6 +206,7 @@
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
@@ -291,9 +293,20 @@
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1235573135402" name="jetbrains.mps.baseLanguage.collections.structure.SingletonSequenceCreator" flags="nn" index="2HTt$P">
+        <child id="1235573175711" name="elementType" index="2HTBi0" />
+        <child id="1235573187520" name="singletonValue" index="2HTEbv" />
       </concept>
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435807" name="elementType" index="HW$YZ" />
@@ -301,6 +314,9 @@
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
+      <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
+      <concept id="1178894719932" name="jetbrains.mps.baseLanguage.collections.structure.DistinctOperation" flags="nn" index="1VAtEI" />
     </language>
   </registry>
   <node concept="13h7C7" id="cJpacq408_">
@@ -905,7 +921,7 @@
           <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
         </node>
       </node>
-      <node concept="3Tm1VV" id="ub9nkyQ909" role="1B3o_S" />
+      <node concept="3Tm1VV" id="3JvidvJxss1" role="1B3o_S" />
       <node concept="3clFbS" id="ub9nkyQ90a" role="3clF47">
         <node concept="3clFbF" id="ub9nkyQaB2" role="3cqZAp">
           <node concept="BsUDl" id="ub9nkyQaB0" role="3clFbG">
@@ -915,78 +931,38 @@
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="4bmM0avMFet" role="3cqZAp">
-          <node concept="3cpWsn" id="4bmM0avMFeu" role="3cpWs9">
-            <property role="TrG5h" value="cr" />
-            <node concept="3Tqbb2" id="4bmM0avMFev" role="1tU5fm" />
-            <node concept="2OqwBi" id="4bmM0avMFew" role="33vP2m">
-              <node concept="13iPFW" id="ub9nkyQaiy" role="2Oq$k0" />
-              <node concept="2Rxl7S" id="4bmM0avMFe$" role="2OqNvi" />
+        <node concept="3clFbF" id="3JvidvJwEzq" role="3cqZAp">
+          <node concept="2YIFZM" id="3JvidvJx6Xi" role="3clFbG">
+            <ref role="37wK5l" node="3JvidvJx5Pp" resolve="updateEditors" />
+            <ref role="1Pybhc" node="3JvidvJwDTf" resolve="RunManuallyUtil" />
+            <node concept="37vLTw" id="3JvidvJx6Xj" role="37wK5m">
+              <ref role="3cqZAo" node="3a2FJuC6OOk" resolve="edCtxOrNull" />
             </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="4bmM0avMFe_" role="3cqZAp">
-          <node concept="2OqwBi" id="4bmM0avMFeA" role="3clFbG">
-            <node concept="2OqwBi" id="4bmM0avMFeB" role="2Oq$k0">
-              <node concept="2YIFZM" id="4bmM0avMFeC" role="2Oq$k0">
-                <ref role="37wK5l" to="kvq8:2WlJ6VKOSU7" resolve="findAllInstances" />
-                <ref role="1Pybhc" to="kvq8:2WlJ6VKOwRU" resolve="EditorComponentHacks" />
-              </node>
-              <node concept="3zZkjj" id="4bmM0avMFeD" role="2OqNvi">
-                <node concept="1bVj0M" id="4bmM0avMFeE" role="23t8la">
-                  <node concept="3clFbS" id="4bmM0avMFeF" role="1bW5cS">
-                    <node concept="3clFbF" id="4bmM0avMFeG" role="3cqZAp">
-                      <node concept="3clFbC" id="4bmM0avMFeH" role="3clFbG">
-                        <node concept="37vLTw" id="4bmM0avMFeI" role="3uHU7w">
-                          <ref role="3cqZAo" node="4bmM0avMFeu" resolve="cr" />
-                        </node>
-                        <node concept="2OqwBi" id="4bmM0avMFeJ" role="3uHU7B">
-                          <node concept="2OqwBi" id="4bmM0avMFeK" role="2Oq$k0">
-                            <node concept="37vLTw" id="4bmM0avMFeL" role="2Oq$k0">
-                              <ref role="3cqZAo" node="4bmM0avMFeO" resolve="it" />
-                            </node>
-                            <node concept="liA8E" id="4bmM0avMFeM" role="2OqNvi">
-                              <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
-                            </node>
-                          </node>
-                          <node concept="liA8E" id="4bmM0avMFeN" role="2OqNvi">
-                            <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="Rh6nW" id="4bmM0avMFeO" role="1bW2Oz">
-                    <property role="TrG5h" value="it" />
-                    <node concept="2jxLKc" id="4bmM0avMFeP" role="1tU5fm" />
-                  </node>
+            <node concept="2ShNRf" id="3JvidvJx6Xk" role="37wK5m">
+              <node concept="2HTt$P" id="3JvidvJx6Xl" role="2ShVmc">
+                <node concept="3Tqbb2" id="3JvidvJx6Xm" role="2HTBi0">
+                  <ref role="ehGHo" to="4kwy:3R3AIvumrSU" resolve="ICanRunCheckManually" />
                 </node>
-              </node>
-            </node>
-            <node concept="2es0OD" id="4bmM0avMFeQ" role="2OqNvi">
-              <node concept="1bVj0M" id="4bmM0avMFeR" role="23t8la">
-                <node concept="3clFbS" id="4bmM0avMFeS" role="1bW5cS">
-                  <node concept="3clFbF" id="4bmM0avMFeT" role="3cqZAp">
-                    <node concept="2OqwBi" id="4bmM0avMFeU" role="3clFbG">
-                      <node concept="37vLTw" id="4bmM0avMFeV" role="2Oq$k0">
-                        <ref role="3cqZAo" node="4bmM0avMFeX" resolve="it" />
-                      </node>
-                      <node concept="liA8E" id="4bmM0avMFeW" role="2OqNvi">
-                        <ref role="37wK5l" to="exr9:~EditorComponent.update()" resolve="update" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="Rh6nW" id="4bmM0avMFeX" role="1bW2Oz">
-                  <property role="TrG5h" value="it" />
-                  <node concept="2jxLKc" id="4bmM0avMFeY" role="1tU5fm" />
-                </node>
+                <node concept="13iPFW" id="3JvidvJx6Xn" role="2HTEbv" />
               </node>
             </node>
           </node>
         </node>
       </node>
       <node concept="3cqZAl" id="ub9nkyQ90b" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="3JvidvJx7iM" role="13h7CS">
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="performAdditionalEditorUpdate" />
+      <node concept="37vLTG" id="2BQOEA1w$fl" role="3clF46">
+        <property role="TrG5h" value="edCtxOrNull" />
+        <node concept="3uibUv" id="2BQOEA1w$fm" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3JvidvJ$Iej" role="1B3o_S" />
+      <node concept="3cqZAl" id="3JvidvJx7lJ" role="3clF45" />
+      <node concept="3clFbS" id="3JvidvJx7iP" role="3clF47" />
     </node>
     <node concept="13i0hz" id="4b4fYXfo1HZ" role="13h7CS">
       <property role="13i0iv" value="false" />
@@ -2499,6 +2475,186 @@
     <node concept="13hLZK" id="6BCTLIjCrat" role="13h7CW">
       <node concept="3clFbS" id="6BCTLIjCrau" role="2VODD2" />
     </node>
+  </node>
+  <node concept="312cEu" id="3JvidvJwDTf">
+    <property role="3GE5qa" value="adapter" />
+    <property role="TrG5h" value="RunManuallyUtil" />
+    <node concept="2tJIrI" id="3JvidvJwE3Z" role="jymVt" />
+    <node concept="2YIFZL" id="3JvidvJx5Pp" role="jymVt">
+      <property role="TrG5h" value="updateEditors" />
+      <node concept="37vLTG" id="3JvidvJx5TO" role="3clF46">
+        <property role="TrG5h" value="edCtxOrNull" />
+        <node concept="3uibUv" id="3JvidvJx5TP" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3JvidvJx5Ux" role="3clF46">
+        <property role="TrG5h" value="nodes" />
+        <node concept="A3Dl8" id="3JvidvJx5Uy" role="1tU5fm">
+          <node concept="3Tqbb2" id="3JvidvJx5Uz" role="A3Ik2">
+            <ref role="ehGHo" to="4kwy:3R3AIvumrSU" resolve="ICanRunCheckManually" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbS" id="3JvidvJx5Ps" role="3clF47">
+        <node concept="3clFbF" id="3JvidvJxdSa" role="3cqZAp">
+          <node concept="2OqwBi" id="3JvidvJxe4$" role="3clFbG">
+            <node concept="37vLTw" id="3JvidvJxdS8" role="2Oq$k0">
+              <ref role="3cqZAo" node="3JvidvJx5Ux" resolve="nodes" />
+            </node>
+            <node concept="2es0OD" id="3JvidvJxeej" role="2OqNvi">
+              <node concept="1bVj0M" id="3JvidvJxeel" role="23t8la">
+                <node concept="3clFbS" id="3JvidvJxeem" role="1bW5cS">
+                  <node concept="3clFbF" id="3JvidvJxehH" role="3cqZAp">
+                    <node concept="2OqwBi" id="3JvidvJxemu" role="3clFbG">
+                      <node concept="37vLTw" id="3JvidvJxehG" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3JvidvJxeen" resolve="it" />
+                      </node>
+                      <node concept="2qgKlT" id="3JvidvJxew9" role="2OqNvi">
+                        <ref role="37wK5l" node="3JvidvJx7iM" resolve="performAdditionalEditorUpdate" />
+                        <node concept="37vLTw" id="3JvidvJxeBJ" role="37wK5m">
+                          <ref role="3cqZAo" node="3JvidvJx5TO" resolve="edCtxOrNull" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="3JvidvJxeen" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="3JvidvJxeeo" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3JvidvJx5Yq" role="3cqZAp">
+          <node concept="1rXfSq" id="3JvidvJx5Yo" role="3clFbG">
+            <ref role="37wK5l" node="3JvidvJwE4P" resolve="rebuildAffectedEditors" />
+            <node concept="37vLTw" id="3JvidvJx6Qs" role="37wK5m">
+              <ref role="3cqZAo" node="3JvidvJx5Ux" resolve="nodes" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3JvidvJx5Lb" role="1B3o_S" />
+      <node concept="3cqZAl" id="3JvidvJx5P4" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3JvidvJx5HD" role="jymVt" />
+    <node concept="2YIFZL" id="3JvidvJwE4P" role="jymVt">
+      <property role="TrG5h" value="rebuildAffectedEditors" />
+      <node concept="37vLTG" id="3JvidvJwHcs" role="3clF46">
+        <property role="TrG5h" value="nodes" />
+        <node concept="A3Dl8" id="3JvidvJwSQk" role="1tU5fm">
+          <node concept="3Tqbb2" id="3JvidvJwSQm" role="A3Ik2">
+            <ref role="ehGHo" to="4kwy:3R3AIvumrSU" resolve="ICanRunCheckManually" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbS" id="3JvidvJwE4S" role="3clF47">
+        <node concept="3cpWs8" id="3JvidvJwIRZ" role="3cqZAp">
+          <node concept="3cpWsn" id="3JvidvJwIS2" role="3cpWs9">
+            <property role="TrG5h" value="roots" />
+            <node concept="_YKpA" id="3JvidvJwT3G" role="1tU5fm">
+              <node concept="3Tqbb2" id="3JvidvJwT3I" role="_ZDj9" />
+            </node>
+            <node concept="2OqwBi" id="3JvidvJwTCv" role="33vP2m">
+              <node concept="2OqwBi" id="3JvidvJwNXf" role="2Oq$k0">
+                <node concept="2OqwBi" id="3JvidvJwL5e" role="2Oq$k0">
+                  <node concept="37vLTw" id="3JvidvJwJB9" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3JvidvJwHcs" resolve="nodes" />
+                  </node>
+                  <node concept="3$u5V9" id="3JvidvJwMre" role="2OqNvi">
+                    <node concept="1bVj0M" id="3JvidvJwMrg" role="23t8la">
+                      <node concept="3clFbS" id="3JvidvJwMrh" role="1bW5cS">
+                        <node concept="3clFbF" id="3JvidvJwMGj" role="3cqZAp">
+                          <node concept="2OqwBi" id="3JvidvJwN1D" role="3clFbG">
+                            <node concept="37vLTw" id="3JvidvJwMGi" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3JvidvJwMri" resolve="it" />
+                            </node>
+                            <node concept="2Rxl7S" id="3JvidvJwNwU" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="3JvidvJwMri" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="3JvidvJwMrj" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1VAtEI" id="3JvidvJwOGa" role="2OqNvi" />
+              </node>
+              <node concept="ANE8D" id="3JvidvJwTZW" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3JvidvJwF9Z" role="3cqZAp">
+          <node concept="2OqwBi" id="4bmM0avMFeA" role="3clFbG">
+            <node concept="2OqwBi" id="4bmM0avMFeB" role="2Oq$k0">
+              <node concept="2YIFZM" id="4bmM0avMFeC" role="2Oq$k0">
+                <ref role="1Pybhc" to="kvq8:2WlJ6VKOwRU" resolve="EditorComponentHacks" />
+                <ref role="37wK5l" to="kvq8:2WlJ6VKOSU7" resolve="findAllInstances" />
+              </node>
+              <node concept="3zZkjj" id="4bmM0avMFeD" role="2OqNvi">
+                <node concept="1bVj0M" id="4bmM0avMFeE" role="23t8la">
+                  <node concept="3clFbS" id="4bmM0avMFeF" role="1bW5cS">
+                    <node concept="3clFbF" id="3JvidvJwPfb" role="3cqZAp">
+                      <node concept="2OqwBi" id="3JvidvJwQdM" role="3clFbG">
+                        <node concept="37vLTw" id="3JvidvJwPf9" role="2Oq$k0">
+                          <ref role="3cqZAo" node="3JvidvJwIS2" resolve="roots" />
+                        </node>
+                        <node concept="3JPx81" id="3JvidvJwRh$" role="2OqNvi">
+                          <node concept="2OqwBi" id="4bmM0avMFeJ" role="25WWJ7">
+                            <node concept="2OqwBi" id="4bmM0avMFeK" role="2Oq$k0">
+                              <node concept="37vLTw" id="4bmM0avMFeL" role="2Oq$k0">
+                                <ref role="3cqZAo" node="4bmM0avMFeO" resolve="it" />
+                              </node>
+                              <node concept="liA8E" id="4bmM0avMFeM" role="2OqNvi">
+                                <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="4bmM0avMFeN" role="2OqNvi">
+                              <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="4bmM0avMFeO" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="4bmM0avMFeP" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2es0OD" id="4bmM0avMFeQ" role="2OqNvi">
+              <node concept="1bVj0M" id="4bmM0avMFeR" role="23t8la">
+                <node concept="3clFbS" id="4bmM0avMFeS" role="1bW5cS">
+                  <node concept="3clFbF" id="4bmM0avMFeT" role="3cqZAp">
+                    <node concept="2OqwBi" id="4bmM0avMFeU" role="3clFbG">
+                      <node concept="37vLTw" id="4bmM0avMFeV" role="2Oq$k0">
+                        <ref role="3cqZAo" node="4bmM0avMFeX" resolve="it" />
+                      </node>
+                      <node concept="liA8E" id="4bmM0avMFeW" role="2OqNvi">
+                        <ref role="37wK5l" to="exr9:~EditorComponent.update()" resolve="update" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="4bmM0avMFeX" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="4bmM0avMFeY" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="3JvidvJx6Av" role="1B3o_S" />
+      <node concept="3cqZAl" id="3JvidvJwE4E" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="3JvidvJwDTg" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -94,9 +94,6 @@
         <property id="1225194472834" name="isAbstract" index="13i0iv" />
         <reference id="1225194472831" name="overriddenMethod" index="13i0hy" />
       </concept>
-      <concept id="1225194628440" name="jetbrains.mps.lang.behavior.structure.SuperNodeExpression" flags="nn" index="13iAh5">
-        <reference id="5299096511375896640" name="superConcept" index="3eA5LN" />
-      </concept>
       <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
       <concept id="1703835097132541506" name="jetbrains.mps.lang.behavior.structure.ThisConceptExpression" flags="ng" index="1fM9EW" />
     </language>
@@ -3377,24 +3374,17 @@
         <node concept="3Tqbb2" id="7obiejCzVLM" role="1tU5fm" />
       </node>
     </node>
-    <node concept="13i0hz" id="2BQOEA1w$eF" role="13h7CS">
-      <property role="TrG5h" value="runManuallyWithUIUpdate" />
-      <ref role="13i0hy" to="gdgh:ub9nkyQ908" resolve="runManuallyWithUIUpdate" />
-      <node concept="3Tm1VV" id="2BQOEA1w$eI" role="1B3o_S" />
-      <node concept="3clFbS" id="2BQOEA1w$fk" role="3clF47">
-        <node concept="3clFbF" id="1LbYOz9xuLs" role="3cqZAp">
-          <node concept="2OqwBi" id="1LbYOz9xxjT" role="3clFbG">
-            <node concept="13iAh5" id="1LbYOz9xwLB" role="2Oq$k0">
-              <ref role="3eA5LN" to="4kwy:3R3AIvumrSU" resolve="ICanRunCheckManually" />
-            </node>
-            <node concept="2qgKlT" id="1LbYOz9xzPw" role="2OqNvi">
-              <ref role="37wK5l" to="gdgh:ub9nkyQ908" resolve="runManuallyWithUIUpdate" />
-              <node concept="37vLTw" id="1LbYOz9x$18" role="37wK5m">
-                <ref role="3cqZAo" node="2BQOEA1w$fl" resolve="edCtxOrNull" />
-              </node>
-            </node>
-          </node>
+    <node concept="13i0hz" id="3JvidvJxaoX" role="13h7CS">
+      <property role="TrG5h" value="performAdditionalEditorUpdate" />
+      <ref role="13i0hy" to="gdgh:3JvidvJx7iM" resolve="performAdditionalEditorUpdate" />
+      <node concept="37vLTG" id="3JvidvJxdvI" role="3clF46">
+        <property role="TrG5h" value="edCtxOrNull" />
+        <node concept="3uibUv" id="3JvidvJxdvJ" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
         </node>
+      </node>
+      <node concept="3Tmbuc" id="3JvidvJxsAW" role="1B3o_S" />
+      <node concept="3clFbS" id="3JvidvJxap1" role="3clF47">
         <node concept="3cpWs8" id="2BQOEA1wC7e" role="3cqZAp">
           <node concept="3cpWsn" id="2BQOEA1wC7f" role="3cpWs9">
             <property role="TrG5h" value="result" />
@@ -3438,7 +3428,7 @@
                     </node>
                     <node concept="2OqwBi" id="2BQOEA1wC7q" role="10QFUP">
                       <node concept="37vLTw" id="2BQOEA1wC7r" role="2Oq$k0">
-                        <ref role="3cqZAo" node="2BQOEA1w$fl" resolve="edCtxOrNull" />
+                        <ref role="3cqZAo" node="3JvidvJxdvI" resolve="edCtxOrNull" />
                       </node>
                       <node concept="liA8E" id="2BQOEA1wC7s" role="2OqNvi">
                         <ref role="37wK5l" to="cj4x:~EditorContext.getEditorComponent()" resolve="getEditorComponent" />
@@ -3528,8 +3518,8 @@
                           <ref role="1Px2BO" to="2gg1:~MessageStatus" resolve="MessageStatus" />
                         </node>
                         <node concept="2YIFZM" id="2BQOEA1wC80" role="37wK5m">
-                          <ref role="37wK5l" to="rie3:4_qY3E51Kpe" resolve="colorForItem" />
                           <ref role="1Pybhc" to="rie3:ub9nkyNtXz" resolve="TestColors" />
+                          <ref role="37wK5l" to="rie3:4_qY3E51Kpe" resolve="colorForItem" />
                           <node concept="37vLTw" id="2BQOEA1wC81" role="37wK5m">
                             <ref role="3cqZAo" node="2BQOEA1wC7f" resolve="result" />
                           </node>
@@ -3572,19 +3562,13 @@
           </node>
           <node concept="3y3z36" id="2BQOEA1wC8d" role="3clFbw">
             <node concept="37vLTw" id="2BQOEA1wC8e" role="3uHU7B">
-              <ref role="3cqZAo" node="2BQOEA1w$fl" resolve="edCtxOrNull" />
+              <ref role="3cqZAo" node="3JvidvJxdvI" resolve="edCtxOrNull" />
             </node>
             <node concept="10Nm6u" id="2BQOEA1wC8f" role="3uHU7w" />
           </node>
         </node>
       </node>
-      <node concept="37vLTG" id="2BQOEA1w$fl" role="3clF46">
-        <property role="TrG5h" value="edCtxOrNull" />
-        <node concept="3uibUv" id="2BQOEA1w$fm" role="1tU5fm">
-          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
-        </node>
-      </node>
-      <node concept="3cqZAl" id="2BQOEA1w$fn" role="3clF45" />
+      <node concept="3cqZAl" id="3JvidvJxap2" role="3clF45" />
     </node>
     <node concept="13i0hz" id="3a2FJuC70jg" role="13h7CS">
       <property role="13i0iv" value="false" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/intentions.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/intentions.mps
@@ -284,6 +284,9 @@
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
       <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
         <child id="1153944400369" name="variable" index="2Gsz3X" />
         <child id="1153944424730" name="inputSequence" index="2GsD0m" />
@@ -429,13 +432,26 @@
     </node>
     <node concept="2Sbjvc" id="ub9nkyPcj7" role="2ZfgGD">
       <node concept="3clFbS" id="ub9nkyPcj8" role="2VODD2">
-        <node concept="3clFbF" id="ub9nkyPdsa" role="3cqZAp">
-          <node concept="2OqwBi" id="ub9nkyPe0i" role="3clFbG">
-            <node concept="2OqwBi" id="ub9nkyPduT" role="2Oq$k0">
-              <node concept="2Sf5sV" id="ub9nkyPds1" role="2Oq$k0" />
-              <node concept="2qgKlT" id="4_qY3E4Dr0U" role="2OqNvi">
+        <node concept="3cpWs8" id="3JvidvJx5cB" role="3cqZAp">
+          <node concept="3cpWsn" id="3JvidvJx5cC" role="3cpWs9">
+            <property role="TrG5h" value="nonEmptyItems" />
+            <node concept="A3Dl8" id="3JvidvJx591" role="1tU5fm">
+              <node concept="3Tqbb2" id="3JvidvJx594" role="A3Ik2">
+                <ref role="ehGHo" to="av4b:78hTg1$THIw" resolve="AbstractTestItem" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3JvidvJx5cD" role="33vP2m">
+              <node concept="2Sf5sV" id="3JvidvJx5cE" role="2Oq$k0" />
+              <node concept="2qgKlT" id="3JvidvJx5cF" role="2OqNvi">
                 <ref role="37wK5l" to="xk6s:59WscmUTju7" resolve="nonEmptyItems" />
               </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="ub9nkyPdsa" role="3cqZAp">
+          <node concept="2OqwBi" id="ub9nkyPe0i" role="3clFbG">
+            <node concept="37vLTw" id="3JvidvJx5cG" role="2Oq$k0">
+              <ref role="3cqZAo" node="3JvidvJx5cC" resolve="nonEmptyItems" />
             </node>
             <node concept="2es0OD" id="ub9nkyPfpg" role="2OqNvi">
               <node concept="1bVj0M" id="ub9nkyPfpi" role="23t8la">
@@ -446,7 +462,7 @@
                         <ref role="3cqZAo" node="ub9nkyPfpk" resolve="it" />
                       </node>
                       <node concept="2qgKlT" id="ub9nkyQb6k" role="2OqNvi">
-                        <ref role="37wK5l" to="gdgh:ub9nkyQ908" resolve="runManuallyWithUIUpdate" />
+                        <ref role="37wK5l" to="gdgh:3R3AIvumrTm" resolve="runManually" />
                         <node concept="1XNTG" id="6$2dS_IVMf6" role="37wK5m" />
                       </node>
                     </node>
@@ -460,7 +476,16 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="BuchFagR_g" role="3cqZAp" />
+        <node concept="3clFbF" id="3JvidvJx4Kd" role="3cqZAp">
+          <node concept="2YIFZM" id="3JvidvJx6cH" role="3clFbG">
+            <ref role="37wK5l" to="gdgh:3JvidvJx5Pp" resolve="updateEditors" />
+            <ref role="1Pybhc" to="gdgh:3JvidvJwDTf" resolve="RunManuallyUtil" />
+            <node concept="1XNTG" id="3JvidvJx6cI" role="37wK5m" />
+            <node concept="37vLTw" id="3JvidvJx6cJ" role="37wK5m">
+              <ref role="3cqZAo" node="3JvidvJx5cC" resolve="nonEmptyItems" />
+            </node>
+          </node>
+        </node>
       </node>
     </node>
     <node concept="1SWQZ3" id="ub9nkyPcjd" role="lGtFl">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.plugin/models/org/iets3/core/plugin/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.plugin/models/org/iets3/core/plugin/plugin.mps
@@ -277,7 +277,6 @@
       </concept>
       <concept id="1212008292747" name="jetbrains.mps.lang.smodel.structure.Model_GetLongNameOperation" flags="nn" index="LkI2h" />
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
-      <concept id="1171310072040" name="jetbrains.mps.lang.smodel.structure.Node_GetContainingRootOperation" flags="nn" index="2Rxl7S" />
       <concept id="1171315804604" name="jetbrains.mps.lang.smodel.structure.Model_RootsOperation" flags="nn" index="2RRcyG">
         <child id="6750920497477046361" name="conceptArgument" index="3MHsoP" />
       </concept>
@@ -321,7 +320,6 @@
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
-      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
@@ -640,76 +638,9 @@
                             <ref role="3cqZAo" node="7TU$2foe_N7" resolve="checkable" />
                           </node>
                           <node concept="2qgKlT" id="7QODtLwgm$0" role="2OqNvi">
-                            <ref role="37wK5l" to="gdgh:3R3AIvumrTm" resolve="runManually" />
+                            <ref role="37wK5l" to="gdgh:ub9nkyQ908" resolve="runManuallyWithUIUpdate" />
                             <node concept="37vLTw" id="7QODtLwgm$1" role="37wK5m">
                               <ref role="3cqZAo" node="7Z_fDCwjnD9" resolve="context" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3cpWs8" id="4Pi6J8CbquQ" role="3cqZAp">
-                        <node concept="3cpWsn" id="4Pi6J8CbquR" role="3cpWs9">
-                          <property role="TrG5h" value="cr" />
-                          <node concept="3Tqbb2" id="4Pi6J8CbquS" role="1tU5fm" />
-                          <node concept="2OqwBi" id="4Pi6J8CbquT" role="33vP2m">
-                            <node concept="37vLTw" id="4Pi6J8CbquU" role="2Oq$k0">
-                              <ref role="3cqZAo" node="7TU$2foe_N7" resolve="checkable" />
-                            </node>
-                            <node concept="2Rxl7S" id="4Pi6J8CbquV" role="2OqNvi" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbF" id="4Pi6J8Cbqv4" role="3cqZAp">
-                        <node concept="2OqwBi" id="4Pi6J8Cbqv5" role="3clFbG">
-                          <node concept="2es0OD" id="4Pi6J8Cbqvl" role="2OqNvi">
-                            <node concept="1bVj0M" id="4Pi6J8Cbqvm" role="23t8la">
-                              <node concept="3clFbS" id="4Pi6J8Cbqvn" role="1bW5cS">
-                                <node concept="3clFbF" id="4Pi6J8Cbqvo" role="3cqZAp">
-                                  <node concept="2OqwBi" id="4Pi6J8Cbqvp" role="3clFbG">
-                                    <node concept="37vLTw" id="4Pi6J8Cbqvq" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="4Pi6J8Cbqvs" resolve="it" />
-                                    </node>
-                                    <node concept="liA8E" id="4Pi6J8Cbqvr" role="2OqNvi">
-                                      <ref role="37wK5l" to="exr9:~EditorComponent.update()" resolve="update" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="Rh6nW" id="4Pi6J8Cbqvs" role="1bW2Oz">
-                                <property role="TrG5h" value="it" />
-                                <node concept="2jxLKc" id="4Pi6J8Cbqvt" role="1tU5fm" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="2OqwBi" id="6$exEYdVUGB" role="2Oq$k0">
-                            <node concept="3zZkjj" id="6$exEYdVUGC" role="2OqNvi">
-                              <node concept="1bVj0M" id="6$exEYdVUGD" role="23t8la">
-                                <node concept="3clFbS" id="6$exEYdVUGE" role="1bW5cS">
-                                  <node concept="3clFbF" id="6$exEYdVUGF" role="3cqZAp">
-                                    <node concept="3clFbC" id="6$exEYdVUGG" role="3clFbG">
-                                      <node concept="2OqwBi" id="6$exEYdVUGH" role="3uHU7B">
-                                        <node concept="37vLTw" id="6$exEYdVUGI" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="6$exEYdVUGL" resolve="it" />
-                                        </node>
-                                        <node concept="liA8E" id="6$exEYdVUGJ" role="2OqNvi">
-                                          <ref role="37wK5l" to="exr9:~EditorComponent.getEditedNode()" resolve="getEditedNode" />
-                                        </node>
-                                      </node>
-                                      <node concept="37vLTw" id="6$exEYdVUGK" role="3uHU7w">
-                                        <ref role="3cqZAo" node="4Pi6J8CbquR" resolve="cr" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="Rh6nW" id="6$exEYdVUGL" role="1bW2Oz">
-                                  <property role="TrG5h" value="it" />
-                                  <node concept="2jxLKc" id="6$exEYdVUGM" role="1tU5fm" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="2YIFZM" id="6$exEYdVUGN" role="2Oq$k0">
-                              <ref role="37wK5l" to="kvq8:2WlJ6VKOSU7" resolve="findAllInstances" />
-                              <ref role="1Pybhc" to="kvq8:2WlJ6VKOwRU" resolve="EditorComponentHacks" />
                             </node>
                           </node>
                         </node>
@@ -955,66 +886,15 @@
                           </node>
                         </node>
                       </node>
-                      <node concept="3clFbF" id="4bmM0avMBSo" role="3cqZAp">
-                        <node concept="2OqwBi" id="4bmM0avMBSp" role="3clFbG">
-                          <node concept="2OqwBi" id="4bmM0avMCpa" role="2Oq$k0">
-                            <node concept="2YIFZM" id="4bmM0avMBSq" role="2Oq$k0">
-                              <ref role="37wK5l" to="kvq8:2WlJ6VKOSU7" resolve="findAllInstances" />
-                              <ref role="1Pybhc" to="kvq8:2WlJ6VKOwRU" resolve="EditorComponentHacks" />
-                            </node>
-                            <node concept="3zZkjj" id="4bmM0avMD33" role="2OqNvi">
-                              <node concept="1bVj0M" id="4bmM0avMD35" role="23t8la">
-                                <node concept="3clFbS" id="4bmM0avMD36" role="1bW5cS">
-                                  <node concept="3clFbF" id="4bmM0avMDa8" role="3cqZAp">
-                                    <node concept="3clFbC" id="4bmM0avMEZG" role="3clFbG">
-                                      <node concept="2OqwBi" id="4bmM0avMKFI" role="3uHU7w">
-                                        <node concept="2WthIp" id="4bmM0avMK_R" role="2Oq$k0" />
-                                        <node concept="3gHZIF" id="4bmM0avMKO6" role="2OqNvi">
-                                          <ref role="2WH_rO" node="4bmM0avMBS$" resolve="root" />
-                                        </node>
-                                      </node>
-                                      <node concept="2OqwBi" id="4bmM0avMDVv" role="3uHU7B">
-                                        <node concept="2OqwBi" id="4bmM0avMDin" role="2Oq$k0">
-                                          <node concept="37vLTw" id="4bmM0avMDa7" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="4bmM0avMD37" resolve="it" />
-                                          </node>
-                                          <node concept="liA8E" id="4bmM0avMDQn" role="2OqNvi">
-                                            <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
-                                          </node>
-                                        </node>
-                                        <node concept="liA8E" id="4bmM0avME3w" role="2OqNvi">
-                                          <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="Rh6nW" id="4bmM0avMD37" role="1bW2Oz">
-                                  <property role="TrG5h" value="it" />
-                                  <node concept="2jxLKc" id="4bmM0avMD38" role="1tU5fm" />
-                                </node>
-                              </node>
-                            </node>
+                      <node concept="3clFbF" id="3JvidvJxk7I" role="3cqZAp">
+                        <node concept="2YIFZM" id="3JvidvJxk7J" role="3clFbG">
+                          <ref role="37wK5l" to="gdgh:3JvidvJx5Pp" resolve="updateEditors" />
+                          <ref role="1Pybhc" to="gdgh:3JvidvJwDTf" resolve="RunManuallyUtil" />
+                          <node concept="37vLTw" id="3JvidvJxk7K" role="37wK5m">
+                            <ref role="3cqZAo" node="53f0GWHVRQg" resolve="context" />
                           </node>
-                          <node concept="2es0OD" id="4bmM0avMBSr" role="2OqNvi">
-                            <node concept="1bVj0M" id="4bmM0avMBSs" role="23t8la">
-                              <node concept="3clFbS" id="4bmM0avMBSt" role="1bW5cS">
-                                <node concept="3clFbF" id="4bmM0avMBSu" role="3cqZAp">
-                                  <node concept="2OqwBi" id="4bmM0avMBSv" role="3clFbG">
-                                    <node concept="37vLTw" id="4bmM0avMBSw" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="4bmM0avMBSy" resolve="it" />
-                                    </node>
-                                    <node concept="liA8E" id="4bmM0avMBSx" role="2OqNvi">
-                                      <ref role="37wK5l" to="exr9:~EditorComponent.update()" resolve="update" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="Rh6nW" id="4bmM0avMBSy" role="1bW2Oz">
-                                <property role="TrG5h" value="it" />
-                                <node concept="2jxLKc" id="4bmM0avMBSz" role="1tU5fm" />
-                              </node>
-                            </node>
+                          <node concept="37vLTw" id="3JvidvJxk7L" role="37wK5m">
+                            <ref role="3cqZAo" node="4bmM0avMH1U" resolve="manuals" />
                           </node>
                         </node>
                       </node>
@@ -1263,31 +1143,15 @@
                           </node>
                         </node>
                       </node>
-                      <node concept="3clFbF" id="3HmE5WaYae_" role="3cqZAp">
-                        <node concept="2OqwBi" id="3HmE5WaYaeA" role="3clFbG">
-                          <node concept="2YIFZM" id="3HmE5WaYaeC" role="2Oq$k0">
-                            <ref role="37wK5l" to="kvq8:2WlJ6VKOSU7" resolve="findAllInstances" />
-                            <ref role="1Pybhc" to="kvq8:2WlJ6VKOwRU" resolve="EditorComponentHacks" />
+                      <node concept="3clFbF" id="3JvidvJxhbz" role="3cqZAp">
+                        <node concept="2YIFZM" id="3JvidvJxhw$" role="3clFbG">
+                          <ref role="37wK5l" to="gdgh:3JvidvJx5Pp" resolve="updateEditors" />
+                          <ref role="1Pybhc" to="gdgh:3JvidvJwDTf" resolve="RunManuallyUtil" />
+                          <node concept="37vLTw" id="3JvidvJxhLL" role="37wK5m">
+                            <ref role="3cqZAo" node="53f0GWHVUTa" resolve="context" />
                           </node>
-                          <node concept="2es0OD" id="3HmE5WaYaeS" role="2OqNvi">
-                            <node concept="1bVj0M" id="3HmE5WaYaeT" role="23t8la">
-                              <node concept="3clFbS" id="3HmE5WaYaeU" role="1bW5cS">
-                                <node concept="3clFbF" id="3HmE5WaYaeV" role="3cqZAp">
-                                  <node concept="2OqwBi" id="3HmE5WaYaeW" role="3clFbG">
-                                    <node concept="37vLTw" id="3HmE5WaYaeX" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="3HmE5WaYaeZ" resolve="it" />
-                                    </node>
-                                    <node concept="liA8E" id="3HmE5WaYaeY" role="2OqNvi">
-                                      <ref role="37wK5l" to="exr9:~EditorComponent.update()" resolve="update" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="Rh6nW" id="3HmE5WaYaeZ" role="1bW2Oz">
-                                <property role="TrG5h" value="it" />
-                                <node concept="2jxLKc" id="3HmE5WaYaf0" role="1tU5fm" />
-                              </node>
-                            </node>
+                          <node concept="37vLTw" id="3JvidvJxip0" role="37wK5m">
+                            <ref role="3cqZAo" node="3HmE5WaYmiA" resolve="manuals" />
                           </node>
                         </node>
                       </node>
@@ -1448,78 +1312,15 @@
                           </node>
                         </node>
                       </node>
-                      <node concept="3cpWs8" id="TuTPrvRoFt" role="3cqZAp">
-                        <node concept="3cpWsn" id="TuTPrvRoFu" role="3cpWs9">
-                          <property role="TrG5h" value="cr" />
-                          <node concept="3Tqbb2" id="TuTPrvRoFv" role="1tU5fm" />
-                          <node concept="2OqwBi" id="TuTPrvRoFw" role="33vP2m">
-                            <node concept="2OqwBi" id="TuTPrvRC5_" role="2Oq$k0">
-                              <node concept="2WthIp" id="TuTPrvRBN$" role="2Oq$k0" />
-                              <node concept="3gHZIF" id="TuTPrvRCDt" role="2OqNvi">
-                                <ref role="2WH_rO" node="TuTPrvRoFX" resolve="selected" />
-                              </node>
-                            </node>
-                            <node concept="2Rxl7S" id="TuTPrvRoFy" role="2OqNvi" />
+                      <node concept="3clFbF" id="3JvidvJxlnK" role="3cqZAp">
+                        <node concept="2YIFZM" id="3JvidvJxlnL" role="3clFbG">
+                          <ref role="37wK5l" to="gdgh:3JvidvJx5Pp" resolve="updateEditors" />
+                          <ref role="1Pybhc" to="gdgh:3JvidvJwDTf" resolve="RunManuallyUtil" />
+                          <node concept="37vLTw" id="3JvidvJxlnM" role="37wK5m">
+                            <ref role="3cqZAo" node="53f0GWHVzdy" resolve="context" />
                           </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbF" id="TuTPrvRoFz" role="3cqZAp">
-                        <node concept="2OqwBi" id="TuTPrvRoF$" role="3clFbG">
-                          <node concept="2OqwBi" id="TuTPrvRoF_" role="2Oq$k0">
-                            <node concept="2YIFZM" id="TuTPrvRoFA" role="2Oq$k0">
-                              <ref role="37wK5l" to="kvq8:2WlJ6VKOSU7" resolve="findAllInstances" />
-                              <ref role="1Pybhc" to="kvq8:2WlJ6VKOwRU" resolve="EditorComponentHacks" />
-                            </node>
-                            <node concept="3zZkjj" id="TuTPrvRoFB" role="2OqNvi">
-                              <node concept="1bVj0M" id="TuTPrvRoFC" role="23t8la">
-                                <node concept="3clFbS" id="TuTPrvRoFD" role="1bW5cS">
-                                  <node concept="3clFbF" id="TuTPrvRoFE" role="3cqZAp">
-                                    <node concept="3clFbC" id="TuTPrvRoFF" role="3clFbG">
-                                      <node concept="37vLTw" id="TuTPrvRoFG" role="3uHU7w">
-                                        <ref role="3cqZAo" node="TuTPrvRoFu" resolve="cr" />
-                                      </node>
-                                      <node concept="2OqwBi" id="TuTPrvRoFH" role="3uHU7B">
-                                        <node concept="2OqwBi" id="TuTPrvRoFI" role="2Oq$k0">
-                                          <node concept="37vLTw" id="TuTPrvRoFJ" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="TuTPrvRoFM" resolve="it" />
-                                          </node>
-                                          <node concept="liA8E" id="TuTPrvRoFK" role="2OqNvi">
-                                            <ref role="37wK5l" to="exr9:~EditorComponent.getRootCell()" resolve="getRootCell" />
-                                          </node>
-                                        </node>
-                                        <node concept="liA8E" id="TuTPrvRoFL" role="2OqNvi">
-                                          <ref role="37wK5l" to="f4zo:~EditorCell.getSNode()" resolve="getSNode" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="Rh6nW" id="TuTPrvRoFM" role="1bW2Oz">
-                                  <property role="TrG5h" value="it" />
-                                  <node concept="2jxLKc" id="TuTPrvRoFN" role="1tU5fm" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="2es0OD" id="TuTPrvRoFO" role="2OqNvi">
-                            <node concept="1bVj0M" id="TuTPrvRoFP" role="23t8la">
-                              <node concept="3clFbS" id="TuTPrvRoFQ" role="1bW5cS">
-                                <node concept="3clFbF" id="TuTPrvRoFR" role="3cqZAp">
-                                  <node concept="2OqwBi" id="TuTPrvRoFS" role="3clFbG">
-                                    <node concept="37vLTw" id="TuTPrvRoFT" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="TuTPrvRoFV" resolve="it" />
-                                    </node>
-                                    <node concept="liA8E" id="TuTPrvRoFU" role="2OqNvi">
-                                      <ref role="37wK5l" to="exr9:~EditorComponent.update()" resolve="update" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="Rh6nW" id="TuTPrvRoFV" role="1bW2Oz">
-                                <property role="TrG5h" value="it" />
-                                <node concept="2jxLKc" id="TuTPrvRoFW" role="1tU5fm" />
-                              </node>
-                            </node>
+                          <node concept="37vLTw" id="3JvidvJxmBD" role="37wK5m">
+                            <ref role="3cqZAo" node="TuTPrvR$bE" resolve="manuallyRunNodes" />
                           </node>
                         </node>
                       </node>


### PR DESCRIPTION
I introduce an additional method `performAdditionalEditorUpdate` in `ICanRunCheckManually` where concepts can contribute further editor updates such as displaying the test result in the error stripe.
Also the editor is updated now only once after all checks are done.
This is a big performance improvement for huge test suites such as [collections](http://127.0.0.1:63320/node?ref=r%3A2309ed17-e7b4-45b5-b25e-2c0f3ea87e8b%28test.in.expr.os.collections%40tests%29%2F7740953487930555503).