### PR TITLE
[minor] Typesystem: handle cases where computeSupertype returns an error

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
@@ -182,6 +182,9 @@
         <child id="1144231399730" name="condition" index="1Dwp0S" />
         <child id="1144231408325" name="iteration" index="1Dwrff" />
       </concept>
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
       <concept id="1082113931046" name="jetbrains.mps.baseLanguage.structure.ContinueStatement" flags="nn" index="3N13vt" />
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
@@ -372,6 +375,14 @@
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
       <concept id="1145567426890" name="jetbrains.mps.lang.smodel.structure.SNodeListCreator" flags="nn" index="2T8Vx0">
         <child id="1145567471833" name="createdType" index="2T96Bj" />
@@ -7328,31 +7339,39 @@
           </node>
         </node>
       </node>
-      <node concept="3clFbJ" id="3zml08RoGB6" role="3cqZAp">
-        <node concept="3clFbS" id="3zml08RoGB8" role="3clFbx">
-          <node concept="2MkqsV" id="3zml08RoH6O" role="3cqZAp">
-            <node concept="Xl_RD" id="3zml08RoH70" role="2MkJ7o">
-              <property role="Xl_RC" value="cast not allowed; no common supertype found." />
-            </node>
-            <node concept="2OqwBi" id="3zml08RoHfl" role="1urrMF">
-              <node concept="1YBJjd" id="3zml08RoH7W" role="2Oq$k0">
+      <node concept="Jncv_" id="TcaAhODpaj" role="3cqZAp">
+        <ref role="JncvD" to="tpd4:hfSilrT" resolve="RuntimeErrorType" />
+        <node concept="3clFbS" id="TcaAhODpan" role="Jncv$">
+          <node concept="2MkqsV" id="TcaAhODpHV" role="3cqZAp">
+            <node concept="2OqwBi" id="TcaAhOG0JJ" role="1urrMF">
+              <node concept="1YBJjd" id="TcaAhODrtH" role="2Oq$k0">
                 <ref role="1YBMHb" node="3zml08RoAfJ" resolve="ce" />
               </node>
-              <node concept="3TrEf2" id="3zml08RoHzw" role="2OqNvi">
+              <node concept="3TrEf2" id="TcaAhOG1rJ" role="2OqNvi">
                 <ref role="3Tt5mk" to="hm2y:252QIDzztQk" resolve="expr" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="TcaAhOG$c5" role="2MkJ7o">
+              <node concept="Xl_RD" id="TcaAhOG$cJ" role="3uHU7B">
+                <property role="Xl_RC" value="The cast ist not allowed, no common supertype found:" />
+              </node>
+              <node concept="2OqwBi" id="TcaAhODq_G" role="3uHU7w">
+                <node concept="Jnkvi" id="TcaAhODqaP" role="2Oq$k0">
+                  <ref role="1M0zk5" node="TcaAhODpap" resolve="errorType" />
+                </node>
+                <node concept="3TrcHB" id="TcaAhODr7d" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpd4:hfSilrU" resolve="errorText" />
+                </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="2OqwBi" id="3zml08RoGSj" role="3clFbw">
-          <node concept="37vLTw" id="3zml08RoGBM" role="2Oq$k0">
-            <ref role="3cqZAo" node="3zml08RoGow" resolve="st" />
-          </node>
-          <node concept="1mIQ4w" id="3zml08RoH08" role="2OqNvi">
-            <node concept="chp4Y" id="3zml08RoH1V" role="cj9EA">
-              <ref role="cht4Q" to="tpd4:hfSilrT" resolve="RuntimeErrorType" />
-            </node>
-          </node>
+        <node concept="JncvC" id="TcaAhODpap" role="JncvA">
+          <property role="TrG5h" value="errorType" />
+          <node concept="2jxLKc" id="TcaAhODpaq" role="1tU5fm" />
+        </node>
+        <node concept="37vLTw" id="TcaAhOG1ZD" role="JncvB">
+          <ref role="3cqZAo" node="3zml08RoGow" resolve="st" />
         </node>
       </node>
     </node>
@@ -8784,31 +8803,39 @@
           </node>
         </node>
       </node>
-      <node concept="3clFbJ" id="5a_u3OzTDoP" role="3cqZAp">
-        <node concept="3clFbS" id="5a_u3OzTDoQ" role="3clFbx">
-          <node concept="2MkqsV" id="5a_u3OzTDoR" role="3cqZAp">
-            <node concept="Xl_RD" id="5a_u3OzTDoS" role="2MkJ7o">
-              <property role="Xl_RC" value="cast not allowed; no common supertype found." />
-            </node>
-            <node concept="2OqwBi" id="5a_u3OzTDoT" role="1urrMF">
-              <node concept="1YBJjd" id="5a_u3OzTGAk" role="2Oq$k0">
+      <node concept="Jncv_" id="TcaAhOH61d" role="3cqZAp">
+        <ref role="JncvD" to="tpd4:hfSilrT" resolve="RuntimeErrorType" />
+        <node concept="3clFbS" id="TcaAhOH61e" role="Jncv$">
+          <node concept="2MkqsV" id="TcaAhOH61f" role="3cqZAp">
+            <node concept="2OqwBi" id="TcaAhOH61g" role="1urrMF">
+              <node concept="1YBJjd" id="TcaAhOH61h" role="2Oq$k0">
                 <ref role="1YBMHb" node="5a_u3OzTDo3" resolve="cc" />
               </node>
-              <node concept="3TrEf2" id="5a_u3OzTDoV" role="2OqNvi">
+              <node concept="3TrEf2" id="TcaAhOH61i" role="2OqNvi">
                 <ref role="3Tt5mk" to="hm2y:5a_u3OzTCw6" resolve="expr" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="TcaAhOH61j" role="2MkJ7o">
+              <node concept="Xl_RD" id="TcaAhOH61k" role="3uHU7B">
+                <property role="Xl_RC" value="The cast ist not allowed, no common supertype found:" />
+              </node>
+              <node concept="2OqwBi" id="TcaAhOH61l" role="3uHU7w">
+                <node concept="Jnkvi" id="TcaAhOH61m" role="2Oq$k0">
+                  <ref role="1M0zk5" node="TcaAhOH61o" resolve="errorType" />
+                </node>
+                <node concept="3TrcHB" id="TcaAhOH61n" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpd4:hfSilrU" resolve="errorText" />
+                </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="2OqwBi" id="5a_u3OzTDoW" role="3clFbw">
-          <node concept="37vLTw" id="5a_u3OzTDoX" role="2Oq$k0">
-            <ref role="3cqZAo" node="5a_u3OzTDoJ" resolve="st" />
-          </node>
-          <node concept="1mIQ4w" id="5a_u3OzTDoY" role="2OqNvi">
-            <node concept="chp4Y" id="5a_u3OzTDoZ" role="cj9EA">
-              <ref role="cht4Q" to="tpd4:hfSilrT" resolve="RuntimeErrorType" />
-            </node>
-          </node>
+        <node concept="JncvC" id="TcaAhOH61o" role="JncvA">
+          <property role="TrG5h" value="errorType" />
+          <node concept="2jxLKc" id="TcaAhOH61p" role="1tU5fm" />
+        </node>
+        <node concept="37vLTw" id="TcaAhOH61q" role="JncvB">
+          <ref role="3cqZAo" node="5a_u3OzTDoJ" resolve="st" />
         </node>
       </node>
     </node>
@@ -8999,6 +9026,55 @@
                         <node concept="1Z2H0r" id="1RwPUjzg$RC" role="mwGJk">
                           <node concept="1YBJjd" id="1RwPUjzg_26" role="1Z2MuG">
                             <ref role="1YBMHb" node="1RwPUjzgk2X" resolve="amme" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="TcaAhOIcix" role="3cqZAp">
+                      <node concept="3clFbS" id="TcaAhOIciz" role="3clFbx">
+                        <node concept="3SKdUt" id="TcaAhOIdO0" role="3cqZAp">
+                          <node concept="1PaTwC" id="TcaAhOIdO1" role="1aUNEU">
+                            <node concept="3oM_SD" id="TcaAhOIez2" role="1PaTwD">
+                              <property role="3oM_SC" value="No" />
+                            </node>
+                            <node concept="3oM_SD" id="TcaAhOIeIp" role="1PaTwD">
+                              <property role="3oM_SC" value="need" />
+                            </node>
+                            <node concept="3oM_SD" id="TcaAhOIeIs" role="1PaTwD">
+                              <property role="3oM_SC" value="to" />
+                            </node>
+                            <node concept="3oM_SD" id="TcaAhOIeIw" role="1PaTwD">
+                              <property role="3oM_SC" value="continue." />
+                            </node>
+                            <node concept="3oM_SD" id="TcaAhOIf8r" role="1PaTwD">
+                              <property role="3oM_SC" value="There" />
+                            </node>
+                            <node concept="3oM_SD" id="TcaAhOIffx" role="1PaTwD">
+                              <property role="3oM_SC" value="was" />
+                            </node>
+                            <node concept="3oM_SD" id="TcaAhOIffC" role="1PaTwD">
+                              <property role="3oM_SC" value="already" />
+                            </node>
+                            <node concept="3oM_SD" id="TcaAhOIffK" role="1PaTwD">
+                              <property role="3oM_SC" value="a" />
+                            </node>
+                            <node concept="3oM_SD" id="TcaAhOIffT" role="1PaTwD">
+                              <property role="3oM_SC" value="reported" />
+                            </node>
+                            <node concept="3oM_SD" id="TcaAhOIfg3" role="1PaTwD">
+                              <property role="3oM_SC" value="error." />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs6" id="TcaAhOId_U" role="3cqZAp" />
+                      </node>
+                      <node concept="2OqwBi" id="TcaAhOIcKX" role="3clFbw">
+                        <node concept="37vLTw" id="TcaAhOIcqG" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2ufoZQJ1aYf" resolve="elementSupertype" />
+                        </node>
+                        <node concept="1mIQ4w" id="TcaAhOId17" role="2OqNvi">
+                          <node concept="chp4Y" id="TcaAhOId8x" role="cj9EA">
+                            <ref role="cht4Q" to="tpd4:hfSilrT" resolve="RuntimeErrorType" />
                           </node>
                         </node>
                       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/typesystem.mps
@@ -109,6 +109,9 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
@@ -259,6 +262,14 @@
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
@@ -470,6 +481,37 @@
                             </node>
                           </node>
                         </node>
+                      </node>
+                    </node>
+                    <node concept="Jncv_" id="TcaAhODpaj" role="3cqZAp">
+                      <ref role="JncvD" to="tpd4:hfSilrT" resolve="RuntimeErrorType" />
+                      <node concept="37vLTw" id="TcaAhODph1" role="JncvB">
+                        <ref role="3cqZAo" node="7rdMSLlpzv2" resolve="elementSupertype" />
+                      </node>
+                      <node concept="3clFbS" id="TcaAhODpan" role="Jncv$">
+                        <node concept="2MkqsV" id="TcaAhODpHV" role="3cqZAp">
+                          <node concept="1YBJjd" id="TcaAhODrtH" role="1urrMF">
+                            <ref role="1YBMHb" node="6zmBjqUipC$" resolve="literal" />
+                          </node>
+                          <node concept="3cpWs3" id="TcaAhOJ3xK" role="2MkJ7o">
+                            <node concept="Xl_RD" id="TcaAhOJ4bz" role="3uHU7B">
+                              <property role="Xl_RC" value="No common supertype found:" />
+                            </node>
+                            <node concept="2OqwBi" id="TcaAhODq_G" role="3uHU7w">
+                              <node concept="Jnkvi" id="TcaAhODqaP" role="2Oq$k0">
+                                <ref role="1M0zk5" node="TcaAhODpap" resolve="errorType" />
+                              </node>
+                              <node concept="3TrcHB" id="TcaAhODr7d" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpd4:hfSilrU" resolve="errorText" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs6" id="TcaAhOLGsy" role="3cqZAp" />
+                      </node>
+                      <node concept="JncvC" id="TcaAhODpap" role="JncvA">
+                        <property role="TrG5h" value="errorType" />
+                        <node concept="2jxLKc" id="TcaAhODpaq" role="1tU5fm" />
                       </node>
                     </node>
                     <node concept="3clFbJ" id="7rdMSLlpzva" role="3cqZAp">
@@ -1945,6 +1987,37 @@
                           </node>
                         </node>
                         <node concept="3Tqbb2" id="2ufoZQJ05rB" role="1tU5fm" />
+                      </node>
+                    </node>
+                    <node concept="Jncv_" id="TcaAhOIN_j" role="3cqZAp">
+                      <ref role="JncvD" to="tpd4:hfSilrT" resolve="RuntimeErrorType" />
+                      <node concept="37vLTw" id="TcaAhOIN_k" role="JncvB">
+                        <ref role="3cqZAo" node="2ufoZQJ05rA" resolve="elementSupertype" />
+                      </node>
+                      <node concept="3clFbS" id="TcaAhOIN_l" role="Jncv$">
+                        <node concept="2MkqsV" id="TcaAhOIN_m" role="3cqZAp">
+                          <node concept="1YBJjd" id="TcaAhOIN_n" role="1urrMF">
+                            <ref role="1YBMHb" node="7GwCuf2WbPx" resolve="literal" />
+                          </node>
+                          <node concept="3cpWs3" id="TcaAhOJ6Rx" role="2MkJ7o">
+                            <node concept="2OqwBi" id="TcaAhOIN_o" role="3uHU7w">
+                              <node concept="Jnkvi" id="TcaAhOIN_p" role="2Oq$k0">
+                                <ref role="1M0zk5" node="TcaAhOIN_s" resolve="errorType" />
+                              </node>
+                              <node concept="3TrcHB" id="TcaAhOIN_q" role="2OqNvi">
+                                <ref role="3TsBF5" to="tpd4:hfSilrU" resolve="errorText" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="TcaAhOJ7h3" role="3uHU7B">
+                              <property role="Xl_RC" value="No common supertype found:" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3cpWs6" id="TcaAhOIN_r" role="3cqZAp" />
+                      </node>
+                      <node concept="JncvC" id="TcaAhOIN_s" role="JncvA">
+                        <property role="TrG5h" value="errorType" />
+                        <node concept="2jxLKc" id="TcaAhOIN_t" role="1tU5fm" />
                       </node>
                     </node>
                     <node concept="3clFbJ" id="2ufoZQIYH0s" role="3cqZAp">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/typesystem.mps
@@ -95,6 +95,7 @@
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6" />
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
@@ -122,6 +123,9 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
@@ -206,6 +210,14 @@
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
@@ -904,6 +916,37 @@
                           </node>
                         </node>
                       </node>
+                    </node>
+                  </node>
+                  <node concept="Jncv_" id="TcaAhODpaj" role="3cqZAp">
+                    <ref role="JncvD" to="tpd4:hfSilrT" resolve="RuntimeErrorType" />
+                    <node concept="37vLTw" id="TcaAhODph1" role="JncvB">
+                      <ref role="3cqZAo" node="2NHHcg2MxT6" resolve="elementSupertype" />
+                    </node>
+                    <node concept="3clFbS" id="TcaAhODpan" role="Jncv$">
+                      <node concept="2MkqsV" id="TcaAhODpHV" role="3cqZAp">
+                        <node concept="1YBJjd" id="TcaAhODrtH" role="1urrMF">
+                          <ref role="1YBMHb" node="5avmkTFlBXd" resolve="re" />
+                        </node>
+                        <node concept="3cpWs3" id="TcaAhOJ8Y$" role="2MkJ7o">
+                          <node concept="2OqwBi" id="TcaAhODq_G" role="3uHU7w">
+                            <node concept="Jnkvi" id="TcaAhODqaP" role="2Oq$k0">
+                              <ref role="1M0zk5" node="TcaAhODpap" resolve="errorType" />
+                            </node>
+                            <node concept="3TrcHB" id="TcaAhODr7d" role="2OqNvi">
+                              <ref role="3TsBF5" to="tpd4:hfSilrU" resolve="errorText" />
+                            </node>
+                          </node>
+                          <node concept="Xl_RD" id="TcaAhOJ7h3" role="3uHU7B">
+                            <property role="Xl_RC" value="No common supertype found:" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs6" id="TcaAhODX4a" role="3cqZAp" />
+                    </node>
+                    <node concept="JncvC" id="TcaAhODpap" role="JncvA">
+                      <property role="TrG5h" value="errorType" />
+                      <node concept="2jxLKc" id="TcaAhODpaq" role="1tU5fm" />
                     </node>
                   </node>
                   <node concept="3cpWs8" id="VApoyDzGBW" role="3cqZAp">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
@@ -124,6 +124,9 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
@@ -241,6 +244,14 @@
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
@@ -261,6 +272,9 @@
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
@@ -428,6 +442,37 @@
                           </node>
                         </node>
                       </node>
+                    </node>
+                  </node>
+                  <node concept="Jncv_" id="TcaAhODpaj" role="3cqZAp">
+                    <ref role="JncvD" to="tpd4:hfSilrT" resolve="RuntimeErrorType" />
+                    <node concept="3clFbS" id="TcaAhODpan" role="Jncv$">
+                      <node concept="2MkqsV" id="TcaAhODpHV" role="3cqZAp">
+                        <node concept="1YBJjd" id="TcaAhODrtH" role="1urrMF">
+                          <ref role="1YBMHb" node="50smQ1V92UJ" resolve="tl" />
+                        </node>
+                        <node concept="3cpWs3" id="TcaAhOIXyJ" role="2MkJ7o">
+                          <node concept="2OqwBi" id="TcaAhODq_G" role="3uHU7w">
+                            <node concept="Jnkvi" id="TcaAhODqaP" role="2Oq$k0">
+                              <ref role="1M0zk5" node="TcaAhODpap" resolve="errorType" />
+                            </node>
+                            <node concept="3TrcHB" id="TcaAhODr7d" role="2OqNvi">
+                              <ref role="3TsBF5" to="tpd4:hfSilrU" resolve="errorText" />
+                            </node>
+                          </node>
+                          <node concept="Xl_RD" id="TcaAhOJ7h3" role="3uHU7B">
+                            <property role="Xl_RC" value="No common supertype found:" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs6" id="TcaAhODX4a" role="3cqZAp" />
+                    </node>
+                    <node concept="JncvC" id="TcaAhODpap" role="JncvA">
+                      <property role="TrG5h" value="errorType" />
+                      <node concept="2jxLKc" id="TcaAhODpaq" role="1tU5fm" />
+                    </node>
+                    <node concept="37vLTw" id="TcaAhOIXpK" role="JncvB">
+                      <ref role="3cqZAo" node="2NHHcg2MxT6" resolve="sliceSupertype" />
                     </node>
                   </node>
                   <node concept="3clFbJ" id="2LepRDoQrkO" role="3cqZAp">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/typesystem.mps
@@ -124,6 +124,11 @@
         <child id="1144231399730" name="condition" index="1Dwp0S" />
         <child id="1144231408325" name="iteration" index="1Dwrff" />
       </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
       <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
         <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
       </concept>
@@ -1681,13 +1686,8 @@
             <node concept="Xl_RD" id="3Y6fbK16uBK" role="2MkJ7o">
               <property role="Xl_RC" value="non-valued enums cannot have values" />
             </node>
-            <node concept="2OqwBi" id="3Y6fbK16va9" role="1urrMF">
-              <node concept="1YBJjd" id="3Y6fbK16uBL" role="2Oq$k0">
-                <ref role="1YBMHb" node="3Y6fbK16s$S" resolve="enumLiteral" />
-              </node>
-              <node concept="3TrEf2" id="3Y6fbK16vl9" role="2OqNvi">
-                <ref role="3Tt5mk" to="yv47:3Y6fbK15FM4" resolve="value" />
-              </node>
+            <node concept="1YBJjd" id="3Y6fbK16uBL" role="1urrMF">
+              <ref role="1YBMHb" node="3Y6fbK16s$S" resolve="enumLiteral" />
             </node>
             <node concept="3Cnw8n" id="7Xf3oOM1CAA" role="1urrFz">
               <ref role="QpYPw" node="7Xf3oOM1$AS" resolve="specifyValueType" />
@@ -1822,73 +1822,100 @@
     </node>
     <node concept="Q5ZZ6" id="7Xf3oOM1$AT" role="Q6x$H">
       <node concept="3clFbS" id="7Xf3oOM1$AU" role="2VODD2">
-        <node concept="3clFbF" id="7Xf3oOLUxu$" role="3cqZAp">
-          <node concept="37vLTI" id="7Xf3oOLUyrG" role="3clFbG">
-            <node concept="1PxgMI" id="7Xf3oOLUYCw" role="37vLTx">
-              <node concept="2YIFZM" id="7Xf3oOM1BZ_" role="1m5AlR">
+        <node concept="3cpWs8" id="TcaAhOKhYR" role="3cqZAp">
+          <node concept="3cpWsn" id="TcaAhOKhYS" role="3cpWs9">
+            <property role="TrG5h" value="superType" />
+            <node concept="3Tqbb2" id="TcaAhOKbxq" role="1tU5fm">
+              <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+            </node>
+            <node concept="1PxgMI" id="TcaAhOKCg8" role="33vP2m">
+              <property role="1BlNFB" value="true" />
+              <node concept="chp4Y" id="TcaAhOKCC8" role="3oSUPX">
+                <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+              </node>
+              <node concept="2YIFZM" id="TcaAhOKhYT" role="1m5AlR">
                 <ref role="37wK5l" to="t4jv:12WRc293zuo" resolve="computeRegularSupertype" />
                 <ref role="1Pybhc" to="t4jv:12WRc28WG_m" resolve="TypingHelper" />
-                <node concept="2OqwBi" id="7Xf3oOLUYff" role="37wK5m">
-                  <node concept="2OqwBi" id="7Xf3oOLUYfg" role="2Oq$k0">
-                    <node concept="2OqwBi" id="7Xf3oOLUYfh" role="2Oq$k0">
-                      <node concept="QwW4i" id="7Xf3oOM1BrW" role="2Oq$k0">
+                <node concept="2OqwBi" id="TcaAhOKhYU" role="37wK5m">
+                  <node concept="2OqwBi" id="TcaAhOKhYV" role="2Oq$k0">
+                    <node concept="2OqwBi" id="TcaAhOKhYW" role="2Oq$k0">
+                      <node concept="QwW4i" id="TcaAhOKhYX" role="2Oq$k0">
                         <ref role="QwW4h" node="7Xf3oOM1AEM" resolve="enumDeclaration" />
                       </node>
-                      <node concept="2qgKlT" id="olugnm0NqC" role="2OqNvi">
+                      <node concept="2qgKlT" id="TcaAhOKhYY" role="2OqNvi">
                         <ref role="37wK5l" to="nu60:olugnm0Egc" resolve="effectiveLiterals" />
                       </node>
                     </node>
-                    <node concept="3zZkjj" id="7Xf3oOLUYfk" role="2OqNvi">
-                      <node concept="1bVj0M" id="7Xf3oOLUYfl" role="23t8la">
-                        <node concept="3clFbS" id="7Xf3oOLUYfm" role="1bW5cS">
-                          <node concept="3clFbF" id="7Xf3oOLUYfn" role="3cqZAp">
-                            <node concept="2OqwBi" id="7Xf3oOLUYfo" role="3clFbG">
-                              <node concept="2OqwBi" id="7Xf3oOLUYfp" role="2Oq$k0">
-                                <node concept="37vLTw" id="7Xf3oOLUYfq" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="7Xf3oOLUYft" resolve="it" />
+                    <node concept="3zZkjj" id="TcaAhOKhYZ" role="2OqNvi">
+                      <node concept="1bVj0M" id="TcaAhOKhZ0" role="23t8la">
+                        <node concept="3clFbS" id="TcaAhOKhZ1" role="1bW5cS">
+                          <node concept="3clFbF" id="TcaAhOKhZ2" role="3cqZAp">
+                            <node concept="2OqwBi" id="TcaAhOKhZ3" role="3clFbG">
+                              <node concept="2OqwBi" id="TcaAhOKhZ4" role="2Oq$k0">
+                                <node concept="37vLTw" id="TcaAhOKhZ5" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="TcaAhOKhZ8" resolve="it" />
                                 </node>
-                                <node concept="3TrEf2" id="7Xf3oOLUYfr" role="2OqNvi">
+                                <node concept="3TrEf2" id="TcaAhOKhZ6" role="2OqNvi">
                                   <ref role="3Tt5mk" to="yv47:3Y6fbK15FM4" resolve="value" />
                                 </node>
                               </node>
-                              <node concept="3x8VRR" id="7Xf3oOLUYfs" role="2OqNvi" />
+                              <node concept="3x8VRR" id="TcaAhOKhZ7" role="2OqNvi" />
                             </node>
                           </node>
                         </node>
-                        <node concept="Rh6nW" id="7Xf3oOLUYft" role="1bW2Oz">
+                        <node concept="Rh6nW" id="TcaAhOKhZ8" role="1bW2Oz">
                           <property role="TrG5h" value="it" />
-                          <node concept="2jxLKc" id="7Xf3oOLUYfu" role="1tU5fm" />
+                          <node concept="2jxLKc" id="TcaAhOKhZ9" role="1tU5fm" />
                         </node>
                       </node>
                     </node>
                   </node>
-                  <node concept="3$u5V9" id="7Xf3oOLUYfv" role="2OqNvi">
-                    <node concept="1bVj0M" id="7Xf3oOLUYfw" role="23t8la">
-                      <node concept="3clFbS" id="7Xf3oOLUYfx" role="1bW5cS">
-                        <node concept="3clFbF" id="7Xf3oOLUYfy" role="3cqZAp">
-                          <node concept="2OqwBi" id="7Xf3oOLUYfz" role="3clFbG">
-                            <node concept="2OqwBi" id="7Xf3oOLUYf$" role="2Oq$k0">
-                              <node concept="37vLTw" id="7Xf3oOLUYf_" role="2Oq$k0">
-                                <ref role="3cqZAo" node="7Xf3oOLUYfC" resolve="it" />
+                  <node concept="3$u5V9" id="TcaAhOKhZa" role="2OqNvi">
+                    <node concept="1bVj0M" id="TcaAhOKhZb" role="23t8la">
+                      <node concept="3clFbS" id="TcaAhOKhZc" role="1bW5cS">
+                        <node concept="3clFbF" id="TcaAhOKhZd" role="3cqZAp">
+                          <node concept="2OqwBi" id="TcaAhOKhZe" role="3clFbG">
+                            <node concept="2OqwBi" id="TcaAhOKhZf" role="2Oq$k0">
+                              <node concept="37vLTw" id="TcaAhOKhZg" role="2Oq$k0">
+                                <ref role="3cqZAo" node="TcaAhOKhZj" resolve="it" />
                               </node>
-                              <node concept="3TrEf2" id="7Xf3oOLUYfA" role="2OqNvi">
+                              <node concept="3TrEf2" id="TcaAhOKhZh" role="2OqNvi">
                                 <ref role="3Tt5mk" to="yv47:3Y6fbK15FM4" resolve="value" />
                               </node>
                             </node>
-                            <node concept="3JvlWi" id="7Xf3oOLUYfB" role="2OqNvi" />
+                            <node concept="3JvlWi" id="TcaAhOKhZi" role="2OqNvi" />
                           </node>
                         </node>
                       </node>
-                      <node concept="Rh6nW" id="7Xf3oOLUYfC" role="1bW2Oz">
+                      <node concept="Rh6nW" id="TcaAhOKhZj" role="1bW2Oz">
                         <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="7Xf3oOLUYfD" role="1tU5fm" />
+                        <node concept="2jxLKc" id="TcaAhOKhZk" role="1tU5fm" />
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="chp4Y" id="6b_jefnKzkD" role="3oSUPX">
-                <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="TcaAhOKEh1" role="3cqZAp">
+          <node concept="37vLTI" id="TcaAhOKFoD" role="3clFbG">
+            <node concept="3K4zz7" id="TcaAhOKGcY" role="37vLTx">
+              <node concept="37vLTw" id="TcaAhOKGln" role="3K4E3e">
+                <ref role="3cqZAo" node="TcaAhOKhYS" resolve="superType" />
+              </node>
+              <node concept="2ShNRf" id="TcaAhOKGmj" role="3K4GZi">
+                <node concept="3zrR0B" id="TcaAhOKG$f" role="2ShVmc">
+                  <node concept="3Tqbb2" id="TcaAhOKG$h" role="3zrR0E">
+                    <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="TcaAhOKFER" role="3K4Cdx">
+                <node concept="37vLTw" id="TcaAhOKFxB" role="2Oq$k0">
+                  <ref role="3cqZAo" node="TcaAhOKhYS" resolve="superType" />
+                </node>
+                <node concept="3x8VRR" id="TcaAhOKFNH" role="2OqNvi" />
               </node>
             </node>
             <node concept="2OqwBi" id="7Xf3oOLUxLR" role="37vLTJ">
@@ -1901,6 +1928,7 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="TcaAhOKEgt" role="3cqZAp" />
       </node>
     </node>
     <node concept="QznSV" id="7Xf3oOM1_fN" role="QzAvj">


### PR DESCRIPTION
Error message: `Can't cast node: 4621384398004576888, concept: jetbrains.mps.lang.typesystem.structure.RuntimeErrorType to concept: org.iets3.core.expr.base.structure.Type`

The original problem is that we calculate the super type in some rules such as the ImmutableListLiteral, IfExpression etc. and then we cast the returned node (`:Type`). The implementation of the super type method for units can return nodes of type `RuntimeErrorType` that have to be handeled separately. I've checked all instances where this method or a similar method is used and opted for throwing a type system error instead of  using a safe cast (as)  and just swallowing the error message. To me, it looks safer to not calculate a type in those cases instead of returning null and have types like List<null>.
In some cases, `RuntimeErrorType` is assigned directly as the type of the node. In those cases, a separate [checking rule](http://127.0.0.1:63320/node?ref=r%3A42a3bc53-29b1-44d6-9767-7c921cef7ba0%28org.iets3.core.expr.typetags.typesystem%29%2F7718893141589766030) is responsible for showing the error.