### PR TITLE
Clean up build setup tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
 
 ### Using Gradle
 If you just want to build the project, no prerequisites are required. Just run `./gradlew build` from the checkout
-directory. This will download a pre-built version the mbeddr platform from the itemis Nexus repository. Run 
-`./gradlew setup` to generate the `libraries.xml` file so that the mbeddr platform libraries are loaded during the 
-start of mps.
+directory. This will download required version of the mbeddr platform language library from the itemis Nexus repository.
+When the build has finished, you can open the project in MPS from the folder `<iets3.opensource>/code/languages/org.iets3.opensource`
 
 To publish this project's artifacts to the Maven local repository run `./gradlew publishToMavenLocal`.
 

--- a/build.gradle
+++ b/build.gradle
@@ -167,7 +167,7 @@ task resolvePcollections(type: Sync) {
     }
 }
 
-task resolveDependencies(dependsOn: ['downloadJbr', resolveLanguageLibs, resolvePcollections])
+task resolveDependencies(dependsOn: ['downloadJbr', resolveMps, resolveLanguageLibs, resolvePcollections])
 
 // Default arguments for ant scripts
 def defaultScriptArgs = [
@@ -184,16 +184,11 @@ if (gradle.startParameter.logLevel.toString() != "LIFECYCLE") {
 // enables https://github.com/mbeddr/mps-gradle-plugin#providing-global-defaults
 ext["itemis.mps.gradle.ant.defaultScriptArgs"] = defaultScriptArgs.collect { "-D$it.key=$it.value".toString() }
 ext["itemis.mps.gradle.ant.defaultScriptClasspath"] = project.configurations.junitAnt.fileCollection { true }
-
-task setup {
-    doFirst{
-        project.ext["itemis.mps.gradle.ant.defaultJavaExecutable"] = tasks.getByName('downloadJbr').javaExecutable
-    }
-    dependsOn resolveDependencies
-    description 'Set up MPS project libraries. Libraries are read in from projectlibraries.properties file.'
+afterEvaluate {
+    project.ext["itemis.mps.gradle.ant.defaultJavaExecutable"] = tasks.getByName('downloadJbr').javaExecutable
 }
 
-task buildAllScripts(type: BuildLanguages, dependsOn: [setup, resolveMps, resolveDependencies]) {
+task buildAllScripts(type: BuildLanguages, dependsOn: resolveDependencies) {
     script "$buildDir/scripts/build-allScripts.xml"
 }
 
@@ -271,29 +266,27 @@ static def addDependency(Object pom, Configuration config) {
 publishing {
     repositories {
         maven {
-                url = project.publishingRepository
-                if (project.hasProperty("artifacts.itemis.cloud.user") && project.hasProperty("artifacts.itemis.cloud.pw")) {
-                    credentials {
-                        username = project.findProperty("artifacts.itemis.cloud.user")
-                        password = project.findProperty("artifacts.itemis.cloud.pw")
-                    }
+            url = project.publishingRepository
+            if (project.hasProperty("artifacts.itemis.cloud.user") && project.hasProperty("artifacts.itemis.cloud.pw")) {
+                credentials {
+                    username = project.findProperty("artifacts.itemis.cloud.user")
+                    password = project.findProperty("artifacts.itemis.cloud.pw")
                 }
+            }
         }
-    }
-    repositories {
-        if(currentBranch == "master" || currentBranch.startsWith("maintenance") || currentBranch.startsWith("mps")) {
-                maven {
-                    name = "GitHubPackages"
-                    url = uri("https://maven.pkg.github.com/IETS3/iets3.opensource")
-                    if(project.hasProperty("gpr.token")) {
-                        credentials {
-                            username = project.findProperty("gpr.user")
-                            password = project.findProperty("gpr.token")
-                        }
+        if (currentBranch == "master" || currentBranch.startsWith("maintenance") || currentBranch.startsWith("mps")) {
+            maven {
+                name = "GitHubPackages"
+                url = uri("https://maven.pkg.github.com/IETS3/iets3.opensource")
+                if (project.hasProperty("gpr.token")) {
+                    credentials {
+                        username = project.findProperty("gpr.user")
+                        password = project.findProperty("gpr.token")
                     }
                 }
             }
         }
+    }
 
     publications {
         openSource(MavenPublication) {

--- a/projectlibraries.overrides.properties.example
+++ b/projectlibraries.overrides.properties.example
@@ -1,2 +1,0 @@
-# To override values defined in this file create projectlibraries.overrides.properties and put overridden values there.
-mbeddr.plattform=${mbeddr.github.core.home}/code/languages

--- a/projectlibraries.properties
+++ b/projectlibraries.properties
@@ -1,2 +1,0 @@
-# To override values defined in this file create projectlibraries.overrides.properties and put overridden values there.
-mbeddr.plattform=$PROJECT_DIR$/../../../build/dependencies/com.mbeddr.platform


### PR DESCRIPTION
In the past we used `setup` task to generate libraries.xml file for the MPS project and to resolve language libraries used in the project. This approach seems now to be abandoned as the libraries.xml is provided in the repo and no one needs to rewrite it with custom paths on a regular basis. The specific task for generating libraries.xml has been apparently anyway removed from the project at some time earlier. And typically when setting up the project, the user would first need to run the build which resolves the required dependencies under the location specified in the checked-in libraries.xml file. 

I suggest to clean up the project setup a bit and drop the `setup` build task entirely. Instead `resolveDependencies` task can be used separately to get JBR, MPS and language libraries according to the specified versions and set up the project.

In order to configure the path to the java executable based on the `downloadJbr` task, I have used afterEvaluate closure in the project instead of the `setup` task.