### PR TITLE
Fix `add comment` transformation action in auto completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 ### Fixed
 
 - Computation of the least-common-supertype for expressions with different return types has been fixed. The typesystem now correctly infers a join type (c.f. [original issue](https://github.com/IETS3/iets3.opensource/issues/505))
-- Naming constraint of IValidNamedConcept is customizable [original issue](https://github.com/IETS3/iets3.opensource/pull/631)
+- Naming constraint of IValidNamedConcept is customizable [original request](https://github.com/IETS3/iets3.opensource/pull/631)
+- Made transformation action [applyCommentsToIDocumentable](http://127.0.0.1:63320/node?ref=r%3A80fb0853-eb3b-4e84-aebd-cc7fdb011d97%28org.iets3.core.base.editor%29%2F5981628904839421072) only applicable if documentation is allowed [original request](https://github.com/IETS3/iets3.opensource/pull/626)
 
 ### Added
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/editor.mps
@@ -149,6 +149,7 @@
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -163,6 +164,7 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
@@ -184,11 +186,17 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
       <concept id="1111509017652" name="jetbrains.mps.baseLanguage.structure.FloatingPointConstant" flags="nn" index="3b6qkQ">
         <property id="1113006610751" name="value" index="$nhwW" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
       </concept>
       <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
@@ -295,13 +303,6 @@
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
-      </concept>
-      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
-        <property id="709746936026609031" name="linkId" index="3V$3ak" />
-        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
-      </concept>
-      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
-        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
       </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
@@ -742,98 +743,16 @@
                 </node>
               </node>
             </node>
-            <node concept="3cpWs8" id="7MFzeeGrQBc" role="3cqZAp">
-              <node concept="3cpWsn" id="7MFzeeGrQBd" role="3cpWs9">
-                <property role="TrG5h" value="nextNonEmptyNode" />
-                <node concept="3Tqbb2" id="7MFzeeGrQBe" role="1tU5fm" />
-                <node concept="2OqwBi" id="7MFzeeGrQBf" role="33vP2m">
-                  <node concept="2OqwBi" id="7MFzeeGrQBg" role="2Oq$k0">
-                    <node concept="7Obwk" id="7MFzeeGrQBh" role="2Oq$k0" />
-                    <node concept="2TlYAL" id="7MFzeeGrQBi" role="2OqNvi" />
-                  </node>
-                  <node concept="1z4cxt" id="7MFzeeGrQBj" role="2OqNvi">
-                    <node concept="1bVj0M" id="7MFzeeGrQBk" role="23t8la">
-                      <node concept="3clFbS" id="7MFzeeGrQBl" role="1bW5cS">
-                        <node concept="3clFbF" id="7MFzeeGrQBm" role="3cqZAp">
-                          <node concept="3fqX7Q" id="7MFzeeGrQBn" role="3clFbG">
-                            <node concept="2OqwBi" id="7MFzeeGrQBo" role="3fr31v">
-                              <node concept="37vLTw" id="7MFzeeGrQBp" role="2Oq$k0">
-                                <ref role="3cqZAo" node="7MFzeeGrQBs" resolve="it" />
-                              </node>
-                              <node concept="1mIQ4w" id="7MFzeeGrQBq" role="2OqNvi">
-                                <node concept="chp4Y" id="7MFzeeGrQBr" role="cj9EA">
-                                  <ref role="cht4Q" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="Rh6nW" id="7MFzeeGrQBs" role="1bW2Oz">
-                        <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="7MFzeeGrQBt" role="1tU5fm" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="7MFzeeGrQBu" role="3cqZAp">
-              <node concept="3cpWsn" id="7MFzeeGrQBv" role="3cpWs9">
-                <property role="TrG5h" value="canExecute" />
-                <node concept="10P_77" id="7MFzeeGrQBw" role="1tU5fm" />
-                <node concept="1Wc70l" id="7MFzeeGrQBx" role="33vP2m">
-                  <node concept="1Wc70l" id="7MFzeeGrQBB" role="3uHU7B">
-                    <node concept="2OqwBi" id="7MFzeeGrQBC" role="3uHU7B">
-                      <node concept="37vLTw" id="7MFzeeGrQBD" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7MFzeeGrQBd" resolve="nextNonEmptyNode" />
-                      </node>
-                      <node concept="3x8VRR" id="7MFzeeGrQBE" role="2OqNvi" />
-                    </node>
-                    <node concept="2OqwBi" id="7MFzeeGrQBF" role="3uHU7w">
-                      <node concept="37vLTw" id="7MFzeeGrQBG" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7MFzeeGrQBd" resolve="nextNonEmptyNode" />
-                      </node>
-                      <node concept="1mIQ4w" id="7MFzeeGrQBH" role="2OqNvi">
-                        <node concept="chp4Y" id="7MFzeeGrQBI" role="cj9EA">
-                          <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="7MFzeeGrQBy" role="3uHU7w">
-                    <node concept="1PxgMI" id="7MFzeeGrQBz" role="2Oq$k0">
-                      <node concept="chp4Y" id="7MFzeeGrQB$" role="3oSUPX">
-                        <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
-                      </node>
-                      <node concept="37vLTw" id="7MFzeeGrQB_" role="1m5AlR">
-                        <ref role="3cqZAo" node="7MFzeeGrQBd" resolve="nextNonEmptyNode" />
-                      </node>
-                    </node>
-                    <node concept="2qgKlT" id="7MFzeeGrQBA" role="2OqNvi">
-                      <ref role="37wK5l" to="hwgx:3ni3WiduMNJ" resolve="isDocumentationAllowed" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="3clFbF" id="7MFzeeGrQSa" role="3cqZAp">
               <node concept="3K4zz7" id="7MFzeeGrReL" role="3clFbG">
                 <node concept="Xl_RD" id="7MFzeeGrRuu" role="3K4E3e">
                   <property role="Xl_RC" value="//" />
                 </node>
                 <node concept="10Nm6u" id="7MFzeeGrRAS" role="3K4GZi" />
-                <node concept="37vLTw" id="7MFzeeGrQS8" role="3K4Cdx">
-                  <ref role="3cqZAo" node="7MFzeeGrQBv" resolve="canExecute" />
-                </node>
-              </node>
-            </node>
-            <node concept="1X3_iC" id="7MFzeeGtso_" role="lGtFl">
-              <property role="3V$3am" value="statement" />
-              <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-              <node concept="3clFbF" id="2iOyL3BmlOX" role="8Wnug">
-                <node concept="Xl_RD" id="2iOyL3BmlOW" role="3clFbG">
-                  <property role="Xl_RC" value="//" />
+                <node concept="2YIFZM" id="1RXwPEXP9kI" role="3K4Cdx">
+                  <ref role="37wK5l" node="1RXwPEXP7Z$" resolve="isCommentApplyable" />
+                  <ref role="1Pybhc" node="1RXwPEXP7V2" resolve="IDocumentableHelper" />
+                  <node concept="7Obwk" id="1RXwPEXP9DE" role="37wK5m" />
                 </node>
               </node>
             </node>
@@ -871,45 +790,6 @@
                       <node concept="Rh6nW" id="7MFzeeGr9NQ" role="1bW2Oz">
                         <property role="TrG5h" value="it" />
                         <node concept="2jxLKc" id="7MFzeeGr9NR" role="1tU5fm" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="7MFzeeGra9X" role="3cqZAp">
-              <node concept="3cpWsn" id="7MFzeeGra9Y" role="3cpWs9">
-                <property role="TrG5h" value="canExecute" />
-                <node concept="10P_77" id="7MFzeeGr9Wv" role="1tU5fm" />
-                <node concept="1Wc70l" id="7MFzeeGra9Z" role="33vP2m">
-                  <node concept="2OqwBi" id="7MFzeeGraa0" role="3uHU7w">
-                    <node concept="1PxgMI" id="7MFzeeGraa1" role="2Oq$k0">
-                      <node concept="chp4Y" id="7MFzeeGraa2" role="3oSUPX">
-                        <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
-                      </node>
-                      <node concept="37vLTw" id="7MFzeeGraa3" role="1m5AlR">
-                        <ref role="3cqZAo" node="7MFzeeGr9NB" resolve="nextNonEmptyNode" />
-                      </node>
-                    </node>
-                    <node concept="2qgKlT" id="7MFzeeGraa4" role="2OqNvi">
-                      <ref role="37wK5l" to="hwgx:3ni3WiduMNJ" resolve="isDocumentationAllowed" />
-                    </node>
-                  </node>
-                  <node concept="1Wc70l" id="7MFzeeGraa5" role="3uHU7B">
-                    <node concept="2OqwBi" id="7MFzeeGraa6" role="3uHU7B">
-                      <node concept="37vLTw" id="7MFzeeGraa7" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7MFzeeGr9NB" resolve="nextNonEmptyNode" />
-                      </node>
-                      <node concept="3x8VRR" id="7MFzeeGraa8" role="2OqNvi" />
-                    </node>
-                    <node concept="2OqwBi" id="7MFzeeGraa9" role="3uHU7w">
-                      <node concept="37vLTw" id="7MFzeeGraaa" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7MFzeeGr9NB" resolve="nextNonEmptyNode" />
-                      </node>
-                      <node concept="1mIQ4w" id="7MFzeeGraab" role="2OqNvi">
-                        <node concept="chp4Y" id="7MFzeeGraac" role="cj9EA">
-                          <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
-                        </node>
                       </node>
                     </node>
                   </node>
@@ -956,40 +836,6 @@
                 </node>
                 <node concept="3oM_SD" id="7MFzeeGrbPa" role="1PaTwD">
                   <property role="3oM_SC" value="false" />
-                </node>
-              </node>
-            </node>
-            <node concept="3SKdUt" id="7MFzeeGrc7e" role="3cqZAp">
-              <node concept="1PaTwC" id="7MFzeeGrc7f" role="1aUNEU">
-                <node concept="3oM_SD" id="7MFzeeGrcoU" role="1PaTwD">
-                  <property role="3oM_SC" value="Therefore" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrcoW" role="1PaTwD">
-                  <property role="3oM_SC" value="we" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrcoZ" role="1PaTwD">
-                  <property role="3oM_SC" value="need" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrcp3" role="1PaTwD">
-                  <property role="3oM_SC" value="an" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrcp8" role="1PaTwD">
-                  <property role="3oM_SC" value="additional" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrcpe" role="1PaTwD">
-                  <property role="3oM_SC" value="check," />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrcpA" role="1PaTwD">
-                  <property role="3oM_SC" value="until" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrcpI" role="1PaTwD">
-                  <property role="3oM_SC" value="this" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrcpR" role="1PaTwD">
-                  <property role="3oM_SC" value="is" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrcq1" role="1PaTwD">
-                  <property role="3oM_SC" value="fixed" />
                 </node>
               </node>
             </node>
@@ -1102,83 +948,21 @@
                   </node>
                 </node>
               </node>
-              <node concept="37vLTw" id="7MFzeeGraUr" role="3clFbw">
-                <ref role="3cqZAo" node="7MFzeeGra9Y" resolve="canExecute" />
+              <node concept="2YIFZM" id="1RXwPEXPbhn" role="3clFbw">
+                <ref role="1Pybhc" node="1RXwPEXP7V2" resolve="IDocumentableHelper" />
+                <ref role="37wK5l" node="1RXwPEXP7Z$" resolve="isCommentApplyable" />
+                <node concept="7Obwk" id="1RXwPEXPbho" role="37wK5m" />
               </node>
             </node>
           </node>
         </node>
         <node concept="27VH4U" id="2iOyL3Bmm9Z" role="2jiSrf">
           <node concept="3clFbS" id="2iOyL3Bmma0" role="2VODD2">
-            <node concept="3cpWs8" id="7MFzeeGr4Vi" role="3cqZAp">
-              <node concept="3cpWsn" id="7MFzeeGr4Vj" role="3cpWs9">
-                <property role="TrG5h" value="nextNonEmptyNode" />
-                <node concept="3Tqbb2" id="7MFzeeGr4JH" role="1tU5fm" />
-                <node concept="2OqwBi" id="7MFzeeGr4Vk" role="33vP2m">
-                  <node concept="2OqwBi" id="7MFzeeGr4Vl" role="2Oq$k0">
-                    <node concept="7Obwk" id="7MFzeeGr4Vm" role="2Oq$k0" />
-                    <node concept="2TlYAL" id="7MFzeeGr4Vn" role="2OqNvi" />
-                  </node>
-                  <node concept="1z4cxt" id="7MFzeeGr4Vo" role="2OqNvi">
-                    <node concept="1bVj0M" id="7MFzeeGr4Vp" role="23t8la">
-                      <node concept="3clFbS" id="7MFzeeGr4Vq" role="1bW5cS">
-                        <node concept="3clFbF" id="7MFzeeGr4Vr" role="3cqZAp">
-                          <node concept="3fqX7Q" id="7MFzeeGr4Vs" role="3clFbG">
-                            <node concept="2OqwBi" id="7MFzeeGr4Vt" role="3fr31v">
-                              <node concept="37vLTw" id="7MFzeeGr4Vu" role="2Oq$k0">
-                                <ref role="3cqZAo" node="7MFzeeGr4Vx" resolve="it" />
-                              </node>
-                              <node concept="1mIQ4w" id="7MFzeeGr4Vv" role="2OqNvi">
-                                <node concept="chp4Y" id="7MFzeeGr4Vw" role="cj9EA">
-                                  <ref role="cht4Q" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="Rh6nW" id="7MFzeeGr4Vx" role="1bW2Oz">
-                        <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="7MFzeeGr4Vy" role="1tU5fm" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="2iOyL3Bmmah" role="3cqZAp">
-              <node concept="1Wc70l" id="7MFzeeGr7OZ" role="3clFbG">
-                <node concept="2OqwBi" id="7MFzeeGr8Bd" role="3uHU7w">
-                  <node concept="1PxgMI" id="7MFzeeGr8c8" role="2Oq$k0">
-                    <node concept="chp4Y" id="7MFzeeGr8qI" role="3oSUPX">
-                      <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
-                    </node>
-                    <node concept="37vLTw" id="7MFzeeGr802" role="1m5AlR">
-                      <ref role="3cqZAo" node="7MFzeeGr4Vj" resolve="nextNonEmptyNode" />
-                    </node>
-                  </node>
-                  <node concept="2qgKlT" id="7MFzeeGr8TC" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:3ni3WiduMNJ" resolve="isDocumentationAllowed" />
-                  </node>
-                </node>
-                <node concept="1Wc70l" id="7MFzeeGr6MK" role="3uHU7B">
-                  <node concept="2OqwBi" id="7MFzeeGr727" role="3uHU7B">
-                    <node concept="37vLTw" id="7MFzeeGr6Qj" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7MFzeeGr4Vj" resolve="nextNonEmptyNode" />
-                    </node>
-                    <node concept="3x8VRR" id="7MFzeeGr7mN" role="2OqNvi" />
-                  </node>
-                  <node concept="2OqwBi" id="7MFzeeGr5DH" role="3uHU7w">
-                    <node concept="37vLTw" id="7MFzeeGr4Vz" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7MFzeeGr4Vj" resolve="nextNonEmptyNode" />
-                    </node>
-                    <node concept="1mIQ4w" id="7MFzeeGr5YQ" role="2OqNvi">
-                      <node concept="chp4Y" id="7MFzeeGr69z" role="cj9EA">
-                        <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
+            <node concept="3clFbF" id="1RXwPEXPbb_" role="3cqZAp">
+              <node concept="2YIFZM" id="1RXwPEXPbbB" role="3clFbG">
+                <ref role="37wK5l" node="1RXwPEXP7Z$" resolve="isCommentApplyable" />
+                <ref role="1Pybhc" node="1RXwPEXP7V2" resolve="IDocumentableHelper" />
+                <node concept="7Obwk" id="1RXwPEXPbbC" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -1200,175 +984,16 @@
       <node concept="IWgqT" id="5c30WK3apOK" role="1Qtc8A">
         <node concept="1hCUdq" id="5c30WK3apOM" role="1hCUd6">
           <node concept="3clFbS" id="5c30WK3apOO" role="2VODD2">
-            <node concept="3SKdUt" id="7MFzeeGt_Wx" role="3cqZAp">
-              <node concept="1PaTwC" id="7MFzeeGt_Wy" role="1aUNEU">
-                <node concept="3oM_SD" id="7MFzeeGt_Wz" role="1PaTwD">
-                  <property role="3oM_SC" value="Bug:" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_W$" role="1PaTwD">
-                  <property role="3oM_SC" value="`execute`" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_W_" role="1PaTwD">
-                  <property role="3oM_SC" value="is" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WA" role="1PaTwD">
-                  <property role="3oM_SC" value="run" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WB" role="1PaTwD">
-                  <property role="3oM_SC" value="regardless" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WC" role="1PaTwD">
-                  <property role="3oM_SC" value="of" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WD" role="1PaTwD">
-                  <property role="3oM_SC" value="whether" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WE" role="1PaTwD">
-                  <property role="3oM_SC" value="`can" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WF" role="1PaTwD">
-                  <property role="3oM_SC" value="execute`" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WG" role="1PaTwD">
-                  <property role="3oM_SC" value="is" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WH" role="1PaTwD">
-                  <property role="3oM_SC" value="true" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WI" role="1PaTwD">
-                  <property role="3oM_SC" value="or" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WJ" role="1PaTwD">
-                  <property role="3oM_SC" value="false" />
-                </node>
-              </node>
-            </node>
-            <node concept="3SKdUt" id="7MFzeeGt_WK" role="3cqZAp">
-              <node concept="1PaTwC" id="7MFzeeGt_WL" role="1aUNEU">
-                <node concept="3oM_SD" id="7MFzeeGt_WM" role="1PaTwD">
-                  <property role="3oM_SC" value="Therefore" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WN" role="1PaTwD">
-                  <property role="3oM_SC" value="we" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WO" role="1PaTwD">
-                  <property role="3oM_SC" value="need" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WP" role="1PaTwD">
-                  <property role="3oM_SC" value="an" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WQ" role="1PaTwD">
-                  <property role="3oM_SC" value="additional" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WR" role="1PaTwD">
-                  <property role="3oM_SC" value="check," />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WS" role="1PaTwD">
-                  <property role="3oM_SC" value="until" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WT" role="1PaTwD">
-                  <property role="3oM_SC" value="this" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WU" role="1PaTwD">
-                  <property role="3oM_SC" value="is" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGt_WV" role="1PaTwD">
-                  <property role="3oM_SC" value="fixed" />
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="7MFzeeGt_WW" role="3cqZAp">
-              <node concept="3cpWsn" id="7MFzeeGt_WX" role="3cpWs9">
-                <property role="TrG5h" value="nextNonEmptyNode" />
-                <node concept="3Tqbb2" id="7MFzeeGt_WY" role="1tU5fm" />
-                <node concept="2OqwBi" id="7MFzeeGt_WZ" role="33vP2m">
-                  <node concept="2OqwBi" id="7MFzeeGt_X0" role="2Oq$k0">
-                    <node concept="7Obwk" id="7MFzeeGt_X1" role="2Oq$k0" />
-                    <node concept="2TlYAL" id="7MFzeeGt_X2" role="2OqNvi" />
-                  </node>
-                  <node concept="1z4cxt" id="7MFzeeGt_X3" role="2OqNvi">
-                    <node concept="1bVj0M" id="7MFzeeGt_X4" role="23t8la">
-                      <node concept="3clFbS" id="7MFzeeGt_X5" role="1bW5cS">
-                        <node concept="3clFbF" id="7MFzeeGt_X6" role="3cqZAp">
-                          <node concept="3fqX7Q" id="7MFzeeGt_X7" role="3clFbG">
-                            <node concept="2OqwBi" id="7MFzeeGt_X8" role="3fr31v">
-                              <node concept="37vLTw" id="7MFzeeGt_X9" role="2Oq$k0">
-                                <ref role="3cqZAo" node="7MFzeeGt_Xc" resolve="it" />
-                              </node>
-                              <node concept="1mIQ4w" id="7MFzeeGt_Xa" role="2OqNvi">
-                                <node concept="chp4Y" id="7MFzeeGt_Xb" role="cj9EA">
-                                  <ref role="cht4Q" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="Rh6nW" id="7MFzeeGt_Xc" role="1bW2Oz">
-                        <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="7MFzeeGt_Xd" role="1tU5fm" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="7MFzeeGt_Xe" role="3cqZAp">
-              <node concept="3cpWsn" id="7MFzeeGt_Xf" role="3cpWs9">
-                <property role="TrG5h" value="canExecute" />
-                <node concept="10P_77" id="7MFzeeGt_Xg" role="1tU5fm" />
-                <node concept="1Wc70l" id="7MFzeeGt_Xh" role="33vP2m">
-                  <node concept="1Wc70l" id="7MFzeeGt_Xi" role="3uHU7B">
-                    <node concept="2OqwBi" id="7MFzeeGt_Xj" role="3uHU7B">
-                      <node concept="37vLTw" id="7MFzeeGt_Xk" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7MFzeeGt_WX" resolve="nextNonEmptyNode" />
-                      </node>
-                      <node concept="3x8VRR" id="7MFzeeGt_Xl" role="2OqNvi" />
-                    </node>
-                    <node concept="2OqwBi" id="7MFzeeGt_Xm" role="3uHU7w">
-                      <node concept="37vLTw" id="7MFzeeGt_Xn" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7MFzeeGt_WX" resolve="nextNonEmptyNode" />
-                      </node>
-                      <node concept="1mIQ4w" id="7MFzeeGt_Xo" role="2OqNvi">
-                        <node concept="chp4Y" id="7MFzeeGt_Xp" role="cj9EA">
-                          <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="7MFzeeGt_Xq" role="3uHU7w">
-                    <node concept="1PxgMI" id="7MFzeeGt_Xr" role="2Oq$k0">
-                      <node concept="chp4Y" id="7MFzeeGt_Xs" role="3oSUPX">
-                        <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
-                      </node>
-                      <node concept="37vLTw" id="7MFzeeGt_Xt" role="1m5AlR">
-                        <ref role="3cqZAo" node="7MFzeeGt_WX" resolve="nextNonEmptyNode" />
-                      </node>
-                    </node>
-                    <node concept="2qgKlT" id="7MFzeeGt_Xu" role="2OqNvi">
-                      <ref role="37wK5l" to="hwgx:3ni3WiduMNJ" resolve="isDocumentationAllowed" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="3clFbF" id="7MFzeeGt_Xv" role="3cqZAp">
               <node concept="3K4zz7" id="7MFzeeGt_Xw" role="3clFbG">
                 <node concept="Xl_RD" id="7MFzeeGt_Xx" role="3K4E3e">
                   <property role="Xl_RC" value="//" />
                 </node>
                 <node concept="10Nm6u" id="7MFzeeGt_Xy" role="3K4GZi" />
-                <node concept="37vLTw" id="7MFzeeGt_Xz" role="3K4Cdx">
-                  <ref role="3cqZAo" node="7MFzeeGt_Xf" resolve="canExecute" />
-                </node>
-              </node>
-            </node>
-            <node concept="1X3_iC" id="7MFzeeGt_Rp" role="lGtFl">
-              <property role="3V$3am" value="statement" />
-              <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-              <node concept="3clFbF" id="4u1MGlrTFaB" role="8Wnug">
-                <node concept="Xl_RD" id="5c30WK3a_n0" role="3clFbG">
-                  <property role="Xl_RC" value="//" />
+                <node concept="2YIFZM" id="1RXwPEXPbY6" role="3K4Cdx">
+                  <ref role="37wK5l" node="1RXwPEXP7Z$" resolve="isCommentApplyable" />
+                  <ref role="1Pybhc" node="1RXwPEXP7V2" resolve="IDocumentableHelper" />
+                  <node concept="7Obwk" id="1RXwPEXPbY7" role="37wK5m" />
                 </node>
               </node>
             </node>
@@ -1409,122 +1034,6 @@
                       </node>
                     </node>
                   </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="7MFzeeGrfQG" role="3cqZAp">
-              <node concept="3cpWsn" id="7MFzeeGrfQH" role="3cpWs9">
-                <property role="TrG5h" value="canExecute" />
-                <node concept="10P_77" id="7MFzeeGrfQI" role="1tU5fm" />
-                <node concept="1Wc70l" id="7MFzeeGrfQJ" role="33vP2m">
-                  <node concept="2OqwBi" id="7MFzeeGrfQK" role="3uHU7w">
-                    <node concept="1PxgMI" id="7MFzeeGrfQL" role="2Oq$k0">
-                      <node concept="chp4Y" id="7MFzeeGrfQM" role="3oSUPX">
-                        <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
-                      </node>
-                      <node concept="37vLTw" id="7MFzeeGrfQN" role="1m5AlR">
-                        <ref role="3cqZAo" node="7MFzeeGrfQr" resolve="nextNonEmptyNode" />
-                      </node>
-                    </node>
-                    <node concept="2qgKlT" id="7MFzeeGrfQO" role="2OqNvi">
-                      <ref role="37wK5l" to="hwgx:3ni3WiduMNJ" resolve="isDocumentationAllowed" />
-                    </node>
-                  </node>
-                  <node concept="1Wc70l" id="7MFzeeGrfQP" role="3uHU7B">
-                    <node concept="2OqwBi" id="7MFzeeGrfQQ" role="3uHU7B">
-                      <node concept="37vLTw" id="7MFzeeGrfQR" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7MFzeeGrfQr" resolve="nextNonEmptyNode" />
-                      </node>
-                      <node concept="3x8VRR" id="7MFzeeGrfQS" role="2OqNvi" />
-                    </node>
-                    <node concept="2OqwBi" id="7MFzeeGrfQT" role="3uHU7w">
-                      <node concept="37vLTw" id="7MFzeeGrfQU" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7MFzeeGrfQr" resolve="nextNonEmptyNode" />
-                      </node>
-                      <node concept="1mIQ4w" id="7MFzeeGrfQV" role="2OqNvi">
-                        <node concept="chp4Y" id="7MFzeeGrfQW" role="cj9EA">
-                          <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3SKdUt" id="7MFzeeGrfQX" role="3cqZAp">
-              <node concept="1PaTwC" id="7MFzeeGrfQY" role="1aUNEU">
-                <node concept="3oM_SD" id="7MFzeeGrfQZ" role="1PaTwD">
-                  <property role="3oM_SC" value="Bug:" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfR0" role="1PaTwD">
-                  <property role="3oM_SC" value="`execute`" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfR1" role="1PaTwD">
-                  <property role="3oM_SC" value="is" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfR2" role="1PaTwD">
-                  <property role="3oM_SC" value="run" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfR3" role="1PaTwD">
-                  <property role="3oM_SC" value="regardless" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfR4" role="1PaTwD">
-                  <property role="3oM_SC" value="of" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfR5" role="1PaTwD">
-                  <property role="3oM_SC" value="whether" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfR6" role="1PaTwD">
-                  <property role="3oM_SC" value="`can" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfR7" role="1PaTwD">
-                  <property role="3oM_SC" value="execute`" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfR8" role="1PaTwD">
-                  <property role="3oM_SC" value="is" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfR9" role="1PaTwD">
-                  <property role="3oM_SC" value="true" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfRa" role="1PaTwD">
-                  <property role="3oM_SC" value="or" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfRb" role="1PaTwD">
-                  <property role="3oM_SC" value="false" />
-                </node>
-              </node>
-            </node>
-            <node concept="3SKdUt" id="7MFzeeGrfRc" role="3cqZAp">
-              <node concept="1PaTwC" id="7MFzeeGrfRd" role="1aUNEU">
-                <node concept="3oM_SD" id="7MFzeeGrfRe" role="1PaTwD">
-                  <property role="3oM_SC" value="Therefore" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfRf" role="1PaTwD">
-                  <property role="3oM_SC" value="we" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfRg" role="1PaTwD">
-                  <property role="3oM_SC" value="need" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfRh" role="1PaTwD">
-                  <property role="3oM_SC" value="an" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfRi" role="1PaTwD">
-                  <property role="3oM_SC" value="additional" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfRj" role="1PaTwD">
-                  <property role="3oM_SC" value="check," />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfRk" role="1PaTwD">
-                  <property role="3oM_SC" value="until" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfRl" role="1PaTwD">
-                  <property role="3oM_SC" value="this" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfRm" role="1PaTwD">
-                  <property role="3oM_SC" value="is" />
-                </node>
-                <node concept="3oM_SD" id="7MFzeeGrfRn" role="1PaTwD">
-                  <property role="3oM_SC" value="fixed" />
                 </node>
               </node>
             </node>
@@ -1637,83 +1146,21 @@
                   </node>
                 </node>
               </node>
-              <node concept="37vLTw" id="7MFzeeGrfS2" role="3clFbw">
-                <ref role="3cqZAo" node="7MFzeeGrfQH" resolve="canExecute" />
+              <node concept="2YIFZM" id="1RXwPEXPd42" role="3clFbw">
+                <ref role="37wK5l" node="1RXwPEXP7Z$" resolve="isCommentApplyable" />
+                <ref role="1Pybhc" node="1RXwPEXP7V2" resolve="IDocumentableHelper" />
+                <node concept="7Obwk" id="1RXwPEXPd43" role="37wK5m" />
               </node>
             </node>
           </node>
         </node>
         <node concept="27VH4U" id="5c30WK3a_U2" role="2jiSrf">
           <node concept="3clFbS" id="5c30WK3a_U3" role="2VODD2">
-            <node concept="3cpWs8" id="7MFzeeGrfyK" role="3cqZAp">
-              <node concept="3cpWsn" id="7MFzeeGrfyL" role="3cpWs9">
-                <property role="TrG5h" value="nextNonEmptyNode" />
-                <node concept="3Tqbb2" id="7MFzeeGrfyM" role="1tU5fm" />
-                <node concept="2OqwBi" id="7MFzeeGrfyN" role="33vP2m">
-                  <node concept="2OqwBi" id="7MFzeeGrfyO" role="2Oq$k0">
-                    <node concept="7Obwk" id="7MFzeeGrfyP" role="2Oq$k0" />
-                    <node concept="2TlYAL" id="7MFzeeGrfyQ" role="2OqNvi" />
-                  </node>
-                  <node concept="1z4cxt" id="7MFzeeGrfyR" role="2OqNvi">
-                    <node concept="1bVj0M" id="7MFzeeGrfyS" role="23t8la">
-                      <node concept="3clFbS" id="7MFzeeGrfyT" role="1bW5cS">
-                        <node concept="3clFbF" id="7MFzeeGrfyU" role="3cqZAp">
-                          <node concept="3fqX7Q" id="7MFzeeGrfyV" role="3clFbG">
-                            <node concept="2OqwBi" id="7MFzeeGrfyW" role="3fr31v">
-                              <node concept="37vLTw" id="7MFzeeGrfyX" role="2Oq$k0">
-                                <ref role="3cqZAo" node="7MFzeeGrfz0" resolve="it" />
-                              </node>
-                              <node concept="1mIQ4w" id="7MFzeeGrfyY" role="2OqNvi">
-                                <node concept="chp4Y" id="7MFzeeGrfyZ" role="cj9EA">
-                                  <ref role="cht4Q" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="Rh6nW" id="7MFzeeGrfz0" role="1bW2Oz">
-                        <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="7MFzeeGrfz1" role="1tU5fm" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="7MFzeeGrfz2" role="3cqZAp">
-              <node concept="1Wc70l" id="7MFzeeGrfz3" role="3clFbG">
-                <node concept="2OqwBi" id="7MFzeeGrfz4" role="3uHU7w">
-                  <node concept="1PxgMI" id="7MFzeeGrfz5" role="2Oq$k0">
-                    <node concept="chp4Y" id="7MFzeeGrfz6" role="3oSUPX">
-                      <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
-                    </node>
-                    <node concept="37vLTw" id="7MFzeeGrfz7" role="1m5AlR">
-                      <ref role="3cqZAo" node="7MFzeeGrfyL" resolve="nextNonEmptyNode" />
-                    </node>
-                  </node>
-                  <node concept="2qgKlT" id="7MFzeeGrfz8" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:3ni3WiduMNJ" resolve="isDocumentationAllowed" />
-                  </node>
-                </node>
-                <node concept="1Wc70l" id="7MFzeeGrfz9" role="3uHU7B">
-                  <node concept="2OqwBi" id="7MFzeeGrfza" role="3uHU7B">
-                    <node concept="37vLTw" id="7MFzeeGrfzb" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7MFzeeGrfyL" resolve="nextNonEmptyNode" />
-                    </node>
-                    <node concept="3x8VRR" id="7MFzeeGrfzc" role="2OqNvi" />
-                  </node>
-                  <node concept="2OqwBi" id="7MFzeeGrfzd" role="3uHU7w">
-                    <node concept="37vLTw" id="7MFzeeGrfze" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7MFzeeGrfyL" resolve="nextNonEmptyNode" />
-                    </node>
-                    <node concept="1mIQ4w" id="7MFzeeGrfzf" role="2OqNvi">
-                      <node concept="chp4Y" id="7MFzeeGrfzg" role="cj9EA">
-                        <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
+            <node concept="3clFbF" id="1RXwPEXPxKC" role="3cqZAp">
+              <node concept="2YIFZM" id="1RXwPEXPxKE" role="3clFbG">
+                <ref role="37wK5l" node="1RXwPEXP7Z$" resolve="isCommentApplyable" />
+                <ref role="1Pybhc" node="1RXwPEXP7V2" resolve="IDocumentableHelper" />
+                <node concept="7Obwk" id="1RXwPEXPxKF" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -1823,6 +1270,106 @@
         <property role="TrG5h" value="IETS3_KEYWORD_ALIAS_EDITOR_COMPONENT" />
       </node>
     </node>
+  </node>
+  <node concept="312cEu" id="1RXwPEXP7V2">
+    <property role="TrG5h" value="IDocumentableHelper" />
+    <node concept="2tJIrI" id="1RXwPEXP7WA" role="jymVt" />
+    <node concept="2YIFZL" id="1RXwPEXP7Z$" role="jymVt">
+      <property role="TrG5h" value="isCommentApplyable" />
+      <node concept="3clFbS" id="1RXwPEXP7ZB" role="3clF47">
+        <node concept="3cpWs8" id="1RXwPEXP84T" role="3cqZAp">
+          <node concept="3cpWsn" id="1RXwPEXP84U" role="3cpWs9">
+            <property role="TrG5h" value="nextNonEmptyNode" />
+            <node concept="3Tqbb2" id="1RXwPEXP84V" role="1tU5fm" />
+            <node concept="2OqwBi" id="1RXwPEXP84W" role="33vP2m">
+              <node concept="2OqwBi" id="1RXwPEXP84X" role="2Oq$k0">
+                <node concept="37vLTw" id="1RXwPEXP8jC" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1RXwPEXP81s" resolve="node" />
+                </node>
+                <node concept="2TlYAL" id="1RXwPEXP84Z" role="2OqNvi" />
+              </node>
+              <node concept="1z4cxt" id="1RXwPEXP850" role="2OqNvi">
+                <node concept="1bVj0M" id="1RXwPEXP851" role="23t8la">
+                  <node concept="3clFbS" id="1RXwPEXP852" role="1bW5cS">
+                    <node concept="3clFbF" id="1RXwPEXP853" role="3cqZAp">
+                      <node concept="3fqX7Q" id="1RXwPEXP854" role="3clFbG">
+                        <node concept="2OqwBi" id="1RXwPEXP855" role="3fr31v">
+                          <node concept="37vLTw" id="1RXwPEXP856" role="2Oq$k0">
+                            <ref role="3cqZAo" node="1RXwPEXP859" resolve="it" />
+                          </node>
+                          <node concept="1mIQ4w" id="1RXwPEXP857" role="2OqNvi">
+                            <node concept="chp4Y" id="1RXwPEXP858" role="cj9EA">
+                              <ref role="cht4Q" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="1RXwPEXP859" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="1RXwPEXP85a" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1RXwPEXP85b" role="3cqZAp">
+          <node concept="3cpWsn" id="1RXwPEXP85c" role="3cpWs9">
+            <property role="TrG5h" value="canExecute" />
+            <node concept="10P_77" id="1RXwPEXP85d" role="1tU5fm" />
+            <node concept="1Wc70l" id="1RXwPEXP85e" role="33vP2m">
+              <node concept="1Wc70l" id="1RXwPEXP85f" role="3uHU7B">
+                <node concept="2OqwBi" id="1RXwPEXP85g" role="3uHU7B">
+                  <node concept="37vLTw" id="1RXwPEXP85h" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1RXwPEXP84U" resolve="nextNonEmptyNode" />
+                  </node>
+                  <node concept="3x8VRR" id="1RXwPEXP85i" role="2OqNvi" />
+                </node>
+                <node concept="2OqwBi" id="1RXwPEXP85j" role="3uHU7w">
+                  <node concept="37vLTw" id="1RXwPEXP85k" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1RXwPEXP84U" resolve="nextNonEmptyNode" />
+                  </node>
+                  <node concept="1mIQ4w" id="1RXwPEXP85l" role="2OqNvi">
+                    <node concept="chp4Y" id="1RXwPEXP85m" role="cj9EA">
+                      <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="1RXwPEXP85n" role="3uHU7w">
+                <node concept="1PxgMI" id="1RXwPEXP85o" role="2Oq$k0">
+                  <node concept="chp4Y" id="1RXwPEXP85p" role="3oSUPX">
+                    <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+                  </node>
+                  <node concept="37vLTw" id="1RXwPEXP85q" role="1m5AlR">
+                    <ref role="3cqZAo" node="1RXwPEXP84U" resolve="nextNonEmptyNode" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="1RXwPEXP85r" role="2OqNvi">
+                  <ref role="37wK5l" to="hwgx:3ni3WiduMNJ" resolve="isDocumentationAllowed" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1RXwPEXP8Be" role="3cqZAp">
+          <node concept="37vLTw" id="1RXwPEXP8Bc" role="3clFbG">
+            <ref role="3cqZAo" node="1RXwPEXP85c" resolve="canExecute" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1RXwPEXP7XH" role="1B3o_S" />
+      <node concept="10P_77" id="1RXwPEXP7Zp" role="3clF45" />
+      <node concept="37vLTG" id="1RXwPEXP81s" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="1RXwPEXP81r" role="1tU5fm">
+          <ref role="ehGHo" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="1RXwPEXP7V3" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/editor.mps
@@ -2,10 +2,10 @@
 <model ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)">
   <persistence version="9" />
   <languages>
-    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
-    <use id="62a3babb-5d40-4920-897f-d4144dc99c9d" name="com.mbeddr.mpsutil.userstyles" version="0" />
-    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
-    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="-1" />
+    <use id="62a3babb-5d40-4920-897f-d4144dc99c9d" name="com.mbeddr.mpsutil.userstyles" version="-1" />
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="-1" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="-1" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -14,6 +14,7 @@
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
+    <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" />
     <import index="4kwy" ref="r:657c9fde-2f36-4e61-ae17-20f02b8630ad(org.iets3.core.base.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
@@ -170,6 +171,7 @@
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
@@ -192,7 +194,6 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
-      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
@@ -231,9 +232,13 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
-      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
@@ -257,6 +262,7 @@
       <concept id="1140725362528" name="jetbrains.mps.lang.smodel.structure.Link_SetTargetOperation" flags="nn" index="2oxUTD">
         <child id="1140725362529" name="linkTarget" index="2oxUTC" />
       </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
@@ -267,6 +273,7 @@
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
@@ -288,6 +295,13 @@
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
+        <property id="709746936026609031" name="linkId" index="3V$3ak" />
+        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
+      </concept>
+      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
+        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
       </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
@@ -651,63 +665,250 @@
       <node concept="IWgqT" id="2iOyL3BmlG1" role="1Qtc8A">
         <node concept="1hCUdq" id="2iOyL3BmlG2" role="1hCUd6">
           <node concept="3clFbS" id="2iOyL3BmlG3" role="2VODD2">
-            <node concept="3clFbF" id="2iOyL3BmlOX" role="3cqZAp">
-              <node concept="Xl_RD" id="2iOyL3BmlOW" role="3clFbG">
-                <property role="Xl_RC" value="//" />
+            <node concept="3SKdUt" id="7MFzeeGt$EH" role="3cqZAp">
+              <node concept="1PaTwC" id="7MFzeeGt$EI" role="1aUNEU">
+                <node concept="3oM_SD" id="7MFzeeGt$EJ" role="1PaTwD">
+                  <property role="3oM_SC" value="Bug:" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$EK" role="1PaTwD">
+                  <property role="3oM_SC" value="`execute`" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$EL" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$EM" role="1PaTwD">
+                  <property role="3oM_SC" value="run" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$EN" role="1PaTwD">
+                  <property role="3oM_SC" value="regardless" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$EO" role="1PaTwD">
+                  <property role="3oM_SC" value="of" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$EP" role="1PaTwD">
+                  <property role="3oM_SC" value="whether" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$EQ" role="1PaTwD">
+                  <property role="3oM_SC" value="`can" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$ER" role="1PaTwD">
+                  <property role="3oM_SC" value="execute`" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$ES" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$ET" role="1PaTwD">
+                  <property role="3oM_SC" value="true" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$EU" role="1PaTwD">
+                  <property role="3oM_SC" value="or" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$EV" role="1PaTwD">
+                  <property role="3oM_SC" value="false" />
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="7MFzeeGt$EW" role="3cqZAp">
+              <node concept="1PaTwC" id="7MFzeeGt$EX" role="1aUNEU">
+                <node concept="3oM_SD" id="7MFzeeGt$EY" role="1PaTwD">
+                  <property role="3oM_SC" value="Therefore" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$EZ" role="1PaTwD">
+                  <property role="3oM_SC" value="we" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$F0" role="1PaTwD">
+                  <property role="3oM_SC" value="need" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$F1" role="1PaTwD">
+                  <property role="3oM_SC" value="an" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$F2" role="1PaTwD">
+                  <property role="3oM_SC" value="additional" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$F3" role="1PaTwD">
+                  <property role="3oM_SC" value="check," />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$F4" role="1PaTwD">
+                  <property role="3oM_SC" value="until" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$F5" role="1PaTwD">
+                  <property role="3oM_SC" value="this" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$F6" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt$F7" role="1PaTwD">
+                  <property role="3oM_SC" value="fixed" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="7MFzeeGrQBc" role="3cqZAp">
+              <node concept="3cpWsn" id="7MFzeeGrQBd" role="3cpWs9">
+                <property role="TrG5h" value="nextNonEmptyNode" />
+                <node concept="3Tqbb2" id="7MFzeeGrQBe" role="1tU5fm" />
+                <node concept="2OqwBi" id="7MFzeeGrQBf" role="33vP2m">
+                  <node concept="2OqwBi" id="7MFzeeGrQBg" role="2Oq$k0">
+                    <node concept="7Obwk" id="7MFzeeGrQBh" role="2Oq$k0" />
+                    <node concept="2TlYAL" id="7MFzeeGrQBi" role="2OqNvi" />
+                  </node>
+                  <node concept="1z4cxt" id="7MFzeeGrQBj" role="2OqNvi">
+                    <node concept="1bVj0M" id="7MFzeeGrQBk" role="23t8la">
+                      <node concept="3clFbS" id="7MFzeeGrQBl" role="1bW5cS">
+                        <node concept="3clFbF" id="7MFzeeGrQBm" role="3cqZAp">
+                          <node concept="3fqX7Q" id="7MFzeeGrQBn" role="3clFbG">
+                            <node concept="2OqwBi" id="7MFzeeGrQBo" role="3fr31v">
+                              <node concept="37vLTw" id="7MFzeeGrQBp" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7MFzeeGrQBs" resolve="it" />
+                              </node>
+                              <node concept="1mIQ4w" id="7MFzeeGrQBq" role="2OqNvi">
+                                <node concept="chp4Y" id="7MFzeeGrQBr" role="cj9EA">
+                                  <ref role="cht4Q" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="7MFzeeGrQBs" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="7MFzeeGrQBt" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="7MFzeeGrQBu" role="3cqZAp">
+              <node concept="3cpWsn" id="7MFzeeGrQBv" role="3cpWs9">
+                <property role="TrG5h" value="canExecute" />
+                <node concept="10P_77" id="7MFzeeGrQBw" role="1tU5fm" />
+                <node concept="1Wc70l" id="7MFzeeGrQBx" role="33vP2m">
+                  <node concept="1Wc70l" id="7MFzeeGrQBB" role="3uHU7B">
+                    <node concept="2OqwBi" id="7MFzeeGrQBC" role="3uHU7B">
+                      <node concept="37vLTw" id="7MFzeeGrQBD" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7MFzeeGrQBd" resolve="nextNonEmptyNode" />
+                      </node>
+                      <node concept="3x8VRR" id="7MFzeeGrQBE" role="2OqNvi" />
+                    </node>
+                    <node concept="2OqwBi" id="7MFzeeGrQBF" role="3uHU7w">
+                      <node concept="37vLTw" id="7MFzeeGrQBG" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7MFzeeGrQBd" resolve="nextNonEmptyNode" />
+                      </node>
+                      <node concept="1mIQ4w" id="7MFzeeGrQBH" role="2OqNvi">
+                        <node concept="chp4Y" id="7MFzeeGrQBI" role="cj9EA">
+                          <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7MFzeeGrQBy" role="3uHU7w">
+                    <node concept="1PxgMI" id="7MFzeeGrQBz" role="2Oq$k0">
+                      <node concept="chp4Y" id="7MFzeeGrQB$" role="3oSUPX">
+                        <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+                      </node>
+                      <node concept="37vLTw" id="7MFzeeGrQB_" role="1m5AlR">
+                        <ref role="3cqZAo" node="7MFzeeGrQBd" resolve="nextNonEmptyNode" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="7MFzeeGrQBA" role="2OqNvi">
+                      <ref role="37wK5l" to="hwgx:3ni3WiduMNJ" resolve="isDocumentationAllowed" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7MFzeeGrQSa" role="3cqZAp">
+              <node concept="3K4zz7" id="7MFzeeGrReL" role="3clFbG">
+                <node concept="Xl_RD" id="7MFzeeGrRuu" role="3K4E3e">
+                  <property role="Xl_RC" value="//" />
+                </node>
+                <node concept="10Nm6u" id="7MFzeeGrRAS" role="3K4GZi" />
+                <node concept="37vLTw" id="7MFzeeGrQS8" role="3K4Cdx">
+                  <ref role="3cqZAo" node="7MFzeeGrQBv" resolve="canExecute" />
+                </node>
+              </node>
+            </node>
+            <node concept="1X3_iC" id="7MFzeeGtso_" role="lGtFl">
+              <property role="3V$3am" value="statement" />
+              <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+              <node concept="3clFbF" id="2iOyL3BmlOX" role="8Wnug">
+                <node concept="Xl_RD" id="2iOyL3BmlOW" role="3clFbG">
+                  <property role="Xl_RC" value="//" />
+                </node>
               </node>
             </node>
           </node>
         </node>
         <node concept="IWg2L" id="2iOyL3BmlG4" role="IWgqQ">
           <node concept="3clFbS" id="2iOyL3BmlG5" role="2VODD2">
-            <node concept="3cpWs8" id="2iOyL3BmmMJ" role="3cqZAp">
-              <node concept="3cpWsn" id="2iOyL3BmmMK" role="3cpWs9">
-                <property role="TrG5h" value="iDocumentableNode" />
-                <node concept="3Tqbb2" id="2iOyL3BmmML" role="1tU5fm">
-                  <ref role="ehGHo" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
-                </node>
-                <node concept="1PxgMI" id="2iOyL3BmmMM" role="33vP2m">
-                  <node concept="chp4Y" id="2iOyL3BmmMN" role="3oSUPX">
-                    <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+            <node concept="3cpWs8" id="7MFzeeGr9NA" role="3cqZAp">
+              <node concept="3cpWsn" id="7MFzeeGr9NB" role="3cpWs9">
+                <property role="TrG5h" value="nextNonEmptyNode" />
+                <node concept="3Tqbb2" id="7MFzeeGr9NC" role="1tU5fm" />
+                <node concept="2OqwBi" id="7MFzeeGr9ND" role="33vP2m">
+                  <node concept="2OqwBi" id="7MFzeeGr9NE" role="2Oq$k0">
+                    <node concept="7Obwk" id="7MFzeeGr9NF" role="2Oq$k0" />
+                    <node concept="2TlYAL" id="7MFzeeGr9NG" role="2OqNvi" />
                   </node>
-                  <node concept="2OqwBi" id="2iOyL3BmmMO" role="1m5AlR">
-                    <node concept="2OqwBi" id="2iOyL3BmmMP" role="2Oq$k0">
-                      <node concept="7Obwk" id="2iOyL3BmmMQ" role="2Oq$k0" />
-                      <node concept="2TlYAL" id="2iOyL3BmmMR" role="2OqNvi" />
-                    </node>
-                    <node concept="1z4cxt" id="2iOyL3BmmMS" role="2OqNvi">
-                      <node concept="1bVj0M" id="2iOyL3BmmMT" role="23t8la">
-                        <node concept="3clFbS" id="2iOyL3BmmMU" role="1bW5cS">
-                          <node concept="3clFbF" id="2iOyL3BmmMV" role="3cqZAp">
-                            <node concept="1Wc70l" id="2iOyL3BmmMW" role="3clFbG">
-                              <node concept="2OqwBi" id="2iOyL3BmmMX" role="3uHU7B">
-                                <node concept="37vLTw" id="2iOyL3BmmMY" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="2iOyL3BmmN6" resolve="it" />
-                                </node>
-                                <node concept="1mIQ4w" id="2iOyL3BmmMZ" role="2OqNvi">
-                                  <node concept="chp4Y" id="2iOyL3BmmN0" role="cj9EA">
-                                    <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
-                                  </node>
-                                </node>
+                  <node concept="1z4cxt" id="7MFzeeGr9NH" role="2OqNvi">
+                    <node concept="1bVj0M" id="7MFzeeGr9NI" role="23t8la">
+                      <node concept="3clFbS" id="7MFzeeGr9NJ" role="1bW5cS">
+                        <node concept="3clFbF" id="7MFzeeGr9NK" role="3cqZAp">
+                          <node concept="3fqX7Q" id="7MFzeeGr9NL" role="3clFbG">
+                            <node concept="2OqwBi" id="7MFzeeGr9NM" role="3fr31v">
+                              <node concept="37vLTw" id="7MFzeeGr9NN" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7MFzeeGr9NQ" resolve="it" />
                               </node>
-                              <node concept="3fqX7Q" id="2iOyL3BmmN1" role="3uHU7w">
-                                <node concept="2OqwBi" id="2iOyL3BmmN2" role="3fr31v">
-                                  <node concept="37vLTw" id="2iOyL3BmmN3" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="2iOyL3BmmN6" resolve="it" />
-                                  </node>
-                                  <node concept="1mIQ4w" id="2iOyL3BmmN4" role="2OqNvi">
-                                    <node concept="chp4Y" id="2iOyL3BmmN5" role="cj9EA">
-                                      <ref role="cht4Q" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
-                                    </node>
-                                  </node>
+                              <node concept="1mIQ4w" id="7MFzeeGr9NO" role="2OqNvi">
+                                <node concept="chp4Y" id="7MFzeeGr9NP" role="cj9EA">
+                                  <ref role="cht4Q" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
-                        <node concept="Rh6nW" id="2iOyL3BmmN6" role="1bW2Oz">
-                          <property role="TrG5h" value="it" />
-                          <node concept="2jxLKc" id="2iOyL3BmmN7" role="1tU5fm" />
+                      </node>
+                      <node concept="Rh6nW" id="7MFzeeGr9NQ" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="7MFzeeGr9NR" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="7MFzeeGra9X" role="3cqZAp">
+              <node concept="3cpWsn" id="7MFzeeGra9Y" role="3cpWs9">
+                <property role="TrG5h" value="canExecute" />
+                <node concept="10P_77" id="7MFzeeGr9Wv" role="1tU5fm" />
+                <node concept="1Wc70l" id="7MFzeeGra9Z" role="33vP2m">
+                  <node concept="2OqwBi" id="7MFzeeGraa0" role="3uHU7w">
+                    <node concept="1PxgMI" id="7MFzeeGraa1" role="2Oq$k0">
+                      <node concept="chp4Y" id="7MFzeeGraa2" role="3oSUPX">
+                        <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+                      </node>
+                      <node concept="37vLTw" id="7MFzeeGraa3" role="1m5AlR">
+                        <ref role="3cqZAo" node="7MFzeeGr9NB" resolve="nextNonEmptyNode" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="7MFzeeGraa4" role="2OqNvi">
+                      <ref role="37wK5l" to="hwgx:3ni3WiduMNJ" resolve="isDocumentationAllowed" />
+                    </node>
+                  </node>
+                  <node concept="1Wc70l" id="7MFzeeGraa5" role="3uHU7B">
+                    <node concept="2OqwBi" id="7MFzeeGraa6" role="3uHU7B">
+                      <node concept="37vLTw" id="7MFzeeGraa7" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7MFzeeGr9NB" resolve="nextNonEmptyNode" />
+                      </node>
+                      <node concept="3x8VRR" id="7MFzeeGraa8" role="2OqNvi" />
+                    </node>
+                    <node concept="2OqwBi" id="7MFzeeGraa9" role="3uHU7w">
+                      <node concept="37vLTw" id="7MFzeeGraaa" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7MFzeeGr9NB" resolve="nextNonEmptyNode" />
+                      </node>
+                      <node concept="1mIQ4w" id="7MFzeeGraab" role="2OqNvi">
+                        <node concept="chp4Y" id="7MFzeeGraac" role="cj9EA">
+                          <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
                         </node>
                       </node>
                     </node>
@@ -715,125 +916,265 @@
                 </node>
               </node>
             </node>
-            <node concept="3clFbH" id="2iOyL3BmmN8" role="3cqZAp" />
-            <node concept="3clFbJ" id="2iOyL3BmmN9" role="3cqZAp">
-              <node concept="3clFbS" id="2iOyL3BmmNa" role="3clFbx">
-                <node concept="3cpWs8" id="2iOyL3BmmNb" role="3cqZAp">
-                  <node concept="3cpWsn" id="2iOyL3BmmNc" role="3cpWs9">
-                    <property role="TrG5h" value="d" />
-                    <node concept="3Tqbb2" id="2iOyL3BmmNd" role="1tU5fm">
-                      <ref role="ehGHo" to="vs0r:3m8H$lmFM5W" resolve="ElementDocumentation" />
+            <node concept="3SKdUt" id="7MFzeeGrbxV" role="3cqZAp">
+              <node concept="1PaTwC" id="7MFzeeGrbxW" role="1aUNEU">
+                <node concept="3oM_SD" id="7MFzeeGrbNo" role="1PaTwD">
+                  <property role="3oM_SC" value="Bug:" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrbPn" role="1PaTwD">
+                  <property role="3oM_SC" value="`execute`" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrbNH" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrbNL" role="1PaTwD">
+                  <property role="3oM_SC" value="run" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrbNQ" role="1PaTwD">
+                  <property role="3oM_SC" value="regardless" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrbNW" role="1PaTwD">
+                  <property role="3oM_SC" value="of" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrbO3" role="1PaTwD">
+                  <property role="3oM_SC" value="whether" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrbOb" role="1PaTwD">
+                  <property role="3oM_SC" value="`can" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrbNE" role="1PaTwD">
+                  <property role="3oM_SC" value="execute`" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrbOD" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrbON" role="1PaTwD">
+                  <property role="3oM_SC" value="true" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrbOY" role="1PaTwD">
+                  <property role="3oM_SC" value="or" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrbPa" role="1PaTwD">
+                  <property role="3oM_SC" value="false" />
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="7MFzeeGrc7e" role="3cqZAp">
+              <node concept="1PaTwC" id="7MFzeeGrc7f" role="1aUNEU">
+                <node concept="3oM_SD" id="7MFzeeGrcoU" role="1PaTwD">
+                  <property role="3oM_SC" value="Therefore" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrcoW" role="1PaTwD">
+                  <property role="3oM_SC" value="we" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrcoZ" role="1PaTwD">
+                  <property role="3oM_SC" value="need" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrcp3" role="1PaTwD">
+                  <property role="3oM_SC" value="an" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrcp8" role="1PaTwD">
+                  <property role="3oM_SC" value="additional" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrcpe" role="1PaTwD">
+                  <property role="3oM_SC" value="check," />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrcpA" role="1PaTwD">
+                  <property role="3oM_SC" value="until" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrcpI" role="1PaTwD">
+                  <property role="3oM_SC" value="this" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrcpR" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrcq1" role="1PaTwD">
+                  <property role="3oM_SC" value="fixed" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="7MFzeeGr9zY" role="3cqZAp">
+              <node concept="3clFbS" id="7MFzeeGr9$0" role="3clFbx">
+                <node concept="3cpWs8" id="7MFzeeGreo0" role="3cqZAp">
+                  <node concept="3cpWsn" id="7MFzeeGreo1" role="3cpWs9">
+                    <property role="TrG5h" value="iDocumentableNode" />
+                    <node concept="3Tqbb2" id="7MFzeeGre9S" role="1tU5fm">
+                      <ref role="ehGHo" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
                     </node>
-                    <node concept="2ShNRf" id="2iOyL3BmmNe" role="33vP2m">
-                      <node concept="2fJWfE" id="2iOyL3BmmNf" role="2ShVmc">
-                        <node concept="3Tqbb2" id="2iOyL3BmmNg" role="3zrR0E">
-                          <ref role="ehGHo" to="vs0r:3m8H$lmFM5W" resolve="ElementDocumentation" />
-                        </node>
+                    <node concept="1PxgMI" id="7MFzeeGreBr" role="33vP2m">
+                      <node concept="chp4Y" id="7MFzeeGreCv" role="3oSUPX">
+                        <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+                      </node>
+                      <node concept="37vLTw" id="7MFzeeGreo2" role="1m5AlR">
+                        <ref role="3cqZAo" node="7MFzeeGr9NB" resolve="nextNonEmptyNode" />
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="3clFbF" id="2iOyL3BmmNh" role="3cqZAp">
-                  <node concept="2OqwBi" id="2iOyL3BmmNi" role="3clFbG">
-                    <node concept="2OqwBi" id="2iOyL3BmmNj" role="2Oq$k0">
-                      <node concept="37vLTw" id="2iOyL3BmmNk" role="2Oq$k0">
-                        <ref role="3cqZAo" node="2iOyL3BmmMK" resolve="iDocumentableNode" />
+                <node concept="3clFbJ" id="2iOyL3BmmN9" role="3cqZAp">
+                  <node concept="3clFbS" id="2iOyL3BmmNa" role="3clFbx">
+                    <node concept="3cpWs8" id="2iOyL3BmmNb" role="3cqZAp">
+                      <node concept="3cpWsn" id="2iOyL3BmmNc" role="3cpWs9">
+                        <property role="TrG5h" value="d" />
+                        <node concept="3Tqbb2" id="2iOyL3BmmNd" role="1tU5fm">
+                          <ref role="ehGHo" to="vs0r:3m8H$lmFM5W" resolve="ElementDocumentation" />
+                        </node>
+                        <node concept="2ShNRf" id="2iOyL3BmmNe" role="33vP2m">
+                          <node concept="2fJWfE" id="2iOyL3BmmNf" role="2ShVmc">
+                            <node concept="3Tqbb2" id="2iOyL3BmmNg" role="3zrR0E">
+                              <ref role="ehGHo" to="vs0r:3m8H$lmFM5W" resolve="ElementDocumentation" />
+                            </node>
+                          </node>
+                        </node>
                       </node>
-                      <node concept="3CFZ6_" id="2iOyL3BmmNl" role="2OqNvi">
-                        <node concept="3CFYIy" id="2iOyL3BmmNm" role="3CFYIz">
+                    </node>
+                    <node concept="3clFbF" id="2iOyL3BmmNh" role="3cqZAp">
+                      <node concept="2OqwBi" id="2iOyL3BmmNi" role="3clFbG">
+                        <node concept="2OqwBi" id="2iOyL3BmmNj" role="2Oq$k0">
+                          <node concept="37vLTw" id="2iOyL3BmmNk" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7MFzeeGreo1" resolve="iDocumentableNode" />
+                          </node>
+                          <node concept="3CFZ6_" id="2iOyL3BmmNl" role="2OqNvi">
+                            <node concept="3CFYIy" id="2iOyL3BmmNm" role="3CFYIz">
+                              <ref role="3CFYIx" to="vs0r:3m8H$lmFM5W" resolve="ElementDocumentation" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2oxUTD" id="2iOyL3BmmNn" role="2OqNvi">
+                          <node concept="37vLTw" id="2iOyL3BmmNo" role="2oxUTC">
+                            <ref role="3cqZAo" node="2iOyL3BmmNc" resolve="d" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="2iOyL3BmmNp" role="3cqZAp">
+                      <node concept="2OqwBi" id="2iOyL3BmmNq" role="3clFbG">
+                        <node concept="37vLTw" id="2iOyL3BmmNr" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2iOyL3BmmNc" resolve="d" />
+                        </node>
+                        <node concept="1OKiuA" id="2iOyL3BmmNs" role="2OqNvi">
+                          <node concept="1Q80Hx" id="2iOyL3BmmNt" role="lBI5i" />
+                          <node concept="2B6iha" id="2iOyL3BmmNu" role="lGT1i">
+                            <property role="1lyBwo" value="1S2pyLby17G/firstEditable" />
+                          </node>
+                          <node concept="3cmrfG" id="2iOyL3BmmNv" role="3dN3m$">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbC" id="2iOyL3BmmNw" role="3clFbw">
+                    <node concept="2OqwBi" id="2iOyL3BmmNx" role="3uHU7B">
+                      <node concept="37vLTw" id="7MFzeeGreo3" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7MFzeeGreo1" resolve="iDocumentableNode" />
+                      </node>
+                      <node concept="3CFZ6_" id="2iOyL3BmmNz" role="2OqNvi">
+                        <node concept="3CFYIy" id="2iOyL3BmmN$" role="3CFYIz">
                           <ref role="3CFYIx" to="vs0r:3m8H$lmFM5W" resolve="ElementDocumentation" />
                         </node>
                       </node>
                     </node>
-                    <node concept="2oxUTD" id="2iOyL3BmmNn" role="2OqNvi">
-                      <node concept="37vLTw" id="2iOyL3BmmNo" role="2oxUTC">
-                        <ref role="3cqZAo" node="2iOyL3BmmNc" resolve="d" />
-                      </node>
-                    </node>
+                    <node concept="10Nm6u" id="2iOyL3BmmN_" role="3uHU7w" />
                   </node>
                 </node>
-                <node concept="3clFbF" id="2iOyL3BmmNp" role="3cqZAp">
-                  <node concept="2OqwBi" id="2iOyL3BmmNq" role="3clFbG">
-                    <node concept="37vLTw" id="2iOyL3BmmNr" role="2Oq$k0">
-                      <ref role="3cqZAo" node="2iOyL3BmmNc" resolve="d" />
+                <node concept="3clFbF" id="7MFzeeGsHU2" role="3cqZAp">
+                  <node concept="2OqwBi" id="7MFzeeGsIyl" role="3clFbG">
+                    <node concept="2OqwBi" id="7MFzeeGsI4e" role="2Oq$k0">
+                      <node concept="37vLTw" id="7MFzeeGsHU0" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7MFzeeGreo1" resolve="iDocumentableNode" />
+                      </node>
+                      <node concept="3CFZ6_" id="7MFzeeGsIeE" role="2OqNvi">
+                        <node concept="3CFYIy" id="7MFzeeGsIiA" role="3CFYIz">
+                          <ref role="3CFYIx" to="vs0r:3m8H$lmFM5W" resolve="ElementDocumentation" />
+                        </node>
+                      </node>
                     </node>
-                    <node concept="1OKiuA" id="2iOyL3BmmNs" role="2OqNvi">
-                      <node concept="1Q80Hx" id="2iOyL3BmmNt" role="lBI5i" />
-                      <node concept="2B6iha" id="2iOyL3BmmNu" role="lGT1i">
+                    <node concept="1OKiuA" id="7MFzeeGsISw" role="2OqNvi">
+                      <node concept="1Q80Hx" id="7MFzeeGsIUw" role="lBI5i" />
+                      <node concept="2B6iha" id="7MFzeeGsJ3G" role="lGT1i">
                         <property role="1lyBwo" value="1S2pyLby17G/firstEditable" />
                       </node>
-                      <node concept="3cmrfG" id="2iOyL3BmmNv" role="3dN3m$">
+                      <node concept="3cmrfG" id="7MFzeeGsP$B" role="3dN3m$">
                         <property role="3cmrfH" value="0" />
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="3clFbC" id="2iOyL3BmmNw" role="3clFbw">
-                <node concept="2OqwBi" id="2iOyL3BmmNx" role="3uHU7B">
-                  <node concept="37vLTw" id="2iOyL3BmmNy" role="2Oq$k0">
-                    <ref role="3cqZAo" node="2iOyL3BmmMK" resolve="iDocumentableNode" />
-                  </node>
-                  <node concept="3CFZ6_" id="2iOyL3BmmNz" role="2OqNvi">
-                    <node concept="3CFYIy" id="2iOyL3BmmN$" role="3CFYIz">
-                      <ref role="3CFYIx" to="vs0r:3m8H$lmFM5W" resolve="ElementDocumentation" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="10Nm6u" id="2iOyL3BmmN_" role="3uHU7w" />
-              </node>
-            </node>
-            <node concept="3clFbF" id="2iOyL3BmmNA" role="3cqZAp">
-              <node concept="2OqwBi" id="2iOyL3BmmNB" role="3clFbG">
-                <node concept="7Obwk" id="2iOyL3BmmNC" role="2Oq$k0" />
-                <node concept="3YRAZt" id="2iOyL3BmmND" role="2OqNvi" />
+              <node concept="37vLTw" id="7MFzeeGraUr" role="3clFbw">
+                <ref role="3cqZAo" node="7MFzeeGra9Y" resolve="canExecute" />
               </node>
             </node>
           </node>
         </node>
         <node concept="27VH4U" id="2iOyL3Bmm9Z" role="2jiSrf">
           <node concept="3clFbS" id="2iOyL3Bmma0" role="2VODD2">
-            <node concept="3clFbF" id="2iOyL3Bmmah" role="3cqZAp">
-              <node concept="3y3z36" id="2iOyL3Bmmai" role="3clFbG">
-                <node concept="10Nm6u" id="2iOyL3Bmmaj" role="3uHU7w" />
-                <node concept="2OqwBi" id="2iOyL3Bmmak" role="3uHU7B">
-                  <node concept="2OqwBi" id="2iOyL3Bmmal" role="2Oq$k0">
-                    <node concept="7Obwk" id="2iOyL3Bmmam" role="2Oq$k0" />
-                    <node concept="2TlYAL" id="2iOyL3Bmman" role="2OqNvi" />
+            <node concept="3cpWs8" id="7MFzeeGr4Vi" role="3cqZAp">
+              <node concept="3cpWsn" id="7MFzeeGr4Vj" role="3cpWs9">
+                <property role="TrG5h" value="nextNonEmptyNode" />
+                <node concept="3Tqbb2" id="7MFzeeGr4JH" role="1tU5fm" />
+                <node concept="2OqwBi" id="7MFzeeGr4Vk" role="33vP2m">
+                  <node concept="2OqwBi" id="7MFzeeGr4Vl" role="2Oq$k0">
+                    <node concept="7Obwk" id="7MFzeeGr4Vm" role="2Oq$k0" />
+                    <node concept="2TlYAL" id="7MFzeeGr4Vn" role="2OqNvi" />
                   </node>
-                  <node concept="1z4cxt" id="2iOyL3Bmmao" role="2OqNvi">
-                    <node concept="1bVj0M" id="2iOyL3Bmmap" role="23t8la">
-                      <node concept="3clFbS" id="2iOyL3Bmmaq" role="1bW5cS">
-                        <node concept="3clFbF" id="2iOyL3Bmmar" role="3cqZAp">
-                          <node concept="1Wc70l" id="2iOyL3Bmmas" role="3clFbG">
-                            <node concept="3fqX7Q" id="2iOyL3Bmmat" role="3uHU7w">
-                              <node concept="2OqwBi" id="2iOyL3Bmmau" role="3fr31v">
-                                <node concept="37vLTw" id="2iOyL3Bmmav" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="2iOyL3BmmaA" resolve="it" />
-                                </node>
-                                <node concept="1mIQ4w" id="2iOyL3Bmmaw" role="2OqNvi">
-                                  <node concept="chp4Y" id="2iOyL3Bmmax" role="cj9EA">
-                                    <ref role="cht4Q" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
-                                  </node>
-                                </node>
+                  <node concept="1z4cxt" id="7MFzeeGr4Vo" role="2OqNvi">
+                    <node concept="1bVj0M" id="7MFzeeGr4Vp" role="23t8la">
+                      <node concept="3clFbS" id="7MFzeeGr4Vq" role="1bW5cS">
+                        <node concept="3clFbF" id="7MFzeeGr4Vr" role="3cqZAp">
+                          <node concept="3fqX7Q" id="7MFzeeGr4Vs" role="3clFbG">
+                            <node concept="2OqwBi" id="7MFzeeGr4Vt" role="3fr31v">
+                              <node concept="37vLTw" id="7MFzeeGr4Vu" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7MFzeeGr4Vx" resolve="it" />
                               </node>
-                            </node>
-                            <node concept="2OqwBi" id="2iOyL3Bmmay" role="3uHU7B">
-                              <node concept="37vLTw" id="2iOyL3Bmmaz" role="2Oq$k0">
-                                <ref role="3cqZAo" node="2iOyL3BmmaA" resolve="it" />
-                              </node>
-                              <node concept="1mIQ4w" id="2iOyL3Bmma$" role="2OqNvi">
-                                <node concept="chp4Y" id="2iOyL3Bmma_" role="cj9EA">
-                                  <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+                              <node concept="1mIQ4w" id="7MFzeeGr4Vv" role="2OqNvi">
+                                <node concept="chp4Y" id="7MFzeeGr4Vw" role="cj9EA">
+                                  <ref role="cht4Q" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
-                      <node concept="Rh6nW" id="2iOyL3BmmaA" role="1bW2Oz">
+                      <node concept="Rh6nW" id="7MFzeeGr4Vx" role="1bW2Oz">
                         <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="2iOyL3BmmaB" role="1tU5fm" />
+                        <node concept="2jxLKc" id="7MFzeeGr4Vy" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="2iOyL3Bmmah" role="3cqZAp">
+              <node concept="1Wc70l" id="7MFzeeGr7OZ" role="3clFbG">
+                <node concept="2OqwBi" id="7MFzeeGr8Bd" role="3uHU7w">
+                  <node concept="1PxgMI" id="7MFzeeGr8c8" role="2Oq$k0">
+                    <node concept="chp4Y" id="7MFzeeGr8qI" role="3oSUPX">
+                      <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+                    </node>
+                    <node concept="37vLTw" id="7MFzeeGr802" role="1m5AlR">
+                      <ref role="3cqZAo" node="7MFzeeGr4Vj" resolve="nextNonEmptyNode" />
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="7MFzeeGr8TC" role="2OqNvi">
+                    <ref role="37wK5l" to="hwgx:3ni3WiduMNJ" resolve="isDocumentationAllowed" />
+                  </node>
+                </node>
+                <node concept="1Wc70l" id="7MFzeeGr6MK" role="3uHU7B">
+                  <node concept="2OqwBi" id="7MFzeeGr727" role="3uHU7B">
+                    <node concept="37vLTw" id="7MFzeeGr6Qj" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7MFzeeGr4Vj" resolve="nextNonEmptyNode" />
+                    </node>
+                    <node concept="3x8VRR" id="7MFzeeGr7mN" role="2OqNvi" />
+                  </node>
+                  <node concept="2OqwBi" id="7MFzeeGr5DH" role="3uHU7w">
+                    <node concept="37vLTw" id="7MFzeeGr4Vz" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7MFzeeGr4Vj" resolve="nextNonEmptyNode" />
+                    </node>
+                    <node concept="1mIQ4w" id="7MFzeeGr5YQ" role="2OqNvi">
+                      <node concept="chp4Y" id="7MFzeeGr69z" role="cj9EA">
+                        <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
                       </node>
                     </node>
                   </node>
@@ -859,63 +1200,250 @@
       <node concept="IWgqT" id="5c30WK3apOK" role="1Qtc8A">
         <node concept="1hCUdq" id="5c30WK3apOM" role="1hCUd6">
           <node concept="3clFbS" id="5c30WK3apOO" role="2VODD2">
-            <node concept="3clFbF" id="4u1MGlrTFaB" role="3cqZAp">
-              <node concept="Xl_RD" id="5c30WK3a_n0" role="3clFbG">
-                <property role="Xl_RC" value="//" />
+            <node concept="3SKdUt" id="7MFzeeGt_Wx" role="3cqZAp">
+              <node concept="1PaTwC" id="7MFzeeGt_Wy" role="1aUNEU">
+                <node concept="3oM_SD" id="7MFzeeGt_Wz" role="1PaTwD">
+                  <property role="3oM_SC" value="Bug:" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_W$" role="1PaTwD">
+                  <property role="3oM_SC" value="`execute`" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_W_" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WA" role="1PaTwD">
+                  <property role="3oM_SC" value="run" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WB" role="1PaTwD">
+                  <property role="3oM_SC" value="regardless" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WC" role="1PaTwD">
+                  <property role="3oM_SC" value="of" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WD" role="1PaTwD">
+                  <property role="3oM_SC" value="whether" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WE" role="1PaTwD">
+                  <property role="3oM_SC" value="`can" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WF" role="1PaTwD">
+                  <property role="3oM_SC" value="execute`" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WG" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WH" role="1PaTwD">
+                  <property role="3oM_SC" value="true" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WI" role="1PaTwD">
+                  <property role="3oM_SC" value="or" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WJ" role="1PaTwD">
+                  <property role="3oM_SC" value="false" />
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="7MFzeeGt_WK" role="3cqZAp">
+              <node concept="1PaTwC" id="7MFzeeGt_WL" role="1aUNEU">
+                <node concept="3oM_SD" id="7MFzeeGt_WM" role="1PaTwD">
+                  <property role="3oM_SC" value="Therefore" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WN" role="1PaTwD">
+                  <property role="3oM_SC" value="we" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WO" role="1PaTwD">
+                  <property role="3oM_SC" value="need" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WP" role="1PaTwD">
+                  <property role="3oM_SC" value="an" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WQ" role="1PaTwD">
+                  <property role="3oM_SC" value="additional" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WR" role="1PaTwD">
+                  <property role="3oM_SC" value="check," />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WS" role="1PaTwD">
+                  <property role="3oM_SC" value="until" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WT" role="1PaTwD">
+                  <property role="3oM_SC" value="this" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WU" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGt_WV" role="1PaTwD">
+                  <property role="3oM_SC" value="fixed" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="7MFzeeGt_WW" role="3cqZAp">
+              <node concept="3cpWsn" id="7MFzeeGt_WX" role="3cpWs9">
+                <property role="TrG5h" value="nextNonEmptyNode" />
+                <node concept="3Tqbb2" id="7MFzeeGt_WY" role="1tU5fm" />
+                <node concept="2OqwBi" id="7MFzeeGt_WZ" role="33vP2m">
+                  <node concept="2OqwBi" id="7MFzeeGt_X0" role="2Oq$k0">
+                    <node concept="7Obwk" id="7MFzeeGt_X1" role="2Oq$k0" />
+                    <node concept="2TlYAL" id="7MFzeeGt_X2" role="2OqNvi" />
+                  </node>
+                  <node concept="1z4cxt" id="7MFzeeGt_X3" role="2OqNvi">
+                    <node concept="1bVj0M" id="7MFzeeGt_X4" role="23t8la">
+                      <node concept="3clFbS" id="7MFzeeGt_X5" role="1bW5cS">
+                        <node concept="3clFbF" id="7MFzeeGt_X6" role="3cqZAp">
+                          <node concept="3fqX7Q" id="7MFzeeGt_X7" role="3clFbG">
+                            <node concept="2OqwBi" id="7MFzeeGt_X8" role="3fr31v">
+                              <node concept="37vLTw" id="7MFzeeGt_X9" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7MFzeeGt_Xc" resolve="it" />
+                              </node>
+                              <node concept="1mIQ4w" id="7MFzeeGt_Xa" role="2OqNvi">
+                                <node concept="chp4Y" id="7MFzeeGt_Xb" role="cj9EA">
+                                  <ref role="cht4Q" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="7MFzeeGt_Xc" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="7MFzeeGt_Xd" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="7MFzeeGt_Xe" role="3cqZAp">
+              <node concept="3cpWsn" id="7MFzeeGt_Xf" role="3cpWs9">
+                <property role="TrG5h" value="canExecute" />
+                <node concept="10P_77" id="7MFzeeGt_Xg" role="1tU5fm" />
+                <node concept="1Wc70l" id="7MFzeeGt_Xh" role="33vP2m">
+                  <node concept="1Wc70l" id="7MFzeeGt_Xi" role="3uHU7B">
+                    <node concept="2OqwBi" id="7MFzeeGt_Xj" role="3uHU7B">
+                      <node concept="37vLTw" id="7MFzeeGt_Xk" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7MFzeeGt_WX" resolve="nextNonEmptyNode" />
+                      </node>
+                      <node concept="3x8VRR" id="7MFzeeGt_Xl" role="2OqNvi" />
+                    </node>
+                    <node concept="2OqwBi" id="7MFzeeGt_Xm" role="3uHU7w">
+                      <node concept="37vLTw" id="7MFzeeGt_Xn" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7MFzeeGt_WX" resolve="nextNonEmptyNode" />
+                      </node>
+                      <node concept="1mIQ4w" id="7MFzeeGt_Xo" role="2OqNvi">
+                        <node concept="chp4Y" id="7MFzeeGt_Xp" role="cj9EA">
+                          <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="7MFzeeGt_Xq" role="3uHU7w">
+                    <node concept="1PxgMI" id="7MFzeeGt_Xr" role="2Oq$k0">
+                      <node concept="chp4Y" id="7MFzeeGt_Xs" role="3oSUPX">
+                        <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+                      </node>
+                      <node concept="37vLTw" id="7MFzeeGt_Xt" role="1m5AlR">
+                        <ref role="3cqZAo" node="7MFzeeGt_WX" resolve="nextNonEmptyNode" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="7MFzeeGt_Xu" role="2OqNvi">
+                      <ref role="37wK5l" to="hwgx:3ni3WiduMNJ" resolve="isDocumentationAllowed" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7MFzeeGt_Xv" role="3cqZAp">
+              <node concept="3K4zz7" id="7MFzeeGt_Xw" role="3clFbG">
+                <node concept="Xl_RD" id="7MFzeeGt_Xx" role="3K4E3e">
+                  <property role="Xl_RC" value="//" />
+                </node>
+                <node concept="10Nm6u" id="7MFzeeGt_Xy" role="3K4GZi" />
+                <node concept="37vLTw" id="7MFzeeGt_Xz" role="3K4Cdx">
+                  <ref role="3cqZAo" node="7MFzeeGt_Xf" resolve="canExecute" />
+                </node>
+              </node>
+            </node>
+            <node concept="1X3_iC" id="7MFzeeGt_Rp" role="lGtFl">
+              <property role="3V$3am" value="statement" />
+              <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+              <node concept="3clFbF" id="4u1MGlrTFaB" role="8Wnug">
+                <node concept="Xl_RD" id="5c30WK3a_n0" role="3clFbG">
+                  <property role="Xl_RC" value="//" />
+                </node>
               </node>
             </node>
           </node>
         </node>
         <node concept="IWg2L" id="5c30WK3apOQ" role="IWgqQ">
           <node concept="3clFbS" id="5c30WK3apOS" role="2VODD2">
-            <node concept="3cpWs8" id="5c30WK3aESW" role="3cqZAp">
-              <node concept="3cpWsn" id="5c30WK3aESX" role="3cpWs9">
-                <property role="TrG5h" value="iDocumentableNode" />
-                <node concept="3Tqbb2" id="5c30WK3aESU" role="1tU5fm">
-                  <ref role="ehGHo" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
-                </node>
-                <node concept="1PxgMI" id="4u1MGlrTLHY" role="33vP2m">
-                  <node concept="chp4Y" id="4u1MGlrTLRy" role="3oSUPX">
-                    <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+            <node concept="3cpWs8" id="7MFzeeGrfQq" role="3cqZAp">
+              <node concept="3cpWsn" id="7MFzeeGrfQr" role="3cpWs9">
+                <property role="TrG5h" value="nextNonEmptyNode" />
+                <node concept="3Tqbb2" id="7MFzeeGrfQs" role="1tU5fm" />
+                <node concept="2OqwBi" id="7MFzeeGrfQt" role="33vP2m">
+                  <node concept="2OqwBi" id="7MFzeeGrfQu" role="2Oq$k0">
+                    <node concept="7Obwk" id="7MFzeeGrfQv" role="2Oq$k0" />
+                    <node concept="2TlYAL" id="7MFzeeGrfQw" role="2OqNvi" />
                   </node>
-                  <node concept="2OqwBi" id="4u1MGlrTLtg" role="1m5AlR">
-                    <node concept="2OqwBi" id="4u1MGlrTLth" role="2Oq$k0">
-                      <node concept="7Obwk" id="4u1MGlrTLti" role="2Oq$k0" />
-                      <node concept="2TlYAL" id="4u1MGlrTLtj" role="2OqNvi" />
-                    </node>
-                    <node concept="1z4cxt" id="4u1MGlrTLtk" role="2OqNvi">
-                      <node concept="1bVj0M" id="4u1MGlrTLtl" role="23t8la">
-                        <node concept="3clFbS" id="4u1MGlrTLtm" role="1bW5cS">
-                          <node concept="3clFbF" id="4u1MGlrTLtn" role="3cqZAp">
-                            <node concept="1Wc70l" id="2iOyL3BkyU1" role="3clFbG">
-                              <node concept="2OqwBi" id="4u1MGlrTLto" role="3uHU7B">
-                                <node concept="37vLTw" id="4u1MGlrTLtp" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="4u1MGlrTLts" resolve="it" />
-                                </node>
-                                <node concept="1mIQ4w" id="4u1MGlrTLtq" role="2OqNvi">
-                                  <node concept="chp4Y" id="4u1MGlrTLtr" role="cj9EA">
-                                    <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
-                                  </node>
-                                </node>
+                  <node concept="1z4cxt" id="7MFzeeGrfQx" role="2OqNvi">
+                    <node concept="1bVj0M" id="7MFzeeGrfQy" role="23t8la">
+                      <node concept="3clFbS" id="7MFzeeGrfQz" role="1bW5cS">
+                        <node concept="3clFbF" id="7MFzeeGrfQ$" role="3cqZAp">
+                          <node concept="3fqX7Q" id="7MFzeeGrfQ_" role="3clFbG">
+                            <node concept="2OqwBi" id="7MFzeeGrfQA" role="3fr31v">
+                              <node concept="37vLTw" id="7MFzeeGrfQB" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7MFzeeGrfQE" resolve="it" />
                               </node>
-                              <node concept="3fqX7Q" id="2iOyL3BkyYG" role="3uHU7w">
-                                <node concept="2OqwBi" id="2iOyL3BkyYH" role="3fr31v">
-                                  <node concept="37vLTw" id="2iOyL3BkyYI" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="4u1MGlrTLts" resolve="it" />
-                                  </node>
-                                  <node concept="1mIQ4w" id="2iOyL3BkyYJ" role="2OqNvi">
-                                    <node concept="chp4Y" id="2iOyL3BkyYK" role="cj9EA">
-                                      <ref role="cht4Q" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
-                                    </node>
-                                  </node>
+                              <node concept="1mIQ4w" id="7MFzeeGrfQC" role="2OqNvi">
+                                <node concept="chp4Y" id="7MFzeeGrfQD" role="cj9EA">
+                                  <ref role="cht4Q" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
-                        <node concept="Rh6nW" id="4u1MGlrTLts" role="1bW2Oz">
-                          <property role="TrG5h" value="it" />
-                          <node concept="2jxLKc" id="4u1MGlrTLtt" role="1tU5fm" />
+                      </node>
+                      <node concept="Rh6nW" id="7MFzeeGrfQE" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="7MFzeeGrfQF" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="7MFzeeGrfQG" role="3cqZAp">
+              <node concept="3cpWsn" id="7MFzeeGrfQH" role="3cpWs9">
+                <property role="TrG5h" value="canExecute" />
+                <node concept="10P_77" id="7MFzeeGrfQI" role="1tU5fm" />
+                <node concept="1Wc70l" id="7MFzeeGrfQJ" role="33vP2m">
+                  <node concept="2OqwBi" id="7MFzeeGrfQK" role="3uHU7w">
+                    <node concept="1PxgMI" id="7MFzeeGrfQL" role="2Oq$k0">
+                      <node concept="chp4Y" id="7MFzeeGrfQM" role="3oSUPX">
+                        <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+                      </node>
+                      <node concept="37vLTw" id="7MFzeeGrfQN" role="1m5AlR">
+                        <ref role="3cqZAo" node="7MFzeeGrfQr" resolve="nextNonEmptyNode" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="7MFzeeGrfQO" role="2OqNvi">
+                      <ref role="37wK5l" to="hwgx:3ni3WiduMNJ" resolve="isDocumentationAllowed" />
+                    </node>
+                  </node>
+                  <node concept="1Wc70l" id="7MFzeeGrfQP" role="3uHU7B">
+                    <node concept="2OqwBi" id="7MFzeeGrfQQ" role="3uHU7B">
+                      <node concept="37vLTw" id="7MFzeeGrfQR" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7MFzeeGrfQr" resolve="nextNonEmptyNode" />
+                      </node>
+                      <node concept="3x8VRR" id="7MFzeeGrfQS" role="2OqNvi" />
+                    </node>
+                    <node concept="2OqwBi" id="7MFzeeGrfQT" role="3uHU7w">
+                      <node concept="37vLTw" id="7MFzeeGrfQU" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7MFzeeGrfQr" resolve="nextNonEmptyNode" />
+                      </node>
+                      <node concept="1mIQ4w" id="7MFzeeGrfQV" role="2OqNvi">
+                        <node concept="chp4Y" id="7MFzeeGrfQW" role="cj9EA">
+                          <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
                         </node>
                       </node>
                     </node>
@@ -923,125 +1451,265 @@
                 </node>
               </node>
             </node>
-            <node concept="3clFbH" id="5c30WK3aJ6I" role="3cqZAp" />
-            <node concept="3clFbJ" id="3m8H$lmFM6W" role="3cqZAp">
-              <node concept="3clFbS" id="3m8H$lmFM6X" role="3clFbx">
-                <node concept="3cpWs8" id="3m8H$lmFM6Y" role="3cqZAp">
-                  <node concept="3cpWsn" id="3m8H$lmFM6Z" role="3cpWs9">
-                    <property role="TrG5h" value="d" />
-                    <node concept="3Tqbb2" id="3m8H$lmFM70" role="1tU5fm">
-                      <ref role="ehGHo" to="vs0r:3m8H$lmFM5W" resolve="ElementDocumentation" />
+            <node concept="3SKdUt" id="7MFzeeGrfQX" role="3cqZAp">
+              <node concept="1PaTwC" id="7MFzeeGrfQY" role="1aUNEU">
+                <node concept="3oM_SD" id="7MFzeeGrfQZ" role="1PaTwD">
+                  <property role="3oM_SC" value="Bug:" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfR0" role="1PaTwD">
+                  <property role="3oM_SC" value="`execute`" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfR1" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfR2" role="1PaTwD">
+                  <property role="3oM_SC" value="run" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfR3" role="1PaTwD">
+                  <property role="3oM_SC" value="regardless" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfR4" role="1PaTwD">
+                  <property role="3oM_SC" value="of" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfR5" role="1PaTwD">
+                  <property role="3oM_SC" value="whether" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfR6" role="1PaTwD">
+                  <property role="3oM_SC" value="`can" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfR7" role="1PaTwD">
+                  <property role="3oM_SC" value="execute`" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfR8" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfR9" role="1PaTwD">
+                  <property role="3oM_SC" value="true" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfRa" role="1PaTwD">
+                  <property role="3oM_SC" value="or" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfRb" role="1PaTwD">
+                  <property role="3oM_SC" value="false" />
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="7MFzeeGrfRc" role="3cqZAp">
+              <node concept="1PaTwC" id="7MFzeeGrfRd" role="1aUNEU">
+                <node concept="3oM_SD" id="7MFzeeGrfRe" role="1PaTwD">
+                  <property role="3oM_SC" value="Therefore" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfRf" role="1PaTwD">
+                  <property role="3oM_SC" value="we" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfRg" role="1PaTwD">
+                  <property role="3oM_SC" value="need" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfRh" role="1PaTwD">
+                  <property role="3oM_SC" value="an" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfRi" role="1PaTwD">
+                  <property role="3oM_SC" value="additional" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfRj" role="1PaTwD">
+                  <property role="3oM_SC" value="check," />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfRk" role="1PaTwD">
+                  <property role="3oM_SC" value="until" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfRl" role="1PaTwD">
+                  <property role="3oM_SC" value="this" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfRm" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="7MFzeeGrfRn" role="1PaTwD">
+                  <property role="3oM_SC" value="fixed" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="7MFzeeGrfRo" role="3cqZAp">
+              <node concept="3clFbS" id="7MFzeeGrfRp" role="3clFbx">
+                <node concept="3cpWs8" id="7MFzeeGrfRq" role="3cqZAp">
+                  <node concept="3cpWsn" id="7MFzeeGrfRr" role="3cpWs9">
+                    <property role="TrG5h" value="iDocumentableNode" />
+                    <node concept="3Tqbb2" id="7MFzeeGrfRs" role="1tU5fm">
+                      <ref role="ehGHo" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
                     </node>
-                    <node concept="2ShNRf" id="3m8H$lmFM71" role="33vP2m">
-                      <node concept="2fJWfE" id="3m8H$lmFM72" role="2ShVmc">
-                        <node concept="3Tqbb2" id="3m8H$lmFM73" role="3zrR0E">
-                          <ref role="ehGHo" to="vs0r:3m8H$lmFM5W" resolve="ElementDocumentation" />
-                        </node>
+                    <node concept="1PxgMI" id="7MFzeeGrfRt" role="33vP2m">
+                      <node concept="chp4Y" id="7MFzeeGrfRu" role="3oSUPX">
+                        <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+                      </node>
+                      <node concept="37vLTw" id="7MFzeeGrfRv" role="1m5AlR">
+                        <ref role="3cqZAo" node="7MFzeeGrfQr" resolve="nextNonEmptyNode" />
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="3clFbF" id="3m8H$lmFM74" role="3cqZAp">
-                  <node concept="2OqwBi" id="3m8H$lmFM75" role="3clFbG">
-                    <node concept="2OqwBi" id="3m8H$lmFM76" role="2Oq$k0">
-                      <node concept="37vLTw" id="5c30WK3aGWw" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5c30WK3aESX" resolve="iDocumentableNode" />
+                <node concept="3clFbJ" id="7MFzeeGrfRw" role="3cqZAp">
+                  <node concept="3clFbS" id="7MFzeeGrfRx" role="3clFbx">
+                    <node concept="3cpWs8" id="7MFzeeGrfRy" role="3cqZAp">
+                      <node concept="3cpWsn" id="7MFzeeGrfRz" role="3cpWs9">
+                        <property role="TrG5h" value="d" />
+                        <node concept="3Tqbb2" id="7MFzeeGrfR$" role="1tU5fm">
+                          <ref role="ehGHo" to="vs0r:3m8H$lmFM5W" resolve="ElementDocumentation" />
+                        </node>
+                        <node concept="2ShNRf" id="7MFzeeGrfR_" role="33vP2m">
+                          <node concept="2fJWfE" id="7MFzeeGrfRA" role="2ShVmc">
+                            <node concept="3Tqbb2" id="7MFzeeGrfRB" role="3zrR0E">
+                              <ref role="ehGHo" to="vs0r:3m8H$lmFM5W" resolve="ElementDocumentation" />
+                            </node>
+                          </node>
+                        </node>
                       </node>
-                      <node concept="3CFZ6_" id="3m8H$lmFM78" role="2OqNvi">
-                        <node concept="3CFYIy" id="3m8H$lmFM79" role="3CFYIz">
+                    </node>
+                    <node concept="3clFbF" id="7MFzeeGrfRC" role="3cqZAp">
+                      <node concept="2OqwBi" id="7MFzeeGrfRD" role="3clFbG">
+                        <node concept="2OqwBi" id="7MFzeeGrfRE" role="2Oq$k0">
+                          <node concept="37vLTw" id="7MFzeeGrfRF" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7MFzeeGrfRr" resolve="iDocumentableNode" />
+                          </node>
+                          <node concept="3CFZ6_" id="7MFzeeGrfRG" role="2OqNvi">
+                            <node concept="3CFYIy" id="7MFzeeGrfRH" role="3CFYIz">
+                              <ref role="3CFYIx" to="vs0r:3m8H$lmFM5W" resolve="ElementDocumentation" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2oxUTD" id="7MFzeeGrfRI" role="2OqNvi">
+                          <node concept="37vLTw" id="7MFzeeGrfRJ" role="2oxUTC">
+                            <ref role="3cqZAo" node="7MFzeeGrfRz" resolve="d" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="7MFzeeGrfRK" role="3cqZAp">
+                      <node concept="2OqwBi" id="7MFzeeGrfRL" role="3clFbG">
+                        <node concept="37vLTw" id="7MFzeeGrfRM" role="2Oq$k0">
+                          <ref role="3cqZAo" node="7MFzeeGrfRz" resolve="d" />
+                        </node>
+                        <node concept="1OKiuA" id="7MFzeeGrfRN" role="2OqNvi">
+                          <node concept="1Q80Hx" id="7MFzeeGrfRO" role="lBI5i" />
+                          <node concept="2B6iha" id="7MFzeeGrfRP" role="lGT1i">
+                            <property role="1lyBwo" value="1S2pyLby17G/firstEditable" />
+                          </node>
+                          <node concept="3cmrfG" id="7MFzeeGrfRQ" role="3dN3m$">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbC" id="7MFzeeGrfRR" role="3clFbw">
+                    <node concept="2OqwBi" id="7MFzeeGrfRS" role="3uHU7B">
+                      <node concept="37vLTw" id="7MFzeeGrfRT" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7MFzeeGrfRr" resolve="iDocumentableNode" />
+                      </node>
+                      <node concept="3CFZ6_" id="7MFzeeGrfRU" role="2OqNvi">
+                        <node concept="3CFYIy" id="7MFzeeGrfRV" role="3CFYIz">
                           <ref role="3CFYIx" to="vs0r:3m8H$lmFM5W" resolve="ElementDocumentation" />
                         </node>
                       </node>
                     </node>
-                    <node concept="2oxUTD" id="3m8H$lmFM7a" role="2OqNvi">
-                      <node concept="37vLTw" id="3m8H$lmFM7b" role="2oxUTC">
-                        <ref role="3cqZAo" node="3m8H$lmFM6Z" resolve="d" />
-                      </node>
-                    </node>
+                    <node concept="10Nm6u" id="7MFzeeGrfRW" role="3uHU7w" />
                   </node>
                 </node>
-                <node concept="3clFbF" id="6PYNGEsWb08" role="3cqZAp">
-                  <node concept="2OqwBi" id="6PYNGEsWbas" role="3clFbG">
-                    <node concept="37vLTw" id="6PYNGEsY682" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3m8H$lmFM6Z" resolve="d" />
+                <node concept="3clFbF" id="7MFzeeGtAIs" role="3cqZAp">
+                  <node concept="2OqwBi" id="7MFzeeGtAIt" role="3clFbG">
+                    <node concept="2OqwBi" id="7MFzeeGtAIu" role="2Oq$k0">
+                      <node concept="37vLTw" id="7MFzeeGtAIv" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7MFzeeGrfRr" resolve="iDocumentableNode" />
+                      </node>
+                      <node concept="3CFZ6_" id="7MFzeeGtAIw" role="2OqNvi">
+                        <node concept="3CFYIy" id="7MFzeeGtAIx" role="3CFYIz">
+                          <ref role="3CFYIx" to="vs0r:3m8H$lmFM5W" resolve="ElementDocumentation" />
+                        </node>
+                      </node>
                     </node>
-                    <node concept="1OKiuA" id="6PYNGEsWpuz" role="2OqNvi">
-                      <node concept="1Q80Hx" id="5c30WK3aJ3b" role="lBI5i" />
-                      <node concept="2B6iha" id="6PYNGEsY68K" role="lGT1i">
+                    <node concept="1OKiuA" id="7MFzeeGtAIy" role="2OqNvi">
+                      <node concept="1Q80Hx" id="7MFzeeGtAIz" role="lBI5i" />
+                      <node concept="2B6iha" id="7MFzeeGtAI$" role="lGT1i">
                         <property role="1lyBwo" value="1S2pyLby17G/firstEditable" />
                       </node>
-                      <node concept="3cmrfG" id="6PYNGEsXXqh" role="3dN3m$">
+                      <node concept="3cmrfG" id="7MFzeeGtAI_" role="3dN3m$">
                         <property role="3cmrfH" value="0" />
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="3clFbC" id="3m8H$lmFM7h" role="3clFbw">
-                <node concept="2OqwBi" id="3m8H$lmFM7i" role="3uHU7B">
-                  <node concept="37vLTw" id="5c30WK3aGPv" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5c30WK3aESX" resolve="iDocumentableNode" />
-                  </node>
-                  <node concept="3CFZ6_" id="3m8H$lmFM7k" role="2OqNvi">
-                    <node concept="3CFYIy" id="3m8H$lmFM7l" role="3CFYIz">
-                      <ref role="3CFYIx" to="vs0r:3m8H$lmFM5W" resolve="ElementDocumentation" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="10Nm6u" id="3m8H$lmFM7m" role="3uHU7w" />
-              </node>
-            </node>
-            <node concept="3clFbF" id="4u1MGlrTM9S" role="3cqZAp">
-              <node concept="2OqwBi" id="4u1MGlrTMnc" role="3clFbG">
-                <node concept="7Obwk" id="4u1MGlrTM9Q" role="2Oq$k0" />
-                <node concept="3YRAZt" id="4u1MGlrTMR4" role="2OqNvi" />
+              <node concept="37vLTw" id="7MFzeeGrfS2" role="3clFbw">
+                <ref role="3cqZAo" node="7MFzeeGrfQH" resolve="canExecute" />
               </node>
             </node>
           </node>
         </node>
         <node concept="27VH4U" id="5c30WK3a_U2" role="2jiSrf">
           <node concept="3clFbS" id="5c30WK3a_U3" role="2VODD2">
-            <node concept="3clFbF" id="4u1MGlrTFu4" role="3cqZAp">
-              <node concept="3y3z36" id="4u1MGlrTKNJ" role="3clFbG">
-                <node concept="10Nm6u" id="4u1MGlrTL11" role="3uHU7w" />
-                <node concept="2OqwBi" id="4u1MGlrTHiv" role="3uHU7B">
-                  <node concept="2OqwBi" id="4u1MGlrTFFM" role="2Oq$k0">
-                    <node concept="7Obwk" id="4u1MGlrTFu2" role="2Oq$k0" />
-                    <node concept="2TlYAL" id="4u1MGlrTG3X" role="2OqNvi" />
+            <node concept="3cpWs8" id="7MFzeeGrfyK" role="3cqZAp">
+              <node concept="3cpWsn" id="7MFzeeGrfyL" role="3cpWs9">
+                <property role="TrG5h" value="nextNonEmptyNode" />
+                <node concept="3Tqbb2" id="7MFzeeGrfyM" role="1tU5fm" />
+                <node concept="2OqwBi" id="7MFzeeGrfyN" role="33vP2m">
+                  <node concept="2OqwBi" id="7MFzeeGrfyO" role="2Oq$k0">
+                    <node concept="7Obwk" id="7MFzeeGrfyP" role="2Oq$k0" />
+                    <node concept="2TlYAL" id="7MFzeeGrfyQ" role="2OqNvi" />
                   </node>
-                  <node concept="1z4cxt" id="4u1MGlrTJpF" role="2OqNvi">
-                    <node concept="1bVj0M" id="4u1MGlrTJpH" role="23t8la">
-                      <node concept="3clFbS" id="4u1MGlrTJpI" role="1bW5cS">
-                        <node concept="3clFbF" id="4u1MGlrTJCZ" role="3cqZAp">
-                          <node concept="1Wc70l" id="2iOyL3Bkx9G" role="3clFbG">
-                            <node concept="3fqX7Q" id="2iOyL3Bkxlw" role="3uHU7w">
-                              <node concept="2OqwBi" id="2iOyL3BkxJ5" role="3fr31v">
-                                <node concept="37vLTw" id="2iOyL3Bkxxh" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="4u1MGlrTJpJ" resolve="it" />
-                                </node>
-                                <node concept="1mIQ4w" id="2iOyL3BkycY" role="2OqNvi">
-                                  <node concept="chp4Y" id="2iOyL3Bkyss" role="cj9EA">
-                                    <ref role="cht4Q" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
-                                  </node>
-                                </node>
+                  <node concept="1z4cxt" id="7MFzeeGrfyR" role="2OqNvi">
+                    <node concept="1bVj0M" id="7MFzeeGrfyS" role="23t8la">
+                      <node concept="3clFbS" id="7MFzeeGrfyT" role="1bW5cS">
+                        <node concept="3clFbF" id="7MFzeeGrfyU" role="3cqZAp">
+                          <node concept="3fqX7Q" id="7MFzeeGrfyV" role="3clFbG">
+                            <node concept="2OqwBi" id="7MFzeeGrfyW" role="3fr31v">
+                              <node concept="37vLTw" id="7MFzeeGrfyX" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7MFzeeGrfz0" resolve="it" />
                               </node>
-                            </node>
-                            <node concept="2OqwBi" id="4u1MGlrTJSw" role="3uHU7B">
-                              <node concept="37vLTw" id="4u1MGlrTJCY" role="2Oq$k0">
-                                <ref role="3cqZAo" node="4u1MGlrTJpJ" resolve="it" />
-                              </node>
-                              <node concept="1mIQ4w" id="4u1MGlrTKgx" role="2OqNvi">
-                                <node concept="chp4Y" id="4u1MGlrTKwF" role="cj9EA">
-                                  <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+                              <node concept="1mIQ4w" id="7MFzeeGrfyY" role="2OqNvi">
+                                <node concept="chp4Y" id="7MFzeeGrfyZ" role="cj9EA">
+                                  <ref role="cht4Q" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
-                      <node concept="Rh6nW" id="4u1MGlrTJpJ" role="1bW2Oz">
+                      <node concept="Rh6nW" id="7MFzeeGrfz0" role="1bW2Oz">
                         <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="4u1MGlrTJpK" role="1tU5fm" />
+                        <node concept="2jxLKc" id="7MFzeeGrfz1" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7MFzeeGrfz2" role="3cqZAp">
+              <node concept="1Wc70l" id="7MFzeeGrfz3" role="3clFbG">
+                <node concept="2OqwBi" id="7MFzeeGrfz4" role="3uHU7w">
+                  <node concept="1PxgMI" id="7MFzeeGrfz5" role="2Oq$k0">
+                    <node concept="chp4Y" id="7MFzeeGrfz6" role="3oSUPX">
+                      <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+                    </node>
+                    <node concept="37vLTw" id="7MFzeeGrfz7" role="1m5AlR">
+                      <ref role="3cqZAo" node="7MFzeeGrfyL" resolve="nextNonEmptyNode" />
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="7MFzeeGrfz8" role="2OqNvi">
+                    <ref role="37wK5l" to="hwgx:3ni3WiduMNJ" resolve="isDocumentationAllowed" />
+                  </node>
+                </node>
+                <node concept="1Wc70l" id="7MFzeeGrfz9" role="3uHU7B">
+                  <node concept="2OqwBi" id="7MFzeeGrfza" role="3uHU7B">
+                    <node concept="37vLTw" id="7MFzeeGrfzb" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7MFzeeGrfyL" resolve="nextNonEmptyNode" />
+                    </node>
+                    <node concept="3x8VRR" id="7MFzeeGrfzc" role="2OqNvi" />
+                  </node>
+                  <node concept="2OqwBi" id="7MFzeeGrfzd" role="3uHU7w">
+                    <node concept="37vLTw" id="7MFzeeGrfze" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7MFzeeGrfyL" resolve="nextNonEmptyNode" />
+                    </node>
+                    <node concept="1mIQ4w" id="7MFzeeGrfzf" role="2OqNvi">
+                      <node concept="chp4Y" id="7MFzeeGrfzg" role="cj9EA">
+                        <ref role="cht4Q" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
                       </node>
                     </node>
                   </node>

--- a/code/languages/org.iets3.opensource/solutions/test.org.iets3.core.comments/models/tests@tests.mps
+++ b/code/languages/org.iets3.opensource/solutions/test.org.iets3.core.comments/models/tests@tests.mps
@@ -118,6 +118,7 @@
     <node concept="1qefOq" id="17Nm8oCo9ax" role="25YQFr">
       <node concept="1i1ALs" id="5kwEgmAi6Gw" role="1qenE9">
         <property role="TrG5h" value="TestChunk" />
+        <node concept="1i1AuW" id="7MFzeeGSGW5" role="1i1AA4" />
         <node concept="1i1XBj" id="5kwEgmAi6Gz" role="1i1AA4">
           <property role="TrG5h" value="CP0" />
           <node concept="H_j2F" id="59rcyU3GDmR" role="1i1XAe">
@@ -188,6 +189,7 @@
             <node concept="H_vQO" id="59rcyU3GDmY" role="H_jLS" />
           </node>
           <node concept="GnABt" id="5kwEgmAh7si" role="1i1XAe">
+            <node concept="GnyP7" id="7MFzeeGSH4c" role="GnABu" />
             <node concept="1i6xzV" id="5kwEgmAh7sl" role="GnABu">
               <node concept="1i1fwW" id="5kwEgmAh7sm" role="MGl3R">
                 <ref role="1i1fwX" node="5kwEgmAh7sp" resolve="CP1" />
@@ -255,6 +257,7 @@
           <node concept="H_j2F" id="59rcyU3GDn3" role="1i1XAe">
             <node concept="H_vQO" id="59rcyU3GDn4" role="H_jLS" />
           </node>
+          <node concept="1i1Xx2" id="7MFzeeGSQKm" role="1i1XAe" />
           <node concept="GnABt" id="5kwEgmAi6Me" role="1i1XAe">
             <node concept="1z9TsT" id="12ACZ2oN$Wx" role="lGtFl">
               <node concept="OjmMv" id="12ACZ2oN$Wy" role="1w35rA">


### PR DESCRIPTION
# Change-log
The transformation action applyCommentsToIDocumentable to add a comment to an IDocumentable node is improved to only be available depending on IDocumentable.isDocumentationAllowed(). Furthermore it only jumps over IEmpty nodes to reach an IDocumentable node instead of jumping as well over non-IDocumentable nodes.

# Problem
- The `applyCommentsToIDocumentable` contribution menu to add comments to nodes isn't customizable in the sense, that it's not possible to deactivate it for specific concepts, though there is `IDocumentable.isDocumentationAllowed`. It's not enough to just remove the `IDocumentable` interface, because it can be applied implicitly via several other interfaces, due to the interface hierarchy.
- Further more in this case the `execute` method is executed even though `can execute` returns `false`.
- The action adds a comment to the next node via `next-siblings` and jumps over `IEmpty` nodes, which is okay, and non-`IDocumentable` nodes, which is not okay, because  it may seem to the user totally random.
- Additionally, if the targeted next node, i.e. the node that should get a comment, already has a comment, the current node ( = `IEmpty` node) is detached, which is unexpected and weird. 

# What changed
- Added a check, so `IDocumentable.isDocumentationAllowed` is considered and it's possible to specify which concepts can be commented.
- Added additional checks in `text` and `execute` methods in the `applyCommentsToIDocumentable` contribution menu, to circumvent the bug disregarding the `can execute` result
- The search for the target node stops at the next non-`IEmpty` sibling node.
  - If it is an `IDocumentable` and doesn't have a comment, a comment is added to it.
  - If it has a comment, the cursor will jump into that comment. 
  - If the target node is not an `IDocumentable` the transformation-text `//` is not recognized and shows up as an error.

# Todos
- [x] Add release comment

