### PR TITLE
Extend DataTableLookUp with optional argument: default row

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.behavior.mps
@@ -44,9 +44,21 @@
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1173175405605" name="jetbrains.mps.baseLanguage.structure.ArrayAccessExpression" flags="nn" index="AH0OO">
+        <child id="1173175577737" name="index" index="AHEQo" />
+        <child id="1173175590490" name="array" index="AHHXb" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
@@ -58,6 +70,9 @@
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534760951" name="jetbrains.mps.baseLanguage.structure.ArrayType" flags="in" index="10Q1$e">
+        <child id="1070534760952" name="componentType" index="10Q1$1" />
+      </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -65,6 +80,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -85,6 +101,9 @@
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
@@ -109,11 +128,24 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1184950988562" name="jetbrains.mps.baseLanguage.structure.ArrayCreator" flags="nn" index="3$_iS1">
+        <child id="1184951007469" name="componentType" index="3$_nBY" />
+        <child id="1184952969026" name="dimensionExpression" index="3$GQph" />
+      </concept>
+      <concept id="1184952934362" name="jetbrains.mps.baseLanguage.structure.DimensionExpression" flags="nn" index="3$GHV9">
+        <child id="1184953288404" name="expression" index="3$I4v7" />
+      </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
@@ -142,6 +174,7 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179168000618" name="jetbrains.mps.lang.smodel.structure.Node_GetIndexInParentOperation" flags="nn" index="2bSWHS" />
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
@@ -158,8 +191,14 @@
       <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
         <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
       </concept>
+      <concept id="3562215692195599741" name="jetbrains.mps.lang.smodel.structure.SLinkImplicitSelect" flags="nn" index="13MTOL">
+        <reference id="3562215692195600259" name="link" index="13MTZf" />
+      </concept>
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
       <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
@@ -194,6 +233,9 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="1176903168877" name="jetbrains.mps.baseLanguage.collections.structure.UnionOperation" flags="nn" index="4Tj9Z" />
       <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="nn" index="56pJg">
         <child id="1176906787974" name="rightExpression" index="576Qk" />
@@ -201,16 +243,21 @@
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
+      <concept id="1235566831861" name="jetbrains.mps.baseLanguage.collections.structure.AllOperation" flags="nn" index="2HxqBE" />
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1205753243362" name="jetbrains.mps.baseLanguage.collections.structure.ChunkOperation" flags="nn" index="2WvAvU">
         <child id="1205753261887" name="length" index="2WvESB" />
       </concept>
       <concept id="1205753630278" name="jetbrains.mps.baseLanguage.collections.structure.TailOperation" flags="nn" index="2Wx4Xu" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
     </language>
   </registry>
   <node concept="13h7C7" id="cPLa7Fr1kl">
@@ -587,6 +634,185 @@
         <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
       </node>
     </node>
+    <node concept="13i0hz" id="7EHDEMiCP6D" role="13h7CS">
+      <property role="TrG5h" value="getColumn" />
+      <node concept="3Tm1VV" id="7EHDEMiCP6E" role="1B3o_S" />
+      <node concept="A3Dl8" id="7EHDEMiCPYE" role="3clF45">
+        <node concept="3Tqbb2" id="7EHDEMiCPYR" role="A3Ik2">
+          <ref role="ehGHo" to="e9k1:cPLa7FpcCS" resolve="DataCell" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="7EHDEMiCP6G" role="3clF47">
+        <node concept="3clFbF" id="7EHDEMiCQ1F" role="3cqZAp">
+          <node concept="2OqwBi" id="7EHDEMiCT61" role="3clFbG">
+            <node concept="2OqwBi" id="7EHDEMiCQ1G" role="2Oq$k0">
+              <node concept="2OqwBi" id="7EHDEMiCQ1H" role="2Oq$k0">
+                <node concept="13iPFW" id="7EHDEMiCQ1I" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="7EHDEMiCQ1J" role="2OqNvi">
+                  <ref role="3TtcxE" to="e9k1:cPLa7FpRVO" resolve="rows" />
+                </node>
+              </node>
+              <node concept="13MTOL" id="7EHDEMiCSoO" role="2OqNvi">
+                <ref role="13MTZf" to="e9k1:cPLa7FpcRm" resolve="cells" />
+              </node>
+            </node>
+            <node concept="3zZkjj" id="7EHDEMiCXlI" role="2OqNvi">
+              <node concept="1bVj0M" id="7EHDEMiCXlK" role="23t8la">
+                <node concept="3clFbS" id="7EHDEMiCXlL" role="1bW5cS">
+                  <node concept="3clFbF" id="7EHDEMiCXlM" role="3cqZAp">
+                    <node concept="3clFbC" id="7EHDEMiCXlN" role="3clFbG">
+                      <node concept="2OqwBi" id="7EHDEMiD5q$" role="3uHU7w">
+                        <node concept="37vLTw" id="7EHDEMiCXlO" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7EHDEMiCPZz" resolve="columDefinition" />
+                        </node>
+                        <node concept="2bSWHS" id="7EHDEMiD5KV" role="2OqNvi" />
+                      </node>
+                      <node concept="2OqwBi" id="7EHDEMiCXlP" role="3uHU7B">
+                        <node concept="2OqwBi" id="7EHDEMiCXlQ" role="2Oq$k0">
+                          <node concept="37vLTw" id="7EHDEMiCXlR" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7EHDEMiCXlU" resolve="it" />
+                          </node>
+                          <node concept="3TrEf2" id="7EHDEMiCXlS" role="2OqNvi">
+                            <ref role="3Tt5mk" to="e9k1:cPLa7FpdsY" resolve="col" />
+                          </node>
+                        </node>
+                        <node concept="2bSWHS" id="7EHDEMiCXlT" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="7EHDEMiCXlU" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="7EHDEMiCXlV" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7EHDEMiCPZz" role="3clF46">
+        <property role="TrG5h" value="columDefinition" />
+        <node concept="3Tqbb2" id="7EHDEMiD19B" role="1tU5fm">
+          <ref role="ehGHo" to="e9k1:cPLa7FpaUQ" resolve="DataColDef" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="7EHDEMix7cr" role="13h7CS">
+      <property role="TrG5h" value="allColumnsContainAnEmptyLiteral" />
+      <node concept="3Tm1VV" id="7EHDEMix7cs" role="1B3o_S" />
+      <node concept="10P_77" id="7EHDEMix8mU" role="3clF45" />
+      <node concept="3clFbS" id="7EHDEMix7cu" role="3clF47">
+        <node concept="3cpWs8" id="7EHDEMiyBfz" role="3cqZAp">
+          <node concept="3cpWsn" id="7EHDEMiyBfA" role="3cpWs9">
+            <property role="TrG5h" value="columnWithEmptyListeral" />
+            <node concept="10Q1$e" id="7EHDEMiyB$X" role="1tU5fm">
+              <node concept="10P_77" id="7EHDEMiyBfx" role="10Q1$1" />
+            </node>
+            <node concept="2ShNRf" id="7EHDEMiyDfF" role="33vP2m">
+              <node concept="3$_iS1" id="7EHDEMiyDfD" role="2ShVmc">
+                <node concept="3$GHV9" id="7EHDEMiyDoC" role="3$GQph">
+                  <node concept="2OqwBi" id="7EHDEMiyzPQ" role="3$I4v7">
+                    <node concept="2OqwBi" id="7EHDEMiytlI" role="2Oq$k0">
+                      <node concept="13iPFW" id="7EHDEMiytlJ" role="2Oq$k0" />
+                      <node concept="3Tsc0h" id="7EHDEMiytlK" role="2OqNvi">
+                        <ref role="3TtcxE" to="e9k1:cPLa7FpckA" resolve="dataCols" />
+                      </node>
+                    </node>
+                    <node concept="34oBXx" id="7EHDEMiy$gX" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="10P_77" id="7EHDEMiyDfE" role="3$_nBY" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7EHDEMiyNVs" role="3cqZAp">
+          <node concept="2OqwBi" id="7EHDEMiybuf" role="3clFbG">
+            <node concept="2OqwBi" id="7EHDEMiybug" role="2Oq$k0">
+              <node concept="13iPFW" id="7EHDEMiybuh" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="7EHDEMiybui" role="2OqNvi">
+                <ref role="3TtcxE" to="e9k1:cPLa7FpRVO" resolve="rows" />
+              </node>
+            </node>
+            <node concept="2es0OD" id="7EHDEMiyJro" role="2OqNvi">
+              <node concept="1bVj0M" id="7EHDEMiyJrq" role="23t8la">
+                <node concept="3clFbS" id="7EHDEMiyJrr" role="1bW5cS">
+                  <node concept="3clFbF" id="7EHDEMiyJrs" role="3cqZAp">
+                    <node concept="2OqwBi" id="7EHDEMiyJrt" role="3clFbG">
+                      <node concept="2OqwBi" id="7EHDEMiyJru" role="2Oq$k0">
+                        <node concept="37vLTw" id="7EHDEMiyJrv" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7EHDEMiyJry" resolve="it" />
+                        </node>
+                        <node concept="2qgKlT" id="7EHDEMiyJrw" role="2OqNvi">
+                          <ref role="37wK5l" node="7EHDEMixjI5" resolve="getEmptyLiterals" />
+                        </node>
+                      </node>
+                      <node concept="2es0OD" id="7EHDEMiyJOU" role="2OqNvi">
+                        <node concept="1bVj0M" id="7EHDEMiyJOW" role="23t8la">
+                          <node concept="3clFbS" id="7EHDEMiyJOX" role="1bW5cS">
+                            <node concept="3clFbF" id="7EHDEMiyJXs" role="3cqZAp">
+                              <node concept="37vLTI" id="7EHDEMiyNao" role="3clFbG">
+                                <node concept="3clFbT" id="7EHDEMiyNkx" role="37vLTx">
+                                  <property role="3clFbU" value="true" />
+                                </node>
+                                <node concept="AH0OO" id="7EHDEMiyMtE" role="37vLTJ">
+                                  <node concept="37vLTw" id="7EHDEMiyLCG" role="AHHXb">
+                                    <ref role="3cqZAo" node="7EHDEMiyBfA" resolve="columnWithEmptyListeral" />
+                                  </node>
+                                  <node concept="2OqwBi" id="7EHDEMiyKez" role="AHEQo">
+                                    <node concept="37vLTw" id="7EHDEMiyJXr" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="7EHDEMiyJOY" resolve="it" />
+                                    </node>
+                                    <node concept="2bSWHS" id="7EHDEMiyKEB" role="2OqNvi" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="7EHDEMiyJOY" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="7EHDEMiyJOZ" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="7EHDEMiyJry" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="7EHDEMiyJrz" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7EHDEMiB3$O" role="3cqZAp">
+          <node concept="2OqwBi" id="7EHDEMi_xiV" role="3clFbG">
+            <node concept="2OqwBi" id="7EHDEMi_xiW" role="2Oq$k0">
+              <node concept="37vLTw" id="7EHDEMi_xiX" role="2Oq$k0">
+                <ref role="3cqZAo" node="7EHDEMiyBfA" resolve="columnWithEmptyListeral" />
+              </node>
+              <node concept="39bAoz" id="7EHDEMi_xiY" role="2OqNvi" />
+            </node>
+            <node concept="2HxqBE" id="7EHDEMi_xiZ" role="2OqNvi">
+              <node concept="1bVj0M" id="7EHDEMi_xj0" role="23t8la">
+                <node concept="3clFbS" id="7EHDEMi_xj1" role="1bW5cS">
+                  <node concept="3clFbF" id="7EHDEMi_xj2" role="3cqZAp">
+                    <node concept="37vLTw" id="7EHDEMi_xj3" role="3clFbG">
+                      <ref role="3cqZAo" node="7EHDEMi_xj4" resolve="it" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="7EHDEMi_xj4" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="7EHDEMi_xj5" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="13h7C7" id="cPLa7FtsME">
     <ref role="13h7C2" to="e9k1:cPLa7Ft09N" resolve="DataColOp" />
@@ -725,6 +951,54 @@
         </node>
       </node>
       <node concept="10P_77" id="3NUSEp5ykEP" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="7EHDEMixjI5" role="13h7CS">
+      <property role="TrG5h" value="getEmptyLiterals" />
+      <node concept="3Tm1VV" id="7EHDEMixjI6" role="1B3o_S" />
+      <node concept="3clFbS" id="7EHDEMixjI8" role="3clF47">
+        <node concept="3clFbF" id="7EHDEMi_9jh" role="3cqZAp">
+          <node concept="2OqwBi" id="7EHDEMizgAC" role="3clFbG">
+            <node concept="2OqwBi" id="7EHDEMizgAD" role="2Oq$k0">
+              <node concept="13iPFW" id="7EHDEMizgAE" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="7EHDEMizgAF" role="2OqNvi">
+                <ref role="3TtcxE" to="e9k1:cPLa7FpcRm" resolve="cells" />
+              </node>
+            </node>
+            <node concept="3zZkjj" id="7EHDEMizgAG" role="2OqNvi">
+              <node concept="1bVj0M" id="7EHDEMizgAH" role="23t8la">
+                <node concept="3clFbS" id="7EHDEMizgAI" role="1bW5cS">
+                  <node concept="3clFbF" id="7EHDEMizgAJ" role="3cqZAp">
+                    <node concept="2OqwBi" id="7EHDEMizgAK" role="3clFbG">
+                      <node concept="2OqwBi" id="7EHDEMizgAL" role="2Oq$k0">
+                        <node concept="37vLTw" id="7EHDEMizgAM" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7EHDEMizgAQ" resolve="it" />
+                        </node>
+                        <node concept="3TrEf2" id="7EHDEMizgAN" role="2OqNvi">
+                          <ref role="3Tt5mk" to="e9k1:cPLa7Fpe9f" resolve="value" />
+                        </node>
+                      </node>
+                      <node concept="1mIQ4w" id="7EHDEMizgAO" role="2OqNvi">
+                        <node concept="chp4Y" id="7EHDEMizgAP" role="cj9EA">
+                          <ref role="cht4Q" to="hm2y:MNXm1ElbHo" resolve="IEmptyLiteral" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="7EHDEMizgAQ" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="7EHDEMizgAR" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="7EHDEMiyq1Q" role="3clF45">
+        <node concept="3Tqbb2" id="7EHDEMiyqf8" role="A3Ik2">
+          <ref role="ehGHo" to="e9k1:cPLa7FpcCS" resolve="DataCell" />
+        </node>
+      </node>
     </node>
   </node>
   <node concept="13h7C7" id="3NUSEp5ykH6">
@@ -993,6 +1267,29 @@
       </node>
       <node concept="3uibUv" id="7F9023_OrDC" role="3clF45">
         <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="5nzoslouECc" role="13h7CS">
+      <property role="TrG5h" value="getDataSelector" />
+      <node concept="3Tm1VV" id="5nzoslouECd" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5nzoslouHf5" role="3clF45">
+        <ref role="ehGHo" to="e9k1:cPLa7Fstqs" resolve="DataSelector" />
+      </node>
+      <node concept="3clFbS" id="5nzoslouECf" role="3clF47">
+        <node concept="3clFbF" id="5nzoslouSh$" role="3cqZAp">
+          <node concept="1PxgMI" id="5nzoslouJeT" role="3clFbG">
+            <property role="1BlNFB" value="true" />
+            <node concept="chp4Y" id="5nzoslouJeU" role="3oSUPX">
+              <ref role="cht4Q" to="e9k1:cPLa7Fstqs" resolve="DataSelector" />
+            </node>
+            <node concept="2OqwBi" id="5nzoslouJeV" role="1m5AlR">
+              <node concept="13iPFW" id="5nzoslouJeW" role="2Oq$k0" />
+              <node concept="2qgKlT" id="5nzoslouJeX" role="2OqNvi">
+                <ref role="37wK5l" to="pbu6:6zmBjqUivyF" resolve="contextExpression" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.constraints.mps
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:d01b97ee-eb54-4b3c-b85e-f72b7435869b(org.iets3.core.expr.data.constraints)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="5dae8159-ab99-46bb-a40d-0cee30ee7018" name="jetbrains.mps.lang.constraints.rules.kinds" version="0" />
     <use id="ea3159bf-f48e-4720-bde2-86dba75f0d34" name="jetbrains.mps.lang.context.defs" version="0" />
@@ -16,11 +17,12 @@
   </languages>
   <imports>
     <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
+    <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
     <import index="e9k1" ref="r:00903dee-f0b0-48de-9335-7cb3f90ae462(org.iets3.core.expr.data.structure)" implicit="true" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" implicit="true" />
     <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" implicit="true" />
-    <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
+    <import index="ux24" ref="r:74ad67c1-3cf0-4c00-bd30-edf8df02cfe5(org.iets3.core.expr.data.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -451,6 +453,61 @@
               </node>
               <node concept="3clFbT" id="6WstIz8MKEx" role="37wK5m">
                 <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="1WMFq5x4gkL">
+    <ref role="1M2myG" to="e9k1:1WMFq5x4fLm" resolve="DataRowRefForLookup" />
+    <node concept="1N5Pfh" id="1WMFq5x4gm0" role="1Mr941">
+      <ref role="1N5Vy1" to="e9k1:1WMFq5x4fLn" resolve="dataRow" />
+      <node concept="3dgokm" id="1WMFq5x4gm1" role="1N6uqs">
+        <node concept="3clFbS" id="1WMFq5x4gm2" role="2VODD2">
+          <node concept="3clFbF" id="1WMFq5x4gm3" role="3cqZAp">
+            <node concept="2YIFZM" id="1WMFq5x4gm4" role="3clFbG">
+              <ref role="37wK5l" to="o8zo:4IP40Bi3eAf" resolve="forNamedElements" />
+              <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+              <node concept="2OqwBi" id="1WMFq5x4gm5" role="37wK5m">
+                <node concept="2OqwBi" id="1WMFq5x4gm6" role="2Oq$k0">
+                  <node concept="2OqwBi" id="5nzoslouWGn" role="2Oq$k0">
+                    <node concept="2OqwBi" id="5nzoslouW5T" role="2Oq$k0">
+                      <node concept="2rP1CM" id="1WMFq5x4gmb" role="2Oq$k0" />
+                      <node concept="2Xjw5R" id="5nzoslouWot" role="2OqNvi">
+                        <node concept="1xMEDy" id="5nzoslouWov" role="1xVPHs">
+                          <node concept="chp4Y" id="5nzoslouWvn" role="ri$Ld">
+                            <ref role="cht4Q" to="e9k1:stdmzxm7Y2" resolve="DataTableLookUp" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="5nzoslouWNj" role="2OqNvi">
+                      <ref role="37wK5l" to="ux24:5nzoslouECc" resolve="getDataSelector" />
+                    </node>
+                  </node>
+                  <node concept="3TrEf2" id="1WMFq5x4gmh" role="2OqNvi">
+                    <ref role="3Tt5mk" to="e9k1:cPLa7FstD4" resolve="table" />
+                  </node>
+                </node>
+                <node concept="3Tsc0h" id="1WMFq5x4gmi" role="2OqNvi">
+                  <ref role="3TtcxE" to="e9k1:cPLa7FpRVO" resolve="rows" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="9S07l" id="1WMFq5x4jil" role="9Vyp8">
+      <node concept="3clFbS" id="1WMFq5x4jim" role="2VODD2">
+        <node concept="3clFbF" id="1WMFq5x4jiH" role="3cqZAp">
+          <node concept="2OqwBi" id="67dYdlPOTzy" role="3clFbG">
+            <node concept="nLn13" id="67dYdlPOSXB" role="2Oq$k0" />
+            <node concept="1mIQ4w" id="67dYdlPOTJ9" role="2OqNvi">
+              <node concept="chp4Y" id="67dYdlPOTT1" role="cj9EA">
+                <ref role="cht4Q" to="e9k1:stdmzxm7Y2" resolve="DataTableLookUp" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
@@ -21,6 +21,7 @@
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="1402906326895675325" name="jetbrains.mps.lang.editor.structure.CellActionMap_FunctionParm_selectedNode" flags="nn" index="0IXxy" />
       <concept id="5991739802479784074" name="jetbrains.mps.lang.editor.structure.MenuTypeNamed" flags="ng" index="22hDWg" />
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi">
         <child id="1078153129734" name="inspectedCellModel" index="6VMZX" />
@@ -76,6 +77,15 @@
       <concept id="2896773699153795590" name="jetbrains.mps.lang.editor.structure.TransformationLocation_SideTransform" flags="ng" index="3cWJ9i">
         <child id="3473224453637651919" name="placeInCell" index="CtIbM" />
       </concept>
+      <concept id="1139535219966" name="jetbrains.mps.lang.editor.structure.CellActionMapDeclaration" flags="ig" index="1h_SRR">
+        <reference id="1139535219968" name="applicableConcept" index="1h_SK9" />
+        <child id="1139535219969" name="item" index="1h_SK8" />
+      </concept>
+      <concept id="1139535280617" name="jetbrains.mps.lang.editor.structure.CellActionMapItem" flags="lg" index="1hA7zw">
+        <property id="1139535298778" name="actionId" index="1hAc7j" />
+        <child id="1139535280620" name="executeFunction" index="1hA7z_" />
+      </concept>
+      <concept id="1139535439104" name="jetbrains.mps.lang.editor.structure.CellActionMap_ExecuteFunction" flags="in" index="1hAIg9" />
       <concept id="5692353713941573329" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_ActionLabelText" flags="ig" index="1hCUdq" />
       <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
         <child id="1088186146602" name="editorComponent" index="1sWHZn" />
@@ -96,6 +106,7 @@
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
+        <reference id="1139959269582" name="actionMap" index="1ERwB7" />
         <child id="1142887637401" name="renderingCondition" index="pqm2j" />
         <child id="4202667662392416064" name="transformationMenu" index="3vIgyS" />
       </concept>
@@ -1186,6 +1197,7 @@
       <node concept="2iRfu4" id="7EHDEMiDE43" role="2iSdaV" />
       <node concept="1iCGBv" id="1WMFq5x4fLp" role="3EZMnx">
         <ref role="1NtTu8" to="e9k1:1WMFq5x4fLn" resolve="dataRow" />
+        <ref role="1ERwB7" node="4dez30I6DgH" resolve="DataRowRefForLookup_Actions" />
         <node concept="1sVBvm" id="1WMFq5x4fLq" role="1sWHZn">
           <node concept="3F0A7n" id="1WMFq5x4fLr" role="2wV5jI">
             <property role="1Intyy" value="true" />
@@ -1236,6 +1248,36 @@
       <node concept="3cWJ9i" id="5NQtOFqe3BT" role="1Qtc8$">
         <node concept="CtIbL" id="5NQtOFqe3BV" role="CtIbM">
           <property role="CtIbK" value="30NnNOohrQL/RIGHT" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1h_SRR" id="4dez30I6DgH">
+    <property role="TrG5h" value="DataRowRefForLookup_Actions" />
+    <ref role="1h_SK9" to="e9k1:1WMFq5x4fLm" resolve="DataRowRefForLookup" />
+    <node concept="1hA7zw" id="4dez30I6DgI" role="1h_SK8">
+      <property role="1hAc7j" value="7P1WhNABvta/backspace_action_id" />
+      <node concept="1hAIg9" id="4dez30I6DgJ" role="1hA7z_">
+        <node concept="3clFbS" id="4dez30I6DgK" role="2VODD2">
+          <node concept="3clFbF" id="4dez30I7H_a" role="3cqZAp">
+            <node concept="2OqwBi" id="4dez30I7K9X" role="3clFbG">
+              <node concept="0IXxy" id="4dez30I7H_9" role="2Oq$k0" />
+              <node concept="3YRAZt" id="4dez30I7L4n" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1hA7zw" id="4dez30I6DgW" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <node concept="1hAIg9" id="4dez30I6DgX" role="1hA7z_">
+        <node concept="3clFbS" id="4dez30I6DgY" role="2VODD2">
+          <node concept="3clFbF" id="4dez30I8hnq" role="3cqZAp">
+            <node concept="2OqwBi" id="4dez30I8hnr" role="3clFbG">
+              <node concept="0IXxy" id="4dez30I8hns" role="2Oq$k0" />
+              <node concept="3YRAZt" id="4dez30I8hnt" role="2OqNvi" />
+            </node>
+          </node>
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
@@ -21,9 +21,11 @@
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="5991739802479784074" name="jetbrains.mps.lang.editor.structure.MenuTypeNamed" flags="ng" index="22hDWg" />
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi">
         <child id="1078153129734" name="inspectedCellModel" index="6VMZX" />
       </concept>
+      <concept id="1597643335227097138" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_TransformationMenu_node" flags="ng" index="7Obwk" />
       <concept id="1140524381322" name="jetbrains.mps.lang.editor.structure.CellModel_ListWithRole" flags="ng" index="2czfm3">
         <property id="1140524450557" name="separatorText" index="2czwfO" />
         <child id="1140524464360" name="cellLayout" index="2czzBx" />
@@ -38,6 +40,17 @@
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
       <concept id="795210086017940429" name="jetbrains.mps.lang.editor.structure.ReadOnlyStyleClassItem" flags="lg" index="xShMh" />
+      <concept id="6718020819487620873" name="jetbrains.mps.lang.editor.structure.TransformationMenuReference_Named" flags="ng" index="A1WHu">
+        <reference id="6718020819487620874" name="menu" index="A1WHt" />
+      </concept>
+      <concept id="3473224453637651916" name="jetbrains.mps.lang.editor.structure.TransformationLocation_SideTransform_PlaceInCellHolder" flags="ng" index="CtIbL">
+        <property id="3473224453637651917" name="placeInCell" index="CtIbK" />
+      </concept>
+      <concept id="1638911550608610798" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_Execute" flags="ig" index="IWg2L" />
+      <concept id="1638911550608610278" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_Action" flags="ng" index="IWgqT">
+        <child id="1638911550608610281" name="executeFunction" index="IWgqQ" />
+        <child id="5692353713941573325" name="textFunction" index="1hCUd6" />
+      </concept>
       <concept id="1078938745671" name="jetbrains.mps.lang.editor.structure.EditorComponentDeclaration" flags="ig" index="PKFIW" />
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
         <reference id="1078939183255" name="editorComponent" index="PMmxG" />
@@ -54,8 +67,16 @@
       </concept>
       <concept id="1186414860679" name="jetbrains.mps.lang.editor.structure.EditableStyleClassItem" flags="ln" index="VPxyj" />
       <concept id="1186414928363" name="jetbrains.mps.lang.editor.structure.SelectableStyleSheetItem" flags="ln" index="VPM3Z" />
+      <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ng" index="2ZABuq">
+        <reference id="6591946374543067572" name="conceptDeclaration" index="aqKnT" />
+        <child id="5991739802479788259" name="type" index="22hAXT" />
+      </concept>
       <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
       <concept id="1233759184865" name="jetbrains.mps.lang.editor.structure.PunctuationRightStyleClassItem" flags="ln" index="11LMrY" />
+      <concept id="2896773699153795590" name="jetbrains.mps.lang.editor.structure.TransformationLocation_SideTransform" flags="ng" index="3cWJ9i">
+        <child id="3473224453637651919" name="placeInCell" index="CtIbM" />
+      </concept>
+      <concept id="5692353713941573329" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_ActionLabelText" flags="ig" index="1hCUdq" />
       <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
         <child id="1088186146602" name="editorComponent" index="1sWHZn" />
       </concept>
@@ -76,6 +97,7 @@
       </concept>
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
         <child id="1142887637401" name="renderingCondition" index="pqm2j" />
+        <child id="4202667662392416064" name="transformationMenu" index="3vIgyS" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
@@ -99,11 +121,19 @@
       <concept id="1225900081164" name="jetbrains.mps.lang.editor.structure.CellModel_ReadOnlyModelAccessor" flags="sg" stub="3708815482283559694" index="1HlG4h">
         <child id="1225900141900" name="modelAccessor" index="1HlULh" />
       </concept>
+      <concept id="5624877018226900666" name="jetbrains.mps.lang.editor.structure.TransformationMenu" flags="ng" index="3ICUPy" />
+      <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ng" index="3INCJE">
+        <child id="1638911550608572412" name="sections" index="IW6Ez" />
+      </concept>
       <concept id="1088612959204" name="jetbrains.mps.lang.editor.structure.CellModel_Alternation" flags="sg" stub="8104358048506729361" index="1QoScp">
         <property id="1088613081987" name="vertical" index="1QpmdY" />
         <child id="1145918517974" name="alternationCondition" index="3e4ffs" />
         <child id="1088612958265" name="ifTrueCellModel" index="1QoS34" />
         <child id="1088612973955" name="ifFalseCellModel" index="1QoVPY" />
+      </concept>
+      <concept id="7980428675268276156" name="jetbrains.mps.lang.editor.structure.TransformationMenuSection" flags="ng" index="1Qtc8_">
+        <child id="7980428675268276157" name="locations" index="1Qtc8$" />
+        <child id="7980428675268276159" name="parts" index="1Qtc8A" />
       </concept>
       <concept id="1176717841777" name="jetbrains.mps.lang.editor.structure.QueryFunction_ModelAccess_Getter" flags="in" index="3TQlhw" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
@@ -125,6 +155,9 @@
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
@@ -949,6 +982,9 @@
           <node concept="VechU" id="6_rxy3GUPdE" role="3F10Kt">
             <property role="Vb096" value="fLJRk5_/gray" />
           </node>
+          <node concept="A1WHu" id="4dez30I2Dxr" role="3vIgyS">
+            <ref role="A1WHt" node="5NQtOFqdCUu" resolve="DataTableLookUp_SideTransformationForEmptyDefaultColumn" />
+          </node>
         </node>
       </node>
       <node concept="_tjkj" id="67dYdlPPfmg" role="3EZMnx">
@@ -1140,6 +1176,9 @@
     <node concept="3EZMnI" id="7EHDEMiDE42" role="2wV5jI">
       <node concept="PMmxH" id="7EHDEMiDE4h" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+        <node concept="xShMh" id="4dez30I51Ia" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
       </node>
       <node concept="3F0ifn" id="7EHDEMiDE4s" role="3EZMnx">
         <property role="3F0ifm" value="=" />
@@ -1152,6 +1191,51 @@
             <property role="1Intyy" value="true" />
             <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
           </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="3ICUPy" id="5NQtOFqdCUu">
+    <ref role="aqKnT" to="e9k1:stdmzxm7Y2" resolve="DataTableLookUp" />
+    <node concept="22hDWg" id="5NQtOFqdCUv" role="22hAXT">
+      <property role="TrG5h" value="DataTableLookUp_SideTransformationForEmptyDefaultColumn" />
+    </node>
+    <node concept="1Qtc8_" id="5NQtOFqe3BP" role="IW6Ez">
+      <node concept="IWgqT" id="5NQtOFqe3C1" role="1Qtc8A">
+        <node concept="1hCUdq" id="5NQtOFqe3C3" role="1hCUd6">
+          <node concept="3clFbS" id="5NQtOFqe3C5" role="2VODD2">
+            <node concept="3clFbF" id="5NQtOFqe3GT" role="3cqZAp">
+              <node concept="Xl_RD" id="5NQtOFqe3GS" role="3clFbG">
+                <property role="Xl_RC" value="," />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="IWg2L" id="5NQtOFqe3C7" role="IWgqQ">
+          <node concept="3clFbS" id="5NQtOFqe3C9" role="2VODD2">
+            <node concept="3clFbF" id="4dez30I4tkc" role="3cqZAp">
+              <node concept="37vLTI" id="4dez30I4ulX" role="3clFbG">
+                <node concept="2ShNRf" id="4dez30I4uoo" role="37vLTx">
+                  <node concept="3zrR0B" id="4dez30I4uom" role="2ShVmc">
+                    <node concept="3Tqbb2" id="4dez30I4uon" role="3zrR0E">
+                      <ref role="ehGHo" to="e9k1:1WMFq5x4fLm" resolve="DataRowRefForLookup" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="4dez30I4tux" role="37vLTJ">
+                  <node concept="7Obwk" id="4dez30I4tkb" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4dez30I4tMV" role="2OqNvi">
+                    <ref role="3Tt5mk" to="e9k1:3RQ2yxdeEit" resolve="defaultRow" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cWJ9i" id="5NQtOFqe3BT" role="1Qtc8$">
+        <node concept="CtIbL" id="5NQtOFqe3BV" role="CtIbM">
+          <property role="CtIbK" value="30NnNOohrQL/RIGHT" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
@@ -1185,13 +1185,13 @@
   <node concept="24kQdi" id="1WMFq5x4fLo">
     <ref role="1XX52x" to="e9k1:1WMFq5x4fLm" resolve="DataRowRefForLookup" />
     <node concept="3EZMnI" id="7EHDEMiDE42" role="2wV5jI">
-      <node concept="3F0ifn" id="30tzQ1E08Bz" role="3EZMnx">
-        <property role="3F0ifm" value="default" />
+      <node concept="PMmxH" id="5$Ug$eZ8DzN" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
         <ref role="1ERwB7" node="4dez30I6DgH" resolve="DataRowRefForLookup_Actions" />
+        <node concept="VPxyj" id="5$Ug$eZ8DzU" role="3F10Kt" />
       </node>
       <node concept="3F0ifn" id="30tzQ1E08BO" role="3EZMnx">
         <property role="3F0ifm" value="=" />
-        <ref role="1ERwB7" node="4dez30I6DgH" resolve="DataRowRefForLookup_Actions" />
       </node>
       <node concept="2iRfu4" id="7EHDEMiDE43" role="2iSdaV" />
       <node concept="1iCGBv" id="1WMFq5x4fLp" role="3EZMnx">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
@@ -1185,14 +1185,13 @@
   <node concept="24kQdi" id="1WMFq5x4fLo">
     <ref role="1XX52x" to="e9k1:1WMFq5x4fLm" resolve="DataRowRefForLookup" />
     <node concept="3EZMnI" id="7EHDEMiDE42" role="2wV5jI">
-      <node concept="PMmxH" id="7EHDEMiDE4h" role="3EZMnx">
-        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
-        <node concept="xShMh" id="4dez30I51Ia" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
+      <node concept="3F0ifn" id="30tzQ1E08Bz" role="3EZMnx">
+        <property role="3F0ifm" value="default" />
+        <ref role="1ERwB7" node="4dez30I6DgH" resolve="DataRowRefForLookup_Actions" />
       </node>
-      <node concept="3F0ifn" id="7EHDEMiDE4s" role="3EZMnx">
+      <node concept="3F0ifn" id="30tzQ1E08BO" role="3EZMnx">
         <property role="3F0ifm" value="=" />
+        <ref role="1ERwB7" node="4dez30I6DgH" resolve="DataRowRefForLookup_Actions" />
       </node>
       <node concept="2iRfu4" id="7EHDEMiDE43" role="2iSdaV" />
       <node concept="1iCGBv" id="1WMFq5x4fLp" role="3EZMnx">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
@@ -951,12 +951,24 @@
           </node>
         </node>
       </node>
-      <node concept="3F0ifn" id="7F9023_KKU3" role="3EZMnx">
-        <property role="3F0ifm" value="&gt;" />
-        <node concept="11L4FC" id="7F9023_KKUj" role="3F10Kt">
-          <property role="VOm3f" value="true" />
+      <node concept="_tjkj" id="67dYdlPPfmg" role="3EZMnx">
+        <node concept="3EZMnI" id="67dYdlPPfLs" role="_tjki">
+          <node concept="3F0ifn" id="67dYdlPPfLD" role="3EZMnx">
+            <property role="3F0ifm" value="," />
+            <node concept="11L4FC" id="2sfIqvUwT3E" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+          <node concept="3F1sOY" id="67dYdlPOe94" role="3EZMnx">
+            <ref role="1NtTu8" to="e9k1:3RQ2yxdeEit" resolve="defaultRow" />
+          </node>
+          <node concept="2iRfu4" id="67dYdlPPfLv" role="2iSdaV" />
+          <node concept="VPM3Z" id="67dYdlPPfLw" role="3F10Kt" />
         </node>
-        <node concept="11LMrY" id="7F9023_KKUo" role="3F10Kt">
+      </node>
+      <node concept="3F0ifn" id="67dYdlPMe4a" role="3EZMnx">
+        <property role="3F0ifm" value="&gt;" />
+        <node concept="11L4FC" id="2sfIqvUwT3C" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
       </node>
@@ -1118,6 +1130,27 @@
           </node>
           <node concept="VechU" id="6WstIz8MKZX" role="3F10Kt">
             <property role="Vb096" value="fLJRk5B/darkGray" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="1WMFq5x4fLo">
+    <ref role="1XX52x" to="e9k1:1WMFq5x4fLm" resolve="DataRowRefForLookup" />
+    <node concept="3EZMnI" id="7EHDEMiDE42" role="2wV5jI">
+      <node concept="PMmxH" id="7EHDEMiDE4h" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      </node>
+      <node concept="3F0ifn" id="7EHDEMiDE4s" role="3EZMnx">
+        <property role="3F0ifm" value="=" />
+      </node>
+      <node concept="2iRfu4" id="7EHDEMiDE43" role="2iSdaV" />
+      <node concept="1iCGBv" id="1WMFq5x4fLp" role="3EZMnx">
+        <ref role="1NtTu8" to="e9k1:1WMFq5x4fLn" resolve="dataRow" />
+        <node concept="1sVBvm" id="1WMFq5x4fLq" role="1sWHZn">
+          <node concept="3F0A7n" id="1WMFq5x4fLr" role="2wV5jI">
+            <property role="1Intyy" value="true" />
+            <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.structure.mps
@@ -214,6 +214,12 @@
       <property role="20kJfa" value="col" />
       <ref role="20lvS9" node="7F9023_OqBf" resolve="DataColDefRef" />
     </node>
+    <node concept="1TJgyj" id="3RQ2yxdeEit" role="1TKVEi">
+      <property role="IQ2ns" value="4464767248795083933" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="defaultRow" />
+      <ref role="20lvS9" node="1WMFq5x4fLm" resolve="DataRowRefForLookup" />
+    </node>
     <node concept="1TJgyj" id="stdmzxm7Y5" role="1TKVEi">
       <property role="IQ2ns" value="512624657163648901" />
       <property role="20kJfa" value="col_old" />
@@ -269,6 +275,18 @@
       <property role="IQ2ns" value="4073179274522615557" />
       <property role="20kJfa" value="dataRow" />
       <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="cPLa7Fpiy9" resolve="DataRow" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="1WMFq5x4fLm">
+    <property role="EcuMT" value="2248050072641141846" />
+    <property role="TrG5h" value="DataRowRefForLookup" />
+    <property role="34LRSv" value="default" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="1WMFq5x4fLn" role="1TKVEi">
+      <property role="20lbJX" value="fLJekj4/1" />
+      <property role="IQ2ns" value="2248050072641141847" />
+      <property role="20kJfa" value="dataRow" />
       <ref role="20lvS9" node="cPLa7Fpiy9" resolve="DataRow" />
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.typesystem.mps
@@ -91,6 +91,11 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
@@ -116,6 +121,9 @@
       </concept>
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1207055528241" name="jetbrains.mps.lang.typesystem.structure.WarningStatement" flags="nn" index="a7r0C">
+        <child id="1207055552304" name="warningText" index="a7wSD" />
+      </concept>
       <concept id="1185788614172" name="jetbrains.mps.lang.typesystem.structure.NormalTypeClause" flags="ng" index="mw_s8">
         <child id="1185788644032" name="normalType" index="mwGJk" />
       </concept>
@@ -226,9 +234,7 @@
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
-      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
-        <property id="1238684351431" name="asCast" index="1BlNFB" />
-      </concept>
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -265,6 +271,7 @@
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
       <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
@@ -599,6 +606,26 @@
                     <node concept="2jxLKc" id="2KRUNf1mHhJ" role="1tU5fm" />
                   </node>
                 </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="7EHDEMiyTLp" role="3cqZAp">
+            <node concept="3clFbS" id="7EHDEMiyTLr" role="3clFbx">
+              <node concept="a7r0C" id="7EHDEMiyTUn" role="3cqZAp">
+                <node concept="Xl_RD" id="7EHDEMiyTUG" role="a7wSD">
+                  <property role="Xl_RC" value="All columns contain an empty value. Usage of default column in lookUpBy functions doesn't make sense" />
+                </node>
+                <node concept="1YBJjd" id="7EHDEMiyU0y" role="1urrMF">
+                  <ref role="1YBMHb" node="cPLa7FrPf0" resolve="dataTable" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7EHDEMiySnm" role="3clFbw">
+              <node concept="1YBJjd" id="7EHDEMiyS5k" role="2Oq$k0">
+                <ref role="1YBMHb" node="cPLa7FrPf0" resolve="dataTable" />
+              </node>
+              <node concept="2qgKlT" id="7EHDEMiyTif" role="2OqNvi">
+                <ref role="37wK5l" to="ux24:7EHDEMix7cr" resolve="allColumnsContainAnEmptyLiteral" />
               </node>
             </node>
           </node>
@@ -1004,27 +1031,12 @@
             <ref role="ehGHo" to="e9k1:cPLa7Fp8FI" resolve="DataTable" />
           </node>
           <node concept="2OqwBi" id="2SzGbCMN8yw" role="33vP2m">
-            <node concept="1PxgMI" id="2SzGbCMN8yx" role="2Oq$k0">
-              <property role="1BlNFB" value="true" />
-              <node concept="chp4Y" id="2SzGbCMN8yy" role="3oSUPX">
-                <ref role="cht4Q" to="e9k1:cPLa7Fstqs" resolve="DataSelector" />
+            <node concept="2OqwBi" id="2SzGbCMN8yA" role="2Oq$k0">
+              <node concept="1YBJjd" id="2SzGbCMN8yB" role="2Oq$k0">
+                <ref role="1YBMHb" node="2SzGbCMLSpS" resolve="dataTableLookUp" />
               </node>
-              <node concept="2OqwBi" id="2SzGbCMN8yz" role="1m5AlR">
-                <node concept="1PxgMI" id="2SzGbCMN8y$" role="2Oq$k0">
-                  <property role="1BlNFB" value="true" />
-                  <node concept="chp4Y" id="2SzGbCMN8y_" role="3oSUPX">
-                    <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
-                  </node>
-                  <node concept="2OqwBi" id="2SzGbCMN8yA" role="1m5AlR">
-                    <node concept="1YBJjd" id="2SzGbCMN8yB" role="2Oq$k0">
-                      <ref role="1YBMHb" node="2SzGbCMLSpS" resolve="dataTableLookUp" />
-                    </node>
-                    <node concept="1mfA1w" id="2SzGbCMN8yC" role="2OqNvi" />
-                  </node>
-                </node>
-                <node concept="3TrEf2" id="2SzGbCMN8yD" role="2OqNvi">
-                  <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
-                </node>
+              <node concept="2qgKlT" id="5nzoslouUi0" role="2OqNvi">
+                <ref role="37wK5l" to="ux24:5nzoslouECc" resolve="getDataSelector" />
               </node>
             </node>
             <node concept="3TrEf2" id="2SzGbCMN8yE" role="2OqNvi">
@@ -1094,6 +1106,168 @@
           </node>
         </node>
       </node>
+      <node concept="3clFbH" id="7EHDEMitcxa" role="3cqZAp" />
+      <node concept="3cpWs8" id="7EHDEMitcAD" role="3cqZAp">
+        <node concept="3cpWsn" id="7EHDEMitcAE" role="3cpWs9">
+          <property role="TrG5h" value="lookUpColumn" />
+          <node concept="3Tqbb2" id="7EHDEMitc5M" role="1tU5fm">
+            <ref role="ehGHo" to="e9k1:7F9023_OqBf" resolve="DataColDefRef" />
+          </node>
+          <node concept="3K4zz7" id="7EHDEMitcAF" role="33vP2m">
+            <node concept="2OqwBi" id="7EHDEMitcAG" role="3K4Cdx">
+              <node concept="2OqwBi" id="7EHDEMitcAH" role="2Oq$k0">
+                <node concept="1YBJjd" id="7EHDEMitcAI" role="2Oq$k0">
+                  <ref role="1YBMHb" node="2SzGbCMLSpS" resolve="dataTableLookUp" />
+                </node>
+                <node concept="3TrEf2" id="7EHDEMitcAJ" role="2OqNvi">
+                  <ref role="3Tt5mk" to="e9k1:7F9023_Orfu" resolve="col" />
+                </node>
+              </node>
+              <node concept="3w_OXm" id="7EHDEMitcAK" role="2OqNvi" />
+            </node>
+            <node concept="2OqwBi" id="7EHDEMitcAL" role="3K4E3e">
+              <node concept="37vLTw" id="7EHDEMitcAM" role="2Oq$k0">
+                <ref role="3cqZAo" node="2SzGbCMN8yv" resolve="table" />
+              </node>
+              <node concept="3TrEf2" id="7EHDEMitcAN" role="2OqNvi">
+                <ref role="3Tt5mk" to="e9k1:7F9023_OEld" resolve="defaultLookupColumn" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7EHDEMitcAO" role="3K4GZi">
+              <node concept="1YBJjd" id="7EHDEMitcAP" role="2Oq$k0">
+                <ref role="1YBMHb" node="2SzGbCMLSpS" resolve="dataTableLookUp" />
+              </node>
+              <node concept="3TrEf2" id="7EHDEMitcAQ" role="2OqNvi">
+                <ref role="3Tt5mk" to="e9k1:7F9023_Orfu" resolve="col" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbJ" id="7EHDEMilbgj" role="3cqZAp">
+        <node concept="3clFbS" id="7EHDEMilbgl" role="3clFbx">
+          <node concept="a7r0C" id="7EHDEMivD6A" role="3cqZAp">
+            <node concept="1YBJjd" id="7EHDEMivDpi" role="1urrMF">
+              <ref role="1YBMHb" node="2SzGbCMLSpS" resolve="dataTableLookUp" />
+            </node>
+            <node concept="3cpWs3" id="7EHDEMivD7h" role="a7wSD">
+              <node concept="Xl_RD" id="7EHDEMivD7i" role="3uHU7w">
+                <property role="Xl_RC" value="' can be omitted." />
+              </node>
+              <node concept="3cpWs3" id="7EHDEMivD7j" role="3uHU7B">
+                <node concept="3cpWs3" id="7EHDEMivD7k" role="3uHU7B">
+                  <node concept="Xl_RD" id="7EHDEMivD7l" role="3uHU7w">
+                    <property role="Xl_RC" value="' contains an empty value. That is why '" />
+                  </node>
+                  <node concept="3cpWs3" id="7EHDEMivD7m" role="3uHU7B">
+                    <node concept="Xl_RD" id="7EHDEMivD7n" role="3uHU7B">
+                      <property role="Xl_RC" value="Search column '" />
+                    </node>
+                    <node concept="2OqwBi" id="7EHDEMivD7o" role="3uHU7w">
+                      <node concept="2OqwBi" id="7EHDEMivD7p" role="2Oq$k0">
+                        <node concept="37vLTw" id="7EHDEMivD7q" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7EHDEMitcAE" resolve="lookUpColumn" />
+                        </node>
+                        <node concept="3TrEf2" id="7EHDEMivD7r" role="2OqNvi">
+                          <ref role="3Tt5mk" to="e9k1:7F9023_OqBg" resolve="col" />
+                        </node>
+                      </node>
+                      <node concept="3TrcHB" id="7EHDEMivD7s" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="7EHDEMivD7t" role="3uHU7w">
+                  <node concept="2OqwBi" id="7EHDEMivD7u" role="2Oq$k0">
+                    <node concept="2OqwBi" id="7EHDEMivD7v" role="2Oq$k0">
+                      <node concept="1YBJjd" id="7EHDEMivD7w" role="2Oq$k0">
+                        <ref role="1YBMHb" node="2SzGbCMLSpS" resolve="dataTableLookUp" />
+                      </node>
+                      <node concept="3TrEf2" id="7EHDEMivD7x" role="2OqNvi">
+                        <ref role="3Tt5mk" to="e9k1:3RQ2yxdeEit" resolve="defaultRow" />
+                      </node>
+                    </node>
+                    <node concept="3TrEf2" id="7EHDEMivD7y" role="2OqNvi">
+                      <ref role="3Tt5mk" to="e9k1:1WMFq5x4fLn" resolve="dataRow" />
+                    </node>
+                  </node>
+                  <node concept="3TrcHB" id="7EHDEMivD7z" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1Wc70l" id="5nzoslouwjm" role="3clFbw">
+          <node concept="2OqwBi" id="7EHDEMils0r" role="3uHU7w">
+            <node concept="2OqwBi" id="7EHDEMilcje" role="2Oq$k0">
+              <node concept="37vLTw" id="7EHDEMilc2N" role="2Oq$k0">
+                <ref role="3cqZAo" node="2SzGbCMN8yv" resolve="table" />
+              </node>
+              <node concept="2qgKlT" id="7EHDEMiD6ZQ" role="2OqNvi">
+                <ref role="37wK5l" to="ux24:7EHDEMiCP6D" resolve="getColumn" />
+                <node concept="2OqwBi" id="7EHDEMiD9Uh" role="37wK5m">
+                  <node concept="37vLTw" id="7EHDEMiD77P" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7EHDEMitcAE" resolve="lookUpColumn" />
+                  </node>
+                  <node concept="3TrEf2" id="7EHDEMiDajX" role="2OqNvi">
+                    <ref role="3Tt5mk" to="e9k1:7F9023_OqBg" resolve="col" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2HwmR7" id="7EHDEMilsH0" role="2OqNvi">
+              <node concept="1bVj0M" id="7EHDEMilsH2" role="23t8la">
+                <node concept="3clFbS" id="7EHDEMilsH3" role="1bW5cS">
+                  <node concept="3clFbF" id="7EHDEMilsNI" role="3cqZAp">
+                    <node concept="2OqwBi" id="7EHDEMivQly" role="3clFbG">
+                      <node concept="2OqwBi" id="7EHDEMivPGQ" role="2Oq$k0">
+                        <node concept="37vLTw" id="7EHDEMivPut" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7EHDEMilsH4" resolve="it" />
+                        </node>
+                        <node concept="3TrEf2" id="7EHDEMivQ24" role="2OqNvi">
+                          <ref role="3Tt5mk" to="e9k1:cPLa7Fpe9f" resolve="value" />
+                        </node>
+                      </node>
+                      <node concept="1mIQ4w" id="7EHDEMivQBI" role="2OqNvi">
+                        <node concept="chp4Y" id="7EHDEMivQSZ" role="cj9EA">
+                          <ref role="cht4Q" to="hm2y:MNXm1ElbHo" resolve="IEmptyLiteral" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="7EHDEMilsH4" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="7EHDEMilsH5" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1Wc70l" id="7EHDEMimSDI" role="3uHU7B">
+            <node concept="2OqwBi" id="7EHDEMila_i" role="3uHU7B">
+              <node concept="2OqwBi" id="7EHDEMil7TZ" role="2Oq$k0">
+                <node concept="1YBJjd" id="7EHDEMil75B" role="2Oq$k0">
+                  <ref role="1YBMHb" node="2SzGbCMLSpS" resolve="dataTableLookUp" />
+                </node>
+                <node concept="3TrEf2" id="7EHDEMil8aY" role="2OqNvi">
+                  <ref role="3Tt5mk" to="e9k1:3RQ2yxdeEit" resolve="defaultRow" />
+                </node>
+              </node>
+              <node concept="3x8VRR" id="7EHDEMilc2_" role="2OqNvi" />
+            </node>
+            <node concept="2OqwBi" id="5nzoslouxaQ" role="3uHU7w">
+              <node concept="37vLTw" id="5nzoslouwYy" role="2Oq$k0">
+                <ref role="3cqZAo" node="7EHDEMitcAE" resolve="lookUpColumn" />
+              </node>
+              <node concept="3x8VRR" id="5nzoslouxAH" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="7EHDEMilbRU" role="3cqZAp" />
     </node>
     <node concept="1YaCAy" id="2SzGbCMLSpS" role="1YuTPh">
       <property role="TrG5h" value="dataTableLookUp" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.data.interpreter/models/org.iets3.core.expr.data.interpreter.plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.data.interpreter/models/org.iets3.core.expr.data.interpreter.plugin.mps
@@ -77,6 +77,7 @@
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
+        <child id="1206060520071" name="elsifClauses" index="3eNLev" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
@@ -91,6 +92,10 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
+        <child id="1206060619838" name="condition" index="3eO9$A" />
+        <child id="1206060644605" name="statementList" index="3eOfB_" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -165,6 +170,9 @@
       </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
@@ -425,116 +433,134 @@
                         </node>
                       </node>
                     </node>
-                    <node concept="3cpWs8" id="stdmzxqE5Q" role="3cqZAp">
-                      <node concept="3cpWsn" id="stdmzxqE5R" role="3cpWs9">
-                        <property role="TrG5h" value="found" />
-                        <node concept="1LlUBW" id="stdmzxqE2F" role="1tU5fm">
-                          <node concept="3Tqbb2" id="stdmzxqE2L" role="1Lm7xW">
-                            <ref role="ehGHo" to="e9k1:cPLa7Fpiy9" resolve="DataRow" />
-                          </node>
-                          <node concept="3Tqbb2" id="stdmzxqE2K" role="1Lm7xW">
-                            <ref role="ehGHo" to="e9k1:cPLa7FpcCS" resolve="DataCell" />
+                    <node concept="3cpWs8" id="4JuIOs$LWss" role="3cqZAp">
+                      <node concept="3cpWsn" id="4JuIOs$LWst" role="3cpWs9">
+                        <property role="TrG5h" value="rows" />
+                        <node concept="A3Dl8" id="4JuIOs$LW7Q" role="1tU5fm">
+                          <node concept="1LlUBW" id="4JuIOs$LW7Z" role="A3Ik2">
+                            <node concept="3Tqbb2" id="4JuIOs$LW80" role="1Lm7xW">
+                              <ref role="ehGHo" to="e9k1:cPLa7Fpiy9" resolve="DataRow" />
+                            </node>
+                            <node concept="3Tqbb2" id="4JuIOs$LW81" role="1Lm7xW">
+                              <ref role="ehGHo" to="e9k1:cPLa7FpcCS" resolve="DataCell" />
+                            </node>
                           </node>
                         </node>
-                        <node concept="2OqwBi" id="stdmzxqE5S" role="33vP2m">
-                          <node concept="2OqwBi" id="stdmzxqE5T" role="2Oq$k0">
-                            <node concept="2OqwBi" id="stdmzxqE5U" role="2Oq$k0">
-                              <node concept="2OqwBi" id="stdmzxqE5V" role="2Oq$k0">
-                                <node concept="37vLTw" id="stdmzxqE5W" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="stdmzxodld" resolve="s" />
-                                </node>
-                                <node concept="3TrEf2" id="stdmzxqE5X" role="2OqNvi">
-                                  <ref role="3Tt5mk" to="e9k1:cPLa7FstD4" resolve="table" />
-                                </node>
+                        <node concept="2OqwBi" id="4JuIOs$LWsu" role="33vP2m">
+                          <node concept="2OqwBi" id="4JuIOs$LWsv" role="2Oq$k0">
+                            <node concept="2OqwBi" id="4JuIOs$LWsw" role="2Oq$k0">
+                              <node concept="37vLTw" id="4JuIOs$LWsx" role="2Oq$k0">
+                                <ref role="3cqZAo" node="stdmzxodld" resolve="s" />
                               </node>
-                              <node concept="3Tsc0h" id="stdmzxqE5Y" role="2OqNvi">
-                                <ref role="3TtcxE" to="e9k1:cPLa7FpRVO" resolve="rows" />
+                              <node concept="3TrEf2" id="4JuIOs$LWsy" role="2OqNvi">
+                                <ref role="3Tt5mk" to="e9k1:cPLa7FstD4" resolve="table" />
                               </node>
                             </node>
-                            <node concept="3$u5V9" id="stdmzxqE5Z" role="2OqNvi">
-                              <node concept="1bVj0M" id="stdmzxqE60" role="23t8la">
-                                <node concept="3clFbS" id="stdmzxqE61" role="1bW5cS">
-                                  <node concept="3clFbF" id="stdmzxqE62" role="3cqZAp">
-                                    <node concept="1Ls8ON" id="stdmzxqE63" role="3clFbG">
-                                      <node concept="37vLTw" id="stdmzxqE64" role="1Lso8e">
-                                        <ref role="3cqZAo" node="stdmzxqE6m" resolve="it" />
-                                      </node>
-                                      <node concept="2OqwBi" id="stdmzxqE65" role="1Lso8e">
-                                        <node concept="2OqwBi" id="stdmzxqE66" role="2Oq$k0">
-                                          <node concept="37vLTw" id="stdmzxqE67" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="stdmzxqE6m" resolve="it" />
-                                          </node>
-                                          <node concept="3Tsc0h" id="stdmzxqE68" role="2OqNvi">
-                                            <ref role="3TtcxE" to="e9k1:cPLa7FpcRm" resolve="cells" />
-                                          </node>
+                            <node concept="3Tsc0h" id="4JuIOs$LWsz" role="2OqNvi">
+                              <ref role="3TtcxE" to="e9k1:cPLa7FpRVO" resolve="rows" />
+                            </node>
+                          </node>
+                          <node concept="3$u5V9" id="4JuIOs$LWs$" role="2OqNvi">
+                            <node concept="1bVj0M" id="4JuIOs$LWs_" role="23t8la">
+                              <node concept="3clFbS" id="4JuIOs$LWsA" role="1bW5cS">
+                                <node concept="3clFbF" id="4JuIOs$LWsB" role="3cqZAp">
+                                  <node concept="1Ls8ON" id="4JuIOs$LWsC" role="3clFbG">
+                                    <node concept="37vLTw" id="4JuIOs$LWsD" role="1Lso8e">
+                                      <ref role="3cqZAo" node="4JuIOs$LWsT" resolve="it" />
+                                    </node>
+                                    <node concept="2OqwBi" id="4JuIOs$LWsE" role="1Lso8e">
+                                      <node concept="2OqwBi" id="4JuIOs$LWsF" role="2Oq$k0">
+                                        <node concept="37vLTw" id="4JuIOs$LWsG" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="4JuIOs$LWsT" resolve="it" />
                                         </node>
-                                        <node concept="1z4cxt" id="stdmzxqE69" role="2OqNvi">
-                                          <node concept="1bVj0M" id="stdmzxqE6a" role="23t8la">
-                                            <node concept="3clFbS" id="stdmzxqE6b" role="1bW5cS">
-                                              <node concept="3clFbF" id="stdmzxqE6c" role="3cqZAp">
-                                                <node concept="17R0WA" id="stdmzxqE6d" role="3clFbG">
-                                                  <node concept="37vLTw" id="7F9023_KMR2" role="3uHU7w">
-                                                    <ref role="3cqZAo" node="7F9023_KMQY" resolve="columnToLookUp" />
+                                        <node concept="3Tsc0h" id="4JuIOs$LWsH" role="2OqNvi">
+                                          <ref role="3TtcxE" to="e9k1:cPLa7FpcRm" resolve="cells" />
+                                        </node>
+                                      </node>
+                                      <node concept="1z4cxt" id="4JuIOs$LWsI" role="2OqNvi">
+                                        <node concept="1bVj0M" id="4JuIOs$LWsJ" role="23t8la">
+                                          <node concept="3clFbS" id="4JuIOs$LWsK" role="1bW5cS">
+                                            <node concept="3clFbF" id="4JuIOs$LWsL" role="3cqZAp">
+                                              <node concept="17R0WA" id="4JuIOs$LWsM" role="3clFbG">
+                                                <node concept="37vLTw" id="4JuIOs$LWsN" role="3uHU7w">
+                                                  <ref role="3cqZAo" node="7F9023_KMQY" resolve="columnToLookUp" />
+                                                </node>
+                                                <node concept="2OqwBi" id="4JuIOs$LWsO" role="3uHU7B">
+                                                  <node concept="37vLTw" id="4JuIOs$LWsP" role="2Oq$k0">
+                                                    <ref role="3cqZAo" node="4JuIOs$LWsR" resolve="it" />
                                                   </node>
-                                                  <node concept="2OqwBi" id="stdmzxqE6h" role="3uHU7B">
-                                                    <node concept="37vLTw" id="stdmzxqE6i" role="2Oq$k0">
-                                                      <ref role="3cqZAo" node="stdmzxqE6k" resolve="it" />
-                                                    </node>
-                                                    <node concept="3TrEf2" id="stdmzxqE6j" role="2OqNvi">
-                                                      <ref role="3Tt5mk" to="e9k1:cPLa7FpdsY" resolve="col" />
-                                                    </node>
+                                                  <node concept="3TrEf2" id="4JuIOs$LWsQ" role="2OqNvi">
+                                                    <ref role="3Tt5mk" to="e9k1:cPLa7FpdsY" resolve="col" />
                                                   </node>
                                                 </node>
                                               </node>
                                             </node>
-                                            <node concept="Rh6nW" id="stdmzxqE6k" role="1bW2Oz">
-                                              <property role="TrG5h" value="it" />
-                                              <node concept="2jxLKc" id="stdmzxqE6l" role="1tU5fm" />
-                                            </node>
+                                          </node>
+                                          <node concept="Rh6nW" id="4JuIOs$LWsR" role="1bW2Oz">
+                                            <property role="TrG5h" value="it" />
+                                            <node concept="2jxLKc" id="4JuIOs$LWsS" role="1tU5fm" />
                                           </node>
                                         </node>
                                       </node>
                                     </node>
                                   </node>
                                 </node>
-                                <node concept="Rh6nW" id="stdmzxqE6m" role="1bW2Oz">
-                                  <property role="TrG5h" value="it" />
-                                  <node concept="2jxLKc" id="stdmzxqE6n" role="1tU5fm" />
-                                </node>
+                              </node>
+                              <node concept="Rh6nW" id="4JuIOs$LWsT" role="1bW2Oz">
+                                <property role="TrG5h" value="it" />
+                                <node concept="2jxLKc" id="4JuIOs$LWsU" role="1tU5fm" />
                               </node>
                             </node>
                           </node>
-                          <node concept="1z4cxt" id="stdmzxqE6o" role="2OqNvi">
-                            <node concept="1bVj0M" id="stdmzxqE6p" role="23t8la">
-                              <node concept="3clFbS" id="stdmzxqE6q" role="1bW5cS">
-                                <node concept="3clFbF" id="stdmzxqE6r" role="3cqZAp">
-                                  <node concept="2YIFZM" id="stdmzxqE6s" role="3clFbG">
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="4JuIOs$LYai" role="3cqZAp">
+                      <node concept="3cpWsn" id="4JuIOs$LYaj" role="3cpWs9">
+                        <property role="TrG5h" value="found" />
+                        <node concept="1LlUBW" id="4JuIOs$LY0o" role="1tU5fm">
+                          <node concept="3Tqbb2" id="4JuIOs$LY0t" role="1Lm7xW">
+                            <ref role="ehGHo" to="e9k1:cPLa7Fpiy9" resolve="DataRow" />
+                          </node>
+                          <node concept="3Tqbb2" id="4JuIOs$LY0u" role="1Lm7xW">
+                            <ref role="ehGHo" to="e9k1:cPLa7FpcCS" resolve="DataCell" />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="4JuIOs$LYak" role="33vP2m">
+                          <node concept="37vLTw" id="4JuIOs$LYal" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4JuIOs$LWst" resolve="rows" />
+                          </node>
+                          <node concept="1z4cxt" id="4JuIOs$LYam" role="2OqNvi">
+                            <node concept="1bVj0M" id="4JuIOs$LYan" role="23t8la">
+                              <node concept="3clFbS" id="4JuIOs$LYao" role="1bW5cS">
+                                <node concept="3clFbF" id="4JuIOs$LYap" role="3cqZAp">
+                                  <node concept="2YIFZM" id="4JuIOs$LYaq" role="3clFbG">
                                     <ref role="37wK5l" to="dj6k:VFjlN6eV5u" resolve="eq" />
                                     <ref role="1Pybhc" to="dj6k:VFjlN6eQjY" resolve="ComparisonHelper" />
-                                    <node concept="qpA2v" id="stdmzxqE6t" role="37wK5m">
-                                      <node concept="2OqwBi" id="stdmzxqE6u" role="3SLO0q">
-                                        <node concept="1LFfDK" id="stdmzxqE6v" role="2Oq$k0">
-                                          <node concept="3cmrfG" id="stdmzxqE6w" role="1LF_Uc">
+                                    <node concept="qpA2v" id="4JuIOs$LYar" role="37wK5m">
+                                      <node concept="2OqwBi" id="4JuIOs$LYas" role="3SLO0q">
+                                        <node concept="1LFfDK" id="4JuIOs$LYat" role="2Oq$k0">
+                                          <node concept="3cmrfG" id="4JuIOs$LYau" role="1LF_Uc">
                                             <property role="3cmrfH" value="1" />
                                           </node>
-                                          <node concept="37vLTw" id="stdmzxqE6x" role="1LFl5Q">
-                                            <ref role="3cqZAo" node="stdmzxqE6$" resolve="it" />
+                                          <node concept="37vLTw" id="4JuIOs$LYav" role="1LFl5Q">
+                                            <ref role="3cqZAo" node="4JuIOs$LYay" resolve="it" />
                                           </node>
                                         </node>
-                                        <node concept="3TrEf2" id="stdmzxqE6y" role="2OqNvi">
+                                        <node concept="3TrEf2" id="4JuIOs$LYaw" role="2OqNvi">
                                           <ref role="3Tt5mk" to="e9k1:cPLa7Fpe9f" resolve="value" />
                                         </node>
                                       </node>
                                     </node>
-                                    <node concept="37vLTw" id="stdmzxqE6z" role="37wK5m">
+                                    <node concept="37vLTw" id="4JuIOs$LYax" role="37wK5m">
                                       <ref role="3cqZAo" node="stdmzxpVy1" resolve="searchValue" />
                                     </node>
                                   </node>
                                 </node>
                               </node>
-                              <node concept="Rh6nW" id="stdmzxqE6$" role="1bW2Oz">
+                              <node concept="Rh6nW" id="4JuIOs$LYay" role="1bW2Oz">
                                 <property role="TrG5h" value="it" />
-                                <node concept="2jxLKc" id="stdmzxqE6_" role="1tU5fm" />
+                                <node concept="2jxLKc" id="4JuIOs$LYaz" role="1tU5fm" />
                               </node>
                             </node>
                           </node>
@@ -549,7 +575,7 @@
                               <property role="3cmrfH" value="0" />
                             </node>
                             <node concept="37vLTw" id="stdmzxqE6A" role="1LFl5Q">
-                              <ref role="3cqZAo" node="stdmzxqE5R" resolve="found" />
+                              <ref role="3cqZAo" node="4JuIOs$LYaj" resolve="found" />
                             </node>
                           </node>
                         </node>
@@ -557,7 +583,111 @@
                       <node concept="3y3z36" id="stdmzxqFM5" role="3clFbw">
                         <node concept="10Nm6u" id="stdmzxqGd3" role="3uHU7w" />
                         <node concept="37vLTw" id="stdmzxqF4w" role="3uHU7B">
-                          <ref role="3cqZAo" node="stdmzxqE5R" resolve="found" />
+                          <ref role="3cqZAo" node="4JuIOs$LYaj" resolve="found" />
+                        </node>
+                      </node>
+                      <node concept="3eNFk2" id="4JuIOs$I6cE" role="3eNLev">
+                        <node concept="3clFbS" id="4JuIOs$I6cG" role="3eOfB_">
+                          <node concept="3cpWs8" id="4JuIOs$M12b" role="3cqZAp">
+                            <node concept="3cpWsn" id="4JuIOs$M12c" role="3cpWs9">
+                              <property role="TrG5h" value="result" />
+                              <node concept="1LlUBW" id="4JuIOs$M0TN" role="1tU5fm">
+                                <node concept="3Tqbb2" id="4JuIOs$M0TT" role="1Lm7xW">
+                                  <ref role="ehGHo" to="e9k1:cPLa7Fpiy9" resolve="DataRow" />
+                                </node>
+                                <node concept="3Tqbb2" id="4JuIOs$M0TS" role="1Lm7xW">
+                                  <ref role="ehGHo" to="e9k1:cPLa7FpcCS" resolve="DataCell" />
+                                </node>
+                              </node>
+                              <node concept="2OqwBi" id="4JuIOs$M12d" role="33vP2m">
+                                <node concept="37vLTw" id="4JuIOs$M12e" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="4JuIOs$LWst" resolve="rows" />
+                                </node>
+                                <node concept="1z4cxt" id="4JuIOs$M12f" role="2OqNvi">
+                                  <node concept="1bVj0M" id="4JuIOs$M12g" role="23t8la">
+                                    <node concept="3clFbS" id="4JuIOs$M12h" role="1bW5cS">
+                                      <node concept="3clFbF" id="4JuIOs$M12i" role="3cqZAp">
+                                        <node concept="2YIFZM" id="4JuIOs$M12j" role="3clFbG">
+                                          <ref role="1Pybhc" to="dj6k:VFjlN6eQjY" resolve="ComparisonHelper" />
+                                          <ref role="37wK5l" to="dj6k:VFjlN6eV5u" resolve="eq" />
+                                          <node concept="qpA2v" id="4JuIOs$M12k" role="37wK5m">
+                                            <node concept="2OqwBi" id="4JuIOs$M12l" role="3SLO0q">
+                                              <node concept="1LFfDK" id="4JuIOs$M12m" role="2Oq$k0">
+                                                <node concept="3cmrfG" id="4JuIOs$M12n" role="1LF_Uc">
+                                                  <property role="3cmrfH" value="1" />
+                                                </node>
+                                                <node concept="37vLTw" id="4JuIOs$M12o" role="1LFl5Q">
+                                                  <ref role="3cqZAo" node="4JuIOs$M12s" resolve="it" />
+                                                </node>
+                                              </node>
+                                              <node concept="3TrEf2" id="4JuIOs$M12p" role="2OqNvi">
+                                                <ref role="3Tt5mk" to="e9k1:cPLa7Fpe9f" resolve="value" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                          <node concept="2ShNRf" id="4JuIOs$M12q" role="37wK5m">
+                                            <node concept="HV5vD" id="4JuIOs$M12r" role="2ShVmc">
+                                              <ref role="HV5vE" to="xfg9:3nVyItrYWd7" resolve="DefaultNix" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="Rh6nW" id="4JuIOs$M12s" role="1bW2Oz">
+                                      <property role="TrG5h" value="it" />
+                                      <node concept="2jxLKc" id="4JuIOs$M12t" role="1tU5fm" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbJ" id="4JuIOs$J0a$" role="3cqZAp">
+                            <node concept="3clFbS" id="4JuIOs$J0aA" role="3clFbx">
+                              <node concept="3cpWs6" id="4JuIOs$J1jw" role="3cqZAp">
+                                <node concept="1LFfDK" id="4JuIOs$J1BB" role="3cqZAk">
+                                  <node concept="3cmrfG" id="4JuIOs$J1Cs" role="1LF_Uc">
+                                    <property role="3cmrfH" value="0" />
+                                  </node>
+                                  <node concept="37vLTw" id="4JuIOs$J1jG" role="1LFl5Q">
+                                    <ref role="3cqZAo" node="4JuIOs$M12c" resolve="result" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3y3z36" id="4JuIOs$J13A" role="3clFbw">
+                              <node concept="10Nm6u" id="4JuIOs$J1j1" role="3uHU7w" />
+                              <node concept="37vLTw" id="4JuIOs$J0Ed" role="3uHU7B">
+                                <ref role="3cqZAo" node="4JuIOs$M12c" resolve="result" />
+                              </node>
+                            </node>
+                            <node concept="9aQIb" id="4JuIOs$J1CW" role="9aQIa">
+                              <node concept="3clFbS" id="4JuIOs$J1CX" role="9aQI4">
+                                <node concept="3cpWs6" id="4JuIOs$I9mU" role="3cqZAp">
+                                  <node concept="2OqwBi" id="4JuIOs$I9Xu" role="3cqZAk">
+                                    <node concept="2OqwBi" id="4JuIOs$I9zA" role="2Oq$k0">
+                                      <node concept="oxGPV" id="4JuIOs$I9n4" role="2Oq$k0" />
+                                      <node concept="3TrEf2" id="4JuIOs$I9MC" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="e9k1:3RQ2yxdeEit" resolve="defaultRow" />
+                                      </node>
+                                    </node>
+                                    <node concept="3TrEf2" id="4JuIOs$Ia7R" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="e9k1:1WMFq5x4fLn" resolve="dataRow" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3y3z36" id="4JuIOs$I1_$" role="3eO9$A">
+                          <node concept="10Nm6u" id="4JuIOs$I1HK" role="3uHU7w" />
+                          <node concept="2OqwBi" id="4JuIOs$I11u" role="3uHU7B">
+                            <node concept="oxGPV" id="4JuIOs$I0OV" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="4JuIOs$I1fZ" role="2OqNvi">
+                              <ref role="3Tt5mk" to="e9k1:3RQ2yxdeEit" resolve="defaultRow" />
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.datatable@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.datatable@tests.mps
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:91b05dce-7884-4f58-b31f-cc577eb13b6a(test.in.expr.os.datatable@tests)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
@@ -69,8 +70,15 @@
       <concept id="543569365052765011" name="org.iets3.core.expr.toplevel.structure.EmptyToplevelContent" flags="ng" index="_ixoA" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+      <concept id="779128492853369165" name="jetbrains.mps.lang.core.structure.SideTransformInfo" flags="ng" index="1KehLL">
+        <property id="779128492853934523" name="cellId" index="1K8rM7" />
+        <property id="779128492853699361" name="side" index="1Kfyot" />
       </concept>
     </language>
     <language id="b25b8ad1-4d3d-4e45-8c78-72091b39fdda" name="org.iets3.core.expr.data">
@@ -86,6 +94,7 @@
       <concept id="512624657163648898" name="org.iets3.core.expr.data.structure.DataTableLookUp" flags="ng" index="3AhkFE">
         <child id="8847603084240729054" name="col" index="2v6bfY" />
         <child id="512624657163648903" name="arg" index="3AhkFJ" />
+        <child id="4464767248795083933" name="defaultRow" index="1KNaUP" />
       </concept>
       <concept id="231307155598475891" name="org.iets3.core.expr.data.structure.DataColOp" flags="ng" index="3Cgsri">
         <reference id="231307155598477016" name="col" index="3Cgs9T" />
@@ -114,6 +123,9 @@
       </concept>
       <concept id="231307155597471414" name="org.iets3.core.expr.data.structure.DataColDef" flags="ng" index="3CkmCn">
         <child id="231307155597474194" name="type" index="3CknON" />
+      </concept>
+      <concept id="2248050072641141846" name="org.iets3.core.expr.data.structure.DataRowRefForLookup" flags="ng" index="1Y8_7R">
+        <reference id="2248050072641141847" name="dataRow" index="1Y8_7Q" />
       </concept>
     </language>
   </registry>
@@ -193,7 +205,7 @@
         <node concept="30bXR$" id="7F9023_N8E_" role="3CknON" />
       </node>
       <node concept="3CkeKC" id="7F9023_N8ED" role="3CkFDl">
-        <property role="TrG5h" value="keyA" />
+        <property role="TrG5h" value="keyADefault" />
         <node concept="3CkgUp" id="7F9023_N8EE" role="3Ckg_R">
           <ref role="3Ckhev" node="7F9023_N8E$" resolve="val1" />
           <node concept="30bXRB" id="7F9023_N8EB" role="3CkirI">
@@ -208,7 +220,7 @@
         </node>
       </node>
       <node concept="3CkeKC" id="7F9023_N8EI" role="3CkFDl">
-        <property role="TrG5h" value="keyB" />
+        <property role="TrG5h" value="keyBDefault" />
         <node concept="3CkgUp" id="7F9023_N8EJ" role="3Ckg_R">
           <ref role="3Ckhev" node="7F9023_N8E$" resolve="val1" />
           <node concept="30bXRB" id="7F9023_N8EG" role="3CkirI">
@@ -226,7 +238,7 @@
         <ref role="2v6aBK" node="7F9023_N8E$" resolve="val1" />
       </node>
       <node concept="3CkeKC" id="2KRUNf1m5M7" role="3CkFDl">
-        <property role="TrG5h" value="keyC" />
+        <property role="TrG5h" value="keyCDefault" />
         <node concept="3CkgUp" id="2KRUNf1m5YW" role="3Ckg_R">
           <ref role="3Ckhev" node="7F9023_N8E$" resolve="val1" />
           <node concept="1I1voI" id="3tcv7J0GjZK" role="3CkirI" />
@@ -395,27 +407,75 @@
           </node>
         </node>
       </node>
-      <node concept="_fkuZ" id="7F9023_N90u" role="_fkp5">
-        <node concept="_fku$" id="7F9023_N90v" role="_fkur" />
-        <node concept="1QScDb" id="7F9023_N9a5" role="_fkuY">
-          <node concept="3Cgsri" id="7F9023_O9s$" role="1QScD9">
-            <ref role="3Cgs9T" node="7F9023_N8EA" resolve="val2" />
-          </node>
-          <node concept="wdKpt" id="7F9023_N996" role="30czhm">
-            <node concept="1QScDb" id="7F9023_N97r" role="30czhm">
-              <node concept="3AhkFE" id="7F9023_N97O" role="1QScD9">
-                <node concept="30bXRB" id="7F9023_N98p" role="3AhkFJ">
-                  <property role="30bXRw" value="1" />
-                </node>
-              </node>
-              <node concept="3Ch18X" id="7F9023_N97g" role="30czhm">
-                <ref role="3Ch1V_" node="7F9023_N8Ey" resolve="WithDefault" />
-              </node>
+      <node concept="_fkuZ" id="4JuIOs$Imr1" role="_fkp5">
+        <node concept="_fku$" id="4JuIOs$Imr2" role="_fkur" />
+        <node concept="1QScDb" id="4JuIOs$Imr3" role="_fkuY">
+          <node concept="3AhkFE" id="4JuIOs$Imr4" role="1QScD9">
+            <node concept="2v6aBJ" id="4JuIOs$Imr5" role="2v6bfY">
+              <ref role="2v6aBK" node="cPLa7FroL6" resolve="val1" />
+            </node>
+            <node concept="30bXRB" id="4JuIOs$Imr7" role="3AhkFJ">
+              <property role="30bXRw" value="5" />
             </node>
           </node>
+          <node concept="3Ch18X" id="4JuIOs$Imr8" role="30czhm">
+            <ref role="3Ch1V_" node="cPLa7FroL4" resolve="ExampleTable" />
+          </node>
         </node>
-        <node concept="30bXRB" id="7F9023_O9ux" role="_fkuS">
-          <property role="30bXRw" value="2" />
+        <node concept="1I1voI" id="2sfIqvUwQfb" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="67dYdlPRhFe" role="_fkp5">
+        <node concept="_fku$" id="67dYdlPRhFf" role="_fkur" />
+        <node concept="1QScDb" id="67dYdlPRhFg" role="_fkuY">
+          <node concept="3AhkFE" id="67dYdlPRhFh" role="1QScD9">
+            <node concept="30bXRB" id="67dYdlPRhFi" role="3AhkFJ">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="2v6aBJ" id="67dYdlPRhFj" role="2v6bfY">
+              <ref role="2v6aBK" node="cPLa7FroL6" resolve="val1" />
+            </node>
+            <node concept="1Y8_7R" id="1WMFq5x5amR" role="1KNaUP">
+              <ref role="1Y8_7Q" node="cPLa7FroLg" resolve="keyB" />
+            </node>
+          </node>
+          <node concept="3Ch18X" id="67dYdlPRhFk" role="30czhm">
+            <ref role="3Ch1V_" node="cPLa7FroL4" resolve="ExampleTable" />
+          </node>
+        </node>
+        <node concept="1QScDb" id="67dYdlPRhFl" role="_fkuS">
+          <node concept="3CgUdp" id="67dYdlPRhFm" role="1QScD9">
+            <ref role="3CgUW3" node="cPLa7FroLb" resolve="keyA" />
+          </node>
+          <node concept="3Ch18X" id="67dYdlPRhFn" role="30czhm">
+            <ref role="3Ch1V_" node="cPLa7FroL4" resolve="ExampleTable" />
+          </node>
+        </node>
+      </node>
+      <node concept="_fkuZ" id="4JuIOs$Im1L" role="_fkp5">
+        <node concept="_fku$" id="4JuIOs$Im1M" role="_fkur" />
+        <node concept="1QScDb" id="4JuIOs$Im1N" role="_fkuY">
+          <node concept="3AhkFE" id="4JuIOs$Im1O" role="1QScD9">
+            <node concept="2v6aBJ" id="4JuIOs$Im1P" role="2v6bfY">
+              <ref role="2v6aBK" node="cPLa7FroL6" resolve="val1" />
+            </node>
+            <node concept="1Y8_7R" id="4JuIOs$Im1Q" role="1KNaUP">
+              <ref role="1Y8_7Q" node="cPLa7FroLg" resolve="keyB" />
+            </node>
+            <node concept="30bXRB" id="4JuIOs$Im1R" role="3AhkFJ">
+              <property role="30bXRw" value="5" />
+            </node>
+          </node>
+          <node concept="3Ch18X" id="4JuIOs$Im1S" role="30czhm">
+            <ref role="3Ch1V_" node="cPLa7FroL4" resolve="ExampleTable" />
+          </node>
+        </node>
+        <node concept="1QScDb" id="4JuIOs$Im1T" role="_fkuS">
+          <node concept="3CgUdp" id="4JuIOs$Im1U" role="1QScD9">
+            <ref role="3CgUW3" node="cPLa7FroLg" resolve="keyB" />
+          </node>
+          <node concept="3Ch18X" id="4JuIOs$Im1V" role="30czhm">
+            <ref role="3Ch1V_" node="cPLa7FroL4" resolve="ExampleTable" />
+          </node>
         </node>
       </node>
       <node concept="_fkuZ" id="3y6PJwOsOVG" role="_fkp5">
@@ -478,6 +538,29 @@
         </node>
         <node concept="2vmpn$" id="3y6PJwOvBT0" role="_fkuS" />
       </node>
+      <node concept="_fkuZ" id="7F9023_N90u" role="_fkp5">
+        <node concept="_fku$" id="7F9023_N90v" role="_fkur" />
+        <node concept="1QScDb" id="7F9023_N9a5" role="_fkuY">
+          <node concept="3Cgsri" id="7F9023_O9s$" role="1QScD9">
+            <ref role="3Cgs9T" node="7F9023_N8EA" resolve="val2" />
+          </node>
+          <node concept="wdKpt" id="7F9023_N996" role="30czhm">
+            <node concept="1QScDb" id="7F9023_N97r" role="30czhm">
+              <node concept="3AhkFE" id="7F9023_N97O" role="1QScD9">
+                <node concept="30bXRB" id="7F9023_N98p" role="3AhkFJ">
+                  <property role="30bXRw" value="1" />
+                </node>
+              </node>
+              <node concept="3Ch18X" id="7F9023_N97g" role="30czhm">
+                <ref role="3Ch1V_" node="7F9023_N8Ey" resolve="WithDefault" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="30bXRB" id="7F9023_O9ux" role="_fkuS">
+          <property role="30bXRw" value="2" />
+        </node>
+      </node>
       <node concept="_fkuZ" id="2KRUNf1n5gW" role="_fkp5">
         <node concept="_fku$" id="2KRUNf1n5gX" role="_fkur" />
         <node concept="1QScDb" id="2KRUNf1n5EO" role="_fkuY">
@@ -506,12 +589,89 @@
             <node concept="30bXRB" id="2KRUNf1rIlH" role="3AhkFJ">
               <property role="30bXRw" value="4" />
             </node>
+            <node concept="1KehLL" id="4JuIOs$ODu3" role="lGtFl">
+              <property role="1K8rM7" value="Constant_f1fcw7_e0a" />
+              <property role="1Kfyot" value="Fg1jLUVyTf/left" />
+            </node>
           </node>
           <node concept="3Ch18X" id="2KRUNf1rI45" role="30czhm">
             <ref role="3Ch1V_" node="7F9023_N8Ey" resolve="WithDefault" />
           </node>
         </node>
         <node concept="1I1voI" id="2KRUNf1rIyP" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="4JuIOs$IzlO" role="_fkp5">
+        <node concept="_fku$" id="4JuIOs$IzlP" role="_fkur" />
+        <node concept="1QScDb" id="4JuIOs$IzlQ" role="_fkuY">
+          <node concept="3AhkFE" id="4JuIOs$IzlR" role="1QScD9">
+            <node concept="30bXRB" id="4JuIOs$IzlS" role="3AhkFJ">
+              <property role="30bXRw" value="4" />
+            </node>
+            <node concept="1Y8_7R" id="4JuIOs$IzCa" role="1KNaUP">
+              <ref role="1Y8_7Q" node="7F9023_N8ED" resolve="keyADefault" />
+            </node>
+          </node>
+          <node concept="3Ch18X" id="4JuIOs$IzlT" role="30czhm">
+            <ref role="3Ch1V_" node="7F9023_N8Ey" resolve="WithDefault" />
+          </node>
+        </node>
+        <node concept="1QScDb" id="4JuIOs$IzQm" role="_fkuS">
+          <node concept="3CgUdp" id="4JuIOs$IzVH" role="1QScD9">
+            <ref role="3CgUW3" node="2KRUNf1m5M7" resolve="keyCDefault" />
+          </node>
+          <node concept="3Ch18X" id="4JuIOs$IzLG" role="30czhm">
+            <ref role="3Ch1V_" node="7F9023_N8Ey" resolve="WithDefault" />
+          </node>
+        </node>
+      </node>
+      <node concept="_fkuZ" id="4JuIOs$JipT" role="_fkp5">
+        <node concept="_fku$" id="4JuIOs$JipU" role="_fkur" />
+        <node concept="1QScDb" id="4JuIOs$JipV" role="_fkuY">
+          <node concept="3AhkFE" id="4JuIOs$JipW" role="1QScD9">
+            <node concept="1Y8_7R" id="4JuIOs$JipX" role="1KNaUP">
+              <ref role="1Y8_7Q" node="2KRUNf1m5M7" resolve="keyCDefault" />
+            </node>
+            <node concept="30bXRB" id="4JuIOs$JiT8" role="3AhkFJ">
+              <property role="30bXRw" value="3" />
+            </node>
+          </node>
+          <node concept="3Ch18X" id="4JuIOs$JipZ" role="30czhm">
+            <ref role="3Ch1V_" node="7F9023_N8Ey" resolve="WithDefault" />
+          </node>
+        </node>
+        <node concept="1QScDb" id="4JuIOs$Jiq0" role="_fkuS">
+          <node concept="3CgUdp" id="4JuIOs$Jiq1" role="1QScD9">
+            <ref role="3CgUW3" node="7F9023_N8EI" resolve="keyBDefault" />
+          </node>
+          <node concept="3Ch18X" id="4JuIOs$Jiq2" role="30czhm">
+            <ref role="3Ch1V_" node="7F9023_N8Ey" resolve="WithDefault" />
+          </node>
+        </node>
+      </node>
+      <node concept="_fkuZ" id="4JuIOs$LPcv" role="_fkp5">
+        <node concept="_fku$" id="4JuIOs$LPcw" role="_fkur" />
+        <node concept="1QScDb" id="4JuIOs$LPcx" role="_fkuY">
+          <node concept="3AhkFE" id="4JuIOs$LPcy" role="1QScD9">
+            <node concept="1Y8_7R" id="4JuIOs$LPcz" role="1KNaUP">
+              <ref role="1Y8_7Q" node="7F9023_N8ED" resolve="keyADefault" />
+            </node>
+            <node concept="2v6aBJ" id="4JuIOs$LPc$" role="2v6bfY">
+              <ref role="2v6aBK" node="7F9023_N8EA" resolve="val2" />
+            </node>
+            <node concept="1I1voI" id="4JuIOs$LPDz" role="3AhkFJ" />
+          </node>
+          <node concept="3Ch18X" id="4JuIOs$LPcA" role="30czhm">
+            <ref role="3Ch1V_" node="7F9023_N8Ey" resolve="WithDefault" />
+          </node>
+        </node>
+        <node concept="1QScDb" id="4JuIOs$LPcB" role="_fkuS">
+          <node concept="3CgUdp" id="4JuIOs$LPcC" role="1QScD9">
+            <ref role="3CgUW3" node="7F9023_N8ED" resolve="keyADefault" />
+          </node>
+          <node concept="3Ch18X" id="4JuIOs$LPcD" role="30czhm">
+            <ref role="3Ch1V_" node="7F9023_N8Ey" resolve="WithDefault" />
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -39,7 +39,9 @@
       <concept id="1215507671101" name="jetbrains.mps.lang.test.structure.NodeErrorCheckOperation" flags="ng" index="1TM$A">
         <child id="8489045168660938517" name="errorRef" index="3lydEf" />
       </concept>
-      <concept id="1215511704609" name="jetbrains.mps.lang.test.structure.NodeWarningCheckOperation" flags="ng" index="29bkU" />
+      <concept id="1215511704609" name="jetbrains.mps.lang.test.structure.NodeWarningCheckOperation" flags="ng" index="29bkU">
+        <child id="8489045168660938635" name="warningRef" index="3lydCh" />
+      </concept>
       <concept id="1215603922101" name="jetbrains.mps.lang.test.structure.NodeOperationsContainer" flags="ng" index="7CXmI">
         <child id="1215604436604" name="nodeOperations" index="7EUXB" />
       </concept>
@@ -57,6 +59,7 @@
         <reference id="8333855927540250453" name="declaration" index="39XzEq" />
       </concept>
       <concept id="428590876651279930" name="jetbrains.mps.lang.test.structure.NodeTypeSystemErrorCheckOperation" flags="ng" index="2DdRWr" />
+      <concept id="4531408400486526326" name="jetbrains.mps.lang.test.structure.WarningStatementReference" flags="ng" index="2PQEqo" />
       <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
       <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
@@ -179,6 +182,11 @@
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
     </language>
+    <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
+      <concept id="3693790620639876318" name="com.mbeddr.mpsutil.blutil.structure.BLDoc" flags="ng" index="2aEySx">
+        <child id="3693790620639876319" name="text" index="2aEySw" />
+      </concept>
+    </language>
     <language id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base">
       <concept id="7831630342157089621" name="org.iets3.core.base.structure.IDetectNeedToRunManually" flags="ng" index="0Rz4o">
         <property id="7831630342157089649" name="__hash" index="0Rz4W" />
@@ -210,6 +218,7 @@
       <concept id="606861080870797309" name="org.iets3.core.expr.base.structure.IfElseSection" flags="ng" index="pf3Wd">
         <child id="606861080870797310" name="expr" index="pf3We" />
       </concept>
+      <concept id="7425695345928347719" name="org.iets3.core.expr.base.structure.Expression" flags="ng" index="2vmvVl" />
       <concept id="2390066428848651932" name="org.iets3.core.expr.base.structure.BangOp" flags="ng" index="wdKpt" />
       <concept id="7089558164909884363" name="org.iets3.core.expr.base.structure.TryErrorClause" flags="ng" index="2zzUxt">
         <child id="7089558164909884398" name="expr" index="2zzUxS" />
@@ -647,6 +656,14 @@
       </concept>
     </language>
     <language id="b25b8ad1-4d3d-4e45-8c78-72091b39fdda" name="org.iets3.core.expr.data">
+      <concept id="8847603084240726479" name="org.iets3.core.expr.data.structure.DataColDefRef" flags="ng" index="2v6aBJ">
+        <reference id="8847603084240726480" name="col" index="2v6aBK" />
+      </concept>
+      <concept id="512624657163648898" name="org.iets3.core.expr.data.structure.DataTableLookUp" flags="ng" index="3AhkFE">
+        <child id="8847603084240729054" name="col" index="2v6bfY" />
+        <child id="512624657163648903" name="arg" index="3AhkFJ" />
+        <child id="4464767248795083933" name="defaultRow" index="1KNaUP" />
+      </concept>
       <concept id="231307155598632952" name="org.iets3.core.expr.data.structure.DataRowOp" flags="ng" index="3CgUdp">
         <reference id="231307155598633890" name="row" index="3CgUW3" />
       </concept>
@@ -662,11 +679,15 @@
       </concept>
       <concept id="231307155597462254" name="org.iets3.core.expr.data.structure.DataTable" flags="ng" index="3CkkTf">
         <property id="3324695263690995252" name="allowLookup" index="sAwqe" />
+        <child id="8847603084240790861" name="defaultLookupColumn" index="2v6UlH" />
         <child id="231307155597477158" name="dataCols" index="3Ckg67" />
         <child id="231307155597655796" name="rows" index="3CkFDl" />
       </concept>
       <concept id="231307155597471414" name="org.iets3.core.expr.data.structure.DataColDef" flags="ng" index="3CkmCn">
         <child id="231307155597474194" name="type" index="3CknON" />
+      </concept>
+      <concept id="2248050072641141846" name="org.iets3.core.expr.data.structure.DataRowRefForLookup" flags="ng" index="1Y8_7R">
+        <reference id="2248050072641141847" name="dataRow" index="1Y8_7Q" />
       </concept>
     </language>
     <language id="f3eafff0-30d2-46d6-9150-f0f3b880ce27" name="org.iets3.core.expr.path">
@@ -15382,6 +15403,53 @@
     <node concept="1qefOq" id="4PRpvcZw5HP" role="1SKRRt">
       <node concept="_iOnV" id="7aAW5BPgQC$" role="1qenE9">
         <property role="TrG5h" value="myTest" />
+        <node concept="3CkkTf" id="5nzosloxC6w" role="_iOnC">
+          <property role="TrG5h" value="noLookUpTable" />
+          <property role="sAwqe" value="false" />
+          <node concept="3CkmCn" id="5nzosloxC6x" role="3Ckg67">
+            <property role="TrG5h" value="val1" />
+            <node concept="30bXR$" id="5nzosloxC6y" role="3CknON" />
+          </node>
+          <node concept="3CkmCn" id="5nzosloxC6z" role="3Ckg67">
+            <property role="TrG5h" value="val2" />
+            <node concept="30bXR$" id="5nzosloxC6$" role="3CknON" />
+          </node>
+          <node concept="3CkeKC" id="5nzosloxC6_" role="3CkFDl">
+            <property role="TrG5h" value="keyA" />
+            <node concept="3CkgUp" id="5nzosloxC6A" role="3Ckg_R">
+              <ref role="3Ckhev" node="5nzosloxC6x" resolve="val1" />
+              <node concept="30bXRB" id="5nzosloxC6B" role="3CkirI">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="5nzosloxC6C" role="3Ckg_R">
+              <ref role="3Ckhev" node="5nzosloxC6z" resolve="val2" />
+              <node concept="30bXRB" id="5nzosloxC6D" role="3CkirI">
+                <property role="30bXRw" value="2" />
+              </node>
+            </node>
+          </node>
+          <node concept="3CkeKC" id="5nzosloxC6E" role="3CkFDl">
+            <property role="TrG5h" value="keyB" />
+            <node concept="3CkgUp" id="5nzosloxC6F" role="3Ckg_R">
+              <ref role="3Ckhev" node="5nzosloxC6x" resolve="val1" />
+              <node concept="30bXRB" id="5nzosloxC6G" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="5nzosloxC6H" role="3Ckg_R">
+              <ref role="3Ckhev" node="5nzosloxC6z" resolve="val2" />
+              <node concept="30bXRB" id="5nzosloxC6I" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+          </node>
+          <node concept="7CXmI" id="5nzosloxC6J" role="lGtFl">
+            <node concept="7OXhh" id="5nzosloxC6K" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
         <node concept="3CkkTf" id="4PRpvcZw5HZ" role="_iOnC">
           <property role="TrG5h" value="myTable" />
           <property role="sAwqe" value="true" />
@@ -15429,16 +15497,121 @@
             </node>
           </node>
         </node>
+        <node concept="3CkkTf" id="5nzosloxC2w" role="_iOnC">
+          <property role="TrG5h" value="myTableWithDefault" />
+          <property role="sAwqe" value="true" />
+          <node concept="3CkmCn" id="5nzosloxC2x" role="3Ckg67">
+            <property role="TrG5h" value="val1" />
+            <node concept="30bXR$" id="5nzosloxC2y" role="3CknON" />
+          </node>
+          <node concept="3CkmCn" id="5nzosloxC2z" role="3Ckg67">
+            <property role="TrG5h" value="val2" />
+            <node concept="30bXR$" id="5nzosloxC2$" role="3CknON" />
+          </node>
+          <node concept="3CkeKC" id="5nzosloxC2_" role="3CkFDl">
+            <property role="TrG5h" value="keyA" />
+            <node concept="3CkgUp" id="5nzosloxC2A" role="3Ckg_R">
+              <ref role="3Ckhev" node="5nzosloxC2x" resolve="val1" />
+              <node concept="30bXRB" id="5nzosloxC2B" role="3CkirI">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="5nzosloxC2C" role="3Ckg_R">
+              <ref role="3Ckhev" node="5nzosloxC2z" resolve="val2" />
+              <node concept="30bXRB" id="5nzosloxC2D" role="3CkirI">
+                <property role="30bXRw" value="2" />
+              </node>
+            </node>
+          </node>
+          <node concept="3CkeKC" id="5nzosloxC2E" role="3CkFDl">
+            <property role="TrG5h" value="keyB" />
+            <node concept="3CkgUp" id="5nzosloxC2F" role="3Ckg_R">
+              <ref role="3Ckhev" node="5nzosloxC2x" resolve="val1" />
+              <node concept="30bXRB" id="5nzosloxC2G" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="5nzosloxC2H" role="3Ckg_R">
+              <ref role="3Ckhev" node="5nzosloxC2z" resolve="val2" />
+              <node concept="30bXRB" id="5nzosloxC2I" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+          </node>
+          <node concept="7CXmI" id="5nzosloxC2J" role="lGtFl">
+            <node concept="7OXhh" id="5nzosloxC2K" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+          <node concept="2v6aBJ" id="5nzosloxCeR" role="2v6UlH">
+            <ref role="2v6aBK" node="5nzosloxC2z" resolve="val2" />
+          </node>
+        </node>
+        <node concept="3CkkTf" id="5T8tZL2g$6P" role="_iOnC">
+          <property role="TrG5h" value="myTableWithDefaultColWithoutLookup" />
+          <property role="sAwqe" value="false" />
+          <node concept="3CkmCn" id="5T8tZL2g$6Q" role="3Ckg67">
+            <property role="TrG5h" value="val1" />
+            <node concept="30bXR$" id="5T8tZL2g$6R" role="3CknON" />
+          </node>
+          <node concept="3CkmCn" id="5T8tZL2g$6S" role="3Ckg67">
+            <property role="TrG5h" value="val2" />
+            <node concept="30bXR$" id="5T8tZL2g$6T" role="3CknON" />
+          </node>
+          <node concept="3CkeKC" id="5T8tZL2g$6U" role="3CkFDl">
+            <property role="TrG5h" value="keyA" />
+            <node concept="3CkgUp" id="5T8tZL2g$6V" role="3Ckg_R">
+              <ref role="3Ckhev" node="5T8tZL2g$6Q" resolve="val1" />
+              <node concept="30bXRB" id="5T8tZL2g$6W" role="3CkirI">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="5T8tZL2g$6X" role="3Ckg_R">
+              <ref role="3Ckhev" node="5T8tZL2g$6S" resolve="val2" />
+              <node concept="30bXRB" id="5T8tZL2g$Mw" role="3CkirI">
+                <property role="30bXRw" value="2" />
+              </node>
+            </node>
+          </node>
+          <node concept="3CkeKC" id="5T8tZL2g$77" role="3CkFDl">
+            <property role="TrG5h" value="keyB" />
+            <node concept="3CkgUp" id="5T8tZL2g$78" role="3Ckg_R">
+              <ref role="3Ckhev" node="5T8tZL2g$6Q" resolve="val1" />
+              <node concept="30bXRB" id="5T8tZL2g$79" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="5T8tZL2g$7a" role="3Ckg_R">
+              <ref role="3Ckhev" node="5T8tZL2g$6S" resolve="val2" />
+              <node concept="30bXRB" id="5T8tZL2g$7b" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+          </node>
+          <node concept="2v6aBJ" id="5T8tZL2g$px" role="2v6UlH">
+            <ref role="2v6aBK" node="5T8tZL2g$6Q" resolve="val1" />
+          </node>
+          <node concept="7CXmI" id="5T8tZL2g_dA" role="lGtFl">
+            <node concept="1TM$A" id="5T8tZL2g_Ay" role="7EUXB">
+              <node concept="2PYRI3" id="5T8tZL2g_Az" role="3lydEf">
+                <ref role="39XzEq" to="rpit:7F9023_N69d" />
+              </node>
+            </node>
+            <node concept="2aEySx" id="5T8tZL2g_AF" role="lGtFl">
+              <node concept="19SGf9" id="5T8tZL2g_AG" role="2aEySw">
+                <node concept="19SUe$" id="5T8tZL2g_AH" role="19SJt6">
+                  <property role="19SUeA" value="Table with default column needs allow lookup" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3CkkTf" id="2KRUNf1mScG" role="_iOnC">
-          <property role="TrG5h" value="myTableWithDefaults" />
+          <property role="TrG5h" value="myTableWithEmptyColumn" />
           <property role="sAwqe" value="true" />
           <node concept="3CkmCn" id="2KRUNf1mScI" role="3Ckg67">
             <property role="TrG5h" value="val1" />
             <node concept="30bXR$" id="2KRUNf1mScH" role="3CknON" />
-          </node>
-          <node concept="3CkmCn" id="2KRUNf1mScK" role="3Ckg67">
-            <property role="TrG5h" value="val2" />
-            <node concept="30bXR$" id="2KRUNf1mScJ" role="3CknON" />
           </node>
           <node concept="3CkeKC" id="2KRUNf1mScN" role="3CkFDl">
             <property role="TrG5h" value="keyA" />
@@ -15446,12 +15619,6 @@
               <ref role="3Ckhev" node="2KRUNf1mScI" resolve="val1" />
               <node concept="30bXRB" id="2KRUNf1mScL" role="3CkirI">
                 <property role="30bXRw" value="1" />
-              </node>
-            </node>
-            <node concept="3CkgUp" id="2KRUNf1mScP" role="3Ckg_R">
-              <ref role="3Ckhev" node="2KRUNf1mScK" resolve="val2" />
-              <node concept="30bXRB" id="2KRUNf1mScM" role="3CkirI">
-                <property role="30bXRw" value="2" />
               </node>
             </node>
             <node concept="3CkgUp" id="2KRUNf1n4iJ" role="3Ckg_R">
@@ -15467,18 +15634,19 @@
                 <property role="30bXRw" value="3" />
               </node>
             </node>
-            <node concept="3CkgUp" id="2KRUNf1mScU" role="3Ckg_R">
-              <ref role="3Ckhev" node="2KRUNf1mScK" resolve="val2" />
-              <node concept="30bXRB" id="2KRUNf1qvm7" role="3CkirI">
-                <property role="30bXRw" value="4" />
-              </node>
-            </node>
             <node concept="3CkgUp" id="2KRUNf1n4js" role="3Ckg_R">
               <ref role="3Ckhev" node="2KRUNf1n4ie" resolve="val3" />
               <node concept="7CXmI" id="2KRUNf1n4Hs" role="lGtFl">
                 <node concept="1TM$A" id="2KRUNf1n4TX" role="7EUXB">
                   <node concept="2PYRI3" id="2KRUNf1n4TY" role="3lydEf">
                     <ref role="39XzEq" to="rpit:2KRUNf1mOp9" />
+                  </node>
+                </node>
+                <node concept="2aEySx" id="5T8tZL2gNsp" role="lGtFl">
+                  <node concept="19SGf9" id="5T8tZL2gNsq" role="2aEySw">
+                    <node concept="19SUe$" id="5T8tZL2gNsr" role="19SJt6">
+                      <property role="19SUeA" value="Only one empty per column allowed" />
+                    </node>
                   </node>
                 </node>
               </node>
@@ -15489,95 +15657,56 @@
             <property role="TrG5h" value="val3" />
             <node concept="30bdrU" id="2KRUNf1n4i_" role="3CknON" />
           </node>
-          <node concept="3CkeKC" id="2KRUNf1qvjX" role="3CkFDl">
-            <property role="TrG5h" value="keyC" />
-            <node concept="3CkgUp" id="2KRUNf1qvmY" role="3Ckg_R">
-              <ref role="3Ckhev" node="2KRUNf1mScI" resolve="val1" />
-              <node concept="1I1voI" id="3tcv7J0GjZR" role="3CkirI" />
-            </node>
-            <node concept="3CkgUp" id="2KRUNf1qvnz" role="3Ckg_R">
-              <ref role="3Ckhev" node="2KRUNf1mScK" resolve="val2" />
-              <node concept="1I1voI" id="3tcv7J0GjZW" role="3CkirI" />
-            </node>
-            <node concept="3CkgUp" id="2KRUNf1qvqK" role="3Ckg_R">
-              <ref role="3Ckhev" node="2KRUNf1n4ie" resolve="val3" />
-              <node concept="30bdrP" id="2KRUNf1qvrE" role="3CkirI" />
-            </node>
-          </node>
         </node>
-        <node concept="3CkkTf" id="MNXm1ErN04" role="_iOnC">
-          <property role="TrG5h" value="myTableWithDefaultsEmptyMixed" />
+        <node concept="3CkkTf" id="5T8tZL2gN_E" role="_iOnC">
+          <property role="TrG5h" value="myTableWithEmptyInEveryColumn" />
           <property role="sAwqe" value="true" />
-          <node concept="3CkmCn" id="MNXm1ErN05" role="3Ckg67">
+          <node concept="3CkmCn" id="5T8tZL2gN_F" role="3Ckg67">
             <property role="TrG5h" value="val1" />
-            <node concept="30bXR$" id="MNXm1ErN06" role="3CknON" />
+            <node concept="30bXR$" id="5T8tZL2gN_G" role="3CknON" />
           </node>
-          <node concept="3CkmCn" id="MNXm1ErN07" role="3Ckg67">
-            <property role="TrG5h" value="val2" />
-            <node concept="30bXR$" id="MNXm1ErN08" role="3CknON" />
-          </node>
-          <node concept="3CkeKC" id="MNXm1ErN09" role="3CkFDl">
+          <node concept="3CkeKC" id="5T8tZL2gN_H" role="3CkFDl">
             <property role="TrG5h" value="keyA" />
-            <node concept="3CkgUp" id="MNXm1ErN0a" role="3Ckg_R">
-              <ref role="3Ckhev" node="MNXm1ErN05" resolve="val1" />
-              <node concept="30bXRB" id="MNXm1ErN0b" role="3CkirI">
+            <node concept="3CkgUp" id="5T8tZL2gN_I" role="3Ckg_R">
+              <ref role="3Ckhev" node="5T8tZL2gN_F" resolve="val1" />
+              <node concept="30bXRB" id="5T8tZL2gN_J" role="3CkirI">
                 <property role="30bXRw" value="1" />
               </node>
             </node>
-            <node concept="3CkgUp" id="MNXm1ErN0c" role="3Ckg_R">
-              <ref role="3Ckhev" node="MNXm1ErN07" resolve="val2" />
-              <node concept="30bXRB" id="MNXm1ErN0d" role="3CkirI">
-                <property role="30bXRw" value="2" />
-              </node>
-            </node>
-            <node concept="3CkgUp" id="MNXm1ErN0e" role="3Ckg_R">
-              <ref role="3Ckhev" node="MNXm1ErN0q" resolve="val3" />
-              <node concept="1I1voI" id="3tcv7J0Gk0m" role="3CkirI" />
+            <node concept="3CkgUp" id="5T8tZL2gN_K" role="3Ckg_R">
+              <ref role="3Ckhev" node="5T8tZL2gN_X" resolve="val3" />
+              <node concept="1I1voI" id="5T8tZL2gN_L" role="3CkirI" />
             </node>
           </node>
-          <node concept="3CkeKC" id="MNXm1ErN0g" role="3CkFDl">
+          <node concept="3CkeKC" id="5T8tZL2gN_M" role="3CkFDl">
             <property role="TrG5h" value="keyB" />
-            <node concept="3CkgUp" id="MNXm1ErN0h" role="3Ckg_R">
-              <ref role="3Ckhev" node="MNXm1ErN05" resolve="val1" />
-              <node concept="30bXRB" id="MNXm1ErN0i" role="3CkirI">
-                <property role="30bXRw" value="3" />
+            <node concept="3CkgUp" id="5T8tZL2gN_N" role="3Ckg_R">
+              <ref role="3Ckhev" node="5T8tZL2gN_F" resolve="val1" />
+              <node concept="1I1voI" id="5T8tZL2gNF$" role="3CkirI" />
+            </node>
+            <node concept="3CkgUp" id="5T8tZL2gNSq" role="3Ckg_R">
+              <ref role="3Ckhev" node="5T8tZL2gN_X" resolve="val3" />
+              <node concept="30bdrP" id="5T8tZL2gNT8" role="3CkirI">
+                <property role="30bdrQ" value="a" />
               </node>
             </node>
-            <node concept="3CkgUp" id="MNXm1ErN0j" role="3Ckg_R">
-              <ref role="3Ckhev" node="MNXm1ErN07" resolve="val2" />
-              <node concept="30bXRB" id="MNXm1ErN0k" role="3CkirI">
-                <property role="30bXRw" value="4" />
+          </node>
+          <node concept="3CkmCn" id="5T8tZL2gN_X" role="3Ckg67">
+            <property role="TrG5h" value="val3" />
+            <node concept="30bdrU" id="5T8tZL2gN_Y" role="3CknON" />
+          </node>
+          <node concept="7CXmI" id="5T8tZL2gNTD" role="lGtFl">
+            <node concept="29bkU" id="5T8tZL2gOe_" role="7EUXB">
+              <node concept="2PQEqo" id="5T8tZL2gOeA" role="3lydCh">
+                <ref role="39XzEq" to="rpit:7EHDEMiyTUn" />
               </node>
             </node>
-            <node concept="3CkgUp" id="MNXm1ErN0l" role="3Ckg_R">
-              <ref role="3Ckhev" node="MNXm1ErN0q" resolve="val3" />
-              <node concept="1I1voI" id="MNXm1ErN4w" role="3CkirI" />
-              <node concept="7CXmI" id="MNXm1ErN0n" role="lGtFl">
-                <node concept="1TM$A" id="MNXm1ErN0o" role="7EUXB">
-                  <node concept="2PYRI3" id="MNXm1ErN0p" role="3lydEf">
-                    <ref role="39XzEq" to="rpit:2KRUNf1mOp9" />
-                  </node>
+            <node concept="2aEySx" id="5T8tZL2gOeI" role="lGtFl">
+              <node concept="19SGf9" id="5T8tZL2gOeJ" role="2aEySw">
+                <node concept="19SUe$" id="5T8tZL2gOeK" role="19SJt6">
+                  <property role="19SUeA" value="no default column needed, when all columns contain an empty" />
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="3CkmCn" id="MNXm1ErN0q" role="3Ckg67">
-            <property role="TrG5h" value="val3" />
-            <node concept="30bdrU" id="MNXm1ErN0r" role="3CknON" />
-          </node>
-          <node concept="3CkeKC" id="MNXm1ErN0s" role="3CkFDl">
-            <property role="TrG5h" value="keyC" />
-            <node concept="3CkgUp" id="MNXm1ErN0t" role="3Ckg_R">
-              <ref role="3Ckhev" node="MNXm1ErN05" resolve="val1" />
-              <node concept="1I1voI" id="3tcv7J0Gk0r" role="3CkirI" />
-            </node>
-            <node concept="3CkgUp" id="MNXm1ErN0v" role="3Ckg_R">
-              <ref role="3Ckhev" node="MNXm1ErN07" resolve="val2" />
-              <node concept="1I1voI" id="3tcv7J0Gk0w" role="3CkirI" />
-            </node>
-            <node concept="3CkgUp" id="MNXm1ErN0x" role="3Ckg_R">
-              <ref role="3Ckhev" node="MNXm1ErN0q" resolve="val3" />
-              <node concept="30bdrP" id="MNXm1ErN0y" role="3CkirI" />
             </node>
           </node>
         </node>
@@ -15624,6 +15753,13 @@
                       <ref role="39XzEq" to="rpit:3tcv7J0Q0xB" />
                     </node>
                   </node>
+                  <node concept="2aEySx" id="5T8tZL2gNsQ" role="lGtFl">
+                    <node concept="19SGf9" id="5T8tZL2gNsR" role="2aEySw">
+                      <node concept="19SUe$" id="5T8tZL2gNsS" role="19SJt6">
+                        <property role="19SUeA" value="empty only allowed in allows lookup tables" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -15661,6 +15797,13 @@
                   <node concept="1TM$A" id="4PRpvcZw9Js" role="7EUXB">
                     <node concept="2PYRI3" id="4PRpvcZw9Jt" role="3lydEf">
                       <ref role="39XzEq" to="rpit:4PRpvcZvBk8" />
+                    </node>
+                  </node>
+                  <node concept="2aEySx" id="5T8tZL2gzpU" role="lGtFl">
+                    <node concept="19SGf9" id="5T8tZL2gzpV" role="2aEySw">
+                      <node concept="19SUe$" id="5T8tZL2gzpW" role="19SJt6">
+                        <property role="19SUeA" value="only literals supporting look up are allowed" />
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -16061,6 +16204,361 @@
             <ref role="3Ch1V_" node="4QQXQNDkZhT" resolve="data_imp" />
           </node>
         </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="1BTo9BuDrsr">
+    <property role="TrG5h" value="dataTableLookUp" />
+    <node concept="1qefOq" id="1BTo9BuDu7r" role="1SKRRt">
+      <node concept="_iOnU" id="1BTo9BuDu7v" role="1qenE9">
+        <property role="1XBH2A" value="true" />
+        <property role="TrG5h" value="dummy" />
+        <node concept="3CkkTf" id="1BTo9BuDvc4" role="_iOnB">
+          <property role="TrG5h" value="noLookup" />
+          <node concept="3CkmCn" id="1BTo9BuDvc6" role="3Ckg67">
+            <property role="TrG5h" value="val1" />
+            <node concept="30bXR$" id="1BTo9BuDvc5" role="3CknON" />
+          </node>
+          <node concept="3CkmCn" id="1BTo9BuDvc8" role="3Ckg67">
+            <property role="TrG5h" value="val2" />
+            <node concept="30bXR$" id="1BTo9BuDvc7" role="3CknON" />
+          </node>
+          <node concept="3CkeKC" id="1BTo9BuDvcb" role="3CkFDl">
+            <property role="TrG5h" value="keyA" />
+            <node concept="3CkgUp" id="1BTo9BuDvcc" role="3Ckg_R">
+              <ref role="3Ckhev" node="1BTo9BuDvc6" resolve="val1" />
+              <node concept="30bXRB" id="1BTo9BuDvc9" role="3CkirI">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="1BTo9BuDvcd" role="3Ckg_R">
+              <ref role="3Ckhev" node="1BTo9BuDvc8" resolve="val2" />
+              <node concept="30bXRB" id="1BTo9BuDvca" role="3CkirI">
+                <property role="30bXRw" value="2" />
+              </node>
+            </node>
+          </node>
+          <node concept="3CkeKC" id="1BTo9BuDvcg" role="3CkFDl">
+            <property role="TrG5h" value="keyB" />
+            <node concept="3CkgUp" id="1BTo9BuDvch" role="3Ckg_R">
+              <ref role="3Ckhev" node="1BTo9BuDvc6" resolve="val1" />
+              <node concept="30bXRB" id="1BTo9BuDvce" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="1BTo9BuDvci" role="3Ckg_R">
+              <ref role="3Ckhev" node="1BTo9BuDvc8" resolve="val2" />
+              <node concept="30bXRB" id="1BTo9BuDvcf" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+          </node>
+          <node concept="7CXmI" id="5nzosloxJFC" role="lGtFl">
+            <node concept="7OXhh" id="5nzosloxJGg" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="3CkkTf" id="1BTo9BuDrHb" role="_iOnB">
+          <property role="TrG5h" value="lookUpTable" />
+          <property role="sAwqe" value="true" />
+          <node concept="3CkmCn" id="1BTo9BuDrHd" role="3Ckg67">
+            <property role="TrG5h" value="val1" />
+            <node concept="30bXR$" id="1BTo9BuDrHc" role="3CknON" />
+          </node>
+          <node concept="3CkmCn" id="1BTo9BuDrHf" role="3Ckg67">
+            <property role="TrG5h" value="val2" />
+            <node concept="30bXR$" id="1BTo9BuDrHe" role="3CknON" />
+          </node>
+          <node concept="3CkeKC" id="1BTo9BuDrHi" role="3CkFDl">
+            <property role="TrG5h" value="keyA" />
+            <node concept="3CkgUp" id="1BTo9BuDrHj" role="3Ckg_R">
+              <ref role="3Ckhev" node="1BTo9BuDrHd" resolve="val1" />
+              <node concept="30bXRB" id="1BTo9BuDrHg" role="3CkirI">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="1BTo9BuDrHk" role="3Ckg_R">
+              <ref role="3Ckhev" node="1BTo9BuDrHf" resolve="val2" />
+              <node concept="30bXRB" id="1BTo9BuDrMX" role="3CkirI">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+          </node>
+          <node concept="3CkeKC" id="1BTo9BuDrHn" role="3CkFDl">
+            <property role="TrG5h" value="keyB" />
+            <node concept="3CkgUp" id="1BTo9BuDrHo" role="3Ckg_R">
+              <ref role="3Ckhev" node="1BTo9BuDrHd" resolve="val1" />
+              <node concept="30bXRB" id="1BTo9BuDrHl" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="1BTo9BuDrHp" role="3Ckg_R">
+              <ref role="3Ckhev" node="1BTo9BuDrHf" resolve="val2" />
+              <node concept="30bXRB" id="1BTo9BuDrHm" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+          </node>
+          <node concept="3CkeKC" id="1BTo9BuDrL3" role="3CkFDl">
+            <property role="TrG5h" value="keyC" />
+            <node concept="3CkgUp" id="1BTo9BuDrLm" role="3Ckg_R">
+              <ref role="3Ckhev" node="1BTo9BuDrHd" resolve="val1" />
+              <node concept="1I1voI" id="1BTo9BuDrLl" role="3CkirI" />
+            </node>
+            <node concept="3CkgUp" id="1BTo9BuDrL$" role="3Ckg_R">
+              <ref role="3Ckhev" node="1BTo9BuDrHf" resolve="val2" />
+              <node concept="30bXRB" id="1BTo9BuDrLz" role="3CkirI">
+                <property role="30bXRw" value="4" />
+              </node>
+            </node>
+          </node>
+          <node concept="7CXmI" id="5nzosloxJGO" role="lGtFl">
+            <node concept="7OXhh" id="5nzosloxJJr" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="3CkkTf" id="5nzosloxJWU" role="_iOnB">
+          <property role="TrG5h" value="defaultLookUpTable" />
+          <property role="sAwqe" value="true" />
+          <node concept="3CkmCn" id="5nzosloxJWV" role="3Ckg67">
+            <property role="TrG5h" value="val1" />
+            <node concept="30bXR$" id="5nzosloxJWW" role="3CknON" />
+          </node>
+          <node concept="3CkmCn" id="5nzosloxJWX" role="3Ckg67">
+            <property role="TrG5h" value="val2" />
+            <node concept="30bXR$" id="5nzosloxJWY" role="3CknON" />
+          </node>
+          <node concept="3CkeKC" id="5nzosloxJWZ" role="3CkFDl">
+            <property role="TrG5h" value="keyA" />
+            <node concept="3CkgUp" id="5nzosloxJX0" role="3Ckg_R">
+              <ref role="3Ckhev" node="5nzosloxJWV" resolve="val1" />
+              <node concept="30bXRB" id="5nzosloxJX1" role="3CkirI">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="5nzosloxJX2" role="3Ckg_R">
+              <ref role="3Ckhev" node="5nzosloxJWX" resolve="val2" />
+              <node concept="30bXRB" id="5nzosloxJX3" role="3CkirI">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+          </node>
+          <node concept="3CkeKC" id="5nzosloxJX4" role="3CkFDl">
+            <property role="TrG5h" value="keyB" />
+            <node concept="3CkgUp" id="5nzosloxJX5" role="3Ckg_R">
+              <ref role="3Ckhev" node="5nzosloxJWV" resolve="val1" />
+              <node concept="30bXRB" id="5nzosloxJX6" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+            <node concept="3CkgUp" id="5nzosloxJX7" role="3Ckg_R">
+              <ref role="3Ckhev" node="5nzosloxJWX" resolve="val2" />
+              <node concept="30bXRB" id="5nzosloxJX8" role="3CkirI">
+                <property role="30bXRw" value="3" />
+              </node>
+            </node>
+          </node>
+          <node concept="3CkeKC" id="5nzosloxJX9" role="3CkFDl">
+            <property role="TrG5h" value="keyC" />
+            <node concept="3CkgUp" id="5nzosloxJXa" role="3Ckg_R">
+              <ref role="3Ckhev" node="5nzosloxJWV" resolve="val1" />
+              <node concept="1I1voI" id="5nzosloxJXb" role="3CkirI" />
+            </node>
+            <node concept="3CkgUp" id="5nzosloxJXc" role="3Ckg_R">
+              <ref role="3Ckhev" node="5nzosloxJWX" resolve="val2" />
+              <node concept="30bXRB" id="5nzosloxJXd" role="3CkirI">
+                <property role="30bXRw" value="4" />
+              </node>
+            </node>
+          </node>
+          <node concept="2v6aBJ" id="5nzosloxJXe" role="2v6UlH">
+            <ref role="2v6aBK" node="5nzosloxJWX" resolve="val2" />
+          </node>
+          <node concept="7CXmI" id="5nzosloxKgw" role="lGtFl">
+            <node concept="7OXhh" id="5nzosloxKg$" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="1BTo9BuDu7$" role="_iOnB" />
+        <node concept="2zPypq" id="5nzosloxKlj" role="_iOnB">
+          <property role="TrG5h" value="valid_without_defaultValue" />
+          <node concept="1QScDb" id="5nzosloxKlk" role="2zPyp_">
+            <node concept="3AhkFE" id="5nzosloxKll" role="1QScD9">
+              <node concept="30bXRB" id="5nzosloxKlm" role="3AhkFJ">
+                <property role="30bXRw" value="1" />
+              </node>
+              <node concept="2v6aBJ" id="5nzosloxKln" role="2v6bfY">
+                <ref role="2v6aBK" node="1BTo9BuDrHd" resolve="val1" />
+              </node>
+            </node>
+            <node concept="3Ch18X" id="5nzosloxKlo" role="30czhm">
+              <ref role="3Ch1V_" node="1BTo9BuDrHb" resolve="lookUpTable" />
+            </node>
+          </node>
+          <node concept="7CXmI" id="5nzosloxLSQ" role="lGtFl">
+            <node concept="7OXhh" id="5nzosloxLVq" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5nzosloxKlp" role="_iOnB">
+          <property role="TrG5h" value="valid_with_defaultValue" />
+          <node concept="1QScDb" id="5nzosloxKlq" role="2zPyp_">
+            <node concept="3AhkFE" id="5nzosloxKlr" role="1QScD9">
+              <node concept="2v6aBJ" id="5nzosloxKls" role="2v6bfY">
+                <ref role="2v6aBK" node="1BTo9BuDrHf" resolve="val2" />
+              </node>
+              <node concept="1Y8_7R" id="5nzosloxKlt" role="1KNaUP">
+                <ref role="1Y8_7Q" node="1BTo9BuDrHn" resolve="keyB" />
+              </node>
+              <node concept="30bXRB" id="5nzosloxKlu" role="3AhkFJ">
+                <property role="30bXRw" value="5" />
+              </node>
+            </node>
+            <node concept="3Ch18X" id="5nzosloxKlv" role="30czhm">
+              <ref role="3Ch1V_" node="1BTo9BuDrHb" resolve="lookUpTable" />
+            </node>
+          </node>
+          <node concept="7CXmI" id="5nzosloxM1_" role="lGtFl">
+            <node concept="7OXhh" id="5nzosloxM3n" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5nzosloxKlw" role="_iOnB">
+          <property role="TrG5h" value="valid_with_defaultCol" />
+          <node concept="1QScDb" id="5nzosloxKlx" role="2zPyp_">
+            <node concept="3AhkFE" id="5nzosloxKly" role="1QScD9">
+              <node concept="1Y8_7R" id="5nzosloxKlz" role="1KNaUP">
+                <ref role="1Y8_7Q" node="5nzosloxJX4" resolve="keyB" />
+              </node>
+              <node concept="30bXRB" id="5nzosloxKl$" role="3AhkFJ">
+                <property role="30bXRw" value="5" />
+              </node>
+            </node>
+            <node concept="3Ch18X" id="5nzosloxKl_" role="30czhm">
+              <ref role="3Ch1V_" node="5nzosloxJWU" resolve="defaultLookUpTable" />
+            </node>
+          </node>
+          <node concept="7CXmI" id="5nzosloxM59" role="lGtFl">
+            <node concept="7OXhh" id="5nzosloxM7f" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5nzosloy0l3" role="_iOnB">
+          <property role="TrG5h" value="valid_with_defaultCol_and_defaultValue" />
+          <node concept="1QScDb" id="5nzosloy0l4" role="2zPyp_">
+            <node concept="3AhkFE" id="5nzosloy0l5" role="1QScD9">
+              <node concept="1Y8_7R" id="5nzosloy0l6" role="1KNaUP">
+                <ref role="1Y8_7Q" node="5nzosloxJX4" resolve="keyB" />
+              </node>
+              <node concept="30bXRB" id="5nzosloy0l7" role="3AhkFJ">
+                <property role="30bXRw" value="5" />
+              </node>
+            </node>
+            <node concept="3Ch18X" id="5nzosloy0l8" role="30czhm">
+              <ref role="3Ch1V_" node="5nzosloxJWU" resolve="defaultLookUpTable" />
+            </node>
+          </node>
+          <node concept="7CXmI" id="5nzosloy0l9" role="lGtFl">
+            <node concept="7OXhh" id="5nzosloy0la" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="5nzosloxKgC" role="_iOnB" />
+        <node concept="_ixoA" id="5nzosloxM91" role="_iOnB" />
+        <node concept="2zPypq" id="1BTo9BuDvgl" role="_iOnB">
+          <property role="TrG5h" value="a" />
+          <node concept="1QScDb" id="1BTo9BuDviw" role="2zPyp_">
+            <node concept="3Ch18X" id="1BTo9BuDvij" role="30czhm">
+              <ref role="3Ch1V_" node="1BTo9BuDvc4" resolve="noLookup" />
+            </node>
+            <node concept="3AhkFE" id="1BTo9BuDvwv" role="1QScD9">
+              <node concept="2vmvVl" id="1BTo9BuDvwx" role="3AhkFJ" />
+              <node concept="7CXmI" id="1BTo9BvlzOp" role="lGtFl">
+                <node concept="1TM$A" id="1BTo9BvlzYe" role="7EUXB">
+                  <node concept="2PYRI3" id="1BTo9BvlzYf" role="3lydEf">
+                    <ref role="39XzEq" to="rpit:2SzGbCMLSq3" />
+                  </node>
+                </node>
+                <node concept="2aEySx" id="1BTo9Bvl_u3" role="lGtFl">
+                  <node concept="19SGf9" id="1BTo9Bvl_u4" role="2aEySw">
+                    <node concept="19SUe$" id="1BTo9Bvl_u5" role="19SJt6">
+                      <property role="19SUeA" value="Table with no lookup functionality does not allow look up" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="1BTo9BuDugq" role="_iOnB">
+          <property role="TrG5h" value="b" />
+          <node concept="1QScDb" id="1BTo9BuDuhp" role="2zPyp_">
+            <node concept="3AhkFE" id="1BTo9BuDuhO" role="1QScD9">
+              <node concept="30bXRB" id="1BTo9BvlzZa" role="3AhkFJ">
+                <property role="30bXRw" value="1" />
+              </node>
+              <node concept="7CXmI" id="1BTo9Bvl$NN" role="lGtFl">
+                <node concept="1TM$A" id="1BTo9Bvl$Y8" role="7EUXB">
+                  <node concept="2PYRI3" id="1BTo9Bvl$Y9" role="3lydEf">
+                    <ref role="39XzEq" to="rpit:7F9023_KKPN" />
+                  </node>
+                </node>
+                <node concept="2aEySx" id="1BTo9Bvl_uJ" role="lGtFl">
+                  <node concept="19SGf9" id="1BTo9Bvl_uK" role="2aEySw">
+                    <node concept="19SUe$" id="1BTo9Bvl_uL" role="19SJt6">
+                      <property role="19SUeA" value="Table has look up functionality but no default column" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3Ch18X" id="1BTo9BuDuhe" role="30czhm">
+              <ref role="3Ch1V_" node="1BTo9BuDrHb" resolve="lookUpTable" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="1BTo9BuDvZg" role="_iOnB">
+          <property role="TrG5h" value="c" />
+          <node concept="1QScDb" id="1BTo9BuDw1$" role="2zPyp_">
+            <node concept="3AhkFE" id="1BTo9BuDw2b" role="1QScD9">
+              <node concept="30bXRB" id="1BTo9BvlznR" role="3AhkFJ">
+                <property role="30bXRw" value="1" />
+              </node>
+              <node concept="1Y8_7R" id="1BTo9Bvlzl1" role="1KNaUP">
+                <ref role="1Y8_7Q" node="1BTo9BuDrHn" resolve="keyB" />
+              </node>
+              <node concept="7CXmI" id="1BTo9BvlzpD" role="lGtFl">
+                <node concept="29bkU" id="1BTo9BvlzAX" role="7EUXB">
+                  <node concept="2PQEqo" id="1BTo9BvlzAY" role="3lydCh">
+                    <ref role="39XzEq" to="rpit:7EHDEMivD6A" />
+                  </node>
+                </node>
+                <node concept="2aEySx" id="1BTo9Bvl_wx" role="lGtFl">
+                  <node concept="19SGf9" id="1BTo9Bvl_wy" role="2aEySw">
+                    <node concept="19SUe$" id="1BTo9Bvl_wz" role="19SJt6">
+                      <property role="19SUeA" value="Table has an empty value in the selected column, so default row will never be the result" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2v6aBJ" id="1BTo9Bvl_vC" role="2v6bfY">
+                <ref role="2v6aBK" node="1BTo9BuDrHd" resolve="val1" />
+              </node>
+            </node>
+            <node concept="3Ch18X" id="1BTo9BuDw1p" role="30czhm">
+              <ref role="3Ch1V_" node="1BTo9BuDrHb" resolve="lookUpTable" />
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="1BTo9BuDvE9" role="_iOnB" />
+        <node concept="_ixoA" id="1BTo9BuDu9V" role="_iOnB" />
       </node>
     </node>
   </node>


### PR DESCRIPTION
# What changed
- `DataTableLookUp` is extended with an optional argument `defaultRow`. This argument allows to specify a default row for the lookup, so in case the looked for value was not found in the searched column, the default row will be returned. Unless the column contains an `empty` value, then the row of the `empty` is returned. (If the look up doesn't specify a column for the search, the tables default column is used)
- Tests for `DataTableLookUp` and `DataTable` are cleaned up and improved

## Limitations
- Resolved with [45b6c56](https://github.com/IETS3/iets3.opensource/pull/624/commits/45b6c5656ae3e8d2a4cfcead352a99d15268148c):   
When the `DataTableLookUp` doesn't specify a default column, but uses the tables default column and is about to add the `defaultRow` argument, the code completion menu suggests the `, ` two times. ![image](https://user-images.githubusercontent.com/5792623/205396434-500b40d5-b138-4aab-bf16-6782a8868dab.png) Currently it's too hard to resolve this:
  - Either remove the menu item by removing the [IDotTarget_TransformationMenu](http://127.0.0.1:63320/node?ref=r%3A8405f486-53b5-4fe6-af3e-7f68358bd631%28org.iets3.core.expr.base.editor%29%2F2853962202203059943). This has an impact on every `IDotTarget`
  - Add a transformation menu to the `DataTableLookUp`, but then other invalid entries are proposed
  - This can even be influenced by MPS changes, when calculations are changed on how the entries for the menu are accumulated


# Todos
- [x] Clarify whether the changed behavior regarding the default is okay (@wsafonov, @mgronover, @AlexeiQ )
- [x] Clarify the `#alias#` versus constant-cell question
- [x] Add release comment
- [x] Remove Draft, add Reviewers and `Prio`-label
