### PR TITLE
Merge datev-staging branch

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
@@ -1621,26 +1621,65 @@
               </node>
             </node>
             <node concept="3clFbS" id="1Mp62pP0JhF" role="3clFbx">
-              <node concept="1Z5TYs" id="1Mp62pP0Kiq" role="3cqZAp">
-                <node concept="mw_s8" id="1Mp62pP0KqY" role="1ZfhKB">
-                  <node concept="2OqwBi" id="1Mp62pP0KHS" role="mwGJk">
-                    <node concept="1PxgMI" id="1Mp62pP0Kxj" role="2Oq$k0">
-                      <node concept="chp4Y" id="1Mp62pP0KxL" role="3oSUPX">
-                        <ref role="cht4Q" to="l462:50smQ1V8i89" resolve="TemporalType" />
-                      </node>
-                      <node concept="2X3wrD" id="1Mp62pP0KqW" role="1m5AlR">
-                        <ref role="2X3Bk0" node="1Mp62pP0IvA" resolve="ctxType" />
+              <node concept="3clFbJ" id="5ggxKBpYbiE" role="3cqZAp">
+                <node concept="3clFbS" id="5ggxKBpYbiG" role="3clFbx">
+                  <node concept="1Z5TYs" id="5ggxKBpYdIO" role="3cqZAp">
+                    <node concept="mw_s8" id="5ggxKBpYg04" role="1ZfhKB">
+                      <node concept="2YIFZM" id="5ggxKBpYg5z" role="mwGJk">
+                        <ref role="37wK5l" to="xfg9:2Qbt$1tTQdc" resolve="createRealType" />
+                        <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+                        <node concept="10Nm6u" id="5ggxKBpYnI_" role="37wK5m" />
                       </node>
                     </node>
-                    <node concept="3TrEf2" id="1Mp62pP0L4g" role="2OqNvi">
-                      <ref role="3Tt5mk" to="l462:50smQ1V8i8a" resolve="baseType" />
+                    <node concept="mw_s8" id="5ggxKBpYdIV" role="1ZfhK$">
+                      <node concept="1Z2H0r" id="5ggxKBpYdIW" role="mwGJk">
+                        <node concept="1YBJjd" id="5ggxKBpYdIX" role="1Z2MuG">
+                          <ref role="1YBMHb" node="1Mp62pP0HRo" resolve="reduce" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
-                <node concept="mw_s8" id="1Mp62pP0Kit" role="1ZfhK$">
-                  <node concept="1Z2H0r" id="1Mp62pP0K9n" role="mwGJk">
-                    <node concept="1YBJjd" id="1Mp62pP0Kb9" role="1Z2MuG">
+                <node concept="2OqwBi" id="5ggxKBpYcNW" role="3clFbw">
+                  <node concept="2OqwBi" id="5ggxKBpYbLA" role="2Oq$k0">
+                    <node concept="1YBJjd" id="5ggxKBpYb$3" role="2Oq$k0">
                       <ref role="1YBMHb" node="1Mp62pP0HRo" resolve="reduce" />
+                    </node>
+                    <node concept="3TrEf2" id="5ggxKBpYcay" role="2OqNvi">
+                      <ref role="3Tt5mk" to="l462:1Mp62pP0G9w" resolve="strategy" />
+                    </node>
+                  </node>
+                  <node concept="1mIQ4w" id="5ggxKBpYd6L" role="2OqNvi">
+                    <node concept="chp4Y" id="5ggxKBpYdd$" role="cj9EA">
+                      <ref role="cht4Q" to="l462:6nEpT4GTaVD" resolve="ReduceStrategyWeighted" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="9aQIb" id="5ggxKBpYdE7" role="9aQIa">
+                  <node concept="3clFbS" id="5ggxKBpYdE8" role="9aQI4">
+                    <node concept="1Z5TYs" id="1Mp62pP0Kiq" role="3cqZAp">
+                      <node concept="mw_s8" id="1Mp62pP0KqY" role="1ZfhKB">
+                        <node concept="2OqwBi" id="1Mp62pP0KHS" role="mwGJk">
+                          <node concept="1PxgMI" id="1Mp62pP0Kxj" role="2Oq$k0">
+                            <node concept="chp4Y" id="1Mp62pP0KxL" role="3oSUPX">
+                              <ref role="cht4Q" to="l462:50smQ1V8i89" resolve="TemporalType" />
+                            </node>
+                            <node concept="2X3wrD" id="1Mp62pP0KqW" role="1m5AlR">
+                              <ref role="2X3Bk0" node="1Mp62pP0IvA" resolve="ctxType" />
+                            </node>
+                          </node>
+                          <node concept="3TrEf2" id="1Mp62pP0L4g" role="2OqNvi">
+                            <ref role="3Tt5mk" to="l462:50smQ1V8i8a" resolve="baseType" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="mw_s8" id="1Mp62pP0Kit" role="1ZfhK$">
+                        <node concept="1Z2H0r" id="1Mp62pP0K9n" role="mwGJk">
+                          <node concept="1YBJjd" id="1Mp62pP0Kb9" role="1Z2MuG">
+                            <ref role="1YBMHb" node="1Mp62pP0HRo" resolve="reduce" />
+                          </node>
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -64,6 +64,7 @@
     <import index="kpve" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.message(MPS.Editor/)" />
     <import index="2gg1" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.errors(MPS.Core/)" />
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="wcxw" ref="r:b9f36c08-4a75-4513-9277-a390d3426e0f(jetbrains.mps.editor.runtime.impl.cellActions)" />
     <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -418,6 +419,9 @@
       </concept>
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz">
         <reference id="6677504323281689839" name="conceptDeclaraton" index="3bZ5Sy" />
+      </concept>
+      <concept id="1182511038748" name="jetbrains.mps.lang.smodel.structure.Model_NodesIncludingImportedOperation" flags="nn" index="1j9C0f">
+        <child id="6750920497477143623" name="conceptArgument" index="3MHPCF" />
       </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
@@ -2033,8 +2037,9 @@
                   <ref role="3cqZAo" node="1KPsfaLJpk$" resolve="res" />
                 </node>
                 <node concept="X8dFx" id="1KPsfaLJujm" role="2OqNvi">
-                  <node concept="2OqwBi" id="5$JCxfbTwjt" role="25WWJ7">
-                    <node concept="2OqwBi" id="5$JCxfbTwju" role="2Oq$k0">
+                  <node concept="2OqwBi" id="230lIJUbgs" role="25WWJ7">
+                    <node concept="2OqwBi" id="4QQXQNDecuu" role="2Oq$k0">
+                      <node concept="13iPFW" id="5$JCxfbTwjv" role="2Oq$k0" />
                       <node concept="2Rf3mk" id="2c2AzQdhomR" role="2OqNvi">
                         <node concept="1xMEDy" id="2c2AzQdhomT" role="1xVPHs">
                           <node concept="chp4Y" id="2c2AzQdhoCp" role="ri$Ld">
@@ -2042,32 +2047,14 @@
                           </node>
                         </node>
                       </node>
-                      <node concept="13iPFW" id="5$JCxfbTwjv" role="2Oq$k0" />
                     </node>
-                    <node concept="3zZkjj" id="5$JCxfbTwjx" role="2OqNvi">
-                      <node concept="1bVj0M" id="5$JCxfbTwjy" role="23t8la">
-                        <node concept="3clFbS" id="5$JCxfbTwjz" role="1bW5cS">
-                          <node concept="3clFbF" id="5$JCxfbTwj$" role="3cqZAp">
-                            <node concept="2OqwBi" id="5$JCxfbTwj_" role="3clFbG">
-                              <node concept="37vLTw" id="5$JCxfbTwjA" role="2Oq$k0">
-                                <ref role="3cqZAo" node="5$JCxfbTwjE" resolve="it" />
-                              </node>
-                              <node concept="1mIQ4w" id="5$JCxfbTwjB" role="2OqNvi">
-                                <node concept="25Kdxt" id="5$JCxfbTwjC" role="cj9EA">
-                                  <node concept="2OqwBi" id="1mDdTGHnpv" role="25KhWn">
-                                    <node concept="37vLTw" id="5$JCxfbTwjD" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="5$JCxfbTgvQ" resolve="targetConcept" />
-                                    </node>
-                                    <node concept="1rGIog" id="1mDdTGHnMK" role="2OqNvi" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
+                    <node concept="v3k3i" id="230lIJUfBi" role="2OqNvi">
+                      <node concept="25Kdxt" id="230lIJUhGN" role="v3oSu">
+                        <node concept="2OqwBi" id="230lIJUlC6" role="25KhWn">
+                          <node concept="37vLTw" id="230lIJUjQS" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5$JCxfbTgvQ" resolve="targetConcept" />
                           </node>
-                        </node>
-                        <node concept="Rh6nW" id="5$JCxfbTwjE" role="1bW2Oz">
-                          <property role="TrG5h" value="it" />
-                          <node concept="2jxLKc" id="5$JCxfbTwjF" role="1tU5fm" />
+                          <node concept="1rGIog" id="230lIJUo4M" role="2OqNvi" />
                         </node>
                       </node>
                     </node>
@@ -2079,24 +2066,26 @@
           <node concept="9aQIb" id="5$JCxfbTixX" role="9aQIa">
             <node concept="3clFbS" id="5$JCxfbTixY" role="9aQI4">
               <node concept="3clFbF" id="5m_JEEZZMav" role="3cqZAp">
-                <node concept="2OqwBi" id="5m_JEEZZOeu" role="3clFbG">
+                <node concept="2OqwBi" id="4QQXQNDig7j" role="3clFbG">
                   <node concept="37vLTw" id="5m_JEEZZMat" role="2Oq$k0">
                     <ref role="3cqZAo" node="1KPsfaLJpk$" resolve="res" />
                   </node>
                   <node concept="liA8E" id="5m_JEEZZP$o" role="2OqNvi">
                     <ref role="37wK5l" to="33ny:~List.addAll(java.util.Collection)" resolve="addAll" />
-                    <node concept="2YIFZM" id="5m_JEEZZlEm" role="37wK5m">
-                      <ref role="1Pybhc" to="i8bi:5IkW5anFaW6" resolve="SModelOperations" />
-                      <ref role="37wK5l" to="i8bi:6cG5ul0xAxx" resolve="nodesIncludingImported" />
-                      <node concept="2OqwBi" id="5m_JEEZZm93" role="37wK5m">
+                    <node concept="2OqwBi" id="230lIJTTtd" role="37wK5m">
+                      <node concept="2OqwBi" id="5m_JEEZZm93" role="2Oq$k0">
                         <node concept="13iPFW" id="5m_JEEZZlID" role="2Oq$k0" />
                         <node concept="I4A8Y" id="5m_JEEZZmPd" role="2OqNvi" />
                       </node>
-                      <node concept="2OqwBi" id="5m_JEEZZKze" role="37wK5m">
-                        <node concept="37vLTw" id="5m_JEEZZKjw" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5$JCxfbTgvQ" resolve="targetConcept" />
+                      <node concept="1j9C0f" id="230lIJTVBo" role="2OqNvi">
+                        <node concept="25Kdxt" id="230lIJTXRs" role="3MHPCF">
+                          <node concept="2OqwBi" id="230lIJU1LH" role="25KhWn">
+                            <node concept="37vLTw" id="230lIJTZd6" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5$JCxfbTgvQ" resolve="targetConcept" />
+                            </node>
+                            <node concept="1rGIog" id="230lIJU2UF" role="2OqNvi" />
+                          </node>
                         </node>
-                        <node concept="1rGIog" id="5m_JEEZZKQC" role="2OqNvi" />
                       </node>
                     </node>
                   </node>
@@ -2143,8 +2132,31 @@
           </node>
         </node>
         <node concept="3clFbF" id="1KPsfaLJH5h" role="3cqZAp">
-          <node concept="37vLTw" id="1KPsfaLJH5f" role="3clFbG">
-            <ref role="3cqZAo" node="1KPsfaLJpk$" resolve="res" />
+          <node concept="2OqwBi" id="230lIJTLgN" role="3clFbG">
+            <node concept="37vLTw" id="1KPsfaLJH5f" role="2Oq$k0">
+              <ref role="3cqZAo" node="1KPsfaLJpk$" resolve="res" />
+            </node>
+            <node concept="3zZkjj" id="230lIJTFuU" role="2OqNvi">
+              <node concept="1bVj0M" id="230lIJTFuW" role="23t8la">
+                <node concept="3clFbS" id="230lIJTFuX" role="1bW5cS">
+                  <node concept="3clFbF" id="230lIJTF$c" role="3cqZAp">
+                    <node concept="3fqX7Q" id="230lIJTGhW" role="3clFbG">
+                      <node concept="2YIFZM" id="230lIJTGhY" role="3fr31v">
+                        <ref role="37wK5l" to="wcxw:7YnpPzFReKN" resolve="isCommentedOut" />
+                        <ref role="1Pybhc" to="wcxw:5FzO4t9gN3W" resolve="CommentUtil" />
+                        <node concept="37vLTw" id="230lIJTGhZ" role="37wK5m">
+                          <ref role="3cqZAo" node="230lIJTFuY" resolve="it" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="230lIJTFuY" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="230lIJTFuZ" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/org.iets3.core.expr.tests.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/org.iets3.core.expr.tests.mpl
@@ -162,6 +162,7 @@
     <dependency reexport="false">ecfb9949-7433-4db5-85de-0f84d172e4ce(de.q60.mps.collections.libs)</dependency>
     <dependency reexport="false">9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)</dependency>
     <dependency reexport="false">f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)</dependency>
+    <dependency reexport="false">34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3b3dc28-fee3-49e1-a46e-685e96389094:com.mbeddr.mpsutil.bldoc" version="0" />
@@ -265,6 +266,7 @@
     <module reference="f61473f9-130f-42f6-b98d-6c438812c2f6(jetbrains.mps.baseLanguage.unitTest)" version="0" />
     <module reference="83f155ff-422c-4b5a-a2f2-b459302dd215(jetbrains.mps.baseLanguage.unitTest.libs)" version="0" />
     <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
+    <module reference="34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)" version="0" />
     <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
     <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -39,6 +39,7 @@
     <import index="gdgh" ref="r:e4d9478b-ae0e-416e-be60-73d136571015(org.iets3.core.base.behavior)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="pq1l" ref="r:93cd1fe8-b296-405c-a6e6-040c940ccfa1(org.iets3.core.expr.toplevel.plugin)" />
+    <import index="wcxw" ref="r:b9f36c08-4a75-4513-9277-a390d3426e0f(jetbrains.mps.editor.runtime.impl.cellActions)" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -7206,12 +7207,35 @@
       <node concept="3Tm1VV" id="5VEHrQcW_FX" role="1B3o_S" />
       <node concept="3clFbS" id="5VEHrQcW_G1" role="3clF47">
         <node concept="3clFbF" id="5VEHrQcWBW6" role="3cqZAp">
-          <node concept="2OqwBi" id="1sudaVNnj0y" role="3clFbG">
-            <node concept="13iPFW" id="1sudaVNniFF" role="2Oq$k0" />
-            <node concept="2Rf3mk" id="1sudaVNnjqU" role="2OqNvi">
-              <node concept="1xMEDy" id="1sudaVNnjqW" role="1xVPHs">
-                <node concept="chp4Y" id="1sudaVNnjsk" role="ri$Ld">
-                  <ref role="cht4Q" to="yv47:2uR5X5ayM7T" resolve="IToplevelExprContent" />
+          <node concept="2OqwBi" id="230lIJTCqL" role="3clFbG">
+            <node concept="2OqwBi" id="4QQXQNDjvKv" role="2Oq$k0">
+              <node concept="13iPFW" id="1sudaVNniFF" role="2Oq$k0" />
+              <node concept="2Rf3mk" id="1sudaVNnjqU" role="2OqNvi">
+                <node concept="1xMEDy" id="1sudaVNnjqW" role="1xVPHs">
+                  <node concept="chp4Y" id="1sudaVNnjsk" role="ri$Ld">
+                    <ref role="cht4Q" to="yv47:2uR5X5ayM7T" resolve="IToplevelExprContent" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3zZkjj" id="230lIJTFuU" role="2OqNvi">
+              <node concept="1bVj0M" id="230lIJTFuW" role="23t8la">
+                <node concept="3clFbS" id="230lIJTFuX" role="1bW5cS">
+                  <node concept="3clFbF" id="230lIJTF$c" role="3cqZAp">
+                    <node concept="3fqX7Q" id="230lIJTGhW" role="3clFbG">
+                      <node concept="2YIFZM" id="230lIJTGhY" role="3fr31v">
+                        <ref role="37wK5l" to="wcxw:7YnpPzFReKN" resolve="isCommentedOut" />
+                        <ref role="1Pybhc" to="wcxw:5FzO4t9gN3W" resolve="CommentUtil" />
+                        <node concept="37vLTw" id="230lIJTGhZ" role="37wK5m">
+                          <ref role="3cqZAo" node="230lIJTFuY" resolve="it" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="230lIJTFuY" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="230lIJTFuZ" role="1tU5fm" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -1996,13 +1996,6 @@
               <property role="VOm3f" value="true" />
             </node>
           </node>
-          <node concept="ZYGn8" id="68WOIGeG1KK" role="ZWbT9">
-            <node concept="3clFbS" id="68WOIGeG1KL" role="2VODD2">
-              <node concept="3clFbF" id="68WOIGeG1KV" role="3cqZAp">
-                <node concept="10Nm6u" id="68WOIGeG1KU" role="3clFbG" />
-              </node>
-            </node>
-          </node>
         </node>
         <node concept="l2Vlx" id="3WWvqarUGzE" role="2iSdaV" />
         <node concept="3F0ifn" id="3WWvqarUGzF" role="3EZMnx">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/org.iets3.core.expr.toplevel.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/org.iets3.core.expr.toplevel.mpl
@@ -29,6 +29,7 @@
     <dependency reexport="false">726886d1-ef90-4249-a08f-1e3ec23a7113(com.mbeddr.mpsutil.traceExplorer)</dependency>
     <dependency reexport="false">28583149-5b6e-4663-9c02-b9a8fa3cb099(com.mbeddr.mpsutil.contextactions.runtime)</dependency>
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
+    <dependency reexport="false">34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:677f00fb-4488-405e-9885-abb75d472fd1:com.mbeddr.mpsutil.contextactions" version="0" />
@@ -117,6 +118,7 @@
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
+    <module reference="34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)" version="0" />
     <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
     <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="8d29d73f-ed99-4652-ae0a-083cdfe53c34(jetbrains.mps.ide.platform)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.plugin/models/org/iets3/req/plugin/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.plugin/models/org/iets3/req/plugin/plugin.mps
@@ -164,6 +164,7 @@
       <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
         <property id="8355037393041754995" name="isNative" index="2aFKle" />
       </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
@@ -357,13 +358,13 @@
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
+      <concept id="1224414427926" name="jetbrains.mps.baseLanguage.collections.structure.SequenceCreator" flags="nn" index="kMnCb" />
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
-      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
       <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435807" name="elementType" index="HW$YZ" />
@@ -613,12 +614,7 @@
             <node concept="2YIFZM" id="5Zn2KFQQWTp" role="geMah">
               <ref role="37wK5l" node="5Zn2KFQQNJT" resolve="getValidDocContents" />
               <ref role="1Pybhc" node="5Zn2KFQQ$_B" resolve="Helper" />
-              <node concept="2OqwBi" id="5Zn2KFQQY7t" role="37wK5m">
-                <node concept="gKNx_" id="5Zn2KFQQXxb" role="2Oq$k0" />
-                <node concept="liA8E" id="5Zn2KFQQYIx" role="2OqNvi">
-                  <ref role="37wK5l" to="1ne1:5tr7YH$UxYk" resolve="getModel" />
-                </node>
-              </node>
+              <node concept="gKNx_" id="5Zn2KFQQXxb" role="37wK5m" />
             </node>
           </node>
         </node>
@@ -779,58 +775,10 @@
                 </node>
               </node>
             </node>
-            <node concept="2OqwBi" id="5Zn2KFQRMdY" role="geMah">
-              <node concept="2OqwBi" id="5Zn2KFQRMdZ" role="2Oq$k0">
-                <node concept="2OqwBi" id="5Zn2KFQRMe0" role="2Oq$k0">
-                  <node concept="35c_gC" id="5Zn2KFQRMe1" role="2Oq$k0">
-                    <ref role="35c_gD" to="2c95:5mf_X_La_N$" resolve="FormattedText" />
-                  </node>
-                  <node concept="LSoRf" id="5Zn2KFQRMe2" role="2OqNvi">
-                    <node concept="2OqwBi" id="5Zn2KFQRMe3" role="1iTxcG">
-                      <node concept="gKNx_" id="5Zn2KFQRMe4" role="2Oq$k0" />
-                      <node concept="liA8E" id="5Zn2KFQRMe5" role="2OqNvi">
-                        <ref role="37wK5l" to="1ne1:5tr7YH$UxYk" resolve="getModel" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3zZkjj" id="5Zn2KFQRMe6" role="2OqNvi">
-                  <node concept="1bVj0M" id="5Zn2KFQRMe7" role="23t8la">
-                    <node concept="3clFbS" id="5Zn2KFQRMe8" role="1bW5cS">
-                      <node concept="3clFbF" id="5Zn2KFQRMe9" role="3cqZAp">
-                        <node concept="1Wc70l" id="5Zn2KFQRMea" role="3clFbG">
-                          <node concept="3fqX7Q" id="5Zn2KFQRMeb" role="3uHU7w">
-                            <node concept="2OqwBi" id="5Zn2KFQRMec" role="3fr31v">
-                              <node concept="2OqwBi" id="5Zn2KFQRMed" role="2Oq$k0">
-                                <node concept="37vLTw" id="5Zn2KFQRMee" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="5Zn2KFQRMel" resolve="cc" />
-                                </node>
-                                <node concept="3n3YKJ" id="5Zn2KFQRMef" role="2OqNvi" />
-                              </node>
-                              <node concept="17RlXB" id="5Zn2KFQRMeg" role="2OqNvi" />
-                            </node>
-                          </node>
-                          <node concept="3fqX7Q" id="5Zn2KFQRMeh" role="3uHU7B">
-                            <node concept="2OqwBi" id="5Zn2KFQRMei" role="3fr31v">
-                              <node concept="37vLTw" id="5Zn2KFQRMej" role="2Oq$k0">
-                                <ref role="3cqZAo" node="5Zn2KFQRMel" resolve="cc" />
-                              </node>
-                              <node concept="liA8E" id="5Zn2KFQRMek" role="2OqNvi">
-                                <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="Rh6nW" id="5Zn2KFQRMel" role="1bW2Oz">
-                      <property role="TrG5h" value="cc" />
-                      <node concept="2jxLKc" id="5Zn2KFQRMem" role="1tU5fm" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="ANE8D" id="5Zn2KFQRMen" role="2OqNvi" />
+            <node concept="2YIFZM" id="34Lz1M9DvlR" role="geMah">
+              <ref role="37wK5l" node="3Vv_jNR0RaX" resolve="getValidFormattingContents" />
+              <ref role="1Pybhc" node="5Zn2KFQQ$_B" resolve="Helper" />
+              <node concept="gKNx_" id="34Lz1M9DvFM" role="37wK5m" />
             </node>
           </node>
         </node>
@@ -1003,64 +951,10 @@
         <node concept="3bZ5Sz" id="7Dcax7Ai7wF" role="geMaj">
           <ref role="3bZ5Sy" to="plfp:4tXyFaWylGs" resolve="Tag" />
         </node>
-        <node concept="2OqwBi" id="1T$QQLd4dsx" role="geMah">
-          <node concept="2OqwBi" id="1T$QQLd4dsy" role="2Oq$k0">
-            <node concept="2OqwBi" id="1T$QQLd4dsz" role="2Oq$k0">
-              <node concept="35c_gC" id="1T$QQLd4ds$" role="2Oq$k0">
-                <ref role="35c_gD" to="plfp:4tXyFaWylGs" resolve="Tag" />
-              </node>
-              <node concept="LSoRf" id="1T$QQLd4ds_" role="2OqNvi">
-                <node concept="2OqwBi" id="1T$QQLd4dsA" role="1iTxcG">
-                  <node concept="gKNx_" id="1T$QQLd4lko" role="2Oq$k0" />
-                  <node concept="liA8E" id="1T$QQLd4dsC" role="2OqNvi">
-                    <ref role="37wK5l" to="1ne1:5tr7YH$UxYk" resolve="getModel" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3zZkjj" id="1T$QQLd4dsD" role="2OqNvi">
-              <node concept="1bVj0M" id="1T$QQLd4dsE" role="23t8la">
-                <node concept="3clFbS" id="1T$QQLd4dsF" role="1bW5cS">
-                  <node concept="3clFbF" id="1T$QQLd4dsG" role="3cqZAp">
-                    <node concept="3fqX7Q" id="1T$QQLd4dsH" role="3clFbG">
-                      <node concept="2OqwBi" id="1T$QQLd4dsI" role="3fr31v">
-                        <node concept="37vLTw" id="1T$QQLd4dsJ" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1T$QQLd4dsL" resolve="tag" />
-                        </node>
-                        <node concept="liA8E" id="1T$QQLd4dsK" role="2OqNvi">
-                          <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="Rh6nW" id="1T$QQLd4dsL" role="1bW2Oz">
-                  <property role="TrG5h" value="tag" />
-                  <node concept="2jxLKc" id="1T$QQLd4dsM" role="1tU5fm" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3zZkjj" id="1T$QQLd4dsN" role="2OqNvi">
-            <node concept="1bVj0M" id="1T$QQLd4dsO" role="23t8la">
-              <node concept="3clFbS" id="1T$QQLd4dsP" role="1bW5cS">
-                <node concept="3clFbF" id="1T$QQLd4gVi" role="3cqZAp">
-                  <node concept="2YIFZM" id="1T$QQLd4hio" role="3clFbG">
-                    <ref role="37wK5l" node="hzYhIjiQKh" resolve="checkTag" />
-                    <ref role="1Pybhc" node="5Zn2KFQQ$_B" resolve="Helper" />
-                    <node concept="gKNx_" id="1T$QQLd4jKE" role="37wK5m" />
-                    <node concept="37vLTw" id="1T$QQLd4kmr" role="37wK5m">
-                      <ref role="3cqZAo" node="1T$QQLd4dsU" resolve="tag" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="Rh6nW" id="1T$QQLd4dsU" role="1bW2Oz">
-                <property role="TrG5h" value="tag" />
-                <node concept="2jxLKc" id="1T$QQLd4dsV" role="1tU5fm" />
-              </node>
-            </node>
-          </node>
+        <node concept="2YIFZM" id="34Lz1M9DEAg" role="geMah">
+          <ref role="37wK5l" node="34Lz1M9Dz$N" resolve="getValidTagsContents" />
+          <ref role="1Pybhc" node="5Zn2KFQQ$_B" resolve="Helper" />
+          <node concept="gKNx_" id="34Lz1M9DF0$" role="37wK5m" />
         </node>
       </node>
     </node>
@@ -1203,6 +1097,26 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbJ" id="3Vv_jNR0Jo7" role="3cqZAp">
+          <node concept="3clFbS" id="3Vv_jNR0Jo9" role="3clFbx">
+            <node concept="3cpWs6" id="3Vv_jNR0N64" role="3cqZAp">
+              <node concept="37vLTw" id="3Vv_jNR0Nsg" role="3cqZAk">
+                <ref role="3cqZAo" node="5Zn2KFQQRmU" resolve="res" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="3Vv_jNR0M5E" role="3clFbw">
+            <node concept="10Nm6u" id="3Vv_jNR0MKa" role="3uHU7w" />
+            <node concept="2OqwBi" id="34Lz1M9DL3N" role="3uHU7B">
+              <node concept="37vLTw" id="34Lz1M9DL3O" role="2Oq$k0">
+                <ref role="3cqZAo" node="34Lz1M9DJ86" resolve="ctx" />
+              </node>
+              <node concept="liA8E" id="34Lz1M9DL3P" role="2OqNvi">
+                <ref role="37wK5l" to="1ne1:5tr7YH$UxYk" resolve="getModel" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="5Zn2KFQQUg$" role="3cqZAp">
           <node concept="2OqwBi" id="5Zn2KFQQUsN" role="3clFbG">
             <node concept="37vLTw" id="5Zn2KFQQUgy" role="2Oq$k0">
@@ -1215,8 +1129,13 @@
                     <ref role="35c_gD" to="plfp:7Dcax7AgAPg" resolve="IReqDocContent" />
                   </node>
                   <node concept="LSoRf" id="5Zn2KFQQNNY" role="2OqNvi">
-                    <node concept="37vLTw" id="5Zn2KFQQTPT" role="1iTxcG">
-                      <ref role="3cqZAo" node="5Zn2KFQQTKZ" resolve="m" />
+                    <node concept="2OqwBi" id="34Lz1M9DKnO" role="1iTxcG">
+                      <node concept="37vLTw" id="5Zn2KFQQTPT" role="2Oq$k0">
+                        <ref role="3cqZAo" node="34Lz1M9DJ86" resolve="ctx" />
+                      </node>
+                      <node concept="liA8E" id="34Lz1M9DKS9" role="2OqNvi">
+                        <ref role="37wK5l" to="1ne1:5tr7YH$UxYk" resolve="getModel" />
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -1301,9 +1220,205 @@
           </node>
         </node>
       </node>
-      <node concept="37vLTG" id="5Zn2KFQQTKZ" role="3clF46">
-        <property role="TrG5h" value="m" />
-        <node concept="H_c77" id="5Zn2KFQQTKY" role="1tU5fm" />
+      <node concept="37vLTG" id="34Lz1M9DJ86" role="3clF46">
+        <property role="TrG5h" value="ctx" />
+        <node concept="3uibUv" id="34Lz1M9DJ87" role="1tU5fm">
+          <ref role="3uigEE" to="1ne1:5tr7YH$Ux6m" resolve="IContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3Vv_jNR0OJ7" role="jymVt" />
+    <node concept="2YIFZL" id="3Vv_jNR0RaX" role="jymVt">
+      <property role="TrG5h" value="getValidFormattingContents" />
+      <node concept="3clFbS" id="3Vv_jNR0Rb0" role="3clF47">
+        <node concept="3clFbJ" id="3Vv_jNR0Rus" role="3cqZAp">
+          <node concept="3clFbS" id="3Vv_jNR0Rut" role="3clFbx">
+            <node concept="3cpWs6" id="3Vv_jNR0Ruu" role="3cqZAp">
+              <node concept="2ShNRf" id="34Lz1M9DrXz" role="3cqZAk">
+                <node concept="kMnCb" id="34Lz1M9DuhF" role="2ShVmc" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="3Vv_jNR0Ruw" role="3clFbw">
+            <node concept="10Nm6u" id="3Vv_jNR0Rux" role="3uHU7w" />
+            <node concept="2OqwBi" id="34Lz1M9DIB5" role="3uHU7B">
+              <node concept="37vLTw" id="3Vv_jNR0Ruy" role="2Oq$k0">
+                <ref role="3cqZAo" node="34Lz1M9DIek" resolve="ctx" />
+              </node>
+              <node concept="liA8E" id="34Lz1M9DIRl" role="2OqNvi">
+                <ref role="37wK5l" to="1ne1:5tr7YH$UxYk" resolve="getModel" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="34Lz1M9Dy4L" role="3cqZAp">
+          <node concept="2OqwBi" id="5Zn2KFQRMdZ" role="3clFbG">
+            <node concept="2OqwBi" id="5Zn2KFQRMe0" role="2Oq$k0">
+              <node concept="35c_gC" id="5Zn2KFQRMe1" role="2Oq$k0">
+                <ref role="35c_gD" to="2c95:5mf_X_La_N$" resolve="FormattedText" />
+              </node>
+              <node concept="LSoRf" id="5Zn2KFQRMe2" role="2OqNvi">
+                <node concept="2OqwBi" id="34Lz1M9DIXi" role="1iTxcG">
+                  <node concept="37vLTw" id="34Lz1M9DIXj" role="2Oq$k0">
+                    <ref role="3cqZAo" node="34Lz1M9DIek" resolve="ctx" />
+                  </node>
+                  <node concept="liA8E" id="34Lz1M9DIXk" role="2OqNvi">
+                    <ref role="37wK5l" to="1ne1:5tr7YH$UxYk" resolve="getModel" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3zZkjj" id="5Zn2KFQRMe6" role="2OqNvi">
+              <node concept="1bVj0M" id="5Zn2KFQRMe7" role="23t8la">
+                <node concept="3clFbS" id="5Zn2KFQRMe8" role="1bW5cS">
+                  <node concept="3clFbF" id="5Zn2KFQRMe9" role="3cqZAp">
+                    <node concept="1Wc70l" id="5Zn2KFQRMea" role="3clFbG">
+                      <node concept="3fqX7Q" id="5Zn2KFQRMeb" role="3uHU7w">
+                        <node concept="2OqwBi" id="5Zn2KFQRMec" role="3fr31v">
+                          <node concept="2OqwBi" id="5Zn2KFQRMed" role="2Oq$k0">
+                            <node concept="37vLTw" id="5Zn2KFQRMee" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5Zn2KFQRMel" resolve="cc" />
+                            </node>
+                            <node concept="3n3YKJ" id="5Zn2KFQRMef" role="2OqNvi" />
+                          </node>
+                          <node concept="17RlXB" id="5Zn2KFQRMeg" role="2OqNvi" />
+                        </node>
+                      </node>
+                      <node concept="3fqX7Q" id="5Zn2KFQRMeh" role="3uHU7B">
+                        <node concept="2OqwBi" id="5Zn2KFQRMei" role="3fr31v">
+                          <node concept="37vLTw" id="5Zn2KFQRMej" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5Zn2KFQRMel" resolve="cc" />
+                          </node>
+                          <node concept="liA8E" id="5Zn2KFQRMek" role="2OqNvi">
+                            <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="5Zn2KFQRMel" role="1bW2Oz">
+                  <property role="TrG5h" value="cc" />
+                  <node concept="2jxLKc" id="5Zn2KFQRMem" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3Vv_jNR0OWt" role="1B3o_S" />
+      <node concept="A3Dl8" id="34Lz1M9DreQ" role="3clF45">
+        <node concept="3bZ5Sz" id="34Lz1M9DreS" role="A3Ik2">
+          <ref role="3bZ5Sy" to="2c95:5mf_X_La_N$" resolve="FormattedText" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="34Lz1M9DIek" role="3clF46">
+        <property role="TrG5h" value="ctx" />
+        <node concept="3uibUv" id="34Lz1M9DIel" role="1tU5fm">
+          <ref role="3uigEE" to="1ne1:5tr7YH$Ux6m" resolve="IContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="34Lz1M9DzPn" role="jymVt" />
+    <node concept="2YIFZL" id="34Lz1M9Dz$N" role="jymVt">
+      <property role="TrG5h" value="getValidTagsContents" />
+      <node concept="3clFbS" id="34Lz1M9Dz$O" role="3clF47">
+        <node concept="3clFbJ" id="34Lz1M9Dz$P" role="3cqZAp">
+          <node concept="3clFbS" id="34Lz1M9Dz$Q" role="3clFbx">
+            <node concept="3cpWs6" id="34Lz1M9Dz$R" role="3cqZAp">
+              <node concept="2ShNRf" id="34Lz1M9Dz$S" role="3cqZAk">
+                <node concept="kMnCb" id="34Lz1M9Dz$T" role="2ShVmc" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="34Lz1M9Dz$U" role="3clFbw">
+            <node concept="10Nm6u" id="34Lz1M9Dz$V" role="3uHU7w" />
+            <node concept="2OqwBi" id="34Lz1M9DH1F" role="3uHU7B">
+              <node concept="37vLTw" id="34Lz1M9Dz$W" role="2Oq$k0">
+                <ref role="3cqZAo" node="34Lz1M9DCrr" resolve="ctx" />
+              </node>
+              <node concept="liA8E" id="34Lz1M9DHow" role="2OqNvi">
+                <ref role="37wK5l" to="1ne1:5tr7YH$UxYk" resolve="getModel" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="34Lz1M9D$5K" role="3cqZAp">
+          <node concept="2OqwBi" id="1T$QQLd4dsx" role="3clFbG">
+            <node concept="2OqwBi" id="1T$QQLd4dsy" role="2Oq$k0">
+              <node concept="2OqwBi" id="1T$QQLd4dsz" role="2Oq$k0">
+                <node concept="35c_gC" id="1T$QQLd4ds$" role="2Oq$k0">
+                  <ref role="35c_gD" to="plfp:4tXyFaWylGs" resolve="Tag" />
+                </node>
+                <node concept="LSoRf" id="1T$QQLd4ds_" role="2OqNvi">
+                  <node concept="2OqwBi" id="34Lz1M9DHG0" role="1iTxcG">
+                    <node concept="37vLTw" id="34Lz1M9D$vr" role="2Oq$k0">
+                      <ref role="3cqZAo" node="34Lz1M9DCrr" resolve="ctx" />
+                    </node>
+                    <node concept="liA8E" id="34Lz1M9DI3d" role="2OqNvi">
+                      <ref role="37wK5l" to="1ne1:5tr7YH$UxYk" resolve="getModel" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3zZkjj" id="1T$QQLd4dsD" role="2OqNvi">
+                <node concept="1bVj0M" id="1T$QQLd4dsE" role="23t8la">
+                  <node concept="3clFbS" id="1T$QQLd4dsF" role="1bW5cS">
+                    <node concept="3clFbF" id="1T$QQLd4dsG" role="3cqZAp">
+                      <node concept="3fqX7Q" id="1T$QQLd4dsH" role="3clFbG">
+                        <node concept="2OqwBi" id="1T$QQLd4dsI" role="3fr31v">
+                          <node concept="37vLTw" id="1T$QQLd4dsJ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="1T$QQLd4dsL" resolve="tag" />
+                          </node>
+                          <node concept="liA8E" id="1T$QQLd4dsK" role="2OqNvi">
+                            <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="1T$QQLd4dsL" role="1bW2Oz">
+                    <property role="TrG5h" value="tag" />
+                    <node concept="2jxLKc" id="1T$QQLd4dsM" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3zZkjj" id="1T$QQLd4dsN" role="2OqNvi">
+              <node concept="1bVj0M" id="1T$QQLd4dsO" role="23t8la">
+                <node concept="3clFbS" id="1T$QQLd4dsP" role="1bW5cS">
+                  <node concept="3clFbF" id="1T$QQLd4gVi" role="3cqZAp">
+                    <node concept="1rXfSq" id="34Lz1M9DA_S" role="3clFbG">
+                      <ref role="37wK5l" node="hzYhIjiQKh" resolve="checkTag" />
+                      <node concept="37vLTw" id="34Lz1M9DCY5" role="37wK5m">
+                        <ref role="3cqZAo" node="34Lz1M9DCrr" resolve="ctx" />
+                      </node>
+                      <node concept="37vLTw" id="1T$QQLd4kmr" role="37wK5m">
+                        <ref role="3cqZAo" node="1T$QQLd4dsU" resolve="tag" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="1T$QQLd4dsU" role="1bW2Oz">
+                  <property role="TrG5h" value="tag" />
+                  <node concept="2jxLKc" id="1T$QQLd4dsV" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="34Lz1M9Dz_k" role="1B3o_S" />
+      <node concept="A3Dl8" id="34Lz1M9Dz_l" role="3clF45">
+        <node concept="3bZ5Sz" id="34Lz1M9Dz_m" role="A3Ik2">
+          <ref role="3bZ5Sy" to="plfp:4tXyFaWylGs" resolve="Tag" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="34Lz1M9DCrr" role="3clF46">
+        <property role="TrG5h" value="ctx" />
+        <node concept="3uibUv" id="34Lz1M9DCrs" role="1tU5fm">
+          <ref role="3uigEE" to="1ne1:5tr7YH$Ux6m" resolve="IContext" />
+        </node>
       </node>
     </node>
     <node concept="2tJIrI" id="hzYhIjhS1f" role="jymVt" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -3698,6 +3698,11 @@
             <ref role="3bR37D" to="al5i:7vUP_qcXuSh" resolve="com.mbeddr.mpsutil.contextactions.runtime" />
           </node>
         </node>
+        <node concept="1SiIV0" id="230lIJVLiE" role="3bR37C">
+          <node concept="3bR9La" id="230lIJVLiF" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="5a_u3OzLedQ" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -4878,6 +4883,11 @@
         <node concept="1SiIV0" id="BuchFahldt" role="3bR37C">
           <node concept="3bR9La" id="BuchFahldu" role="1SiIV1">
             <ref role="3bR37D" to="90a9:64TsoMQT2qP" resolve="de.slisson.mps.hacks.editor" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="230lIJVLk_" role="3bR37C">
+          <node concept="3bR9La" id="230lIJVLkA" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
           </node>
         </node>
       </node>
@@ -8033,6 +8043,69 @@
         <node concept="3LEDTy" id="3HiHZeyCp43" role="3LEDUa">
           <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
         </node>
+        <node concept="3LEDTy" id="230lIJVLqG" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L2l" resolve="jetbrains.mps.baseLanguage.logging" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqH" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:$bJ0jguQfr" resolve="com.mbeddr.core.base" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqI" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0j" resolve="jetbrains.mps.baseLanguage.unitTest" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqJ" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L9O" resolve="jetbrains.mps.lang.smodel" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqK" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI23Wm" resolve="jetbrains.mps.lang.migration" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqL" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:1CtrbKI2fIc" resolve="jetbrains.mps.baseLanguage.lightweightdsl" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqM" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:14x5$qAUbkb" resolve="jetbrains.mps.lang.access" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqN" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L4p" resolve="jetbrains.mps.lang.behavior" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqO" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqP" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqQ" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:Vtr7jyAKU4" resolve="com.mbeddr.mpsutil.filepicker" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqR" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqS" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqT" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZA" resolve="jetbrains.mps.baseLanguage.classifiers" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqU" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:1sO539bGQvB" resolve="de.slisson.mps.richtext" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqV" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:2bBLuwR9LnB" resolve="com.mbeddr.mpsutil.interpreter.test" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqW" role="3LEDUa">
+          <ref role="3LEDTV" to="90a9:2NyZxKpUE9j" resolve="com.mbeddr.mpsutil.blutil" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqX" role="3LEDUa">
+          <ref role="3LEDTV" to="al5i:5GUwywcVavP" resolve="com.mbeddr.mpsutil.interpreter" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqY" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:ymnOULAU0H" resolve="jetbrains.mps.lang.test" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLqZ" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZ0" resolve="jetbrains.mps.baseLanguageInternal" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLr0" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC_4Ut" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -8432,6 +8505,18 @@
         </node>
         <node concept="3LEDTy" id="CZ7JsUXByc" role="3LEDUa">
           <ref role="3LEDTV" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLrL" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6L0h" resolve="jetbrains.mps.baseLanguage.collections" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLrM" role="3LEDUa">
+          <ref role="3LEDTV" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLrN" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qVBy" resolve="org.iets3.core.expr.genjava.simpleTypes" />
+        </node>
+        <node concept="3LEDTy" id="230lIJVLrO" role="3LEDUa">
+          <ref role="3LEDTV" node="26tZ$Z4qSzW" resolve="org.iets3.core.expr.genjava.base" />
         </node>
       </node>
       <node concept="1E1JtA" id="4YDVTWrP3Qy" role="2G$12L">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/temporal@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/temporal@tests.mps
@@ -4049,23 +4049,6 @@
         </node>
       </node>
     </node>
-    <node concept="2zPypq" id="2Wqs7XmgUe6" role="_iOnB">
-      <property role="TrG5h" value="reduceFirstYearWithoutSlices8" />
-      <property role="0Rz4W" value="-1740576778" />
-      <node concept="1QScDb" id="2Wqs7XmgUe7" role="2zPyp_">
-        <node concept="1DAXCi" id="2Wqs7XmgUe8" role="1QScD9">
-          <node concept="2X6tET" id="2Wqs7XmgWxr" role="1DAXD6" />
-          <node concept="1f6kyV" id="2Wqs7XmgUea" role="1DAXD0">
-            <node concept="30bXRB" id="2Wqs7XmgUeb" role="1f6kyW">
-              <property role="30bXRw" value="2000" />
-            </node>
-          </node>
-        </node>
-        <node concept="_emDc" id="2Wqs7XmgUec" role="30czhm">
-          <ref role="_emDf" node="7SY$c$iikZU" resolve="toReduceWithoutSlices2" />
-        </node>
-      </node>
-    </node>
     <node concept="2zPypq" id="2Wqs7XmgUed" role="_iOnB">
       <property role="TrG5h" value="reduceFirstYearWithoutSlices9" />
       <property role="0Rz4W" value="-1740576778" />
@@ -4097,23 +4080,6 @@
         </node>
         <node concept="_emDc" id="2Wqs7XmgWMR" role="30czhm">
           <ref role="_emDf" node="7SY$c$iikdt" resolve="toReduceWithoutSlices1" />
-        </node>
-      </node>
-    </node>
-    <node concept="2zPypq" id="2Wqs7XmgWMS" role="_iOnB">
-      <property role="TrG5h" value="reduceFirstYearWithoutSlices11" />
-      <property role="0Rz4W" value="-1740576778" />
-      <node concept="1QScDb" id="2Wqs7XmgWMT" role="2zPyp_">
-        <node concept="1DAXCi" id="2Wqs7XmgWMU" role="1QScD9">
-          <node concept="193G_S" id="2Wqs7XmgXF4" role="1DAXD6" />
-          <node concept="1f6kyV" id="2Wqs7XmgWMW" role="1DAXD0">
-            <node concept="30bXRB" id="2Wqs7XmgWMX" role="1f6kyW">
-              <property role="30bXRw" value="2000" />
-            </node>
-          </node>
-        </node>
-        <node concept="_emDc" id="2Wqs7XmgWMY" role="30czhm">
-          <ref role="_emDf" node="7SY$c$iikZU" resolve="toReduceWithoutSlices2" />
         </node>
       </node>
     </node>
@@ -4224,17 +4190,6 @@
           <property role="30bXRw" value="0" />
         </node>
       </node>
-      <node concept="_fkuZ" id="2Wqs7XmgY2K" role="_fkp5">
-        <node concept="_fku$" id="2Wqs7XmgY2L" role="_fkur" />
-        <node concept="_emDc" id="2Wqs7XmgY2M" role="_fkuY">
-          <ref role="_emDf" node="2Wqs7XmgUe6" resolve="reduceFirstYearWithoutSlices8" />
-        </node>
-        <node concept="3iBYfx" id="2Wqs7XmgY2N" role="_fkuS">
-          <node concept="ygwf7" id="2Wqs7XmgY2O" role="ygBzB">
-            <node concept="2vmvy5" id="2Wqs7XmgY2P" role="ygwf4" />
-          </node>
-        </node>
-      </node>
       <node concept="_fkuZ" id="2Wqs7XmgY4p" role="_fkp5">
         <node concept="_fku$" id="2Wqs7XmgY4q" role="_fkur" />
         <node concept="_emDc" id="2Wqs7XmgY4r" role="_fkuY">
@@ -4252,17 +4207,6 @@
         </node>
         <node concept="30bXRB" id="2Wqs7XmgZYu" role="_fkuS">
           <property role="30bXRw" value="0" />
-        </node>
-      </node>
-      <node concept="_fkuZ" id="2Wqs7XmgY4z" role="_fkp5">
-        <node concept="_fku$" id="2Wqs7XmgY4$" role="_fkur" />
-        <node concept="_emDc" id="2Wqs7XmgY4_" role="_fkuY">
-          <ref role="_emDf" node="2Wqs7XmgWMS" resolve="reduceFirstYearWithoutSlices11" />
-        </node>
-        <node concept="3iBYfx" id="2Wqs7XmgY4w" role="_fkuS">
-          <node concept="ygwf7" id="2Wqs7XmgY4x" role="ygBzB">
-            <node concept="2vmvy5" id="2Wqs7XmgY4y" role="ygwf4" />
-          </node>
         </node>
       </node>
       <node concept="_fkuZ" id="2Wqs7XmgY4B" role="_fkp5">

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -29,6 +29,8 @@
     <import index="byea" ref="r:55ae05df-8f25-48f0-a826-0655584ce598(org.iets3.core.expr.adt.typesystem)" />
     <import index="rpit" ref="r:e29c70b2-feb7-465e-9534-7fdb395635c2(org.iets3.core.expr.data.typesystem)" />
     <import index="2e51" ref="r:e3651d26-951a-4ffc-9443-e8b8de452a77(org.iets3.core.expr.simpleTypes.constraints)" />
+    <import index="9dqq" ref="r:dfbbc430-47fe-4054-9d32-72c481150c72(org.iets3.core.expr.toplevel.constraints)" />
+    <import index="j68y" ref="r:d01b97ee-eb54-4b3c-b85e-f72b7435869b(org.iets3.core.expr.data.constraints)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
   </imports>
@@ -369,6 +371,9 @@
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
+      <concept id="8255774724000586868" name="org.iets3.core.expr.tests.structure.ReportTestItem" flags="ng" index="2F9BGE">
+        <child id="543569365052056267" name="actual" index="_fkuZ" />
+      </concept>
       <concept id="4173623957598806325" name="org.iets3.core.expr.tests.structure.TestItemVectorCollection" flags="ng" index="1jlL7l" />
       <concept id="4173623957598806298" name="org.iets3.core.expr.tests.structure.VectorTestItem" flags="ng" index="1jlL7U">
         <child id="4173623957599346846" name="subject" index="1jbP1Y" />
@@ -442,6 +447,7 @@
       <concept id="543569365052765011" name="org.iets3.core.expr.toplevel.structure.EmptyToplevelContent" flags="ng" index="_ixoA" />
       <concept id="543569365052711055" name="org.iets3.core.expr.toplevel.structure.Library" flags="ng" index="_iOnV">
         <child id="543569365052711058" name="contents" index="_iOnC" />
+        <child id="6839478809833656927" name="imports" index="3i6evy" />
       </concept>
       <concept id="6527211908667934109" name="org.iets3.core.expr.toplevel.structure.EnumIsTarget" flags="ng" index="2JjPkS">
         <reference id="6527211908668528862" name="literal" index="2Jt$xV" />
@@ -567,6 +573,9 @@
       <concept id="3857533489766146428" name="com.mbeddr.core.base.structure.ElementDocumentation" flags="ng" index="1z9TsT">
         <child id="4052432714772608243" name="text" index="1w35rA" />
       </concept>
+      <concept id="747084250476811597" name="com.mbeddr.core.base.structure.DefaultGenericChunkDependency" flags="ng" index="3GEVxB">
+        <reference id="747084250476878887" name="chunk" index="3GEb4d" />
+      </concept>
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
@@ -623,6 +632,7 @@
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -637,6 +647,12 @@
       </concept>
     </language>
     <language id="b25b8ad1-4d3d-4e45-8c78-72091b39fdda" name="org.iets3.core.expr.data">
+      <concept id="231307155598632952" name="org.iets3.core.expr.data.structure.DataRowOp" flags="ng" index="3CgUdp">
+        <reference id="231307155598633890" name="row" index="3CgUW3" />
+      </concept>
+      <concept id="231307155598333596" name="org.iets3.core.expr.data.structure.DataSelector" flags="ng" index="3Ch18X">
+        <reference id="231307155598334532" name="table" index="3Ch1V_" />
+      </concept>
       <concept id="231307155597502601" name="org.iets3.core.expr.data.structure.DataRow" flags="ng" index="3CkeKC">
         <child id="231307155597479382" name="cells" index="3Ckg_R" />
       </concept>
@@ -15665,6 +15681,384 @@
                 <property role="30bXRw" value="3" />
               </node>
             </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="4QQXQNDkWUR">
+    <property role="TrG5h" value="commentedContent" />
+    <property role="3GE5qa" value="commented" />
+    <node concept="1qefOq" id="230lIJVQUM" role="1SKRRt">
+      <node concept="_iOnU" id="230lIJVQWI" role="1qenE9">
+        <property role="TrG5h" value="TestSuiteUsingCommented" />
+        <node concept="2zPypq" id="230lIJWjRd" role="_iOnB">
+          <property role="TrG5h" value="commented_enum" />
+          <node concept="5mhuz" id="230lIJW3UB" role="2zPyp_">
+            <ref role="5mhpJ" node="4QQXQNDkZhv" resolve="B" />
+            <node concept="7CXmI" id="230lIJW3UC" role="lGtFl">
+              <node concept="39XrGg" id="230lIJW3UD" role="7EUXB">
+                <node concept="2u4KIi" id="230lIJW3UE" role="39rjcI">
+                  <ref role="39XzEq" to="9dqq:67Y8mp$DO6l" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="230lIJWjXG" role="_iOnB">
+          <property role="TrG5h" value="commented_data" />
+          <node concept="1QScDb" id="230lIJWbE2" role="2zPyp_">
+            <node concept="3CgUdp" id="230lIJWbE3" role="1QScD9">
+              <ref role="3CgUW3" node="4QQXQNDkZi5" resolve="keyB" />
+            </node>
+            <node concept="3Ch18X" id="230lIJWbE4" role="30czhm">
+              <ref role="3Ch1V_" node="4QQXQNDkZhT" resolve="data_imp" />
+              <node concept="7CXmI" id="230lIJWbGL" role="lGtFl">
+                <node concept="39XrGg" id="230lIJWbOK" role="7EUXB">
+                  <node concept="2u4KIi" id="230lIJWbOL" role="39rjcI">
+                    <ref role="39XzEq" to="j68y:cPLa7Fswqh" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="230lIJWjQa" role="_iOnB" />
+        <node concept="_fkuM" id="230lIJVR1g" role="_iOnB">
+          <property role="TrG5h" value="test_case_using_commented_stuff" />
+          <node concept="2F9BGE" id="230lIJWbwM" role="_fkp5">
+            <node concept="30cPrO" id="230lIJW3Ul" role="_fkuZ">
+              <node concept="_emDc" id="230lIJVR1A" role="30dEsF">
+                <ref role="_emDf" node="4QQXQNDl37m" resolve="ref_enum_imp" />
+              </node>
+              <node concept="_emDc" id="230lIJWjTs" role="30dEs_">
+                <ref role="_emDf" node="230lIJWjRd" resolve="commented_enum" />
+              </node>
+            </node>
+          </node>
+          <node concept="2F9BGE" id="230lIJWbCO" role="_fkp5">
+            <node concept="30cPrO" id="230lIJWbDC" role="_fkuZ">
+              <node concept="_emDc" id="230lIJWbDu" role="30dEsF">
+                <ref role="_emDf" node="4QQXQNDl37r" resolve="ref_data_imp" />
+              </node>
+              <node concept="_emDc" id="230lIJWk1d" role="30dEs_">
+                <ref role="_emDf" node="230lIJWjXG" resolve="commented_data" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="230lIJVR1c" role="_iOnB" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="4QQXQNDkWXU" role="1SKRRt">
+      <node concept="_iOnV" id="4QQXQNDkX10" role="1qenE9">
+        <property role="TrG5h" value="LibUsingCommented" />
+        <node concept="1X3_iC" id="4QQXQNDkX$_" role="lGtFl">
+          <property role="3V$3am" value="contents" />
+          <property role="3V$3ak" value="71934284-d7d1-45ee-a054-8c072591085f/543569365052711055/543569365052711058" />
+          <node concept="2zPypq" id="4QQXQNDkX45" role="8Wnug">
+            <property role="TrG5h" value="val_loc" />
+            <node concept="30bXRB" id="4QQXQNDkX7k" role="2zPyp_">
+              <property role="30bXRw" value="10" />
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="4QQXQNDl1kd" role="lGtFl">
+          <property role="3V$3am" value="contents" />
+          <property role="3V$3ak" value="71934284-d7d1-45ee-a054-8c072591085f/543569365052711055/543569365052711058" />
+          <node concept="5mgZ8" id="4QQXQNDl0ba" role="8Wnug">
+            <property role="TrG5h" value="enum_loc" />
+            <node concept="5mgYR" id="4QQXQNDl0bb" role="5mgYi">
+              <property role="TrG5h" value="A" />
+            </node>
+            <node concept="5mgYR" id="4QQXQNDl0bc" role="5mgYi">
+              <property role="TrG5h" value="B" />
+            </node>
+            <node concept="5mgYR" id="4QQXQNDl0bd" role="5mgYi">
+              <property role="TrG5h" value="C" />
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="4QQXQNDl28Y" role="lGtFl">
+          <property role="3V$3am" value="contents" />
+          <property role="3V$3ak" value="71934284-d7d1-45ee-a054-8c072591085f/543569365052711055/543569365052711058" />
+          <node concept="3CkkTf" id="4QQXQNDl0be" role="8Wnug">
+            <property role="TrG5h" value="data_loc" />
+            <node concept="3CkmCn" id="4QQXQNDl0bf" role="3Ckg67">
+              <property role="TrG5h" value="val1" />
+              <node concept="30bXR$" id="4QQXQNDl0bg" role="3CknON" />
+            </node>
+            <node concept="3CkmCn" id="4QQXQNDl0bh" role="3Ckg67">
+              <property role="TrG5h" value="val2" />
+              <node concept="30bXR$" id="4QQXQNDl0bi" role="3CknON" />
+            </node>
+            <node concept="3CkeKC" id="4QQXQNDl0bj" role="3CkFDl">
+              <property role="TrG5h" value="keyA" />
+              <node concept="3CkgUp" id="4QQXQNDl0bk" role="3Ckg_R">
+                <ref role="3Ckhev" node="4QQXQNDl0bf" resolve="val1" />
+                <node concept="30bXRB" id="4QQXQNDl0bl" role="3CkirI">
+                  <property role="30bXRw" value="1" />
+                </node>
+              </node>
+              <node concept="3CkgUp" id="4QQXQNDl0bm" role="3Ckg_R">
+                <ref role="3Ckhev" node="4QQXQNDl0bh" resolve="val2" />
+                <node concept="30bXRB" id="4QQXQNDl0bn" role="3CkirI">
+                  <property role="30bXRw" value="2" />
+                </node>
+              </node>
+            </node>
+            <node concept="3CkeKC" id="4QQXQNDl0bo" role="3CkFDl">
+              <property role="TrG5h" value="keyB" />
+              <node concept="3CkgUp" id="4QQXQNDl0bp" role="3Ckg_R">
+                <ref role="3Ckhev" node="4QQXQNDl0bf" resolve="val1" />
+                <node concept="30bXRB" id="4QQXQNDl0bq" role="3CkirI">
+                  <property role="30bXRw" value="3" />
+                </node>
+              </node>
+              <node concept="3CkgUp" id="4QQXQNDl0br" role="3Ckg_R">
+                <ref role="3Ckhev" node="4QQXQNDl0bh" resolve="val2" />
+                <node concept="30bXRB" id="4QQXQNDl0bs" role="3CkirI">
+                  <property role="30bXRw" value="3" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="4QQXQNDl2Jm" role="lGtFl">
+          <property role="3V$3am" value="contents" />
+          <property role="3V$3ak" value="71934284-d7d1-45ee-a054-8c072591085f/543569365052711055/543569365052711058" />
+          <node concept="1aga60" id="4QQXQNDl0bt" role="8Wnug">
+            <property role="TrG5h" value="fun_loc" />
+            <node concept="1aduha" id="4QQXQNDl2oe" role="1ahQXP">
+              <node concept="30bXRB" id="4QQXQNDl2oq" role="1aduh9">
+                <property role="30bXRw" value="100" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="4QQXQNDl0aD" role="_iOnC" />
+        <node concept="_ixoA" id="4QQXQNDl0aT" role="_iOnC" />
+        <node concept="2zPypq" id="4QQXQNDkXdU" role="_iOnC">
+          <property role="TrG5h" value="ref_val_loc" />
+          <node concept="_emDc" id="4QQXQNDkXhc" role="2zPyp_">
+            <ref role="_emDf" node="4QQXQNDkX45" resolve="val_loc" />
+            <node concept="7CXmI" id="4QQXQNDkXCD" role="lGtFl">
+              <node concept="39XrGg" id="4QQXQNDkXEc" role="7EUXB">
+                <node concept="2u4KIi" id="4QQXQNDkXEd" role="39rjcI">
+                  <ref role="39XzEq" to="9dqq:ub9nkyGFQs" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="4QQXQNDl0MQ" role="_iOnC">
+          <property role="TrG5h" value="ref_enum_loc" />
+          <node concept="5mhuz" id="4QQXQNDl11H" role="2zPyp_">
+            <ref role="5mhpJ" node="4QQXQNDl0bc" resolve="B" />
+            <node concept="7CXmI" id="4QQXQNDl1oo" role="lGtFl">
+              <node concept="39XrGg" id="4QQXQNDl1uW" role="7EUXB">
+                <node concept="2u4KIi" id="4QQXQNDl1uX" role="39rjcI">
+                  <ref role="39XzEq" to="9dqq:67Y8mp$DO6l" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="4QQXQNDl1yc" role="_iOnC">
+          <property role="TrG5h" value="ref_data_loc" />
+          <node concept="1QScDb" id="4QQXQNDl1Zb" role="2zPyp_">
+            <node concept="3CgUdp" id="4QQXQNDl25E" role="1QScD9">
+              <ref role="3CgUW3" node="4QQXQNDl0bo" resolve="keyB" />
+            </node>
+            <node concept="3Ch18X" id="4QQXQNDl1VW" role="30czhm">
+              <ref role="3Ch1V_" node="4QQXQNDl0be" resolve="data_loc" />
+              <node concept="7CXmI" id="4QQXQNDl2dB" role="lGtFl">
+                <node concept="39XrGg" id="4QQXQNDl2hK" role="7EUXB">
+                  <node concept="2u4KIi" id="4QQXQNDl2hL" role="39rjcI">
+                    <ref role="39XzEq" to="j68y:cPLa7Fswqh" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="4QQXQNDl2wK" role="_iOnC">
+          <property role="TrG5h" value="ref_fun_loc" />
+          <node concept="1af_rf" id="4QQXQNDl2CR" role="2zPyp_">
+            <ref role="1afhQb" node="4QQXQNDl0bt" resolve="fun_loc" />
+            <node concept="7CXmI" id="4QQXQNDl2OD" role="lGtFl">
+              <node concept="39XrGg" id="4QQXQNDl2U8" role="7EUXB">
+                <node concept="2u4KIi" id="4QQXQNDl2U9" role="39rjcI">
+                  <ref role="39XzEq" to="9dqq:49WTic8gFlS" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="4QQXQNDl1E$" role="_iOnC" />
+        <node concept="2zPypq" id="4QQXQNDl37h" role="_iOnC">
+          <property role="TrG5h" value="ref_val_imp" />
+          <node concept="_emDc" id="4QQXQNDl37i" role="2zPyp_">
+            <ref role="_emDf" node="4QQXQNDkYj9" resolve="val_imp" />
+            <node concept="7CXmI" id="4QQXQNDl37j" role="lGtFl">
+              <node concept="39XrGg" id="4QQXQNDl37k" role="7EUXB">
+                <node concept="2u4KIi" id="4QQXQNDl37l" role="39rjcI">
+                  <ref role="39XzEq" to="9dqq:ub9nkyGFQs" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="4QQXQNDl37m" role="_iOnC">
+          <property role="TrG5h" value="ref_enum_imp" />
+          <node concept="5mhuz" id="4QQXQNDl37n" role="2zPyp_">
+            <ref role="5mhpJ" node="4QQXQNDkZhv" resolve="B" />
+            <node concept="7CXmI" id="4QQXQNDl37o" role="lGtFl">
+              <node concept="39XrGg" id="4QQXQNDl37p" role="7EUXB">
+                <node concept="2u4KIi" id="4QQXQNDl37q" role="39rjcI">
+                  <ref role="39XzEq" to="9dqq:67Y8mp$DO6l" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="4QQXQNDl37r" role="_iOnC">
+          <property role="TrG5h" value="ref_data_imp" />
+          <node concept="1QScDb" id="4QQXQNDl37s" role="2zPyp_">
+            <node concept="3CgUdp" id="4QQXQNDl37t" role="1QScD9">
+              <ref role="3CgUW3" node="4QQXQNDkZi5" resolve="keyB" />
+            </node>
+            <node concept="3Ch18X" id="4QQXQNDl37u" role="30czhm">
+              <ref role="3Ch1V_" node="4QQXQNDkZhT" resolve="data_imp" />
+              <node concept="7CXmI" id="4QQXQNDl37v" role="lGtFl">
+                <node concept="39XrGg" id="4QQXQNDl37w" role="7EUXB">
+                  <node concept="2u4KIi" id="4QQXQNDl37x" role="39rjcI">
+                    <ref role="39XzEq" to="j68y:cPLa7Fswqh" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="4QQXQNDl37y" role="_iOnC">
+          <property role="TrG5h" value="ref_fun_imp" />
+          <node concept="1af_rf" id="4QQXQNDl37z" role="2zPyp_">
+            <ref role="1afhQb" node="4QQXQNDkZKN" resolve="fun_imp" />
+            <node concept="7CXmI" id="4QQXQNDl37$" role="lGtFl">
+              <node concept="39XrGg" id="4QQXQNDl37_" role="7EUXB">
+                <node concept="2u4KIi" id="4QQXQNDl37A" role="39rjcI">
+                  <ref role="39XzEq" to="9dqq:49WTic8gFlS" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="7CXmI" id="4QQXQNDkXVT" role="lGtFl">
+          <node concept="7OXhh" id="4QQXQNDkXYY" role="7EUXB">
+            <property role="GvXf4" value="true" />
+          </node>
+        </node>
+        <node concept="3GEVxB" id="4QQXQNDkYMH" role="3i6evy">
+          <ref role="3GEb4d" node="4QQXQNDkYg5" resolve="ImportedLibWithCommented" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="_iOnV" id="4QQXQNDkYg5">
+    <property role="3GE5qa" value="commented" />
+    <property role="TrG5h" value="ImportedLibWithCommented" />
+    <node concept="1X3_iC" id="1v1SQd_KHG8" role="lGtFl">
+      <property role="3V$3am" value="contents" />
+      <property role="3V$3ak" value="71934284-d7d1-45ee-a054-8c072591085f/543569365052711055/543569365052711058" />
+      <node concept="2zPypq" id="4QQXQNDkYj9" role="8Wnug">
+        <property role="TrG5h" value="val_imp" />
+        <node concept="30bXRB" id="4QQXQNDkYmq" role="2zPyp_">
+          <property role="30bXRw" value="10" />
+        </node>
+      </node>
+    </node>
+    <node concept="1X3_iC" id="1v1SQd_KHJ7" role="lGtFl">
+      <property role="3V$3am" value="contents" />
+      <property role="3V$3ak" value="71934284-d7d1-45ee-a054-8c072591085f/543569365052711055/543569365052711058" />
+      <node concept="5mgZ8" id="4QQXQNDkZgV" role="8Wnug">
+        <property role="TrG5h" value="enum_imp" />
+        <node concept="5mgYR" id="4QQXQNDkZhp" role="5mgYi">
+          <property role="TrG5h" value="A" />
+          <node concept="30bXRB" id="1v1SQd_KDAZ" role="Y$80S">
+            <property role="30bXRw" value="10" />
+          </node>
+        </node>
+        <node concept="5mgYR" id="4QQXQNDkZhv" role="5mgYi">
+          <property role="TrG5h" value="B" />
+          <node concept="30bXRB" id="1v1SQd_KDEw" role="Y$80S">
+            <property role="30bXRw" value="20" />
+          </node>
+        </node>
+        <node concept="5mgYR" id="4QQXQNDkZhA" role="5mgYi">
+          <property role="TrG5h" value="C" />
+          <node concept="30bXRB" id="1v1SQd_KDL5" role="Y$80S">
+            <property role="30bXRw" value="30" />
+          </node>
+        </node>
+        <node concept="30bXR$" id="1v1SQd_KDAK" role="3c3ckp" />
+      </node>
+    </node>
+    <node concept="1X3_iC" id="1v1SQd_KHLD" role="lGtFl">
+      <property role="3V$3am" value="contents" />
+      <property role="3V$3ak" value="71934284-d7d1-45ee-a054-8c072591085f/543569365052711055/543569365052711058" />
+      <node concept="3CkkTf" id="4QQXQNDkZhT" role="8Wnug">
+        <property role="TrG5h" value="data_imp" />
+        <node concept="3CkmCn" id="4QQXQNDkZhV" role="3Ckg67">
+          <property role="TrG5h" value="val1" />
+          <node concept="30bXR$" id="4QQXQNDkZhU" role="3CknON" />
+        </node>
+        <node concept="3CkmCn" id="4QQXQNDkZhX" role="3Ckg67">
+          <property role="TrG5h" value="val2" />
+          <node concept="30bXR$" id="4QQXQNDkZhW" role="3CknON" />
+        </node>
+        <node concept="3CkeKC" id="4QQXQNDkZi0" role="3CkFDl">
+          <property role="TrG5h" value="keyA" />
+          <node concept="3CkgUp" id="4QQXQNDkZi1" role="3Ckg_R">
+            <ref role="3Ckhev" node="4QQXQNDkZhV" resolve="val1" />
+            <node concept="30bXRB" id="4QQXQNDkZhY" role="3CkirI">
+              <property role="30bXRw" value="1" />
+            </node>
+          </node>
+          <node concept="3CkgUp" id="4QQXQNDkZi2" role="3Ckg_R">
+            <ref role="3Ckhev" node="4QQXQNDkZhX" resolve="val2" />
+            <node concept="30bXRB" id="4QQXQNDkZhZ" role="3CkirI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+        </node>
+        <node concept="3CkeKC" id="4QQXQNDkZi5" role="3CkFDl">
+          <property role="TrG5h" value="keyB" />
+          <node concept="3CkgUp" id="4QQXQNDkZi6" role="3Ckg_R">
+            <ref role="3Ckhev" node="4QQXQNDkZhV" resolve="val1" />
+            <node concept="30bXRB" id="4QQXQNDkZi3" role="3CkirI">
+              <property role="30bXRw" value="3" />
+            </node>
+          </node>
+          <node concept="3CkgUp" id="4QQXQNDkZi7" role="3Ckg_R">
+            <ref role="3Ckhev" node="4QQXQNDkZhX" resolve="val2" />
+            <node concept="30bXRB" id="4QQXQNDkZi4" role="3CkirI">
+              <property role="30bXRw" value="3" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1X3_iC" id="1v1SQd_KHOC" role="lGtFl">
+      <property role="3V$3am" value="contents" />
+      <property role="3V$3ak" value="71934284-d7d1-45ee-a054-8c072591085f/543569365052711055/543569365052711058" />
+      <node concept="1aga60" id="4QQXQNDkZKN" role="8Wnug">
+        <property role="TrG5h" value="fun_imp" />
+        <node concept="1QScDb" id="4QQXQNDkZRK" role="1ahQXP">
+          <node concept="3CgUdp" id="4QQXQNDkZVd" role="1QScD9">
+            <ref role="3CgUW3" node="4QQXQNDkZi0" resolve="keyA" />
+          </node>
+          <node concept="3Ch18X" id="4QQXQNDkZRz" role="30czhm">
+            <ref role="3Ch1V_" node="4QQXQNDkZhT" resolve="data_imp" />
           </node>
         </node>
       </node>


### PR DESCRIPTION
This PRs includes fixes for several issues:
- exclude commented elements from the visible elements scope: [Library](http://127.0.0.1:63320/node?ref=r%3Ada65683e-ff6f-430d-ab68-32a77df72c93%28org.iets3.core.expr.toplevel.structure%29%2F543569365052711055)/[TestSuite ](http://127.0.0.1:63320/node?ref=r%3Aba7faab6-2b80-43d5-8b95-0c440665312c%28org.iets3.core.expr.tests.structure%29%2F543569365052711055) IVisibleElementProvider scope has been adjusted to exclude commented elements from the result
- use real type for reduce op with weighted strategy: using weighted strategy in [ReduceOP](http://127.0.0.1:63320/node?ref=r%3Ad6904536-4de8-40ba-b54e-09fcdfe1b62a%28org.iets3.core.expr.temporal.structure%29%2F2060704857949651508) results in correct real type for the computed value
- added check for empty context model in requirements context actions: fixes possible NPE during context actions initialization