### PR TITLE
[minor] Collections (interpreter): make eval arg class check less strict

### DIFF
--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.interpreter/models/plugin.mps
@@ -2552,7 +2552,7 @@
               <node concept="3fqX7Q" id="k9boAtTrKw" role="3clFbw">
                 <node concept="2ZW3vV" id="k9boAtTrKx" role="3fr31v">
                   <node concept="3uibUv" id="k9boAtTrKy" role="2ZW6by">
-                    <ref role="3uigEE" to="j10v:~PVector" resolve="PVector" />
+                    <ref role="3uigEE" to="j10v:~PCollection" resolve="PCollection" />
                   </node>
                   <node concept="37vLTw" id="k9boAtTsa0" role="2ZW6bz">
                     <ref role="3cqZAo" node="46cplYxU9f0" resolve="evaledArg" />


### PR DESCRIPTION
Runtime exceptions can occur because of this check.