### PR TITLE
Fix substitution menu of various tables + small fixes for LookupTable

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
@@ -134,6 +134,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -169,6 +170,9 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
@@ -268,6 +272,7 @@
       </concept>
       <concept id="7946551912908713904" name="de.slisson.mps.tables.structure.SubstituteNodeFunction" flags="ig" index="3om3PG">
         <reference id="8767719180164875849" name="cellRootConcept" index="1xHBhH" />
+        <reference id="8767719180164876002" name="conceptForMenu" index="1xHBj6" />
       </concept>
       <concept id="7946551912910240557" name="de.slisson.mps.tables.structure.SubstituteNodeFunction_NewValue" flags="ng" index="3oseBL" />
       <concept id="1515263624310660132" name="de.slisson.mps.tables.structure.HeaderQuery_Delete" flags="ig" index="3x7d0o" />
@@ -291,6 +296,14 @@
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
@@ -298,6 +311,7 @@
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
+      <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -332,6 +346,7 @@
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="3055999550620853964" name="jetbrains.mps.baseLanguage.collections.structure.RemoveWhereOperation" flags="nn" index="1aUR6E" />
       <concept id="1225621920911" name="jetbrains.mps.baseLanguage.collections.structure.InsertElementOperation" flags="nn" index="1sK_Qi">
         <child id="1225621943565" name="element" index="1sKFgg" />
         <child id="1225621960341" name="index" index="1sKJu8" />
@@ -736,7 +751,8 @@
             </node>
           </node>
           <node concept="3om3PG" id="4_sn_QHmQrX" role="3ot9go">
-            <ref role="1xHBhH" to="hm2y:6sdnDbSla17" resolve="Expression" />
+            <ref role="1xHBhH" to="tpck:gw2VY9q" resolve="BaseConcept" />
+            <ref role="1xHBj6" to="hm2y:6sdnDbSla17" resolve="Expression" />
             <node concept="3clFbS" id="4_sn_QHmQrY" role="2VODD2">
               <node concept="3cpWs8" id="4_sn_QHnvmi" role="3cqZAp">
                 <node concept="3cpWsn" id="4_sn_QHnvmj" role="3cpWs9">
@@ -765,37 +781,182 @@
               </node>
               <node concept="3clFbJ" id="4_sn_QHnvm$" role="3cqZAp">
                 <node concept="3clFbS" id="4_sn_QHnvm_" role="3clFbx">
-                  <node concept="3clFbF" id="4_sn_QHnvmA" role="3cqZAp">
-                    <node concept="2OqwBi" id="4_sn_QHnvmB" role="3clFbG">
-                      <node concept="2OqwBi" id="4_sn_QHnvmC" role="2Oq$k0">
-                        <node concept="37vLTw" id="4_sn_QHnvmD" role="2Oq$k0">
-                          <ref role="3cqZAo" node="4_sn_QHnvms" resolve="row" />
-                        </node>
-                        <node concept="3Tsc0h" id="cPLa7FqjLa" role="2OqNvi">
-                          <ref role="3TtcxE" to="e9k1:cPLa7FpcRm" resolve="cells" />
-                        </node>
-                      </node>
-                      <node concept="TSZUe" id="4_sn_QHnvmF" role="2OqNvi">
-                        <node concept="2pJPEk" id="4_sn_QHnvmG" role="25WWJ7">
-                          <node concept="2pJPED" id="4_sn_QHnvmH" role="2pJPEn">
-                            <ref role="2pJxaS" to="e9k1:cPLa7FpcCS" resolve="DataCell" />
-                            <node concept="2pIpSj" id="4_sn_QHnvmI" role="2pJxcM">
-                              <ref role="2pIpSl" to="e9k1:cPLa7FpdsY" resolve="col" />
-                              <node concept="36biLy" id="4_sn_QHnvmJ" role="28nt2d">
-                                <node concept="37vLTw" id="4_sn_QHnvmK" role="36biLW">
-                                  <ref role="3cqZAo" node="4_sn_QHnvmj" resolve="ch" />
+                  <node concept="Jncv_" id="1tbxNVtwfAT" role="3cqZAp">
+                    <ref role="JncvD" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                    <node concept="3oseBL" id="1tbxNVtwfJ7" role="JncvB" />
+                    <node concept="3clFbS" id="1tbxNVtwfAX" role="Jncv$">
+                      <node concept="3clFbF" id="1tbxNVtwntr" role="3cqZAp">
+                        <node concept="2OqwBi" id="1tbxNVtwq5l" role="3clFbG">
+                          <node concept="2OqwBi" id="1tbxNVtwnQM" role="2Oq$k0">
+                            <node concept="37vLTw" id="1tbxNVtwntp" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4_sn_QHnvms" resolve="row" />
+                            </node>
+                            <node concept="3Tsc0h" id="1tbxNVtwow3" role="2OqNvi">
+                              <ref role="3TtcxE" to="e9k1:cPLa7FpcRm" resolve="cells" />
+                            </node>
+                          </node>
+                          <node concept="1aUR6E" id="1tbxNVtwt0q" role="2OqNvi">
+                            <node concept="1bVj0M" id="1tbxNVtwt0s" role="23t8la">
+                              <node concept="3clFbS" id="1tbxNVtwt0t" role="1bW5cS">
+                                <node concept="3clFbF" id="1tbxNVtwvxU" role="3cqZAp">
+                                  <node concept="17R0WA" id="1tbxNVtwBlb" role="3clFbG">
+                                    <node concept="37vLTw" id="1tbxNVtwDKw" role="3uHU7w">
+                                      <ref role="3cqZAo" node="4_sn_QHnvmj" resolve="ch" />
+                                    </node>
+                                    <node concept="2OqwBi" id="1tbxNVtwy5H" role="3uHU7B">
+                                      <node concept="37vLTw" id="1tbxNVtwvxT" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="1tbxNVtwt0u" resolve="it" />
+                                      </node>
+                                      <node concept="3TrEf2" id="1tbxNVtw$Fs" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="e9k1:cPLa7FpdsY" resolve="col" />
+                                      </node>
+                                    </node>
+                                  </node>
                                 </node>
                               </node>
-                            </node>
-                            <node concept="2pIpSj" id="4_sn_QHnvmL" role="2pJxcM">
-                              <ref role="2pIpSl" to="e9k1:cPLa7Fpe9f" resolve="value" />
-                              <node concept="36biLy" id="4_sn_QHnvmN" role="28nt2d">
-                                <node concept="3oseBL" id="4_sn_QHnvmO" role="36biLW" />
+                              <node concept="Rh6nW" id="1tbxNVtwt0u" role="1bW2Oz">
+                                <property role="TrG5h" value="it" />
+                                <node concept="2jxLKc" id="1tbxNVtwt0v" role="1tU5fm" />
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
+                      <node concept="3clFbF" id="4_sn_QHnvmA" role="3cqZAp">
+                        <node concept="2OqwBi" id="4_sn_QHnvmB" role="3clFbG">
+                          <node concept="2OqwBi" id="4_sn_QHnvmC" role="2Oq$k0">
+                            <node concept="37vLTw" id="4_sn_QHnvmD" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4_sn_QHnvms" resolve="row" />
+                            </node>
+                            <node concept="3Tsc0h" id="cPLa7FqjLa" role="2OqNvi">
+                              <ref role="3TtcxE" to="e9k1:cPLa7FpcRm" resolve="cells" />
+                            </node>
+                          </node>
+                          <node concept="TSZUe" id="4_sn_QHnvmF" role="2OqNvi">
+                            <node concept="2pJPEk" id="4_sn_QHnvmG" role="25WWJ7">
+                              <node concept="2pJPED" id="4_sn_QHnvmH" role="2pJPEn">
+                                <ref role="2pJxaS" to="e9k1:cPLa7FpcCS" resolve="DataCell" />
+                                <node concept="2pIpSj" id="4_sn_QHnvmI" role="2pJxcM">
+                                  <ref role="2pIpSl" to="e9k1:cPLa7FpdsY" resolve="col" />
+                                  <node concept="36biLy" id="4_sn_QHnvmJ" role="28nt2d">
+                                    <node concept="37vLTw" id="4_sn_QHnvmK" role="36biLW">
+                                      <ref role="3cqZAo" node="4_sn_QHnvmj" resolve="ch" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="2pIpSj" id="4_sn_QHnvmL" role="2pJxcM">
+                                  <ref role="2pIpSl" to="e9k1:cPLa7Fpe9f" resolve="value" />
+                                  <node concept="36biLy" id="4_sn_QHnvmN" role="28nt2d">
+                                    <node concept="2OqwBi" id="1tbxNVtwhP6" role="36biLW">
+                                      <node concept="Jnkvi" id="1tbxNVtwhyA" role="2Oq$k0">
+                                        <ref role="1M0zk5" node="1tbxNVtwfAZ" resolve="expr" />
+                                      </node>
+                                      <node concept="1$rogu" id="1tbxNVtwifW" role="2OqNvi" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="JncvC" id="1tbxNVtwfAZ" role="JncvA">
+                      <property role="TrG5h" value="expr" />
+                      <node concept="2jxLKc" id="1tbxNVtwfB0" role="1tU5fm" />
+                    </node>
+                  </node>
+                  <node concept="Jncv_" id="1tbxNVtwiuL" role="3cqZAp">
+                    <ref role="JncvD" to="e9k1:cPLa7FpcCS" resolve="DataCell" />
+                    <node concept="3oseBL" id="1tbxNVtwiuM" role="JncvB" />
+                    <node concept="3clFbS" id="1tbxNVtwiuN" role="Jncv$">
+                      <node concept="3cpWs8" id="1tbxNVtwkB_" role="3cqZAp">
+                        <node concept="3cpWsn" id="1tbxNVtwkBC" role="3cpWs9">
+                          <property role="TrG5h" value="newDataCell" />
+                          <node concept="3Tqbb2" id="1tbxNVtwkBz" role="1tU5fm">
+                            <ref role="ehGHo" to="e9k1:cPLa7FpcCS" resolve="DataCell" />
+                          </node>
+                          <node concept="2OqwBi" id="1tbxNVtwmx0" role="33vP2m">
+                            <node concept="Jnkvi" id="1tbxNVtwm87" role="2Oq$k0">
+                              <ref role="1M0zk5" node="1tbxNVtwiv4" resolve="dataCell" />
+                            </node>
+                            <node concept="1$rogu" id="1tbxNVtwmWG" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="1tbxNVtx124" role="3cqZAp">
+                        <node concept="37vLTI" id="1tbxNVtxfol" role="3clFbG">
+                          <node concept="37vLTw" id="1tbxNVtxjXr" role="37vLTx">
+                            <ref role="3cqZAo" node="4_sn_QHnvmj" resolve="ch" />
+                          </node>
+                          <node concept="2OqwBi" id="1tbxNVtx5D5" role="37vLTJ">
+                            <node concept="37vLTw" id="1tbxNVtx122" role="2Oq$k0">
+                              <ref role="3cqZAo" node="1tbxNVtwkBC" resolve="newDataCell" />
+                            </node>
+                            <node concept="3TrEf2" id="1tbxNVtxaln" role="2OqNvi">
+                              <ref role="3Tt5mk" to="e9k1:cPLa7FpdsY" resolve="col" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="1tbxNVtwIRC" role="3cqZAp">
+                        <node concept="2OqwBi" id="1tbxNVtwIRE" role="3clFbG">
+                          <node concept="2OqwBi" id="1tbxNVtwIRF" role="2Oq$k0">
+                            <node concept="37vLTw" id="1tbxNVtwIRG" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4_sn_QHnvms" resolve="row" />
+                            </node>
+                            <node concept="3Tsc0h" id="1tbxNVtwIRH" role="2OqNvi">
+                              <ref role="3TtcxE" to="e9k1:cPLa7FpcRm" resolve="cells" />
+                            </node>
+                          </node>
+                          <node concept="1aUR6E" id="1tbxNVtwIRI" role="2OqNvi">
+                            <node concept="1bVj0M" id="1tbxNVtwIRJ" role="23t8la">
+                              <node concept="3clFbS" id="1tbxNVtwIRK" role="1bW5cS">
+                                <node concept="3clFbF" id="1tbxNVtwIRL" role="3cqZAp">
+                                  <node concept="17R0WA" id="1tbxNVtwIRM" role="3clFbG">
+                                    <node concept="37vLTw" id="1tbxNVtwIRN" role="3uHU7w">
+                                      <ref role="3cqZAo" node="4_sn_QHnvmj" resolve="ch" />
+                                    </node>
+                                    <node concept="2OqwBi" id="1tbxNVtwIRO" role="3uHU7B">
+                                      <node concept="37vLTw" id="1tbxNVtwIRP" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="1tbxNVtwIRR" resolve="it" />
+                                      </node>
+                                      <node concept="3TrEf2" id="1tbxNVtwIRQ" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="e9k1:cPLa7FpdsY" resolve="col" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="Rh6nW" id="1tbxNVtwIRR" role="1bW2Oz">
+                                <property role="TrG5h" value="it" />
+                                <node concept="2jxLKc" id="1tbxNVtwIRS" role="1tU5fm" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="1tbxNVtwiuO" role="3cqZAp">
+                        <node concept="2OqwBi" id="1tbxNVtwiuP" role="3clFbG">
+                          <node concept="2OqwBi" id="1tbxNVtwiuQ" role="2Oq$k0">
+                            <node concept="37vLTw" id="1tbxNVtwiuR" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4_sn_QHnvms" resolve="row" />
+                            </node>
+                            <node concept="3Tsc0h" id="1tbxNVtwiuS" role="2OqNvi">
+                              <ref role="3TtcxE" to="e9k1:cPLa7FpcRm" resolve="cells" />
+                            </node>
+                          </node>
+                          <node concept="TSZUe" id="1tbxNVtwiuT" role="2OqNvi">
+                            <node concept="37vLTw" id="1tbxNVtxt2H" role="25WWJ7">
+                              <ref role="3cqZAo" node="1tbxNVtwkBC" resolve="newDataCell" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="JncvC" id="1tbxNVtwiv4" role="JncvA">
+                      <property role="TrG5h" value="dataCell" />
+                      <node concept="2jxLKc" id="1tbxNVtwiv5" role="1tU5fm" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lookup/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lookup/models/constraints.mps
@@ -72,7 +72,9 @@
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
-      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
@@ -82,24 +84,25 @@
     <ref role="1M2myG" to="8qwc:55lPkJH1wUe" resolve="LookupTarget" />
     <node concept="9S07l" id="55lPkJH1ECh" role="9Vyp8">
       <node concept="3clFbS" id="55lPkJH1ECi" role="2VODD2">
-        <node concept="3clFbF" id="55lPkJH1EJx" role="3cqZAp">
-          <node concept="2OqwBi" id="55lPkJH1HYY" role="3clFbG">
-            <node concept="2OqwBi" id="55lPkJH1GrJ" role="2Oq$k0">
-              <node concept="2OqwBi" id="55lPkJH1Fvs" role="2Oq$k0">
-                <node concept="1PxgMI" id="55lPkJH1F1J" role="2Oq$k0">
-                  <node concept="chp4Y" id="55lPkJH1F9s" role="3oSUPX">
+        <node concept="3clFbF" id="1tbxNVtFa_r" role="3cqZAp">
+          <node concept="2OqwBi" id="1tbxNVtFckv" role="3clFbG">
+            <node concept="2OqwBi" id="1tbxNVtFbWJ" role="2Oq$k0">
+              <node concept="2OqwBi" id="1tbxNVtFbk5" role="2Oq$k0">
+                <node concept="1PxgMI" id="1tbxNVtFaIV" role="2Oq$k0">
+                  <property role="1BlNFB" value="true" />
+                  <node concept="chp4Y" id="1tbxNVtFaTH" role="3oSUPX">
                     <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
                   </node>
-                  <node concept="nLn13" id="55lPkJH1EJw" role="1m5AlR" />
+                  <node concept="nLn13" id="1tbxNVtFaSM" role="1m5AlR" />
                 </node>
-                <node concept="3TrEf2" id="55lPkJH1FRw" role="2OqNvi">
+                <node concept="3TrEf2" id="1tbxNVtFbIj" role="2OqNvi">
                   <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
                 </node>
               </node>
-              <node concept="3JvlWi" id="55lPkJH1Hyn" role="2OqNvi" />
+              <node concept="3JvlWi" id="1tbxNVtFcca" role="2OqNvi" />
             </node>
-            <node concept="1mIQ4w" id="55lPkJH1IkA" role="2OqNvi">
-              <node concept="chp4Y" id="55lPkJH1I$$" role="cj9EA">
+            <node concept="1mIQ4w" id="1tbxNVtFcsH" role="2OqNvi">
+              <node concept="chp4Y" id="1tbxNVtFcxk" role="cj9EA">
                 <ref role="cht4Q" to="8qwc:55lPkJGZwPb" resolve="LookupTableType" />
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lookup/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lookup/models/editor.mps
@@ -57,6 +57,10 @@
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
@@ -76,6 +80,8 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -111,6 +117,9 @@
         <child id="1163668914799" name="condition" index="3K4Cdx" />
         <child id="1163668922816" name="ifTrue" index="3K4E3e" />
         <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
       </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
@@ -193,6 +202,7 @@
       <concept id="6097863121587719264" name="de.slisson.mps.tables.structure.GridPostprocessor" flags="ig" index="3nFNDj" />
       <concept id="7946551912908713904" name="de.slisson.mps.tables.structure.SubstituteNodeFunction" flags="ig" index="3om3PG">
         <reference id="8767719180164875849" name="cellRootConcept" index="1xHBhH" />
+        <reference id="8767719180164876002" name="conceptForMenu" index="1xHBj6" />
       </concept>
       <concept id="7946551912910240557" name="de.slisson.mps.tables.structure.SubstituteNodeFunction_NewValue" flags="ng" index="3oseBL" />
       <concept id="1450914667648882274" name="de.slisson.mps.tables.structure.QueryParameter_Grid" flags="ng" index="3wJN_h" />
@@ -202,7 +212,16 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt" />
+      <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -239,6 +258,7 @@
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="3055999550620853964" name="jetbrains.mps.baseLanguage.collections.structure.RemoveWhereOperation" flags="nn" index="1aUR6E" />
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
@@ -400,7 +420,8 @@
               </node>
               <node concept="1g0IQG" id="55lPkJGGNw_" role="1geGt4" />
               <node concept="3om3PG" id="55lPkJGKbWk" role="3ot9go">
-                <ref role="1xHBhH" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                <ref role="1xHBhH" to="tpck:gw2VY9q" resolve="BaseConcept" />
+                <ref role="1xHBj6" to="hm2y:6sdnDbSla17" resolve="Expression" />
                 <node concept="3clFbS" id="55lPkJGKbWl" role="2VODD2">
                   <node concept="3cpWs8" id="3DYDRw0KtmC" role="3cqZAp">
                     <node concept="3cpWsn" id="3DYDRw0KtmD" role="3cpWs9">
@@ -442,43 +463,222 @@
                   </node>
                   <node concept="3clFbJ" id="3DYDRw0KtfD" role="3cqZAp">
                     <node concept="3clFbS" id="3DYDRw0KtfE" role="3clFbx">
-                      <node concept="3clFbF" id="3DYDRw0LC29" role="3cqZAp">
-                        <node concept="2OqwBi" id="3DYDRw0LCJb" role="3clFbG">
-                          <node concept="2OqwBi" id="3DYDRw0LC6z" role="2Oq$k0">
-                            <node concept="2r2w_c" id="3DYDRw0LC27" role="2Oq$k0" />
-                            <node concept="3Tsc0h" id="55lPkJGKjrz" role="2OqNvi">
-                              <ref role="3TtcxE" to="8qwc:55lPkJGINeh" resolve="cells" />
-                            </node>
-                          </node>
-                          <node concept="TSZUe" id="3DYDRw0LDNq" role="2OqNvi">
-                            <node concept="2pJPEk" id="3DYDRw0M6OE" role="25WWJ7">
-                              <node concept="2pJPED" id="3DYDRw0M6Zv" role="2pJPEn">
-                                <ref role="2pJxaS" to="8qwc:55lPkJGIN9r" resolve="LookupTableCell" />
-                                <node concept="2pIpSj" id="3DYDRw0M7Z8" role="2pJxcM">
-                                  <ref role="2pIpSl" to="8qwc:55lPkJGINbj" resolve="row" />
-                                  <node concept="36biLy" id="3DYDRw0M89G" role="28nt2d">
-                                    <node concept="37vLTw" id="3DYDRw0M8_u" role="36biLW">
-                                      <ref role="3cqZAo" node="3DYDRw0KtmM" resolve="rh" />
+                      <node concept="Jncv_" id="1tbxNVt_Oy1" role="3cqZAp">
+                        <ref role="JncvD" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                        <node concept="3oseBL" id="1tbxNVt_OGq" role="JncvB" />
+                        <node concept="3clFbS" id="1tbxNVt_Oy5" role="Jncv$">
+                          <node concept="3clFbF" id="1tbxNVtC0_r" role="3cqZAp">
+                            <node concept="2OqwBi" id="1tbxNVtC0_t" role="3clFbG">
+                              <node concept="2OqwBi" id="1tbxNVtC0_u" role="2Oq$k0">
+                                <node concept="2r2w_c" id="1tbxNVtC0_v" role="2Oq$k0" />
+                                <node concept="3Tsc0h" id="1tbxNVtC0_w" role="2OqNvi">
+                                  <ref role="3TtcxE" to="8qwc:55lPkJGINeh" resolve="cells" />
+                                </node>
+                              </node>
+                              <node concept="1aUR6E" id="1tbxNVtC0_x" role="2OqNvi">
+                                <node concept="1bVj0M" id="1tbxNVtC0_y" role="23t8la">
+                                  <node concept="3clFbS" id="1tbxNVtC0_z" role="1bW5cS">
+                                    <node concept="3clFbF" id="1tbxNVtC0_$" role="3cqZAp">
+                                      <node concept="1Wc70l" id="1tbxNVtC0__" role="3clFbG">
+                                        <node concept="17R0WA" id="1tbxNVtC0_A" role="3uHU7B">
+                                          <node concept="2OqwBi" id="1tbxNVtC0_B" role="3uHU7B">
+                                            <node concept="37vLTw" id="1tbxNVtC0_C" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="1tbxNVtC0_K" resolve="it" />
+                                            </node>
+                                            <node concept="3TrEf2" id="1tbxNVtC0_D" role="2OqNvi">
+                                              <ref role="3Tt5mk" to="8qwc:55lPkJGINbj" resolve="row" />
+                                            </node>
+                                          </node>
+                                          <node concept="37vLTw" id="1tbxNVtC0_E" role="3uHU7w">
+                                            <ref role="3cqZAo" node="3DYDRw0KtmM" resolve="rh" />
+                                          </node>
+                                        </node>
+                                        <node concept="17R0WA" id="1tbxNVtC0_F" role="3uHU7w">
+                                          <node concept="37vLTw" id="1tbxNVtC0_G" role="3uHU7w">
+                                            <ref role="3cqZAo" node="3DYDRw0KtmD" resolve="ch" />
+                                          </node>
+                                          <node concept="2OqwBi" id="1tbxNVtC0_H" role="3uHU7B">
+                                            <node concept="37vLTw" id="1tbxNVtC0_I" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="1tbxNVtC0_K" resolve="it" />
+                                            </node>
+                                            <node concept="3TrEf2" id="1tbxNVtC0_J" role="2OqNvi">
+                                              <ref role="3Tt5mk" to="8qwc:55lPkJGINbs" resolve="col" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
                                     </node>
                                   </node>
-                                </node>
-                                <node concept="2pIpSj" id="3DYDRw0M7kg" role="2pJxcM">
-                                  <ref role="2pIpSl" to="8qwc:55lPkJGINbs" resolve="col" />
-                                  <node concept="36biLy" id="3DYDRw0M7uY" role="28nt2d">
-                                    <node concept="37vLTw" id="3DYDRw0M7DE" role="36biLW">
-                                      <ref role="3cqZAo" node="3DYDRw0KtmD" resolve="ch" />
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="2pIpSj" id="3DYDRw0M8UT" role="2pJxcM">
-                                  <ref role="2pIpSl" to="8qwc:55lPkJGINbe" resolve="val" />
-                                  <node concept="36biLy" id="3DYDRw0M95E" role="28nt2d">
-                                    <node concept="3oseBL" id="3DYDRw0M9fb" role="36biLW" />
+                                  <node concept="Rh6nW" id="1tbxNVtC0_K" role="1bW2Oz">
+                                    <property role="TrG5h" value="it" />
+                                    <node concept="2jxLKc" id="1tbxNVtC0_L" role="1tU5fm" />
                                   </node>
                                 </node>
                               </node>
                             </node>
                           </node>
+                          <node concept="3clFbF" id="1tbxNVt_Pig" role="3cqZAp">
+                            <node concept="2OqwBi" id="1tbxNVt_RV4" role="3clFbG">
+                              <node concept="2OqwBi" id="1tbxNVt_PGQ" role="2Oq$k0">
+                                <node concept="2r2w_c" id="1tbxNVt_Pif" role="2Oq$k0" />
+                                <node concept="3Tsc0h" id="1tbxNVt_Qr4" role="2OqNvi">
+                                  <ref role="3TtcxE" to="8qwc:55lPkJGINeh" resolve="cells" />
+                                </node>
+                              </node>
+                              <node concept="TSZUe" id="1tbxNVt_Ufe" role="2OqNvi">
+                                <node concept="2pJPEk" id="3DYDRw0M6OE" role="25WWJ7">
+                                  <node concept="2pJPED" id="3DYDRw0M6Zv" role="2pJPEn">
+                                    <ref role="2pJxaS" to="8qwc:55lPkJGIN9r" resolve="LookupTableCell" />
+                                    <node concept="2pIpSj" id="3DYDRw0M7Z8" role="2pJxcM">
+                                      <ref role="2pIpSl" to="8qwc:55lPkJGINbj" resolve="row" />
+                                      <node concept="36biLy" id="3DYDRw0M89G" role="28nt2d">
+                                        <node concept="37vLTw" id="3DYDRw0M8_u" role="36biLW">
+                                          <ref role="3cqZAo" node="3DYDRw0KtmM" resolve="rh" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="2pIpSj" id="3DYDRw0M7kg" role="2pJxcM">
+                                      <ref role="2pIpSl" to="8qwc:55lPkJGINbs" resolve="col" />
+                                      <node concept="36biLy" id="3DYDRw0M7uY" role="28nt2d">
+                                        <node concept="37vLTw" id="3DYDRw0M7DE" role="36biLW">
+                                          <ref role="3cqZAo" node="3DYDRw0KtmD" resolve="ch" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="2pIpSj" id="3DYDRw0M8UT" role="2pJxcM">
+                                      <ref role="2pIpSl" to="8qwc:55lPkJGINbe" resolve="val" />
+                                      <node concept="36biLy" id="3DYDRw0M95E" role="28nt2d">
+                                        <node concept="3oseBL" id="3DYDRw0M9fb" role="36biLW" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="JncvC" id="1tbxNVt_Oy7" role="JncvA">
+                          <property role="TrG5h" value="expression" />
+                          <node concept="2jxLKc" id="1tbxNVt_Oy8" role="1tU5fm" />
+                        </node>
+                      </node>
+                      <node concept="Jncv_" id="1tbxNVt_VTi" role="3cqZAp">
+                        <ref role="JncvD" to="8qwc:55lPkJGIN9r" resolve="LookupTableCell" />
+                        <node concept="3oseBL" id="1tbxNVt_W3N" role="JncvB" />
+                        <node concept="3clFbS" id="1tbxNVt_VTm" role="Jncv$">
+                          <node concept="3cpWs8" id="1tbxNVt_WWW" role="3cqZAp">
+                            <node concept="3cpWsn" id="1tbxNVt_WWZ" role="3cpWs9">
+                              <property role="TrG5h" value="newDataCell" />
+                              <node concept="3Tqbb2" id="1tbxNVt_WWV" role="1tU5fm">
+                                <ref role="ehGHo" to="8qwc:55lPkJGIN9r" resolve="LookupTableCell" />
+                              </node>
+                              <node concept="2OqwBi" id="1tbxNVt_Yi$" role="33vP2m">
+                                <node concept="Jnkvi" id="1tbxNVtBxq4" role="2Oq$k0">
+                                  <ref role="1M0zk5" node="1tbxNVt_VTo" resolve="lookupCell" />
+                                </node>
+                                <node concept="1$rogu" id="1tbxNVt_YEV" role="2OqNvi" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="1tbxNVt_YZA" role="3cqZAp">
+                            <node concept="37vLTI" id="1tbxNVtA07E" role="3clFbG">
+                              <node concept="37vLTw" id="1tbxNVtA0hH" role="37vLTx">
+                                <ref role="3cqZAo" node="3DYDRw0KtmM" resolve="rh" />
+                              </node>
+                              <node concept="2OqwBi" id="1tbxNVt_ZjE" role="37vLTJ">
+                                <node concept="37vLTw" id="1tbxNVt_YZ$" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1tbxNVt_WWZ" resolve="newDataCell" />
+                                </node>
+                                <node concept="3TrEf2" id="1tbxNVt_ZNf" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="8qwc:55lPkJGINbj" resolve="row" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="1tbxNVtA0Ao" role="3cqZAp">
+                            <node concept="37vLTI" id="1tbxNVtA1wW" role="3clFbG">
+                              <node concept="37vLTw" id="1tbxNVtA1QW" role="37vLTx">
+                                <ref role="3cqZAo" node="3DYDRw0KtmD" resolve="ch" />
+                              </node>
+                              <node concept="2OqwBi" id="1tbxNVtA0MU" role="37vLTJ">
+                                <node concept="37vLTw" id="1tbxNVtA0Am" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1tbxNVt_WWZ" resolve="newDataCell" />
+                                </node>
+                                <node concept="3TrEf2" id="1tbxNVtA0XZ" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="8qwc:55lPkJGINbs" resolve="col" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="1tbxNVtA2f3" role="3cqZAp">
+                            <node concept="2OqwBi" id="1tbxNVtA4QL" role="3clFbG">
+                              <node concept="2OqwBi" id="1tbxNVtA2BE" role="2Oq$k0">
+                                <node concept="2r2w_c" id="1tbxNVtA2f2" role="2Oq$k0" />
+                                <node concept="3Tsc0h" id="1tbxNVtA3mF" role="2OqNvi">
+                                  <ref role="3TtcxE" to="8qwc:55lPkJGINeh" resolve="cells" />
+                                </node>
+                              </node>
+                              <node concept="1aUR6E" id="1tbxNVtAc$W" role="2OqNvi">
+                                <node concept="1bVj0M" id="1tbxNVtAc$Y" role="23t8la">
+                                  <node concept="3clFbS" id="1tbxNVtAc$Z" role="1bW5cS">
+                                    <node concept="3clFbF" id="1tbxNVtAf0f" role="3cqZAp">
+                                      <node concept="1Wc70l" id="1tbxNVtBihG" role="3clFbG">
+                                        <node concept="17R0WA" id="1tbxNVtAmxZ" role="3uHU7B">
+                                          <node concept="2OqwBi" id="1tbxNVtAhvw" role="3uHU7B">
+                                            <node concept="37vLTw" id="1tbxNVtAf0e" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="1tbxNVtAc_0" resolve="it" />
+                                            </node>
+                                            <node concept="3TrEf2" id="1tbxNVtAk2o" role="2OqNvi">
+                                              <ref role="3Tt5mk" to="8qwc:55lPkJGINbj" resolve="row" />
+                                            </node>
+                                          </node>
+                                          <node concept="37vLTw" id="1tbxNVtAoY0" role="3uHU7w">
+                                            <ref role="3cqZAo" node="3DYDRw0KtmM" resolve="rh" />
+                                          </node>
+                                        </node>
+                                        <node concept="17R0WA" id="1tbxNVtADJh" role="3uHU7w">
+                                          <node concept="37vLTw" id="1tbxNVtBsw8" role="3uHU7w">
+                                            <ref role="3cqZAo" node="3DYDRw0KtmD" resolve="ch" />
+                                          </node>
+                                          <node concept="2OqwBi" id="1tbxNVtAwf3" role="3uHU7B">
+                                            <node concept="37vLTw" id="1tbxNVtAtJ_" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="1tbxNVtAc_0" resolve="it" />
+                                            </node>
+                                            <node concept="3TrEf2" id="1tbxNVtAyKV" role="2OqNvi">
+                                              <ref role="3Tt5mk" to="8qwc:55lPkJGINbs" resolve="col" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="Rh6nW" id="1tbxNVtAc_0" role="1bW2Oz">
+                                    <property role="TrG5h" value="it" />
+                                    <node concept="2jxLKc" id="1tbxNVtAc_1" role="1tU5fm" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="1tbxNVtAL0s" role="3cqZAp">
+                            <node concept="2OqwBi" id="1tbxNVtAUsh" role="3clFbG">
+                              <node concept="2OqwBi" id="1tbxNVtANBD" role="2Oq$k0">
+                                <node concept="2r2w_c" id="1tbxNVtAL0r" role="2Oq$k0" />
+                                <node concept="3Tsc0h" id="1tbxNVtAQzx" role="2OqNvi">
+                                  <ref role="3TtcxE" to="8qwc:55lPkJGINeh" resolve="cells" />
+                                </node>
+                              </node>
+                              <node concept="TSZUe" id="1tbxNVtAYV9" role="2OqNvi">
+                                <node concept="37vLTw" id="1tbxNVtB1mY" role="25WWJ7">
+                                  <ref role="3cqZAo" node="1tbxNVt_WWZ" resolve="newDataCell" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="JncvC" id="1tbxNVt_VTo" role="JncvA">
+                          <property role="TrG5h" value="lookupCell" />
+                          <node concept="2jxLKc" id="1tbxNVt_VTp" role="1tU5fm" />
                         </node>
                       </node>
                     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lookup/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lookup/models/typesystem.mps
@@ -386,65 +386,76 @@
       <node concept="3clFbH" id="55lPkJGOQMT" role="3cqZAp" />
       <node concept="3clFbJ" id="55lPkJGON6e" role="3cqZAp">
         <node concept="3clFbS" id="55lPkJGON6g" role="3clFbx">
-          <node concept="1Z5TYs" id="55lPkJGON3i" role="3cqZAp">
-            <node concept="mw_s8" id="55lPkJGON48" role="1ZfhKB">
-              <node concept="2pJPEk" id="55lPkJH15$C" role="mwGJk">
-                <node concept="2pJPED" id="55lPkJH15Of" role="2pJPEn">
-                  <ref role="2pJxaS" to="8qwc:55lPkJGZwPb" resolve="LookupTableType" />
-                  <node concept="2pIpSj" id="55lPkJH15P9" role="2pJxcM">
-                    <ref role="2pIpSl" to="8qwc:55lPkJGZxnb" resolve="rowType" />
-                    <node concept="36biLy" id="55lPkJH15PZ" role="28nt2d">
-                      <node concept="2OqwBi" id="55lPkJH17Le" role="36biLW">
-                        <node concept="2OqwBi" id="55lPkJH16bg" role="2Oq$k0">
-                          <node concept="1YBJjd" id="55lPkJH15Qg" role="2Oq$k0">
-                            <ref role="1YBMHb" node="55lPkJGOMCu" resolve="lookupTable" />
-                          </node>
-                          <node concept="3TrEf2" id="55lPkJH179S" role="2OqNvi">
-                            <ref role="3Tt5mk" to="8qwc:55lPkJGFLTi" resolve="rowType" />
+          <node concept="nvevp" id="1tbxNVtCllI" role="3cqZAp">
+            <node concept="3clFbS" id="1tbxNVtCllK" role="nvhr_">
+              <node concept="1Z5TYs" id="55lPkJGON3i" role="3cqZAp">
+                <node concept="mw_s8" id="55lPkJGON48" role="1ZfhKB">
+                  <node concept="2pJPEk" id="55lPkJH15$C" role="mwGJk">
+                    <node concept="2pJPED" id="55lPkJH15Of" role="2pJPEn">
+                      <ref role="2pJxaS" to="8qwc:55lPkJGZwPb" resolve="LookupTableType" />
+                      <node concept="2pIpSj" id="55lPkJH15P9" role="2pJxcM">
+                        <ref role="2pIpSl" to="8qwc:55lPkJGZxnb" resolve="rowType" />
+                        <node concept="36biLy" id="55lPkJH15PZ" role="28nt2d">
+                          <node concept="2OqwBi" id="55lPkJH17Le" role="36biLW">
+                            <node concept="2OqwBi" id="55lPkJH16bg" role="2Oq$k0">
+                              <node concept="1YBJjd" id="55lPkJH15Qg" role="2Oq$k0">
+                                <ref role="1YBMHb" node="55lPkJGOMCu" resolve="lookupTable" />
+                              </node>
+                              <node concept="3TrEf2" id="55lPkJH179S" role="2OqNvi">
+                                <ref role="3Tt5mk" to="8qwc:55lPkJGFLTi" resolve="rowType" />
+                              </node>
+                            </node>
+                            <node concept="1$rogu" id="55lPkJH18kw" role="2OqNvi" />
                           </node>
                         </node>
-                        <node concept="1$rogu" id="55lPkJH18kw" role="2OqNvi" />
+                      </node>
+                      <node concept="2pIpSj" id="55lPkJH18zh" role="2pJxcM">
+                        <ref role="2pIpSl" to="8qwc:55lPkJGZxng" resolve="colType" />
+                        <node concept="36biLy" id="55lPkJH18zi" role="28nt2d">
+                          <node concept="2OqwBi" id="55lPkJH18zj" role="36biLW">
+                            <node concept="2OqwBi" id="55lPkJH18zk" role="2Oq$k0">
+                              <node concept="1YBJjd" id="55lPkJH18zl" role="2Oq$k0">
+                                <ref role="1YBMHb" node="55lPkJGOMCu" resolve="lookupTable" />
+                              </node>
+                              <node concept="3TrEf2" id="55lPkJH19GH" role="2OqNvi">
+                                <ref role="3Tt5mk" to="8qwc:55lPkJGFLTn" resolve="colType" />
+                              </node>
+                            </node>
+                            <node concept="1$rogu" id="55lPkJH18zn" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2pIpSj" id="55lPkJH18CS" role="2pJxcM">
+                        <ref role="2pIpSl" to="8qwc:55lPkJGZxnp" resolve="resType" />
+                        <node concept="36biLy" id="55lPkJH18CT" role="28nt2d">
+                          <node concept="1PxgMI" id="1tbxNVtClwT" role="36biLW">
+                            <node concept="chp4Y" id="1tbxNVtClx_" role="3oSUPX">
+                              <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                            </node>
+                            <node concept="2X3wrD" id="1tbxNVtCm8$" role="1m5AlR">
+                              <ref role="2X3Bk0" node="1tbxNVtCllO" resolve="concreteResultType" />
+                            </node>
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="2pIpSj" id="55lPkJH18zh" role="2pJxcM">
-                    <ref role="2pIpSl" to="8qwc:55lPkJGZxng" resolve="colType" />
-                    <node concept="36biLy" id="55lPkJH18zi" role="28nt2d">
-                      <node concept="2OqwBi" id="55lPkJH18zj" role="36biLW">
-                        <node concept="2OqwBi" id="55lPkJH18zk" role="2Oq$k0">
-                          <node concept="1YBJjd" id="55lPkJH18zl" role="2Oq$k0">
-                            <ref role="1YBMHb" node="55lPkJGOMCu" resolve="lookupTable" />
-                          </node>
-                          <node concept="3TrEf2" id="55lPkJH19GH" role="2OqNvi">
-                            <ref role="3Tt5mk" to="8qwc:55lPkJGFLTn" resolve="colType" />
-                          </node>
-                        </node>
-                        <node concept="1$rogu" id="55lPkJH18zn" role="2OqNvi" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2pIpSj" id="55lPkJH18CS" role="2pJxcM">
-                    <ref role="2pIpSl" to="8qwc:55lPkJGZxnp" resolve="resType" />
-                    <node concept="36biLy" id="55lPkJH18CT" role="28nt2d">
-                      <node concept="1PxgMI" id="6C0OSEaGERE" role="36biLW">
-                        <node concept="chp4Y" id="6C0OSEaGESi" role="3oSUPX">
-                          <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
-                        </node>
-                        <node concept="1Z$b5t" id="55lPkJH1a0f" role="1m5AlR">
-                          <ref role="1Z$eMM" node="55lPkJGOMNy" resolve="resultType" />
-                        </node>
-                      </node>
+                </node>
+                <node concept="mw_s8" id="55lPkJGON3l" role="1ZfhK$">
+                  <node concept="1Z2H0r" id="55lPkJGOMOn" role="mwGJk">
+                    <node concept="1YBJjd" id="55lPkJGOMOY" role="1Z2MuG">
+                      <ref role="1YBMHb" node="55lPkJGOMCu" resolve="lookupTable" />
                     </node>
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="mw_s8" id="55lPkJGON3l" role="1ZfhK$">
-              <node concept="1Z2H0r" id="55lPkJGOMOn" role="mwGJk">
-                <node concept="1YBJjd" id="55lPkJGOMOY" role="1Z2MuG">
-                  <ref role="1YBMHb" node="55lPkJGOMCu" resolve="lookupTable" />
-                </node>
-              </node>
+            <node concept="1Z$b5t" id="1tbxNVtCm7_" role="nvjzm">
+              <ref role="1Z$eMM" node="55lPkJGOMNy" resolve="resultType" />
+            </node>
+            <node concept="2X1qdy" id="1tbxNVtCllO" role="2X0Ygz">
+              <property role="TrG5h" value="concreteResultType" />
+              <node concept="2jxLKc" id="1tbxNVtCllP" role="1tU5fm" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lookup/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lookup/models/typesystem.mps
@@ -635,5 +635,35 @@
       <ref role="1YaFvo" to="8qwc:55lPkJH1wUe" resolve="LookupTarget" />
     </node>
   </node>
+  <node concept="1YbPZF" id="1tbxNVtFwVL">
+    <property role="TrG5h" value="typeof_LookupTableRef" />
+    <node concept="3clFbS" id="1tbxNVtFwVM" role="18ibNy">
+      <node concept="1Z5TYs" id="1tbxNVtFx7m" role="3cqZAp">
+        <node concept="mw_s8" id="1tbxNVtFx7E" role="1ZfhKB">
+          <node concept="1Z2H0r" id="1tbxNVtFx7A" role="mwGJk">
+            <node concept="2OqwBi" id="1tbxNVtFxiC" role="1Z2MuG">
+              <node concept="1YBJjd" id="1tbxNVtFx7V" role="2Oq$k0">
+                <ref role="1YBMHb" node="1tbxNVtFwVO" resolve="lookupTableRef" />
+              </node>
+              <node concept="3TrEf2" id="1tbxNVtFxxu" role="2OqNvi">
+                <ref role="3Tt5mk" to="8qwc:55lPkJH2uuj" resolve="table" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="1tbxNVtFx7p" role="1ZfhK$">
+          <node concept="1Z2H0r" id="1tbxNVtFwVS" role="mwGJk">
+            <node concept="1YBJjd" id="1tbxNVtFwXK" role="1Z2MuG">
+              <ref role="1YBMHb" node="1tbxNVtFwVO" resolve="lookupTableRef" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="1tbxNVtFwVO" role="1YuTPh">
+      <property role="TrG5h" value="lookupTableRef" />
+      <ref role="1YaFvo" to="8qwc:55lPkJH2urb" resolve="LookupTableRef" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/editor.mps
@@ -252,6 +252,9 @@
         <child id="1163668922816" name="ifTrue" index="3K4E3e" />
         <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
@@ -403,6 +406,7 @@
       <concept id="6097863121587719264" name="de.slisson.mps.tables.structure.GridPostprocessor" flags="ig" index="3nFNDj" />
       <concept id="7946551912908713904" name="de.slisson.mps.tables.structure.SubstituteNodeFunction" flags="ig" index="3om3PG">
         <reference id="8767719180164875849" name="cellRootConcept" index="1xHBhH" />
+        <reference id="8767719180164876002" name="conceptForMenu" index="1xHBj6" />
       </concept>
       <concept id="7946551912910240557" name="de.slisson.mps.tables.structure.SubstituteNodeFunction_NewValue" flags="ng" index="3oseBL" />
       <concept id="1515263624310660132" name="de.slisson.mps.tables.structure.HeaderQuery_Delete" flags="ig" index="3x7d0o" />
@@ -430,6 +434,14 @@
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1145567426890" name="jetbrains.mps.lang.smodel.structure.SNodeListCreator" flags="nn" index="2T8Vx0">
         <child id="1145567471833" name="createdType" index="2T96Bj" />
       </concept>
@@ -447,6 +459,7 @@
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
+      <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
         <property id="1238684351431" name="asCast" index="1BlNFB" />
       </concept>
@@ -489,6 +502,7 @@
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="3055999550620853964" name="jetbrains.mps.baseLanguage.collections.structure.RemoveWhereOperation" flags="nn" index="1aUR6E" />
       <concept id="1225621920911" name="jetbrains.mps.baseLanguage.collections.structure.InsertElementOperation" flags="nn" index="1sK_Qi">
         <child id="1225621943565" name="element" index="1sKFgg" />
         <child id="1225621960341" name="index" index="1sKJu8" />
@@ -2091,7 +2105,8 @@
             </node>
           </node>
           <node concept="3om3PG" id="4_sn_QHmQrX" role="3ot9go">
-            <ref role="1xHBhH" to="hm2y:6sdnDbSla17" resolve="Expression" />
+            <ref role="1xHBhH" to="tpck:gw2VY9q" resolve="BaseConcept" />
+            <ref role="1xHBj6" to="hm2y:6sdnDbSla17" resolve="Expression" />
             <node concept="3clFbS" id="4_sn_QHmQrY" role="2VODD2">
               <node concept="3cpWs8" id="4_sn_QHnvmi" role="3cqZAp">
                 <node concept="3cpWsn" id="4_sn_QHnvmj" role="3cpWs9">
@@ -2120,39 +2135,184 @@
               </node>
               <node concept="3clFbJ" id="4_sn_QHnvm$" role="3cqZAp">
                 <node concept="3clFbS" id="4_sn_QHnvm_" role="3clFbx">
-                  <node concept="3clFbF" id="4_sn_QHnvmA" role="3cqZAp">
-                    <node concept="2OqwBi" id="4_sn_QHnvmB" role="3clFbG">
-                      <node concept="2OqwBi" id="4_sn_QHnvmC" role="2Oq$k0">
-                        <node concept="37vLTw" id="4_sn_QHnvmD" role="2Oq$k0">
-                          <ref role="3cqZAo" node="4_sn_QHnvms" resolve="row" />
-                        </node>
-                        <node concept="3Tsc0h" id="4_sn_QHnvmE" role="2OqNvi">
-                          <ref role="3TtcxE" to="kfo3:8XWEtdYkjq" resolve="contents" />
-                        </node>
-                      </node>
-                      <node concept="TSZUe" id="4_sn_QHnvmF" role="2OqNvi">
-                        <node concept="2pJPEk" id="4_sn_QHnvmG" role="25WWJ7">
-                          <node concept="2pJPED" id="4_sn_QHnvmH" role="2pJPEn">
-                            <ref role="2pJxaS" to="kfo3:8XWEtdYkhC" resolve="Content" />
-                            <node concept="2pIpSj" id="4_sn_QHnvmI" role="2pJxcM">
-                              <ref role="2pIpSl" to="kfo3:8XWEtdYkmU" resolve="col" />
-                              <node concept="36biLy" id="4_sn_QHnvmJ" role="28nt2d">
-                                <node concept="37vLTw" id="4_sn_QHnvmK" role="36biLW">
-                                  <ref role="3cqZAo" node="4_sn_QHnvmj" resolve="ch" />
+                  <node concept="Jncv_" id="1tbxNVtGHtO" role="3cqZAp">
+                    <ref role="JncvD" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                    <node concept="3oseBL" id="1tbxNVtGHGv" role="JncvB" />
+                    <node concept="3clFbS" id="1tbxNVtGHtS" role="Jncv$">
+                      <node concept="3clFbF" id="1tbxNVtGHZK" role="3cqZAp">
+                        <node concept="2OqwBi" id="1tbxNVtGKmE" role="3clFbG">
+                          <node concept="2OqwBi" id="1tbxNVtGIj0" role="2Oq$k0">
+                            <node concept="37vLTw" id="1tbxNVtGHZJ" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4_sn_QHnvms" resolve="row" />
+                            </node>
+                            <node concept="3Tsc0h" id="1tbxNVtGIC_" role="2OqNvi">
+                              <ref role="3TtcxE" to="kfo3:8XWEtdYkjq" resolve="contents" />
+                            </node>
+                          </node>
+                          <node concept="1aUR6E" id="1tbxNVtGMJn" role="2OqNvi">
+                            <node concept="1bVj0M" id="1tbxNVtGMJp" role="23t8la">
+                              <node concept="3clFbS" id="1tbxNVtGMJq" role="1bW5cS">
+                                <node concept="3clFbF" id="1tbxNVtGP$p" role="3cqZAp">
+                                  <node concept="17R0WA" id="1tbxNVtGYbr" role="3clFbG">
+                                    <node concept="2OqwBi" id="1tbxNVtGSqA" role="3uHU7B">
+                                      <node concept="37vLTw" id="1tbxNVtGP$o" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="1tbxNVtGMJr" resolve="it" />
+                                      </node>
+                                      <node concept="3TrEf2" id="1tbxNVtGVjP" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="kfo3:8XWEtdYkmU" resolve="col" />
+                                      </node>
+                                    </node>
+                                    <node concept="37vLTw" id="1tbxNVtH1ai" role="3uHU7w">
+                                      <ref role="3cqZAo" node="4_sn_QHnvmj" resolve="ch" />
+                                    </node>
+                                  </node>
                                 </node>
                               </node>
+                              <node concept="Rh6nW" id="1tbxNVtGMJr" role="1bW2Oz">
+                                <property role="TrG5h" value="it" />
+                                <node concept="2jxLKc" id="1tbxNVtGMJs" role="1tU5fm" />
+                              </node>
                             </node>
-                            <node concept="2pIpSj" id="4_sn_QHnvmL" role="2pJxcM">
-                              <ref role="2pIpSl" to="kfo3:8XWEtdYkjo" resolve="exprs" />
-                              <node concept="36be1Y" id="4_sn_QHnvmM" role="28nt2d">
-                                <node concept="36biLy" id="4_sn_QHnvmN" role="36be1Z">
-                                  <node concept="3oseBL" id="4_sn_QHnvmO" role="36biLW" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4_sn_QHnvmA" role="3cqZAp">
+                        <node concept="2OqwBi" id="4_sn_QHnvmB" role="3clFbG">
+                          <node concept="2OqwBi" id="4_sn_QHnvmC" role="2Oq$k0">
+                            <node concept="37vLTw" id="4_sn_QHnvmD" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4_sn_QHnvms" resolve="row" />
+                            </node>
+                            <node concept="3Tsc0h" id="4_sn_QHnvmE" role="2OqNvi">
+                              <ref role="3TtcxE" to="kfo3:8XWEtdYkjq" resolve="contents" />
+                            </node>
+                          </node>
+                          <node concept="TSZUe" id="4_sn_QHnvmF" role="2OqNvi">
+                            <node concept="2pJPEk" id="4_sn_QHnvmG" role="25WWJ7">
+                              <node concept="2pJPED" id="4_sn_QHnvmH" role="2pJPEn">
+                                <ref role="2pJxaS" to="kfo3:8XWEtdYkhC" resolve="Content" />
+                                <node concept="2pIpSj" id="4_sn_QHnvmI" role="2pJxcM">
+                                  <ref role="2pIpSl" to="kfo3:8XWEtdYkmU" resolve="col" />
+                                  <node concept="36biLy" id="4_sn_QHnvmJ" role="28nt2d">
+                                    <node concept="37vLTw" id="4_sn_QHnvmK" role="36biLW">
+                                      <ref role="3cqZAo" node="4_sn_QHnvmj" resolve="ch" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="2pIpSj" id="4_sn_QHnvmL" role="2pJxcM">
+                                  <ref role="2pIpSl" to="kfo3:8XWEtdYkjo" resolve="exprs" />
+                                  <node concept="36be1Y" id="4_sn_QHnvmM" role="28nt2d">
+                                    <node concept="36biLy" id="4_sn_QHnvmN" role="36be1Z">
+                                      <node concept="2OqwBi" id="1tbxNVtHk6f" role="36biLW">
+                                        <node concept="Jnkvi" id="1tbxNVtHhik" role="2Oq$k0">
+                                          <ref role="1M0zk5" node="1tbxNVtGHtU" resolve="expr" />
+                                        </node>
+                                        <node concept="1$rogu" id="1tbxNVtHnav" role="2OqNvi" />
+                                      </node>
+                                    </node>
+                                  </node>
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
+                    </node>
+                    <node concept="JncvC" id="1tbxNVtGHtU" role="JncvA">
+                      <property role="TrG5h" value="expr" />
+                      <node concept="2jxLKc" id="1tbxNVtGHtV" role="1tU5fm" />
+                    </node>
+                  </node>
+                  <node concept="Jncv_" id="1tbxNVtHsxv" role="3cqZAp">
+                    <ref role="JncvD" to="kfo3:8XWEtdYkhC" resolve="Content" />
+                    <node concept="3oseBL" id="1tbxNVtHvba" role="JncvB" />
+                    <node concept="3clFbS" id="1tbxNVtHsxz" role="Jncv$">
+                      <node concept="3cpWs8" id="1tbxNVtHBhk" role="3cqZAp">
+                        <node concept="3cpWsn" id="1tbxNVtHBhn" role="3cpWs9">
+                          <property role="TrG5h" value="newContent" />
+                          <node concept="3Tqbb2" id="1tbxNVtHBhj" role="1tU5fm">
+                            <ref role="ehGHo" to="kfo3:8XWEtdYkhC" resolve="Content" />
+                          </node>
+                          <node concept="2OqwBi" id="1tbxNVtHRCb" role="33vP2m">
+                            <node concept="Jnkvi" id="1tbxNVtHOP5" role="2Oq$k0">
+                              <ref role="1M0zk5" node="1tbxNVtHsx_" resolve="content" />
+                            </node>
+                            <node concept="1$rogu" id="1tbxNVtHUwa" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="1tbxNVtHZMJ" role="3cqZAp">
+                        <node concept="37vLTI" id="1tbxNVtI8ke" role="3clFbG">
+                          <node concept="37vLTw" id="1tbxNVtIb4b" role="37vLTx">
+                            <ref role="3cqZAo" node="4_sn_QHnvmj" resolve="ch" />
+                          </node>
+                          <node concept="2OqwBi" id="1tbxNVtI2sk" role="37vLTJ">
+                            <node concept="37vLTw" id="1tbxNVtHZMH" role="2Oq$k0">
+                              <ref role="3cqZAo" node="1tbxNVtHBhn" resolve="newContent" />
+                            </node>
+                            <node concept="3TrEf2" id="1tbxNVtI5wN" role="2OqNvi">
+                              <ref role="3Tt5mk" to="kfo3:8XWEtdYkmU" resolve="col" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="1tbxNVtImjq" role="3cqZAp">
+                        <node concept="2OqwBi" id="1tbxNVtImjr" role="3clFbG">
+                          <node concept="2OqwBi" id="1tbxNVtImjs" role="2Oq$k0">
+                            <node concept="37vLTw" id="1tbxNVtImjt" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4_sn_QHnvms" resolve="row" />
+                            </node>
+                            <node concept="3Tsc0h" id="1tbxNVtImju" role="2OqNvi">
+                              <ref role="3TtcxE" to="kfo3:8XWEtdYkjq" resolve="contents" />
+                            </node>
+                          </node>
+                          <node concept="1aUR6E" id="1tbxNVtImjv" role="2OqNvi">
+                            <node concept="1bVj0M" id="1tbxNVtImjw" role="23t8la">
+                              <node concept="3clFbS" id="1tbxNVtImjx" role="1bW5cS">
+                                <node concept="3clFbF" id="1tbxNVtImjy" role="3cqZAp">
+                                  <node concept="17R0WA" id="1tbxNVtImjz" role="3clFbG">
+                                    <node concept="2OqwBi" id="1tbxNVtImj$" role="3uHU7B">
+                                      <node concept="37vLTw" id="1tbxNVtImj_" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="1tbxNVtImjC" resolve="it" />
+                                      </node>
+                                      <node concept="3TrEf2" id="1tbxNVtImjA" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="kfo3:8XWEtdYkmU" resolve="col" />
+                                      </node>
+                                    </node>
+                                    <node concept="37vLTw" id="1tbxNVtImjB" role="3uHU7w">
+                                      <ref role="3cqZAo" node="4_sn_QHnvmj" resolve="ch" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="Rh6nW" id="1tbxNVtImjC" role="1bW2Oz">
+                                <property role="TrG5h" value="it" />
+                                <node concept="2jxLKc" id="1tbxNVtImjD" role="1tU5fm" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="1tbxNVtI_W3" role="3cqZAp">
+                        <node concept="2OqwBi" id="1tbxNVtIR3v" role="3clFbG">
+                          <node concept="2OqwBi" id="1tbxNVtIFbf" role="2Oq$k0">
+                            <node concept="37vLTw" id="1tbxNVtI_W1" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4_sn_QHnvms" resolve="row" />
+                            </node>
+                            <node concept="3Tsc0h" id="1tbxNVtIKlB" role="2OqNvi">
+                              <ref role="3TtcxE" to="kfo3:8XWEtdYkjq" resolve="contents" />
+                            </node>
+                          </node>
+                          <node concept="TSZUe" id="1tbxNVtIYza" role="2OqNvi">
+                            <node concept="37vLTw" id="1tbxNVtJ3Qd" role="25WWJ7">
+                              <ref role="3cqZAo" node="1tbxNVtHBhn" resolve="newContent" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="JncvC" id="1tbxNVtHsx_" role="JncvA">
+                      <property role="TrG5h" value="content" />
+                      <node concept="2jxLKc" id="1tbxNVtHsxA" role="1tU5fm" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/editor.mps
@@ -33,9 +33,9 @@
     <import index="r4b4" ref="r:1784e088-20fd-4fdb-96b8-bc57f0056d94(com.mbeddr.core.base.editor)" />
     <import index="oghc" ref="r:356c0504-b4a3-4458-9604-13fbb48838d7(de.slisson.mps.tables.runtime.style)" />
     <import index="g1qu" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util.ui(MPS.IDEA/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="epcs" ref="b33d119e-196d-4497-977c-5c167b21fe33/r:b7f325a3-1f57-46bc-8b14-d2d7c5ff6714(com.mbeddr.mpsutil.framecell/com.mbeddr.mpsutil.framecell.editor)" implicit="true" />
-    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="wthy" ref="r:a4614e23-a6b5-4dbe-9bc5-9ff1ecfd0a3a(org.iets3.core.expr.util.behavior)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
@@ -208,6 +208,7 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
@@ -960,7 +961,8 @@
               </node>
             </node>
             <node concept="3om3PG" id="6VI$CVc23FF" role="3ot9go">
-              <ref role="1xHBhH" to="hm2y:6sdnDbSla17" resolve="Expression" />
+              <ref role="1xHBhH" to="tpck:gw2VY9q" resolve="BaseConcept" />
+              <ref role="1xHBj6" to="hm2y:6sdnDbSla17" resolve="Expression" />
               <node concept="3clFbS" id="6VI$CVc23FG" role="2VODD2">
                 <node concept="3cpWs8" id="3DYDRw0KtmC" role="3cqZAp">
                   <node concept="3cpWsn" id="3DYDRw0KtmD" role="3cpWs9">
@@ -1002,70 +1004,253 @@
                 </node>
                 <node concept="3clFbJ" id="3DYDRw0KtfD" role="3cqZAp">
                   <node concept="3clFbS" id="3DYDRw0KtfE" role="3clFbx">
-                    <node concept="3cpWs8" id="5crSXL__Y7" role="3cqZAp">
-                      <node concept="3cpWsn" id="5crSXL__Ya" role="3cpWs9">
-                        <property role="TrG5h" value="newValAsList" />
-                        <node concept="2I9FWS" id="5crSXL__Y5" role="1tU5fm">
-                          <ref role="2I9WkF" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                    <node concept="3clFbH" id="1tbxNVtK_bm" role="3cqZAp" />
+                    <node concept="Jncv_" id="1tbxNVtK_Cg" role="3cqZAp">
+                      <ref role="JncvD" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                      <node concept="3oseBL" id="1tbxNVtK_Wf" role="JncvB" />
+                      <node concept="3clFbS" id="1tbxNVtK_Ck" role="Jncv$">
+                        <node concept="3clFbF" id="1tbxNVtKAQP" role="3cqZAp">
+                          <node concept="2OqwBi" id="1tbxNVtKEtp" role="3clFbG">
+                            <node concept="2OqwBi" id="1tbxNVtKBuK" role="2Oq$k0">
+                              <node concept="2r2w_c" id="1tbxNVtKAQO" role="2Oq$k0" />
+                              <node concept="3Tsc0h" id="1tbxNVtKC_s" role="2OqNvi">
+                                <ref role="3TtcxE" to="kfo3:3DYDRw0K4d9" resolve="contents" />
+                              </node>
+                            </node>
+                            <node concept="1aUR6E" id="1tbxNVtKGTK" role="2OqNvi">
+                              <node concept="1bVj0M" id="1tbxNVtKGTM" role="23t8la">
+                                <node concept="3clFbS" id="1tbxNVtKGTN" role="1bW5cS">
+                                  <node concept="3clFbF" id="1tbxNVtKJQS" role="3cqZAp">
+                                    <node concept="1Wc70l" id="1tbxNVtKYYg" role="3clFbG">
+                                      <node concept="17R0WA" id="1tbxNVtLaVU" role="3uHU7w">
+                                        <node concept="37vLTw" id="1tbxNVtLdWZ" role="3uHU7w">
+                                          <ref role="3cqZAo" node="3DYDRw0KtmD" resolve="ch" />
+                                        </node>
+                                        <node concept="2OqwBi" id="1tbxNVtL4Kk" role="3uHU7B">
+                                          <node concept="37vLTw" id="1tbxNVtL1Lv" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="1tbxNVtKGTO" resolve="it" />
+                                          </node>
+                                          <node concept="3TrEf2" id="1tbxNVtL7Qq" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="kfo3:3DYDRw0K4cW" resolve="col" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="17R0WA" id="1tbxNVtKSWe" role="3uHU7B">
+                                        <node concept="2OqwBi" id="1tbxNVtKMQZ" role="3uHU7B">
+                                          <node concept="37vLTw" id="1tbxNVtKJQR" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="1tbxNVtKGTO" resolve="it" />
+                                          </node>
+                                          <node concept="3TrEf2" id="1tbxNVtKPSv" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="kfo3:3DYDRw0K4cT" resolve="row" />
+                                          </node>
+                                        </node>
+                                        <node concept="37vLTw" id="1tbxNVtKVU6" role="3uHU7w">
+                                          <ref role="3cqZAo" node="3DYDRw0KtmM" resolve="rh" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="Rh6nW" id="1tbxNVtKGTO" role="1bW2Oz">
+                                  <property role="TrG5h" value="it" />
+                                  <node concept="2jxLKc" id="1tbxNVtKGTP" role="1tU5fm" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
                         </node>
-                        <node concept="2ShNRf" id="5crSXL_Dkk" role="33vP2m">
-                          <node concept="2T8Vx0" id="5crSXL_Dki" role="2ShVmc">
-                            <node concept="2I9FWS" id="5crSXL_Dkj" role="2T96Bj">
+                        <node concept="3cpWs8" id="5crSXL__Y7" role="3cqZAp">
+                          <node concept="3cpWsn" id="5crSXL__Ya" role="3cpWs9">
+                            <property role="TrG5h" value="newValAsList" />
+                            <node concept="2I9FWS" id="5crSXL__Y5" role="1tU5fm">
                               <ref role="2I9WkF" to="hm2y:6sdnDbSla17" resolve="Expression" />
                             </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="5crSXL_GHn" role="3cqZAp">
-                      <node concept="2OqwBi" id="5crSXL_IPh" role="3clFbG">
-                        <node concept="37vLTw" id="5crSXL_GHl" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5crSXL__Ya" resolve="newValAsList" />
-                        </node>
-                        <node concept="TSZUe" id="5crSXL_OtO" role="2OqNvi">
-                          <node concept="3oseBL" id="5crSXL_P25" role="25WWJ7" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="3DYDRw0LC29" role="3cqZAp">
-                      <node concept="2OqwBi" id="3DYDRw0LCJb" role="3clFbG">
-                        <node concept="2OqwBi" id="3DYDRw0LC6z" role="2Oq$k0">
-                          <node concept="2r2w_c" id="3DYDRw0LC27" role="2Oq$k0" />
-                          <node concept="3Tsc0h" id="3DYDRw0LCfK" role="2OqNvi">
-                            <ref role="3TtcxE" to="kfo3:3DYDRw0K4d9" resolve="contents" />
-                          </node>
-                        </node>
-                        <node concept="TSZUe" id="3DYDRw0LDNq" role="2OqNvi">
-                          <node concept="2pJPEk" id="3DYDRw0M6OE" role="25WWJ7">
-                            <node concept="2pJPED" id="3DYDRw0M6Zv" role="2pJPEn">
-                              <ref role="2pJxaS" to="kfo3:3DYDRw0K4ce" resolve="DecTabContent" />
-                              <node concept="2pIpSj" id="3DYDRw0M7Z8" role="2pJxcM">
-                                <ref role="2pIpSl" to="kfo3:3DYDRw0K4cT" resolve="row" />
-                                <node concept="36biLy" id="3DYDRw0M89G" role="28nt2d">
-                                  <node concept="37vLTw" id="3DYDRw0M8_u" role="36biLW">
-                                    <ref role="3cqZAo" node="3DYDRw0KtmM" resolve="rh" />
-                                  </node>
+                            <node concept="2ShNRf" id="5crSXL_Dkk" role="33vP2m">
+                              <node concept="2T8Vx0" id="5crSXL_Dki" role="2ShVmc">
+                                <node concept="2I9FWS" id="5crSXL_Dkj" role="2T96Bj">
+                                  <ref role="2I9WkF" to="hm2y:6sdnDbSla17" resolve="Expression" />
                                 </node>
                               </node>
-                              <node concept="2pIpSj" id="3DYDRw0M7kg" role="2pJxcM">
-                                <ref role="2pIpSl" to="kfo3:3DYDRw0K4cW" resolve="col" />
-                                <node concept="36biLy" id="3DYDRw0M7uY" role="28nt2d">
-                                  <node concept="37vLTw" id="3DYDRw0M7DE" role="36biLW">
-                                    <ref role="3cqZAo" node="3DYDRw0KtmD" resolve="ch" />
-                                  </node>
-                                </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="5crSXL_GHn" role="3cqZAp">
+                          <node concept="2OqwBi" id="5crSXL_IPh" role="3clFbG">
+                            <node concept="37vLTw" id="5crSXL_GHl" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5crSXL__Ya" resolve="newValAsList" />
+                            </node>
+                            <node concept="TSZUe" id="5crSXL_OtO" role="2OqNvi">
+                              <node concept="Jnkvi" id="1tbxNVtLphr" role="25WWJ7">
+                                <ref role="1M0zk5" node="1tbxNVtK_Cm" resolve="expr" />
                               </node>
-                              <node concept="2pIpSj" id="5crSXL_xf7" role="2pJxcM">
-                                <ref role="2pIpSl" to="kfo3:3DYDRw0K4cg" resolve="expressions" />
-                                <node concept="36biLy" id="5crSXL_E1$" role="28nt2d">
-                                  <node concept="37vLTw" id="5crSXL_Gl5" role="36biLW">
-                                    <ref role="3cqZAo" node="5crSXL__Ya" resolve="newValAsList" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="3DYDRw0LC29" role="3cqZAp">
+                          <node concept="2OqwBi" id="3DYDRw0LCJb" role="3clFbG">
+                            <node concept="2OqwBi" id="3DYDRw0LC6z" role="2Oq$k0">
+                              <node concept="2r2w_c" id="3DYDRw0LC27" role="2Oq$k0" />
+                              <node concept="3Tsc0h" id="3DYDRw0LCfK" role="2OqNvi">
+                                <ref role="3TtcxE" to="kfo3:3DYDRw0K4d9" resolve="contents" />
+                              </node>
+                            </node>
+                            <node concept="TSZUe" id="3DYDRw0LDNq" role="2OqNvi">
+                              <node concept="2pJPEk" id="3DYDRw0M6OE" role="25WWJ7">
+                                <node concept="2pJPED" id="3DYDRw0M6Zv" role="2pJPEn">
+                                  <ref role="2pJxaS" to="kfo3:3DYDRw0K4ce" resolve="DecTabContent" />
+                                  <node concept="2pIpSj" id="3DYDRw0M7Z8" role="2pJxcM">
+                                    <ref role="2pIpSl" to="kfo3:3DYDRw0K4cT" resolve="row" />
+                                    <node concept="36biLy" id="3DYDRw0M89G" role="28nt2d">
+                                      <node concept="37vLTw" id="3DYDRw0M8_u" role="36biLW">
+                                        <ref role="3cqZAo" node="3DYDRw0KtmM" resolve="rh" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="2pIpSj" id="3DYDRw0M7kg" role="2pJxcM">
+                                    <ref role="2pIpSl" to="kfo3:3DYDRw0K4cW" resolve="col" />
+                                    <node concept="36biLy" id="3DYDRw0M7uY" role="28nt2d">
+                                      <node concept="37vLTw" id="3DYDRw0M7DE" role="36biLW">
+                                        <ref role="3cqZAo" node="3DYDRw0KtmD" resolve="ch" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="2pIpSj" id="5crSXL_xf7" role="2pJxcM">
+                                    <ref role="2pIpSl" to="kfo3:3DYDRw0K4cg" resolve="expressions" />
+                                    <node concept="36biLy" id="5crSXL_E1$" role="28nt2d">
+                                      <node concept="37vLTw" id="5crSXL_Gl5" role="36biLW">
+                                        <ref role="3cqZAo" node="5crSXL__Ya" resolve="newValAsList" />
+                                      </node>
+                                    </node>
                                   </node>
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
+                      </node>
+                      <node concept="JncvC" id="1tbxNVtK_Cm" role="JncvA">
+                        <property role="TrG5h" value="expr" />
+                        <node concept="2jxLKc" id="1tbxNVtK_Cn" role="1tU5fm" />
+                      </node>
+                    </node>
+                    <node concept="3clFbH" id="1tbxNVtLs6y" role="3cqZAp" />
+                    <node concept="Jncv_" id="1tbxNVtLv4G" role="3cqZAp">
+                      <ref role="JncvD" to="kfo3:3DYDRw0K4ce" resolve="DecTabContent" />
+                      <node concept="3oseBL" id="1tbxNVtLxXo" role="JncvB" />
+                      <node concept="3clFbS" id="1tbxNVtLv4K" role="Jncv$">
+                        <node concept="3cpWs8" id="1tbxNVtLNWz" role="3cqZAp">
+                          <node concept="3cpWsn" id="1tbxNVtLNWA" role="3cpWs9">
+                            <property role="TrG5h" value="newContent" />
+                            <node concept="3Tqbb2" id="1tbxNVtLNWy" role="1tU5fm">
+                              <ref role="ehGHo" to="kfo3:3DYDRw0K4ce" resolve="DecTabContent" />
+                            </node>
+                            <node concept="2OqwBi" id="1tbxNVtM7Xk" role="33vP2m">
+                              <node concept="Jnkvi" id="1tbxNVtM51u" role="2Oq$k0">
+                                <ref role="1M0zk5" node="1tbxNVtLv4M" resolve="content" />
+                              </node>
+                              <node concept="1$rogu" id="1tbxNVtMaZs" role="2OqNvi" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="1tbxNVtNeYz" role="3cqZAp">
+                          <node concept="2OqwBi" id="1tbxNVtNpYh" role="3clFbG">
+                            <node concept="2OqwBi" id="1tbxNVtNi6T" role="2Oq$k0">
+                              <node concept="2r2w_c" id="1tbxNVtNeYy" role="2Oq$k0" />
+                              <node concept="3Tsc0h" id="1tbxNVtNlAs" role="2OqNvi">
+                                <ref role="3TtcxE" to="kfo3:3DYDRw0K4d9" resolve="contents" />
+                              </node>
+                            </node>
+                            <node concept="1aUR6E" id="1tbxNVtNuVq" role="2OqNvi">
+                              <node concept="1bVj0M" id="1tbxNVtNuVs" role="23t8la">
+                                <node concept="3clFbS" id="1tbxNVtNuVt" role="1bW5cS">
+                                  <node concept="3clFbF" id="1tbxNVtN$nk" role="3cqZAp">
+                                    <node concept="1Wc70l" id="1tbxNVtNZWy" role="3clFbG">
+                                      <node concept="17R0WA" id="1tbxNVtOm7A" role="3uHU7w">
+                                        <node concept="37vLTw" id="1tbxNVtOrwH" role="3uHU7w">
+                                          <ref role="3cqZAo" node="3DYDRw0KtmD" resolve="ch" />
+                                        </node>
+                                        <node concept="2OqwBi" id="1tbxNVtOaWu" role="3uHU7B">
+                                          <node concept="37vLTw" id="1tbxNVtO5gr" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="1tbxNVtNuVu" resolve="it" />
+                                          </node>
+                                          <node concept="3TrEf2" id="1tbxNVtOgze" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="kfo3:3DYDRw0K4cW" resolve="col" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="17R0WA" id="1tbxNVtNPdR" role="3uHU7B">
+                                        <node concept="2OqwBi" id="1tbxNVtNDRA" role="3uHU7B">
+                                          <node concept="37vLTw" id="1tbxNVtN$nj" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="1tbxNVtNuVu" resolve="it" />
+                                          </node>
+                                          <node concept="3TrEf2" id="1tbxNVtNJDu" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="kfo3:3DYDRw0K4cT" resolve="row" />
+                                          </node>
+                                        </node>
+                                        <node concept="37vLTw" id="1tbxNVtNU_e" role="3uHU7w">
+                                          <ref role="3cqZAo" node="3DYDRw0KtmM" resolve="rh" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="Rh6nW" id="1tbxNVtNuVu" role="1bW2Oz">
+                                  <property role="TrG5h" value="it" />
+                                  <node concept="2jxLKc" id="1tbxNVtNuVv" role="1tU5fm" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="1tbxNVtMgPZ" role="3cqZAp">
+                          <node concept="37vLTI" id="1tbxNVtM_zZ" role="3clFbG">
+                            <node concept="37vLTw" id="1tbxNVtMCpr" role="37vLTx">
+                              <ref role="3cqZAo" node="3DYDRw0KtmM" resolve="rh" />
+                            </node>
+                            <node concept="2OqwBi" id="1tbxNVtMv8c" role="37vLTJ">
+                              <node concept="37vLTw" id="1tbxNVtMgPX" role="2Oq$k0">
+                                <ref role="3cqZAo" node="1tbxNVtLNWA" resolve="newContent" />
+                              </node>
+                              <node concept="3TrEf2" id="1tbxNVtMyam" role="2OqNvi">
+                                <ref role="3Tt5mk" to="kfo3:3DYDRw0K4cT" resolve="row" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="1tbxNVtMI5d" role="3cqZAp">
+                          <node concept="37vLTI" id="1tbxNVtMRwD" role="3clFbG">
+                            <node concept="37vLTw" id="1tbxNVtMUxT" role="37vLTx">
+                              <ref role="3cqZAo" node="3DYDRw0KtmD" resolve="ch" />
+                            </node>
+                            <node concept="2OqwBi" id="1tbxNVtML0c" role="37vLTJ">
+                              <node concept="37vLTw" id="1tbxNVtMI5b" role="2Oq$k0">
+                                <ref role="3cqZAo" node="1tbxNVtLNWA" resolve="newContent" />
+                              </node>
+                              <node concept="3TrEf2" id="1tbxNVtN6eM" role="2OqNvi">
+                                <ref role="3Tt5mk" to="kfo3:3DYDRw0K4cW" resolve="col" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbF" id="1tbxNVtOAp1" role="3cqZAp">
+                          <node concept="2OqwBi" id="1tbxNVtOSUx" role="3clFbG">
+                            <node concept="2OqwBi" id="1tbxNVtOG0E" role="2Oq$k0">
+                              <node concept="2r2w_c" id="1tbxNVtOAp0" role="2Oq$k0" />
+                              <node concept="3Tsc0h" id="1tbxNVtOM0w" role="2OqNvi">
+                                <ref role="3TtcxE" to="kfo3:3DYDRw0K4d9" resolve="contents" />
+                              </node>
+                            </node>
+                            <node concept="TSZUe" id="1tbxNVtP0nn" role="2OqNvi">
+                              <node concept="37vLTw" id="1tbxNVtP5Q1" role="25WWJ7">
+                                <ref role="3cqZAo" node="1tbxNVtLNWA" resolve="newContent" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="JncvC" id="1tbxNVtLv4M" role="JncvA">
+                        <property role="TrG5h" value="content" />
+                        <node concept="2jxLKc" id="1tbxNVtLv4N" role="1tU5fm" />
                       </node>
                     </node>
                   </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.lookuptable@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.lookuptable@tests.mps
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:e0544697-59c7-4559-b285-77a436064a3e(test.in.expr.os.lookuptable@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="0406e4b3-cffd-4d16-8533-6bc50680ab3b" name="org.iets3.core.expr.lookup" version="0" />
+    <devkit ref="c4e521ab-b605-4ef9-a7c3-68075da058f0(org.iets3.core.expr.core.devkit)" />
+  </languages>
+  <imports />
+  <registry>
+    <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
+      <concept id="5115872837156802409" name="org.iets3.core.expr.base.structure.UnaryExpression" flags="ng" index="30czhk">
+        <child id="5115872837156802411" name="expr" index="30czhm" />
+      </concept>
+      <concept id="9002563722476995145" name="org.iets3.core.expr.base.structure.DotExpression" flags="ng" index="1QScDb">
+        <child id="9002563722476995147" name="target" index="1QScD9" />
+      </concept>
+    </language>
+    <language id="d441fba0-f46b-43cd-b723-dad7b65da615" name="org.iets3.core.expr.tests">
+      <concept id="543569365052056273" name="org.iets3.core.expr.tests.structure.EqualsTestOp" flags="ng" index="_fku$" />
+      <concept id="543569365052056263" name="org.iets3.core.expr.tests.structure.TestCase" flags="ng" index="_fkuM">
+        <child id="543569365052056368" name="items" index="_fkp5" />
+      </concept>
+      <concept id="543569365052056266" name="org.iets3.core.expr.tests.structure.AssertTestItem" flags="ng" index="_fkuZ">
+        <child id="543569365052056302" name="op" index="_fkur" />
+        <child id="543569365052056269" name="expected" index="_fkuS" />
+        <child id="543569365052056267" name="actual" index="_fkuY" />
+      </concept>
+      <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
+        <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
+        <child id="543569365052711058" name="contents" index="_iOnB" />
+      </concept>
+      <concept id="5285810042889815162" name="org.iets3.core.expr.tests.structure.EmptyTestItem" flags="ng" index="3dYjL0" />
+    </language>
+    <language id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes">
+      <concept id="5115872837157054169" name="org.iets3.core.expr.simpleTypes.structure.IntegerType" flags="ng" index="30bXR$" />
+      <concept id="5115872837157054170" name="org.iets3.core.expr.simpleTypes.structure.NumberLiteral" flags="ng" index="30bXRB">
+        <property id="5115872837157054173" name="value" index="30bXRw" />
+      </concept>
+    </language>
+    <language id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel">
+      <concept id="543569365052765011" name="org.iets3.core.expr.toplevel.structure.EmptyToplevelContent" flags="ng" index="_ixoA" />
+    </language>
+    <language id="0406e4b3-cffd-4d16-8533-6bc50680ab3b" name="org.iets3.core.expr.lookup">
+      <concept id="5860825012168429198" name="org.iets3.core.expr.lookup.structure.LookupTarget" flags="ng" index="2WkXJ5">
+        <child id="5860825012168430592" name="rowVal" index="2WkW5b" />
+        <child id="5860825012168430730" name="colVal" index="2WkW71" />
+      </concept>
+      <concept id="5860825012168681163" name="org.iets3.core.expr.lookup.structure.LookupTableRef" flags="ng" index="2Wn3e0">
+        <reference id="5860825012168681363" name="table" index="2Wn3bo" />
+      </concept>
+      <concept id="5860825012164260232" name="org.iets3.core.expr.lookup.structure.LookupTableHeader" flags="ng" index="2X$Uj3">
+        <child id="5860825012164260365" name="val" index="2X$Ut6" />
+      </concept>
+      <concept id="5860825012163523163" name="org.iets3.core.expr.lookup.structure.LookupTableCell" flags="ng" index="2XVIsg">
+        <reference id="5860825012163523292" name="col" index="2XVIun" />
+        <reference id="5860825012163523283" name="row" index="2XVIuo" />
+        <child id="5860825012163523278" name="val" index="2XVIu5" />
+      </concept>
+      <concept id="5860825012162728630" name="org.iets3.core.expr.lookup.structure.LookupTable" flags="ng" index="2XYGvX">
+        <child id="5860825012163143238" name="rows" index="2XSbcd" />
+        <child id="5860825012162833454" name="cols" index="2XTn__" />
+        <child id="5860825012163523473" name="cells" index="2XVIrq" />
+        <child id="5860825012162731602" name="rowType" index="2XYGGp" />
+        <child id="5860825012162731607" name="colType" index="2XYGGs" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="_iOnU" id="1tbxNVtEJ5i">
+    <property role="1XBH2A" value="true" />
+    <property role="TrG5h" value="LookupTable" />
+    <node concept="2XYGvX" id="1tbxNVtEPJD" role="_iOnB">
+      <property role="TrG5h" value="MyLook" />
+      <node concept="2X$Uj3" id="1tbxNVtEPJE" role="2XTn__">
+        <node concept="30bXRB" id="1tbxNVtEPLW" role="2X$Ut6">
+          <property role="30bXRw" value="2" />
+        </node>
+      </node>
+      <node concept="2X$Uj3" id="1tbxNVtEPJG" role="2XSbcd">
+        <node concept="30bXRB" id="1tbxNVtEPLh" role="2X$Ut6">
+          <property role="30bXRw" value="1" />
+        </node>
+      </node>
+      <node concept="2XVIsg" id="1tbxNVtEPJI" role="2XVIrq">
+        <ref role="2XVIun" node="1tbxNVtEPJE" />
+        <ref role="2XVIuo" node="1tbxNVtEPJG" />
+        <node concept="30bXRB" id="1tbxNVtEPMU" role="2XVIu5">
+          <property role="30bXRw" value="3" />
+        </node>
+      </node>
+      <node concept="30bXR$" id="1tbxNVtEPKS" role="2XYGGp" />
+      <node concept="30bXR$" id="1tbxNVtEPKz" role="2XYGGs" />
+    </node>
+    <node concept="_ixoA" id="1tbxNVtG3iw" role="_iOnB" />
+    <node concept="_fkuM" id="1tbxNVtEJ5j" role="_iOnB">
+      <property role="TrG5h" value="simpleLookUp" />
+      <node concept="_fkuZ" id="1tbxNVtFa9R" role="_fkp5">
+        <node concept="_fku$" id="1tbxNVtFa9S" role="_fkur" />
+        <node concept="30bXRB" id="1tbxNVtFOl1" role="_fkuS">
+          <property role="30bXRw" value="3" />
+        </node>
+        <node concept="1QScDb" id="1tbxNVtFwo6" role="_fkuY">
+          <node concept="2WkXJ5" id="1tbxNVtFO6Y" role="1QScD9">
+            <node concept="30bXRB" id="1tbxNVtFObF" role="2WkW5b">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="1tbxNVtG2Aa" role="2WkW71">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="2Wn3e0" id="1tbxNVtFwnW" role="30czhm">
+            <ref role="2Wn3bo" node="1tbxNVtEPJD" resolve="MyLook" />
+          </node>
+        </node>
+      </node>
+      <node concept="3dYjL0" id="1tbxNVtG3xF" role="_fkp5" />
+      <node concept="3dYjL0" id="1tbxNVtG3xQ" role="_fkp5" />
+    </node>
+  </node>
+</model>
+


### PR DESCRIPTION
This PR fixes #539.

I've changed the substitution menu, so that they work, when an expression is paste into a table cell. The problem is that an expression is pasted to a cell in the table and these concepts are of course incompatible (a cell contains an expression).
I've also fixed the `LookupTable`, so that I can at least test my changes.