### PR TITLE
Migrate to 2021.2.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ def major = "2021"
 def minor = "2"
 
 // Dependency versions
-ext.mpsVersion = '2021.2.5'
+ext.mpsVersion = '2021.2.6'
 
 def mbeddrVersion = "2021.2+"
 


### PR DESCRIPTION
No breaking changes in this minor release as far as I can tell ([Release notes](https://youtrack.jetbrains.com/issues/MPS?q=%23Resolved%20%20project:%20MPS%20version:%202021.2.6&_ga=2.3773168.1193796523.1669010815-2058359210.1628057624&_gl=1*1ypeka8*_ga*MjA1ODM1OTIxMC4xNjI4MDU3NjI0*_ga_9J976DJZ68*MTY2OTEyODAzMS40MzAuMC4xNjY5MTI4MDMxLjYwLjAuMA..)).