### PR TITLE
Support hexadecimal number literals and hexadecimal number ranges

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/plugin.mps
@@ -1153,6 +1153,19 @@
         </node>
       </node>
     </node>
+    <node concept="2tJIrI" id="4NJAaUg11Bg" role="jymVt" />
+    <node concept="3clFb_" id="4NJAaUg1hYw" role="jymVt">
+      <property role="TrG5h" value="allowHexadecimalNumbers" />
+      <node concept="3clFbS" id="4NJAaUg1hYz" role="3clF47">
+        <node concept="3clFbF" id="4NJAaUg1ie9" role="3cqZAp">
+          <node concept="3clFbT" id="4NJAaUg1ie8" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4NJAaUg1fSe" role="1B3o_S" />
+      <node concept="10P_77" id="4NJAaUg1hXd" role="3clF45" />
+    </node>
     <node concept="2tJIrI" id="2q0DACtJfgT" role="jymVt" />
     <node concept="3Tm1VV" id="2Qbt$1tSnqi" role="1B3o_S" />
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.simpleTypes/generator/template/org.iets3.core.expr.genjava.simpleTypes@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.simpleTypes/generator/template/org.iets3.core.expr.genjava.simpleTypes@generator.mps
@@ -3,6 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <use id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator" version="4" />
     <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
   </languages>
   <imports>
@@ -3856,11 +3857,11 @@
                     <property role="2qtEX9" value="value" />
                     <node concept="3zFVjK" id="6IxV2nSdQnr" role="3zH0cK">
                       <node concept="3clFbS" id="6IxV2nSdQns" role="2VODD2">
-                        <node concept="3clFbF" id="6IxV2nSdQw9" role="3cqZAp">
-                          <node concept="2OqwBi" id="6IxV2nSdQNc" role="3clFbG">
-                            <node concept="30H73N" id="6IxV2nSdQw8" role="2Oq$k0" />
-                            <node concept="3TrcHB" id="6IxV2nSdRs9" role="2OqNvi">
-                              <ref role="3TsBF5" to="5qo5:4rZeNQ6Oert" resolve="value" />
+                        <node concept="3cpWs6" id="SIMVVogFvP" role="3cqZAp">
+                          <node concept="2OqwBi" id="SIMVVogFWd" role="3cqZAk">
+                            <node concept="30H73N" id="SIMVVogFDg" role="2Oq$k0" />
+                            <node concept="2qgKlT" id="SIMVVogGnt" role="2OqNvi">
+                              <ref role="37wK5l" to="b1h1:2oUyrt$QPvb" resolve="valueWithDotInsteadOfComma" />
                             </node>
                           </node>
                         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.simpleTypes/generator/template/org.iets3.core.expr.genjava.simpleTypes@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.simpleTypes/generator/template/org.iets3.core.expr.genjava.simpleTypes@generator.mps
@@ -6030,8 +6030,8 @@
                               <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                             </node>
                           </node>
-                          <node concept="3TrcHB" id="1wEm9ap1EdG" role="2OqNvi">
-                            <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+                          <node concept="2qgKlT" id="SIMVVotkSH" role="2OqNvi">
+                            <ref role="37wK5l" to="b1h1:SIMVVosRGL" resolve="getMinimum" />
                           </node>
                         </node>
                       </node>
@@ -6103,8 +6103,8 @@
                               <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                             </node>
                           </node>
-                          <node concept="3TrcHB" id="1wEm9ap1FOO" role="2OqNvi">
-                            <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+                          <node concept="2qgKlT" id="SIMVVouyLD" role="2OqNvi">
+                            <ref role="37wK5l" to="b1h1:SIMVVosRWc" resolve="getMaximum" />
                           </node>
                         </node>
                       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
@@ -449,38 +449,48 @@
       <node concept="10P_77" id="4rZeNQ6Og4t" role="3clF45" />
       <node concept="3clFbS" id="4rZeNQ6Og4u" role="3clF47">
         <node concept="3cpWs6" id="6Mx2TmozOFg" role="3cqZAp">
-          <node concept="1Wc70l" id="6Mx2TmozOFh" role="3cqZAk">
-            <node concept="3y3z36" id="6Mx2TmozOFi" role="3uHU7B">
-              <node concept="10Nm6u" id="6Mx2TmozOFj" role="3uHU7w" />
-              <node concept="37vLTw" id="6Mx2TmozOFk" role="3uHU7B">
+          <node concept="22lmx$" id="SIMVVoecA7" role="3cqZAk">
+            <node concept="BsUDl" id="SIMVVoecF$" role="3uHU7w">
+              <ref role="37wK5l" node="SIMVVoeaaM" resolve="isHexadecimal" />
+              <node concept="37vLTw" id="SIMVVoecQW" role="37wK5m">
                 <ref role="3cqZAo" node="4rZeNQ6Ogz6" resolve="val" />
               </node>
             </node>
-            <node concept="2OqwBi" id="6Mx2TmozOFl" role="3uHU7w">
-              <node concept="37vLTw" id="6Mx2TmozOFm" role="2Oq$k0">
-                <ref role="3cqZAo" node="4rZeNQ6Ogz6" resolve="val" />
-              </node>
-              <node concept="2kpEY9" id="6Mx2TmozOFn" role="2OqNvi">
-                <node concept="1Qi9sc" id="6Mx2TmozOFo" role="1YN4dH">
-                  <node concept="1OJ37Q" id="6Mx2TmozOFp" role="1QigWp">
-                    <node concept="1OJ37Q" id="6Mx2TmozOFq" role="1OLpdg">
-                      <node concept="1SSJmt" id="6Mx2TmozOFr" role="1OLqdY">
-                        <node concept="1T8lYq" id="6Mx2TmozOFs" role="1T5LoC">
-                          <property role="1T8p8b" value="1" />
-                          <property role="1T8pRJ" value="9" />
-                        </node>
-                      </node>
-                      <node concept="1P8g2x" id="6Mx2TmozOFt" role="1OLpdg">
-                        <node concept="1SLe3L" id="6Mx2TmozOFu" role="1P8hpE">
-                          <node concept="1OC9wW" id="6Mx2TmozOFv" role="1OLDsb">
-                            <property role="1OCb_u" value="-" />
+            <node concept="1eOMI4" id="SIMVVoeceT" role="3uHU7B">
+              <node concept="1Wc70l" id="6Mx2TmozOFh" role="1eOMHV">
+                <node concept="3y3z36" id="6Mx2TmozOFi" role="3uHU7B">
+                  <node concept="10Nm6u" id="6Mx2TmozOFj" role="3uHU7w" />
+                  <node concept="37vLTw" id="6Mx2TmozOFk" role="3uHU7B">
+                    <ref role="3cqZAo" node="4rZeNQ6Ogz6" resolve="val" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="6Mx2TmozOFl" role="3uHU7w">
+                  <node concept="37vLTw" id="6Mx2TmozOFm" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4rZeNQ6Ogz6" resolve="val" />
+                  </node>
+                  <node concept="2kpEY9" id="6Mx2TmozOFn" role="2OqNvi">
+                    <node concept="1Qi9sc" id="6Mx2TmozOFo" role="1YN4dH">
+                      <node concept="1OJ37Q" id="6Mx2TmozOFp" role="1QigWp">
+                        <node concept="1OJ37Q" id="6Mx2TmozOFq" role="1OLpdg">
+                          <node concept="1SSJmt" id="6Mx2TmozOFr" role="1OLqdY">
+                            <node concept="1T8lYq" id="6Mx2TmozOFs" role="1T5LoC">
+                              <property role="1T8p8b" value="1" />
+                              <property role="1T8pRJ" value="9" />
+                            </node>
+                          </node>
+                          <node concept="1P8g2x" id="6Mx2TmozOFt" role="1OLpdg">
+                            <node concept="1SLe3L" id="6Mx2TmozOFu" role="1P8hpE">
+                              <node concept="1OC9wW" id="6Mx2TmozOFv" role="1OLDsb">
+                                <property role="1OCb_u" value="-" />
+                              </node>
+                            </node>
                           </node>
                         </node>
-                      </node>
-                    </node>
-                    <node concept="1OCmVF" id="6Mx2TmozOFw" role="1OLqdY">
-                      <node concept="1SYyG9" id="6Mx2TmozOFx" role="1OLDsb">
-                        <ref role="1SYXPG" to="tpfp:h5SUwpi" resolve="\d" />
+                        <node concept="1OCmVF" id="6Mx2TmozOFw" role="1OLqdY">
+                          <node concept="1SYyG9" id="6Mx2TmozOFx" role="1OLDsb">
+                            <ref role="1SYXPG" to="tpfp:h5SUwpi" resolve="\d" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -493,6 +503,59 @@
       <node concept="37vLTG" id="4rZeNQ6Ogz6" role="3clF46">
         <property role="TrG5h" value="val" />
         <node concept="17QB3L" id="4rZeNQ6Ogz5" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="SIMVVoeaaM" role="13h7CS">
+      <property role="TrG5h" value="isHexadecimal" />
+      <node concept="3Tm1VV" id="SIMVVoeaaN" role="1B3o_S" />
+      <node concept="10P_77" id="SIMVVoea$N" role="3clF45" />
+      <node concept="3clFbS" id="SIMVVoeaaP" role="3clF47">
+        <node concept="3cpWs6" id="SIMVVoea_w" role="3cqZAp">
+          <node concept="1Wc70l" id="SIMVVoebat" role="3cqZAk">
+            <node concept="2OqwBi" id="SIMVVoebg4" role="3uHU7w">
+              <node concept="37vLTw" id="SIMVVoebbd" role="2Oq$k0">
+                <ref role="3cqZAo" node="SIMVVoea_P" resolve="val" />
+              </node>
+              <node concept="2kpEY9" id="SIMVVoebv8" role="2OqNvi">
+                <node concept="1Qi9sc" id="SIMVVoebva" role="1YN4dH">
+                  <node concept="1OJ37Q" id="SIMVVoegyE" role="1QigWp">
+                    <node concept="1OC9wW" id="SIMVVoegyZ" role="1OLpdg">
+                      <property role="1OCb_u" value="0x" />
+                    </node>
+                    <node concept="1OClNT" id="SIMVVongWG" role="1OLqdY">
+                      <node concept="1P8g2x" id="SIMVVongWi" role="1OLDsb">
+                        <node concept="1SSJmt" id="SIMVVoebwF" role="1P8hpE">
+                          <node concept="1T8lYq" id="SIMVVoebx5" role="1T5LoC">
+                            <property role="1T8p8b" value="0" />
+                            <property role="1T8pRJ" value="9" />
+                          </node>
+                          <node concept="1T8lYq" id="SIMVVoebxw" role="1T5LoC">
+                            <property role="1T8p8b" value="a" />
+                            <property role="1T8pRJ" value="f" />
+                          </node>
+                          <node concept="1T8lYq" id="SIMVVoeby6" role="1T5LoC">
+                            <property role="1T8p8b" value="A" />
+                            <property role="1T8pRJ" value="F" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3y3z36" id="SIMVVoeaWF" role="3uHU7B">
+              <node concept="37vLTw" id="SIMVVoeaA$" role="3uHU7B">
+                <ref role="3cqZAo" node="SIMVVoea_P" resolve="val" />
+              </node>
+              <node concept="10Nm6u" id="SIMVVoeb9O" role="3uHU7w" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="SIMVVoea_P" role="3clF46">
+        <property role="TrG5h" value="val" />
+        <node concept="17QB3L" id="SIMVVoea_O" role="1tU5fm" />
       </node>
     </node>
     <node concept="13i0hz" id="4rZeNQ6Og7j" role="13h7CS">
@@ -1024,11 +1087,55 @@
           </node>
           <node concept="9aQIb" id="2oUyrt$QT7R" role="9aQIa">
             <node concept="3clFbS" id="2oUyrt$QT7S" role="9aQI4">
-              <node concept="3cpWs6" id="2oUyrt$QTk1" role="3cqZAp">
-                <node concept="2OqwBi" id="2oUyrt$QTk3" role="3cqZAk">
-                  <node concept="13iPFW" id="2oUyrt$QTk4" role="2Oq$k0" />
-                  <node concept="3TrcHB" id="2oUyrt$QTk5" role="2OqNvi">
-                    <ref role="3TsBF5" to="5qo5:4rZeNQ6Oert" resolve="value" />
+              <node concept="3clFbJ" id="SIMVVofFp4" role="3cqZAp">
+                <node concept="3clFbS" id="SIMVVofFp6" role="3clFbx">
+                  <node concept="3cpWs6" id="SIMVVofGhB" role="3cqZAp">
+                    <node concept="2YIFZM" id="SIMVVofUO8" role="3cqZAk">
+                      <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                      <ref role="37wK5l" to="wyt6:~String.valueOf(int)" resolve="valueOf" />
+                      <node concept="2YIFZM" id="SIMVVofKVo" role="37wK5m">
+                        <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
+                        <ref role="37wK5l" to="wyt6:~Integer.parseInt(java.lang.String,int)" resolve="parseInt" />
+                        <node concept="2OqwBi" id="SIMVVofKVp" role="37wK5m">
+                          <node concept="2OqwBi" id="SIMVVofKVq" role="2Oq$k0">
+                            <node concept="13iPFW" id="SIMVVofKVr" role="2Oq$k0" />
+                            <node concept="3TrcHB" id="SIMVVofKVs" role="2OqNvi">
+                              <ref role="3TsBF5" to="5qo5:4rZeNQ6Oert" resolve="value" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="SIMVVofKVt" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~String.substring(int)" resolve="substring" />
+                            <node concept="3cmrfG" id="SIMVVofKVu" role="37wK5m">
+                              <property role="3cmrfH" value="2" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cmrfG" id="SIMVVopZBa" role="37wK5m">
+                          <property role="3cmrfH" value="16" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="BsUDl" id="SIMVVofFrj" role="3clFbw">
+                  <ref role="37wK5l" node="SIMVVoeaaM" resolve="isHexadecimal" />
+                  <node concept="2OqwBi" id="SIMVVofFP4" role="37wK5m">
+                    <node concept="13iPFW" id="SIMVVofFtu" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="SIMVVofGfk" role="2OqNvi">
+                      <ref role="3TsBF5" to="5qo5:4rZeNQ6Oert" resolve="value" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="9aQIb" id="SIMVVofKZq" role="9aQIa">
+                  <node concept="3clFbS" id="SIMVVofKZr" role="9aQI4">
+                    <node concept="3cpWs6" id="2oUyrt$QTk1" role="3cqZAp">
+                      <node concept="2OqwBi" id="2oUyrt$QTk3" role="3cqZAk">
+                        <node concept="13iPFW" id="2oUyrt$QTk4" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="2oUyrt$QTk5" role="2OqNvi">
+                          <ref role="3TsBF5" to="5qo5:4rZeNQ6Oert" resolve="value" />
+                        </node>
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
@@ -795,6 +795,41 @@
         <node concept="17QB3L" id="4rZeNQ6OgzY" role="1tU5fm" />
       </node>
     </node>
+    <node concept="13i0hz" id="SIMVVorXi8" role="13h7CS">
+      <property role="TrG5h" value="isValidNumber" />
+      <node concept="3Tm1VV" id="SIMVVorXi9" role="1B3o_S" />
+      <node concept="10P_77" id="SIMVVorX$i" role="3clF45" />
+      <node concept="3clFbS" id="SIMVVorXib" role="3clF47">
+        <node concept="3clFbF" id="SIMVVorX_f" role="3cqZAp">
+          <node concept="22lmx$" id="SIMVVorXUL" role="3clFbG">
+            <node concept="BsUDl" id="SIMVVorXWd" role="3uHU7w">
+              <ref role="37wK5l" node="4rZeNQ6Og7j" resolve="isReal" />
+              <node concept="37vLTw" id="SIMVVorXXd" role="37wK5m">
+                <ref role="3cqZAo" node="SIMVVorX$Q" resolve="val" />
+              </node>
+            </node>
+            <node concept="22lmx$" id="SIMVVorXSa" role="3uHU7B">
+              <node concept="BsUDl" id="SIMVVorX_e" role="3uHU7B">
+                <ref role="37wK5l" node="4rZeNQ6OfoS" resolve="isZero" />
+                <node concept="37vLTw" id="SIMVVorX_O" role="37wK5m">
+                  <ref role="3cqZAo" node="SIMVVorX$Q" resolve="val" />
+                </node>
+              </node>
+              <node concept="BsUDl" id="SIMVVorXT4" role="3uHU7w">
+                <ref role="37wK5l" node="4rZeNQ6Og4r" resolve="isInteger" />
+                <node concept="37vLTw" id="SIMVVorXTU" role="37wK5m">
+                  <ref role="3cqZAo" node="SIMVVorX$Q" resolve="val" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="SIMVVorX$Q" role="3clF46">
+        <property role="TrG5h" value="val" />
+        <node concept="17QB3L" id="SIMVVorX$P" role="1tU5fm" />
+      </node>
+    </node>
     <node concept="13i0hz" id="uGVYUijgRw" role="13h7CS">
       <property role="TrG5h" value="canBeInt" />
       <node concept="3Tm1VV" id="uGVYUijgRx" role="1B3o_S" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
@@ -2101,32 +2101,28 @@
                 </node>
               </node>
             </node>
-            <node concept="3clFbF" id="19PglA20EF4" role="3cqZAp">
-              <node concept="37vLTI" id="19PglA20GDf" role="3clFbG">
-                <node concept="37vLTw" id="19PglA20GJG" role="37vLTx">
-                  <ref role="3cqZAo" node="3p6$WoEqc2r" resolve="value" />
+            <node concept="3clFbF" id="SIMVVotQc5" role="3cqZAp">
+              <node concept="2OqwBi" id="SIMVVotQlE" role="3clFbG">
+                <node concept="37vLTw" id="SIMVVotQc3" role="2Oq$k0">
+                  <ref role="3cqZAo" node="19PglA20Ft0" resolve="rg" />
                 </node>
-                <node concept="2OqwBi" id="19PglA20FFz" role="37vLTJ">
-                  <node concept="37vLTw" id="19PglA20Ft6" role="2Oq$k0">
-                    <ref role="3cqZAo" node="19PglA20Ft0" resolve="rg" />
-                  </node>
-                  <node concept="3TrcHB" id="19PglA20Gj9" role="2OqNvi">
-                    <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+                <node concept="2qgKlT" id="SIMVVotQBr" role="2OqNvi">
+                  <ref role="37wK5l" node="SIMVVotJjI" resolve="setMinimum" />
+                  <node concept="37vLTw" id="SIMVVotQEO" role="37wK5m">
+                    <ref role="3cqZAo" node="3p6$WoEqc2r" resolve="value" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="3clFbF" id="19PglA20GRH" role="3cqZAp">
-              <node concept="37vLTI" id="19PglA20Hw$" role="3clFbG">
-                <node concept="37vLTw" id="19PglA20Hx5" role="37vLTx">
-                  <ref role="3cqZAo" node="3p6$WoEqc2r" resolve="value" />
+            <node concept="3clFbF" id="SIMVVotQGX" role="3cqZAp">
+              <node concept="2OqwBi" id="SIMVVotQIZ" role="3clFbG">
+                <node concept="37vLTw" id="SIMVVotQGV" role="2Oq$k0">
+                  <ref role="3cqZAo" node="19PglA20Ft0" resolve="rg" />
                 </node>
-                <node concept="2OqwBi" id="19PglA20GYM" role="37vLTJ">
-                  <node concept="37vLTw" id="19PglA20GRF" role="2Oq$k0">
-                    <ref role="3cqZAo" node="19PglA20Ft0" resolve="rg" />
-                  </node>
-                  <node concept="3TrcHB" id="19PglA20Hau" role="2OqNvi">
-                    <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+                <node concept="2qgKlT" id="SIMVVotQM1" role="2OqNvi">
+                  <ref role="37wK5l" node="SIMVVotK76" resolve="setMaximum" />
+                  <node concept="37vLTw" id="SIMVVotQNU" role="37wK5m">
+                    <ref role="3cqZAo" node="3p6$WoEqc2r" resolve="value" />
                   </node>
                 </node>
               </node>
@@ -2549,8 +2545,8 @@
                     <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                   </node>
                 </node>
-                <node concept="3TrcHB" id="2M9Ik4CWjUN" role="2OqNvi">
-                  <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+                <node concept="2qgKlT" id="SIMVVotqgw" role="2OqNvi">
+                  <ref role="37wK5l" node="SIMVVosRGL" resolve="getMinimum" />
                 </node>
               </node>
               <node concept="10Nm6u" id="2M9Ik4CWksq" role="3uHU7w" />
@@ -2564,8 +2560,8 @@
                     <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                   </node>
                 </node>
-                <node concept="3TrcHB" id="2M9Ik4CWlzm" role="2OqNvi">
-                  <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+                <node concept="2qgKlT" id="SIMVVotqC1" role="2OqNvi">
+                  <ref role="37wK5l" node="SIMVVosRWc" resolve="getMaximum" />
                 </node>
               </node>
             </node>
@@ -2580,8 +2576,8 @@
                   <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                 </node>
               </node>
-              <node concept="3TrcHB" id="2NHHcg2Fnop" role="2OqNvi">
-                <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+              <node concept="2qgKlT" id="SIMVVotrCD" role="2OqNvi">
+                <ref role="37wK5l" node="SIMVVosRGL" resolve="getMinimum" />
               </node>
             </node>
             <node concept="2OqwBi" id="2NHHcg2Fpo4" role="1Lso8e">
@@ -2591,8 +2587,8 @@
                   <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                 </node>
               </node>
-              <node concept="3TrcHB" id="2NHHcg2FpLp" role="2OqNvi">
-                <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+              <node concept="2qgKlT" id="SIMVVots9K" role="2OqNvi">
+                <ref role="37wK5l" node="SIMVVosRWc" resolve="getMaximum" />
               </node>
             </node>
           </node>
@@ -2891,8 +2887,8 @@
                     <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                   </node>
                 </node>
-                <node concept="3TrcHB" id="G5D_q$KXEx" role="2OqNvi">
-                  <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+                <node concept="2qgKlT" id="SIMVVotsx$" role="2OqNvi">
+                  <ref role="37wK5l" node="SIMVVosRGL" resolve="getMinimum" />
                 </node>
               </node>
               <node concept="17RvpY" id="G5D_q$KXuf" role="2OqNvi" />
@@ -2907,8 +2903,8 @@
                     <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                   </node>
                 </node>
-                <node concept="3TrcHB" id="19PglA20RqV" role="2OqNvi">
-                  <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+                <node concept="2qgKlT" id="SIMVVotuDp" role="2OqNvi">
+                  <ref role="37wK5l" node="SIMVVosRGL" resolve="getMinimum" />
                 </node>
               </node>
             </node>
@@ -2937,8 +2933,8 @@
                     <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                   </node>
                 </node>
-                <node concept="3TrcHB" id="G5D_q$KVj0" role="2OqNvi">
-                  <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+                <node concept="2qgKlT" id="SIMVVotvxT" role="2OqNvi">
+                  <ref role="37wK5l" node="SIMVVosRWc" resolve="getMaximum" />
                 </node>
               </node>
               <node concept="17RvpY" id="G5D_q$KX0b" role="2OqNvi" />
@@ -2962,8 +2958,8 @@
                     <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                   </node>
                 </node>
-                <node concept="3TrcHB" id="19PglA20Zee" role="2OqNvi">
-                  <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+                <node concept="2qgKlT" id="SIMVVotw2_" role="2OqNvi">
+                  <ref role="37wK5l" node="SIMVVosRWc" resolve="getMaximum" />
                 </node>
               </node>
             </node>
@@ -3705,8 +3701,8 @@
                       <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                     </node>
                   </node>
-                  <node concept="3TrcHB" id="19PglA24RrA" role="2OqNvi">
-                    <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+                  <node concept="2qgKlT" id="SIMVVotXn8" role="2OqNvi">
+                    <ref role="37wK5l" node="SIMVVosRGL" resolve="getMinimum" />
                   </node>
                 </node>
               </node>
@@ -3722,8 +3718,8 @@
                       <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                     </node>
                   </node>
-                  <node concept="3TrcHB" id="19PglA24RZl" role="2OqNvi">
-                    <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+                  <node concept="2qgKlT" id="SIMVVou0mV" role="2OqNvi">
+                    <ref role="37wK5l" node="SIMVVosRWc" resolve="getMaximum" />
                   </node>
                 </node>
               </node>
@@ -3865,8 +3861,8 @@
                   <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                 </node>
               </node>
-              <node concept="3TrcHB" id="TuTPrvz2SM" role="2OqNvi">
-                <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+              <node concept="2qgKlT" id="SIMVVoty6g" role="2OqNvi">
+                <ref role="37wK5l" node="SIMVVosRWc" resolve="getMaximum" />
               </node>
             </node>
           </node>
@@ -3880,8 +3876,8 @@
                   <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                 </node>
               </node>
-              <node concept="3TrcHB" id="2NHHcg2Ddaz" role="2OqNvi">
-                <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+              <node concept="2qgKlT" id="SIMVVotz0M" role="2OqNvi">
+                <ref role="37wK5l" node="SIMVVosRWc" resolve="getMaximum" />
               </node>
             </node>
             <node concept="liA8E" id="2NHHcg2E51n" role="2OqNvi">
@@ -3935,8 +3931,8 @@
                   <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                 </node>
               </node>
-              <node concept="3TrcHB" id="TuTPrvz2h_" role="2OqNvi">
-                <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+              <node concept="2qgKlT" id="SIMVVotzmC" role="2OqNvi">
+                <ref role="37wK5l" node="SIMVVosRGL" resolve="getMinimum" />
               </node>
             </node>
           </node>
@@ -3950,8 +3946,8 @@
                   <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                 </node>
               </node>
-              <node concept="3TrcHB" id="2NHHcg2DhJW" role="2OqNvi">
-                <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+              <node concept="2qgKlT" id="SIMVVotzGE" role="2OqNvi">
+                <ref role="37wK5l" node="SIMVVosRGL" resolve="getMinimum" />
               </node>
             </node>
             <node concept="liA8E" id="2NHHcg2E2L1" role="2OqNvi">
@@ -3987,32 +3983,28 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="6NHlpK$ONU0" role="3cqZAp">
-          <node concept="37vLTI" id="6NHlpK$OP9M" role="3clFbG">
-            <node concept="37vLTw" id="6NHlpK$OPcc" role="37vLTx">
-              <ref role="3cqZAo" node="6NHlpK$OKgK" resolve="min" />
+        <node concept="3clFbF" id="SIMVVotRJv" role="3cqZAp">
+          <node concept="2OqwBi" id="SIMVVotRVv" role="3clFbG">
+            <node concept="37vLTw" id="SIMVVotRJt" role="2Oq$k0">
+              <ref role="3cqZAo" node="6NHlpK$OOzV" resolve="r" />
             </node>
-            <node concept="2OqwBi" id="6NHlpK$OOJ2" role="37vLTJ">
-              <node concept="37vLTw" id="6NHlpK$OO$1" role="2Oq$k0">
-                <ref role="3cqZAo" node="6NHlpK$OOzV" resolve="r" />
-              </node>
-              <node concept="3TrcHB" id="6NHlpK$OOPe" role="2OqNvi">
-                <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+            <node concept="2qgKlT" id="SIMVVotSyD" role="2OqNvi">
+              <ref role="37wK5l" node="SIMVVotJjI" resolve="setMinimum" />
+              <node concept="37vLTw" id="SIMVVotSDi" role="37wK5m">
+                <ref role="3cqZAo" node="6NHlpK$OKgK" resolve="min" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="6NHlpK$OPem" role="3cqZAp">
-          <node concept="37vLTI" id="6NHlpK$OPen" role="3clFbG">
-            <node concept="37vLTw" id="6NHlpK$OPvP" role="37vLTx">
-              <ref role="3cqZAo" node="6NHlpK$OKgM" resolve="max" />
+        <node concept="3clFbF" id="SIMVVotSJU" role="3cqZAp">
+          <node concept="2OqwBi" id="SIMVVotT3p" role="3clFbG">
+            <node concept="37vLTw" id="SIMVVotSJS" role="2Oq$k0">
+              <ref role="3cqZAo" node="6NHlpK$OOzV" resolve="r" />
             </node>
-            <node concept="2OqwBi" id="6NHlpK$OPep" role="37vLTJ">
-              <node concept="37vLTw" id="6NHlpK$OPeq" role="2Oq$k0">
-                <ref role="3cqZAo" node="6NHlpK$OOzV" resolve="r" />
-              </node>
-              <node concept="3TrcHB" id="6NHlpK$OPpC" role="2OqNvi">
-                <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+            <node concept="2qgKlT" id="SIMVVotTq$" role="2OqNvi">
+              <ref role="37wK5l" node="SIMVVotK76" resolve="setMaximum" />
+              <node concept="37vLTw" id="SIMVVotTvY" role="37wK5m">
+                <ref role="3cqZAo" node="6NHlpK$OKgM" resolve="max" />
               </node>
             </node>
           </node>
@@ -4210,15 +4202,15 @@
                   <node concept="1Wc70l" id="2M9Ik4CWQGh" role="3clFbw">
                     <node concept="3y3z36" id="2M9Ik4CWS9s" role="3uHU7w">
                       <node concept="10Nm6u" id="2M9Ik4CWSeq" role="3uHU7w" />
-                      <node concept="2OqwBi" id="2M9Ik4CWRiQ" role="3uHU7B">
-                        <node concept="2OqwBi" id="2M9Ik4CWQRZ" role="2Oq$k0">
-                          <node concept="13iPFW" id="2M9Ik4CWQJh" role="2Oq$k0" />
-                          <node concept="3TrEf2" id="2M9Ik4CWR3a" role="2OqNvi">
+                      <node concept="2OqwBi" id="SIMVVotDZU" role="3uHU7B">
+                        <node concept="2OqwBi" id="SIMVVotD$W" role="2Oq$k0">
+                          <node concept="13iPFW" id="SIMVVotDn4" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="SIMVVotDRr" role="2OqNvi">
                             <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                           </node>
                         </node>
-                        <node concept="3TrcHB" id="2M9Ik4CWRGR" role="2OqNvi">
-                          <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+                        <node concept="2qgKlT" id="SIMVVotEdi" role="2OqNvi">
+                          <ref role="37wK5l" node="SIMVVosRGL" resolve="getMinimum" />
                         </node>
                       </node>
                     </node>
@@ -4234,49 +4226,47 @@
                   </node>
                   <node concept="3clFbS" id="2M9Ik4CWQ6l" role="3clFbx">
                     <node concept="3clFbF" id="2M9Ik4CXifc" role="3cqZAp">
-                      <node concept="37vLTI" id="2M9Ik4CXjtP" role="3clFbG">
-                        <node concept="2OqwBi" id="2M9Ik4CXiVP" role="37vLTJ">
-                          <node concept="2OqwBi" id="2M9Ik4CXinp" role="2Oq$k0">
-                            <node concept="13iPFW" id="2M9Ik4CXifa" role="2Oq$k0" />
-                            <node concept="3TrEf2" id="2M9Ik4CXiI8" role="2OqNvi">
-                              <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
-                            </node>
-                          </node>
-                          <node concept="3TrcHB" id="2M9Ik4CXj5F" role="2OqNvi">
-                            <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+                      <node concept="2OqwBi" id="SIMVVotUMZ" role="3clFbG">
+                        <node concept="2OqwBi" id="SIMVVotU45" role="2Oq$k0">
+                          <node concept="13iPFW" id="SIMVVotTQd" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="SIMVVotUmy" role="2OqNvi">
+                            <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                           </node>
                         </node>
-                        <node concept="2OqwBi" id="6X2fUL7gKHD" role="37vLTx">
-                          <node concept="2OqwBi" id="6X2fUL7gKHE" role="2Oq$k0">
-                            <node concept="2ShNRf" id="6X2fUL7gKHF" role="2Oq$k0">
-                              <node concept="1pGfFk" id="6X2fUL7gKHG" role="2ShVmc">
-                                <ref role="37wK5l" to="xlxw:~BigDecimal.&lt;init&gt;(java.lang.String)" resolve="BigDecimal" />
-                                <node concept="2OqwBi" id="6X2fUL7gKHH" role="37wK5m">
-                                  <node concept="2OqwBi" id="6X2fUL7gKHI" role="2Oq$k0">
-                                    <node concept="13iPFW" id="6X2fUL7gKHJ" role="2Oq$k0" />
-                                    <node concept="3TrEf2" id="6X2fUL7gKHK" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
+                        <node concept="2qgKlT" id="SIMVVotV0n" role="2OqNvi">
+                          <ref role="37wK5l" node="SIMVVotJjI" resolve="setMinimum" />
+                          <node concept="2OqwBi" id="SIMVVotV4M" role="37wK5m">
+                            <node concept="2OqwBi" id="SIMVVotV4N" role="2Oq$k0">
+                              <node concept="2ShNRf" id="SIMVVotV4O" role="2Oq$k0">
+                                <node concept="1pGfFk" id="SIMVVotV4P" role="2ShVmc">
+                                  <ref role="37wK5l" to="xlxw:~BigDecimal.&lt;init&gt;(java.lang.String)" resolve="BigDecimal" />
+                                  <node concept="2OqwBi" id="SIMVVotV4Q" role="37wK5m">
+                                    <node concept="2OqwBi" id="SIMVVotV4R" role="2Oq$k0">
+                                      <node concept="13iPFW" id="SIMVVotV4S" role="2Oq$k0" />
+                                      <node concept="3TrEf2" id="SIMVVotV4T" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
+                                      </node>
                                     </node>
-                                  </node>
-                                  <node concept="3TrcHB" id="6X2fUL7gKHL" role="2OqNvi">
-                                    <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+                                    <node concept="2qgKlT" id="SIMVVotV4U" role="2OqNvi">
+                                      <ref role="37wK5l" node="SIMVVosRGL" resolve="getMinimum" />
+                                    </node>
                                   </node>
                                 </node>
                               </node>
-                            </node>
-                            <node concept="liA8E" id="6X2fUL7gKHM" role="2OqNvi">
-                              <ref role="37wK5l" to="xlxw:~BigDecimal.setScale(int,java.math.RoundingMode)" resolve="setScale" />
-                              <node concept="37vLTw" id="6X2fUL7gKHN" role="37wK5m">
-                                <ref role="3cqZAo" node="6X2fUL7fWSa" resolve="pp" />
+                              <node concept="liA8E" id="SIMVVotV4V" role="2OqNvi">
+                                <ref role="37wK5l" to="xlxw:~BigDecimal.setScale(int,java.math.RoundingMode)" resolve="setScale" />
+                                <node concept="37vLTw" id="SIMVVotV4W" role="37wK5m">
+                                  <ref role="3cqZAo" node="6X2fUL7fWSa" resolve="pp" />
+                                </node>
+                                <node concept="Rm8GO" id="SIMVVotV4X" role="37wK5m">
+                                  <ref role="1Px2BO" to="xlxw:~RoundingMode" resolve="RoundingMode" />
+                                  <ref role="Rm8GQ" to="xlxw:~RoundingMode.FLOOR" resolve="FLOOR" />
+                                </node>
                               </node>
-                              <node concept="Rm8GO" id="6X2fUL7gKHO" role="37wK5m">
-                                <ref role="Rm8GQ" to="xlxw:~RoundingMode.FLOOR" resolve="FLOOR" />
-                                <ref role="1Px2BO" to="xlxw:~RoundingMode" resolve="RoundingMode" />
-                              </node>
                             </node>
-                          </node>
-                          <node concept="liA8E" id="6X2fUL7gKHP" role="2OqNvi">
-                            <ref role="37wK5l" to="xlxw:~BigDecimal.toPlainString()" resolve="toPlainString" />
+                            <node concept="liA8E" id="SIMVVotV4Y" role="2OqNvi">
+                              <ref role="37wK5l" to="xlxw:~BigDecimal.toPlainString()" resolve="toPlainString" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -4287,15 +4277,15 @@
                   <node concept="1Wc70l" id="2M9Ik4CXl9I" role="3clFbw">
                     <node concept="3y3z36" id="2M9Ik4CXl9J" role="3uHU7w">
                       <node concept="10Nm6u" id="2M9Ik4CXl9K" role="3uHU7w" />
-                      <node concept="2OqwBi" id="2M9Ik4CXl9L" role="3uHU7B">
-                        <node concept="2OqwBi" id="2M9Ik4CXl9M" role="2Oq$k0">
-                          <node concept="13iPFW" id="2M9Ik4CXl9N" role="2Oq$k0" />
-                          <node concept="3TrEf2" id="2M9Ik4CXl9O" role="2OqNvi">
+                      <node concept="2OqwBi" id="SIMVVotEna" role="3uHU7B">
+                        <node concept="2OqwBi" id="SIMVVotEnb" role="2Oq$k0">
+                          <node concept="13iPFW" id="SIMVVotEnc" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="SIMVVotEnd" role="2OqNvi">
                             <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                           </node>
                         </node>
-                        <node concept="3TrcHB" id="2M9Ik4CXl$q" role="2OqNvi">
-                          <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+                        <node concept="2qgKlT" id="SIMVVotEne" role="2OqNvi">
+                          <ref role="37wK5l" node="SIMVVosRWc" resolve="getMaximum" />
                         </node>
                       </node>
                     </node>
@@ -4311,49 +4301,47 @@
                   </node>
                   <node concept="3clFbS" id="2M9Ik4CXl9V" role="3clFbx">
                     <node concept="3clFbF" id="2M9Ik4CXl9W" role="3cqZAp">
-                      <node concept="37vLTI" id="2M9Ik4CXl9X" role="3clFbG">
-                        <node concept="2OqwBi" id="2M9Ik4CXl9Y" role="37vLTJ">
-                          <node concept="2OqwBi" id="2M9Ik4CXl9Z" role="2Oq$k0">
-                            <node concept="13iPFW" id="2M9Ik4CXla0" role="2Oq$k0" />
-                            <node concept="3TrEf2" id="2M9Ik4CXla1" role="2OqNvi">
-                              <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
-                            </node>
-                          </node>
-                          <node concept="3TrcHB" id="2M9Ik4CXlOj" role="2OqNvi">
-                            <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+                      <node concept="2OqwBi" id="SIMVVotW6m" role="3clFbG">
+                        <node concept="2OqwBi" id="SIMVVotVFw" role="2Oq$k0">
+                          <node concept="13iPFW" id="SIMVVotVtD" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="SIMVVotVXR" role="2OqNvi">
+                            <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                           </node>
                         </node>
-                        <node concept="2OqwBi" id="6X2fUL7gL57" role="37vLTx">
-                          <node concept="2OqwBi" id="6X2fUL7gL58" role="2Oq$k0">
-                            <node concept="2ShNRf" id="6X2fUL7gL59" role="2Oq$k0">
-                              <node concept="1pGfFk" id="6X2fUL7gL5a" role="2ShVmc">
-                                <ref role="37wK5l" to="xlxw:~BigDecimal.&lt;init&gt;(java.lang.String)" resolve="BigDecimal" />
-                                <node concept="2OqwBi" id="6X2fUL7gL5b" role="37wK5m">
-                                  <node concept="2OqwBi" id="6X2fUL7gL5c" role="2Oq$k0">
-                                    <node concept="13iPFW" id="6X2fUL7gL5d" role="2Oq$k0" />
-                                    <node concept="3TrEf2" id="6X2fUL7gL5e" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
+                        <node concept="2qgKlT" id="SIMVVotWjI" role="2OqNvi">
+                          <ref role="37wK5l" node="SIMVVotK76" resolve="setMaximum" />
+                          <node concept="2OqwBi" id="SIMVVotWo7" role="37wK5m">
+                            <node concept="2OqwBi" id="SIMVVotWo8" role="2Oq$k0">
+                              <node concept="2ShNRf" id="SIMVVotWo9" role="2Oq$k0">
+                                <node concept="1pGfFk" id="SIMVVotWoa" role="2ShVmc">
+                                  <ref role="37wK5l" to="xlxw:~BigDecimal.&lt;init&gt;(java.lang.String)" resolve="BigDecimal" />
+                                  <node concept="2OqwBi" id="SIMVVotWob" role="37wK5m">
+                                    <node concept="2OqwBi" id="SIMVVotWoc" role="2Oq$k0">
+                                      <node concept="13iPFW" id="SIMVVotWod" role="2Oq$k0" />
+                                      <node concept="3TrEf2" id="SIMVVotWoe" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
+                                      </node>
                                     </node>
-                                  </node>
-                                  <node concept="3TrcHB" id="6X2fUL7gL5f" role="2OqNvi">
-                                    <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+                                    <node concept="2qgKlT" id="SIMVVotWof" role="2OqNvi">
+                                      <ref role="37wK5l" node="SIMVVosRWc" resolve="getMaximum" />
+                                    </node>
                                   </node>
                                 </node>
                               </node>
-                            </node>
-                            <node concept="liA8E" id="6X2fUL7gL5g" role="2OqNvi">
-                              <ref role="37wK5l" to="xlxw:~BigDecimal.setScale(int,java.math.RoundingMode)" resolve="setScale" />
-                              <node concept="37vLTw" id="6X2fUL7gL5h" role="37wK5m">
-                                <ref role="3cqZAo" node="6X2fUL7fWSa" resolve="pp" />
+                              <node concept="liA8E" id="SIMVVotWog" role="2OqNvi">
+                                <ref role="37wK5l" to="xlxw:~BigDecimal.setScale(int,java.math.RoundingMode)" resolve="setScale" />
+                                <node concept="37vLTw" id="SIMVVotWoh" role="37wK5m">
+                                  <ref role="3cqZAo" node="6X2fUL7fWSa" resolve="pp" />
+                                </node>
+                                <node concept="Rm8GO" id="SIMVVotWoi" role="37wK5m">
+                                  <ref role="Rm8GQ" to="xlxw:~RoundingMode.FLOOR" resolve="FLOOR" />
+                                  <ref role="1Px2BO" to="xlxw:~RoundingMode" resolve="RoundingMode" />
+                                </node>
                               </node>
-                              <node concept="Rm8GO" id="6X2fUL7gL5i" role="37wK5m">
-                                <ref role="1Px2BO" to="xlxw:~RoundingMode" resolve="RoundingMode" />
-                                <ref role="Rm8GQ" to="xlxw:~RoundingMode.FLOOR" resolve="FLOOR" />
-                              </node>
                             </node>
-                          </node>
-                          <node concept="liA8E" id="6X2fUL7gL5j" role="2OqNvi">
-                            <ref role="37wK5l" to="xlxw:~BigDecimal.toPlainString()" resolve="toPlainString" />
+                            <node concept="liA8E" id="SIMVVotWoj" role="2OqNvi">
+                              <ref role="37wK5l" to="xlxw:~BigDecimal.toPlainString()" resolve="toPlainString" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -4754,8 +4742,8 @@
                       <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                     </node>
                   </node>
-                  <node concept="3TrcHB" id="3Up1DZuQGnD" role="2OqNvi">
-                    <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+                  <node concept="2qgKlT" id="SIMVVotWTG" role="2OqNvi">
+                    <ref role="37wK5l" node="SIMVVosRGL" resolve="getMinimum" />
                   </node>
                 </node>
                 <node concept="2OqwBi" id="3Up1DZuQJn2" role="3uHU7w">
@@ -4767,8 +4755,8 @@
                       <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                     </node>
                   </node>
-                  <node concept="3TrcHB" id="3Up1DZuQJzj" role="2OqNvi">
-                    <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+                  <node concept="2qgKlT" id="SIMVVotX55" role="2OqNvi">
+                    <ref role="37wK5l" node="SIMVVosRGL" resolve="getMinimum" />
                   </node>
                 </node>
               </node>
@@ -4783,8 +4771,8 @@
                     <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                   </node>
                 </node>
-                <node concept="3TrcHB" id="3Up1DZuQKjv" role="2OqNvi">
-                  <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+                <node concept="2qgKlT" id="SIMVVotXjW" role="2OqNvi">
+                  <ref role="37wK5l" node="SIMVVosRWc" resolve="getMaximum" />
                 </node>
               </node>
               <node concept="2OqwBi" id="3Up1DZuQK6x" role="3uHU7B">
@@ -4794,8 +4782,8 @@
                     <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                   </node>
                 </node>
-                <node concept="3TrcHB" id="3Up1DZuQKvY" role="2OqNvi">
-                  <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+                <node concept="2qgKlT" id="SIMVVotX85" role="2OqNvi">
+                  <ref role="37wK5l" node="SIMVVosRWc" resolve="getMaximum" />
                 </node>
               </node>
             </node>
@@ -5631,17 +5619,11 @@
           <node concept="2YIFZM" id="3tudP___IM$" role="3cqZAk">
             <ref role="1Pybhc" to="oq0c:2NHHcg2EXna" resolve="InfHelper" />
             <ref role="37wK5l" to="oq0c:2NHHcg2F41V" resolve="lessOrEq" />
-            <node concept="2OqwBi" id="3tudP___J8g" role="37wK5m">
-              <node concept="13iPFW" id="3tudP___IZf" role="2Oq$k0" />
-              <node concept="3TrcHB" id="3tudP___Jfn" role="2OqNvi">
-                <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
-              </node>
+            <node concept="BsUDl" id="SIMVVosV9h" role="37wK5m">
+              <ref role="37wK5l" node="SIMVVosRGL" resolve="getMinimum" />
             </node>
-            <node concept="2OqwBi" id="3tudP___Jrp" role="37wK5m">
-              <node concept="13iPFW" id="3tudP___Jiq" role="2Oq$k0" />
-              <node concept="3TrcHB" id="3tudP___JDO" role="2OqNvi">
-                <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
-              </node>
+            <node concept="BsUDl" id="SIMVVosVgd" role="37wK5m">
+              <ref role="37wK5l" node="SIMVVosRWc" resolve="getMaximum" />
             </node>
           </node>
         </node>
@@ -5657,20 +5639,208 @@
             <node concept="2YIFZM" id="1YvLuAYqMr" role="3uHU7w">
               <ref role="37wK5l" to="oq0c:6W9pdfOfpYl" resolve="isPosInf" />
               <ref role="1Pybhc" to="oq0c:2NHHcg2EXna" resolve="InfHelper" />
-              <node concept="2OqwBi" id="1YvLuAYr3k" role="37wK5m">
-                <node concept="13iPFW" id="1YvLuAYqSl" role="2Oq$k0" />
-                <node concept="3TrcHB" id="1YvLuAYrh2" role="2OqNvi">
-                  <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
-                </node>
+              <node concept="BsUDl" id="SIMVVosVPP" role="37wK5m">
+                <ref role="37wK5l" node="SIMVVosRWc" resolve="getMaximum" />
               </node>
             </node>
             <node concept="2YIFZM" id="1YvLuAYpF7" role="3uHU7B">
               <ref role="37wK5l" to="oq0c:1YvLuAXO50" resolve="isNegInf" />
               <ref role="1Pybhc" to="oq0c:2NHHcg2EXna" resolve="InfHelper" />
-              <node concept="2OqwBi" id="1YvLuAYpU0" role="37wK5m">
-                <node concept="13iPFW" id="1YvLuAYpLi" role="2Oq$k0" />
-                <node concept="3TrcHB" id="1YvLuAYq2v" role="2OqNvi">
+              <node concept="BsUDl" id="SIMVVosVMK" role="37wK5m">
+                <ref role="37wK5l" node="SIMVVosRGL" resolve="getMinimum" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="SIMVVotJjI" role="13h7CS">
+      <property role="TrG5h" value="setMinimum" />
+      <node concept="3Tm1VV" id="SIMVVotJjJ" role="1B3o_S" />
+      <node concept="3cqZAl" id="SIMVVotJsc" role="3clF45" />
+      <node concept="3clFbS" id="SIMVVotJjL" role="3clF47">
+        <node concept="3clFbF" id="SIMVVotJsT" role="3cqZAp">
+          <node concept="37vLTI" id="SIMVVotK20" role="3clFbG">
+            <node concept="37vLTw" id="SIMVVotK2q" role="37vLTx">
+              <ref role="3cqZAo" node="SIMVVotJsw" resolve="val" />
+            </node>
+            <node concept="2OqwBi" id="SIMVVotJ$L" role="37vLTJ">
+              <node concept="13iPFW" id="SIMVVotJsS" role="2Oq$k0" />
+              <node concept="3TrcHB" id="SIMVVotJHv" role="2OqNvi">
+                <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="SIMVVotJsw" role="3clF46">
+        <property role="TrG5h" value="val" />
+        <node concept="17QB3L" id="SIMVVotJsv" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="SIMVVosRGL" role="13h7CS">
+      <property role="TrG5h" value="getMinimum" />
+      <node concept="3Tm1VV" id="SIMVVosRGM" role="1B3o_S" />
+      <node concept="17QB3L" id="SIMVVosRO0" role="3clF45" />
+      <node concept="3clFbS" id="SIMVVosRGO" role="3clF47">
+        <node concept="3cpWs8" id="SIMVVosS4R" role="3cqZAp">
+          <node concept="3cpWsn" id="SIMVVosS4S" role="3cpWs9">
+            <property role="TrG5h" value="testNumber" />
+            <node concept="3Tqbb2" id="SIMVVosRPa" role="1tU5fm">
+              <ref role="ehGHo" to="5qo5:4rZeNQ6Oerq" resolve="NumberLiteral" />
+            </node>
+            <node concept="2ShNRf" id="SIMVVosS4T" role="33vP2m">
+              <node concept="3zrR0B" id="SIMVVosS4U" role="2ShVmc">
+                <node concept="3Tqbb2" id="SIMVVosS4V" role="3zrR0E">
+                  <ref role="ehGHo" to="5qo5:4rZeNQ6Oerq" resolve="NumberLiteral" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="SIMVVosS3I" role="3cqZAp">
+          <node concept="3clFbS" id="SIMVVosS3K" role="3clFbx">
+            <node concept="3cpWs6" id="SIMVVosTst" role="3cqZAp">
+              <node concept="2OqwBi" id="SIMVVosE9Z" role="3cqZAk">
+                <node concept="2OqwBi" id="SIMVVosAx8" role="2Oq$k0">
+                  <node concept="37vLTw" id="SIMVVosS4W" role="2Oq$k0">
+                    <ref role="3cqZAo" node="SIMVVosS4S" resolve="testNumber" />
+                  </node>
+                  <node concept="2qgKlT" id="SIMVVosCbj" role="2OqNvi">
+                    <ref role="37wK5l" node="2oUyrt$Tg3c" resolve="set" />
+                    <node concept="2OqwBi" id="SIMVVosUhl" role="37wK5m">
+                      <node concept="13iPFW" id="SIMVVosTDF" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="SIMVVosUiT" role="2OqNvi">
+                        <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="SIMVVosGO3" role="2OqNvi">
+                  <ref role="37wK5l" node="2oUyrt$QPvb" resolve="valueWithDotInsteadOfComma" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="SIMVVosSAr" role="3clFbw">
+            <node concept="37vLTw" id="SIMVVosSiF" role="2Oq$k0">
+              <ref role="3cqZAo" node="SIMVVosS4S" resolve="testNumber" />
+            </node>
+            <node concept="2qgKlT" id="SIMVVosSZn" role="2OqNvi">
+              <ref role="37wK5l" node="SIMVVorXi8" resolve="isValidNumber" />
+              <node concept="2OqwBi" id="SIMVVosThf" role="37wK5m">
+                <node concept="13iPFW" id="SIMVVosT8J" role="2Oq$k0" />
+                <node concept="3TrcHB" id="SIMVVosTri" role="2OqNvi">
                   <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="SIMVVosTFR" role="9aQIa">
+            <node concept="3clFbS" id="SIMVVosTFS" role="9aQI4">
+              <node concept="3cpWs6" id="SIMVVosTPs" role="3cqZAp">
+                <node concept="2OqwBi" id="SIMVVosTY7" role="3cqZAk">
+                  <node concept="13iPFW" id="SIMVVosTPx" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="SIMVVosU7E" role="2OqNvi">
+                    <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="SIMVVotK76" role="13h7CS">
+      <property role="TrG5h" value="setMaximum" />
+      <node concept="3Tm1VV" id="SIMVVotK77" role="1B3o_S" />
+      <node concept="3cqZAl" id="SIMVVotKoz" role="3clF45" />
+      <node concept="3clFbS" id="SIMVVotK79" role="3clF47">
+        <node concept="3clFbF" id="SIMVVotKp6" role="3cqZAp">
+          <node concept="37vLTI" id="SIMVVotL4y" role="3clFbG">
+            <node concept="37vLTw" id="SIMVVotL4W" role="37vLTx">
+              <ref role="3cqZAo" node="SIMVVotKoR" resolve="val" />
+            </node>
+            <node concept="2OqwBi" id="SIMVVotKwY" role="37vLTJ">
+              <node concept="13iPFW" id="SIMVVotKp5" role="2Oq$k0" />
+              <node concept="3TrcHB" id="SIMVVotKDy" role="2OqNvi">
+                <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="SIMVVotKoR" role="3clF46">
+        <property role="TrG5h" value="val" />
+        <node concept="17QB3L" id="SIMVVotKoQ" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="SIMVVosRWc" role="13h7CS">
+      <property role="TrG5h" value="getMaximum" />
+      <node concept="3Tm1VV" id="SIMVVosRWd" role="1B3o_S" />
+      <node concept="17QB3L" id="SIMVVosS2u" role="3clF45" />
+      <node concept="3clFbS" id="SIMVVosRWf" role="3clF47">
+        <node concept="3cpWs8" id="SIMVVosU_7" role="3cqZAp">
+          <node concept="3cpWsn" id="SIMVVosU_8" role="3cpWs9">
+            <property role="TrG5h" value="testNumber" />
+            <node concept="3Tqbb2" id="SIMVVosU_9" role="1tU5fm">
+              <ref role="ehGHo" to="5qo5:4rZeNQ6Oerq" resolve="NumberLiteral" />
+            </node>
+            <node concept="2ShNRf" id="SIMVVosU_a" role="33vP2m">
+              <node concept="3zrR0B" id="SIMVVosU_b" role="2ShVmc">
+                <node concept="3Tqbb2" id="SIMVVosU_c" role="3zrR0E">
+                  <ref role="ehGHo" to="5qo5:4rZeNQ6Oerq" resolve="NumberLiteral" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="SIMVVosU_d" role="3cqZAp">
+          <node concept="3clFbS" id="SIMVVosU_e" role="3clFbx">
+            <node concept="3cpWs6" id="SIMVVosU_f" role="3cqZAp">
+              <node concept="2OqwBi" id="SIMVVosU_g" role="3cqZAk">
+                <node concept="2OqwBi" id="SIMVVosU_h" role="2Oq$k0">
+                  <node concept="37vLTw" id="SIMVVosU_i" role="2Oq$k0">
+                    <ref role="3cqZAo" node="SIMVVosU_8" resolve="testNumber" />
+                  </node>
+                  <node concept="2qgKlT" id="SIMVVosU_j" role="2OqNvi">
+                    <ref role="37wK5l" node="2oUyrt$Tg3c" resolve="set" />
+                    <node concept="2OqwBi" id="SIMVVosU_k" role="37wK5m">
+                      <node concept="13iPFW" id="SIMVVosU_l" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="SIMVVosU_m" role="2OqNvi">
+                        <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="SIMVVosU_n" role="2OqNvi">
+                  <ref role="37wK5l" node="2oUyrt$QPvb" resolve="valueWithDotInsteadOfComma" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="SIMVVosU_o" role="3clFbw">
+            <node concept="37vLTw" id="SIMVVosU_p" role="2Oq$k0">
+              <ref role="3cqZAo" node="SIMVVosU_8" resolve="testNumber" />
+            </node>
+            <node concept="2qgKlT" id="SIMVVosU_q" role="2OqNvi">
+              <ref role="37wK5l" node="SIMVVorXi8" resolve="isValidNumber" />
+              <node concept="2OqwBi" id="SIMVVosU_r" role="37wK5m">
+                <node concept="13iPFW" id="SIMVVosU_s" role="2Oq$k0" />
+                <node concept="3TrcHB" id="SIMVVosU_t" role="2OqNvi">
+                  <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="SIMVVosU_u" role="9aQIa">
+            <node concept="3clFbS" id="SIMVVosU_v" role="9aQI4">
+              <node concept="3cpWs6" id="SIMVVosU_w" role="3cqZAp">
+                <node concept="2OqwBi" id="SIMVVosU_x" role="3cqZAk">
+                  <node concept="13iPFW" id="SIMVVosU_y" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="SIMVVosU_z" role="2OqNvi">
+                    <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+                  </node>
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
@@ -190,6 +190,7 @@
         <child id="8276990574895933173" name="catchBody" index="1zc67A" />
         <child id="8276990574895933172" name="throwable" index="1zc67B" />
       </concept>
+      <concept id="7024111702304501416" name="jetbrains.mps.baseLanguage.structure.OrAssignmentExpression" flags="nn" index="3vZ8r8" />
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
@@ -448,46 +449,42 @@
       <node concept="3Tm1VV" id="4rZeNQ6Og4s" role="1B3o_S" />
       <node concept="10P_77" id="4rZeNQ6Og4t" role="3clF45" />
       <node concept="3clFbS" id="4rZeNQ6Og4u" role="3clF47">
-        <node concept="3cpWs6" id="6Mx2TmozOFg" role="3cqZAp">
-          <node concept="22lmx$" id="SIMVVoecA7" role="3cqZAk">
-            <node concept="BsUDl" id="SIMVVoecF$" role="3uHU7w">
-              <ref role="37wK5l" node="SIMVVoeaaM" resolve="isHexadecimal" />
-              <node concept="37vLTw" id="SIMVVoecQW" role="37wK5m">
-                <ref role="3cqZAo" node="4rZeNQ6Ogz6" resolve="val" />
-              </node>
-            </node>
-            <node concept="1eOMI4" id="SIMVVoeceT" role="3uHU7B">
-              <node concept="1Wc70l" id="6Mx2TmozOFh" role="1eOMHV">
-                <node concept="3y3z36" id="6Mx2TmozOFi" role="3uHU7B">
-                  <node concept="10Nm6u" id="6Mx2TmozOFj" role="3uHU7w" />
-                  <node concept="37vLTw" id="6Mx2TmozOFk" role="3uHU7B">
+        <node concept="3cpWs8" id="4NJAaUg4M3B" role="3cqZAp">
+          <node concept="3cpWsn" id="4NJAaUg4M3C" role="3cpWs9">
+            <property role="TrG5h" value="isInteger" />
+            <node concept="10P_77" id="4NJAaUg4KBh" role="1tU5fm" />
+            <node concept="1eOMI4" id="4NJAaUg4M3D" role="33vP2m">
+              <node concept="1Wc70l" id="4NJAaUg4M3E" role="1eOMHV">
+                <node concept="3y3z36" id="4NJAaUg4M3F" role="3uHU7B">
+                  <node concept="10Nm6u" id="4NJAaUg4M3G" role="3uHU7w" />
+                  <node concept="37vLTw" id="4NJAaUg4M3H" role="3uHU7B">
                     <ref role="3cqZAo" node="4rZeNQ6Ogz6" resolve="val" />
                   </node>
                 </node>
-                <node concept="2OqwBi" id="6Mx2TmozOFl" role="3uHU7w">
-                  <node concept="37vLTw" id="6Mx2TmozOFm" role="2Oq$k0">
+                <node concept="2OqwBi" id="4NJAaUg4M3I" role="3uHU7w">
+                  <node concept="37vLTw" id="4NJAaUg4M3J" role="2Oq$k0">
                     <ref role="3cqZAo" node="4rZeNQ6Ogz6" resolve="val" />
                   </node>
-                  <node concept="2kpEY9" id="6Mx2TmozOFn" role="2OqNvi">
-                    <node concept="1Qi9sc" id="6Mx2TmozOFo" role="1YN4dH">
-                      <node concept="1OJ37Q" id="6Mx2TmozOFp" role="1QigWp">
-                        <node concept="1OJ37Q" id="6Mx2TmozOFq" role="1OLpdg">
-                          <node concept="1SSJmt" id="6Mx2TmozOFr" role="1OLqdY">
-                            <node concept="1T8lYq" id="6Mx2TmozOFs" role="1T5LoC">
+                  <node concept="2kpEY9" id="4NJAaUg4M3K" role="2OqNvi">
+                    <node concept="1Qi9sc" id="4NJAaUg4M3L" role="1YN4dH">
+                      <node concept="1OJ37Q" id="4NJAaUg4M3M" role="1QigWp">
+                        <node concept="1OJ37Q" id="4NJAaUg4M3N" role="1OLpdg">
+                          <node concept="1SSJmt" id="4NJAaUg4M3O" role="1OLqdY">
+                            <node concept="1T8lYq" id="4NJAaUg4M3P" role="1T5LoC">
                               <property role="1T8p8b" value="1" />
                               <property role="1T8pRJ" value="9" />
                             </node>
                           </node>
-                          <node concept="1P8g2x" id="6Mx2TmozOFt" role="1OLpdg">
-                            <node concept="1SLe3L" id="6Mx2TmozOFu" role="1P8hpE">
-                              <node concept="1OC9wW" id="6Mx2TmozOFv" role="1OLDsb">
+                          <node concept="1P8g2x" id="4NJAaUg4M3Q" role="1OLpdg">
+                            <node concept="1SLe3L" id="4NJAaUg4M3R" role="1P8hpE">
+                              <node concept="1OC9wW" id="4NJAaUg4M3S" role="1OLDsb">
                                 <property role="1OCb_u" value="-" />
                               </node>
                             </node>
                           </node>
                         </node>
-                        <node concept="1OCmVF" id="6Mx2TmozOFw" role="1OLqdY">
-                          <node concept="1SYyG9" id="6Mx2TmozOFx" role="1OLDsb">
+                        <node concept="1OCmVF" id="4NJAaUg4M3T" role="1OLqdY">
+                          <node concept="1SYyG9" id="4NJAaUg4M3U" role="1OLDsb">
                             <ref role="1SYXPG" to="tpfp:h5SUwpi" resolve="\d" />
                           </node>
                         </node>
@@ -497,6 +494,32 @@
                 </node>
               </node>
             </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4NJAaUg4M$H" role="3cqZAp">
+          <node concept="3clFbS" id="4NJAaUg4M$J" role="3clFbx">
+            <node concept="3clFbF" id="4NJAaUg50Wv" role="3cqZAp">
+              <node concept="3vZ8r8" id="4NJAaUg512$" role="3clFbG">
+                <node concept="BsUDl" id="4NJAaUg518C" role="37vLTx">
+                  <ref role="37wK5l" node="SIMVVoeaaM" resolve="isHexadecimal" />
+                  <node concept="37vLTw" id="4NJAaUg51so" role="37wK5m">
+                    <ref role="3cqZAo" node="4rZeNQ6Ogz6" resolve="val" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="4NJAaUg50Wu" role="37vLTJ">
+                  <ref role="3cqZAo" node="4NJAaUg4M3C" resolve="isInteger" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2YIFZM" id="4NJAaUg4ZNz" role="3clFbw">
+            <ref role="37wK5l" to="xfg9:4NJAaUg4P5X" resolve="allowHexadecimalNumbers" />
+            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="4NJAaUg51Ja" role="3cqZAp">
+          <node concept="37vLTw" id="4NJAaUg51Pz" role="3cqZAk">
+            <ref role="3cqZAo" node="4NJAaUg4M3C" resolve="isInteger" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
@@ -519,8 +519,17 @@
               <node concept="2kpEY9" id="SIMVVoebv8" role="2OqNvi">
                 <node concept="1Qi9sc" id="SIMVVoebva" role="1YN4dH">
                   <node concept="1OJ37Q" id="SIMVVoegyE" role="1QigWp">
-                    <node concept="1OC9wW" id="SIMVVoegyZ" role="1OLpdg">
-                      <property role="1OCb_u" value="0x" />
+                    <node concept="1OJ37Q" id="7yYa0tu$7T7" role="1OLpdg">
+                      <node concept="1OC9wW" id="SIMVVoegyZ" role="1OLqdY">
+                        <property role="1OCb_u" value="0x" />
+                      </node>
+                      <node concept="1P8g2x" id="7yYa0tu$7Ty" role="1OLpdg">
+                        <node concept="1SLe3L" id="7yYa0tu$7Tz" role="1P8hpE">
+                          <node concept="1OC9wW" id="7yYa0tu$7T$" role="1OLDsb">
+                            <property role="1OCb_u" value="-" />
+                          </node>
+                        </node>
+                      </node>
                     </node>
                     <node concept="1OClNT" id="SIMVVongWG" role="1OLqdY">
                       <node concept="1P8g2x" id="SIMVVongWi" role="1OLDsb">
@@ -1095,9 +1104,20 @@
       <node concept="17QB3L" id="2oUyrt$QPLM" role="3clF45" />
       <node concept="3clFbS" id="2oUyrt$QPve" role="3clF47">
         <node concept="3clFbJ" id="2oUyrt$QQ1o" role="3cqZAp">
-          <node concept="2YIFZM" id="2oUyrt$QQad" role="3clFbw">
-            <ref role="37wK5l" to="xfg9:2oUyrt$QKcQ" resolve="useCommaInsteadOfDotForDecimals" />
-            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+          <node concept="1Wc70l" id="7yYa0tu_iY_" role="3clFbw">
+            <node concept="BsUDl" id="7yYa0tu_j5M" role="3uHU7w">
+              <ref role="37wK5l" node="4rZeNQ6Og7j" resolve="isReal" />
+              <node concept="2OqwBi" id="7yYa0tu_kMb" role="37wK5m">
+                <node concept="13iPFW" id="7yYa0tu_kpx" role="2Oq$k0" />
+                <node concept="3TrcHB" id="7yYa0tu_lfJ" role="2OqNvi">
+                  <ref role="3TsBF5" to="5qo5:4rZeNQ6Oert" resolve="value" />
+                </node>
+              </node>
+            </node>
+            <node concept="2YIFZM" id="2oUyrt$QQad" role="3uHU7B">
+              <ref role="37wK5l" to="xfg9:2oUyrt$QKcQ" resolve="useCommaInsteadOfDotForDecimals" />
+              <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+            </node>
           </node>
           <node concept="3clFbS" id="2oUyrt$QQ1q" role="3clFbx">
             <node concept="3cpWs6" id="2oUyrt$QQfi" role="3cqZAp">
@@ -1124,6 +1144,66 @@
             <node concept="3clFbS" id="2oUyrt$QT7S" role="9aQI4">
               <node concept="3clFbJ" id="SIMVVofFp4" role="3cqZAp">
                 <node concept="3clFbS" id="SIMVVofFp6" role="3clFbx">
+                  <node concept="3cpWs8" id="7yYa0tu_Q2r" role="3cqZAp">
+                    <node concept="3cpWsn" id="7yYa0tu_Q2u" role="3cpWs9">
+                      <property role="TrG5h" value="hexNumber" />
+                      <node concept="17QB3L" id="7yYa0tu_Q2p" role="1tU5fm" />
+                      <node concept="3K4zz7" id="7yYa0tu_Vuq" role="33vP2m">
+                        <node concept="3cpWs3" id="7yYa0tu_Xbw" role="3K4E3e">
+                          <node concept="2OqwBi" id="7yYa0tu_XVf" role="3uHU7w">
+                            <node concept="2OqwBi" id="7yYa0tu_XIl" role="2Oq$k0">
+                              <node concept="13iPFW" id="7yYa0tu_XhH" role="2Oq$k0" />
+                              <node concept="3TrcHB" id="7yYa0tu_XQp" role="2OqNvi">
+                                <ref role="3TsBF5" to="5qo5:4rZeNQ6Oert" resolve="value" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="7yYa0tu_Zvz" role="2OqNvi">
+                              <ref role="37wK5l" to="wyt6:~String.substring(int)" resolve="substring" />
+                              <node concept="3cmrfG" id="7yYa0tu_ZBg" role="37wK5m">
+                                <property role="3cmrfH" value="3" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Xl_RD" id="7yYa0tu_WNH" role="3uHU7B">
+                            <property role="Xl_RC" value="-" />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="7yYa0tuA28L" role="3K4GZi">
+                          <node concept="2OqwBi" id="7yYa0tuA1DG" role="2Oq$k0">
+                            <node concept="13iPFW" id="7yYa0tu_ZTs" role="2Oq$k0" />
+                            <node concept="3TrcHB" id="7yYa0tuA1Mj" role="2OqNvi">
+                              <ref role="3TsBF5" to="5qo5:4rZeNQ6Oert" resolve="value" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="7yYa0tuA2h0" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~String.substring(int)" resolve="substring" />
+                            <node concept="3cmrfG" id="7yYa0tuA2oX" role="37wK5m">
+                              <property role="3cmrfH" value="2" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbC" id="7yYa0tu_Ukb" role="3K4Cdx">
+                          <node concept="1Xhbcc" id="7yYa0tu_UuF" role="3uHU7w">
+                            <property role="1XhdNS" value="-" />
+                          </node>
+                          <node concept="2OqwBi" id="7yYa0tu_RXB" role="3uHU7B">
+                            <node concept="2OqwBi" id="7yYa0tu_RXC" role="2Oq$k0">
+                              <node concept="13iPFW" id="7yYa0tu_RXD" role="2Oq$k0" />
+                              <node concept="3TrcHB" id="7yYa0tu_RXE" role="2OqNvi">
+                                <ref role="3TsBF5" to="5qo5:4rZeNQ6Oert" resolve="value" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="7yYa0tu_RXF" role="2OqNvi">
+                              <ref role="37wK5l" to="wyt6:~String.charAt(int)" resolve="charAt" />
+                              <node concept="3cmrfG" id="7yYa0tu_RXG" role="37wK5m">
+                                <property role="3cmrfH" value="0" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
                   <node concept="3cpWs6" id="SIMVVofGhB" role="3cqZAp">
                     <node concept="2YIFZM" id="SIMVVofUO8" role="3cqZAk">
                       <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
@@ -1131,19 +1211,8 @@
                       <node concept="2YIFZM" id="SIMVVofKVo" role="37wK5m">
                         <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
                         <ref role="37wK5l" to="wyt6:~Integer.parseInt(java.lang.String,int)" resolve="parseInt" />
-                        <node concept="2OqwBi" id="SIMVVofKVp" role="37wK5m">
-                          <node concept="2OqwBi" id="SIMVVofKVq" role="2Oq$k0">
-                            <node concept="13iPFW" id="SIMVVofKVr" role="2Oq$k0" />
-                            <node concept="3TrcHB" id="SIMVVofKVs" role="2OqNvi">
-                              <ref role="3TsBF5" to="5qo5:4rZeNQ6Oert" resolve="value" />
-                            </node>
-                          </node>
-                          <node concept="liA8E" id="SIMVVofKVt" role="2OqNvi">
-                            <ref role="37wK5l" to="wyt6:~String.substring(int)" resolve="substring" />
-                            <node concept="3cmrfG" id="SIMVVofKVu" role="37wK5m">
-                              <property role="3cmrfH" value="2" />
-                            </node>
-                          </node>
+                        <node concept="37vLTw" id="7yYa0tuA4iF" role="37wK5m">
+                          <ref role="3cqZAo" node="7yYa0tu_Q2u" resolve="hexNumber" />
                         </node>
                         <node concept="3cmrfG" id="SIMVVopZBa" role="37wK5m">
                           <property role="3cmrfH" value="16" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/constraints.mps
@@ -15,7 +15,6 @@
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
@@ -202,30 +201,12 @@
       <ref role="EomxK" to="5qo5:4rZeNQ6Oert" resolve="value" />
       <node concept="QB0g5" id="4rZeNQ6Oeyt" role="QCWH9">
         <node concept="3clFbS" id="4rZeNQ6Oeyu" role="2VODD2">
-          <node concept="3clFbF" id="4rZeNQ6OgE7" role="3cqZAp">
-            <node concept="22lmx$" id="4rZeNQ6Ohmk" role="3clFbG">
-              <node concept="2OqwBi" id="4rZeNQ6Ohvd" role="3uHU7w">
-                <node concept="EsrRn" id="4rZeNQ6Ohq_" role="2Oq$k0" />
-                <node concept="2qgKlT" id="4rZeNQ6OhC4" role="2OqNvi">
-                  <ref role="37wK5l" to="b1h1:4rZeNQ6Og7j" resolve="isReal" />
-                  <node concept="1Wqviy" id="4rZeNQ6OhG7" role="37wK5m" />
-                </node>
-              </node>
-              <node concept="22lmx$" id="4rZeNQ6OgXk" role="3uHU7B">
-                <node concept="2OqwBi" id="4rZeNQ6OgH$" role="3uHU7B">
-                  <node concept="EsrRn" id="4rZeNQ6OgE5" role="2Oq$k0" />
-                  <node concept="2qgKlT" id="4rZeNQ6OgP5" role="2OqNvi">
-                    <ref role="37wK5l" to="b1h1:4rZeNQ6OfoS" resolve="isZero" />
-                    <node concept="1Wqviy" id="4rZeNQ6OgSh" role="37wK5m" />
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="4rZeNQ6Oh5c" role="3uHU7w">
-                  <node concept="EsrRn" id="4rZeNQ6Oh0W" role="2Oq$k0" />
-                  <node concept="2qgKlT" id="4rZeNQ6Ohdd" role="2OqNvi">
-                    <ref role="37wK5l" to="b1h1:4rZeNQ6Og4r" resolve="isInteger" />
-                    <node concept="1Wqviy" id="4rZeNQ6OhgP" role="37wK5m" />
-                  </node>
-                </node>
+          <node concept="3clFbF" id="SIMVVorYsz" role="3cqZAp">
+            <node concept="2OqwBi" id="SIMVVorYJO" role="3clFbG">
+              <node concept="EsrRn" id="SIMVVorYsy" role="2Oq$k0" />
+              <node concept="2qgKlT" id="SIMVVorZoT" role="2OqNvi">
+                <ref role="37wK5l" to="b1h1:SIMVVorXi8" resolve="isValidNumber" />
+                <node concept="1Wqviy" id="SIMVVorZqI" role="37wK5m" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/constraints.mps
@@ -37,6 +37,9 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
@@ -125,6 +128,11 @@
         <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
         <child id="8276990574886367508" name="body" index="1zxBo7" />
       </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="1200397529627" name="jetbrains.mps.baseLanguage.structure.CharConstant" flags="nn" index="1Xhbcc">
         <property id="1200397540847" name="charConstant" index="1XhdNS" />
@@ -177,12 +185,12 @@
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
+      <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
+        <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
-      </concept>
-      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
-        <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -446,52 +454,34 @@
       <ref role="EomxK" to="5qo5:19PglA20qXK" resolve="max" />
       <node concept="1LLf8_" id="3tudP___pej" role="1LXaQT">
         <node concept="3clFbS" id="3tudP___pek" role="2VODD2">
-          <node concept="3clFbJ" id="3tudP___qrr" role="3cqZAp">
-            <node concept="3clFbS" id="3tudP___qrt" role="3clFbx">
-              <node concept="3clFbF" id="3tudP___rvG" role="3cqZAp">
-                <node concept="37vLTI" id="3tudP___s5B" role="3clFbG">
-                  <node concept="10M0yZ" id="3tudP___sgV" role="37vLTx">
-                    <ref role="1PxDUh" to="oq0c:2NHHcg2EXna" resolve="InfHelper" />
-                    <ref role="3cqZAo" to="oq0c:2NHHcg2FYHt" resolve="POSINF" />
-                  </node>
-                  <node concept="2OqwBi" id="3tudP___rAG" role="37vLTJ">
-                    <node concept="EsrRn" id="3tudP___rvD" role="2Oq$k0" />
-                    <node concept="3TrcHB" id="3tudP___rH0" role="2OqNvi">
-                      <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="2OqwBi" id="3tudP___r2$" role="3clFbw">
-              <node concept="1Wqviy" id="3tudP___qHm" role="2Oq$k0" />
-              <node concept="liA8E" id="3tudP___rtO" role="2OqNvi">
-                <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                <node concept="Xl_RD" id="3tudP___rtU" role="37wK5m">
-                  <property role="Xl_RC" value="inf" />
-                </node>
-              </node>
-            </node>
-            <node concept="9aQIb" id="3tudP___ssw" role="9aQIa">
-              <node concept="3clFbS" id="3tudP___ssx" role="9aQI4">
-                <node concept="3clFbF" id="3tudP___svW" role="3cqZAp">
-                  <node concept="37vLTI" id="3tudP___t3V" role="3clFbG">
-                    <node concept="2OqwBi" id="3tudP___sAW" role="37vLTJ">
-                      <node concept="EsrRn" id="3tudP___svV" role="2Oq$k0" />
-                      <node concept="3TrcHB" id="3tudP___sHd" role="2OqNvi">
-                        <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+          <node concept="3clFbF" id="SIMVVou57d" role="3cqZAp">
+            <node concept="2OqwBi" id="SIMVVou5c2" role="3clFbG">
+              <node concept="EsrRn" id="SIMVVou57c" role="2Oq$k0" />
+              <node concept="2qgKlT" id="SIMVVou5hA" role="2OqNvi">
+                <ref role="37wK5l" to="b1h1:SIMVVotK76" resolve="setMaximum" />
+                <node concept="3K4zz7" id="SIMVVou5Ac" role="37wK5m">
+                  <node concept="2OqwBi" id="SIMVVou5jB" role="3K4Cdx">
+                    <node concept="1Wqviy" id="SIMVVou5jC" role="2Oq$k0" />
+                    <node concept="liA8E" id="SIMVVou5jD" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                      <node concept="Xl_RD" id="SIMVVou5jE" role="37wK5m">
+                        <property role="Xl_RC" value="inf" />
                       </node>
                     </node>
-                    <node concept="2OqwBi" id="48aoaguqeg8" role="37vLTx">
-                      <node concept="1Wqviy" id="3tudP___tal" role="2Oq$k0" />
-                      <node concept="liA8E" id="48aoaguqeUF" role="2OqNvi">
-                        <ref role="37wK5l" to="wyt6:~String.replace(char,char)" resolve="replace" />
-                        <node concept="1Xhbcc" id="48aoaguqfaG" role="37wK5m">
-                          <property role="1XhdNS" value="," />
-                        </node>
-                        <node concept="1Xhbcc" id="48aoaguqfZX" role="37wK5m">
-                          <property role="1XhdNS" value="." />
-                        </node>
+                  </node>
+                  <node concept="10M0yZ" id="SIMVVou5C_" role="3K4E3e">
+                    <ref role="3cqZAo" to="oq0c:2NHHcg2FYHt" resolve="POSINF" />
+                    <ref role="1PxDUh" to="oq0c:2NHHcg2EXna" resolve="InfHelper" />
+                  </node>
+                  <node concept="2OqwBi" id="48aoaguqeg8" role="3K4GZi">
+                    <node concept="1Wqviy" id="3tudP___tal" role="2Oq$k0" />
+                    <node concept="liA8E" id="48aoaguqeUF" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.replace(char,char)" resolve="replace" />
+                      <node concept="1Xhbcc" id="48aoaguqfaG" role="37wK5m">
+                        <property role="1XhdNS" value="," />
+                      </node>
+                      <node concept="1Xhbcc" id="48aoaguqfZX" role="37wK5m">
+                        <property role="1XhdNS" value="." />
                       </node>
                     </node>
                   </node>
@@ -522,48 +512,18 @@
               </node>
             </node>
           </node>
-          <node concept="3J1_TO" id="3tudP___AaL" role="3cqZAp">
-            <node concept="3uVAMA" id="3tudP___AaS" role="1zxBo5">
-              <node concept="XOnhg" id="3tudP___AaT" role="1zc67B">
-                <property role="3TUv4t" value="false" />
-                <property role="TrG5h" value="ex" />
-                <node concept="nSUau" id="a$oVpNyMScP" role="1tU5fm">
-                  <node concept="3uibUv" id="3tudP___AaU" role="nSUat">
-                    <ref role="3uigEE" to="wyt6:~NumberFormatException" resolve="NumberFormatException" />
+          <node concept="3cpWs6" id="SIMVVos9Q3" role="3cqZAp">
+            <node concept="2OqwBi" id="SIMVVos8JK" role="3cqZAk">
+              <node concept="2ShNRf" id="SIMVVos8f1" role="2Oq$k0">
+                <node concept="3zrR0B" id="SIMVVos8rI" role="2ShVmc">
+                  <node concept="3Tqbb2" id="SIMVVos8rK" role="3zrR0E">
+                    <ref role="ehGHo" to="5qo5:4rZeNQ6Oerq" resolve="NumberLiteral" />
                   </node>
                 </node>
               </node>
-              <node concept="3clFbS" id="3tudP___AaV" role="1zc67A">
-                <node concept="3cpWs6" id="3tudP___AaW" role="3cqZAp">
-                  <node concept="3clFbT" id="3tudP___AaX" role="3cqZAk">
-                    <property role="3clFbU" value="false" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbS" id="3tudP___AaM" role="1zxBo7">
-              <node concept="3clFbF" id="3tudP___AaN" role="3cqZAp">
-                <node concept="2YIFZM" id="3tudP_A1AIB" role="3clFbG">
-                  <ref role="37wK5l" to="wyt6:~Double.parseDouble(java.lang.String)" resolve="parseDouble" />
-                  <ref role="1Pybhc" to="wyt6:~Double" resolve="Double" />
-                  <node concept="2OqwBi" id="4kdJi32PKoZ" role="37wK5m">
-                    <node concept="1Wqviy" id="3tudP_A1AIC" role="2Oq$k0" />
-                    <node concept="liA8E" id="4kdJi32PKH9" role="2OqNvi">
-                      <ref role="37wK5l" to="wyt6:~String.replace(char,char)" resolve="replace" />
-                      <node concept="1Xhbcc" id="4kdJi32PKHg" role="37wK5m">
-                        <property role="1XhdNS" value="," />
-                      </node>
-                      <node concept="1Xhbcc" id="4kdJi32PKKK" role="37wK5m">
-                        <property role="1XhdNS" value="." />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3cpWs6" id="3tudP___AaQ" role="3cqZAp">
-                <node concept="3clFbT" id="3tudP___AaR" role="3cqZAk">
-                  <property role="3clFbU" value="true" />
-                </node>
+              <node concept="2qgKlT" id="SIMVVos9lw" role="2OqNvi">
+                <ref role="37wK5l" to="b1h1:SIMVVorXi8" resolve="isValidNumber" />
+                <node concept="1Wqviy" id="SIMVVos9zi" role="37wK5m" />
               </node>
             </node>
           </node>
@@ -574,52 +534,34 @@
       <ref role="EomxK" to="5qo5:19PglA20qXJ" resolve="min" />
       <node concept="1LLf8_" id="3tudP___tg$" role="1LXaQT">
         <node concept="3clFbS" id="3tudP___tg_" role="2VODD2">
-          <node concept="3clFbJ" id="3tudP___tgA" role="3cqZAp">
-            <node concept="3clFbS" id="3tudP___tgB" role="3clFbx">
-              <node concept="3clFbF" id="3tudP___tgC" role="3cqZAp">
-                <node concept="37vLTI" id="3tudP___tgD" role="3clFbG">
-                  <node concept="10M0yZ" id="3tudP___tgE" role="37vLTx">
+          <node concept="3clFbF" id="SIMVVou3UY" role="3cqZAp">
+            <node concept="2OqwBi" id="SIMVVou45l" role="3clFbG">
+              <node concept="EsrRn" id="SIMVVou3UX" role="2Oq$k0" />
+              <node concept="2qgKlT" id="SIMVVou4aQ" role="2OqNvi">
+                <ref role="37wK5l" to="b1h1:SIMVVotJjI" resolve="setMinimum" />
+                <node concept="3K4zz7" id="SIMVVou4Dp" role="37wK5m">
+                  <node concept="2OqwBi" id="3tudP___tgI" role="3K4Cdx">
+                    <node concept="1Wqviy" id="3tudP___tgJ" role="2Oq$k0" />
+                    <node concept="liA8E" id="3tudP___tgK" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                      <node concept="Xl_RD" id="3tudP___tgL" role="37wK5m">
+                        <property role="Xl_RC" value="-inf" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="10M0yZ" id="SIMVVou4FH" role="3K4E3e">
                     <ref role="1PxDUh" to="oq0c:2NHHcg2EXna" resolve="InfHelper" />
                     <ref role="3cqZAo" to="oq0c:2NHHcg2FVhN" resolve="NEGINF" />
                   </node>
-                  <node concept="2OqwBi" id="3tudP___tgF" role="37vLTJ">
-                    <node concept="EsrRn" id="3tudP___tgG" role="2Oq$k0" />
-                    <node concept="3TrcHB" id="3tudP___ENU" role="2OqNvi">
-                      <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="2OqwBi" id="3tudP___tgI" role="3clFbw">
-              <node concept="1Wqviy" id="3tudP___tgJ" role="2Oq$k0" />
-              <node concept="liA8E" id="3tudP___tgK" role="2OqNvi">
-                <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                <node concept="Xl_RD" id="3tudP___tgL" role="37wK5m">
-                  <property role="Xl_RC" value="-inf" />
-                </node>
-              </node>
-            </node>
-            <node concept="9aQIb" id="3tudP___tgM" role="9aQIa">
-              <node concept="3clFbS" id="3tudP___tgN" role="9aQI4">
-                <node concept="3clFbF" id="3tudP___tgO" role="3cqZAp">
-                  <node concept="37vLTI" id="3tudP___tgP" role="3clFbG">
-                    <node concept="2OqwBi" id="3tudP___tgR" role="37vLTJ">
-                      <node concept="EsrRn" id="3tudP___tgS" role="2Oq$k0" />
-                      <node concept="3TrcHB" id="3tudP___F7L" role="2OqNvi">
-                        <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+                  <node concept="2OqwBi" id="48aoaguqh74" role="3K4GZi">
+                    <node concept="1Wqviy" id="3tudP___tgQ" role="2Oq$k0" />
+                    <node concept="liA8E" id="48aoaguqh9F" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.replace(char,char)" resolve="replace" />
+                      <node concept="1Xhbcc" id="48aoaguqh9G" role="37wK5m">
+                        <property role="1XhdNS" value="," />
                       </node>
-                    </node>
-                    <node concept="2OqwBi" id="48aoaguqh74" role="37vLTx">
-                      <node concept="1Wqviy" id="3tudP___tgQ" role="2Oq$k0" />
-                      <node concept="liA8E" id="48aoaguqh9F" role="2OqNvi">
-                        <ref role="37wK5l" to="wyt6:~String.replace(char,char)" resolve="replace" />
-                        <node concept="1Xhbcc" id="48aoaguqh9G" role="37wK5m">
-                          <property role="1XhdNS" value="," />
-                        </node>
-                        <node concept="1Xhbcc" id="48aoaguqh9H" role="37wK5m">
-                          <property role="1XhdNS" value="." />
-                        </node>
+                      <node concept="1Xhbcc" id="48aoaguqh9H" role="37wK5m">
+                        <property role="1XhdNS" value="." />
                       </node>
                     </node>
                   </node>
@@ -650,48 +592,18 @@
               </node>
             </node>
           </node>
-          <node concept="3J1_TO" id="3tudP___zEh" role="3cqZAp">
-            <node concept="3uVAMA" id="3tudP___zEk" role="1zxBo5">
-              <node concept="XOnhg" id="3tudP___zEm" role="1zc67B">
-                <property role="3TUv4t" value="false" />
-                <property role="TrG5h" value="ex" />
-                <node concept="nSUau" id="a$oVpNyMNdF" role="1tU5fm">
-                  <node concept="3uibUv" id="3tudP____dF" role="nSUat">
-                    <ref role="3uigEE" to="wyt6:~NumberFormatException" resolve="NumberFormatException" />
+          <node concept="3cpWs6" id="SIMVVosa7H" role="3cqZAp">
+            <node concept="2OqwBi" id="SIMVVosa7I" role="3cqZAk">
+              <node concept="2ShNRf" id="SIMVVosa7J" role="2Oq$k0">
+                <node concept="3zrR0B" id="SIMVVosa7K" role="2ShVmc">
+                  <node concept="3Tqbb2" id="SIMVVosa7L" role="3zrR0E">
+                    <ref role="ehGHo" to="5qo5:4rZeNQ6Oerq" resolve="NumberLiteral" />
                   </node>
                 </node>
               </node>
-              <node concept="3clFbS" id="3tudP___zEq" role="1zc67A">
-                <node concept="3cpWs6" id="3tudP____FE" role="3cqZAp">
-                  <node concept="3clFbT" id="3tudP____FQ" role="3cqZAk">
-                    <property role="3clFbU" value="false" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbS" id="3tudP___zEj" role="1zxBo7">
-              <node concept="3clFbF" id="3tudP_A1B3H" role="3cqZAp">
-                <node concept="2YIFZM" id="3tudP_A1B3J" role="3clFbG">
-                  <ref role="37wK5l" to="wyt6:~Double.parseDouble(java.lang.String)" resolve="parseDouble" />
-                  <ref role="1Pybhc" to="wyt6:~Double" resolve="Double" />
-                  <node concept="2OqwBi" id="4kdJi32PKT0" role="37wK5m">
-                    <node concept="1Wqviy" id="3tudP_A1B3K" role="2Oq$k0" />
-                    <node concept="liA8E" id="4kdJi32PL4B" role="2OqNvi">
-                      <ref role="37wK5l" to="wyt6:~String.replace(char,char)" resolve="replace" />
-                      <node concept="1Xhbcc" id="4kdJi32PL4I" role="37wK5m">
-                        <property role="1XhdNS" value="," />
-                      </node>
-                      <node concept="1Xhbcc" id="4kdJi32PL8e" role="37wK5m">
-                        <property role="1XhdNS" value="." />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3cpWs6" id="3tudP___A01" role="3cqZAp">
-                <node concept="3clFbT" id="3tudP___A0h" role="3cqZAk">
-                  <property role="3clFbU" value="true" />
-                </node>
+              <node concept="2qgKlT" id="SIMVVosa7M" role="2OqNvi">
+                <ref role="37wK5l" to="b1h1:SIMVVorXi8" resolve="isValidNumber" />
+                <node concept="1Wqviy" id="SIMVVosa7N" role="37wK5m" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/plugin.mps
@@ -1330,32 +1330,28 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbF" id="2NHHcg2GVcD" role="3cqZAp">
-                    <node concept="37vLTI" id="2NHHcg2GXvh" role="3clFbG">
-                      <node concept="37vLTw" id="2NHHcg2GX_l" role="37vLTx">
-                        <ref role="3cqZAo" node="2NHHcg2GC9t" resolve="lower" />
+                  <node concept="3clFbF" id="SIMVVouaW0" role="3cqZAp">
+                    <node concept="2OqwBi" id="SIMVVoubTR" role="3clFbG">
+                      <node concept="37vLTw" id="SIMVVouaVY" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2NHHcg2GWDC" resolve="r" />
                       </node>
-                      <node concept="2OqwBi" id="2NHHcg2GX1a" role="37vLTJ">
-                        <node concept="37vLTw" id="2NHHcg2GWDI" role="2Oq$k0">
-                          <ref role="3cqZAo" node="2NHHcg2GWDC" resolve="r" />
-                        </node>
-                        <node concept="3TrcHB" id="2NHHcg2GX9b" role="2OqNvi">
-                          <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+                      <node concept="2qgKlT" id="SIMVVoud48" role="2OqNvi">
+                        <ref role="37wK5l" to="b1h1:SIMVVotJjI" resolve="setMinimum" />
+                        <node concept="37vLTw" id="SIMVVouh0k" role="37wK5m">
+                          <ref role="3cqZAo" node="2NHHcg2GC9t" resolve="lower" />
                         </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="3clFbF" id="2NHHcg2GXDs" role="3cqZAp">
-                    <node concept="37vLTI" id="2NHHcg2GXDt" role="3clFbG">
-                      <node concept="37vLTw" id="2NHHcg2GYe2" role="37vLTx">
-                        <ref role="3cqZAo" node="2NHHcg2GUr9" resolve="upper" />
+                  <node concept="3clFbF" id="SIMVVouhLa" role="3cqZAp">
+                    <node concept="2OqwBi" id="SIMVVouiJc" role="3clFbG">
+                      <node concept="37vLTw" id="SIMVVouhL8" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2NHHcg2GWDC" resolve="r" />
                       </node>
-                      <node concept="2OqwBi" id="2NHHcg2GXDv" role="37vLTJ">
-                        <node concept="37vLTw" id="2NHHcg2GXDw" role="2Oq$k0">
-                          <ref role="3cqZAo" node="2NHHcg2GWDC" resolve="r" />
-                        </node>
-                        <node concept="3TrcHB" id="2NHHcg2GY4q" role="2OqNvi">
-                          <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+                      <node concept="2qgKlT" id="SIMVVoujQ2" role="2OqNvi">
+                        <ref role="37wK5l" to="b1h1:SIMVVotK76" resolve="setMaximum" />
+                        <node concept="37vLTw" id="SIMVVoukV0" role="37wK5m">
+                          <ref role="3cqZAo" node="2NHHcg2GUr9" resolve="upper" />
                         </node>
                       </node>
                     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/typesystem.mps
@@ -2699,70 +2699,66 @@
               </node>
             </node>
           </node>
-          <node concept="3clFbF" id="6NHlpK$EjwS" role="3cqZAp">
-            <node concept="37vLTI" id="6NHlpK$Em3F" role="3clFbG">
-              <node concept="2YIFZM" id="3f3yNhCMeu_" role="37vLTx">
-                <ref role="1Pybhc" to="oq0c:2NHHcg2EXna" resolve="InfHelper" />
-                <ref role="37wK5l" to="oq0c:3f3yNhCManF" resolve="negate" />
-                <node concept="2OqwBi" id="6NHlpK$EnNn" role="37wK5m">
-                  <node concept="2OqwBi" id="6NHlpK$EmT0" role="2Oq$k0">
-                    <node concept="37vLTw" id="6NHlpK$EmEE" role="2Oq$k0">
-                      <ref role="3cqZAo" node="6NHlpK$DDAE" resolve="nt" />
-                    </node>
-                    <node concept="3TrEf2" id="6NHlpK$EnsK" role="2OqNvi">
-                      <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
-                    </node>
-                  </node>
-                  <node concept="3TrcHB" id="6NHlpK$Eoal" role="2OqNvi">
-                    <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
-                  </node>
+          <node concept="3clFbF" id="SIMVVoupLK" role="3cqZAp">
+            <node concept="2OqwBi" id="SIMVVouqE3" role="3clFbG">
+              <node concept="2OqwBi" id="SIMVVouq5i" role="2Oq$k0">
+                <node concept="37vLTw" id="SIMVVoupLI" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6NHlpK$DDAE" resolve="nt" />
+                </node>
+                <node concept="3TrEf2" id="SIMVVouq$N" role="2OqNvi">
+                  <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                 </node>
               </node>
-              <node concept="2OqwBi" id="6NHlpK$EkHz" role="37vLTJ">
-                <node concept="2OqwBi" id="6NHlpK$EjMZ" role="2Oq$k0">
-                  <node concept="37vLTw" id="6NHlpK$EjwQ" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6NHlpK$DDAE" resolve="nt" />
+              <node concept="2qgKlT" id="SIMVVouqK3" role="2OqNvi">
+                <ref role="37wK5l" to="b1h1:SIMVVotJjI" resolve="setMinimum" />
+                <node concept="2YIFZM" id="3f3yNhCMeu_" role="37wK5m">
+                  <ref role="37wK5l" to="oq0c:3f3yNhCManF" resolve="negate" />
+                  <ref role="1Pybhc" to="oq0c:2NHHcg2EXna" resolve="InfHelper" />
+                  <node concept="2OqwBi" id="6NHlpK$EnNn" role="37wK5m">
+                    <node concept="2OqwBi" id="6NHlpK$EmT0" role="2Oq$k0">
+                      <node concept="37vLTw" id="6NHlpK$EmEE" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6NHlpK$DDAE" resolve="nt" />
+                      </node>
+                      <node concept="3TrEf2" id="6NHlpK$EnsK" role="2OqNvi">
+                        <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="SIMVVouocT" role="2OqNvi">
+                      <ref role="37wK5l" to="b1h1:SIMVVosRGL" resolve="getMinimum" />
+                    </node>
                   </node>
-                  <node concept="3TrEf2" id="6NHlpK$Ekp$" role="2OqNvi">
-                    <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
-                  </node>
-                </node>
-                <node concept="3TrcHB" id="6NHlpK$EkV2" role="2OqNvi">
-                  <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
                 </node>
               </node>
             </node>
           </node>
-          <node concept="3clFbF" id="6NHlpK$EoDX" role="3cqZAp">
-            <node concept="37vLTI" id="6NHlpK$EoDY" role="3clFbG">
-              <node concept="2YIFZM" id="3f3yNhCMf5J" role="37vLTx">
-                <ref role="1Pybhc" to="oq0c:2NHHcg2EXna" resolve="InfHelper" />
-                <ref role="37wK5l" to="oq0c:3f3yNhCManF" resolve="negate" />
-                <node concept="2OqwBi" id="6NHlpK$EoE0" role="37wK5m">
-                  <node concept="2OqwBi" id="6NHlpK$EoE1" role="2Oq$k0">
-                    <node concept="37vLTw" id="6NHlpK$EoE2" role="2Oq$k0">
-                      <ref role="3cqZAo" node="6NHlpK$DDAE" resolve="nt" />
-                    </node>
-                    <node concept="3TrEf2" id="6NHlpK$EoE3" role="2OqNvi">
-                      <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
-                    </node>
-                  </node>
-                  <node concept="3TrcHB" id="6NHlpK$EpK9" role="2OqNvi">
-                    <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
-                  </node>
+          <node concept="3clFbF" id="SIMVVourjo" role="3cqZAp">
+            <node concept="2OqwBi" id="SIMVVous1Q" role="3clFbG">
+              <node concept="2OqwBi" id="SIMVVourBc" role="2Oq$k0">
+                <node concept="37vLTw" id="SIMVVourjm" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6NHlpK$DDAE" resolve="nt" />
+                </node>
+                <node concept="3TrEf2" id="SIMVVourWq" role="2OqNvi">
+                  <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
                 </node>
               </node>
-              <node concept="2OqwBi" id="6NHlpK$EoE5" role="37vLTJ">
-                <node concept="2OqwBi" id="6NHlpK$EoE6" role="2Oq$k0">
-                  <node concept="37vLTw" id="6NHlpK$EoE7" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6NHlpK$DDAE" resolve="nt" />
+              <node concept="2qgKlT" id="SIMVVous87" role="2OqNvi">
+                <ref role="37wK5l" to="b1h1:SIMVVotK76" resolve="setMaximum" />
+                <node concept="2YIFZM" id="3f3yNhCMf5J" role="37wK5m">
+                  <ref role="37wK5l" to="oq0c:3f3yNhCManF" resolve="negate" />
+                  <ref role="1Pybhc" to="oq0c:2NHHcg2EXna" resolve="InfHelper" />
+                  <node concept="2OqwBi" id="6NHlpK$EoE0" role="37wK5m">
+                    <node concept="2OqwBi" id="6NHlpK$EoE1" role="2Oq$k0">
+                      <node concept="37vLTw" id="6NHlpK$EoE2" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6NHlpK$DDAE" resolve="nt" />
+                      </node>
+                      <node concept="3TrEf2" id="6NHlpK$EoE3" role="2OqNvi">
+                        <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="SIMVVouomg" role="2OqNvi">
+                      <ref role="37wK5l" to="b1h1:SIMVVosRWc" resolve="getMaximum" />
+                    </node>
                   </node>
-                  <node concept="3TrEf2" id="6NHlpK$EoE8" role="2OqNvi">
-                    <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
-                  </node>
-                </node>
-                <node concept="3TrcHB" id="6NHlpK$Epp2" role="2OqNvi">
-                  <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/typesystem.mps
@@ -3561,7 +3561,7 @@
             <node concept="3clFbS" id="3p6$WoEzUg8" role="3clFbx">
               <node concept="2MkqsV" id="3p6$WoEzUA7" role="3cqZAp">
                 <node concept="Xl_RD" id="3p6$WoEzUAm" role="2MkJ7o">
-                  <property role="Xl_RC" value="invalid range (max &lt; min or precison error)" />
+                  <property role="Xl_RC" value="invalid range (max &lt; min or precision error)" />
                 </node>
                 <node concept="1YBJjd" id="3p6$WoEzUBQ" role="1urrMF">
                   <ref role="1YBMHb" node="3p6$WoEzUg2" resolve="nt" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/intentions.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/intentions.mps
@@ -3397,43 +3397,6 @@
           </node>
         </node>
         <node concept="3clFbJ" id="6GGzMC67ztT" role="3cqZAp">
-          <node concept="22lmx$" id="SIMVVoivhW" role="3clFbw">
-            <node concept="2OqwBi" id="SIMVVoixn7" role="3uHU7w">
-              <node concept="37vLTw" id="SIMVVoizU$" role="2Oq$k0">
-                <ref role="3cqZAo" node="SIMVVoizUw" resolve="testLiteral" />
-              </node>
-              <node concept="2qgKlT" id="SIMVVoiCch" role="2OqNvi">
-                <ref role="37wK5l" to="b1h1:4rZeNQ6Og7j" resolve="isReal" />
-                <node concept="37vLTw" id="SIMVVoiDdv" role="37wK5m">
-                  <ref role="3cqZAo" node="6GGzMC67Efh" resolve="l" />
-                </node>
-              </node>
-            </node>
-            <node concept="22lmx$" id="SIMVVoiDB0" role="3uHU7B">
-              <node concept="2OqwBi" id="SIMVVoiErP" role="3uHU7B">
-                <node concept="37vLTw" id="SIMVVoiDOG" role="2Oq$k0">
-                  <ref role="3cqZAo" node="SIMVVoizUw" resolve="testLiteral" />
-                </node>
-                <node concept="2qgKlT" id="SIMVVoiF0T" role="2OqNvi">
-                  <ref role="37wK5l" to="b1h1:4rZeNQ6OfoS" resolve="isZero" />
-                  <node concept="37vLTw" id="SIMVVoiFgi" role="37wK5m">
-                    <ref role="3cqZAo" node="6GGzMC67Efh" resolve="l" />
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="SIMVVoiAP0" role="3uHU7w">
-                <node concept="37vLTw" id="SIMVVoiAeh" role="2Oq$k0">
-                  <ref role="3cqZAo" node="SIMVVoizUw" resolve="testLiteral" />
-                </node>
-                <node concept="2qgKlT" id="SIMVVoiBw5" role="2OqNvi">
-                  <ref role="37wK5l" to="b1h1:4rZeNQ6Og4r" resolve="isInteger" />
-                  <node concept="37vLTw" id="SIMVVoiBOH" role="37wK5m">
-                    <ref role="3cqZAo" node="6GGzMC67Efh" resolve="l" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
           <node concept="3clFbS" id="6GGzMC67ztY" role="3clFbx">
             <node concept="3cpWs6" id="6GGzMC67ztZ" role="3cqZAp">
               <node concept="2OqwBi" id="2oUyrt_3jmX" role="3cqZAk">
@@ -3450,6 +3413,17 @@
                     <ref role="3cqZAo" node="6GGzMC65iRK" resolve="s" />
                   </node>
                 </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="SIMVVos5Gw" role="3clFbw">
+            <node concept="37vLTw" id="SIMVVos5hX" role="2Oq$k0">
+              <ref role="3cqZAo" node="SIMVVoizUw" resolve="testLiteral" />
+            </node>
+            <node concept="2qgKlT" id="SIMVVos6_A" role="2OqNvi">
+              <ref role="37wK5l" to="b1h1:SIMVVorXi8" resolve="isValidNumber" />
+              <node concept="37vLTw" id="SIMVVos6Tb" role="37wK5m">
+                <ref role="3cqZAo" node="6GGzMC67Efh" resolve="l" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/intentions.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/intentions.mps
@@ -19,9 +19,9 @@
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
+    <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" />
     <import index="wthy" ref="r:a4614e23-a6b5-4dbe-9bc5-9ff1ecfd0a3a(org.iets3.core.expr.util.behavior)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
-    <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" implicit="true" />
     <import index="b1h1" ref="r:ac5f749f-6179-4d4f-ad24-ad9edbd8077b(org.iets3.core.expr.simpleTypes.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -3381,15 +3381,56 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbJ" id="6GGzMC67ztT" role="3cqZAp">
-          <node concept="2OqwBi" id="6GGzMC67ztU" role="3clFbw">
-            <node concept="37vLTw" id="6GGzMC67G0T" role="2Oq$k0">
-              <ref role="3cqZAo" node="6GGzMC67Efh" resolve="l" />
+        <node concept="3cpWs8" id="SIMVVoizUv" role="3cqZAp">
+          <node concept="3cpWsn" id="SIMVVoizUw" role="3cpWs9">
+            <property role="TrG5h" value="testLiteral" />
+            <node concept="3Tqbb2" id="SIMVVoiyrd" role="1tU5fm">
+              <ref role="ehGHo" to="5qo5:4rZeNQ6Oerq" resolve="NumberLiteral" />
             </node>
-            <node concept="liA8E" id="6GGzMC67ztW" role="2OqNvi">
-              <ref role="37wK5l" to="wyt6:~String.matches(java.lang.String)" resolve="matches" />
-              <node concept="Xl_RD" id="6GGzMC67ztX" role="37wK5m">
-                <property role="Xl_RC" value="\\d*" />
+            <node concept="2ShNRf" id="SIMVVoizUx" role="33vP2m">
+              <node concept="3zrR0B" id="SIMVVoizUy" role="2ShVmc">
+                <node concept="3Tqbb2" id="SIMVVoizUz" role="3zrR0E">
+                  <ref role="ehGHo" to="5qo5:4rZeNQ6Oerq" resolve="NumberLiteral" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6GGzMC67ztT" role="3cqZAp">
+          <node concept="22lmx$" id="SIMVVoivhW" role="3clFbw">
+            <node concept="2OqwBi" id="SIMVVoixn7" role="3uHU7w">
+              <node concept="37vLTw" id="SIMVVoizU$" role="2Oq$k0">
+                <ref role="3cqZAo" node="SIMVVoizUw" resolve="testLiteral" />
+              </node>
+              <node concept="2qgKlT" id="SIMVVoiCch" role="2OqNvi">
+                <ref role="37wK5l" to="b1h1:4rZeNQ6Og7j" resolve="isReal" />
+                <node concept="37vLTw" id="SIMVVoiDdv" role="37wK5m">
+                  <ref role="3cqZAo" node="6GGzMC67Efh" resolve="l" />
+                </node>
+              </node>
+            </node>
+            <node concept="22lmx$" id="SIMVVoiDB0" role="3uHU7B">
+              <node concept="2OqwBi" id="SIMVVoiErP" role="3uHU7B">
+                <node concept="37vLTw" id="SIMVVoiDOG" role="2Oq$k0">
+                  <ref role="3cqZAo" node="SIMVVoizUw" resolve="testLiteral" />
+                </node>
+                <node concept="2qgKlT" id="SIMVVoiF0T" role="2OqNvi">
+                  <ref role="37wK5l" to="b1h1:4rZeNQ6OfoS" resolve="isZero" />
+                  <node concept="37vLTw" id="SIMVVoiFgi" role="37wK5m">
+                    <ref role="3cqZAo" node="6GGzMC67Efh" resolve="l" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="SIMVVoiAP0" role="3uHU7w">
+                <node concept="37vLTw" id="SIMVVoiAeh" role="2Oq$k0">
+                  <ref role="3cqZAo" node="SIMVVoizUw" resolve="testLiteral" />
+                </node>
+                <node concept="2qgKlT" id="SIMVVoiBw5" role="2OqNvi">
+                  <ref role="37wK5l" to="b1h1:4rZeNQ6Og4r" resolve="isInteger" />
+                  <node concept="37vLTw" id="SIMVVoiBOH" role="37wK5m">
+                    <ref role="3cqZAo" node="6GGzMC67Efh" resolve="l" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -3406,38 +3447,6 @@
                 <node concept="2qgKlT" id="2oUyrt_3jEP" role="2OqNvi">
                   <ref role="37wK5l" to="b1h1:2oUyrt$Tg3c" resolve="set" />
                   <node concept="37vLTw" id="2oUyrt_3kfr" role="37wK5m">
-                    <ref role="3cqZAo" node="6GGzMC65iRK" resolve="s" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="6GGzMC65G1V" role="3cqZAp">
-          <node concept="2OqwBi" id="6GGzMC65G1W" role="3clFbw">
-            <node concept="37vLTw" id="6GGzMC67Gbg" role="2Oq$k0">
-              <ref role="3cqZAo" node="6GGzMC67Efh" resolve="l" />
-            </node>
-            <node concept="liA8E" id="6GGzMC65G1Y" role="2OqNvi">
-              <ref role="37wK5l" to="wyt6:~String.matches(java.lang.String)" resolve="matches" />
-              <node concept="Xl_RD" id="6GGzMC65G1Z" role="37wK5m">
-                <property role="Xl_RC" value="\\d*\\.\\d*" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbS" id="6GGzMC65G20" role="3clFbx">
-            <node concept="3cpWs6" id="2oUyrt_3kNx" role="3cqZAp">
-              <node concept="2OqwBi" id="2oUyrt_3kNy" role="3cqZAk">
-                <node concept="2ShNRf" id="2oUyrt_3kNz" role="2Oq$k0">
-                  <node concept="3zrR0B" id="2oUyrt_3kN$" role="2ShVmc">
-                    <node concept="3Tqbb2" id="2oUyrt_3kN_" role="3zrR0E">
-                      <ref role="ehGHo" to="5qo5:4rZeNQ6Oerq" resolve="NumberLiteral" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="2qgKlT" id="2oUyrt_3kNA" role="2OqNvi">
-                  <ref role="37wK5l" to="b1h1:2oUyrt$Tg3c" resolve="set" />
-                  <node concept="37vLTw" id="2oUyrt_3kNB" role="37wK5m">
                     <ref role="3cqZAo" node="6GGzMC65iRK" resolve="s" />
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.runtime/models/runtime.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.runtime/models/runtime.mps
@@ -1180,6 +1180,23 @@
       <node concept="3Tm1VV" id="2oUyrt$Q$ED" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="2oUyrt$Tbp9" role="jymVt" />
+    <node concept="2YIFZL" id="4NJAaUg4P5X" role="jymVt">
+      <property role="TrG5h" value="allowHexadecimalNumbers" />
+      <node concept="3clFbS" id="4NJAaUg4P5Y" role="3clF47">
+        <node concept="3clFbF" id="4NJAaUg4P5Z" role="3cqZAp">
+          <node concept="2OqwBi" id="4NJAaUg4P60" role="3clFbG">
+            <node concept="1rXfSq" id="4NJAaUg4P61" role="2Oq$k0">
+              <ref role="37wK5l" node="2Qbt$1tTQn5" resolve="resolveMapper" />
+            </node>
+            <node concept="liA8E" id="4NJAaUg4P62" role="2OqNvi">
+              <ref role="37wK5l" to="oq0c:4NJAaUg1hYw" resolve="allowHexadecimalNumbers" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="4NJAaUg4P63" role="3clF45" />
+      <node concept="3Tm1VV" id="4NJAaUg4P64" role="1B3o_S" />
+    </node>
     <node concept="2tJIrI" id="2Qbt$1tTQb0" role="jymVt" />
     <node concept="3Tm1VV" id="2Qbt$1tTQaI" role="1B3o_S" />
   </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.interpreter/models/plugin.mps
@@ -2180,8 +2180,8 @@
                       <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
                       <node concept="2OqwBi" id="uGVYUijjhD" role="37wK5m">
                         <node concept="oxGPV" id="uGVYUijjhE" role="2Oq$k0" />
-                        <node concept="3TrcHB" id="uGVYUijjhF" role="2OqNvi">
-                          <ref role="3TsBF5" to="5qo5:4rZeNQ6Oert" resolve="value" />
+                        <node concept="2qgKlT" id="SIMVVoghRd" role="2OqNvi">
+                          <ref role="37wK5l" to="b1h1:2oUyrt$QPvb" resolve="valueWithDotInsteadOfComma" />
                         </node>
                       </node>
                     </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.interpreter/models/plugin.mps
@@ -1984,23 +1984,49 @@
                 </node>
               </node>
             </node>
+            <node concept="3clFbJ" id="7yYa0tuzwl4" role="3cqZAp">
+              <node concept="3clFbS" id="7yYa0tuzwl6" role="3clFbx">
+                <node concept="3cpWs6" id="7yYa0tuzx1x" role="3cqZAp">
+                  <node concept="37vLTw" id="7yYa0tuzx1A" role="3cqZAk">
+                    <ref role="3cqZAo" node="7DTWJ$8lKcJ" resolve="val" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2ZW3vV" id="7yYa0tuzwrG" role="3clFbw">
+                <node concept="3uibUv" id="7yYa0tuzwsO" role="2ZW6by">
+                  <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                </node>
+                <node concept="37vLTw" id="7yYa0tuzwlV" role="2ZW6bz">
+                  <ref role="3cqZAo" node="7DTWJ$8lKcJ" resolve="val" />
+                </node>
+              </node>
+            </node>
             <node concept="3clFbJ" id="7DTWJ$8lKgV" role="3cqZAp">
               <node concept="3clFbS" id="7DTWJ$8lKgX" role="3clFbx">
+                <node concept="3cpWs8" id="7yYa0tuz6aJ" role="3cqZAp">
+                  <node concept="3cpWsn" id="7yYa0tuz6aK" role="3cpWs9">
+                    <property role="TrG5h" value="decimal" />
+                    <node concept="3uibUv" id="7yYa0tuyY7O" role="1tU5fm">
+                      <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+                    </node>
+                    <node concept="10QFUN" id="7yYa0tuz6aL" role="33vP2m">
+                      <node concept="37vLTw" id="7yYa0tuz6aM" role="10QFUP">
+                        <ref role="3cqZAo" node="7DTWJ$8lKcJ" resolve="val" />
+                      </node>
+                      <node concept="3uibUv" id="7yYa0tuz6aN" role="10QFUM">
+                        <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
                 <node concept="3cpWs8" id="7DTWJ$8nBNE" role="3cqZAp">
                   <node concept="3cpWsn" id="7DTWJ$8nBNF" role="3cpWs9">
                     <property role="TrG5h" value="bd" />
                     <node concept="3uibUv" id="7DTWJ$8nBNC" role="1tU5fm">
                       <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
                     </node>
-                    <node concept="1eOMI4" id="7DTWJ$8nBNG" role="33vP2m">
-                      <node concept="10QFUN" id="7DTWJ$8nBNH" role="1eOMHV">
-                        <node concept="37vLTw" id="7DTWJ$8nBNI" role="10QFUP">
-                          <ref role="3cqZAo" node="7DTWJ$8lKcJ" resolve="val" />
-                        </node>
-                        <node concept="3uibUv" id="7DTWJ$8nBNJ" role="10QFUM">
-                          <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
-                        </node>
-                      </node>
+                    <node concept="37vLTw" id="7yYa0tuz6aO" role="33vP2m">
+                      <ref role="3cqZAo" node="7yYa0tuz6aK" resolve="decimal" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.numbers@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.numbers@tests.mps
@@ -210,6 +210,12 @@
         <property role="30bXRw" value="30" />
       </node>
     </node>
+    <node concept="2zPypq" id="SIMVVo_hzK" role="_iOnB">
+      <property role="TrG5h" value="d" />
+      <node concept="30bXRB" id="SIMVVo_h_A" role="2zPyp_">
+        <property role="30bXRw" value="0xFF" />
+      </node>
+    </node>
     <node concept="_ixoA" id="1RwPUjzhA8q" role="_iOnB" />
     <node concept="_fkuM" id="1RwPUjzhA8r" role="_iOnB">
       <property role="TrG5h" value="testMax" />
@@ -312,6 +318,20 @@
         </node>
         <node concept="_emDc" id="1RwPUjznwao" role="_fkuS">
           <ref role="_emDf" node="1RwPUjzhDo7" resolve="c" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="SIMVVo_hBB" role="_fkp5">
+        <node concept="_fku$" id="SIMVVo_hBC" role="_fkur" />
+        <node concept="_emDc" id="SIMVVo_i2K" role="_fkuS">
+          <ref role="_emDf" node="SIMVVo_hzK" resolve="d" />
+        </node>
+        <node concept="3YCzOX" id="SIMVVo_hCF" role="_fkuY">
+          <node concept="_emDc" id="SIMVVo_hCP" role="3YCpu7">
+            <ref role="_emDf" node="1RwPUjzhDo7" resolve="c" />
+          </node>
+          <node concept="_emDc" id="SIMVVo_hPR" role="3YCpu7">
+            <ref role="_emDf" node="SIMVVo_hzK" resolve="d" />
+          </node>
         </node>
       </node>
     </node>
@@ -1177,6 +1197,17 @@
         </node>
       </node>
     </node>
+    <node concept="2zPypq" id="7yYa0tuxMkz" role="_iOnB">
+      <property role="TrG5h" value="t9" />
+      <node concept="30dDZf" id="7yYa0tuxMto" role="2zPyp_">
+        <node concept="30bXRB" id="7yYa0tuxMxM" role="30dEs_">
+          <property role="30bXRw" value="0xf" />
+        </node>
+        <node concept="_emDc" id="7yYa0tuxMsU" role="30dEsF">
+          <ref role="_emDf" node="7Wa2sv46aOE" resolve="t1" />
+        </node>
+      </node>
+    </node>
     <node concept="_ixoA" id="7Wa2sv469fk" role="_iOnB" />
     <node concept="_fkuM" id="7kyIuXq$TO_" role="_iOnB">
       <property role="TrG5h" value="MixedPrec" />
@@ -1286,6 +1317,15 @@
         </node>
         <node concept="30bXRB" id="7kyIuXq$W6b" role="_fkuS">
           <property role="30bXRw" value="4.0002000" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="7yYa0tuxMFr" role="_fkp5">
+        <node concept="_fku$" id="7yYa0tuxMFs" role="_fkur" />
+        <node concept="_emDc" id="7yYa0tuxMGr" role="_fkuY">
+          <ref role="_emDf" node="7yYa0tuxMkz" resolve="t9" />
+        </node>
+        <node concept="30bXRB" id="7yYa0tuxMGF" role="_fkuS">
+          <property role="30bXRw" value="20.22" />
         </node>
       </node>
     </node>
@@ -1742,6 +1782,15 @@
         </node>
       </node>
     </node>
+    <node concept="1WbbD7" id="7yYa0tuzPjd" role="_iOnB">
+      <property role="TrG5h" value="BPPrecHex" />
+      <node concept="mLuIC" id="7yYa0tuzPje" role="1WbbD4">
+        <node concept="2gteSW" id="7yYa0tuzPjf" role="2gteSx">
+          <property role="2gteSQ" value="0x0" />
+          <property role="2gteSD" value="0x64" />
+        </node>
+      </node>
+    </node>
     <node concept="_ixoA" id="46cplYy4hji" role="_iOnB" />
     <node concept="1aga60" id="1IomA9vXFim" role="_iOnB">
       <property role="TrG5h" value="trunc0" />
@@ -1831,6 +1880,34 @@
           </node>
           <node concept="30bXRB" id="1IomA9w5qcD" role="30czhm">
             <property role="30bXRw" value="80.99" />
+          </node>
+        </node>
+      </node>
+      <node concept="_fkuZ" id="7yYa0tuz2Dj" role="_fkp5">
+        <node concept="_fku$" id="7yYa0tuz2Dk" role="_fkur" />
+        <node concept="30bXRB" id="7yYa0tuz2Dl" role="_fkuS">
+          <property role="30bXRw" value="80" />
+        </node>
+        <node concept="1QScDb" id="7yYa0tuz2Dm" role="_fkuY">
+          <node concept="1He9k6" id="7yYa0tuz2Dn" role="1QScD9">
+            <ref role="1He9kT" node="1IomA9vXFim" resolve="trunc0" />
+          </node>
+          <node concept="30bXRB" id="7yYa0tuz2Do" role="30czhm">
+            <property role="30bXRw" value="80" />
+          </node>
+        </node>
+      </node>
+      <node concept="_fkuZ" id="7yYa0tuzNYm" role="_fkp5">
+        <node concept="_fku$" id="7yYa0tuzNYn" role="_fkur" />
+        <node concept="30bXRB" id="7yYa0tuzNYo" role="_fkuS">
+          <property role="30bXRw" value="15" />
+        </node>
+        <node concept="1QScDb" id="7yYa0tuzNYp" role="_fkuY">
+          <node concept="1He9k6" id="7yYa0tuzNYq" role="1QScD9">
+            <ref role="1He9kT" node="1IomA9vXFim" resolve="trunc0" />
+          </node>
+          <node concept="30bXRB" id="7yYa0tuzNYr" role="30czhm">
+            <property role="30bXRw" value="0xf" />
           </node>
         </node>
       </node>
@@ -1958,6 +2035,48 @@
           <node concept="30bXRB" id="1IomA9vUDDz" role="3zyZNI">
             <property role="30bXRw" value="70" />
           </node>
+        </node>
+      </node>
+      <node concept="_fkuZ" id="7yYa0tuzPou" role="_fkp5">
+        <node concept="_fku$" id="7yYa0tuzPov" role="_fkur" />
+        <node concept="3zyZNN" id="7yYa0tuzPox" role="_fkuY">
+          <node concept="1WbbFT" id="7yYa0tuzPoy" role="3zyZWv">
+            <ref role="1WbbFS" node="7yYa0tuzPjd" resolve="BPPrecHex" />
+          </node>
+          <node concept="30bXRB" id="7yYa0tuzPsv" role="3zyZNI">
+            <property role="30bXRw" value="-10" />
+          </node>
+        </node>
+        <node concept="30bXRB" id="7yYa0tuzPuc" role="_fkuS">
+          <property role="30bXRw" value="0" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="7yYa0tuzPyp" role="_fkp5">
+        <node concept="_fku$" id="7yYa0tuzPyq" role="_fkur" />
+        <node concept="3zyZNN" id="7yYa0tuzPyr" role="_fkuY">
+          <node concept="1WbbFT" id="7yYa0tuzPys" role="3zyZWv">
+            <ref role="1WbbFS" node="7yYa0tuzPjd" resolve="BPPrecHex" />
+          </node>
+          <node concept="30bXRB" id="7yYa0tuzP$p" role="3zyZNI">
+            <property role="30bXRw" value="0x32" />
+          </node>
+        </node>
+        <node concept="30bXRB" id="7yYa0tuzPAK" role="_fkuS">
+          <property role="30bXRw" value="50" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="7yYa0tuzPuq" role="_fkp5">
+        <node concept="_fku$" id="7yYa0tuzPur" role="_fkur" />
+        <node concept="3zyZNN" id="7yYa0tuzPus" role="_fkuY">
+          <node concept="1WbbFT" id="7yYa0tuzPut" role="3zyZWv">
+            <ref role="1WbbFS" node="7yYa0tuzPjd" resolve="BPPrecHex" />
+          </node>
+          <node concept="30bXRB" id="7yYa0tuzPuu" role="3zyZNI">
+            <property role="30bXRw" value="110" />
+          </node>
+        </node>
+        <node concept="30bXRB" id="7yYa0tuzPyb" role="_fkuS">
+          <property role="30bXRw" value="100" />
         </node>
       </node>
       <node concept="3dYjL0" id="1IomA9w4vWd" role="_fkp5" />
@@ -2124,6 +2243,20 @@
           </node>
         </node>
         <node concept="30bXRB" id="60Qa1k_HhjA" role="_fkuS">
+          <property role="30bXRw" value="0" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="7yYa0tuzQgj" role="_fkp5">
+        <node concept="_fku$" id="7yYa0tuzQgk" role="_fkur" />
+        <node concept="15qgo_" id="7yYa0tuzQgl" role="_fkuY">
+          <node concept="mLuIC" id="7yYa0tuzQgm" role="15qgo$">
+            <node concept="2gteSW" id="7yYa0tuzQgn" role="2gteSx">
+              <property role="2gteSQ" value="0x0" />
+              <property role="2gteSD" value="0x64" />
+            </node>
+          </node>
+        </node>
+        <node concept="30bXRB" id="7yYa0tuzQgo" role="_fkuS">
           <property role="30bXRw" value="0" />
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.numbers@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.numbers@tests.mps
@@ -1648,6 +1648,48 @@
         </node>
       </node>
     </node>
+    <node concept="_ixoA" id="SIMVVonDnL" role="_iOnB" />
+    <node concept="_fkuM" id="SIMVVonDBA" role="_iOnB">
+      <property role="TrG5h" value="hexNumbers" />
+      <node concept="_fkuZ" id="SIMVVonDJy" role="_fkp5">
+        <node concept="_fku$" id="SIMVVonDJz" role="_fkur" />
+        <node concept="30bXRB" id="SIMVVonDL5" role="_fkuS">
+          <property role="30bXRw" value="255" />
+        </node>
+        <node concept="30bXRB" id="SIMVVonDKr" role="_fkuY">
+          <property role="30bXRw" value="0xFF" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="SIMVVoqeMW" role="_fkp5">
+        <node concept="_fku$" id="SIMVVoqeMX" role="_fkur" />
+        <node concept="30bXRB" id="SIMVVoqeMY" role="_fkuS">
+          <property role="30bXRw" value="255" />
+        </node>
+        <node concept="30bXRB" id="SIMVVoqeMZ" role="_fkuY">
+          <property role="30bXRw" value="0xff" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="SIMVVoqeNP" role="_fkp5">
+        <node concept="_fku$" id="SIMVVoqeNQ" role="_fkur" />
+        <node concept="30bXRB" id="SIMVVoqeNR" role="_fkuS">
+          <property role="30bXRw" value="0" />
+        </node>
+        <node concept="30bXRB" id="SIMVVoqeNS" role="_fkuY">
+          <property role="30bXRw" value="0x0" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="SIMVVoqeOX" role="_fkp5">
+        <node concept="_fku$" id="SIMVVoqeOY" role="_fkur" />
+        <node concept="30bXRB" id="SIMVVoqeSg" role="_fkuS">
+          <property role="30bXRw" value="-15" />
+        </node>
+        <node concept="30cIq6" id="SIMVVoqeQv" role="_fkuY">
+          <node concept="30bXRB" id="SIMVVoqeP0" role="30czhm">
+            <property role="30bXRw" value="0xF" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="_ixoA" id="1OtF0I6DM8i" role="_iOnB" />
     <node concept="_ixoA" id="1$1rueeDiqO" role="_iOnB" />
     <node concept="_ixoA" id="7Wa2sv44boh" role="_iOnB" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -168,6 +168,7 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
@@ -3823,6 +3824,566 @@
         </node>
       </node>
     </node>
+    <node concept="1LZb2c" id="7yYa0tu$wLr" role="1SL9yI">
+      <property role="TrG5h" value="integerAndHexIntegerSame" />
+      <node concept="3cqZAl" id="7yYa0tu$wLs" role="3clF45" />
+      <node concept="3clFbS" id="7yYa0tu$wLt" role="3clF47">
+        <node concept="3vlDli" id="7yYa0tu$wMy" role="3cqZAp">
+          <node concept="3clFbT" id="7yYa0tu$wMz" role="3tpDZB">
+            <property role="3clFbU" value="true" />
+          </node>
+          <node concept="2OqwBi" id="7yYa0tu$wM$" role="3tpDZA">
+            <node concept="2pJPEk" id="7yYa0tu$wM_" role="2Oq$k0">
+              <node concept="2pJPED" id="7yYa0tu$wMA" role="2pJPEn">
+                <ref role="2pJxaS" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                <node concept="2pIpSj" id="7yYa0tu$wMB" role="2pJxcM">
+                  <ref role="2pIpSl" to="5qo5:19PglA20qY9" resolve="prec" />
+                  <node concept="2pJPED" id="7yYa0tu$wMC" role="28nt2d">
+                    <ref role="2pJxaS" to="5qo5:19PglA20qXW" resolve="NumberPrecSpec" />
+                    <node concept="2pJxcG" id="7yYa0tu$wMD" role="2pJxcM">
+                      <ref role="2pJxcJ" to="5qo5:19PglA20qY6" resolve="prec" />
+                      <node concept="WxPPo" id="7yYa0tu$wME" role="28ntcv">
+                        <node concept="Xl_RD" id="7yYa0tu$wMF" role="WxPPp">
+                          <property role="Xl_RC" value="2" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="7yYa0tu$wMG" role="2pJxcM">
+                  <ref role="2pIpSl" to="5qo5:19PglA20qXS" resolve="range" />
+                  <node concept="2pJPED" id="7yYa0tu$wMH" role="28nt2d">
+                    <ref role="2pJxaS" to="5qo5:19PglA20qX_" resolve="NumberRangeSpec" />
+                    <node concept="2pJxcG" id="7yYa0tu$wMI" role="2pJxcM">
+                      <ref role="2pJxcJ" to="5qo5:19PglA20qXJ" resolve="min" />
+                      <node concept="WxPPo" id="7yYa0tu$wMJ" role="28ntcv">
+                        <node concept="Xl_RD" id="7yYa0tu$wMK" role="WxPPp">
+                          <property role="Xl_RC" value="0" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2pJxcG" id="7yYa0tu$wML" role="2pJxcM">
+                      <ref role="2pJxcJ" to="5qo5:19PglA20qXK" resolve="max" />
+                      <node concept="WxPPo" id="7yYa0tu$wMM" role="28ntcv">
+                        <node concept="Xl_RD" id="7yYa0tu$wMN" role="WxPPp">
+                          <property role="Xl_RC" value="100" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2qgKlT" id="7yYa0tu$wMO" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:fIXgjlt4VE" resolve="isSameAs" />
+              <node concept="2pJPEk" id="7yYa0tu$wMP" role="37wK5m">
+                <node concept="2pJPED" id="7yYa0tu$wMQ" role="2pJPEn">
+                  <ref role="2pJxaS" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                  <node concept="2pIpSj" id="7yYa0tu$wMR" role="2pJxcM">
+                    <ref role="2pIpSl" to="5qo5:19PglA20qY9" resolve="prec" />
+                    <node concept="2pJPED" id="7yYa0tu$wMS" role="28nt2d">
+                      <ref role="2pJxaS" to="5qo5:19PglA20qXW" resolve="NumberPrecSpec" />
+                      <node concept="2pJxcG" id="7yYa0tu$wMT" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:19PglA20qY6" resolve="prec" />
+                        <node concept="WxPPo" id="7yYa0tu$wMU" role="28ntcv">
+                          <node concept="Xl_RD" id="7yYa0tu$wMV" role="WxPPp">
+                            <property role="Xl_RC" value="2" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="7yYa0tu$wMW" role="2pJxcM">
+                    <ref role="2pIpSl" to="5qo5:19PglA20qXS" resolve="range" />
+                    <node concept="2pJPED" id="7yYa0tu$wMX" role="28nt2d">
+                      <ref role="2pJxaS" to="5qo5:19PglA20qX_" resolve="NumberRangeSpec" />
+                      <node concept="2pJxcG" id="7yYa0tu$wMY" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:19PglA20qXJ" resolve="min" />
+                        <node concept="WxPPo" id="7yYa0tu$wMZ" role="28ntcv">
+                          <node concept="Xl_RD" id="7yYa0tu$wN0" role="WxPPp">
+                            <property role="Xl_RC" value="0x0" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2pJxcG" id="7yYa0tu$wN1" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:19PglA20qXK" resolve="max" />
+                        <node concept="WxPPo" id="7yYa0tu$wN2" role="28ntcv">
+                          <node concept="Xl_RD" id="7yYa0tu$wN3" role="WxPPp">
+                            <property role="Xl_RC" value="0x64" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7yYa0tu$yQm" role="3cqZAp" />
+        <node concept="3vlDli" id="7yYa0tu$yL3" role="3cqZAp">
+          <node concept="3clFbT" id="7yYa0tu$yL4" role="3tpDZB">
+            <property role="3clFbU" value="true" />
+          </node>
+          <node concept="2OqwBi" id="7yYa0tu$yL5" role="3tpDZA">
+            <node concept="2pJPEk" id="7yYa0tu$yL6" role="2Oq$k0">
+              <node concept="2pJPED" id="7yYa0tu$yL7" role="2pJPEn">
+                <ref role="2pJxaS" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                <node concept="2pIpSj" id="7yYa0tu$yL8" role="2pJxcM">
+                  <ref role="2pIpSl" to="5qo5:19PglA20qY9" resolve="prec" />
+                  <node concept="2pJPED" id="7yYa0tu$yL9" role="28nt2d">
+                    <ref role="2pJxaS" to="5qo5:19PglA20qXW" resolve="NumberPrecSpec" />
+                    <node concept="2pJxcG" id="7yYa0tu$yLa" role="2pJxcM">
+                      <ref role="2pJxcJ" to="5qo5:19PglA20qY6" resolve="prec" />
+                      <node concept="WxPPo" id="7yYa0tu$yLb" role="28ntcv">
+                        <node concept="Xl_RD" id="7yYa0tu$yLc" role="WxPPp">
+                          <property role="Xl_RC" value="2" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="7yYa0tu$yLd" role="2pJxcM">
+                  <ref role="2pIpSl" to="5qo5:19PglA20qXS" resolve="range" />
+                  <node concept="2pJPED" id="7yYa0tu$yLe" role="28nt2d">
+                    <ref role="2pJxaS" to="5qo5:19PglA20qX_" resolve="NumberRangeSpec" />
+                    <node concept="2pJxcG" id="7yYa0tu$yLf" role="2pJxcM">
+                      <ref role="2pJxcJ" to="5qo5:19PglA20qXJ" resolve="min" />
+                      <node concept="WxPPo" id="7yYa0tu$yLg" role="28ntcv">
+                        <node concept="Xl_RD" id="7yYa0tu$yLh" role="WxPPp">
+                          <property role="Xl_RC" value="-100" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2pJxcG" id="7yYa0tu$yLi" role="2pJxcM">
+                      <ref role="2pJxcJ" to="5qo5:19PglA20qXK" resolve="max" />
+                      <node concept="WxPPo" id="7yYa0tu$yLj" role="28ntcv">
+                        <node concept="Xl_RD" id="7yYa0tu$yLk" role="WxPPp">
+                          <property role="Xl_RC" value="100" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2qgKlT" id="7yYa0tu$yLl" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:fIXgjlt4VE" resolve="isSameAs" />
+              <node concept="2pJPEk" id="7yYa0tu$yLm" role="37wK5m">
+                <node concept="2pJPED" id="7yYa0tu$yLn" role="2pJPEn">
+                  <ref role="2pJxaS" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                  <node concept="2pIpSj" id="7yYa0tu$yLo" role="2pJxcM">
+                    <ref role="2pIpSl" to="5qo5:19PglA20qY9" resolve="prec" />
+                    <node concept="2pJPED" id="7yYa0tu$yLp" role="28nt2d">
+                      <ref role="2pJxaS" to="5qo5:19PglA20qXW" resolve="NumberPrecSpec" />
+                      <node concept="2pJxcG" id="7yYa0tu$yLq" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:19PglA20qY6" resolve="prec" />
+                        <node concept="WxPPo" id="7yYa0tu$yLr" role="28ntcv">
+                          <node concept="Xl_RD" id="7yYa0tu$yLs" role="WxPPp">
+                            <property role="Xl_RC" value="2" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="7yYa0tu$yLt" role="2pJxcM">
+                    <ref role="2pIpSl" to="5qo5:19PglA20qXS" resolve="range" />
+                    <node concept="2pJPED" id="7yYa0tu$yLu" role="28nt2d">
+                      <ref role="2pJxaS" to="5qo5:19PglA20qX_" resolve="NumberRangeSpec" />
+                      <node concept="2pJxcG" id="7yYa0tu$yLv" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:19PglA20qXJ" resolve="min" />
+                        <node concept="WxPPo" id="7yYa0tu$yLw" role="28ntcv">
+                          <node concept="Xl_RD" id="7yYa0tu$yLx" role="WxPPp">
+                            <property role="Xl_RC" value="-0x64" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2pJxcG" id="7yYa0tu$yLy" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:19PglA20qXK" resolve="max" />
+                        <node concept="WxPPo" id="7yYa0tu$yLz" role="28ntcv">
+                          <node concept="Xl_RD" id="7yYa0tu$yL$" role="WxPPp">
+                            <property role="Xl_RC" value="0x64" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7yYa0tu$y$i" role="3cqZAp" />
+        <node concept="3vlDli" id="7yYa0tu$yvL" role="3cqZAp">
+          <node concept="3clFbT" id="7yYa0tu$yAL" role="3tpDZB" />
+          <node concept="2OqwBi" id="7yYa0tu$yvN" role="3tpDZA">
+            <node concept="2pJPEk" id="7yYa0tu$yvO" role="2Oq$k0">
+              <node concept="2pJPED" id="7yYa0tu$yvP" role="2pJPEn">
+                <ref role="2pJxaS" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                <node concept="2pIpSj" id="7yYa0tu$yvQ" role="2pJxcM">
+                  <ref role="2pIpSl" to="5qo5:19PglA20qY9" resolve="prec" />
+                  <node concept="2pJPED" id="7yYa0tu$yvR" role="28nt2d">
+                    <ref role="2pJxaS" to="5qo5:19PglA20qXW" resolve="NumberPrecSpec" />
+                    <node concept="2pJxcG" id="7yYa0tu$yvS" role="2pJxcM">
+                      <ref role="2pJxcJ" to="5qo5:19PglA20qY6" resolve="prec" />
+                      <node concept="WxPPo" id="7yYa0tu$yvT" role="28ntcv">
+                        <node concept="Xl_RD" id="7yYa0tu$yvU" role="WxPPp">
+                          <property role="Xl_RC" value="2" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="7yYa0tu$yvV" role="2pJxcM">
+                  <ref role="2pIpSl" to="5qo5:19PglA20qXS" resolve="range" />
+                  <node concept="2pJPED" id="7yYa0tu$yvW" role="28nt2d">
+                    <ref role="2pJxaS" to="5qo5:19PglA20qX_" resolve="NumberRangeSpec" />
+                    <node concept="2pJxcG" id="7yYa0tu$yvX" role="2pJxcM">
+                      <ref role="2pJxcJ" to="5qo5:19PglA20qXJ" resolve="min" />
+                      <node concept="WxPPo" id="7yYa0tu$yvY" role="28ntcv">
+                        <node concept="Xl_RD" id="7yYa0tu$yvZ" role="WxPPp">
+                          <property role="Xl_RC" value="0" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2pJxcG" id="7yYa0tu$yw0" role="2pJxcM">
+                      <ref role="2pJxcJ" to="5qo5:19PglA20qXK" resolve="max" />
+                      <node concept="WxPPo" id="7yYa0tu$yw1" role="28ntcv">
+                        <node concept="Xl_RD" id="7yYa0tu$yw2" role="WxPPp">
+                          <property role="Xl_RC" value="50" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2qgKlT" id="7yYa0tu$yw3" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:fIXgjlt4VE" resolve="isSameAs" />
+              <node concept="2pJPEk" id="7yYa0tu$yw4" role="37wK5m">
+                <node concept="2pJPED" id="7yYa0tu$yw5" role="2pJPEn">
+                  <ref role="2pJxaS" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                  <node concept="2pIpSj" id="7yYa0tu$yw6" role="2pJxcM">
+                    <ref role="2pIpSl" to="5qo5:19PglA20qY9" resolve="prec" />
+                    <node concept="2pJPED" id="7yYa0tu$yw7" role="28nt2d">
+                      <ref role="2pJxaS" to="5qo5:19PglA20qXW" resolve="NumberPrecSpec" />
+                      <node concept="2pJxcG" id="7yYa0tu$yw8" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:19PglA20qY6" resolve="prec" />
+                        <node concept="WxPPo" id="7yYa0tu$yw9" role="28ntcv">
+                          <node concept="Xl_RD" id="7yYa0tu$ywa" role="WxPPp">
+                            <property role="Xl_RC" value="2" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="7yYa0tu$ywb" role="2pJxcM">
+                    <ref role="2pIpSl" to="5qo5:19PglA20qXS" resolve="range" />
+                    <node concept="2pJPED" id="7yYa0tu$ywc" role="28nt2d">
+                      <ref role="2pJxaS" to="5qo5:19PglA20qX_" resolve="NumberRangeSpec" />
+                      <node concept="2pJxcG" id="7yYa0tu$ywd" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:19PglA20qXJ" resolve="min" />
+                        <node concept="WxPPo" id="7yYa0tu$ywe" role="28ntcv">
+                          <node concept="Xl_RD" id="7yYa0tu$ywf" role="WxPPp">
+                            <property role="Xl_RC" value="0x0" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2pJxcG" id="7yYa0tu$ywg" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:19PglA20qXK" resolve="max" />
+                        <node concept="WxPPo" id="7yYa0tu$ywh" role="28ntcv">
+                          <node concept="Xl_RD" id="7yYa0tu$ywi" role="WxPPp">
+                            <property role="Xl_RC" value="0x64" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7yYa0tu$zv_" role="3cqZAp" />
+        <node concept="3vlDli" id="7yYa0tu$zoH" role="3cqZAp">
+          <node concept="3clFbT" id="7yYa0tu$zoI" role="3tpDZB">
+            <property role="3clFbU" value="true" />
+          </node>
+          <node concept="2OqwBi" id="7yYa0tu$zoJ" role="3tpDZA">
+            <node concept="2pJPEk" id="7yYa0tu$zoK" role="2Oq$k0">
+              <node concept="2pJPED" id="7yYa0tu$zoL" role="2pJPEn">
+                <ref role="2pJxaS" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                <node concept="2pIpSj" id="7yYa0tu$zoM" role="2pJxcM">
+                  <ref role="2pIpSl" to="5qo5:19PglA20qY9" resolve="prec" />
+                  <node concept="2pJPED" id="7yYa0tu$zoN" role="28nt2d">
+                    <ref role="2pJxaS" to="5qo5:19PglA20qXW" resolve="NumberPrecSpec" />
+                    <node concept="2pJxcG" id="7yYa0tu$zoO" role="2pJxcM">
+                      <ref role="2pJxcJ" to="5qo5:19PglA20qY6" resolve="prec" />
+                      <node concept="WxPPo" id="7yYa0tu$zoP" role="28ntcv">
+                        <node concept="Xl_RD" id="7yYa0tu$zoQ" role="WxPPp">
+                          <property role="Xl_RC" value="0" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="7yYa0tu$zoR" role="2pJxcM">
+                  <ref role="2pIpSl" to="5qo5:19PglA20qXS" resolve="range" />
+                  <node concept="2pJPED" id="7yYa0tu$zoS" role="28nt2d">
+                    <ref role="2pJxaS" to="5qo5:19PglA20qX_" resolve="NumberRangeSpec" />
+                    <node concept="2pJxcG" id="7yYa0tu$zoT" role="2pJxcM">
+                      <ref role="2pJxcJ" to="5qo5:19PglA20qXJ" resolve="min" />
+                      <node concept="WxPPo" id="7yYa0tu$zoU" role="28ntcv">
+                        <node concept="Xl_RD" id="7yYa0tu$zoV" role="WxPPp">
+                          <property role="Xl_RC" value="0" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2pJxcG" id="7yYa0tu$zoW" role="2pJxcM">
+                      <ref role="2pJxcJ" to="5qo5:19PglA20qXK" resolve="max" />
+                      <node concept="WxPPo" id="7yYa0tu$zoX" role="28ntcv">
+                        <node concept="Xl_RD" id="7yYa0tu$zoY" role="WxPPp">
+                          <property role="Xl_RC" value="100" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2qgKlT" id="7yYa0tu$zoZ" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:fIXgjlt4VE" resolve="isSameAs" />
+              <node concept="2pJPEk" id="7yYa0tu$zp0" role="37wK5m">
+                <node concept="2pJPED" id="7yYa0tu$zp1" role="2pJPEn">
+                  <ref role="2pJxaS" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                  <node concept="2pIpSj" id="7yYa0tu$zp2" role="2pJxcM">
+                    <ref role="2pIpSl" to="5qo5:19PglA20qY9" resolve="prec" />
+                    <node concept="2pJPED" id="7yYa0tu$zp3" role="28nt2d">
+                      <ref role="2pJxaS" to="5qo5:19PglA20qXW" resolve="NumberPrecSpec" />
+                      <node concept="2pJxcG" id="7yYa0tu$zp4" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:19PglA20qY6" resolve="prec" />
+                        <node concept="WxPPo" id="7yYa0tu$zp5" role="28ntcv">
+                          <node concept="Xl_RD" id="7yYa0tu$zp6" role="WxPPp">
+                            <property role="Xl_RC" value="0" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="7yYa0tu$zp7" role="2pJxcM">
+                    <ref role="2pIpSl" to="5qo5:19PglA20qXS" resolve="range" />
+                    <node concept="2pJPED" id="7yYa0tu$zp8" role="28nt2d">
+                      <ref role="2pJxaS" to="5qo5:19PglA20qX_" resolve="NumberRangeSpec" />
+                      <node concept="2pJxcG" id="7yYa0tu$zp9" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:19PglA20qXJ" resolve="min" />
+                        <node concept="WxPPo" id="7yYa0tu$zpa" role="28ntcv">
+                          <node concept="Xl_RD" id="7yYa0tu$zpb" role="WxPPp">
+                            <property role="Xl_RC" value="0x0" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2pJxcG" id="7yYa0tu$zpc" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:19PglA20qXK" resolve="max" />
+                        <node concept="WxPPo" id="7yYa0tu$zpd" role="28ntcv">
+                          <node concept="Xl_RD" id="7yYa0tu$zpe" role="WxPPp">
+                            <property role="Xl_RC" value="0x64" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7yYa0tu$z3H" role="3cqZAp" />
+        <node concept="3vlDli" id="7yYa0tu$z9e" role="3cqZAp">
+          <node concept="3clFbT" id="7yYa0tu$z9f" role="3tpDZB">
+            <property role="3clFbU" value="true" />
+          </node>
+          <node concept="2OqwBi" id="7yYa0tu$z9g" role="3tpDZA">
+            <node concept="2pJPEk" id="7yYa0tu$z9h" role="2Oq$k0">
+              <node concept="2pJPED" id="7yYa0tu$z9i" role="2pJPEn">
+                <ref role="2pJxaS" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                <node concept="2pIpSj" id="7yYa0tu$z9j" role="2pJxcM">
+                  <ref role="2pIpSl" to="5qo5:19PglA20qY9" resolve="prec" />
+                  <node concept="2pJPED" id="7yYa0tu$z9k" role="28nt2d">
+                    <ref role="2pJxaS" to="5qo5:19PglA20qXW" resolve="NumberPrecSpec" />
+                    <node concept="2pJxcG" id="7yYa0tu$z9l" role="2pJxcM">
+                      <ref role="2pJxcJ" to="5qo5:19PglA20qY6" resolve="prec" />
+                      <node concept="WxPPo" id="7yYa0tu$z9m" role="28ntcv">
+                        <node concept="Xl_RD" id="7yYa0tu$z9n" role="WxPPp">
+                          <property role="Xl_RC" value="0" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="7yYa0tu$z9o" role="2pJxcM">
+                  <ref role="2pIpSl" to="5qo5:19PglA20qXS" resolve="range" />
+                  <node concept="2pJPED" id="7yYa0tu$z9p" role="28nt2d">
+                    <ref role="2pJxaS" to="5qo5:19PglA20qX_" resolve="NumberRangeSpec" />
+                    <node concept="2pJxcG" id="7yYa0tu$z9q" role="2pJxcM">
+                      <ref role="2pJxcJ" to="5qo5:19PglA20qXJ" resolve="min" />
+                      <node concept="WxPPo" id="7yYa0tu$z9r" role="28ntcv">
+                        <node concept="Xl_RD" id="7yYa0tu$z9s" role="WxPPp">
+                          <property role="Xl_RC" value="-100" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2pJxcG" id="7yYa0tu$z9t" role="2pJxcM">
+                      <ref role="2pJxcJ" to="5qo5:19PglA20qXK" resolve="max" />
+                      <node concept="WxPPo" id="7yYa0tu$z9u" role="28ntcv">
+                        <node concept="Xl_RD" id="7yYa0tu$z9v" role="WxPPp">
+                          <property role="Xl_RC" value="100" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2qgKlT" id="7yYa0tu$z9w" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:fIXgjlt4VE" resolve="isSameAs" />
+              <node concept="2pJPEk" id="7yYa0tu$z9x" role="37wK5m">
+                <node concept="2pJPED" id="7yYa0tu$z9y" role="2pJPEn">
+                  <ref role="2pJxaS" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                  <node concept="2pIpSj" id="7yYa0tu$z9z" role="2pJxcM">
+                    <ref role="2pIpSl" to="5qo5:19PglA20qY9" resolve="prec" />
+                    <node concept="2pJPED" id="7yYa0tu$z9$" role="28nt2d">
+                      <ref role="2pJxaS" to="5qo5:19PglA20qXW" resolve="NumberPrecSpec" />
+                      <node concept="2pJxcG" id="7yYa0tu$z9_" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:19PglA20qY6" resolve="prec" />
+                        <node concept="WxPPo" id="7yYa0tu$z9A" role="28ntcv">
+                          <node concept="Xl_RD" id="7yYa0tu$z9B" role="WxPPp">
+                            <property role="Xl_RC" value="0" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="7yYa0tu$z9C" role="2pJxcM">
+                    <ref role="2pIpSl" to="5qo5:19PglA20qXS" resolve="range" />
+                    <node concept="2pJPED" id="7yYa0tu$z9D" role="28nt2d">
+                      <ref role="2pJxaS" to="5qo5:19PglA20qX_" resolve="NumberRangeSpec" />
+                      <node concept="2pJxcG" id="7yYa0tu$z9E" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:19PglA20qXJ" resolve="min" />
+                        <node concept="WxPPo" id="7yYa0tu$z9F" role="28ntcv">
+                          <node concept="Xl_RD" id="7yYa0tu$z9G" role="WxPPp">
+                            <property role="Xl_RC" value="-0x64" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2pJxcG" id="7yYa0tu$z9H" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:19PglA20qXK" resolve="max" />
+                        <node concept="WxPPo" id="7yYa0tu$z9I" role="28ntcv">
+                          <node concept="Xl_RD" id="7yYa0tu$z9J" role="WxPPp">
+                            <property role="Xl_RC" value="0x64" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7yYa0tu$z6Z" role="3cqZAp" />
+        <node concept="3clFbH" id="7yYa0tu$ym6" role="3cqZAp" />
+        <node concept="3vlDli" id="7yYa0tu$yin" role="3cqZAp">
+          <node concept="3clFbT" id="7yYa0tu$yJb" role="3tpDZB" />
+          <node concept="2OqwBi" id="7yYa0tu$yip" role="3tpDZA">
+            <node concept="2pJPEk" id="7yYa0tu$yiq" role="2Oq$k0">
+              <node concept="2pJPED" id="7yYa0tu$yir" role="2pJPEn">
+                <ref role="2pJxaS" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                <node concept="2pIpSj" id="7yYa0tu$yis" role="2pJxcM">
+                  <ref role="2pIpSl" to="5qo5:19PglA20qY9" resolve="prec" />
+                  <node concept="2pJPED" id="7yYa0tu$yit" role="28nt2d">
+                    <ref role="2pJxaS" to="5qo5:19PglA20qXW" resolve="NumberPrecSpec" />
+                    <node concept="2pJxcG" id="7yYa0tu$yiu" role="2pJxcM">
+                      <ref role="2pJxcJ" to="5qo5:19PglA20qY6" resolve="prec" />
+                      <node concept="WxPPo" id="7yYa0tu$yiv" role="28ntcv">
+                        <node concept="Xl_RD" id="7yYa0tu$yiw" role="WxPPp">
+                          <property role="Xl_RC" value="0" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="7yYa0tu$yix" role="2pJxcM">
+                  <ref role="2pIpSl" to="5qo5:19PglA20qXS" resolve="range" />
+                  <node concept="2pJPED" id="7yYa0tu$yiy" role="28nt2d">
+                    <ref role="2pJxaS" to="5qo5:19PglA20qX_" resolve="NumberRangeSpec" />
+                    <node concept="2pJxcG" id="7yYa0tu$yiz" role="2pJxcM">
+                      <ref role="2pJxcJ" to="5qo5:19PglA20qXJ" resolve="min" />
+                      <node concept="WxPPo" id="7yYa0tu$yi$" role="28ntcv">
+                        <node concept="Xl_RD" id="7yYa0tu$yi_" role="WxPPp">
+                          <property role="Xl_RC" value="0" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2pJxcG" id="7yYa0tu$yiA" role="2pJxcM">
+                      <ref role="2pJxcJ" to="5qo5:19PglA20qXK" resolve="max" />
+                      <node concept="WxPPo" id="7yYa0tu$yiB" role="28ntcv">
+                        <node concept="Xl_RD" id="7yYa0tu$yiC" role="WxPPp">
+                          <property role="Xl_RC" value="50" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2qgKlT" id="7yYa0tu$yiD" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:fIXgjlt4VE" resolve="isSameAs" />
+              <node concept="2pJPEk" id="7yYa0tu$yiE" role="37wK5m">
+                <node concept="2pJPED" id="7yYa0tu$yiF" role="2pJPEn">
+                  <ref role="2pJxaS" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+                  <node concept="2pIpSj" id="7yYa0tu$yiG" role="2pJxcM">
+                    <ref role="2pIpSl" to="5qo5:19PglA20qY9" resolve="prec" />
+                    <node concept="2pJPED" id="7yYa0tu$yiH" role="28nt2d">
+                      <ref role="2pJxaS" to="5qo5:19PglA20qXW" resolve="NumberPrecSpec" />
+                      <node concept="2pJxcG" id="7yYa0tu$yiI" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:19PglA20qY6" resolve="prec" />
+                        <node concept="WxPPo" id="7yYa0tu$yiJ" role="28ntcv">
+                          <node concept="Xl_RD" id="7yYa0tu$yiK" role="WxPPp">
+                            <property role="Xl_RC" value="0" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2pIpSj" id="7yYa0tu$yiL" role="2pJxcM">
+                    <ref role="2pIpSl" to="5qo5:19PglA20qXS" resolve="range" />
+                    <node concept="2pJPED" id="7yYa0tu$yiM" role="28nt2d">
+                      <ref role="2pJxaS" to="5qo5:19PglA20qX_" resolve="NumberRangeSpec" />
+                      <node concept="2pJxcG" id="7yYa0tu$yiN" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:19PglA20qXJ" resolve="min" />
+                        <node concept="WxPPo" id="7yYa0tu$yiO" role="28ntcv">
+                          <node concept="Xl_RD" id="7yYa0tu$yiP" role="WxPPp">
+                            <property role="Xl_RC" value="0x0" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2pJxcG" id="7yYa0tu$yiQ" role="2pJxcM">
+                        <ref role="2pJxcJ" to="5qo5:19PglA20qXK" resolve="max" />
+                        <node concept="WxPPo" id="7yYa0tu$yiR" role="28ntcv">
+                          <node concept="Xl_RD" id="7yYa0tu$yiS" role="WxPPp">
+                            <property role="Xl_RC" value="0x64" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="1LZb2c" id="3Up1DZuQp4W" role="1SL9yI">
       <property role="TrG5h" value="aNumberTypeIsNotEqualToOtherTypes" />
       <node concept="3cqZAl" id="3Up1DZuQp4X" role="3clF45" />
@@ -5275,6 +5836,38 @@
           </node>
           <node concept="30bXR$" id="17MOwOjNhDU" role="2zM23F" />
         </node>
+        <node concept="_ixoA" id="7yYa0tu$3Ys" role="_iOnC" />
+        <node concept="2zPypq" id="7yYa0tu$4av" role="_iOnC">
+          <property role="TrG5h" value="hex" />
+          <node concept="30bXRB" id="7yYa0tu$4h2" role="2zPyp_">
+            <property role="30bXRw" value="0xff" />
+          </node>
+          <node concept="30bXR$" id="7yYa0tu$4gO" role="2zM23F" />
+        </node>
+        <node concept="2zPypq" id="7yYa0tu$4pZ" role="_iOnC">
+          <property role="TrG5h" value="hex2" />
+          <node concept="mLuIC" id="7yYa0tu$4wq" role="2zM23F">
+            <node concept="2gteSX" id="7yYa0tu$4wA" role="2gteSx">
+              <property role="2gteSR" value="0x0" />
+              <property role="2gteSE" value="0xff" />
+            </node>
+          </node>
+          <node concept="30bXRB" id="7yYa0tu$4_v" role="2zPyp_">
+            <property role="30bXRw" value="50" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="7yYa0tu$4Ap" role="_iOnC">
+          <property role="TrG5h" value="hex3" />
+          <node concept="mLuIC" id="7yYa0tu$4Aq" role="2zM23F">
+            <node concept="2gteSX" id="7yYa0tu$4Ar" role="2gteSx">
+              <property role="2gteSR" value="-0xf" />
+              <property role="2gteSE" value="0xf" />
+            </node>
+          </node>
+          <node concept="30bXRB" id="7yYa0tu$niF" role="2zPyp_">
+            <property role="30bXRw" value="-1" />
+          </node>
+        </node>
         <node concept="_ixoA" id="17MOwOjM$LU" role="_iOnC" />
         <node concept="7CXmI" id="6rdp$3y_pdc" role="lGtFl">
           <node concept="7OXhh" id="6rdp$3y_pdd" role="7EUXB">
@@ -6038,6 +6631,40 @@
             </node>
           </node>
         </node>
+        <node concept="2zPypq" id="7yYa0tuAvMH" role="_iOnC">
+          <property role="TrG5h" value="a3" />
+          <node concept="30dDZf" id="7yYa0tuAw99" role="2zPyp_">
+            <node concept="30bXRB" id="7yYa0tuAwag" role="30dEs_">
+              <property role="30bXRw" value="0x2" />
+            </node>
+            <node concept="30bXRB" id="7yYa0tuAw6a" role="30dEsF">
+              <property role="30bXRw" value="0x1" />
+            </node>
+          </node>
+          <node concept="mLuIC" id="7yYa0tuAvSy" role="2zM23F">
+            <node concept="2gteSX" id="7yYa0tuAvTu" role="2gteSx">
+              <property role="2gteSR" value="-0xf" />
+              <property role="2gteSE" value="0xf" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7yYa0tuAxBy" role="_iOnC">
+          <property role="TrG5h" value="a4" />
+          <node concept="30dDZf" id="7yYa0tuAxBz" role="2zPyp_">
+            <node concept="30bXRB" id="7yYa0tuAxB$" role="30dEs_">
+              <property role="30bXRw" value="0x2" />
+            </node>
+            <node concept="30bXRB" id="7yYa0tuAxB_" role="30dEsF">
+              <property role="30bXRw" value="0x1" />
+            </node>
+          </node>
+          <node concept="mLuIC" id="7yYa0tuAxBA" role="2zM23F">
+            <node concept="2gteSX" id="7yYa0tuAxBB" role="2gteSx">
+              <property role="2gteSR" value="-1e10" />
+              <property role="2gteSE" value="1e10" />
+            </node>
+          </node>
+        </node>
         <node concept="_ixoA" id="63mrHUnQha6" role="_iOnC" />
         <node concept="1Ws0TD" id="63mrHUnQha7" role="_iOnC">
           <property role="1WsWdv" value="Subtraction" />
@@ -6074,6 +6701,40 @@
             <node concept="2gteSX" id="63mrHUnQhaj" role="2gteSx">
               <property role="2gteSR" value="-2" />
               <property role="2gteSE" value="3" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7yYa0tuAwi8" role="_iOnC">
+          <property role="TrG5h" value="s3" />
+          <node concept="30dvUo" id="7yYa0tuAws5" role="2zPyp_">
+            <node concept="30bXRB" id="7yYa0tuAwts" role="30dEs_">
+              <property role="30bXRw" value="0x2" />
+            </node>
+            <node concept="30bXRB" id="7yYa0tuAwib" role="30dEsF">
+              <property role="30bXRw" value="0x1" />
+            </node>
+          </node>
+          <node concept="mLuIC" id="7yYa0tuAwic" role="2zM23F">
+            <node concept="2gteSX" id="7yYa0tuAwid" role="2gteSx">
+              <property role="2gteSR" value="-0xf" />
+              <property role="2gteSE" value="0xf" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7yYa0tuAxZu" role="_iOnC">
+          <property role="TrG5h" value="s4" />
+          <node concept="30dvUo" id="7yYa0tuAxZv" role="2zPyp_">
+            <node concept="30bXRB" id="7yYa0tuAxZw" role="30dEs_">
+              <property role="30bXRw" value="0x2" />
+            </node>
+            <node concept="30bXRB" id="7yYa0tuAxZx" role="30dEsF">
+              <property role="30bXRw" value="0x1" />
+            </node>
+          </node>
+          <node concept="mLuIC" id="7yYa0tuAxZy" role="2zM23F">
+            <node concept="2gteSX" id="7yYa0tuAxZz" role="2gteSx">
+              <property role="2gteSR" value="-1e10" />
+              <property role="2gteSE" value="1e10" />
             </node>
           </node>
         </node>
@@ -6121,6 +6782,40 @@
             <node concept="2gteSX" id="63mrHUnQha_" role="2gteSx">
               <property role="2gteSR" value="0" />
               <property role="2gteSE" value="7" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7yYa0tuAwBQ" role="_iOnC">
+          <property role="TrG5h" value="p3" />
+          <node concept="30dDTi" id="7yYa0tuAwBR" role="2zPyp_">
+            <node concept="_emDc" id="7yYa0tuAwBS" role="30dEs_">
+              <ref role="_emDf" node="63mrHUnQhas" resolve="p2" />
+            </node>
+            <node concept="_emDc" id="7yYa0tuAwBT" role="30dEsF">
+              <ref role="_emDf" node="63mrHUnQhao" resolve="p1" />
+            </node>
+          </node>
+          <node concept="mLuIC" id="7yYa0tuAwBU" role="2zM23F">
+            <node concept="2gteSX" id="7yYa0tuAwBV" role="2gteSx">
+              <property role="2gteSR" value="-0xf" />
+              <property role="2gteSE" value="0xf" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7yYa0tuACVh" role="_iOnC">
+          <property role="TrG5h" value="p4" />
+          <node concept="30dDTi" id="7yYa0tuACVi" role="2zPyp_">
+            <node concept="_emDc" id="7yYa0tuACVj" role="30dEs_">
+              <ref role="_emDf" node="63mrHUnQhas" resolve="p2" />
+            </node>
+            <node concept="_emDc" id="7yYa0tuACVk" role="30dEsF">
+              <ref role="_emDf" node="63mrHUnQhao" resolve="p1" />
+            </node>
+          </node>
+          <node concept="mLuIC" id="7yYa0tuACVl" role="2zM23F">
+            <node concept="2gteSX" id="7yYa0tuACVm" role="2gteSx">
+              <property role="2gteSR" value="-1e10" />
+              <property role="2gteSE" value="1e10" />
             </node>
           </node>
         </node>
@@ -6253,6 +6948,46 @@
               <property role="2gteSE" value="0.3333333334" />
             </node>
             <node concept="2gteS_" id="63mrHUnQhbl" role="2gteVg">
+              <property role="2gteVv" value="inf" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7yYa0tuAxcY" role="_iOnC">
+          <property role="TrG5h" value="d3" />
+          <node concept="30dvO6" id="7yYa0tuAxcZ" role="2zPyp_">
+            <node concept="_emDc" id="7yYa0tuAxd0" role="30dEsF">
+              <ref role="_emDf" node="63mrHUnQhb7" resolve="d1" />
+            </node>
+            <node concept="_emDc" id="7yYa0tuAxd1" role="30dEs_">
+              <ref role="_emDf" node="63mrHUnQhbb" resolve="d2" />
+            </node>
+          </node>
+          <node concept="mLuIC" id="7yYa0tuAxd2" role="2zM23F">
+            <node concept="2gteSX" id="7yYa0tuAxd3" role="2gteSx">
+              <property role="2gteSR" value="0.0000000000" />
+              <property role="2gteSE" value="0x1" />
+            </node>
+            <node concept="2gteS_" id="7yYa0tuAxd4" role="2gteVg">
+              <property role="2gteVv" value="inf" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7yYa0tuADRG" role="_iOnC">
+          <property role="TrG5h" value="d4" />
+          <node concept="30dvO6" id="7yYa0tuADRH" role="2zPyp_">
+            <node concept="_emDc" id="7yYa0tuADRI" role="30dEsF">
+              <ref role="_emDf" node="63mrHUnQhb7" resolve="d1" />
+            </node>
+            <node concept="_emDc" id="7yYa0tuADRJ" role="30dEs_">
+              <ref role="_emDf" node="63mrHUnQhbb" resolve="d2" />
+            </node>
+          </node>
+          <node concept="mLuIC" id="7yYa0tuADRK" role="2zM23F">
+            <node concept="2gteSX" id="7yYa0tuADRL" role="2gteSx">
+              <property role="2gteSR" value="0.0000000000" />
+              <property role="2gteSE" value="1e1" />
+            </node>
+            <node concept="2gteS_" id="7yYa0tuADRM" role="2gteVg">
               <property role="2gteVv" value="inf" />
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
@@ -718,6 +718,23 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbF" id="7yYa0tuAVTt" role="3cqZAp">
+          <node concept="2OqwBi" id="7yYa0tuAVTu" role="3clFbG">
+            <node concept="2WthIp" id="7yYa0tuAVTv" role="2Oq$k0" />
+            <node concept="2XshWL" id="7yYa0tuAVTw" role="2OqNvi">
+              <ref role="2WH_rO" node="3FpaOZJSRbe" resolve="assertNumberType" />
+              <node concept="3xONca" id="7yYa0tuAVTx" role="2XxRq1">
+                <ref role="3xOPvv" node="7yYa0tuAVug" resolve="specTypeKMyC2" />
+              </node>
+              <node concept="Xl_RD" id="7yYa0tuAVTy" role="2XxRq1">
+                <property role="Xl_RC" value="-273" />
+              </node>
+              <node concept="Xl_RD" id="7yYa0tuAVTz" role="2XxRq1">
+                <property role="Xl_RC" value="-273" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="3FpaOZJSVWd" role="3cqZAp">
           <node concept="2OqwBi" id="3FpaOZJSVWe" role="3clFbG">
             <node concept="2WthIp" id="3FpaOZJSVWf" role="2Oq$k0" />
@@ -1117,6 +1134,26 @@
               </node>
               <node concept="3xLA65" id="77FPJvcWeza" role="lGtFl">
                 <property role="TrG5h" value="specTypeKMyC" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="CIrOH" id="7yYa0tuAVAQ" role="_iOnC">
+          <property role="TrG5h" value="myC2" />
+          <ref role="Rn5ok" node="1KUmgSFvJZV" resolve="myCs" />
+        </node>
+        <node concept="TRoc0" id="7yYa0tuAVub" role="_iOnC">
+          <property role="27Q$Ze" value="false" />
+          <ref role="27Q$ZQ" to="ku0a:5XaocLWHSS8" resolve="K" />
+          <ref role="27Q$ZR" node="7yYa0tuAVAQ" resolve="myC2" />
+          <node concept="27LzZq" id="7yYa0tuAVuc" role="27P04L">
+            <node concept="30dvUo" id="7yYa0tuAVud" role="27K$mF">
+              <node concept="2m5Cep" id="7yYa0tuAVue" role="30dEsF" />
+              <node concept="30bXRB" id="7yYa0tuAVuf" role="30dEs_">
+                <property role="30bXRw" value="0x111" />
+              </node>
+              <node concept="3xLA65" id="7yYa0tuAVug" role="lGtFl">
+                <property role="TrG5h" value="specTypeKMyC2" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
@@ -29,6 +29,7 @@
     <import index="tpd4" ref="r:00000000-0000-4000-0000-011c895902b4(jetbrains.mps.lang.typesystem.structure)" />
     <import index="63ih" ref="r:8b224ec5-7a3e-45b9-8341-eb73ff942246(org.iets3.core.expr.math.typesystem)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
+    <import index="b1h1" ref="r:ac5f749f-6179-4d4f-ad24-ad9edbd8077b(org.iets3.core.expr.simpleTypes.behavior)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
@@ -653,8 +654,8 @@
             <node concept="37vLTw" id="3FpaOZJSU_H" role="2Oq$k0">
               <ref role="3cqZAo" node="3FpaOZJSUoe" resolve="range" />
             </node>
-            <node concept="3TrcHB" id="3FpaOZJSUWJ" role="2OqNvi">
-              <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+            <node concept="2qgKlT" id="SIMVVoux23" role="2OqNvi">
+              <ref role="37wK5l" to="b1h1:SIMVVosRGL" resolve="getMinimum" />
             </node>
           </node>
           <node concept="3_1$Yv" id="3FpaOZJSVlU" role="3_9lra">
@@ -671,8 +672,8 @@
             <node concept="37vLTw" id="3FpaOZJSV03" role="2Oq$k0">
               <ref role="3cqZAo" node="3FpaOZJSUoe" resolve="range" />
             </node>
-            <node concept="3TrcHB" id="3FpaOZJSVeS" role="2OqNvi">
-              <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+            <node concept="2qgKlT" id="SIMVVouxdh" role="2OqNvi">
+              <ref role="37wK5l" to="b1h1:SIMVVosRWc" resolve="getMaximum" />
             </node>
           </node>
           <node concept="3_1$Yv" id="3FpaOZJSVyn" role="3_9lra">


### PR DESCRIPTION
The hexadecimal numbers work similar to the ones in baselanguage. They are considered integers and also support negative values. Internally, they are converted to decimal whenever they are used, that means that the typesystem also converts them to decimal. They are only displayed in hexadecimal form in the editor and the left side of the typesystem debug tool.
Hex values are also now supported in NumberRangeSpecs e.g., `[-0xff | 0xff]`.

Additional fixes:
- `NumberRangeSpec` now validates through the `NumberLiteral` class.
- Precision expression for integers are now not only supported in the generator but also in the interpreter.

Example:

![Screenshot 2022-12-13 at 12 41 33](https://user-images.githubusercontent.com/88385944/207308885-67178441-f764-45d1-a100-9b88f4946de8.png)

