### PR TITLE
build: replaced old itemis nexus by the new itemis cloud nexus

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,10 @@ import java.time.LocalDateTime
 //will pull the groovy classes/types from nexus to the classpath
 buildscript {
     repositories {
-        maven { url 'https://projects.itemis.de/nexus/content/repositories/mbeddr' }
         maven { url 'https://artifacts.itemis.cloud/repository/maven-mps/' }
     }
     dependencies {
-        classpath 'de.itemis.mps:mps-gradle-plugin:1.2.175.cc60dc8'
+        classpath 'de.itemis.mps:mps-gradle-plugin:1.2.177.46341c0'
     }
 }
 
@@ -115,8 +114,6 @@ ext.snapshotRepository = 'https://artifacts.itemis.cloud/repository/maven-mps-sn
 ext.publishingRepository = version.toString().endsWith("-SNAPSHOT") ? snapshotRepository : releaseRepository
 
 ext.dependencyRepositories = [
-    'https://projects.itemis.de/nexus/content/repositories/mbeddr',
-    'https://projects.itemis.de/nexus/content/repositories/mbeddr_snapshots',
     'https://artifacts.itemis.cloud/repository/maven-mps/'
 ]
     
@@ -143,16 +140,11 @@ dependencies {
 }
 
 repositories {
-    mavenLocal()
+    // we don't use mavenLocal() repo, since it can cause various issues with resolving dependencies,
+    // see https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:case-for-maven-local
     for (repoUrl in project.dependencyRepositories) {
         maven {
             url repoUrl
-            if (project.hasProperty('nexusUsername')) {
-                credentials {
-                    username project.nexusUsername
-                    password project.nexusPassword
-                }
-            }
         }
     }
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ import java.time.LocalDateTime
 buildscript {
     repositories {
         maven { url 'https://projects.itemis.de/nexus/content/repositories/mbeddr' }
+        maven { url 'https://artifacts.itemis.cloud/repository/maven-mps/' }
     }
     dependencies {
         classpath 'de.itemis.mps:mps-gradle-plugin:1.2.175.cc60dc8'
@@ -109,14 +110,16 @@ if (!project.hasProperty("mbeddrVersion")) {
 }
 
 
-ext.releaseRepository = 'https://projects.itemis.de/nexus/content/repositories/mbeddr'
-ext.snapshotRepository = 'https://projects.itemis.de/nexus/content/repositories/mbeddr_snapshots'
+ext.releaseRepository = 'https://artifacts.itemis.cloud/repository/maven-mps-releases/'
+ext.snapshotRepository = 'https://artifacts.itemis.cloud/repository/maven-mps-snapshots'
 ext.publishingRepository = version.toString().endsWith("-SNAPSHOT") ? snapshotRepository : releaseRepository
 
 ext.dependencyRepositories = [
     'https://projects.itemis.de/nexus/content/repositories/mbeddr',
-    'https://projects.itemis.de/nexus/content/repositories/mbeddr_snapshots'
+    'https://projects.itemis.de/nexus/content/repositories/mbeddr_snapshots',
+    'https://artifacts.itemis.cloud/repository/maven-mps/'
 ]
+    
 
 ext.artifactsDir = new File(rootDir, 'artifacts')
 ext.incrementalBuild = !project.hasProperty("disableIncrementalBuild")
@@ -244,19 +247,7 @@ assemble.dependsOn packageAllScripts, packageLanguages, packageTests
 publishing {
     repositories {
         maven {
-            url project.publishingRepository
-            if (project.hasProperty('nexusUsername')) {
-                credentials {
-                    username project.nexusUsername
-                    password project.nexusPassword
-                }
-            }
-        }
-        maven {
-                name = "itemisCloud"
-                url = version.toString().endsWith("-SNAPSHOT")
-                        ? uri("https://artifacts.itemis.cloud/repository/maven-mps-snapshots/")
-                        : uri("https://artifacts.itemis.cloud/repository/maven-mps-releases/")
+                url = project.publishingRepository
                 if (project.hasProperty("artifacts.itemis.cloud.user") && project.hasProperty("artifacts.itemis.cloud.pw")) {
                     credentials {
                         username = project.findProperty("artifacts.itemis.cloud.user")


### PR DESCRIPTION
- In the scope of migriting away from https://projects.itemis.de/nexus we now remove the publication to the old repository.
- Instead we now publish all artifacts to https://artifacts.itemis.cloud/
- now only new nexus is used for dependency resolution
- In addition the version of the mps-gradle-plugin was updated to the next available on the new cloud.
- mavenLocal() repo was removed from dependency resolution as a problematic one