### PR TITLE
Make IRecordDeclaration equality check overridable

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -67,6 +67,7 @@
     <import index="wcxw" ref="r:b9f36c08-4a75-4513-9277-a390d3426e0f(jetbrains.mps.editor.runtime.impl.cellActions)" />
     <import index="jpm3" ref="r:e3e5593b-dfcd-4a2e-b10f-f1ed4a43f093(org.iets3.core.expr.plugin.plugin)" />
     <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" implicit="true" />
+    <import index="nu60" ref="r:cfd59c48-ecc8-4b0c-8ae8-6d876c46ebbb(org.iets3.core.expr.toplevel.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -13210,27 +13211,32 @@
                     </node>
                   </node>
                   <node concept="3clFbH" id="5CUQ8Hxoju" role="3cqZAp" />
-                  <node concept="3clFbJ" id="5CUQ8HxoCW" role="3cqZAp">
-                    <node concept="3clFbS" id="5CUQ8HxoCY" role="3clFbx">
-                      <node concept="3cpWs6" id="5CUQ8Hxsrs" role="3cqZAp">
-                        <node concept="3clFbT" id="5CUQ8Hxs_x" role="3cqZAk" />
+                  <node concept="3clFbJ" id="3i_T7GdgzVN" role="3cqZAp">
+                    <node concept="3clFbS" id="3i_T7GdgzVP" role="3clFbx">
+                      <node concept="3cpWs6" id="3i_T7GdgHf4" role="3cqZAp">
+                        <node concept="3clFbT" id="3i_T7GdgI3k" role="3cqZAk" />
                       </node>
                     </node>
-                    <node concept="3y3z36" id="5CUQ8Hxpq6" role="3clFbw">
-                      <node concept="2OqwBi" id="5CUQ8Hxs1s" role="3uHU7w">
-                        <node concept="37vLTw" id="5CUQ8HxrLu" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5CUQ8Hxo9x" resolve="rve" />
+                    <node concept="3fqX7Q" id="3i_T7GdgG0u" role="3clFbw">
+                      <node concept="2OqwBi" id="3i_T7GdgG0w" role="3fr31v">
+                        <node concept="2OqwBi" id="3i_T7GdgG0x" role="2Oq$k0">
+                          <node concept="37vLTw" id="3i_T7GdgG0y" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5CUQ8Hxo03" resolve="rva" />
+                          </node>
+                          <node concept="liA8E" id="3i_T7GdgG0z" role="2OqNvi">
+                            <ref role="37wK5l" to="pq1l:3vxfdxaYUpD" resolve="recordDeclaration" />
+                          </node>
                         </node>
-                        <node concept="liA8E" id="5CUQ8Hxsp3" role="2OqNvi">
-                          <ref role="37wK5l" to="pq1l:3vxfdxaYUpD" resolve="recordDeclaration" />
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="5CUQ8HxoQc" role="3uHU7B">
-                        <node concept="37vLTw" id="5CUQ8HxoEC" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5CUQ8Hxo03" resolve="rva" />
-                        </node>
-                        <node concept="liA8E" id="5CUQ8Hxp09" role="2OqNvi">
-                          <ref role="37wK5l" to="pq1l:3vxfdxaYUpD" resolve="recordDeclaration" />
+                        <node concept="2qgKlT" id="3i_T7GdgG0$" role="2OqNvi">
+                          <ref role="37wK5l" to="nu60:3i_T7GdgtPy" resolve="equals" />
+                          <node concept="2OqwBi" id="3i_T7GdgG0_" role="37wK5m">
+                            <node concept="37vLTw" id="3i_T7GdgG0A" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5CUQ8Hxo9x" resolve="rve" />
+                            </node>
+                            <node concept="liA8E" id="3i_T7GdgG0B" role="2OqNvi">
+                              <ref role="37wK5l" to="pq1l:3vxfdxaYUpD" resolve="recordDeclaration" />
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -110,6 +110,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -3816,20 +3817,23 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5L2mTKmAC$l" role="3cqZAp">
-          <node concept="3clFbC" id="5L2mTKmADmW" role="3clFbG">
-            <node concept="2OqwBi" id="5L2mTKmADAe" role="3uHU7w">
-              <node concept="37vLTw" id="5L2mTKmADt6" role="2Oq$k0">
-                <ref role="3cqZAo" node="5L2mTKmA_fb" resolve="casted" />
-              </node>
-              <node concept="3TrEf2" id="5L2mTKmADZm" role="2OqNvi">
+        <node concept="3clFbF" id="9s1Jez5La1" role="3cqZAp">
+          <node concept="2OqwBi" id="9s1Jez5Man" role="3clFbG">
+            <node concept="2OqwBi" id="9s1Jez5Lpa" role="2Oq$k0">
+              <node concept="13iPFW" id="9s1Jez5L9Z" role="2Oq$k0" />
+              <node concept="3TrEf2" id="9s1Jez5LOU" role="2OqNvi">
                 <ref role="3Tt5mk" to="yv47:7D7uZV2dYz3" resolve="record" />
               </node>
             </node>
-            <node concept="2OqwBi" id="5L2mTKmACJP" role="3uHU7B">
-              <node concept="13iPFW" id="5L2mTKmAC$b" role="2Oq$k0" />
-              <node concept="3TrEf2" id="5L2mTKmACTM" role="2OqNvi">
-                <ref role="3Tt5mk" to="yv47:7D7uZV2dYz3" resolve="record" />
+            <node concept="2qgKlT" id="9s1Jez5N89" role="2OqNvi">
+              <ref role="37wK5l" node="3i_T7GdgtPy" resolve="equals" />
+              <node concept="2OqwBi" id="9s1Jez5Nwh" role="37wK5m">
+                <node concept="37vLTw" id="9s1Jez5Nep" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5L2mTKmA_fb" resolve="casted" />
+                </node>
+                <node concept="3TrEf2" id="9s1Jez5OkV" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yv47:7D7uZV2dYz3" resolve="record" />
+                </node>
               </node>
             </node>
           </node>
@@ -7157,6 +7161,28 @@
               <ref role="3TtcxE" to="yv47:xu7xcKioz5" resolve="members" />
             </node>
           </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="3i_T7GdgtPy" role="13h7CS">
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="equals" />
+      <node concept="3Tm1VV" id="3i_T7GdgtPz" role="1B3o_S" />
+      <node concept="10P_77" id="3i_T7GdguI$" role="3clF45" />
+      <node concept="3clFbS" id="3i_T7GdgtP_" role="3clF47">
+        <node concept="3clFbF" id="3i_T7GdgyLx" role="3cqZAp">
+          <node concept="17R0WA" id="3i_T7Gdgzax" role="3clFbG">
+            <node concept="37vLTw" id="3i_T7Gdgze_" role="3uHU7w">
+              <ref role="3cqZAo" node="3i_T7GdgyKW" resolve="declaration" />
+            </node>
+            <node concept="13iPFW" id="3i_T7GdgyLw" role="3uHU7B" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3i_T7GdgyKW" role="3clF46">
+        <property role="TrG5h" value="declaration" />
+        <node concept="3Tqbb2" id="3i_T7GdgyKV" role="1tU5fm">
+          <ref role="ehGHo" to="yv47:xu7xcKinTJ" resolve="IRecordDeclaration" />
         </node>
       </node>
     </node>


### PR DESCRIPTION
This way, an extending record declaration can use a custom equality check for special cases where two record should be treated as equal (e.g., two records have the same structure but have different version numbers). 