### PR TITLE
Make duplicate check in enum declarations customizable

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/plugin.mps
@@ -14,6 +14,7 @@
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="-1" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -43,11 +44,11 @@
     <import index="z1c4" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="ppzb" ref="r:5db517a0-f62d-4841-a421-11bb7269799d(org.iets3.core.expr.base.shared.runtime)" />
+    <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
     <import index="tprs" ref="r:00000000-0000-4000-0000-011c895904a4(jetbrains.mps.ide.actions)" implicit="true" />
-    <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" implicit="true" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
@@ -13930,6 +13931,34 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="2O$zpZk7gkh" role="1B3o_S" />
+  </node>
+  <node concept="vrV6u" id="3HxoqR_T8F2">
+    <property role="TrG5h" value="typesystemCustomization" />
+    <property role="3GE5qa" value="typesystem" />
+    <node concept="3uibUv" id="3HxoqR_WS1J" role="luc8K">
+      <ref role="3uigEE" node="13FXotcVCgO" resolve="TypesystemCustomizer" />
+    </node>
+  </node>
+  <node concept="312cEu" id="13FXotcVCgO">
+    <property role="TrG5h" value="TypesystemCustomizer" />
+    <property role="1sVAO0" value="true" />
+    <property role="3GE5qa" value="typesystem" />
+    <node concept="2tJIrI" id="13FXotcVChe" role="jymVt" />
+    <node concept="3clFb_" id="2CFPPn7$RyE" role="jymVt">
+      <property role="TrG5h" value="checkDuplicateValuesInEnums" />
+      <node concept="10P_77" id="3HxoqR_TSM5" role="3clF45" />
+      <node concept="3Tm1VV" id="2CFPPn7$RyH" role="1B3o_S" />
+      <node concept="3clFbS" id="2CFPPn7$RyI" role="3clF47">
+        <node concept="3clFbF" id="3HxoqR_TSWP" role="3cqZAp">
+          <node concept="3clFbT" id="3HxoqR_TSWO" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="13FXotcVChh" role="jymVt" />
+    <node concept="2tJIrI" id="13FXotcVChm" role="jymVt" />
+    <node concept="3Tm1VV" id="13FXotcVCgP" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -6643,6 +6643,55 @@
       </node>
       <node concept="10P_77" id="3NUSEp5yf$o" role="3clF45" />
     </node>
+    <node concept="13i0hz" id="1WjCak8S2F0" role="13h7CS">
+      <property role="TrG5h" value="checkDuplicates" />
+      <node concept="3Tm1VV" id="1WjCak8S2F1" role="1B3o_S" />
+      <node concept="10P_77" id="1WjCak8S30h" role="3clF45" />
+      <node concept="3clFbS" id="1WjCak8S2F3" role="3clF47">
+        <node concept="3cpWs8" id="3HxoqR_WSnC" role="3cqZAp">
+          <node concept="3cpWsn" id="3HxoqR_WSnD" role="3cpWs9">
+            <property role="TrG5h" value="customizer" />
+            <node concept="3uibUv" id="3HxoqR_WSlS" role="1tU5fm">
+              <ref role="3uigEE" to="oq0c:13FXotcVCgO" resolve="TypesystemCustomizer" />
+            </node>
+            <node concept="2OqwBi" id="3HxoqR_WSnE" role="33vP2m">
+              <node concept="2OqwBi" id="3HxoqR_WSnF" role="2Oq$k0">
+                <node concept="2O5UvJ" id="3HxoqR_WSnG" role="2Oq$k0">
+                  <ref role="2O5UnU" to="oq0c:3HxoqR_T8F2" resolve="typesystemCustomization" />
+                </node>
+                <node concept="SfwO_" id="3HxoqR_WSnH" role="2OqNvi" />
+              </node>
+              <node concept="1uHKPH" id="3HxoqR_WSnI" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="1WjCak8S3O4" role="3cqZAp">
+          <node concept="3clFbS" id="1WjCak8S3O6" role="3clFbx">
+            <node concept="3cpWs6" id="1WjCak8S40m" role="3cqZAp">
+              <node concept="2OqwBi" id="1WjCak8Rku4" role="3cqZAk">
+                <node concept="37vLTw" id="1WjCak8Rku5" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3HxoqR_WSnD" resolve="customizer" />
+                </node>
+                <node concept="liA8E" id="1WjCak8Rku6" role="2OqNvi">
+                  <ref role="37wK5l" to="oq0c:2CFPPn7$RyE" resolve="checkDuplicateValuesInEnums" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="1WjCak8S3Wj" role="3clFbw">
+            <node concept="10Nm6u" id="1WjCak8S3ZH" role="3uHU7w" />
+            <node concept="37vLTw" id="1WjCak8S3OS" role="3uHU7B">
+              <ref role="3cqZAo" node="3HxoqR_WSnD" resolve="customizer" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="1WjCak8S44J" role="3cqZAp">
+          <node concept="3clFbT" id="1WjCak8S456" role="3cqZAk">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="13h7C7" id="3Y6fbK1lTzW">
     <property role="3GE5qa" value="enum" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/typesystem.mps
@@ -3,6 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
+    <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
     <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
   </languages>
   <imports>
@@ -26,6 +27,7 @@
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
@@ -4053,13 +4055,25 @@
     <property role="3GE5qa" value="enum" />
     <node concept="3clFbS" id="bAwKVX3rBk" role="18ibNy">
       <node concept="3clFbJ" id="bAwKVX3sq$" role="3cqZAp">
-        <node concept="3fqX7Q" id="bAwKVX3tpr" role="3clFbw">
-          <node concept="2OqwBi" id="bAwKVX3tpt" role="3fr31v">
-            <node concept="1YBJjd" id="bAwKVX3tpu" role="2Oq$k0">
-              <ref role="1YBMHb" node="bAwKVX3rBm" resolve="enumDeclaration" />
+        <node concept="22lmx$" id="1WjCak8S51q" role="3clFbw">
+          <node concept="3fqX7Q" id="1WjCak8S6Da" role="3uHU7w">
+            <node concept="2OqwBi" id="1WjCak8S6Dc" role="3fr31v">
+              <node concept="1YBJjd" id="1WjCak8S6Dd" role="2Oq$k0">
+                <ref role="1YBMHb" node="bAwKVX3rBm" resolve="enumDeclaration" />
+              </node>
+              <node concept="2qgKlT" id="1WjCak8S6De" role="2OqNvi">
+                <ref role="37wK5l" to="nu60:1WjCak8S2F0" resolve="checkDuplicates" />
+              </node>
             </node>
-            <node concept="2qgKlT" id="bAwKVX3tpv" role="2OqNvi">
-              <ref role="37wK5l" to="nu60:3Y6fbK16sYK" resolve="isValued" />
+          </node>
+          <node concept="3fqX7Q" id="bAwKVX3tpr" role="3uHU7B">
+            <node concept="2OqwBi" id="bAwKVX3tpt" role="3fr31v">
+              <node concept="1YBJjd" id="bAwKVX3tpu" role="2Oq$k0">
+                <ref role="1YBMHb" node="bAwKVX3rBm" resolve="enumDeclaration" />
+              </node>
+              <node concept="2qgKlT" id="bAwKVX3tpv" role="2OqNvi">
+                <ref role="37wK5l" to="nu60:3Y6fbK16sYK" resolve="isValued" />
+              </node>
             </node>
           </node>
         </node>


### PR DESCRIPTION
- There is now an extension point typesystemCustomization that can change the behavior.
- Fixes #615
- The default behavior is to check for duplicates
