### PR TITLE
Core expr: make NumberType.setRange virtual

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
@@ -3825,6 +3825,7 @@
     </node>
     <node concept="13i0hz" id="6NHlpK$OKdB" role="13h7CS">
       <property role="TrG5h" value="setRange" />
+      <property role="13i0it" value="true" />
       <node concept="3Tm1VV" id="6NHlpK$OKdC" role="1B3o_S" />
       <node concept="3cqZAl" id="6NHlpK$OKdD" role="3clF45" />
       <node concept="3clFbS" id="6NHlpK$OKdE" role="3clF47">


### PR DESCRIPTION
This change is needed so that the method can be overridden.