### PR TITLE
Add a type to the field of FieldSetter

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/typesystem.mps
@@ -3647,6 +3647,20 @@
     <node concept="3clFbS" id="4ptnK4jiabS" role="18ibNy">
       <node concept="nvevp" id="3N0gPb2kZ3u" role="3cqZAp">
         <node concept="3clFbS" id="3N0gPb2kZ3w" role="nvhr_">
+          <node concept="1Z5TYs" id="6gVedWjb_78" role="3cqZAp">
+            <node concept="mw_s8" id="6gVedWjb_fi" role="1ZfhKB">
+              <node concept="2X3wrD" id="6gVedWjb_fg" role="mwGJk">
+                <ref role="2X3Bk0" node="3N0gPb2kZ3$" resolve="orgFieldType" />
+              </node>
+            </node>
+            <node concept="mw_s8" id="6gVedWjb_7b" role="1ZfhK$">
+              <node concept="1Z2H0r" id="6gVedWjb$Yl" role="mwGJk">
+                <node concept="1YBJjd" id="6gVedWjb_06" role="1Z2MuG">
+                  <ref role="1YBMHb" node="4ptnK4jiabU" resolve="fs" />
+                </node>
+              </node>
+            </node>
+          </node>
           <node concept="1ZxtTE" id="kxHAhaMUEK" role="3cqZAp">
             <property role="TrG5h" value="realFieldType" />
           </node>


### PR DESCRIPTION
With this change, the type of the referenced field can be displayed in the builder with SHIFT+CTRL+P.