### PR TITLE
Make duplicate check in EnumDeclaration deactivatable

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -2389,6 +2389,15 @@
         </node>
       </node>
     </node>
+    <node concept="3EZMnI" id="2ZPMv$juhMe" role="6VMZX">
+      <node concept="2iRfu4" id="2ZPMv$juhMf" role="2iSdaV" />
+      <node concept="3F0ifn" id="2ZPMv$juhBi" role="3EZMnx">
+        <property role="3F0ifm" value="disable duplicate check" />
+      </node>
+      <node concept="3F0A7n" id="2ZPMv$juhYx" role="3EZMnx">
+        <ref role="1NtTu8" to="yv47:2ZPMv$jtPzQ" resolve="disableDuplicateCheck" />
+      </node>
+    </node>
   </node>
   <node concept="24kQdi" id="67Y8mp$DN4e">
     <property role="3GE5qa" value="enum" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/structure.mps
@@ -609,6 +609,11 @@
       <property role="IQ2nx" value="7061117989424763681" />
       <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
     </node>
+    <node concept="1TJgyi" id="2ZPMv$jtPzQ" role="1TKVEl">
+      <property role="IQ2nx" value="3455890360687352054" />
+      <property role="TrG5h" value="disableDuplicateCheck" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
   </node>
   <node concept="1TIwiD" id="67Y8mp$DMVh">
     <property role="3GE5qa" value="enum" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/typesystem.mps
@@ -26,6 +26,7 @@
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
@@ -4053,13 +4054,23 @@
     <property role="3GE5qa" value="enum" />
     <node concept="3clFbS" id="bAwKVX3rBk" role="18ibNy">
       <node concept="3clFbJ" id="bAwKVX3sq$" role="3cqZAp">
-        <node concept="3fqX7Q" id="bAwKVX3tpr" role="3clFbw">
-          <node concept="2OqwBi" id="bAwKVX3tpt" role="3fr31v">
-            <node concept="1YBJjd" id="bAwKVX3tpu" role="2Oq$k0">
+        <node concept="22lmx$" id="2ZPMv$jtQmx" role="3clFbw">
+          <node concept="2OqwBi" id="2ZPMv$jtQRz" role="3uHU7w">
+            <node concept="1YBJjd" id="2ZPMv$jtQw2" role="2Oq$k0">
               <ref role="1YBMHb" node="bAwKVX3rBm" resolve="enumDeclaration" />
             </node>
-            <node concept="2qgKlT" id="bAwKVX3tpv" role="2OqNvi">
-              <ref role="37wK5l" to="nu60:3Y6fbK16sYK" resolve="isValued" />
+            <node concept="3TrcHB" id="2ZPMv$jtRSy" role="2OqNvi">
+              <ref role="3TsBF5" to="yv47:2ZPMv$jtPzQ" resolve="disableDuplicateCheck" />
+            </node>
+          </node>
+          <node concept="3fqX7Q" id="bAwKVX3tpr" role="3uHU7B">
+            <node concept="2OqwBi" id="bAwKVX3tpt" role="3fr31v">
+              <node concept="1YBJjd" id="bAwKVX3tpu" role="2Oq$k0">
+                <ref role="1YBMHb" node="bAwKVX3rBm" resolve="enumDeclaration" />
+              </node>
+              <node concept="2qgKlT" id="bAwKVX3tpv" role="2OqNvi">
+                <ref role="37wK5l" to="nu60:3Y6fbK16sYK" resolve="isValued" />
+              </node>
             </node>
           </node>
         </node>


### PR DESCRIPTION
I've added a flag to the inspector so that the duplicate check can be disabled because the check is not desired by everyone (see: https://github.com/IETS3/iets3.opensource/issues/615).