### PR TITLE
cascading merge to align maintenance branches

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -291,18 +291,6 @@ publishing {
                     }
                 }
         }
-        maven {
-                name = "itemisCloud"
-                url = version.toString().endsWith("-SNAPSHOT")
-                        ? uri("https://artifacts.itemis.cloud/repository/maven-mps-snapshots/")
-                        : uri("https://artifacts.itemis.cloud/repository/maven-mps-releases/")
-                if (project.hasProperty("artifacts.itemis.cloud.user") && project.hasProperty("artifacts.itemis.cloud.pw")) {
-                    credentials {
-                        username = project.findProperty("artifacts.itemis.cloud.user")
-                        password = project.findProperty("artifacts.itemis.cloud.pw")
-                    }
-                }
-        }
     }
     repositories {
         if(currentBranch == "master" || currentBranch.startsWith("maintenance") || currentBranch.startsWith("mps")) {

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ def major = "2020"
 def minor = "3"
 
 // Dependency versions
-ext.mpsVersion = '2020.3.4'
+ext.mpsVersion = '2020.3.6'
 
 def mbeddrVersion = "2020.3+"
 


### PR DESCRIPTION
Merging all 20202 -> 20203 chnages.

MPS version has been additionally updated from 2020.3.4 to 2020.3.6 since platform was previously updated to that version and due to some changes in the API also iets3.os has to be built with the same version to get all the tests running.