### PR TITLE
Implement full dark theme support

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/editor.mps
@@ -12,6 +12,7 @@
     <import index="l80j" ref="r:9e71c0de-f9ab-4b67-96cc-7d9c857513f6(org.iets3.analysis.base.structure)" />
     <import index="ich0" ref="r:2c56c15d-9645-459e-8807-414df4bb772a(org.iets3.analysis.base.typesystem)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -276,17 +277,36 @@
         <node concept="3ZlJ5R" id="WieAE6Vwpv" role="VblUZ">
           <node concept="3clFbS" id="WieAE6Vwpw" role="2VODD2">
             <node concept="3cpWs6" id="1LoQHJHx1Sh" role="3cqZAp">
-              <node concept="2ShNRf" id="WieAE6Vwqq" role="3cqZAk">
-                <node concept="1pGfFk" id="WieAE6Vz$8" role="2ShVmc">
-                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                  <node concept="3cmrfG" id="WieAE6Vz_i" role="37wK5m">
-                    <property role="3cmrfH" value="240" />
+              <node concept="2ShNRf" id="2GzLOsT9A24" role="3cqZAk">
+                <node concept="1pGfFk" id="2GzLOsT9POZ" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="2ShNRf" id="WieAE6Vwqq" role="37wK5m">
+                    <node concept="1pGfFk" id="WieAE6Vz$8" role="2ShVmc">
+                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                      <node concept="3cmrfG" id="WieAE6Vz_i" role="37wK5m">
+                        <property role="3cmrfH" value="240" />
+                      </node>
+                      <node concept="3cmrfG" id="WieAE6VzB_" role="37wK5m">
+                        <property role="3cmrfH" value="250" />
+                      </node>
+                      <node concept="3cmrfG" id="WieAE6VzGw" role="37wK5m">
+                        <property role="3cmrfH" value="250" />
+                      </node>
+                    </node>
                   </node>
-                  <node concept="3cmrfG" id="WieAE6VzB_" role="37wK5m">
-                    <property role="3cmrfH" value="250" />
-                  </node>
-                  <node concept="3cmrfG" id="WieAE6VzGw" role="37wK5m">
-                    <property role="3cmrfH" value="250" />
+                  <node concept="2ShNRf" id="2GzLOsT9PYQ" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsT9Qtf" role="2ShVmc">
+                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                      <node concept="3cmrfG" id="2GzLOsT9Qz9" role="37wK5m">
+                        <property role="3cmrfH" value="10" />
+                      </node>
+                      <node concept="3cmrfG" id="2GzLOsT9QEk" role="37wK5m">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                      <node concept="3cmrfG" id="2GzLOsT9QPt" role="37wK5m">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
@@ -44,6 +44,7 @@
     <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
     <import index="zf81" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.net(JDK/)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
     <import index="19m5" ref="r:854255a4-0f76-4555-8c94-d91e2ad4eb02(org.iets3.core.expr.statemachines.structure)" implicit="true" />
   </imports>
@@ -2753,21 +2754,40 @@
       <property role="TrG5h" value="characteristicColor" />
       <node concept="3Tm1VV" id="6$fTUGAuTlS" role="1B3o_S" />
       <node concept="3uibUv" id="6$fTUGAuTlT" role="3clF45">
-        <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
+        <ref role="3uigEE" to="lzb2:~JBColor" resolve="JBColor" />
       </node>
       <node concept="3clFbS" id="6$fTUGAuTlU" role="3clF47">
         <node concept="3clFbF" id="6$fTUGAuYX9" role="3cqZAp">
           <node concept="2ShNRf" id="7Atos1xLApp" role="3clFbG">
             <node concept="1pGfFk" id="7Atos1xLApo" role="2ShVmc">
-              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-              <node concept="3cmrfG" id="7Atos1xLApO" role="37wK5m">
-                <property role="3cmrfH" value="210" />
+              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+              <node concept="2ShNRf" id="2GzLOsT9SNg" role="37wK5m">
+                <node concept="1pGfFk" id="2GzLOsT9TG8" role="2ShVmc">
+                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                  <node concept="3cmrfG" id="7Atos1xLApO" role="37wK5m">
+                    <property role="3cmrfH" value="210" />
+                  </node>
+                  <node concept="3cmrfG" id="7Atos1xLA$B" role="37wK5m">
+                    <property role="3cmrfH" value="210" />
+                  </node>
+                  <node concept="3cmrfG" id="7Atos1xLAEm" role="37wK5m">
+                    <property role="3cmrfH" value="210" />
+                  </node>
+                </node>
               </node>
-              <node concept="3cmrfG" id="7Atos1xLA$B" role="37wK5m">
-                <property role="3cmrfH" value="210" />
-              </node>
-              <node concept="3cmrfG" id="7Atos1xLAEm" role="37wK5m">
-                <property role="3cmrfH" value="210" />
+              <node concept="2ShNRf" id="2GzLOsT9TO7" role="37wK5m">
+                <node concept="1pGfFk" id="2GzLOsT9UEU" role="2ShVmc">
+                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                  <node concept="3cmrfG" id="2GzLOsT9UGs" role="37wK5m">
+                    <property role="3cmrfH" value="210" />
+                  </node>
+                  <node concept="3cmrfG" id="2GzLOsT9UJN" role="37wK5m">
+                    <property role="3cmrfH" value="210" />
+                  </node>
+                  <node concept="3cmrfG" id="2GzLOsT9UNn" role="37wK5m">
+                    <property role="3cmrfH" value="210" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
@@ -1333,18 +1333,9 @@
                 <node concept="1pGfFk" id="4tXyFaWwzSe" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakvelx" resolve="HorizLineCell" />
                   <node concept="pncrf" id="4tXyFaWwzSS" role="37wK5m" />
-                  <node concept="2ShNRf" id="2GzLOsTtNq0" role="37wK5m">
-                    <node concept="1pGfFk" id="2GzLOsTtOxb" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="4tXyFaWw$6n" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="2GzLOsTvTYt" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wfONv4" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                   <node concept="3cmrfG" id="4tXyFaWw$bx" role="37wK5m">
                     <property role="3cmrfH" value="2" />
@@ -1934,18 +1925,9 @@
                   <node concept="1pGfFk" id="x8tpS_VvJD" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                     <node concept="pncrf" id="x8tpS_VvJE" role="37wK5m" />
-                    <node concept="2ShNRf" id="2GzLOsTtMkW" role="37wK5m">
-                      <node concept="1pGfFk" id="2GzLOsTtMkX" role="2ShVmc">
-                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                        <node concept="10M0yZ" id="2GzLOsTtMkY" role="37wK5m">
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                        </node>
-                        <node concept="10M0yZ" id="2GzLOsTtMkZ" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="38mO9wfOLtB" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                   </node>
                 </node>
@@ -1967,18 +1949,9 @@
                   <node concept="1pGfFk" id="x8tpS_VvJN" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                     <node concept="pncrf" id="x8tpS_VvJO" role="37wK5m" />
-                    <node concept="2ShNRf" id="2GzLOsTtMyb" role="37wK5m">
-                      <node concept="1pGfFk" id="2GzLOsTtMyc" role="2ShVmc">
-                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                        <node concept="10M0yZ" id="2GzLOsTtMyd" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                        <node concept="10M0yZ" id="2GzLOsTtMye" role="37wK5m">
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="38mO9wfOLIX" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                   </node>
                 </node>
@@ -2087,18 +2060,9 @@
                 <node concept="1pGfFk" id="x8tpS_RuRp" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                   <node concept="pncrf" id="x8tpS_RuRq" role="37wK5m" />
-                  <node concept="2ShNRf" id="2GzLOsTtM$4" role="37wK5m">
-                    <node concept="1pGfFk" id="2GzLOsTtM$5" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="2GzLOsTtM$6" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                      </node>
-                      <node concept="10M0yZ" id="2GzLOsTtM$7" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wfOLYi" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -8330,18 +8294,9 @@
                     <ref role="3cqZAo" node="mIQkxg7PZL" resolve="cc" />
                   </node>
                 </node>
-                <node concept="2ShNRf" id="2GzLOsTqgv1" role="3K4GZi">
-                  <node concept="1pGfFk" id="2GzLOsTqikm" role="2ShVmc">
-                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                    <node concept="10M0yZ" id="mIQkxg7PZW" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    </node>
-                    <node concept="10M0yZ" id="2GzLOsTqiZs" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    </node>
-                  </node>
+                <node concept="10M0yZ" id="38mO9wfOBX9" role="3K4GZi">
+                  <ref role="3cqZAo" to="lzb2:~JBColor.darkGray" resolve="darkGray" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                 </node>
               </node>
             </node>
@@ -8551,13 +8506,13 @@
                 <node concept="1xnly_" id="7sZ012ggLBB" role="3K4Cdx">
                   <ref role="1xnlzC" node="7sZ012ggL_p" resolve="isInline" />
                 </node>
-                <node concept="10M0yZ" id="siw10FNCar" role="3K4GZi">
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                <node concept="10M0yZ" id="38mO9wfOHok" role="3K4E3e">
+                  <ref role="3cqZAo" to="lzb2:~JBColor.blue" resolve="blue" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                 </node>
-                <node concept="10M0yZ" id="7sZ012ggM1f" role="3K4E3e">
-                  <ref role="3cqZAo" to="z60i:~Color.blue" resolve="blue" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                <node concept="10M0yZ" id="38mO9wfOHmM" role="3K4GZi">
+                  <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                 </node>
               </node>
             </node>
@@ -8655,18 +8610,9 @@
                 <node concept="37vLTw" id="x8tpS_ttF$" role="37vLTJ">
                   <ref role="3cqZAo" node="x8tpS_ttu9" resolve="colorToUse" />
                 </node>
-                <node concept="2ShNRf" id="2GzLOsTy22y" role="37vLTx">
-                  <node concept="1pGfFk" id="2GzLOsTy39I" role="2ShVmc">
-                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                    <node concept="10M0yZ" id="x8tpS_tsxh" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    </node>
-                    <node concept="10M0yZ" id="2GzLOsTy3wx" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    </node>
-                  </node>
+                <node concept="10M0yZ" id="38mO9wfOQCO" role="37vLTx">
+                  <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                 </node>
               </node>
             </node>
@@ -8990,18 +8936,9 @@
                     <ref role="3cqZAo" node="mIQkxg7Qnm" resolve="cc" />
                   </node>
                 </node>
-                <node concept="2ShNRf" id="2GzLOsTy1GG" role="3K4GZi">
-                  <node concept="1pGfFk" id="2GzLOsTy1GH" role="2ShVmc">
-                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                    <node concept="10M0yZ" id="2GzLOsTy1GI" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    </node>
-                    <node concept="10M0yZ" id="2GzLOsTy1GJ" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    </node>
-                  </node>
+                <node concept="10M0yZ" id="38mO9wfOQk8" role="3K4GZi">
+                  <ref role="3cqZAo" to="lzb2:~JBColor.darkGray" resolve="darkGray" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                 </node>
               </node>
             </node>
@@ -9314,18 +9251,9 @@
                       <ref role="3cqZAo" node="mIQkxg7P1s" resolve="cc" />
                     </node>
                   </node>
-                  <node concept="2ShNRf" id="2GzLOsTy0XP" role="3K4GZi">
-                    <node concept="1pGfFk" id="2GzLOsTy0XQ" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="2GzLOsTy0XR" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                      </node>
-                      <node concept="10M0yZ" id="2GzLOsTy0XS" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wfOPyd" role="3K4GZi">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.darkGray" resolve="darkGray" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -12110,18 +12038,9 @@
                   <node concept="1pGfFk" id="x8tpS_Vr2r" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                     <node concept="pncrf" id="2GzLOsTqn3Q" role="37wK5m" />
-                    <node concept="2ShNRf" id="2GzLOsTqn7Y" role="37wK5m">
-                      <node concept="1pGfFk" id="2GzLOsTqocZ" role="2ShVmc">
-                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                        <node concept="10M0yZ" id="x8tpS_Vr2t" role="37wK5m">
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                        </node>
-                        <node concept="10M0yZ" id="2GzLOsTtJoE" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="38mO9wfOIqN" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                   </node>
                 </node>
@@ -12143,18 +12062,9 @@
                   <node concept="1pGfFk" id="x8tpS_Vr2_" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                     <node concept="pncrf" id="x8tpS_Vr2A" role="37wK5m" />
-                    <node concept="2ShNRf" id="2GzLOsTtJ$E" role="37wK5m">
-                      <node concept="1pGfFk" id="2GzLOsTtJ$F" role="2ShVmc">
-                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                        <node concept="10M0yZ" id="2GzLOsTtJ$G" role="37wK5m">
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                        </node>
-                        <node concept="10M0yZ" id="2GzLOsTtJ$H" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="38mO9wfOIzl" role="37wK5m">
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                      <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
                     </node>
                   </node>
                 </node>
@@ -12195,18 +12105,9 @@
                       <node concept="1pGfFk" id="x8tpSAONDv" role="2ShVmc">
                         <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                         <node concept="pncrf" id="x8tpSAONDw" role="37wK5m" />
-                        <node concept="2ShNRf" id="2GzLOsTtJQy" role="37wK5m">
-                          <node concept="1pGfFk" id="2GzLOsTtKXB" role="2ShVmc">
-                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                            <node concept="10M0yZ" id="x8tpSAONDx" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            </node>
-                            <node concept="10M0yZ" id="2GzLOsTtL7x" role="37wK5m">
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                              <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
-                            </node>
-                          </node>
+                        <node concept="10M0yZ" id="38mO9wfOIY7" role="37wK5m">
+                          <ref role="3cqZAo" to="lzb2:~JBColor.white" resolve="white" />
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                         </node>
                       </node>
                     </node>
@@ -12228,18 +12129,9 @@
                       <node concept="1pGfFk" id="x8tpSAONDD" role="2ShVmc">
                         <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                         <node concept="pncrf" id="x8tpSAONDE" role="37wK5m" />
-                        <node concept="2ShNRf" id="2GzLOsTtLiq" role="37wK5m">
-                          <node concept="1pGfFk" id="2GzLOsTtLir" role="2ShVmc">
-                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                            <node concept="10M0yZ" id="2GzLOsTtLis" role="37wK5m">
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                              <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
-                            </node>
-                            <node concept="10M0yZ" id="2GzLOsTtLit" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            </node>
-                          </node>
+                        <node concept="10M0yZ" id="38mO9wfOJi4" role="37wK5m">
+                          <ref role="3cqZAo" to="lzb2:~JBColor.white" resolve="white" />
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                         </node>
                       </node>
                     </node>
@@ -12289,18 +12181,9 @@
                         <node concept="1pGfFk" id="x8tpSARW52" role="2ShVmc">
                           <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                           <node concept="pncrf" id="x8tpSARW53" role="37wK5m" />
-                          <node concept="2ShNRf" id="2GzLOsTtLnH" role="37wK5m">
-                            <node concept="1pGfFk" id="2GzLOsTtLnI" role="2ShVmc">
-                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                              <node concept="10M0yZ" id="2GzLOsTtLnJ" role="37wK5m">
-                                <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                              </node>
-                              <node concept="10M0yZ" id="2GzLOsTtLnK" role="37wK5m">
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
-                              </node>
-                            </node>
+                          <node concept="10M0yZ" id="38mO9wfOJAQ" role="37wK5m">
+                            <ref role="3cqZAo" to="lzb2:~JBColor.white" resolve="white" />
+                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                           </node>
                         </node>
                       </node>
@@ -12322,18 +12205,9 @@
                         <node concept="1pGfFk" id="x8tpSARW5c" role="2ShVmc">
                           <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                           <node concept="pncrf" id="x8tpSARW5d" role="37wK5m" />
-                          <node concept="2ShNRf" id="2GzLOsTtLr9" role="37wK5m">
-                            <node concept="1pGfFk" id="2GzLOsTtLra" role="2ShVmc">
-                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                              <node concept="10M0yZ" id="2GzLOsTtLrb" role="37wK5m">
-                                <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                              </node>
-                              <node concept="10M0yZ" id="2GzLOsTtLrc" role="37wK5m">
-                                <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                              </node>
-                            </node>
+                          <node concept="10M0yZ" id="38mO9wfOJWt" role="37wK5m">
+                            <ref role="3cqZAo" to="lzb2:~JBColor.white" resolve="white" />
+                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                           </node>
                         </node>
                       </node>
@@ -12379,18 +12253,9 @@
                         <node concept="1pGfFk" id="x8tpSARW5z" role="2ShVmc">
                           <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                           <node concept="pncrf" id="x8tpSARW5$" role="37wK5m" />
-                          <node concept="2ShNRf" id="2GzLOsTtLuM" role="37wK5m">
-                            <node concept="1pGfFk" id="2GzLOsTtLuN" role="2ShVmc">
-                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                              <node concept="10M0yZ" id="2GzLOsTtLuO" role="37wK5m">
-                                <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                              </node>
-                              <node concept="10M0yZ" id="2GzLOsTtLuP" role="37wK5m">
-                                <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                              </node>
-                            </node>
+                          <node concept="10M0yZ" id="38mO9wfOKgx" role="37wK5m">
+                            <ref role="3cqZAo" to="lzb2:~JBColor.white" resolve="white" />
+                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                           </node>
                         </node>
                       </node>
@@ -12412,18 +12277,9 @@
                         <node concept="1pGfFk" id="x8tpSARW5H" role="2ShVmc">
                           <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                           <node concept="pncrf" id="x8tpSARW5I" role="37wK5m" />
-                          <node concept="2ShNRf" id="2GzLOsTtLyC" role="37wK5m">
-                            <node concept="1pGfFk" id="2GzLOsTtLyD" role="2ShVmc">
-                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                              <node concept="10M0yZ" id="2GzLOsTtLyE" role="37wK5m">
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
-                              </node>
-                              <node concept="10M0yZ" id="2GzLOsTtLyF" role="37wK5m">
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
-                              </node>
-                            </node>
+                          <node concept="10M0yZ" id="38mO9wfOKx_" role="37wK5m">
+                            <ref role="3cqZAo" to="lzb2:~JBColor.white" resolve="white" />
+                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                           </node>
                         </node>
                       </node>
@@ -12519,18 +12375,9 @@
                 <node concept="1pGfFk" id="x8tpS_RrwG" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                   <node concept="pncrf" id="x8tpS_RrwH" role="37wK5m" />
-                  <node concept="2ShNRf" id="2GzLOsTtLWn" role="37wK5m">
-                    <node concept="1pGfFk" id="2GzLOsTtLWo" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="2GzLOsTtLWp" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="2GzLOsTtLWq" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wfOKOr" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -12666,18 +12513,9 @@
                       <ref role="3cqZAo" node="1yY6_Ujcdqv" resolve="cc" />
                     </node>
                   </node>
-                  <node concept="2ShNRf" id="2GzLOsTxYST" role="3K4GZi">
-                    <node concept="1pGfFk" id="2GzLOsTy0eU" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="1yY6_UjcdqE" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                      </node>
-                      <node concept="10M0yZ" id="2GzLOsTy0p6" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wfOOyO" role="3K4GZi">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.darkGray" resolve="darkGray" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -12986,18 +12824,9 @@
                   <node concept="1pGfFk" id="6Zesk0deSj" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                     <node concept="pncrf" id="6Zesk0deSk" role="37wK5m" />
-                    <node concept="2ShNRf" id="2GzLOsTy5vD" role="37wK5m">
-                      <node concept="1pGfFk" id="2GzLOsTy6_k" role="2ShVmc">
-                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                        <node concept="10M0yZ" id="6Zesk0deSl" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                        <node concept="10M0yZ" id="2GzLOsTy6DD" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="38mO9wfOT5A" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                   </node>
                 </node>
@@ -13019,18 +12848,9 @@
                   <node concept="1pGfFk" id="6Zesk0deSt" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                     <node concept="pncrf" id="6Zesk0deSu" role="37wK5m" />
-                    <node concept="2ShNRf" id="2GzLOsTy6NU" role="37wK5m">
-                      <node concept="1pGfFk" id="2GzLOsTy6NV" role="2ShVmc">
-                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                        <node concept="10M0yZ" id="2GzLOsTy6NW" role="37wK5m">
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                        </node>
-                        <node concept="10M0yZ" id="2GzLOsTy6NX" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="38mO9wfOToU" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                   </node>
                 </node>
@@ -13100,18 +12920,9 @@
                 <node concept="1pGfFk" id="6Zesk0deSP" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                   <node concept="pncrf" id="6Zesk0deSQ" role="37wK5m" />
-                  <node concept="2ShNRf" id="2GzLOsTy6Qd" role="37wK5m">
-                    <node concept="1pGfFk" id="2GzLOsTy6Qe" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="2GzLOsTy6Qf" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="2GzLOsTy6Qg" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wfOTD4" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -13133,18 +12944,9 @@
                   <node concept="1pGfFk" id="1Mw0qFUE6pP" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                     <node concept="pncrf" id="1Mw0qFUE6pQ" role="37wK5m" />
-                    <node concept="2ShNRf" id="2GzLOsTy6SH" role="37wK5m">
-                      <node concept="1pGfFk" id="2GzLOsTy6SI" role="2ShVmc">
-                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                        <node concept="10M0yZ" id="2GzLOsTy6SJ" role="37wK5m">
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                        </node>
-                        <node concept="10M0yZ" id="2GzLOsTy6SK" role="37wK5m">
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="38mO9wfOTV6" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                   </node>
                 </node>
@@ -13223,18 +13025,9 @@
                   <node concept="1pGfFk" id="1Mw0qFUE6pZ" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                     <node concept="pncrf" id="1Mw0qFUE6q0" role="37wK5m" />
-                    <node concept="2ShNRf" id="2GzLOsTy6Vq" role="37wK5m">
-                      <node concept="1pGfFk" id="2GzLOsTy6Vr" role="2ShVmc">
-                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                        <node concept="10M0yZ" id="2GzLOsTy6Vs" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                        <node concept="10M0yZ" id="2GzLOsTy6Vt" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="38mO9wfOUcW" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
@@ -50,8 +50,8 @@
     <import index="ir4w" ref="r:1ee7d695-67a0-4310-b6a9-28ed5f54bc88(org.iets3.core.attributes.editor)" />
     <import index="zf81" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.net(JDK/)" />
     <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
-    <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
+    <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="itrz" ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)" implicit="true" />
@@ -1333,9 +1333,18 @@
                 <node concept="1pGfFk" id="4tXyFaWwzSe" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakvelx" resolve="HorizLineCell" />
                   <node concept="pncrf" id="4tXyFaWwzSS" role="37wK5m" />
-                  <node concept="10M0yZ" id="4tXyFaWw$6n" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                  <node concept="2ShNRf" id="2GzLOsTtNq0" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsTtOxb" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="4tXyFaWw$6n" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsTvTYt" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                   <node concept="3cmrfG" id="4tXyFaWw$bx" role="37wK5m">
                     <property role="3cmrfH" value="2" />
@@ -1925,9 +1934,18 @@
                   <node concept="1pGfFk" id="x8tpS_VvJD" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                     <node concept="pncrf" id="x8tpS_VvJE" role="37wK5m" />
-                    <node concept="10M0yZ" id="x8tpS_VvJF" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                    <node concept="2ShNRf" id="2GzLOsTtMkW" role="37wK5m">
+                      <node concept="1pGfFk" id="2GzLOsTtMkX" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="10M0yZ" id="2GzLOsTtMkY" role="37wK5m">
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                        </node>
+                        <node concept="10M0yZ" id="2GzLOsTtMkZ" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -1949,9 +1967,18 @@
                   <node concept="1pGfFk" id="x8tpS_VvJN" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                     <node concept="pncrf" id="x8tpS_VvJO" role="37wK5m" />
-                    <node concept="10M0yZ" id="x8tpS_VvJP" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                    <node concept="2ShNRf" id="2GzLOsTtMyb" role="37wK5m">
+                      <node concept="1pGfFk" id="2GzLOsTtMyc" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="10M0yZ" id="2GzLOsTtMyd" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                        <node concept="10M0yZ" id="2GzLOsTtMye" role="37wK5m">
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -2060,9 +2087,18 @@
                 <node concept="1pGfFk" id="x8tpS_RuRp" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                   <node concept="pncrf" id="x8tpS_RuRq" role="37wK5m" />
-                  <node concept="10M0yZ" id="x8tpS_RuRr" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                  <node concept="2ShNRf" id="2GzLOsTtM$4" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsTtM$5" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="2GzLOsTtM$6" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsTtM$7" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -8280,10 +8316,6 @@
             </node>
             <node concept="3clFbF" id="mIQkxg7PZU" role="3cqZAp">
               <node concept="3K4zz7" id="mIQkxg7PZV" role="3clFbG">
-                <node concept="10M0yZ" id="mIQkxg7PZW" role="3K4GZi">
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                </node>
                 <node concept="2OqwBi" id="7Atos1xSkJ6" role="3K4E3e">
                   <node concept="37vLTw" id="mIQkxg7PZX" role="2Oq$k0">
                     <ref role="3cqZAo" node="mIQkxg7PZL" resolve="cc" />
@@ -8296,6 +8328,19 @@
                   <node concept="10Nm6u" id="mIQkxg7PZZ" role="3uHU7w" />
                   <node concept="37vLTw" id="mIQkxg7Q00" role="3uHU7B">
                     <ref role="3cqZAo" node="mIQkxg7PZL" resolve="cc" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="2GzLOsTqgv1" role="3K4GZi">
+                  <node concept="1pGfFk" id="2GzLOsTqikm" role="2ShVmc">
+                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                    <node concept="10M0yZ" id="mIQkxg7PZW" role="37wK5m">
+                      <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    </node>
+                    <node concept="10M0yZ" id="2GzLOsTqiZs" role="37wK5m">
+                      <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    </node>
                   </node>
                 </node>
               </node>
@@ -8607,12 +8652,21 @@
           <node concept="3clFbS" id="x8tpS_trC$" role="3clFbx">
             <node concept="3clFbF" id="x8tpS_tsfq" role="3cqZAp">
               <node concept="37vLTI" id="x8tpS_tstt" role="3clFbG">
-                <node concept="10M0yZ" id="x8tpS_tsxh" role="37vLTx">
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
-                </node>
                 <node concept="37vLTw" id="x8tpS_ttF$" role="37vLTJ">
                   <ref role="3cqZAo" node="x8tpS_ttu9" resolve="colorToUse" />
+                </node>
+                <node concept="2ShNRf" id="2GzLOsTy22y" role="37vLTx">
+                  <node concept="1pGfFk" id="2GzLOsTy39I" role="2ShVmc">
+                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                    <node concept="10M0yZ" id="x8tpS_tsxh" role="37wK5m">
+                      <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    </node>
+                    <node concept="10M0yZ" id="2GzLOsTy3wx" role="37wK5m">
+                      <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -8922,10 +8976,6 @@
             </node>
             <node concept="3clFbF" id="mIQkxg7Qnv" role="3cqZAp">
               <node concept="3K4zz7" id="mIQkxg7Qnw" role="3clFbG">
-                <node concept="10M0yZ" id="mIQkxg7Qnx" role="3K4GZi">
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                </node>
                 <node concept="2OqwBi" id="7nsgDAXRGpz" role="3K4E3e">
                   <node concept="37vLTw" id="mIQkxg7Qny" role="2Oq$k0">
                     <ref role="3cqZAo" node="mIQkxg7Qnm" resolve="cc" />
@@ -8938,6 +8988,19 @@
                   <node concept="10Nm6u" id="mIQkxg7Qn$" role="3uHU7w" />
                   <node concept="37vLTw" id="mIQkxg7Qn_" role="3uHU7B">
                     <ref role="3cqZAo" node="mIQkxg7Qnm" resolve="cc" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="2GzLOsTy1GG" role="3K4GZi">
+                  <node concept="1pGfFk" id="2GzLOsTy1GH" role="2ShVmc">
+                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                    <node concept="10M0yZ" id="2GzLOsTy1GI" role="37wK5m">
+                      <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    </node>
+                    <node concept="10M0yZ" id="2GzLOsTy1GJ" role="37wK5m">
+                      <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    </node>
                   </node>
                 </node>
               </node>
@@ -9237,10 +9300,6 @@
               </node>
               <node concept="3clFbF" id="mIQkxg7P7Z" role="3cqZAp">
                 <node concept="3K4zz7" id="mIQkxg7Pja" role="3clFbG">
-                  <node concept="10M0yZ" id="mIQkxg7Pt_" role="3K4GZi">
-                    <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  </node>
                   <node concept="2OqwBi" id="7nsgDAXRFMy" role="3K4E3e">
                     <node concept="37vLTw" id="mIQkxg7Pos" role="2Oq$k0">
                       <ref role="3cqZAo" node="mIQkxg7P1s" resolve="cc" />
@@ -9253,6 +9312,19 @@
                     <node concept="10Nm6u" id="mIQkxg7Phx" role="3uHU7w" />
                     <node concept="37vLTw" id="mIQkxg7P7X" role="3uHU7B">
                       <ref role="3cqZAo" node="mIQkxg7P1s" resolve="cc" />
+                    </node>
+                  </node>
+                  <node concept="2ShNRf" id="2GzLOsTy0XP" role="3K4GZi">
+                    <node concept="1pGfFk" id="2GzLOsTy0XQ" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="2GzLOsTy0XR" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsTy0XS" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -12037,10 +12109,19 @@
                 <node concept="2ShNRf" id="x8tpS_Vr2q" role="3clFbG">
                   <node concept="1pGfFk" id="x8tpS_Vr2r" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
-                    <node concept="pncrf" id="x8tpS_Vr2s" role="37wK5m" />
-                    <node concept="10M0yZ" id="x8tpS_Vr2t" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <node concept="pncrf" id="2GzLOsTqn3Q" role="37wK5m" />
+                    <node concept="2ShNRf" id="2GzLOsTqn7Y" role="37wK5m">
+                      <node concept="1pGfFk" id="2GzLOsTqocZ" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="10M0yZ" id="x8tpS_Vr2t" role="37wK5m">
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                        </node>
+                        <node concept="10M0yZ" id="2GzLOsTtJoE" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -12062,9 +12143,18 @@
                   <node concept="1pGfFk" id="x8tpS_Vr2_" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                     <node concept="pncrf" id="x8tpS_Vr2A" role="37wK5m" />
-                    <node concept="10M0yZ" id="x8tpS_Vr2B" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <node concept="2ShNRf" id="2GzLOsTtJ$E" role="37wK5m">
+                      <node concept="1pGfFk" id="2GzLOsTtJ$F" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="10M0yZ" id="2GzLOsTtJ$G" role="37wK5m">
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                        </node>
+                        <node concept="10M0yZ" id="2GzLOsTtJ$H" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -12105,9 +12195,18 @@
                       <node concept="1pGfFk" id="x8tpSAONDv" role="2ShVmc">
                         <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                         <node concept="pncrf" id="x8tpSAONDw" role="37wK5m" />
-                        <node concept="10M0yZ" id="x8tpSAONDx" role="37wK5m">
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                        <node concept="2ShNRf" id="2GzLOsTtJQy" role="37wK5m">
+                          <node concept="1pGfFk" id="2GzLOsTtKXB" role="2ShVmc">
+                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                            <node concept="10M0yZ" id="x8tpSAONDx" role="37wK5m">
+                              <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            </node>
+                            <node concept="10M0yZ" id="2GzLOsTtL7x" role="37wK5m">
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -12129,9 +12228,18 @@
                       <node concept="1pGfFk" id="x8tpSAONDD" role="2ShVmc">
                         <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                         <node concept="pncrf" id="x8tpSAONDE" role="37wK5m" />
-                        <node concept="10M0yZ" id="x8tpSAONDF" role="37wK5m">
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                        <node concept="2ShNRf" id="2GzLOsTtLiq" role="37wK5m">
+                          <node concept="1pGfFk" id="2GzLOsTtLir" role="2ShVmc">
+                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                            <node concept="10M0yZ" id="2GzLOsTtLis" role="37wK5m">
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                            </node>
+                            <node concept="10M0yZ" id="2GzLOsTtLit" role="37wK5m">
+                              <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -12181,9 +12289,18 @@
                         <node concept="1pGfFk" id="x8tpSARW52" role="2ShVmc">
                           <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                           <node concept="pncrf" id="x8tpSARW53" role="37wK5m" />
-                          <node concept="10M0yZ" id="x8tpSARW54" role="37wK5m">
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                          <node concept="2ShNRf" id="2GzLOsTtLnH" role="37wK5m">
+                            <node concept="1pGfFk" id="2GzLOsTtLnI" role="2ShVmc">
+                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                              <node concept="10M0yZ" id="2GzLOsTtLnJ" role="37wK5m">
+                                <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              </node>
+                              <node concept="10M0yZ" id="2GzLOsTtLnK" role="37wK5m">
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -12205,9 +12322,18 @@
                         <node concept="1pGfFk" id="x8tpSARW5c" role="2ShVmc">
                           <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                           <node concept="pncrf" id="x8tpSARW5d" role="37wK5m" />
-                          <node concept="10M0yZ" id="x8tpSARW5e" role="37wK5m">
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                          <node concept="2ShNRf" id="2GzLOsTtLr9" role="37wK5m">
+                            <node concept="1pGfFk" id="2GzLOsTtLra" role="2ShVmc">
+                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                              <node concept="10M0yZ" id="2GzLOsTtLrb" role="37wK5m">
+                                <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              </node>
+                              <node concept="10M0yZ" id="2GzLOsTtLrc" role="37wK5m">
+                                <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -12253,9 +12379,18 @@
                         <node concept="1pGfFk" id="x8tpSARW5z" role="2ShVmc">
                           <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                           <node concept="pncrf" id="x8tpSARW5$" role="37wK5m" />
-                          <node concept="10M0yZ" id="x8tpSARW5_" role="37wK5m">
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                          <node concept="2ShNRf" id="2GzLOsTtLuM" role="37wK5m">
+                            <node concept="1pGfFk" id="2GzLOsTtLuN" role="2ShVmc">
+                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                              <node concept="10M0yZ" id="2GzLOsTtLuO" role="37wK5m">
+                                <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              </node>
+                              <node concept="10M0yZ" id="2GzLOsTtLuP" role="37wK5m">
+                                <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -12277,9 +12412,18 @@
                         <node concept="1pGfFk" id="x8tpSARW5H" role="2ShVmc">
                           <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                           <node concept="pncrf" id="x8tpSARW5I" role="37wK5m" />
-                          <node concept="10M0yZ" id="x8tpSARW5J" role="37wK5m">
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                          <node concept="2ShNRf" id="2GzLOsTtLyC" role="37wK5m">
+                            <node concept="1pGfFk" id="2GzLOsTtLyD" role="2ShVmc">
+                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                              <node concept="10M0yZ" id="2GzLOsTtLyE" role="37wK5m">
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                              </node>
+                              <node concept="10M0yZ" id="2GzLOsTtLyF" role="37wK5m">
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                <ref role="3cqZAo" to="z60i:~Color.WHITE" resolve="WHITE" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -12375,9 +12519,18 @@
                 <node concept="1pGfFk" id="x8tpS_RrwG" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                   <node concept="pncrf" id="x8tpS_RrwH" role="37wK5m" />
-                  <node concept="10M0yZ" id="x8tpS_RrwI" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <node concept="2ShNRf" id="2GzLOsTtLWn" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsTtLWo" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="2GzLOsTtLWp" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsTtLWq" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -12499,10 +12652,6 @@
               </node>
               <node concept="3clFbF" id="1yY6_UjcdqC" role="3cqZAp">
                 <node concept="3K4zz7" id="1yY6_UjcdqD" role="3clFbG">
-                  <node concept="10M0yZ" id="1yY6_UjcdqE" role="3K4GZi">
-                    <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  </node>
                   <node concept="2OqwBi" id="1yY6_UjcdqF" role="3K4E3e">
                     <node concept="37vLTw" id="1yY6_UjcdqG" role="2Oq$k0">
                       <ref role="3cqZAo" node="1yY6_Ujcdqv" resolve="cc" />
@@ -12515,6 +12664,19 @@
                     <node concept="10Nm6u" id="1yY6_UjcdqJ" role="3uHU7w" />
                     <node concept="37vLTw" id="1yY6_UjcdqK" role="3uHU7B">
                       <ref role="3cqZAo" node="1yY6_Ujcdqv" resolve="cc" />
+                    </node>
+                  </node>
+                  <node concept="2ShNRf" id="2GzLOsTxYST" role="3K4GZi">
+                    <node concept="1pGfFk" id="2GzLOsTy0eU" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="1yY6_UjcdqE" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsTy0p6" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -12824,9 +12986,18 @@
                   <node concept="1pGfFk" id="6Zesk0deSj" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                     <node concept="pncrf" id="6Zesk0deSk" role="37wK5m" />
-                    <node concept="10M0yZ" id="6Zesk0deSl" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <node concept="2ShNRf" id="2GzLOsTy5vD" role="37wK5m">
+                      <node concept="1pGfFk" id="2GzLOsTy6_k" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="10M0yZ" id="6Zesk0deSl" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                        <node concept="10M0yZ" id="2GzLOsTy6DD" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -12848,9 +13019,18 @@
                   <node concept="1pGfFk" id="6Zesk0deSt" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                     <node concept="pncrf" id="6Zesk0deSu" role="37wK5m" />
-                    <node concept="10M0yZ" id="6Zesk0deSv" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <node concept="2ShNRf" id="2GzLOsTy6NU" role="37wK5m">
+                      <node concept="1pGfFk" id="2GzLOsTy6NV" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="10M0yZ" id="2GzLOsTy6NW" role="37wK5m">
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                        </node>
+                        <node concept="10M0yZ" id="2GzLOsTy6NX" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -12920,9 +13100,18 @@
                 <node concept="1pGfFk" id="6Zesk0deSP" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                   <node concept="pncrf" id="6Zesk0deSQ" role="37wK5m" />
-                  <node concept="10M0yZ" id="6Zesk0deSR" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                  <node concept="2ShNRf" id="2GzLOsTy6Qd" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsTy6Qe" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="2GzLOsTy6Qf" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsTy6Qg" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -12944,9 +13133,18 @@
                   <node concept="1pGfFk" id="1Mw0qFUE6pP" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                     <node concept="pncrf" id="1Mw0qFUE6pQ" role="37wK5m" />
-                    <node concept="10M0yZ" id="1Mw0qFUE6pR" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                    <node concept="2ShNRf" id="2GzLOsTy6SH" role="37wK5m">
+                      <node concept="1pGfFk" id="2GzLOsTy6SI" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="10M0yZ" id="2GzLOsTy6SJ" role="37wK5m">
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                        </node>
+                        <node concept="10M0yZ" id="2GzLOsTy6SK" role="37wK5m">
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -13025,9 +13223,18 @@
                   <node concept="1pGfFk" id="1Mw0qFUE6pZ" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                     <node concept="pncrf" id="1Mw0qFUE6q0" role="37wK5m" />
-                    <node concept="10M0yZ" id="1Mw0qFUE6q1" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <node concept="2ShNRf" id="2GzLOsTy6Vq" role="37wK5m">
+                      <node concept="1pGfFk" id="2GzLOsTy6Vr" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="10M0yZ" id="2GzLOsTy6Vs" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                        <node concept="10M0yZ" id="2GzLOsTy6Vt" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
@@ -51,6 +51,7 @@
     <import index="zf81" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.net(JDK/)" />
     <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
     <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="itrz" ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)" implicit="true" />
@@ -1410,16 +1411,35 @@
           <node concept="3clFbS" id="2Df8LH1ei$3" role="2VODD2">
             <node concept="3clFbF" id="2Df8LH1ei$Z" role="3cqZAp">
               <node concept="2ShNRf" id="2Df8LH1ei$X" role="3clFbG">
-                <node concept="1pGfFk" id="2Df8LH1ej4K" role="2ShVmc">
-                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                  <node concept="3cmrfG" id="2Df8LH1ej5U" role="37wK5m">
-                    <property role="3cmrfH" value="29" />
+                <node concept="1pGfFk" id="2GzLOsTeMIC" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="2ShNRf" id="2GzLOsTeMNk" role="37wK5m">
+                    <node concept="1pGfFk" id="2Df8LH1ej4K" role="2ShVmc">
+                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                      <node concept="3cmrfG" id="2Df8LH1ej5U" role="37wK5m">
+                        <property role="3cmrfH" value="29" />
+                      </node>
+                      <node concept="3cmrfG" id="2Df8LH1ej9M" role="37wK5m">
+                        <property role="3cmrfH" value="116" />
+                      </node>
+                      <node concept="3cmrfG" id="2Df8LH1ejiA" role="37wK5m">
+                        <property role="3cmrfH" value="145" />
+                      </node>
+                    </node>
                   </node>
-                  <node concept="3cmrfG" id="2Df8LH1ej9M" role="37wK5m">
-                    <property role="3cmrfH" value="116" />
-                  </node>
-                  <node concept="3cmrfG" id="2Df8LH1ejiA" role="37wK5m">
-                    <property role="3cmrfH" value="145" />
+                  <node concept="2ShNRf" id="2GzLOsTeN0n" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsTeN0m" role="2ShVmc">
+                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                      <node concept="3cmrfG" id="2GzLOsTeN9Y" role="37wK5m">
+                        <property role="3cmrfH" value="63" />
+                      </node>
+                      <node concept="3cmrfG" id="2GzLOsTeN_h" role="37wK5m">
+                        <property role="3cmrfH" value="179" />
+                      </node>
+                      <node concept="3cmrfG" id="2GzLOsTeO8Q" role="37wK5m">
+                        <property role="3cmrfH" value="217" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -1439,16 +1459,35 @@
           <node concept="3clFbS" id="2Df8LH1kXkC" role="2VODD2">
             <node concept="3clFbF" id="2Df8LH1kXkD" role="3cqZAp">
               <node concept="2ShNRf" id="2Df8LH1kXkE" role="3clFbG">
-                <node concept="1pGfFk" id="2Df8LH1kXkF" role="2ShVmc">
-                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                  <node concept="3cmrfG" id="2Df8LH1kXkG" role="37wK5m">
-                    <property role="3cmrfH" value="145" />
+                <node concept="1pGfFk" id="2GzLOsTeRgV" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="2ShNRf" id="2GzLOsTeRlX" role="37wK5m">
+                    <node concept="1pGfFk" id="2Df8LH1kXkF" role="2ShVmc">
+                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                      <node concept="3cmrfG" id="2Df8LH1kXkG" role="37wK5m">
+                        <property role="3cmrfH" value="145" />
+                      </node>
+                      <node concept="3cmrfG" id="2Df8LH1kXkH" role="37wK5m">
+                        <property role="3cmrfH" value="136" />
+                      </node>
+                      <node concept="3cmrfG" id="2Df8LH1kXkI" role="37wK5m">
+                        <property role="3cmrfH" value="1" />
+                      </node>
+                    </node>
                   </node>
-                  <node concept="3cmrfG" id="2Df8LH1kXkH" role="37wK5m">
-                    <property role="3cmrfH" value="136" />
-                  </node>
-                  <node concept="3cmrfG" id="2Df8LH1kXkI" role="37wK5m">
-                    <property role="3cmrfH" value="1" />
+                  <node concept="2ShNRf" id="2GzLOsTeSQd" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsTeTWi" role="2ShVmc">
+                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                      <node concept="3cmrfG" id="2GzLOsTeUaH" role="37wK5m">
+                        <property role="3cmrfH" value="254" />
+                      </node>
+                      <node concept="3cmrfG" id="2GzLOsTeUo3" role="37wK5m">
+                        <property role="3cmrfH" value="237" />
+                      </node>
+                      <node concept="3cmrfG" id="2GzLOsTeUrD" role="37wK5m">
+                        <property role="3cmrfH" value="1" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.req/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.req/models/editor.mps
@@ -8,6 +8,7 @@
   <imports>
     <import index="r4b4" ref="r:1784e088-20fd-4fdb-96b8-bc57f0056d94(com.mbeddr.core.base.editor)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="sf4k" ref="r:c07349ad-48c5-45c4-a238-c8737c1d5f8e(org.iets3.components.req.structure)" implicit="true" />
     <import index="w9y2" ref="r:b3786745-c763-4a49-a754-f84e15236f18(org.iets3.components.core.structure)" implicit="true" />
   </imports>
@@ -119,9 +120,18 @@
                   <node concept="1pGfFk" id="cJpacq5ZtF" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:6Ce4x7KQbw2" resolve="ColoredVerticalBarCell" />
                     <node concept="pncrf" id="cJpacq5Zul" role="37wK5m" />
-                    <node concept="10M0yZ" id="cJpacq5ZAQ" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.blue" resolve="blue" />
+                    <node concept="2ShNRf" id="2GzLOsTyy2W" role="37wK5m">
+                      <node concept="1pGfFk" id="2GzLOsTyySj" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="10M0yZ" id="cJpacq5ZAQ" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.blue" resolve="blue" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                        <node concept="10M0yZ" id="2GzLOsTyyYu" role="37wK5m">
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <ref role="3cqZAo" to="z60i:~Color.blue" resolve="blue" />
+                        </node>
+                      </node>
                     </node>
                     <node concept="3cmrfG" id="cJpacq5ZKp" role="37wK5m">
                       <property role="3cmrfH" value="2" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.req/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.req/models/editor.mps
@@ -120,18 +120,9 @@
                   <node concept="1pGfFk" id="cJpacq5ZtF" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:6Ce4x7KQbw2" resolve="ColoredVerticalBarCell" />
                     <node concept="pncrf" id="cJpacq5Zul" role="37wK5m" />
-                    <node concept="2ShNRf" id="2GzLOsTyy2W" role="37wK5m">
-                      <node concept="1pGfFk" id="2GzLOsTyySj" role="2ShVmc">
-                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                        <node concept="10M0yZ" id="cJpacq5ZAQ" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.blue" resolve="blue" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                        <node concept="10M0yZ" id="2GzLOsTyyYu" role="37wK5m">
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          <ref role="3cqZAo" to="z60i:~Color.blue" resolve="blue" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="38mO9wfTo0B" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.blue" resolve="blue" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                     <node concept="3cmrfG" id="cJpacq5ZKp" role="37wK5m">
                       <property role="3cmrfH" value="2" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.attributes/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.attributes/models/editor.mps
@@ -21,6 +21,7 @@
     <import index="ykok" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.constraints(MPS.Core/)" />
     <import index="i51s" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.lang.smodel.generator.smodelAdapter(MPS.Core/)" />
     <import index="zce0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.smodel.action(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
@@ -300,9 +301,18 @@
                 <node concept="1pGfFk" id="3NBP8_OgZP2" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                   <node concept="pncrf" id="3NBP8_OgZPG" role="37wK5m" />
-                  <node concept="10M0yZ" id="3NBP8_OgZZz" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                  <node concept="2ShNRf" id="2GzLOsTAEiD" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsTAF1C" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="3NBP8_OgZZz" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsTAF7v" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -335,9 +345,18 @@
                 <node concept="1pGfFk" id="3NBP8_Ohq9I" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                   <node concept="pncrf" id="3NBP8_Ohq9J" role="37wK5m" />
-                  <node concept="10M0yZ" id="3NBP8_Ohq9K" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                  <node concept="2ShNRf" id="2GzLOsTBv7j" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsTBv7k" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="2GzLOsTBv7l" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsTBv7m" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.attributes/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.attributes/models/editor.mps
@@ -301,18 +301,9 @@
                 <node concept="1pGfFk" id="3NBP8_OgZP2" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                   <node concept="pncrf" id="3NBP8_OgZPG" role="37wK5m" />
-                  <node concept="2ShNRf" id="2GzLOsTAEiD" role="37wK5m">
-                    <node concept="1pGfFk" id="2GzLOsTAF1C" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="3NBP8_OgZZz" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="2GzLOsTAF7v" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wfTp0_" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -345,18 +336,9 @@
                 <node concept="1pGfFk" id="3NBP8_Ohq9I" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                   <node concept="pncrf" id="3NBP8_Ohq9J" role="37wK5m" />
-                  <node concept="2ShNRf" id="2GzLOsTBv7j" role="37wK5m">
-                    <node concept="1pGfFk" id="2GzLOsTBv7k" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="2GzLOsTBv7l" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="2GzLOsTBv7m" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wfTpb6" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.base/models/editor.mps
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)">
   <persistence version="9" />
-  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="62a3babb-5d40-4920-897f-d4144dc99c9d" name="com.mbeddr.mpsutil.userstyles" version="0" />
@@ -611,9 +610,18 @@
       <node concept="3uibUv" id="2CEi94emCnK" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="10M0yZ" id="4A7H4EzineK" role="33vP2m">
-        <ref role="1PxDUh" to="exr9:~MPSColors" resolve="MPSColors" />
-        <ref role="3cqZAo" to="exr9:~MPSColors.DARK_BLUE" resolve="DARK_BLUE" />
+      <node concept="2ShNRf" id="2GzLOsTpDoc" role="33vP2m">
+        <node concept="1pGfFk" id="2GzLOsTq3xz" role="2ShVmc">
+          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+          <node concept="10M0yZ" id="2GzLOsTq3Ng" role="37wK5m">
+            <ref role="3cqZAo" to="exr9:~MPSColors.DARK_BLUE" resolve="DARK_BLUE" />
+            <ref role="1PxDUh" to="exr9:~MPSColors" resolve="MPSColors" />
+          </node>
+          <node concept="10M0yZ" id="2GzLOsTq3RZ" role="37wK5m">
+            <ref role="3cqZAo" to="exr9:~MPSColors.LIGHT_BLUE" resolve="LIGHT_BLUE" />
+            <ref role="1PxDUh" to="exr9:~MPSColors" resolve="MPSColors" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="Wx3nA" id="7D7uZV2gA03" role="jymVt">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.base/org.iets3.core.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.base/org.iets3.core.base.mpl
@@ -16,7 +16,7 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
     <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
-    <dependency reexport="false">5454dbfd-2075-4de0-b85e-fa645eb6957e(de.itemis.mps.utils.serializer.xml)</dependency>
+    <dependency reexport="false">5454dbfd-2075-4de0-b85e-fa645eb6957e(com.mbeddr.mpsutil.serializer.xml)</dependency>
     <dependency reexport="false">f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)</dependency>
   </dependencies>
   <languageVersions>
@@ -72,10 +72,10 @@
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
     <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />
     <module reference="b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)" version="0" />
+    <module reference="5454dbfd-2075-4de0-b85e-fa645eb6957e(com.mbeddr.mpsutil.serializer.xml)" version="0" />
     <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
     <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
     <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
-    <module reference="5454dbfd-2075-4de0-b85e-fa645eb6957e(de.itemis.mps.utils.serializer.xml)" version="0" />
     <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -44,6 +44,7 @@
     <import index="t4jv" ref="r:80cf2246-750c-4158-9056-a619ebcf894c(org.iets3.core.expr.base.typesystem)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="tpd5" ref="r:00000000-0000-4000-0000-011c895902b5(jetbrains.mps.lang.typesystem.dependencies)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -14920,17 +14921,36 @@
       <node concept="3uibUv" id="18$bUx5wASs" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="2ShNRf" id="18$bUx5AoXo" role="33vP2m">
-        <node concept="1pGfFk" id="18$bUx5AoSG" role="2ShVmc">
-          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-          <node concept="3cmrfG" id="18$bUx5AqlK" role="37wK5m">
-            <property role="3cmrfH" value="23" />
+      <node concept="2ShNRf" id="2GzLOsTCCu5" role="33vP2m">
+        <node concept="1pGfFk" id="2GzLOsTCHXs" role="2ShVmc">
+          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+          <node concept="2ShNRf" id="18$bUx5AoXo" role="37wK5m">
+            <node concept="1pGfFk" id="18$bUx5AoSG" role="2ShVmc">
+              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+              <node concept="3cmrfG" id="18$bUx5AqlK" role="37wK5m">
+                <property role="3cmrfH" value="23" />
+              </node>
+              <node concept="3cmrfG" id="18$bUx5Aqqd" role="37wK5m">
+                <property role="3cmrfH" value="191" />
+              </node>
+              <node concept="3cmrfG" id="18$bUx5Az2F" role="37wK5m">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
           </node>
-          <node concept="3cmrfG" id="18$bUx5Aqqd" role="37wK5m">
-            <property role="3cmrfH" value="191" />
-          </node>
-          <node concept="3cmrfG" id="18$bUx5Az2F" role="37wK5m">
-            <property role="3cmrfH" value="0" />
+          <node concept="2ShNRf" id="2GzLOsTD2M2" role="37wK5m">
+            <node concept="1pGfFk" id="2GzLOsTD2M3" role="2ShVmc">
+              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+              <node concept="3cmrfG" id="2GzLOsTD2M4" role="37wK5m">
+                <property role="3cmrfH" value="23" />
+              </node>
+              <node concept="3cmrfG" id="2GzLOsTD2M5" role="37wK5m">
+                <property role="3cmrfH" value="191" />
+              </node>
+              <node concept="3cmrfG" id="2GzLOsTD2M6" role="37wK5m">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -14942,9 +14962,18 @@
       <node concept="3uibUv" id="18$bUx5wD$p" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="10M0yZ" id="18$bUx5wD$q" role="33vP2m">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
+      <node concept="2ShNRf" id="2GzLOsTDoY_" role="33vP2m">
+        <node concept="1pGfFk" id="2GzLOsTDv70" role="2ShVmc">
+          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+          <node concept="10M0yZ" id="18$bUx5wD$q" role="37wK5m">
+            <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
+            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+          </node>
+          <node concept="10M0yZ" id="2GzLOsTD__B" role="37wK5m">
+            <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
+            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="Wx3nA" id="18$bUx5wDQj" role="jymVt">
@@ -14954,17 +14983,36 @@
       <node concept="3uibUv" id="18$bUx5wDQl" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="2ShNRf" id="18$bUx5A_Jz" role="33vP2m">
-        <node concept="1pGfFk" id="18$bUx5A_Fh" role="2ShVmc">
-          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-          <node concept="3cmrfG" id="18$bUx5AB7W" role="37wK5m">
-            <property role="3cmrfH" value="237" />
+      <node concept="2ShNRf" id="2GzLOsTE2Sl" role="33vP2m">
+        <node concept="1pGfFk" id="2GzLOsTEbop" role="2ShVmc">
+          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+          <node concept="2ShNRf" id="18$bUx5A_Jz" role="37wK5m">
+            <node concept="1pGfFk" id="18$bUx5A_Fh" role="2ShVmc">
+              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+              <node concept="3cmrfG" id="18$bUx5AB7W" role="37wK5m">
+                <property role="3cmrfH" value="237" />
+              </node>
+              <node concept="3cmrfG" id="18$bUx5AEUX" role="37wK5m">
+                <property role="3cmrfH" value="134" />
+              </node>
+              <node concept="3cmrfG" id="18$bUx5ANzc" role="37wK5m">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
           </node>
-          <node concept="3cmrfG" id="18$bUx5AEUX" role="37wK5m">
-            <property role="3cmrfH" value="134" />
-          </node>
-          <node concept="3cmrfG" id="18$bUx5ANzc" role="37wK5m">
-            <property role="3cmrfH" value="0" />
+          <node concept="2ShNRf" id="2GzLOsTEuFS" role="37wK5m">
+            <node concept="1pGfFk" id="2GzLOsTEuFT" role="2ShVmc">
+              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+              <node concept="3cmrfG" id="2GzLOsTEuFU" role="37wK5m">
+                <property role="3cmrfH" value="237" />
+              </node>
+              <node concept="3cmrfG" id="2GzLOsTEuFV" role="37wK5m">
+                <property role="3cmrfH" value="134" />
+              </node>
+              <node concept="3cmrfG" id="2GzLOsTEuFW" role="37wK5m">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -14976,17 +15024,36 @@
       <node concept="3uibUv" id="4WU0y9qgoyN" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="2ShNRf" id="4WU0y9qgoyO" role="33vP2m">
-        <node concept="1pGfFk" id="4WU0y9qgoyP" role="2ShVmc">
-          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-          <node concept="3cmrfG" id="4WU0y9qgoyQ" role="37wK5m">
-            <property role="3cmrfH" value="237" />
+      <node concept="2ShNRf" id="2GzLOsTEERQ" role="33vP2m">
+        <node concept="1pGfFk" id="2GzLOsTEI2S" role="2ShVmc">
+          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+          <node concept="2ShNRf" id="4WU0y9qgoyO" role="37wK5m">
+            <node concept="1pGfFk" id="4WU0y9qgoyP" role="2ShVmc">
+              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+              <node concept="3cmrfG" id="4WU0y9qgoyQ" role="37wK5m">
+                <property role="3cmrfH" value="237" />
+              </node>
+              <node concept="3cmrfG" id="4WU0y9qgoyR" role="37wK5m">
+                <property role="3cmrfH" value="134" />
+              </node>
+              <node concept="3cmrfG" id="4WU0y9qgoyS" role="37wK5m">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
           </node>
-          <node concept="3cmrfG" id="4WU0y9qgoyR" role="37wK5m">
-            <property role="3cmrfH" value="134" />
-          </node>
-          <node concept="3cmrfG" id="4WU0y9qgoyS" role="37wK5m">
-            <property role="3cmrfH" value="0" />
+          <node concept="2ShNRf" id="2GzLOsTELzZ" role="37wK5m">
+            <node concept="1pGfFk" id="2GzLOsTEL$0" role="2ShVmc">
+              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+              <node concept="3cmrfG" id="2GzLOsTEL$1" role="37wK5m">
+                <property role="3cmrfH" value="237" />
+              </node>
+              <node concept="3cmrfG" id="2GzLOsTEL$2" role="37wK5m">
+                <property role="3cmrfH" value="134" />
+              </node>
+              <node concept="3cmrfG" id="2GzLOsTEL$3" role="37wK5m">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -14999,11 +15066,23 @@
       <node concept="3uibUv" id="3TIaSh$oHVG" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="2YIFZM" id="3TIaSh$oHVH" role="33vP2m">
-        <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-        <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-        <node concept="Xl_RD" id="3TIaSh$oHVI" role="37wK5m">
-          <property role="Xl_RC" value="#C4FFE2" />
+      <node concept="2ShNRf" id="2GzLOsTGDrB" role="33vP2m">
+        <node concept="1pGfFk" id="2GzLOsTGGAE" role="2ShVmc">
+          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+          <node concept="2YIFZM" id="3TIaSh$oHVH" role="37wK5m">
+            <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+            <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+            <node concept="Xl_RD" id="3TIaSh$oHVI" role="37wK5m">
+              <property role="Xl_RC" value="#C4FFE2" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="2GzLOsTGNa7" role="37wK5m">
+            <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+            <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+            <node concept="Xl_RD" id="2GzLOsTGNa8" role="37wK5m">
+              <property role="Xl_RC" value="#C4FFE2" />
+            </node>
+          </node>
         </node>
       </node>
     </node>
@@ -15014,11 +15093,23 @@
       <node concept="3uibUv" id="3TIaSh$oHVB" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="2YIFZM" id="3TIaSh$oHVC" role="33vP2m">
-        <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-        <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-        <node concept="Xl_RD" id="3TIaSh$oHVD" role="37wK5m">
-          <property role="Xl_RC" value="#FFE3E7" />
+      <node concept="2ShNRf" id="2GzLOsTGTJc" role="33vP2m">
+        <node concept="1pGfFk" id="2GzLOsTGWUf" role="2ShVmc">
+          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+          <node concept="2YIFZM" id="3TIaSh$oHVC" role="37wK5m">
+            <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+            <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+            <node concept="Xl_RD" id="3TIaSh$oHVD" role="37wK5m">
+              <property role="Xl_RC" value="#FFE3E7" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="2GzLOsTH2Xq" role="37wK5m">
+            <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+            <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+            <node concept="Xl_RD" id="2GzLOsTH2Xr" role="37wK5m">
+              <property role="Xl_RC" value="#FFE3E7" />
+            </node>
+          </node>
         </node>
       </node>
     </node>
@@ -15029,11 +15120,23 @@
       <node concept="3uibUv" id="3TIaSh$oHVy" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="2YIFZM" id="3TIaSh$oHVz" role="33vP2m">
-        <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-        <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-        <node concept="Xl_RD" id="3TIaSh$oHV$" role="37wK5m">
-          <property role="Xl_RC" value="#FEFFD4" />
+      <node concept="2ShNRf" id="2GzLOsTH9$Q" role="33vP2m">
+        <node concept="1pGfFk" id="2GzLOsTHbNA" role="2ShVmc">
+          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+          <node concept="2YIFZM" id="3TIaSh$oHVz" role="37wK5m">
+            <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+            <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+            <node concept="Xl_RD" id="3TIaSh$oHV$" role="37wK5m">
+              <property role="Xl_RC" value="#FEFFD4" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="2GzLOsTHilt" role="37wK5m">
+            <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+            <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+            <node concept="Xl_RD" id="2GzLOsTHilu" role="37wK5m">
+              <property role="Xl_RC" value="#FEFFD4" />
+            </node>
+          </node>
         </node>
       </node>
     </node>
@@ -15044,11 +15147,23 @@
       <node concept="3uibUv" id="3TIaSh_3YmX" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="2YIFZM" id="3TIaSh_3YmY" role="33vP2m">
-        <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-        <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-        <node concept="Xl_RD" id="3TIaSh_3YmZ" role="37wK5m">
-          <property role="Xl_RC" value="#E4FFDB" />
+      <node concept="2ShNRf" id="2GzLOsTHoXr" role="33vP2m">
+        <node concept="1pGfFk" id="2GzLOsTHs8t" role="2ShVmc">
+          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+          <node concept="2YIFZM" id="3TIaSh_3YmY" role="37wK5m">
+            <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+            <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+            <node concept="Xl_RD" id="3TIaSh_3YmZ" role="37wK5m">
+              <property role="Xl_RC" value="#E4FFDB" />
+            </node>
+          </node>
+          <node concept="2YIFZM" id="2GzLOsTHyEn" role="37wK5m">
+            <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+            <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+            <node concept="Xl_RD" id="2GzLOsTHyEo" role="37wK5m">
+              <property role="Xl_RC" value="#E4FFDB" />
+            </node>
+          </node>
         </node>
       </node>
     </node>
@@ -20000,17 +20115,36 @@
       <node concept="3uibUv" id="4XlPKepacWM" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="2ShNRf" id="4XlPKepacWN" role="33vP2m">
-        <node concept="1pGfFk" id="4XlPKepacWO" role="2ShVmc">
-          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-          <node concept="3cmrfG" id="4XlPKepacWP" role="37wK5m">
-            <property role="3cmrfH" value="23" />
+      <node concept="2ShNRf" id="2GzLOsTISrK" role="33vP2m">
+        <node concept="1pGfFk" id="2GzLOsTIYN8" role="2ShVmc">
+          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+          <node concept="2ShNRf" id="4XlPKepacWN" role="37wK5m">
+            <node concept="1pGfFk" id="4XlPKepacWO" role="2ShVmc">
+              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+              <node concept="3cmrfG" id="4XlPKepacWP" role="37wK5m">
+                <property role="3cmrfH" value="23" />
+              </node>
+              <node concept="3cmrfG" id="4XlPKepacWQ" role="37wK5m">
+                <property role="3cmrfH" value="191" />
+              </node>
+              <node concept="3cmrfG" id="4XlPKepacWR" role="37wK5m">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
           </node>
-          <node concept="3cmrfG" id="4XlPKepacWQ" role="37wK5m">
-            <property role="3cmrfH" value="191" />
-          </node>
-          <node concept="3cmrfG" id="4XlPKepacWR" role="37wK5m">
-            <property role="3cmrfH" value="0" />
+          <node concept="2ShNRf" id="2GzLOsTJb$O" role="37wK5m">
+            <node concept="1pGfFk" id="2GzLOsTJb$P" role="2ShVmc">
+              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+              <node concept="3cmrfG" id="2GzLOsTJb$Q" role="37wK5m">
+                <property role="3cmrfH" value="23" />
+              </node>
+              <node concept="3cmrfG" id="2GzLOsTJb$R" role="37wK5m">
+                <property role="3cmrfH" value="191" />
+              </node>
+              <node concept="3cmrfG" id="2GzLOsTJb$S" role="37wK5m">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -20022,9 +20156,18 @@
       <node concept="3uibUv" id="4XlPKepacWU" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="10M0yZ" id="4XlPKepacWV" role="33vP2m">
-        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-        <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
+      <node concept="2ShNRf" id="2GzLOsTJoc5" role="33vP2m">
+        <node concept="1pGfFk" id="2GzLOsTJuNF" role="2ShVmc">
+          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+          <node concept="10M0yZ" id="4XlPKepacWV" role="37wK5m">
+            <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
+            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+          </node>
+          <node concept="10M0yZ" id="2GzLOsTJBaf" role="37wK5m">
+            <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
+            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+          </node>
+        </node>
       </node>
     </node>
     <node concept="Wx3nA" id="4XlPKepacWW" role="jymVt">
@@ -20034,17 +20177,36 @@
       <node concept="3uibUv" id="4XlPKepacWY" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="2ShNRf" id="4XlPKepacWZ" role="33vP2m">
-        <node concept="1pGfFk" id="4XlPKepacX0" role="2ShVmc">
-          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-          <node concept="3cmrfG" id="4XlPKepacX1" role="37wK5m">
-            <property role="3cmrfH" value="237" />
+      <node concept="2ShNRf" id="2GzLOsTJOpQ" role="33vP2m">
+        <node concept="1pGfFk" id="2GzLOsTJTan" role="2ShVmc">
+          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+          <node concept="2ShNRf" id="4XlPKepacWZ" role="37wK5m">
+            <node concept="1pGfFk" id="4XlPKepacX0" role="2ShVmc">
+              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+              <node concept="3cmrfG" id="4XlPKepacX1" role="37wK5m">
+                <property role="3cmrfH" value="237" />
+              </node>
+              <node concept="3cmrfG" id="4XlPKepacX2" role="37wK5m">
+                <property role="3cmrfH" value="134" />
+              </node>
+              <node concept="3cmrfG" id="4XlPKepacX3" role="37wK5m">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
           </node>
-          <node concept="3cmrfG" id="4XlPKepacX2" role="37wK5m">
-            <property role="3cmrfH" value="134" />
-          </node>
-          <node concept="3cmrfG" id="4XlPKepacX3" role="37wK5m">
-            <property role="3cmrfH" value="0" />
+          <node concept="2ShNRf" id="2GzLOsTKjiD" role="37wK5m">
+            <node concept="1pGfFk" id="2GzLOsTKjiE" role="2ShVmc">
+              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+              <node concept="3cmrfG" id="2GzLOsTKjiF" role="37wK5m">
+                <property role="3cmrfH" value="237" />
+              </node>
+              <node concept="3cmrfG" id="2GzLOsTKjiG" role="37wK5m">
+                <property role="3cmrfH" value="134" />
+              </node>
+              <node concept="3cmrfG" id="2GzLOsTKjiH" role="37wK5m">
+                <property role="3cmrfH" value="0" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -26386,6 +26548,153 @@
       <node concept="17QB3L" id="6ngDzsNlH8k" role="3clF45" />
     </node>
   </node>
+  <node concept="13h7C7" id="5r47dOg5pCc">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="13h7C2" to="hm2y:5r47dOfJ8UC" resolve="ITupleMemberDeclaration" />
+    <node concept="13i0hz" id="5r47dOg5pCn" role="13h7CS">
+      <property role="13i0iv" value="true" />
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="type" />
+      <node concept="3Tm1VV" id="5r47dOg5pCo" role="1B3o_S" />
+      <node concept="3Tqbb2" id="5r47dOg5pT$" role="3clF45">
+        <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+      </node>
+      <node concept="3clFbS" id="5r47dOg5pCq" role="3clF47" />
+    </node>
+    <node concept="13hLZK" id="5r47dOg5pCd" role="13h7CW">
+      <node concept="3clFbS" id="5r47dOg5pCe" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="5r47dOfJ8Us">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="13h7C2" to="hm2y:5r47dOfJ8Ur" resolve="ITupleDeclaration" />
+    <node concept="13i0hz" id="5r47dOfJ8UL" role="13h7CS">
+      <property role="13i0iv" value="true" />
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="getMembers" />
+      <node concept="3Tm1VV" id="5r47dOfJ8UM" role="1B3o_S" />
+      <node concept="2I9FWS" id="5r47dOfJ9kG" role="3clF45">
+        <ref role="2I9WkF" to="hm2y:5r47dOfJ8UC" resolve="ITupleMemberDeclaration" />
+      </node>
+      <node concept="3clFbS" id="5r47dOfJ8UO" role="3clF47" />
+    </node>
+    <node concept="13hLZK" id="5r47dOfJ8Ut" role="13h7CW">
+      <node concept="3clFbS" id="5r47dOfJ8Uu" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="6GiZkUz7qWV">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="13h7C2" to="hm2y:6GiZkUz7qWO" resolve="InlineNamedTupleAccess" />
+    <node concept="13hLZK" id="6GiZkUz7qWW" role="13h7CW">
+      <node concept="3clFbS" id="6GiZkUz7qWX" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="6GiZkUz7qX6" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" node="6kR0qIbI2yi" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="6GiZkUz7qX7" role="1B3o_S" />
+      <node concept="3clFbS" id="6GiZkUz7qXa" role="3clF47">
+        <node concept="3clFbF" id="6GiZkUz7Aah" role="3cqZAp">
+          <node concept="2OqwBi" id="6GiZkUz7AIH" role="3clFbG">
+            <node concept="2OqwBi" id="6GiZkUz7AkM" role="2Oq$k0">
+              <node concept="13iPFW" id="6GiZkUz7Aae" role="2Oq$k0" />
+              <node concept="3TrEf2" id="6GiZkUz7A_H" role="2OqNvi">
+                <ref role="3Tt5mk" to="hm2y:6GiZkUz7r1V" resolve="member" />
+              </node>
+            </node>
+            <node concept="3TrcHB" id="6GiZkUz7ASw" role="2OqNvi">
+              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="6GiZkUz7qXb" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="6GiZkUzfnDf" role="13h7CS">
+      <property role="TrG5h" value="expression" />
+      <node concept="3Tm1VV" id="6GiZkUzfnDg" role="1B3o_S" />
+      <node concept="3Tqbb2" id="6GiZkUzfnJ0" role="3clF45">
+        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+      </node>
+      <node concept="3clFbS" id="6GiZkUzfnDi" role="3clF47">
+        <node concept="3clFbF" id="6GiZkUzfnJO" role="3cqZAp">
+          <node concept="2OqwBi" id="6GiZkUzfoIf" role="3clFbG">
+            <node concept="1PxgMI" id="6GiZkUzfor4" role="2Oq$k0">
+              <node concept="chp4Y" id="6GiZkUzfos0" role="3oSUPX">
+                <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+              </node>
+              <node concept="2OqwBi" id="6GiZkUzfnOJ" role="1m5AlR">
+                <node concept="13iPFW" id="6GiZkUzfnJN" role="2Oq$k0" />
+                <node concept="1mfA1w" id="6GiZkUzfnVi" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="3TrEf2" id="6GiZkUzfpIH" role="2OqNvi">
+              <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="6GiZkUzfqE6" role="13h7CS">
+      <property role="TrG5h" value="type" />
+      <node concept="3Tm1VV" id="6GiZkUzfqE7" role="1B3o_S" />
+      <node concept="3Tqbb2" id="6GiZkUzfqRk" role="3clF45">
+        <ref role="ehGHo" to="hm2y:5r47dOfJ9kS" resolve="InlineTupleType" />
+      </node>
+      <node concept="3clFbS" id="6GiZkUzfqE9" role="3clF47">
+        <node concept="3clFbF" id="6GiZkUzfr29" role="3cqZAp">
+          <node concept="1PxgMI" id="6GiZkUzfsfl" role="3clFbG">
+            <property role="1BlNFB" value="true" />
+            <node concept="chp4Y" id="6GiZkUzfsgz" role="3oSUPX">
+              <ref role="cht4Q" to="hm2y:5r47dOfJ9kS" resolve="InlineTupleType" />
+            </node>
+            <node concept="2OqwBi" id="6GiZkUzfrek" role="1m5AlR">
+              <node concept="BsUDl" id="6GiZkUzfr28" role="2Oq$k0">
+                <ref role="37wK5l" node="6GiZkUzfnDf" resolve="expression" />
+              </node>
+              <node concept="3JvlWi" id="6GiZkUzfrHO" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="1c6hIxyZnje" role="13h7CS">
+      <property role="TrG5h" value="tupleDeclaration" />
+      <node concept="3Tm1VV" id="1c6hIxyZnjf" role="1B3o_S" />
+      <node concept="3Tqbb2" id="1c6hIxyZnyV" role="3clF45">
+        <ref role="ehGHo" to="hm2y:5r47dOfJ8Ur" resolve="ITupleDeclaration" />
+      </node>
+      <node concept="3clFbS" id="1c6hIxyZnjh" role="3clF47">
+        <node concept="3clFbF" id="1c6hIxyZn$Y" role="3cqZAp">
+          <node concept="2OqwBi" id="1c6hIxyZn_0" role="3clFbG">
+            <node concept="BsUDl" id="1c6hIxyZn_1" role="2Oq$k0">
+              <ref role="37wK5l" node="6GiZkUzfqE6" resolve="type" />
+            </node>
+            <node concept="3TrEf2" id="1c6hIxyZn_2" role="2OqNvi">
+              <ref role="3Tt5mk" to="hm2y:5r47dOfJ9kT" resolve="decl" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="6GiZkUzfnf3" role="13h7CS">
+      <property role="TrG5h" value="effectDescriptor" />
+      <ref role="13i0hy" node="6GySMNjjWfO" resolve="effectDescriptor" />
+      <node concept="3Tm1VV" id="6GiZkUzfnf4" role="1B3o_S" />
+      <node concept="3clFbS" id="6GiZkUzfnfd" role="3clF47">
+        <node concept="3clFbF" id="6GiZkUzfnq7" role="3cqZAp">
+          <node concept="BsUDl" id="6GiZkUzfnq2" role="3clFbG">
+            <ref role="37wK5l" node="6KxoTHgL$U0" resolve="deriveFrom" />
+            <node concept="BsUDl" id="1c6hIxyZnGy" role="37wK5m">
+              <ref role="37wK5l" node="1c6hIxyZnje" resolve="tupleDeclaration" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="6GiZkUzfnfe" role="3clF45">
+        <ref role="3uigEE" to="oq0c:3ni3WieuV7z" resolve="EffectDescriptor" />
+      </node>
+    </node>
+  </node>
   <node concept="13h7C7" id="6wzrxL38hu5">
     <ref role="13h7C2" to="hm2y:6wzrxL38hak" resolve="IPreferredProposalContext" />
     <node concept="13i0hz" id="6wzrxL3bLaK" role="13h7CS">
@@ -27372,153 +27681,6 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="2nydsCfyYD1" role="1B3o_S" />
-  </node>
-  <node concept="13h7C7" id="5r47dOfJ8Us">
-    <property role="3GE5qa" value="tuples" />
-    <ref role="13h7C2" to="hm2y:5r47dOfJ8Ur" resolve="ITupleDeclaration" />
-    <node concept="13i0hz" id="5r47dOfJ8UL" role="13h7CS">
-      <property role="13i0iv" value="true" />
-      <property role="13i0it" value="true" />
-      <property role="TrG5h" value="getMembers" />
-      <node concept="3Tm1VV" id="5r47dOfJ8UM" role="1B3o_S" />
-      <node concept="2I9FWS" id="5r47dOfJ9kG" role="3clF45">
-        <ref role="2I9WkF" to="hm2y:5r47dOfJ8UC" resolve="ITupleMemberDeclaration" />
-      </node>
-      <node concept="3clFbS" id="5r47dOfJ8UO" role="3clF47" />
-    </node>
-    <node concept="13hLZK" id="5r47dOfJ8Ut" role="13h7CW">
-      <node concept="3clFbS" id="5r47dOfJ8Uu" role="2VODD2" />
-    </node>
-  </node>
-  <node concept="13h7C7" id="5r47dOg5pCc">
-    <property role="3GE5qa" value="tuples" />
-    <ref role="13h7C2" to="hm2y:5r47dOfJ8UC" resolve="ITupleMemberDeclaration" />
-    <node concept="13i0hz" id="5r47dOg5pCn" role="13h7CS">
-      <property role="13i0iv" value="true" />
-      <property role="13i0it" value="true" />
-      <property role="TrG5h" value="type" />
-      <node concept="3Tm1VV" id="5r47dOg5pCo" role="1B3o_S" />
-      <node concept="3Tqbb2" id="5r47dOg5pT$" role="3clF45">
-        <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
-      </node>
-      <node concept="3clFbS" id="5r47dOg5pCq" role="3clF47" />
-    </node>
-    <node concept="13hLZK" id="5r47dOg5pCd" role="13h7CW">
-      <node concept="3clFbS" id="5r47dOg5pCe" role="2VODD2" />
-    </node>
-  </node>
-  <node concept="13h7C7" id="6GiZkUz7qWV">
-    <property role="3GE5qa" value="tuples" />
-    <ref role="13h7C2" to="hm2y:6GiZkUz7qWO" resolve="InlineNamedTupleAccess" />
-    <node concept="13hLZK" id="6GiZkUz7qWW" role="13h7CW">
-      <node concept="3clFbS" id="6GiZkUz7qWX" role="2VODD2" />
-    </node>
-    <node concept="13i0hz" id="6GiZkUz7qX6" role="13h7CS">
-      <property role="TrG5h" value="renderReadable" />
-      <ref role="13i0hy" node="6kR0qIbI2yi" resolve="renderReadable" />
-      <node concept="3Tm1VV" id="6GiZkUz7qX7" role="1B3o_S" />
-      <node concept="3clFbS" id="6GiZkUz7qXa" role="3clF47">
-        <node concept="3clFbF" id="6GiZkUz7Aah" role="3cqZAp">
-          <node concept="2OqwBi" id="6GiZkUz7AIH" role="3clFbG">
-            <node concept="2OqwBi" id="6GiZkUz7AkM" role="2Oq$k0">
-              <node concept="13iPFW" id="6GiZkUz7Aae" role="2Oq$k0" />
-              <node concept="3TrEf2" id="6GiZkUz7A_H" role="2OqNvi">
-                <ref role="3Tt5mk" to="hm2y:6GiZkUz7r1V" resolve="member" />
-              </node>
-            </node>
-            <node concept="3TrcHB" id="6GiZkUz7ASw" role="2OqNvi">
-              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="17QB3L" id="6GiZkUz7qXb" role="3clF45" />
-    </node>
-    <node concept="13i0hz" id="6GiZkUzfnDf" role="13h7CS">
-      <property role="TrG5h" value="expression" />
-      <node concept="3Tm1VV" id="6GiZkUzfnDg" role="1B3o_S" />
-      <node concept="3Tqbb2" id="6GiZkUzfnJ0" role="3clF45">
-        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
-      </node>
-      <node concept="3clFbS" id="6GiZkUzfnDi" role="3clF47">
-        <node concept="3clFbF" id="6GiZkUzfnJO" role="3cqZAp">
-          <node concept="2OqwBi" id="6GiZkUzfoIf" role="3clFbG">
-            <node concept="1PxgMI" id="6GiZkUzfor4" role="2Oq$k0">
-              <node concept="chp4Y" id="6GiZkUzfos0" role="3oSUPX">
-                <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
-              </node>
-              <node concept="2OqwBi" id="6GiZkUzfnOJ" role="1m5AlR">
-                <node concept="13iPFW" id="6GiZkUzfnJN" role="2Oq$k0" />
-                <node concept="1mfA1w" id="6GiZkUzfnVi" role="2OqNvi" />
-              </node>
-            </node>
-            <node concept="3TrEf2" id="6GiZkUzfpIH" role="2OqNvi">
-              <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="13i0hz" id="6GiZkUzfqE6" role="13h7CS">
-      <property role="TrG5h" value="type" />
-      <node concept="3Tm1VV" id="6GiZkUzfqE7" role="1B3o_S" />
-      <node concept="3Tqbb2" id="6GiZkUzfqRk" role="3clF45">
-        <ref role="ehGHo" to="hm2y:5r47dOfJ9kS" resolve="InlineTupleType" />
-      </node>
-      <node concept="3clFbS" id="6GiZkUzfqE9" role="3clF47">
-        <node concept="3clFbF" id="6GiZkUzfr29" role="3cqZAp">
-          <node concept="1PxgMI" id="6GiZkUzfsfl" role="3clFbG">
-            <property role="1BlNFB" value="true" />
-            <node concept="chp4Y" id="6GiZkUzfsgz" role="3oSUPX">
-              <ref role="cht4Q" to="hm2y:5r47dOfJ9kS" resolve="InlineTupleType" />
-            </node>
-            <node concept="2OqwBi" id="6GiZkUzfrek" role="1m5AlR">
-              <node concept="BsUDl" id="6GiZkUzfr28" role="2Oq$k0">
-                <ref role="37wK5l" node="6GiZkUzfnDf" resolve="expression" />
-              </node>
-              <node concept="3JvlWi" id="6GiZkUzfrHO" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="13i0hz" id="1c6hIxyZnje" role="13h7CS">
-      <property role="TrG5h" value="tupleDeclaration" />
-      <node concept="3Tm1VV" id="1c6hIxyZnjf" role="1B3o_S" />
-      <node concept="3Tqbb2" id="1c6hIxyZnyV" role="3clF45">
-        <ref role="ehGHo" to="hm2y:5r47dOfJ8Ur" resolve="ITupleDeclaration" />
-      </node>
-      <node concept="3clFbS" id="1c6hIxyZnjh" role="3clF47">
-        <node concept="3clFbF" id="1c6hIxyZn$Y" role="3cqZAp">
-          <node concept="2OqwBi" id="1c6hIxyZn_0" role="3clFbG">
-            <node concept="BsUDl" id="1c6hIxyZn_1" role="2Oq$k0">
-              <ref role="37wK5l" node="6GiZkUzfqE6" resolve="type" />
-            </node>
-            <node concept="3TrEf2" id="1c6hIxyZn_2" role="2OqNvi">
-              <ref role="3Tt5mk" to="hm2y:5r47dOfJ9kT" resolve="decl" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="13i0hz" id="6GiZkUzfnf3" role="13h7CS">
-      <property role="TrG5h" value="effectDescriptor" />
-      <ref role="13i0hy" node="6GySMNjjWfO" resolve="effectDescriptor" />
-      <node concept="3Tm1VV" id="6GiZkUzfnf4" role="1B3o_S" />
-      <node concept="3clFbS" id="6GiZkUzfnfd" role="3clF47">
-        <node concept="3clFbF" id="6GiZkUzfnq7" role="3cqZAp">
-          <node concept="BsUDl" id="6GiZkUzfnq2" role="3clFbG">
-            <ref role="37wK5l" node="6KxoTHgL$U0" resolve="deriveFrom" />
-            <node concept="BsUDl" id="1c6hIxyZnGy" role="37wK5m">
-              <ref role="37wK5l" node="1c6hIxyZnje" resolve="tupleDeclaration" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3uibUv" id="6GiZkUzfnfe" role="3clF45">
-        <ref role="3uigEE" to="oq0c:3ni3WieuV7z" resolve="EffectDescriptor" />
-      </node>
-    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -20156,18 +20156,9 @@
       <node concept="3uibUv" id="4XlPKepacWU" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="2ShNRf" id="2GzLOsTJoc5" role="33vP2m">
-        <node concept="1pGfFk" id="2GzLOsTJuNF" role="2ShVmc">
-          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-          <node concept="10M0yZ" id="4XlPKepacWV" role="37wK5m">
-            <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
-            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-          </node>
-          <node concept="10M0yZ" id="2GzLOsTJBaf" role="37wK5m">
-            <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
-            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-          </node>
-        </node>
+      <node concept="10M0yZ" id="38mO9wfUdN$" role="33vP2m">
+        <ref role="3cqZAo" to="lzb2:~JBColor.red" resolve="red" />
+        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
       </node>
     </node>
     <node concept="Wx3nA" id="4XlPKepacWW" role="jymVt">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:8405f486-53b5-4fe6-af3e-7f68358bd631(org.iets3.core.expr.base.editor)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells" version="2" />
@@ -3332,9 +3333,18 @@
                 <node concept="1pGfFk" id="6cw1FA3OUp_" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:BsHjoDRDi8" resolve="OpeningBracketCell" />
                   <node concept="pncrf" id="6cw1FA3OUub" role="37wK5m" />
-                  <node concept="10M0yZ" id="6cw1FA3REJN" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <node concept="2ShNRf" id="2GzLOsU3Xud" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsU3Yws" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="6cw1FA3REJN" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsUgQ1H" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -3397,9 +3407,18 @@
                 <node concept="1pGfFk" id="6cw1FA3OWnU" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:4QhMqW2TWbb" resolve="ClosingBracketCell" />
                   <node concept="pncrf" id="6cw1FA3OWnV" role="37wK5m" />
-                  <node concept="10M0yZ" id="6cw1FA3RFWe" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <node concept="2ShNRf" id="2GzLOsU40kP" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsU40kQ" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="2GzLOsU40kR" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsUmVy7" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -4145,9 +4164,18 @@
                           <node concept="1pGfFk" id="43wAXFo$G5g" role="2ShVmc">
                             <ref role="37wK5l" to="r4b4:5aYhgyhCewP" resolve="VerticalBarCellProvider" />
                             <node concept="pncrf" id="43wAXFo$G5h" role="37wK5m" />
-                            <node concept="10M0yZ" id="43wAXFoL0Jm" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            <node concept="2ShNRf" id="2GzLOsUKdTT" role="37wK5m">
+                              <node concept="1pGfFk" id="2GzLOsUKeDY" role="2ShVmc">
+                                <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                                <node concept="10M0yZ" id="43wAXFoL0Jm" role="37wK5m">
+                                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                  <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
+                                </node>
+                                <node concept="10M0yZ" id="2GzLOsUKeWd" role="37wK5m">
+                                  <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
+                                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                </node>
+                              </node>
                             </node>
                             <node concept="3cmrfG" id="43wAXFo$G5j" role="37wK5m">
                               <property role="3cmrfH" value="5" />
@@ -4167,9 +4195,18 @@
                       <node concept="1pGfFk" id="7H91AjXMnmn" role="2ShVmc">
                         <ref role="37wK5l" to="r4b4:5aYhgyhCewP" resolve="VerticalBarCellProvider" />
                         <node concept="pncrf" id="7H91AjXMnmo" role="37wK5m" />
-                        <node concept="10M0yZ" id="7H91AjXMnu5" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.GREEN" resolve="GREEN" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <node concept="2ShNRf" id="2GzLOsUKfBM" role="37wK5m">
+                          <node concept="1pGfFk" id="2GzLOsUKgof" role="2ShVmc">
+                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                            <node concept="10M0yZ" id="7H91AjXMnu5" role="37wK5m">
+                              <ref role="3cqZAo" to="z60i:~Color.GREEN" resolve="GREEN" />
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            </node>
+                            <node concept="10M0yZ" id="2GzLOsUKgE$" role="37wK5m">
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              <ref role="3cqZAo" to="z60i:~Color.GREEN" resolve="GREEN" />
+                            </node>
+                          </node>
                         </node>
                         <node concept="3cmrfG" id="7H91AjXMnmq" role="37wK5m">
                           <property role="3cmrfH" value="5" />
@@ -4191,9 +4228,18 @@
                       <node concept="1pGfFk" id="7H91AjXDtFj" role="2ShVmc">
                         <ref role="37wK5l" to="r4b4:5aYhgyhCewP" resolve="VerticalBarCellProvider" />
                         <node concept="pncrf" id="7H91AjXDtFl" role="37wK5m" />
-                        <node concept="10M0yZ" id="7H91AjXDtN7" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.ORANGE" resolve="ORANGE" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <node concept="2ShNRf" id="2GzLOsUKhn9" role="37wK5m">
+                          <node concept="1pGfFk" id="2GzLOsUKi7Y" role="2ShVmc">
+                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                            <node concept="10M0yZ" id="7H91AjXDtN7" role="37wK5m">
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              <ref role="3cqZAo" to="z60i:~Color.ORANGE" resolve="ORANGE" />
+                            </node>
+                            <node concept="10M0yZ" id="2GzLOsUKi$e" role="37wK5m">
+                              <ref role="3cqZAo" to="z60i:~Color.ORANGE" resolve="ORANGE" />
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            </node>
+                          </node>
                         </node>
                         <node concept="3cmrfG" id="7H91AjXMm_5" role="37wK5m">
                           <property role="3cmrfH" value="5" />
@@ -4215,9 +4261,18 @@
                       <node concept="1pGfFk" id="7H91AjXMmXE" role="2ShVmc">
                         <ref role="37wK5l" to="r4b4:5aYhgyhCewP" resolve="VerticalBarCellProvider" />
                         <node concept="pncrf" id="7H91AjXMmXF" role="37wK5m" />
-                        <node concept="10M0yZ" id="7H91AjXMna4" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <node concept="2ShNRf" id="2GzLOsUKjg4" role="37wK5m">
+                          <node concept="1pGfFk" id="2GzLOsUKk1h" role="2ShVmc">
+                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                            <node concept="10M0yZ" id="7H91AjXMna4" role="37wK5m">
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
+                            </node>
+                            <node concept="10M0yZ" id="2GzLOsUKkuI" role="37wK5m">
+                              <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            </node>
+                          </node>
                         </node>
                         <node concept="3cmrfG" id="7H91AjXMmXH" role="37wK5m">
                           <property role="3cmrfH" value="5" />
@@ -4271,9 +4326,18 @@
                   <node concept="1pGfFk" id="7H91AjXMn_F" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5aYhgyhCewP" resolve="VerticalBarCellProvider" />
                     <node concept="pncrf" id="7H91AjXMn_G" role="37wK5m" />
-                    <node concept="10M0yZ" id="43wAXFoW8zY" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.MAGENTA" resolve="MAGENTA" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <node concept="2ShNRf" id="2GzLOsUKlhF" role="37wK5m">
+                      <node concept="1pGfFk" id="2GzLOsUKm3g" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="10M0yZ" id="43wAXFoW8zY" role="37wK5m">
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <ref role="3cqZAo" to="z60i:~Color.MAGENTA" resolve="MAGENTA" />
+                        </node>
+                        <node concept="10M0yZ" id="2GzLOsUKmxK" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.MAGENTA" resolve="MAGENTA" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                      </node>
                     </node>
                     <node concept="3cmrfG" id="7H91AjXMn_I" role="37wK5m">
                       <property role="3cmrfH" value="5" />
@@ -4662,11 +4726,23 @@
         <node concept="3ZlJ5R" id="91pmpxsdEH" role="VblUZ">
           <node concept="3clFbS" id="91pmpxsdEI" role="2VODD2">
             <node concept="3clFbF" id="91pmpxsdL_" role="3cqZAp">
-              <node concept="2YIFZM" id="91pmpxsdSK" role="3clFbG">
-                <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                <node concept="Xl_RD" id="91pmpxse1g" role="37wK5m">
-                  <property role="Xl_RC" value="#B2DDEB" />
+              <node concept="2ShNRf" id="2GzLOsUR$aJ" role="3clFbG">
+                <node concept="1pGfFk" id="2GzLOsUR$MA" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="2YIFZM" id="91pmpxsdSK" role="37wK5m">
+                    <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                    <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                    <node concept="Xl_RD" id="91pmpxse1g" role="37wK5m">
+                      <property role="Xl_RC" value="#B2DDEB" />
+                    </node>
+                  </node>
+                  <node concept="2YIFZM" id="2GzLOsUR_iE" role="37wK5m">
+                    <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                    <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                    <node concept="Xl_RD" id="2GzLOsUR_iF" role="37wK5m">
+                      <property role="Xl_RC" value="#B2DDEB" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -5944,9 +6020,18 @@
                 <node concept="1pGfFk" id="4CksDrmwcI9" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:BsHjoDRDi8" resolve="OpeningBracketCell" />
                   <node concept="pncrf" id="4CksDrmwcIa" role="37wK5m" />
-                  <node concept="10M0yZ" id="4CksDrmwcIb" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                  <node concept="2ShNRf" id="2GzLOsUNkH_" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsUNloL" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="4CksDrmwcIb" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsUNlz$" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -5975,9 +6060,18 @@
                 <node concept="1pGfFk" id="4CksDrmwcSQ" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:4QhMqW2TWbb" resolve="ClosingBracketCell" />
                   <node concept="pncrf" id="4CksDrmwcSR" role="37wK5m" />
-                  <node concept="10M0yZ" id="4CksDrmwcSS" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <node concept="2ShNRf" id="2GzLOsUNlGY" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsUNlGZ" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="2GzLOsUNlH0" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsUNlH1" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -6249,17 +6343,36 @@
       <node concept="3uibUv" id="43wAXFpMySX" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="2ShNRf" id="2udM7u8D_76" role="33vP2m">
-        <node concept="1pGfFk" id="2udM7u8D_rZ" role="2ShVmc">
-          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-          <node concept="3cmrfG" id="2udM7u8D_s6" role="37wK5m">
-            <property role="3cmrfH" value="255" />
+      <node concept="2ShNRf" id="2GzLOsUKnOd" role="33vP2m">
+        <node concept="1pGfFk" id="2GzLOsUKoyc" role="2ShVmc">
+          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+          <node concept="2ShNRf" id="2udM7u8D_76" role="37wK5m">
+            <node concept="1pGfFk" id="2udM7u8D_rZ" role="2ShVmc">
+              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+              <node concept="3cmrfG" id="2udM7u8D_s6" role="37wK5m">
+                <property role="3cmrfH" value="255" />
+              </node>
+              <node concept="3cmrfG" id="2udM7u8D__W" role="37wK5m">
+                <property role="3cmrfH" value="220" />
+              </node>
+              <node concept="3cmrfG" id="2udM7u8D_EJ" role="37wK5m">
+                <property role="3cmrfH" value="220" />
+              </node>
+            </node>
           </node>
-          <node concept="3cmrfG" id="2udM7u8D__W" role="37wK5m">
-            <property role="3cmrfH" value="220" />
-          </node>
-          <node concept="3cmrfG" id="2udM7u8D_EJ" role="37wK5m">
-            <property role="3cmrfH" value="220" />
+          <node concept="2ShNRf" id="2GzLOsUL0gc" role="37wK5m">
+            <node concept="1pGfFk" id="2GzLOsUL0gd" role="2ShVmc">
+              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+              <node concept="3cmrfG" id="2GzLOsUL0ge" role="37wK5m">
+                <property role="3cmrfH" value="255" />
+              </node>
+              <node concept="3cmrfG" id="2GzLOsUL0gf" role="37wK5m">
+                <property role="3cmrfH" value="220" />
+              </node>
+              <node concept="3cmrfG" id="2GzLOsUL0gg" role="37wK5m">
+                <property role="3cmrfH" value="220" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -6273,17 +6386,36 @@
       <node concept="3uibUv" id="43wAXFpMzmO" role="1tU5fm">
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
-      <node concept="2ShNRf" id="43wAXFoScN0" role="33vP2m">
-        <node concept="1pGfFk" id="43wAXFoScN1" role="2ShVmc">
-          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-          <node concept="3cmrfG" id="43wAXFoScN2" role="37wK5m">
-            <property role="3cmrfH" value="220" />
+      <node concept="2ShNRf" id="2GzLOsUL0rO" role="33vP2m">
+        <node concept="1pGfFk" id="2GzLOsUL19N" role="2ShVmc">
+          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+          <node concept="2ShNRf" id="43wAXFoScN0" role="37wK5m">
+            <node concept="1pGfFk" id="43wAXFoScN1" role="2ShVmc">
+              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+              <node concept="3cmrfG" id="43wAXFoScN2" role="37wK5m">
+                <property role="3cmrfH" value="220" />
+              </node>
+              <node concept="3cmrfG" id="43wAXFoScN3" role="37wK5m">
+                <property role="3cmrfH" value="220" />
+              </node>
+              <node concept="3cmrfG" id="43wAXFoScN4" role="37wK5m">
+                <property role="3cmrfH" value="255" />
+              </node>
+            </node>
           </node>
-          <node concept="3cmrfG" id="43wAXFoScN3" role="37wK5m">
-            <property role="3cmrfH" value="220" />
-          </node>
-          <node concept="3cmrfG" id="43wAXFoScN4" role="37wK5m">
-            <property role="3cmrfH" value="255" />
+          <node concept="2ShNRf" id="2GzLOsUL1l7" role="37wK5m">
+            <node concept="1pGfFk" id="2GzLOsUL1l8" role="2ShVmc">
+              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+              <node concept="3cmrfG" id="2GzLOsUL1l9" role="37wK5m">
+                <property role="3cmrfH" value="220" />
+              </node>
+              <node concept="3cmrfG" id="2GzLOsUL1la" role="37wK5m">
+                <property role="3cmrfH" value="220" />
+              </node>
+              <node concept="3cmrfG" id="2GzLOsUL1lb" role="37wK5m">
+                <property role="3cmrfH" value="255" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -7216,11 +7348,6 @@
     <node concept="2tJIrI" id="jqB9UdvFT2" role="jymVt" />
     <node concept="3Tm1VV" id="jqB9UdvFoA" role="1B3o_S" />
   </node>
-  <node concept="22mcaB" id="6GiZkUz7qWL">
-    <property role="3GE5qa" value="tuples" />
-    <ref role="aqKnT" to="hm2y:5r47dOfJ9kS" resolve="InlineTupleType" />
-    <node concept="22hDWj" id="6GiZkUz7qWM" role="22hAXT" />
-  </node>
   <node concept="22mcaB" id="6GiZkUz7t5K">
     <property role="3GE5qa" value="tuples" />
     <ref role="aqKnT" to="hm2y:6GiZkUz7qWO" resolve="InlineNamedTupleAccess" />
@@ -7367,6 +7494,11 @@
         </node>
       </node>
     </node>
+  </node>
+  <node concept="22mcaB" id="6GiZkUz7qWL">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="aqKnT" to="hm2y:5r47dOfJ9kS" resolve="InlineTupleType" />
+    <node concept="22hDWj" id="6GiZkUz7qWM" role="22hAXT" />
   </node>
   <node concept="24kQdi" id="1c6hIxyRTnQ">
     <property role="3GE5qa" value="tuples" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
@@ -36,10 +36,10 @@
     <import index="9eyi" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.lang.editor.menus.transformation(MPS.Editor/)" />
     <import index="vndm" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.language(MPS.Core/)" />
     <import index="6lvu" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellMenu(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="q4oi" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellActions(MPS.Editor/)" />
     <import index="av1m" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.menus.style(MPS.Editor/)" />
     <import index="fulz" ref="r:6f792c44-2a5d-40e8-9f05-33f7d4ae26ec(jetbrains.mps.editor.runtime.completion)" />
-    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="gdgh" ref="r:e4d9478b-ae0e-416e-be60-73d136571015(org.iets3.core.base.behavior)" implicit="true" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
@@ -3333,18 +3333,9 @@
                 <node concept="1pGfFk" id="6cw1FA3OUp_" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:BsHjoDRDi8" resolve="OpeningBracketCell" />
                   <node concept="pncrf" id="6cw1FA3OUub" role="37wK5m" />
-                  <node concept="2ShNRf" id="2GzLOsU3Xud" role="37wK5m">
-                    <node concept="1pGfFk" id="2GzLOsU3Yws" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="6cw1FA3REJN" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                      </node>
-                      <node concept="10M0yZ" id="2GzLOsUgQ1H" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wfUiiE" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -3407,18 +3398,9 @@
                 <node concept="1pGfFk" id="6cw1FA3OWnU" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:4QhMqW2TWbb" resolve="ClosingBracketCell" />
                   <node concept="pncrf" id="6cw1FA3OWnV" role="37wK5m" />
-                  <node concept="2ShNRf" id="2GzLOsU40kP" role="37wK5m">
-                    <node concept="1pGfFk" id="2GzLOsU40kQ" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="2GzLOsU40kR" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="2GzLOsUmVy7" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wfYr31" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -4164,18 +4146,9 @@
                           <node concept="1pGfFk" id="43wAXFo$G5g" role="2ShVmc">
                             <ref role="37wK5l" to="r4b4:5aYhgyhCewP" resolve="VerticalBarCellProvider" />
                             <node concept="pncrf" id="43wAXFo$G5h" role="37wK5m" />
-                            <node concept="2ShNRf" id="2GzLOsUKdTT" role="37wK5m">
-                              <node concept="1pGfFk" id="2GzLOsUKeDY" role="2ShVmc">
-                                <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                                <node concept="10M0yZ" id="43wAXFoL0Jm" role="37wK5m">
-                                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                  <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
-                                </node>
-                                <node concept="10M0yZ" id="2GzLOsUKeWd" role="37wK5m">
-                                  <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
-                                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                </node>
-                              </node>
+                            <node concept="10M0yZ" id="38mO9wfYsAt" role="37wK5m">
+                              <ref role="3cqZAo" to="lzb2:~JBColor.blue" resolve="blue" />
+                              <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                             </node>
                             <node concept="3cmrfG" id="43wAXFo$G5j" role="37wK5m">
                               <property role="3cmrfH" value="5" />
@@ -4195,18 +4168,9 @@
                       <node concept="1pGfFk" id="7H91AjXMnmn" role="2ShVmc">
                         <ref role="37wK5l" to="r4b4:5aYhgyhCewP" resolve="VerticalBarCellProvider" />
                         <node concept="pncrf" id="7H91AjXMnmo" role="37wK5m" />
-                        <node concept="2ShNRf" id="2GzLOsUKfBM" role="37wK5m">
-                          <node concept="1pGfFk" id="2GzLOsUKgof" role="2ShVmc">
-                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                            <node concept="10M0yZ" id="7H91AjXMnu5" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.GREEN" resolve="GREEN" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            </node>
-                            <node concept="10M0yZ" id="2GzLOsUKgE$" role="37wK5m">
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                              <ref role="3cqZAo" to="z60i:~Color.GREEN" resolve="GREEN" />
-                            </node>
-                          </node>
+                        <node concept="10M0yZ" id="38mO9wfYt8l" role="37wK5m">
+                          <ref role="3cqZAo" to="lzb2:~JBColor.green" resolve="green" />
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                         </node>
                         <node concept="3cmrfG" id="7H91AjXMnmq" role="37wK5m">
                           <property role="3cmrfH" value="5" />
@@ -4228,18 +4192,9 @@
                       <node concept="1pGfFk" id="7H91AjXDtFj" role="2ShVmc">
                         <ref role="37wK5l" to="r4b4:5aYhgyhCewP" resolve="VerticalBarCellProvider" />
                         <node concept="pncrf" id="7H91AjXDtFl" role="37wK5m" />
-                        <node concept="2ShNRf" id="2GzLOsUKhn9" role="37wK5m">
-                          <node concept="1pGfFk" id="2GzLOsUKi7Y" role="2ShVmc">
-                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                            <node concept="10M0yZ" id="7H91AjXDtN7" role="37wK5m">
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                              <ref role="3cqZAo" to="z60i:~Color.ORANGE" resolve="ORANGE" />
-                            </node>
-                            <node concept="10M0yZ" id="2GzLOsUKi$e" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.ORANGE" resolve="ORANGE" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            </node>
-                          </node>
+                        <node concept="10M0yZ" id="38mO9wfYt$T" role="37wK5m">
+                          <ref role="3cqZAo" to="lzb2:~JBColor.orange" resolve="orange" />
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                         </node>
                         <node concept="3cmrfG" id="7H91AjXMm_5" role="37wK5m">
                           <property role="3cmrfH" value="5" />
@@ -4261,18 +4216,9 @@
                       <node concept="1pGfFk" id="7H91AjXMmXE" role="2ShVmc">
                         <ref role="37wK5l" to="r4b4:5aYhgyhCewP" resolve="VerticalBarCellProvider" />
                         <node concept="pncrf" id="7H91AjXMmXF" role="37wK5m" />
-                        <node concept="2ShNRf" id="2GzLOsUKjg4" role="37wK5m">
-                          <node concept="1pGfFk" id="2GzLOsUKk1h" role="2ShVmc">
-                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                            <node concept="10M0yZ" id="7H91AjXMna4" role="37wK5m">
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                              <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
-                            </node>
-                            <node concept="10M0yZ" id="2GzLOsUKkuI" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.RED" resolve="RED" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            </node>
-                          </node>
+                        <node concept="10M0yZ" id="38mO9wfYua3" role="37wK5m">
+                          <ref role="3cqZAo" to="lzb2:~JBColor.red" resolve="red" />
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                         </node>
                         <node concept="3cmrfG" id="7H91AjXMmXH" role="37wK5m">
                           <property role="3cmrfH" value="5" />
@@ -4326,18 +4272,9 @@
                   <node concept="1pGfFk" id="7H91AjXMn_F" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5aYhgyhCewP" resolve="VerticalBarCellProvider" />
                     <node concept="pncrf" id="7H91AjXMn_G" role="37wK5m" />
-                    <node concept="2ShNRf" id="2GzLOsUKlhF" role="37wK5m">
-                      <node concept="1pGfFk" id="2GzLOsUKm3g" role="2ShVmc">
-                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                        <node concept="10M0yZ" id="43wAXFoW8zY" role="37wK5m">
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          <ref role="3cqZAo" to="z60i:~Color.MAGENTA" resolve="MAGENTA" />
-                        </node>
-                        <node concept="10M0yZ" id="2GzLOsUKmxK" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.MAGENTA" resolve="MAGENTA" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="38mO9wfYuLC" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.magenta" resolve="magenta" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                     <node concept="3cmrfG" id="7H91AjXMn_I" role="37wK5m">
                       <property role="3cmrfH" value="5" />
@@ -6020,18 +5957,9 @@
                 <node concept="1pGfFk" id="4CksDrmwcI9" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:BsHjoDRDi8" resolve="OpeningBracketCell" />
                   <node concept="pncrf" id="4CksDrmwcIa" role="37wK5m" />
-                  <node concept="2ShNRf" id="2GzLOsUNkH_" role="37wK5m">
-                    <node concept="1pGfFk" id="2GzLOsUNloL" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="4CksDrmwcIb" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="2GzLOsUNlz$" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wfYvPC" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/plugin.mps
@@ -48,6 +48,7 @@
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="tprs" ref="r:00000000-0000-4000-0000-011c895904a4(jetbrains.mps.ide.actions)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
   </imports>
   <registry>
     <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
@@ -9886,13 +9887,31 @@
                 <node concept="37vLTw" id="6LVVWmzCY4F" role="3K4Cdx">
                   <ref role="3cqZAo" node="6LVVWmzxrW5" resolve="highlight" />
                 </node>
-                <node concept="10M0yZ" id="6LVVWmzD2yV" role="3K4E3e">
-                  <ref role="3cqZAo" to="z60i:~Color.blue" resolve="blue" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                <node concept="2ShNRf" id="2GzLOsURDgg" role="3K4E3e">
+                  <node concept="1pGfFk" id="2GzLOsURGi3" role="2ShVmc">
+                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                    <node concept="10M0yZ" id="6LVVWmzD2yV" role="37wK5m">
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="3cqZAo" to="z60i:~Color.blue" resolve="blue" />
+                    </node>
+                    <node concept="10M0yZ" id="2GzLOsURJko" role="37wK5m">
+                      <ref role="3cqZAo" to="z60i:~Color.blue" resolve="blue" />
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    </node>
+                  </node>
                 </node>
-                <node concept="10M0yZ" id="6LVVWmzD3CP" role="3K4GZi">
-                  <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                <node concept="2ShNRf" id="2GzLOsURKUG" role="3K4GZi">
+                  <node concept="1pGfFk" id="2GzLOsURNud" role="2ShVmc">
+                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                    <node concept="10M0yZ" id="6LVVWmzD3CP" role="37wK5m">
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                    </node>
+                    <node concept="10M0yZ" id="2GzLOsURPJE" role="37wK5m">
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -14084,16 +14103,12 @@
     </node>
     <node concept="3Tm1VV" id="2O$zpZk7gkh" role="1B3o_S" />
   </node>
-  <node concept="3HP615" id="34s7_UnUH2A">
+  <node concept="vrV6u" id="3HxoqR_T8F2">
+    <property role="TrG5h" value="typesystemCustomization" />
     <property role="3GE5qa" value="typesystem" />
-    <property role="TrG5h" value="TypesystemCustomizer" />
-    <node concept="3clFb_" id="34s7_UnUH4e" role="jymVt">
-      <property role="TrG5h" value="checkDuplicateValuesInEnums" />
-      <node concept="10P_77" id="34s7_UnUH4f" role="3clF45" />
-      <node concept="3Tm1VV" id="34s7_UnUH4g" role="1B3o_S" />
-      <node concept="3clFbS" id="34s7_UnUH4h" role="3clF47" />
+    <node concept="3uibUv" id="3HxoqR_WS1J" role="luc8K">
+      <ref role="3uigEE" node="34s7_UnUH2A" resolve="TypesystemCustomizer" />
     </node>
-    <node concept="3Tm1VV" id="34s7_UnUH2B" role="1B3o_S" />
   </node>
   <node concept="312cEu" id="34s7_UnROPW">
     <property role="3GE5qa" value="typesystem" />
@@ -14147,12 +14162,16 @@
       <ref role="3uigEE" node="34s7_UnUH2A" resolve="TypesystemCustomizer" />
     </node>
   </node>
-  <node concept="vrV6u" id="3HxoqR_T8F2">
-    <property role="TrG5h" value="typesystemCustomization" />
+  <node concept="3HP615" id="34s7_UnUH2A">
     <property role="3GE5qa" value="typesystem" />
-    <node concept="3uibUv" id="3HxoqR_WS1J" role="luc8K">
-      <ref role="3uigEE" node="34s7_UnUH2A" resolve="TypesystemCustomizer" />
+    <property role="TrG5h" value="TypesystemCustomizer" />
+    <node concept="3clFb_" id="34s7_UnUH4e" role="jymVt">
+      <property role="TrG5h" value="checkDuplicateValuesInEnums" />
+      <node concept="10P_77" id="34s7_UnUH4f" role="3clF45" />
+      <node concept="3Tm1VV" id="34s7_UnUH4g" role="1B3o_S" />
+      <node concept="3clFbS" id="34s7_UnUH4h" role="3clF47" />
     </node>
+    <node concept="3Tm1VV" id="34s7_UnUH2B" role="1B3o_S" />
   </node>
   <node concept="1lYeZD" id="x6l$aoyUxg">
     <property role="TrG5h" value="DefaultIdentifierConfiguratorExtension" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:9dbbba98-10eb-4541-87eb-0b6e6386b68c(org.iets3.core.expr.data.editor)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="7e450f4e-1ac3-41ef-a851-4598161bdb94" name="de.slisson.mps.tables" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.dataflow/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.dataflow/models/editor.mps
@@ -17,6 +17,7 @@
     <import index="r4b4" ref="r:1784e088-20fd-4fdb-96b8-bc57f0056d94(com.mbeddr.core.base.editor)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="b4m9" ref="r:f73fffcc-e6a1-406e-b40b-65eaaa19bd69(org.iets3.core.expr.dataflow.behavior)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="itrz" ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
@@ -1855,9 +1856,18 @@
                     <node concept="1pGfFk" id="2vkvJYSUXNZ" role="2ShVmc">
                       <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                       <node concept="pncrf" id="2vkvJYSUXTn" role="37wK5m" />
-                      <node concept="10M0yZ" id="5I_8B5ugyUY" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <node concept="2ShNRf" id="2GzLOsUYaRb" role="37wK5m">
+                        <node concept="1pGfFk" id="2GzLOsUYbuw" role="2ShVmc">
+                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                          <node concept="10M0yZ" id="5I_8B5ugyUY" role="37wK5m">
+                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
+                          </node>
+                          <node concept="10M0yZ" id="2GzLOsUYb_r" role="37wK5m">
+                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -1994,9 +2004,18 @@
         <node concept="3ZlJ5R" id="mIQkxg7PZI" role="VblUZ">
           <node concept="3clFbS" id="mIQkxg7PZJ" role="2VODD2">
             <node concept="3clFbF" id="30L$xlchZR5" role="3cqZAp">
-              <node concept="10M0yZ" id="30L$xlchZc0" role="3clFbG">
-                <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+              <node concept="2ShNRf" id="2GzLOsUVY0L" role="3clFbG">
+                <node concept="1pGfFk" id="2GzLOsUVYAp" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="10M0yZ" id="30L$xlchZc0" role="37wK5m">
+                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  </node>
+                  <node concept="10M0yZ" id="2GzLOsUVYFZ" role="37wK5m">
+                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -2159,9 +2178,18 @@
             <node concept="2xDIQ0" id="2HR3cagcgyl" role="2Oq$k0" />
             <node concept="liA8E" id="2HR3cagcgSz" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-              <node concept="10M0yZ" id="30L$xlcgTg2" role="37wK5m">
-                <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+              <node concept="2ShNRf" id="2GzLOsUTNaz" role="37wK5m">
+                <node concept="1pGfFk" id="2GzLOsUTOb6" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="10M0yZ" id="30L$xlcgTg2" role="37wK5m">
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                  </node>
+                  <node concept="10M0yZ" id="2GzLOsUUxLO" role="37wK5m">
+                    <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -2283,9 +2311,18 @@
             <node concept="2xDIQ0" id="2HR3caggQEV" role="2Oq$k0" />
             <node concept="liA8E" id="2HR3caghcq7" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-              <node concept="10M0yZ" id="30L$xlclmsU" role="37wK5m">
-                <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+              <node concept="2ShNRf" id="2GzLOsUVfh6" role="37wK5m">
+                <node concept="1pGfFk" id="2GzLOsUVfTB" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="10M0yZ" id="30L$xlclmsU" role="37wK5m">
+                    <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  </node>
+                  <node concept="10M0yZ" id="2GzLOsUVg0v" role="37wK5m">
+                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -2484,9 +2521,18 @@
                 <node concept="2xDIQ0" id="2HR3cahcbYZ" role="2Oq$k0" />
                 <node concept="liA8E" id="2HR3cahccdC" role="2OqNvi">
                   <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-                  <node concept="10M0yZ" id="30L$xlcnYay" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <node concept="2ShNRf" id="2GzLOsUYV5U" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsUYVIr" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="30L$xlcnYay" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsUYVNx" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -2540,9 +2586,23 @@
                   <node concept="2xDIQ0" id="30L$xlcnYbo" role="2Oq$k0" />
                   <node concept="liA8E" id="30L$xlcnYbp" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-                    <node concept="10M0yZ" id="30L$xlcnYnC" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <node concept="2ShNRf" id="2GzLOsUYVPK" role="37wK5m">
+                      <node concept="1pGfFk" id="2GzLOsUYWuh" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="10M0yZ" id="30L$xlcnYnC" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                        <node concept="2OqwBi" id="2GzLOsUYWNP" role="37wK5m">
+                          <node concept="10M0yZ" id="2GzLOsUYW$l" role="2Oq$k0">
+                            <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          </node>
+                          <node concept="liA8E" id="2GzLOsUYXck" role="2OqNvi">
+                            <ref role="37wK5l" to="z60i:~Color.brighter()" resolve="brighter" />
+                          </node>
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -2865,9 +2925,23 @@
             <node concept="2xDIQ0" id="1gSgWEgx$7d" role="2Oq$k0" />
             <node concept="liA8E" id="1gSgWEgx$qU" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-              <node concept="10M0yZ" id="5Q9FzcI416X" role="37wK5m">
-                <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+              <node concept="2ShNRf" id="2GzLOsUVZkf" role="37wK5m">
+                <node concept="1pGfFk" id="2GzLOsUVZWK" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="10M0yZ" id="5Q9FzcI416X" role="37wK5m">
+                    <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  </node>
+                  <node concept="2OqwBi" id="2GzLOsUW0jI" role="37wK5m">
+                    <node concept="10M0yZ" id="2GzLOsUW0iF" role="2Oq$k0">
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                    </node>
+                    <node concept="liA8E" id="2GzLOsUW0Im" role="2OqNvi">
+                      <ref role="37wK5l" to="z60i:~Color.brighter()" resolve="brighter" />
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -3407,9 +3481,18 @@
             <node concept="2xDIQ0" id="3nAucCgyR49" role="2Oq$k0" />
             <node concept="liA8E" id="3nAucCgyR4a" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-              <node concept="10M0yZ" id="5Q9FzcI40k$" role="37wK5m">
-                <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+              <node concept="2ShNRf" id="2GzLOsUYc8Q" role="37wK5m">
+                <node concept="1pGfFk" id="2GzLOsUYcLn" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="10M0yZ" id="5Q9FzcI40k$" role="37wK5m">
+                    <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  </node>
+                  <node concept="10M0yZ" id="2GzLOsUYcQx" role="37wK5m">
+                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.dataflow/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.dataflow/models/editor.mps
@@ -1856,18 +1856,9 @@
                     <node concept="1pGfFk" id="2vkvJYSUXNZ" role="2ShVmc">
                       <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                       <node concept="pncrf" id="2vkvJYSUXTn" role="37wK5m" />
-                      <node concept="2ShNRf" id="2GzLOsUYaRb" role="37wK5m">
-                        <node concept="1pGfFk" id="2GzLOsUYbuw" role="2ShVmc">
-                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                          <node concept="10M0yZ" id="5I_8B5ugyUY" role="37wK5m">
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                          </node>
-                          <node concept="10M0yZ" id="2GzLOsUYb_r" role="37wK5m">
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                          </node>
-                        </node>
+                      <node concept="10M0yZ" id="38mO9wg4zm$" role="37wK5m">
+                        <ref role="3cqZAo" to="lzb2:~JBColor.darkGray" resolve="darkGray" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                       </node>
                     </node>
                   </node>
@@ -2004,18 +1995,9 @@
         <node concept="3ZlJ5R" id="mIQkxg7PZI" role="VblUZ">
           <node concept="3clFbS" id="mIQkxg7PZJ" role="2VODD2">
             <node concept="3clFbF" id="30L$xlchZR5" role="3cqZAp">
-              <node concept="2ShNRf" id="2GzLOsUVY0L" role="3clFbG">
-                <node concept="1pGfFk" id="2GzLOsUVYAp" role="2ShVmc">
-                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                  <node concept="10M0yZ" id="30L$xlchZc0" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  </node>
-                  <node concept="10M0yZ" id="2GzLOsUVYFZ" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  </node>
-                </node>
+              <node concept="10M0yZ" id="38mO9wg3fVE" role="3clFbG">
+                <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
               </node>
             </node>
           </node>
@@ -2178,18 +2160,9 @@
             <node concept="2xDIQ0" id="2HR3cagcgyl" role="2Oq$k0" />
             <node concept="liA8E" id="2HR3cagcgSz" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-              <node concept="2ShNRf" id="2GzLOsUTNaz" role="37wK5m">
-                <node concept="1pGfFk" id="2GzLOsUTOb6" role="2ShVmc">
-                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                  <node concept="10M0yZ" id="30L$xlcgTg2" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                  </node>
-                  <node concept="10M0yZ" id="2GzLOsUUxLO" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  </node>
-                </node>
+              <node concept="10M0yZ" id="38mO9wg3fwj" role="37wK5m">
+                <ref role="3cqZAo" to="lzb2:~JBColor.lightGray" resolve="lightGray" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
               </node>
             </node>
           </node>
@@ -2521,18 +2494,9 @@
                 <node concept="2xDIQ0" id="2HR3cahcbYZ" role="2Oq$k0" />
                 <node concept="liA8E" id="2HR3cahccdC" role="2OqNvi">
                   <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-                  <node concept="2ShNRf" id="2GzLOsUYV5U" role="37wK5m">
-                    <node concept="1pGfFk" id="2GzLOsUYVIr" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="30L$xlcnYay" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="2GzLOsUYVNx" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wg4$fE" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.darkGray" resolve="darkGray" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -2586,23 +2550,9 @@
                   <node concept="2xDIQ0" id="30L$xlcnYbo" role="2Oq$k0" />
                   <node concept="liA8E" id="30L$xlcnYbp" role="2OqNvi">
                     <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-                    <node concept="2ShNRf" id="2GzLOsUYVPK" role="37wK5m">
-                      <node concept="1pGfFk" id="2GzLOsUYWuh" role="2ShVmc">
-                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                        <node concept="10M0yZ" id="30L$xlcnYnC" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                        <node concept="2OqwBi" id="2GzLOsUYWNP" role="37wK5m">
-                          <node concept="10M0yZ" id="2GzLOsUYW$l" role="2Oq$k0">
-                            <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          </node>
-                          <node concept="liA8E" id="2GzLOsUYXck" role="2OqNvi">
-                            <ref role="37wK5l" to="z60i:~Color.brighter()" resolve="brighter" />
-                          </node>
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="38mO9wg4$ko" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                   </node>
                 </node>
@@ -2925,23 +2875,9 @@
             <node concept="2xDIQ0" id="1gSgWEgx$7d" role="2Oq$k0" />
             <node concept="liA8E" id="1gSgWEgx$qU" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-              <node concept="2ShNRf" id="2GzLOsUVZkf" role="37wK5m">
-                <node concept="1pGfFk" id="2GzLOsUVZWK" role="2ShVmc">
-                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                  <node concept="10M0yZ" id="5Q9FzcI416X" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  </node>
-                  <node concept="2OqwBi" id="2GzLOsUW0jI" role="37wK5m">
-                    <node concept="10M0yZ" id="2GzLOsUW0iF" role="2Oq$k0">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                    </node>
-                    <node concept="liA8E" id="2GzLOsUW0Im" role="2OqNvi">
-                      <ref role="37wK5l" to="z60i:~Color.brighter()" resolve="brighter" />
-                    </node>
-                  </node>
-                </node>
+              <node concept="10M0yZ" id="38mO9wg4xsC" role="37wK5m">
+                <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
               </node>
             </node>
           </node>
@@ -3481,18 +3417,9 @@
             <node concept="2xDIQ0" id="3nAucCgyR49" role="2Oq$k0" />
             <node concept="liA8E" id="3nAucCgyR4a" role="2OqNvi">
               <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
-              <node concept="2ShNRf" id="2GzLOsUYc8Q" role="37wK5m">
-                <node concept="1pGfFk" id="2GzLOsUYcLn" role="2ShVmc">
-                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                  <node concept="10M0yZ" id="5Q9FzcI40k$" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  </node>
-                  <node concept="10M0yZ" id="2GzLOsUYcQx" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  </node>
-                </node>
+              <node concept="10M0yZ" id="38mO9wg4zRL" role="37wK5m">
+                <ref role="3cqZAo" to="lzb2:~JBColor.darkGray" resolve="darkGray" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.datetime/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.datetime/models/editor.mps
@@ -9,6 +9,7 @@
   <imports>
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="mi3w" ref="r:9ec53fca-e669-4a18-ba8b-6c9f4f1cb361(org.iets3.core.expr.datetime.structure)" implicit="true" />
     <import index="itrz" ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
@@ -31,6 +32,9 @@
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
         <reference id="1078939183255" name="editorComponent" index="PMmxG" />
       </concept>
+      <concept id="1186402211651" name="jetbrains.mps.lang.editor.structure.StyleSheet" flags="ng" index="V5hpn">
+        <child id="1186402402630" name="styles" index="V601i" />
+      </concept>
       <concept id="1186403694788" name="jetbrains.mps.lang.editor.structure.ColorStyleClassItem" flags="ln" index="VaVBg">
         <child id="1186403803051" name="query" index="VblUZ" />
       </concept>
@@ -41,6 +45,7 @@
       <concept id="1186414860679" name="jetbrains.mps.lang.editor.structure.EditableStyleClassItem" flags="ln" index="VPxyj" />
       <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
       <concept id="1233759184865" name="jetbrains.mps.lang.editor.structure.PunctuationRightStyleClassItem" flags="ln" index="11LMrY" />
+      <concept id="3383245079137382180" name="jetbrains.mps.lang.editor.structure.StyleClass" flags="ig" index="14StLt" />
       <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
       </concept>
@@ -70,6 +75,9 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
@@ -92,6 +100,7 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
     </language>
     <language id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells">
       <concept id="9041925471455857605" name="com.mbeddr.mpsutil.grammarcells.structure.Cell_DescriptionText" flags="ig" index="uPpia" />
@@ -143,98 +152,28 @@
     <node concept="3EZMnI" id="3nGzaxURa4M" role="2wV5jI">
       <node concept="3F0ifn" id="3nGzaxURa5a" role="3EZMnx">
         <property role="3F0ifm" value="/" />
+        <ref role="1k5W1q" node="2GzLOsV0qKA" resolve="defaultDateColor" />
         <node concept="11LMrY" id="3nGzaxURa5c" role="3F10Kt">
           <property role="VOm3f" value="true" />
-        </node>
-        <node concept="VechU" id="3nGzaxUSFB0" role="3F10Kt">
-          <node concept="3ZlJ5R" id="3nGzaxUSFB2" role="VblUZ">
-            <node concept="3clFbS" id="3nGzaxUSFB3" role="2VODD2">
-              <node concept="3clFbF" id="3nGzaxUSGTS" role="3cqZAp">
-                <node concept="2YIFZM" id="3nGzaxUSH7Z" role="3clFbG">
-                  <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                  <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                  <node concept="Xl_RD" id="3nGzaxUSHgs" role="37wK5m">
-                    <property role="Xl_RC" value="#822100" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
         </node>
       </node>
       <node concept="3F0A7n" id="3nGzaxURa54" role="3EZMnx">
         <ref role="1NtTu8" to="mi3w:3nGzaxURa4k" resolve="dd" />
-        <node concept="VechU" id="6C0OSEaGBuF" role="3F10Kt">
-          <node concept="3ZlJ5R" id="6C0OSEaGBuG" role="VblUZ">
-            <node concept="3clFbS" id="6C0OSEaGBuH" role="2VODD2">
-              <node concept="3clFbF" id="6C0OSEaGBuI" role="3cqZAp">
-                <node concept="2YIFZM" id="6C0OSEaGBuJ" role="3clFbG">
-                  <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                  <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                  <node concept="Xl_RD" id="6C0OSEaGBuK" role="37wK5m">
-                    <property role="Xl_RC" value="#822100" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
+        <ref role="1k5W1q" node="2GzLOsV0qKA" resolve="defaultDateColor" />
       </node>
       <node concept="3F0A7n" id="3nGzaxURa4Y" role="3EZMnx">
         <ref role="1NtTu8" to="mi3w:3nGzaxURa4l" resolve="mm" />
-        <node concept="VechU" id="6C0OSEaGBll" role="3F10Kt">
-          <node concept="3ZlJ5R" id="6C0OSEaGBlm" role="VblUZ">
-            <node concept="3clFbS" id="6C0OSEaGBln" role="2VODD2">
-              <node concept="3clFbF" id="6C0OSEaGBlo" role="3cqZAp">
-                <node concept="2YIFZM" id="6C0OSEaGBlp" role="3clFbG">
-                  <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                  <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                  <node concept="Xl_RD" id="6C0OSEaGBlq" role="37wK5m">
-                    <property role="Xl_RC" value="#822100" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
+        <ref role="1k5W1q" node="2GzLOsV0qKA" resolve="defaultDateColor" />
       </node>
       <node concept="3F0A7n" id="3nGzaxURa4S" role="3EZMnx">
         <ref role="1NtTu8" to="mi3w:3nGzaxURa4m" resolve="yyyy" />
-        <node concept="VechU" id="6C0OSEaGBcc" role="3F10Kt">
-          <node concept="3ZlJ5R" id="6C0OSEaGBcd" role="VblUZ">
-            <node concept="3clFbS" id="6C0OSEaGBce" role="2VODD2">
-              <node concept="3clFbF" id="6C0OSEaGBcf" role="3cqZAp">
-                <node concept="2YIFZM" id="6C0OSEaGBcg" role="3clFbG">
-                  <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                  <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                  <node concept="Xl_RD" id="6C0OSEaGBch" role="37wK5m">
-                    <property role="Xl_RC" value="#822100" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
+        <ref role="1k5W1q" node="2GzLOsV0qKA" resolve="defaultDateColor" />
       </node>
       <node concept="3F0ifn" id="3nGzaxURa57" role="3EZMnx">
         <property role="3F0ifm" value="/" />
+        <ref role="1k5W1q" node="2GzLOsV0qKA" resolve="defaultDateColor" />
         <node concept="11L4FC" id="3nGzaxURa5j" role="3F10Kt">
           <property role="VOm3f" value="true" />
-        </node>
-        <node concept="VechU" id="6C0OSEaGBCh" role="3F10Kt">
-          <node concept="3ZlJ5R" id="6C0OSEaGBCi" role="VblUZ">
-            <node concept="3clFbS" id="6C0OSEaGBCj" role="2VODD2">
-              <node concept="3clFbF" id="6C0OSEaGBCk" role="3cqZAp">
-                <node concept="2YIFZM" id="6C0OSEaGBCl" role="3clFbG">
-                  <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                  <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                  <node concept="Xl_RD" id="6C0OSEaGBCm" role="37wK5m">
-                    <property role="Xl_RC" value="#822100" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
         </node>
       </node>
       <node concept="2iRfu4" id="3nGzaxURa4P" role="2iSdaV" />
@@ -370,26 +309,12 @@
       </node>
       <node concept="3F0ifn" id="7khFtBHlNKZ" role="3EZMnx">
         <property role="3F0ifm" value="/" />
+        <ref role="1k5W1q" node="2GzLOsV0qKA" resolve="defaultDateColor" />
         <node concept="11LMrY" id="7khFtBHlV9$" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
         <node concept="11L4FC" id="7khFtBHlViY" role="3F10Kt">
           <property role="VOm3f" value="true" />
-        </node>
-        <node concept="VechU" id="7khFtBHlV9_" role="3F10Kt">
-          <node concept="3ZlJ5R" id="7khFtBHlV9A" role="VblUZ">
-            <node concept="3clFbS" id="7khFtBHlV9B" role="2VODD2">
-              <node concept="3clFbF" id="7khFtBHlV9C" role="3cqZAp">
-                <node concept="2YIFZM" id="7khFtBHlV9D" role="3clFbG">
-                  <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                  <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                  <node concept="Xl_RD" id="7khFtBHlV9E" role="37wK5m">
-                    <property role="Xl_RC" value="#822100" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
         </node>
       </node>
       <node concept="3F1sOY" id="7khFtBHlNLF" role="3EZMnx">
@@ -403,23 +328,9 @@
       </node>
       <node concept="3F0ifn" id="7khFtBHlNL7" role="3EZMnx">
         <property role="3F0ifm" value="/" />
+        <ref role="1k5W1q" node="2GzLOsV0qKA" resolve="defaultDateColor" />
         <node concept="11L4FC" id="7khFtBHlVjc" role="3F10Kt">
           <property role="VOm3f" value="true" />
-        </node>
-        <node concept="VechU" id="7khFtBHlVjd" role="3F10Kt">
-          <node concept="3ZlJ5R" id="7khFtBHlVje" role="VblUZ">
-            <node concept="3clFbS" id="7khFtBHlVjf" role="2VODD2">
-              <node concept="3clFbF" id="7khFtBHlVjg" role="3cqZAp">
-                <node concept="2YIFZM" id="7khFtBHlVjh" role="3clFbG">
-                  <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                  <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                  <node concept="Xl_RD" id="7khFtBHlVji" role="37wK5m">
-                    <property role="Xl_RC" value="#822100" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
         </node>
       </node>
     </node>
@@ -711,42 +622,14 @@
     <node concept="3EZMnI" id="3HiHZey9pdy" role="2wV5jI">
       <node concept="3F0ifn" id="3HiHZey9pdz" role="3EZMnx">
         <property role="3F0ifm" value="\" />
+        <ref role="1k5W1q" node="2GzLOsV0qKA" resolve="defaultDateColor" />
         <node concept="11LMrY" id="3HiHZey9pd$" role="3F10Kt">
           <property role="VOm3f" value="true" />
-        </node>
-        <node concept="VechU" id="3HiHZey9pd_" role="3F10Kt">
-          <node concept="3ZlJ5R" id="3HiHZey9pdA" role="VblUZ">
-            <node concept="3clFbS" id="3HiHZey9pdB" role="2VODD2">
-              <node concept="3clFbF" id="3HiHZey9pdC" role="3cqZAp">
-                <node concept="2YIFZM" id="3HiHZey9pdD" role="3clFbG">
-                  <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                  <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                  <node concept="Xl_RD" id="3HiHZey9pdE" role="37wK5m">
-                    <property role="Xl_RC" value="#822100" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
         </node>
       </node>
       <node concept="3F0A7n" id="3HiHZey9pdF" role="3EZMnx">
         <ref role="1NtTu8" to="mi3w:3HiHZey9lUb" resolve="hh" />
-        <node concept="VechU" id="3HiHZey9pdG" role="3F10Kt">
-          <node concept="3ZlJ5R" id="3HiHZey9pdH" role="VblUZ">
-            <node concept="3clFbS" id="3HiHZey9pdI" role="2VODD2">
-              <node concept="3clFbF" id="3HiHZey9pdJ" role="3cqZAp">
-                <node concept="2YIFZM" id="3HiHZey9pdK" role="3clFbG">
-                  <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                  <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                  <node concept="Xl_RD" id="3HiHZey9pdL" role="37wK5m">
-                    <property role="Xl_RC" value="#822100" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
+        <ref role="1k5W1q" node="2GzLOsV0qKA" resolve="defaultDateColor" />
       </node>
       <node concept="3F0ifn" id="3HiHZey9pqa" role="3EZMnx">
         <property role="3F0ifm" value=":" />
@@ -759,21 +642,7 @@
       </node>
       <node concept="3F0A7n" id="3HiHZey9pdM" role="3EZMnx">
         <ref role="1NtTu8" to="mi3w:3HiHZey9lUd" resolve="mm" />
-        <node concept="VechU" id="3HiHZey9pdN" role="3F10Kt">
-          <node concept="3ZlJ5R" id="3HiHZey9pdO" role="VblUZ">
-            <node concept="3clFbS" id="3HiHZey9pdP" role="2VODD2">
-              <node concept="3clFbF" id="3HiHZey9pdQ" role="3cqZAp">
-                <node concept="2YIFZM" id="3HiHZey9pdR" role="3clFbG">
-                  <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                  <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                  <node concept="Xl_RD" id="3HiHZey9pdS" role="37wK5m">
-                    <property role="Xl_RC" value="#822100" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
+        <ref role="1k5W1q" node="2GzLOsV0qKA" resolve="defaultDateColor" />
       </node>
       <node concept="3F0ifn" id="3HiHZeyb5Uv" role="3EZMnx">
         <property role="3F0ifm" value=":" />
@@ -786,41 +655,13 @@
       </node>
       <node concept="3F0A7n" id="3HiHZeyb5VB" role="3EZMnx">
         <ref role="1NtTu8" to="mi3w:3HiHZeyb5uA" resolve="ss" />
-        <node concept="VechU" id="3HiHZeybvRr" role="3F10Kt">
-          <node concept="3ZlJ5R" id="3HiHZeybvRs" role="VblUZ">
-            <node concept="3clFbS" id="3HiHZeybvRt" role="2VODD2">
-              <node concept="3clFbF" id="3HiHZeybvRu" role="3cqZAp">
-                <node concept="2YIFZM" id="3HiHZeybvRv" role="3clFbG">
-                  <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                  <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                  <node concept="Xl_RD" id="3HiHZeybvRw" role="37wK5m">
-                    <property role="Xl_RC" value="#822100" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
+        <ref role="1k5W1q" node="2GzLOsV0qKA" resolve="defaultDateColor" />
       </node>
       <node concept="3F0ifn" id="3HiHZey9pe0" role="3EZMnx">
         <property role="3F0ifm" value="\" />
+        <ref role="1k5W1q" node="2GzLOsV0qKA" resolve="defaultDateColor" />
         <node concept="11L4FC" id="3HiHZey9pe1" role="3F10Kt">
           <property role="VOm3f" value="true" />
-        </node>
-        <node concept="VechU" id="3HiHZey9pe2" role="3F10Kt">
-          <node concept="3ZlJ5R" id="3HiHZey9pe3" role="VblUZ">
-            <node concept="3clFbS" id="3HiHZey9pe4" role="2VODD2">
-              <node concept="3clFbF" id="3HiHZey9pe5" role="3cqZAp">
-                <node concept="2YIFZM" id="3HiHZey9pe6" role="3clFbG">
-                  <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                  <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                  <node concept="Xl_RD" id="3HiHZey9pe7" role="37wK5m">
-                    <property role="Xl_RC" value="#822100" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
         </node>
       </node>
       <node concept="2iRfu4" id="3HiHZey9pe8" role="2iSdaV" />
@@ -836,26 +677,12 @@
       </node>
       <node concept="3F0ifn" id="3HiHZeyanOZ" role="3EZMnx">
         <property role="3F0ifm" value="\" />
+        <ref role="1k5W1q" node="2GzLOsV0qKA" resolve="defaultDateColor" />
         <node concept="11LMrY" id="3HiHZeyanP0" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
         <node concept="11L4FC" id="3HiHZeyanP1" role="3F10Kt">
           <property role="VOm3f" value="true" />
-        </node>
-        <node concept="VechU" id="3HiHZeyanP2" role="3F10Kt">
-          <node concept="3ZlJ5R" id="3HiHZeyanP3" role="VblUZ">
-            <node concept="3clFbS" id="3HiHZeyanP4" role="2VODD2">
-              <node concept="3clFbF" id="3HiHZeyanP5" role="3cqZAp">
-                <node concept="2YIFZM" id="3HiHZeyanP6" role="3clFbG">
-                  <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                  <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                  <node concept="Xl_RD" id="3HiHZeyanP7" role="37wK5m">
-                    <property role="Xl_RC" value="#822100" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
         </node>
       </node>
       <node concept="3F1sOY" id="3HiHZeyanP8" role="3EZMnx">
@@ -887,23 +714,9 @@
       </node>
       <node concept="3F0ifn" id="3HiHZeyanPb" role="3EZMnx">
         <property role="3F0ifm" value="\" />
+        <ref role="1k5W1q" node="2GzLOsV0qKA" resolve="defaultDateColor" />
         <node concept="11L4FC" id="3HiHZeyanPc" role="3F10Kt">
           <property role="VOm3f" value="true" />
-        </node>
-        <node concept="VechU" id="3HiHZeyanPd" role="3F10Kt">
-          <node concept="3ZlJ5R" id="3HiHZeyanPe" role="VblUZ">
-            <node concept="3clFbS" id="3HiHZeyanPf" role="2VODD2">
-              <node concept="3clFbF" id="3HiHZeyanPg" role="3cqZAp">
-                <node concept="2YIFZM" id="3HiHZeyanPh" role="3clFbG">
-                  <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                  <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                  <node concept="Xl_RD" id="3HiHZeyanPi" role="37wK5m">
-                    <property role="Xl_RC" value="#822100" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
         </node>
       </node>
     </node>
@@ -991,6 +804,40 @@
     <node concept="3F0ifn" id="7MYpJaZ9zRQ" role="2wV5jI">
       <property role="3F0ifm" value="currentDate" />
       <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
+    </node>
+  </node>
+  <node concept="V5hpn" id="2GzLOsV0qKw">
+    <property role="3GE5qa" value="date" />
+    <property role="TrG5h" value="dateDefaultStyles" />
+    <node concept="14StLt" id="2GzLOsV0qKA" role="V601i">
+      <property role="TrG5h" value="defaultDateColor" />
+      <node concept="VechU" id="2GzLOsV0qKD" role="3F10Kt">
+        <node concept="3ZlJ5R" id="2GzLOsV0qKV" role="VblUZ">
+          <node concept="3clFbS" id="2GzLOsV0qKW" role="2VODD2">
+            <node concept="3clFbF" id="2GzLOsV0qWT" role="3cqZAp">
+              <node concept="2ShNRf" id="2GzLOsUZP5r" role="3clFbG">
+                <node concept="1pGfFk" id="2GzLOsUZP5s" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="2YIFZM" id="2GzLOsUZP5t" role="37wK5m">
+                    <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                    <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                    <node concept="Xl_RD" id="2GzLOsUZP5u" role="37wK5m">
+                      <property role="Xl_RC" value="#822100" />
+                    </node>
+                  </node>
+                  <node concept="2YIFZM" id="2GzLOsUZP5v" role="37wK5m">
+                    <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                    <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                    <node concept="Xl_RD" id="2GzLOsUZP5w" role="37wK5m">
+                      <property role="Xl_RC" value="#b32d00" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.doc/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.doc/models/editor.mps
@@ -634,18 +634,9 @@
                 <node concept="1pGfFk" id="2c2AzQcFQIJ" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:6Ce4x7KQbw2" resolve="ColoredVerticalBarCell" />
                   <node concept="pncrf" id="2c2AzQcFQM_" role="37wK5m" />
-                  <node concept="2ShNRf" id="2GzLOsV20$P" role="37wK5m">
-                    <node concept="1pGfFk" id="2GzLOsV21v4" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="2c2AzQcFRxe" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                      </node>
-                      <node concept="10M0yZ" id="2GzLOsV21z8" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wg5rGO" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                   <node concept="3cmrfG" id="2c2AzQcFREw" role="37wK5m">
                     <property role="3cmrfH" value="2" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.doc/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.doc/models/editor.mps
@@ -14,6 +14,7 @@
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
     <import index="hyam" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.event(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="34lm" ref="r:04cb519f-2059-4c60-9414-918c7823fd79(org.iets3.core.expr.doc.structure)" implicit="true" />
     <import index="itrz" ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
@@ -633,9 +634,18 @@
                 <node concept="1pGfFk" id="2c2AzQcFQIJ" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:6Ce4x7KQbw2" resolve="ColoredVerticalBarCell" />
                   <node concept="pncrf" id="2c2AzQcFQM_" role="37wK5m" />
-                  <node concept="10M0yZ" id="2c2AzQcFRxe" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <node concept="2ShNRf" id="2GzLOsV20$P" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsV21v4" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="2c2AzQcFRxe" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsV21z8" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                      </node>
+                    </node>
                   </node>
                   <node concept="3cmrfG" id="2c2AzQcFREw" role="37wK5m">
                     <property role="3cmrfH" value="2" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/editor.mps
@@ -17,6 +17,7 @@
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="oq0c" ref="r:6c6155f0-4bbe-4af5-8c26-244d570e21e4(org.iets3.core.expr.base.plugin)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
@@ -269,6 +270,7 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
@@ -1192,11 +1194,23 @@
         <node concept="3ZlJ5R" id="4qVjx3jYYFO" role="VblUZ">
           <node concept="3clFbS" id="4qVjx3jYYFP" role="2VODD2">
             <node concept="3clFbF" id="4qVjx3jZ2fk" role="3cqZAp">
-              <node concept="2YIFZM" id="4qVjx3jZ2tu" role="3clFbG">
-                <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                <node concept="Xl_RD" id="4qVjx3jZ2_X" role="37wK5m">
-                  <property role="Xl_RC" value="#FF5319" />
+              <node concept="2ShNRf" id="2GzLOsV23Ah" role="3clFbG">
+                <node concept="1pGfFk" id="2GzLOsV24pR" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="2YIFZM" id="4qVjx3jZ2tu" role="37wK5m">
+                    <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                    <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                    <node concept="Xl_RD" id="4qVjx3jZ2_X" role="37wK5m">
+                      <property role="Xl_RC" value="#FF5319" />
+                    </node>
+                  </node>
+                  <node concept="2YIFZM" id="2GzLOsV24x6" role="37wK5m">
+                    <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                    <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                    <node concept="Xl_RD" id="2GzLOsV24x7" role="37wK5m">
+                      <property role="Xl_RC" value="#FF5319" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
@@ -383,18 +383,9 @@
                 <node concept="1pGfFk" id="4tXyFaWwzSe" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakvelx" resolve="HorizLineCell" />
                   <node concept="pncrf" id="4tXyFaWwzSS" role="37wK5m" />
-                  <node concept="2ShNRf" id="2GzLOsV3nhq" role="37wK5m">
-                    <node concept="1pGfFk" id="2GzLOsV3o7D" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="4tXyFaWw$6n" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="2GzLOsV3ohm" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wg5sL8" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                   <node concept="3cmrfG" id="4tXyFaWw$bx" role="37wK5m">
                     <property role="3cmrfH" value="2" />
@@ -421,18 +412,9 @@
                 <node concept="1pGfFk" id="3vxfdxblMJG" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakvelx" resolve="HorizLineCell" />
                   <node concept="pncrf" id="3vxfdxblMJH" role="37wK5m" />
-                  <node concept="2ShNRf" id="2GzLOsV3QRS" role="37wK5m">
-                    <node concept="1pGfFk" id="2GzLOsV3QRT" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="2GzLOsV3QRU" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="2GzLOsV3QRV" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wg5t3q" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                   <node concept="3cmrfG" id="3vxfdxblMJJ" role="37wK5m">
                     <property role="3cmrfH" value="2" />
@@ -482,18 +464,9 @@
                 <node concept="1pGfFk" id="3vxfdxblKxR" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakvelx" resolve="HorizLineCell" />
                   <node concept="pncrf" id="3vxfdxblKxS" role="37wK5m" />
-                  <node concept="2ShNRf" id="2GzLOsV3QVT" role="37wK5m">
-                    <node concept="1pGfFk" id="2GzLOsV3QVU" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="2GzLOsV3QVV" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="2GzLOsV3QVW" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wg5tkO" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                   <node concept="3cmrfG" id="3vxfdxblKxU" role="37wK5m">
                     <property role="3cmrfH" value="2" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
@@ -15,6 +15,7 @@
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="kelk" ref="r:1a11ce0d-cf54-4682-9b8a-ab4ee15fc129(org.iets3.core.expr.messages.structure)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
@@ -382,9 +383,18 @@
                 <node concept="1pGfFk" id="4tXyFaWwzSe" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakvelx" resolve="HorizLineCell" />
                   <node concept="pncrf" id="4tXyFaWwzSS" role="37wK5m" />
-                  <node concept="10M0yZ" id="4tXyFaWw$6n" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <node concept="2ShNRf" id="2GzLOsV3nhq" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsV3o7D" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="4tXyFaWw$6n" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsV3ohm" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                   <node concept="3cmrfG" id="4tXyFaWw$bx" role="37wK5m">
                     <property role="3cmrfH" value="2" />
@@ -411,9 +421,18 @@
                 <node concept="1pGfFk" id="3vxfdxblMJG" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakvelx" resolve="HorizLineCell" />
                   <node concept="pncrf" id="3vxfdxblMJH" role="37wK5m" />
-                  <node concept="10M0yZ" id="3vxfdxblMJI" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <node concept="2ShNRf" id="2GzLOsV3QRS" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsV3QRT" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="2GzLOsV3QRU" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsV3QRV" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                      </node>
+                    </node>
                   </node>
                   <node concept="3cmrfG" id="3vxfdxblMJJ" role="37wK5m">
                     <property role="3cmrfH" value="2" />
@@ -463,9 +482,18 @@
                 <node concept="1pGfFk" id="3vxfdxblKxR" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakvelx" resolve="HorizLineCell" />
                   <node concept="pncrf" id="3vxfdxblKxS" role="37wK5m" />
-                  <node concept="10M0yZ" id="3vxfdxblKxT" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <node concept="2ShNRf" id="2GzLOsV3QVT" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsV3QVU" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="2GzLOsV3QVV" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsV3QVW" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                   <node concept="3cmrfG" id="3vxfdxblKxU" role="37wK5m">
                     <property role="3cmrfH" value="2" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.natlang/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.natlang/models/editor.mps
@@ -25,6 +25,7 @@
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="iwwu" ref="r:2c4d9270-b6d6-44af-aecd-e01a223680db(jetbrains.mps.kernel.model)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -1492,16 +1493,35 @@
         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
       </node>
       <node concept="2ShNRf" id="5MZGKPSI3zN" role="33vP2m">
-        <node concept="1pGfFk" id="5MZGKPSI3NM" role="2ShVmc">
-          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-          <node concept="3cmrfG" id="5MZGKPSI3W0" role="37wK5m">
-            <property role="3cmrfH" value="33" />
+        <node concept="1pGfFk" id="2GzLOsV4_bO" role="2ShVmc">
+          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+          <node concept="2ShNRf" id="2GzLOsV4_cO" role="37wK5m">
+            <node concept="1pGfFk" id="5MZGKPSI3NM" role="2ShVmc">
+              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+              <node concept="3cmrfG" id="5MZGKPSI3W0" role="37wK5m">
+                <property role="3cmrfH" value="33" />
+              </node>
+              <node concept="3cmrfG" id="5MZGKPSI4eK" role="37wK5m">
+                <property role="3cmrfH" value="122" />
+              </node>
+              <node concept="3cmrfG" id="5MZGKPSI5lr" role="37wK5m">
+                <property role="3cmrfH" value="57" />
+              </node>
+            </node>
           </node>
-          <node concept="3cmrfG" id="5MZGKPSI4eK" role="37wK5m">
-            <property role="3cmrfH" value="122" />
-          </node>
-          <node concept="3cmrfG" id="5MZGKPSI5lr" role="37wK5m">
-            <property role="3cmrfH" value="57" />
+          <node concept="2ShNRf" id="2GzLOsV4_mz" role="37wK5m">
+            <node concept="1pGfFk" id="2GzLOsV4A4_" role="2ShVmc">
+              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+              <node concept="3cmrfG" id="2GzLOsV4Ac2" role="37wK5m">
+                <property role="3cmrfH" value="15" />
+              </node>
+              <node concept="3cmrfG" id="2GzLOsV4AlE" role="37wK5m">
+                <property role="3cmrfH" value="138" />
+              </node>
+              <node concept="3cmrfG" id="2GzLOsV4AEo" role="37wK5m">
+                <property role="3cmrfH" value="48" />
+              </node>
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.process/models/org.iets3.core.expr.process.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.process/models/org.iets3.core.expr.process.editor.mps
@@ -93,9 +93,6 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
-      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
-        <child id="1145553007750" name="creator" index="2ShVmc" />
-      </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
@@ -114,11 +111,6 @@
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
-        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
-        <child id="1068499141038" name="actualArgument" index="37wK5m" />
-      </concept>
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
     </language>
     <language id="b33d119e-196d-4497-977c-5c167b21fe33" name="com.mbeddr.mpsutil.framecell">
       <concept id="8760592470373336790" name="com.mbeddr.mpsutil.framecell.structure.CellModel_FrameCell" flags="ng" index="3j0QqT">
@@ -179,18 +171,9 @@
               <node concept="3sjG9q" id="3wXkdMVqOin" role="3tD6jU">
                 <node concept="3clFbS" id="3wXkdMVqOio" role="2VODD2">
                   <node concept="3clFbF" id="3wXkdMVqOip" role="3cqZAp">
-                    <node concept="2ShNRf" id="2GzLOsV5ulC" role="3clFbG">
-                      <node concept="1pGfFk" id="2GzLOsV5uXm" role="2ShVmc">
-                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                        <node concept="10M0yZ" id="3wXkdMVqOiq" role="37wK5m">
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                        </node>
-                        <node concept="10M0yZ" id="2GzLOsV5v44" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="38mO9wg6oo0" role="3clFbG">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                   </node>
                 </node>
@@ -257,18 +240,9 @@
               <node concept="3sjG9q" id="3wXkdMVr42z" role="3tD6jU">
                 <node concept="3clFbS" id="3wXkdMVr42$" role="2VODD2">
                   <node concept="3clFbF" id="3wXkdMVr42_" role="3cqZAp">
-                    <node concept="2ShNRf" id="2GzLOsV5v97" role="3clFbG">
-                      <node concept="1pGfFk" id="2GzLOsV5v98" role="2ShVmc">
-                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                        <node concept="10M0yZ" id="2GzLOsV5v99" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                        <node concept="10M0yZ" id="2GzLOsV5v9a" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="38mO9wg6ouu" role="3clFbG">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                   </node>
                 </node>
@@ -418,18 +392,9 @@
               <node concept="3sjG9q" id="3wXkdMVqXIu" role="3tD6jU">
                 <node concept="3clFbS" id="3wXkdMVqXIv" role="2VODD2">
                   <node concept="3clFbF" id="3wXkdMVqXIw" role="3cqZAp">
-                    <node concept="2ShNRf" id="2GzLOsV5vaE" role="3clFbG">
-                      <node concept="1pGfFk" id="2GzLOsV5vaF" role="2ShVmc">
-                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                        <node concept="10M0yZ" id="2GzLOsV5vaG" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                        <node concept="10M0yZ" id="2GzLOsV5vaH" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="38mO9wg6oFZ" role="3clFbG">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                   </node>
                 </node>
@@ -558,18 +523,9 @@
           <node concept="3sjG9q" id="3wXkdMVq6R3" role="3tD6jU">
             <node concept="3clFbS" id="3wXkdMVq6R4" role="2VODD2">
               <node concept="3clFbF" id="3wXkdMVqj80" role="3cqZAp">
-                <node concept="2ShNRf" id="2GzLOsV5vfS" role="3clFbG">
-                  <node concept="1pGfFk" id="2GzLOsV5vfT" role="2ShVmc">
-                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                    <node concept="10M0yZ" id="2GzLOsV5vfU" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    </node>
-                    <node concept="10M0yZ" id="2GzLOsV5vfV" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                    </node>
-                  </node>
+                <node concept="10M0yZ" id="38mO9wg6oM7" role="3clFbG">
+                  <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.process/models/org.iets3.core.expr.process.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.process/models/org.iets3.core.expr.process.editor.mps
@@ -10,6 +10,7 @@
   </languages>
   <imports>
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="7y2b" ref="r:13070af3-81df-4cc3-ad8a-1790d69e5b93(org.iets3.core.expr.process.structure)" implicit="true" />
     <import index="epcs" ref="b33d119e-196d-4497-977c-5c167b21fe33/r:b7f325a3-1f57-46bc-8b14-d2d7c5ff6714(com.mbeddr.mpsutil.framecell/com.mbeddr.mpsutil.framecell.editor)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
@@ -92,6 +93,9 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
@@ -110,6 +114,11 @@
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
     </language>
     <language id="b33d119e-196d-4497-977c-5c167b21fe33" name="com.mbeddr.mpsutil.framecell">
       <concept id="8760592470373336790" name="com.mbeddr.mpsutil.framecell.structure.CellModel_FrameCell" flags="ng" index="3j0QqT">
@@ -170,9 +179,18 @@
               <node concept="3sjG9q" id="3wXkdMVqOin" role="3tD6jU">
                 <node concept="3clFbS" id="3wXkdMVqOio" role="2VODD2">
                   <node concept="3clFbF" id="3wXkdMVqOip" role="3cqZAp">
-                    <node concept="10M0yZ" id="3wXkdMVqOiq" role="3clFbG">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                    <node concept="2ShNRf" id="2GzLOsV5ulC" role="3clFbG">
+                      <node concept="1pGfFk" id="2GzLOsV5uXm" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="10M0yZ" id="3wXkdMVqOiq" role="37wK5m">
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                        </node>
+                        <node concept="10M0yZ" id="2GzLOsV5v44" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -239,9 +257,18 @@
               <node concept="3sjG9q" id="3wXkdMVr42z" role="3tD6jU">
                 <node concept="3clFbS" id="3wXkdMVr42$" role="2VODD2">
                   <node concept="3clFbF" id="3wXkdMVr42_" role="3cqZAp">
-                    <node concept="10M0yZ" id="3wXkdMVr42A" role="3clFbG">
-                      <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <node concept="2ShNRf" id="2GzLOsV5v97" role="3clFbG">
+                      <node concept="1pGfFk" id="2GzLOsV5v98" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="10M0yZ" id="2GzLOsV5v99" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                        <node concept="10M0yZ" id="2GzLOsV5v9a" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -391,9 +418,18 @@
               <node concept="3sjG9q" id="3wXkdMVqXIu" role="3tD6jU">
                 <node concept="3clFbS" id="3wXkdMVqXIv" role="2VODD2">
                   <node concept="3clFbF" id="3wXkdMVqXIw" role="3cqZAp">
-                    <node concept="10M0yZ" id="3wXkdMVqXIx" role="3clFbG">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                    <node concept="2ShNRf" id="2GzLOsV5vaE" role="3clFbG">
+                      <node concept="1pGfFk" id="2GzLOsV5vaF" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="10M0yZ" id="2GzLOsV5vaG" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                        <node concept="10M0yZ" id="2GzLOsV5vaH" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -522,9 +558,18 @@
           <node concept="3sjG9q" id="3wXkdMVq6R3" role="3tD6jU">
             <node concept="3clFbS" id="3wXkdMVq6R4" role="2VODD2">
               <node concept="3clFbF" id="3wXkdMVqj80" role="3cqZAp">
-                <node concept="10M0yZ" id="3wXkdMVqjBb" role="3clFbG">
-                  <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                <node concept="2ShNRf" id="2GzLOsV5vfS" role="3clFbG">
+                  <node concept="1pGfFk" id="2GzLOsV5vfT" role="2ShVmc">
+                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                    <node concept="10M0yZ" id="2GzLOsV5vfU" role="37wK5m">
+                      <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    </node>
+                    <node concept="10M0yZ" id="2GzLOsV5vfV" role="37wK5m">
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.query/models/org.iets3.core.expr.query.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.query/models/org.iets3.core.expr.query.editor.mps
@@ -9,6 +9,7 @@
   <imports>
     <import index="r4b4" ref="r:1784e088-20fd-4fdb-96b8-bc57f0056d94(com.mbeddr.core.base.editor)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="ysgh" ref="r:9ed37aa3-295d-400f-9a08-9c363b19e30b(org.iets3.core.expr.query.structure)" implicit="true" />
     <import index="itrz" ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)" implicit="true" />
     <import index="s7zn" ref="r:b65cb578-8493-4caa-a542-f37923f34ed8(org.iets3.core.expr.metafunction.structure)" implicit="true" />
@@ -111,9 +112,18 @@
                 <node concept="1pGfFk" id="5QDPRL$sBhE" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:BsHjoDRDi8" resolve="OpeningBracketCell" />
                   <node concept="pncrf" id="5QDPRL$sBoP" role="37wK5m" />
-                  <node concept="10M0yZ" id="5QDPRL$x0ki" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <node concept="2ShNRf" id="2GzLOsV5ulC" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsV5uXm" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="3wXkdMVqOiq" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsV5v44" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -221,9 +231,18 @@
                 <node concept="1pGfFk" id="5QDPRL$sC9m" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:4QhMqW2TWbb" resolve="ClosingBracketCell" />
                   <node concept="pncrf" id="5QDPRL$sCdW" role="37wK5m" />
-                  <node concept="10M0yZ" id="5QDPRL$x0A$" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                  <node concept="2ShNRf" id="2GzLOsV5HAW" role="37wK5m">
+                    <node concept="1pGfFk" id="2GzLOsV5HAX" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="2GzLOsV5HAY" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="2GzLOsV5HAZ" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.query/models/org.iets3.core.expr.query.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.query/models/org.iets3.core.expr.query.editor.mps
@@ -112,18 +112,9 @@
                 <node concept="1pGfFk" id="5QDPRL$sBhE" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:BsHjoDRDi8" resolve="OpeningBracketCell" />
                   <node concept="pncrf" id="5QDPRL$sBoP" role="37wK5m" />
-                  <node concept="2ShNRf" id="2GzLOsV5ulC" role="37wK5m">
-                    <node concept="1pGfFk" id="2GzLOsV5uXm" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="3wXkdMVqOiq" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="2GzLOsV5v44" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wg6JjA" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -231,18 +222,9 @@
                 <node concept="1pGfFk" id="5QDPRL$sC9m" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:4QhMqW2TWbb" resolve="ClosingBracketCell" />
                   <node concept="pncrf" id="5QDPRL$sCdW" role="37wK5m" />
-                  <node concept="2ShNRf" id="2GzLOsV5HAW" role="37wK5m">
-                    <node concept="1pGfFk" id="2GzLOsV5HAX" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="2GzLOsV5HAY" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="2GzLOsV5HAZ" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wg6JzW" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.query/org.iets3.core.expr.query.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.query/org.iets3.core.expr.query.mpl
@@ -16,6 +16,7 @@
     <dependency reexport="false">10e056b2-49fd-40ca-8b64-de69c81163ac(org.iets3.core.expr.query)</dependency>
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
     <dependency reexport="false">2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)</dependency>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:b92f861d-0184-446d-b88b-6dcf0e070241:com.mbeddr.mpsutil.intentions" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/editor.mps
@@ -674,18 +674,9 @@
                                     <ref role="37wK5l" to="oq0c:4nY0kF82jiw" resolve="toString" />
                                   </node>
                                 </node>
-                                <node concept="2ShNRf" id="1O3benwjbha" role="37wK5m">
-                                  <node concept="1pGfFk" id="1O3benwjd06" role="2ShVmc">
-                                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                                    <node concept="10M0yZ" id="1O3benwjdni" role="37wK5m">
-                                      <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                    </node>
-                                    <node concept="10M0yZ" id="1O3benwjdEk" role="37wK5m">
-                                      <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                    </node>
-                                  </node>
+                                <node concept="10M0yZ" id="38mO9wgocoW" role="37wK5m">
+                                  <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                                 </node>
                               </node>
                             </node>
@@ -765,31 +756,13 @@
                             <ref role="37wK5l" to="31n1:2QxWJFK_S9T" resolve="isReferenceable" />
                           </node>
                         </node>
-                        <node concept="2ShNRf" id="1O3benwjeZk" role="3K4E3e">
-                          <node concept="1pGfFk" id="1O3benwjgwn" role="2ShVmc">
-                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                            <node concept="10M0yZ" id="1O3benwjhKr" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            </node>
-                            <node concept="10M0yZ" id="1O3benwjjKN" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            </node>
-                          </node>
+                        <node concept="10M0yZ" id="38mO9wgodVA" role="3K4E3e">
+                          <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                         </node>
-                        <node concept="2ShNRf" id="1O3benwjkh1" role="3K4GZi">
-                          <node concept="1pGfFk" id="1O3benwjlsi" role="2ShVmc">
-                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                            <node concept="10M0yZ" id="1O3benwjoko" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            </node>
-                            <node concept="10M0yZ" id="1O3benwjp_H" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            </node>
-                          </node>
+                        <node concept="10M0yZ" id="38mO9wgolrB" role="3K4GZi">
+                          <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                         </node>
                       </node>
                     </node>
@@ -846,31 +819,13 @@
                             <ref role="37wK5l" to="31n1:2QxWJFK_S9T" resolve="isReferenceable" />
                           </node>
                         </node>
-                        <node concept="2ShNRf" id="1O3benwjq79" role="3K4E3e">
-                          <node concept="1pGfFk" id="1O3benwjq7a" role="2ShVmc">
-                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                            <node concept="10M0yZ" id="1O3benwjq7b" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            </node>
-                            <node concept="10M0yZ" id="1O3benwjq7c" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            </node>
-                          </node>
+                        <node concept="10M0yZ" id="38mO9wgolRt" role="3K4E3e">
+                          <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                         </node>
-                        <node concept="2ShNRf" id="1O3benwjq7d" role="3K4GZi">
-                          <node concept="1pGfFk" id="1O3benwjq7e" role="2ShVmc">
-                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                            <node concept="10M0yZ" id="1O3benwjq7f" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            </node>
-                            <node concept="10M0yZ" id="1O3benwjq7g" role="37wK5m">
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                              <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                            </node>
-                          </node>
+                        <node concept="10M0yZ" id="38mO9wgonX$" role="3K4GZi">
+                          <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                         </node>
                       </node>
                     </node>
@@ -967,18 +922,9 @@
                 </node>
               </node>
               <node concept="3cpWs6" id="4nY0kF8uqN3" role="3cqZAp">
-                <node concept="2ShNRf" id="1O3benwjscE" role="3cqZAk">
-                  <node concept="1pGfFk" id="1O3benwjt4T" role="2ShVmc">
-                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                    <node concept="10M0yZ" id="4nY0kF8uRw6" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
-                    </node>
-                    <node concept="10M0yZ" id="1O3benwjtOB" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    </node>
-                  </node>
+                <node concept="10M0yZ" id="38mO9wgoouD" role="3cqZAk">
+                  <ref role="3cqZAo" to="lzb2:~JBColor.white" resolve="white" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                 </node>
               </node>
             </node>
@@ -1020,18 +966,9 @@
                       <node concept="3uibUv" id="2AmZaIYoK0h" role="1tU5fm">
                         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
                       </node>
-                      <node concept="2ShNRf" id="1O3benwjv2m" role="33vP2m">
-                        <node concept="1pGfFk" id="1O3benwjwdg" role="2ShVmc">
-                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                          <node concept="10M0yZ" id="2AmZaIYoKXN" role="37wK5m">
-                            <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          </node>
-                          <node concept="10M0yZ" id="1O3benwjyIV" role="37wK5m">
-                            <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          </node>
-                        </node>
+                      <node concept="10M0yZ" id="38mO9wgou5L" role="33vP2m">
+                        <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                       </node>
                     </node>
                   </node>
@@ -1099,18 +1036,9 @@
                                           <property role="1K8rM7" value="property_name" />
                                         </node>
                                       </node>
-                                      <node concept="2ShNRf" id="1O3benwj$Ta" role="37vLTx">
-                                        <node concept="1pGfFk" id="1O3benwjA5t" role="2ShVmc">
-                                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                                          <node concept="10M0yZ" id="2AmZaIYoLIY" role="37wK5m">
-                                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                            <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
-                                          </node>
-                                          <node concept="10M0yZ" id="1O3benwjBUf" role="37wK5m">
-                                            <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
-                                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                          </node>
-                                        </node>
+                                      <node concept="10M0yZ" id="38mO9wgopyg" role="37vLTx">
+                                        <ref role="3cqZAo" to="lzb2:~JBColor.red" resolve="red" />
+                                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                                       </node>
                                     </node>
                                   </node>
@@ -1466,18 +1394,9 @@
                                     <node concept="37vLTw" id="2AmZaIYoMiv" role="37vLTJ">
                                       <ref role="3cqZAo" node="2AmZaIYoK0g" resolve="color" />
                                     </node>
-                                    <node concept="2ShNRf" id="1O3benwjCtA" role="37vLTx">
-                                      <node concept="1pGfFk" id="1O3benwjCtB" role="2ShVmc">
-                                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                                        <node concept="10M0yZ" id="1O3benwjCtC" role="37wK5m">
-                                          <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
-                                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                        </node>
-                                        <node concept="10M0yZ" id="1O3benwjCtD" role="37wK5m">
-                                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                          <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
-                                        </node>
-                                      </node>
+                                    <node concept="10M0yZ" id="38mO9wgoq$Y" role="37vLTx">
+                                      <ref role="3cqZAo" to="lzb2:~JBColor.red" resolve="red" />
+                                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                                     </node>
                                   </node>
                                 </node>
@@ -1508,18 +1427,9 @@
                                 <node concept="37vLTw" id="2AmZaIYoMMk" role="37vLTJ">
                                   <ref role="3cqZAo" node="2AmZaIYoK0g" resolve="color" />
                                 </node>
-                                <node concept="2ShNRf" id="1O3benwjDTn" role="37vLTx">
-                                  <node concept="1pGfFk" id="1O3benwjEPg" role="2ShVmc">
-                                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                                    <node concept="10M0yZ" id="2AmZaIYoMV3" role="37wK5m">
-                                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                      <ref role="3cqZAo" to="z60i:~Color.orange" resolve="orange" />
-                                    </node>
-                                    <node concept="10M0yZ" id="1O3benwjFfn" role="37wK5m">
-                                      <ref role="3cqZAo" to="z60i:~Color.orange" resolve="orange" />
-                                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                    </node>
-                                  </node>
+                                <node concept="10M0yZ" id="38mO9wgorKp" role="37vLTx">
+                                  <ref role="3cqZAo" to="lzb2:~JBColor.orange" resolve="orange" />
+                                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                                 </node>
                               </node>
                             </node>
@@ -1563,18 +1473,9 @@
                             <node concept="37vLTw" id="2AmZaIYoNsz" role="37vLTJ">
                               <ref role="3cqZAo" node="2AmZaIYoK0g" resolve="color" />
                             </node>
-                            <node concept="2ShNRf" id="1O3benwjFZH" role="37vLTx">
-                              <node concept="1pGfFk" id="1O3benwjFZI" role="2ShVmc">
-                                <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                                <node concept="10M0yZ" id="1O3benwjFZJ" role="37wK5m">
-                                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                  <ref role="3cqZAo" to="z60i:~Color.orange" resolve="orange" />
-                                </node>
-                                <node concept="10M0yZ" id="1O3benwjFZK" role="37wK5m">
-                                  <ref role="3cqZAo" to="z60i:~Color.orange" resolve="orange" />
-                                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                </node>
-                              </node>
+                            <node concept="10M0yZ" id="38mO9wgosZO" role="37vLTx">
+                              <ref role="3cqZAo" to="lzb2:~JBColor.orange" resolve="orange" />
+                              <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                             </node>
                           </node>
                         </node>
@@ -2583,18 +2484,9 @@
                                 <ref role="37wK5l" to="oq0c:4nY0kF82jiw" resolve="toString" />
                               </node>
                             </node>
-                            <node concept="2ShNRf" id="1O3benwosXc" role="37wK5m">
-                              <node concept="1pGfFk" id="1O3benwotFW" role="2ShVmc">
-                                <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                                <node concept="10M0yZ" id="1O3benwouCj" role="37wK5m">
-                                  <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                </node>
-                                <node concept="10M0yZ" id="1O3benwov70" role="37wK5m">
-                                  <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
-                                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                </node>
-                              </node>
+                            <node concept="10M0yZ" id="38mO9wgovIu" role="37wK5m">
+                              <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                              <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                             </node>
                           </node>
                         </node>
@@ -2968,18 +2860,9 @@
                         </node>
                         <node concept="liA8E" id="5avmkTFzVuU" role="2OqNvi">
                           <ref role="37wK5l" to="g51k:~EditorCell_Label.setTextColor(java.awt.Color)" resolve="setTextColor" />
-                          <node concept="2ShNRf" id="1O3benwowLG" role="37wK5m">
-                            <node concept="1pGfFk" id="1O3benwoxvq" role="2ShVmc">
-                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                              <node concept="10M0yZ" id="5avmkTFzWE7" role="37wK5m">
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
-                              </node>
-                              <node concept="10M0yZ" id="1O3benwoxyF" role="37wK5m">
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
-                              </node>
-                            </node>
+                          <node concept="10M0yZ" id="38mO9wgoxrt" role="37wK5m">
+                            <ref role="3cqZAo" to="lzb2:~JBColor.white" resolve="white" />
+                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                           </node>
                         </node>
                       </node>
@@ -3012,18 +2895,9 @@
                           <node concept="1Z6Ecs" id="1CcsU$uSq$T" role="37wK5m">
                             <ref role="1Z6EpT" to="reoo:5PDTdguqQmB" resolve="shade-color" />
                           </node>
-                          <node concept="2ShNRf" id="1O3benwoxE5" role="37wK5m">
-                            <node concept="1pGfFk" id="1O3benwoyqb" role="2ShVmc">
-                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                              <node concept="10M0yZ" id="5avmkTFyf4E" role="37wK5m">
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                              </node>
-                              <node concept="10M0yZ" id="1O3benwoyzu" role="37wK5m">
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                              </node>
-                            </node>
+                          <node concept="10M0yZ" id="38mO9wgoxfW" role="37wK5m">
+                            <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                           </node>
                         </node>
                       </node>
@@ -3043,18 +2917,9 @@
                             <ref role="3cqZAo" to="5ueo:~StyleAttributes.TEXT_COLOR" resolve="TEXT_COLOR" />
                             <ref role="1PxDUh" to="5ueo:~StyleAttributes" resolve="StyleAttributes" />
                           </node>
-                          <node concept="2ShNRf" id="1O3benwoyB7" role="37wK5m">
-                            <node concept="1pGfFk" id="1O3benwoyB8" role="2ShVmc">
-                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                              <node concept="10M0yZ" id="1O3benwoyB9" role="37wK5m">
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
-                              </node>
-                              <node concept="10M0yZ" id="1O3benwoyBa" role="37wK5m">
-                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                              </node>
-                            </node>
+                          <node concept="10M0yZ" id="38mO9wgoxzx" role="37wK5m">
+                            <ref role="3cqZAo" to="lzb2:~JBColor.white" resolve="white" />
+                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                           </node>
                         </node>
                       </node>
@@ -3128,18 +2993,9 @@
                         </node>
                         <node concept="liA8E" id="5avmkTF$j60" role="2OqNvi">
                           <ref role="37wK5l" to="g51k:~EditorCell_Label.setTextColor(java.awt.Color)" resolve="setTextColor" />
-                          <node concept="2ShNRf" id="1O3benwoyIm" role="37wK5m">
-                            <node concept="1pGfFk" id="1O3benwoyIn" role="2ShVmc">
-                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                              <node concept="10M0yZ" id="1O3benwoyIo" role="37wK5m">
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
-                              </node>
-                              <node concept="10M0yZ" id="1O3benwoyIp" role="37wK5m">
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
-                              </node>
-                            </node>
+                          <node concept="10M0yZ" id="38mO9wgoxJd" role="37wK5m">
+                            <ref role="3cqZAo" to="lzb2:~JBColor.white" resolve="white" />
+                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                           </node>
                         </node>
                       </node>
@@ -3172,18 +3028,9 @@
                           <node concept="1Z6Ecs" id="5avmkTF9ZFn" role="37wK5m">
                             <ref role="1Z6EpT" to="reoo:5PDTdguqQmB" resolve="shade-color" />
                           </node>
-                          <node concept="2ShNRf" id="1O3benwoyMA" role="37wK5m">
-                            <node concept="1pGfFk" id="1O3benwoyMB" role="2ShVmc">
-                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                              <node concept="10M0yZ" id="1O3benwoyMC" role="37wK5m">
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                              </node>
-                              <node concept="10M0yZ" id="1O3benwoyMD" role="37wK5m">
-                                <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                              </node>
-                            </node>
+                          <node concept="10M0yZ" id="38mO9wgoxVO" role="37wK5m">
+                            <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                           </node>
                         </node>
                       </node>
@@ -3203,18 +3050,9 @@
                             <ref role="3cqZAo" to="5ueo:~StyleAttributes.TEXT_COLOR" resolve="TEXT_COLOR" />
                             <ref role="1PxDUh" to="5ueo:~StyleAttributes" resolve="StyleAttributes" />
                           </node>
-                          <node concept="2ShNRf" id="1O3benwoyVA" role="37wK5m">
-                            <node concept="1pGfFk" id="1O3benwoyVB" role="2ShVmc">
-                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                              <node concept="10M0yZ" id="1O3benwoyVC" role="37wK5m">
-                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                              </node>
-                              <node concept="10M0yZ" id="1O3benwoyVD" role="37wK5m">
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
-                              </node>
-                            </node>
+                          <node concept="10M0yZ" id="38mO9wgoy32" role="37wK5m">
+                            <ref role="3cqZAo" to="lzb2:~JBColor.white" resolve="white" />
+                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                           </node>
                         </node>
                       </node>
@@ -3286,18 +3124,9 @@
             <node concept="3clFbJ" id="5avmkTF_XDU" role="3cqZAp">
               <node concept="3clFbS" id="5avmkTF_XDV" role="3clFbx">
                 <node concept="3cpWs6" id="5avmkTF_XDW" role="3cqZAp">
-                  <node concept="2ShNRf" id="1O3benw7pNn" role="3cqZAk">
-                    <node concept="1pGfFk" id="1O3benw7qAS" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="5avmkTF_XYG" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="1O3benw7sFn" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wgmqXv" role="3cqZAk">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -3314,18 +3143,9 @@
             <node concept="3clFbJ" id="5avmkTFSZAd" role="3cqZAp">
               <node concept="3clFbS" id="5avmkTFSZAf" role="3clFbx">
                 <node concept="3cpWs6" id="1O3benw7rA0" role="3cqZAp">
-                  <node concept="2ShNRf" id="1O3benw7rA1" role="3cqZAk">
-                    <node concept="1pGfFk" id="1O3benw7rA2" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="1O3benw7rA3" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="1O3benw7sY7" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wgmrAd" role="3cqZAk">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -3347,18 +3167,9 @@
               </node>
             </node>
             <node concept="3cpWs6" id="5avmkTFAIhe" role="3cqZAp">
-              <node concept="2ShNRf" id="1O3benw7tnO" role="3cqZAk">
-                <node concept="1pGfFk" id="1O3benw7u6A" role="2ShVmc">
-                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                  <node concept="10M0yZ" id="1O3benw7uzh" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  </node>
-                  <node concept="10M0yZ" id="1O3benw7v8n" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  </node>
-                </node>
+              <node concept="10M0yZ" id="38mO9wgmsfd" role="3cqZAk">
+                <ref role="3cqZAo" to="lzb2:~JBColor.lightGray" resolve="lightGray" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
               </node>
             </node>
           </node>
@@ -3371,18 +3182,9 @@
             <node concept="3clFbJ" id="5avmkTFA1_n" role="3cqZAp">
               <node concept="3clFbS" id="5avmkTFA1_o" role="3clFbx">
                 <node concept="3cpWs6" id="1O3benw9hhp" role="3cqZAp">
-                  <node concept="2ShNRf" id="1O3benw9hhq" role="3cqZAk">
-                    <node concept="1pGfFk" id="1O3benw9hhr" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="1O3benw9hhs" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                      </node>
-                      <node concept="10M0yZ" id="1O3benw9hht" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wgmsKo" role="3cqZAk">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -3399,18 +3201,9 @@
             <node concept="3clFbJ" id="5avmkTFTam3" role="3cqZAp">
               <node concept="3clFbS" id="5avmkTFTam4" role="3clFbx">
                 <node concept="3cpWs6" id="1O3benw9idH" role="3cqZAp">
-                  <node concept="2ShNRf" id="1O3benw9idI" role="3cqZAk">
-                    <node concept="1pGfFk" id="1O3benw9idJ" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="1O3benw9idK" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                      </node>
-                      <node concept="10M0yZ" id="1O3benw9idL" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wgmteZ" role="3cqZAk">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -3432,18 +3225,9 @@
               </node>
             </node>
             <node concept="3cpWs6" id="1O3benw9itq" role="3cqZAp">
-              <node concept="2ShNRf" id="1O3benw9itr" role="3cqZAk">
-                <node concept="1pGfFk" id="1O3benw9its" role="2ShVmc">
-                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                  <node concept="10M0yZ" id="1O3benw9itt" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                  </node>
-                  <node concept="10M0yZ" id="1O3benw9itu" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                  </node>
-                </node>
+              <node concept="10M0yZ" id="38mO9wgmtNa" role="3cqZAk">
+                <ref role="3cqZAo" to="lzb2:~JBColor.lightGray" resolve="lightGray" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
               </node>
             </node>
           </node>
@@ -3456,18 +3240,9 @@
             <node concept="3clFbJ" id="5avmkTFA2L3" role="3cqZAp">
               <node concept="3clFbS" id="5avmkTFA2L4" role="3clFbx">
                 <node concept="3cpWs6" id="1O3benw9iPx" role="3cqZAp">
-                  <node concept="2ShNRf" id="1O3benw9iPy" role="3cqZAk">
-                    <node concept="1pGfFk" id="1O3benw9iPz" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="1O3benw9iP$" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                      </node>
-                      <node concept="10M0yZ" id="1O3benw9iP_" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wgmugM" role="3cqZAk">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -3484,18 +3259,9 @@
             <node concept="3clFbJ" id="5avmkTFTaJk" role="3cqZAp">
               <node concept="3clFbS" id="5avmkTFTaJl" role="3clFbx">
                 <node concept="3cpWs6" id="1O3benw9jd4" role="3cqZAp">
-                  <node concept="2ShNRf" id="1O3benw9jd5" role="3cqZAk">
-                    <node concept="1pGfFk" id="1O3benw9jd6" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="1O3benw9jd7" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                      </node>
-                      <node concept="10M0yZ" id="1O3benw9jd8" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wgmuJZ" role="3cqZAk">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -3517,18 +3283,9 @@
               </node>
             </node>
             <node concept="3cpWs6" id="1O3benw9jto" role="3cqZAp">
-              <node concept="2ShNRf" id="1O3benw9jtp" role="3cqZAk">
-                <node concept="1pGfFk" id="1O3benw9jtq" role="2ShVmc">
-                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                  <node concept="10M0yZ" id="1O3benw9jtr" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  </node>
-                  <node concept="10M0yZ" id="1O3benw9jts" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                  </node>
-                </node>
+              <node concept="10M0yZ" id="38mO9wgmvcT" role="3cqZAk">
+                <ref role="3cqZAo" to="lzb2:~JBColor.lightGray" resolve="lightGray" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
               </node>
             </node>
           </node>
@@ -3541,18 +3298,9 @@
             <node concept="3clFbJ" id="5avmkTFA3SR" role="3cqZAp">
               <node concept="3clFbS" id="5avmkTFA3SS" role="3clFbx">
                 <node concept="3cpWs6" id="1O3benw9jQ6" role="3cqZAp">
-                  <node concept="2ShNRf" id="1O3benw9jQ7" role="3cqZAk">
-                    <node concept="1pGfFk" id="1O3benw9jQ8" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="1O3benw9jQ9" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                      </node>
-                      <node concept="10M0yZ" id="1O3benw9jQa" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wgmvDx" role="3cqZAk">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -3569,18 +3317,9 @@
             <node concept="3clFbJ" id="5avmkTFTbig" role="3cqZAp">
               <node concept="3clFbS" id="5avmkTFTbih" role="3clFbx">
                 <node concept="3cpWs6" id="1O3benw9keg" role="3cqZAp">
-                  <node concept="2ShNRf" id="1O3benw9keh" role="3cqZAk">
-                    <node concept="1pGfFk" id="1O3benw9kei" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="1O3benw9kej" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="1O3benw9kek" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wgmwbJ" role="3cqZAk">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -3602,18 +3341,9 @@
               </node>
             </node>
             <node concept="3cpWs6" id="1O3benw9kvb" role="3cqZAp">
-              <node concept="2ShNRf" id="1O3benw9kvc" role="3cqZAk">
-                <node concept="1pGfFk" id="1O3benw9kvd" role="2ShVmc">
-                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                  <node concept="10M0yZ" id="1O3benw9kve" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  </node>
-                  <node concept="10M0yZ" id="1O3benw9kvf" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                  </node>
-                </node>
+              <node concept="10M0yZ" id="38mO9wgmwDd" role="3cqZAk">
+                <ref role="3cqZAo" to="lzb2:~JBColor.lightGray" resolve="lightGray" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
               </node>
             </node>
           </node>
@@ -3742,18 +3472,9 @@
                     <node concept="3clFbJ" id="5TsxM4BC0RS" role="3cqZAp">
                       <node concept="3clFbS" id="5TsxM4BC0RU" role="3clFbx">
                         <node concept="3cpWs6" id="5TsxM4BC4CL" role="3cqZAp">
-                          <node concept="2ShNRf" id="1O3benw6RHy" role="3cqZAk">
-                            <node concept="1pGfFk" id="1O3benw6SVw" role="2ShVmc">
-                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                              <node concept="10M0yZ" id="5TsxM4BC91o" role="37wK5m">
-                                <ref role="3cqZAo" to="z60i:~Color.yellow" resolve="yellow" />
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                              </node>
-                              <node concept="10M0yZ" id="1O3benw6Tbc" role="37wK5m">
-                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                <ref role="3cqZAo" to="z60i:~Color.yellow" resolve="yellow" />
-                              </node>
-                            </node>
+                          <node concept="10M0yZ" id="38mO9wgmxtz" role="3cqZAk">
+                            <ref role="3cqZAo" to="lzb2:~JBColor.yellow" resolve="yellow" />
+                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                           </node>
                         </node>
                       </node>
@@ -4473,18 +4194,9 @@
                 <node concept="3ZlJ5R" id="1O3benwaZzf" role="VblUZ">
                   <node concept="3clFbS" id="1O3benwaZzg" role="2VODD2">
                     <node concept="3clFbF" id="1O3benwaZB7" role="3cqZAp">
-                      <node concept="2ShNRf" id="1O3benwaZB5" role="3clFbG">
-                        <node concept="1pGfFk" id="1O3benwb0lD" role="2ShVmc">
-                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                          <node concept="10M0yZ" id="1O3benwb0Iw" role="37wK5m">
-                            <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          </node>
-                          <node concept="10M0yZ" id="1O3benwcE0R" role="37wK5m">
-                            <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          </node>
-                        </node>
+                      <node concept="10M0yZ" id="38mO9wgmy7o" role="3clFbG">
+                        <ref role="3cqZAo" to="lzb2:~JBColor.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                       </node>
                     </node>
                   </node>
@@ -5118,31 +4830,13 @@
                                     <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
                                   </node>
                                 </node>
-                                <node concept="2ShNRf" id="1O3benw9mbR" role="37wK5m">
-                                  <node concept="1pGfFk" id="1O3benw9niP" role="2ShVmc">
-                                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                                    <node concept="10M0yZ" id="6GwlCCBaM$5" role="37wK5m">
-                                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                      <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                                    </node>
-                                    <node concept="10M0yZ" id="1O3benw9otY" role="37wK5m">
-                                      <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                    </node>
-                                  </node>
+                                <node concept="10M0yZ" id="38mO9wgmzov" role="37wK5m">
+                                  <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                                 </node>
-                                <node concept="2ShNRf" id="1O3benw9pFo" role="37wK5m">
-                                  <node concept="1pGfFk" id="1O3benw9qNr" role="2ShVmc">
-                                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                                    <node concept="10M0yZ" id="2ufoZQJzKAa" role="37wK5m">
-                                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                      <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                                    </node>
-                                    <node concept="10M0yZ" id="1O3benw9sxF" role="37wK5m">
-                                      <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                    </node>
-                                  </node>
+                                <node concept="10M0yZ" id="38mO9wgm$bf" role="37wK5m">
+                                  <ref role="3cqZAo" to="lzb2:~JBColor.lightGray" resolve="lightGray" />
+                                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                                 </node>
                               </node>
                             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/editor.mps
@@ -33,6 +33,7 @@
     <import index="reoo" ref="r:1e59a084-7ebe-4e95-89ab-c58a7e396583(de.slisson.mps.tables.editor)" />
     <import index="5ueo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.style(MPS.Editor/)" />
     <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" implicit="true" />
@@ -512,6 +513,9 @@
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
+      <concept id="779128492853369165" name="jetbrains.mps.lang.core.structure.SideTransformInfo" flags="ng" index="1KehLL">
+        <property id="779128492853934523" name="cellId" index="1K8rM7" />
+      </concept>
     </language>
     <language id="3bdedd09-792a-4e15-a4db-83970df3ee86" name="de.itemis.mps.editor.collapsible">
       <concept id="4767615435807737350" name="de.itemis.mps.editor.collapsible.structure.CellModel_Collapsible" flags="ng" index="3uPbVW">
@@ -553,11 +557,23 @@
           <node concept="3ZlJ5R" id="5U8d23QsP3G" role="VblUZ">
             <node concept="3clFbS" id="5U8d23QsP3H" role="2VODD2">
               <node concept="3clFbF" id="4nY0kF8n3UW" role="3cqZAp">
-                <node concept="2YIFZM" id="4nY0kF8n3UY" role="3clFbG">
-                  <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                  <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                  <node concept="Xl_RD" id="4nY0kF8n3UZ" role="37wK5m">
-                    <property role="Xl_RC" value="#EDEDED" />
+                <node concept="2ShNRf" id="1O3benwj8IG" role="3clFbG">
+                  <node concept="1pGfFk" id="1O3benwj9sw" role="2ShVmc">
+                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                    <node concept="2YIFZM" id="4nY0kF8n3UY" role="37wK5m">
+                      <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                      <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                      <node concept="Xl_RD" id="4nY0kF8n3UZ" role="37wK5m">
+                        <property role="Xl_RC" value="#EDEDED" />
+                      </node>
+                    </node>
+                    <node concept="2YIFZM" id="1O3benwjabi" role="37wK5m">
+                      <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                      <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                      <node concept="Xl_RD" id="1O3benwjadg" role="37wK5m">
+                        <property role="Xl_RC" value="#1a1a1a" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -568,12 +584,24 @@
           <ref role="3tD7wE" to="epcs:7AjS6YEz03l" resolve="frame-color" />
           <node concept="3sjG9q" id="5U8d23Qodv1" role="3tD6jU">
             <node concept="3clFbS" id="5U8d23Qodv2" role="2VODD2">
-              <node concept="3clFbF" id="4nY0kF8miiU" role="3cqZAp">
-                <node concept="2YIFZM" id="4nY0kF8mhA3" role="3clFbG">
-                  <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                  <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                  <node concept="Xl_RD" id="4nY0kF8mhKH" role="37wK5m">
-                    <property role="Xl_RC" value="#EDEDED" />
+              <node concept="3clFbF" id="1O3benwja_N" role="3cqZAp">
+                <node concept="2ShNRf" id="1O3benwja_O" role="3clFbG">
+                  <node concept="1pGfFk" id="1O3benwja_P" role="2ShVmc">
+                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                    <node concept="2YIFZM" id="1O3benwja_Q" role="37wK5m">
+                      <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                      <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                      <node concept="Xl_RD" id="1O3benwja_R" role="37wK5m">
+                        <property role="Xl_RC" value="#EDEDED" />
+                      </node>
+                    </node>
+                    <node concept="2YIFZM" id="1O3benwja_S" role="37wK5m">
+                      <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                      <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                      <node concept="Xl_RD" id="1O3benwja_T" role="37wK5m">
+                        <property role="Xl_RC" value="#1a1a1a" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -646,9 +674,18 @@
                                     <ref role="37wK5l" to="oq0c:4nY0kF82jiw" resolve="toString" />
                                   </node>
                                 </node>
-                                <node concept="10M0yZ" id="4nY0kF8lSK$" role="37wK5m">
-                                  <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                <node concept="2ShNRf" id="1O3benwjbha" role="37wK5m">
+                                  <node concept="1pGfFk" id="1O3benwjd06" role="2ShVmc">
+                                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                                    <node concept="10M0yZ" id="1O3benwjdni" role="37wK5m">
+                                      <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                    </node>
+                                    <node concept="10M0yZ" id="1O3benwjdEk" role="37wK5m">
+                                      <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                    </node>
+                                  </node>
                                 </node>
                               </node>
                             </node>
@@ -722,18 +759,36 @@
                   <node concept="3clFbS" id="4nY0kF8k75V" role="2VODD2">
                     <node concept="3clFbF" id="4nY0kF8k75W" role="3cqZAp">
                       <node concept="3K4zz7" id="4nY0kF8k75X" role="3clFbG">
-                        <node concept="10M0yZ" id="4nY0kF8k75Y" role="3K4E3e">
-                          <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                        <node concept="10M0yZ" id="4nY0kF8k75Z" role="3K4GZi">
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
                         <node concept="2OqwBi" id="4nY0kF8k760" role="3K4Cdx">
                           <node concept="pncrf" id="4nY0kF8k761" role="2Oq$k0" />
                           <node concept="2qgKlT" id="4nY0kF8k762" role="2OqNvi">
                             <ref role="37wK5l" to="31n1:2QxWJFK_S9T" resolve="isReferenceable" />
+                          </node>
+                        </node>
+                        <node concept="2ShNRf" id="1O3benwjeZk" role="3K4E3e">
+                          <node concept="1pGfFk" id="1O3benwjgwn" role="2ShVmc">
+                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                            <node concept="10M0yZ" id="1O3benwjhKr" role="37wK5m">
+                              <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            </node>
+                            <node concept="10M0yZ" id="1O3benwjjKN" role="37wK5m">
+                              <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2ShNRf" id="1O3benwjkh1" role="3K4GZi">
+                          <node concept="1pGfFk" id="1O3benwjlsi" role="2ShVmc">
+                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                            <node concept="10M0yZ" id="1O3benwjoko" role="37wK5m">
+                              <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            </node>
+                            <node concept="10M0yZ" id="1O3benwjp_H" role="37wK5m">
+                              <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -783,20 +838,38 @@
               <node concept="VechU" id="4nY0kF8k76h" role="3F10Kt">
                 <node concept="3ZlJ5R" id="4nY0kF8k76i" role="VblUZ">
                   <node concept="3clFbS" id="4nY0kF8k76j" role="2VODD2">
-                    <node concept="3clFbF" id="4nY0kF8k76k" role="3cqZAp">
-                      <node concept="3K4zz7" id="4nY0kF8k76l" role="3clFbG">
-                        <node concept="10M0yZ" id="4nY0kF8k76m" role="3K4E3e">
-                          <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                        <node concept="10M0yZ" id="4nY0kF8k76n" role="3K4GZi">
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                        </node>
-                        <node concept="2OqwBi" id="4nY0kF8k76o" role="3K4Cdx">
-                          <node concept="pncrf" id="4nY0kF8k76p" role="2Oq$k0" />
-                          <node concept="2qgKlT" id="4nY0kF8k76q" role="2OqNvi">
+                    <node concept="3clFbF" id="1O3benwjq77" role="3cqZAp">
+                      <node concept="3K4zz7" id="1O3benwjq78" role="3clFbG">
+                        <node concept="2OqwBi" id="1O3benwjq7h" role="3K4Cdx">
+                          <node concept="pncrf" id="1O3benwjq7i" role="2Oq$k0" />
+                          <node concept="2qgKlT" id="1O3benwjq7j" role="2OqNvi">
                             <ref role="37wK5l" to="31n1:2QxWJFK_S9T" resolve="isReferenceable" />
+                          </node>
+                        </node>
+                        <node concept="2ShNRf" id="1O3benwjq79" role="3K4E3e">
+                          <node concept="1pGfFk" id="1O3benwjq7a" role="2ShVmc">
+                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                            <node concept="10M0yZ" id="1O3benwjq7b" role="37wK5m">
+                              <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            </node>
+                            <node concept="10M0yZ" id="1O3benwjq7c" role="37wK5m">
+                              <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2ShNRf" id="1O3benwjq7d" role="3K4GZi">
+                          <node concept="1pGfFk" id="1O3benwjq7e" role="2ShVmc">
+                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                            <node concept="10M0yZ" id="1O3benwjq7f" role="37wK5m">
+                              <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            </node>
+                            <node concept="10M0yZ" id="1O3benwjq7g" role="37wK5m">
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -823,12 +896,24 @@
             <node concept="3clFbS" id="4nY0kF8udUv" role="2VODD2">
               <node concept="3clFbJ" id="4nY0kF8ufkM" role="3cqZAp">
                 <node concept="3clFbS" id="4nY0kF8ufkO" role="3clFbx">
-                  <node concept="3cpWs6" id="4nY0kF8upGu" role="3cqZAp">
-                    <node concept="2YIFZM" id="4nY0kF8upGw" role="3cqZAk">
-                      <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                      <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                      <node concept="Xl_RD" id="4nY0kF8upGx" role="37wK5m">
-                        <property role="Xl_RC" value="#EDEDED" />
+                  <node concept="3cpWs6" id="1O3benwjr$S" role="3cqZAp">
+                    <node concept="2ShNRf" id="1O3benwjrfi" role="3cqZAk">
+                      <node concept="1pGfFk" id="1O3benwjrfj" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="2YIFZM" id="1O3benwjrfk" role="37wK5m">
+                          <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                          <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                          <node concept="Xl_RD" id="1O3benwjrfl" role="37wK5m">
+                            <property role="Xl_RC" value="#EDEDED" />
+                          </node>
+                        </node>
+                        <node concept="2YIFZM" id="1O3benwjrfm" role="37wK5m">
+                          <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                          <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                          <node concept="Xl_RD" id="1O3benwjrfn" role="37wK5m">
+                            <property role="Xl_RC" value="#1a1a1a" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -853,11 +938,23 @@
               <node concept="3clFbJ" id="4nY0kF8uqMV" role="3cqZAp">
                 <node concept="3clFbS" id="4nY0kF8uqMW" role="3clFbx">
                   <node concept="3cpWs6" id="4nY0kF8uqMX" role="3cqZAp">
-                    <node concept="2YIFZM" id="4nY0kF8uqMY" role="3cqZAk">
-                      <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                      <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                      <node concept="Xl_RD" id="4nY0kF8uqMZ" role="37wK5m">
-                        <property role="Xl_RC" value="#EDEDED" />
+                    <node concept="2ShNRf" id="1O3benwjrQt" role="3cqZAk">
+                      <node concept="1pGfFk" id="1O3benwjrQu" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="2YIFZM" id="1O3benwjrQv" role="37wK5m">
+                          <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                          <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                          <node concept="Xl_RD" id="1O3benwjrQw" role="37wK5m">
+                            <property role="Xl_RC" value="#EDEDED" />
+                          </node>
+                        </node>
+                        <node concept="2YIFZM" id="1O3benwjrQx" role="37wK5m">
+                          <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                          <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                          <node concept="Xl_RD" id="1O3benwjrQy" role="37wK5m">
+                            <property role="Xl_RC" value="#1a1a1a" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -870,9 +967,18 @@
                 </node>
               </node>
               <node concept="3cpWs6" id="4nY0kF8uqN3" role="3cqZAp">
-                <node concept="10M0yZ" id="4nY0kF8uRw6" role="3cqZAk">
-                  <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                <node concept="2ShNRf" id="1O3benwjscE" role="3cqZAk">
+                  <node concept="1pGfFk" id="1O3benwjt4T" role="2ShVmc">
+                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                    <node concept="10M0yZ" id="4nY0kF8uRw6" role="37wK5m">
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                    </node>
+                    <node concept="10M0yZ" id="1O3benwjtOB" role="37wK5m">
+                      <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -914,9 +1020,18 @@
                       <node concept="3uibUv" id="2AmZaIYoK0h" role="1tU5fm">
                         <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
                       </node>
-                      <node concept="10M0yZ" id="2AmZaIYoKXN" role="33vP2m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                      <node concept="2ShNRf" id="1O3benwjv2m" role="33vP2m">
+                        <node concept="1pGfFk" id="1O3benwjwdg" role="2ShVmc">
+                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                          <node concept="10M0yZ" id="2AmZaIYoKXN" role="37wK5m">
+                            <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          </node>
+                          <node concept="10M0yZ" id="1O3benwjyIV" role="37wK5m">
+                            <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -978,12 +1093,24 @@
                                   </node>
                                   <node concept="3clFbF" id="2AmZaIYoL8l" role="3cqZAp">
                                     <node concept="37vLTI" id="2AmZaIYoLvz" role="3clFbG">
-                                      <node concept="10M0yZ" id="2AmZaIYoLIY" role="37vLTx">
-                                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                        <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
-                                      </node>
                                       <node concept="37vLTw" id="2AmZaIYoL8j" role="37vLTJ">
                                         <ref role="3cqZAo" node="2AmZaIYoK0g" resolve="color" />
+                                        <node concept="1KehLL" id="1O3benwjzWE" role="lGtFl">
+                                          <property role="1K8rM7" value="property_name" />
+                                        </node>
+                                      </node>
+                                      <node concept="2ShNRf" id="1O3benwj$Ta" role="37vLTx">
+                                        <node concept="1pGfFk" id="1O3benwjA5t" role="2ShVmc">
+                                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                                          <node concept="10M0yZ" id="2AmZaIYoLIY" role="37wK5m">
+                                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                            <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
+                                          </node>
+                                          <node concept="10M0yZ" id="1O3benwjBUf" role="37wK5m">
+                                            <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
+                                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                          </node>
+                                        </node>
                                       </node>
                                     </node>
                                   </node>
@@ -1336,12 +1463,21 @@
                                 </node>
                                 <node concept="3clFbF" id="2AmZaIYoMis" role="3cqZAp">
                                   <node concept="37vLTI" id="2AmZaIYoMit" role="3clFbG">
-                                    <node concept="10M0yZ" id="2AmZaIYoMiu" role="37vLTx">
-                                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                      <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
-                                    </node>
                                     <node concept="37vLTw" id="2AmZaIYoMiv" role="37vLTJ">
                                       <ref role="3cqZAo" node="2AmZaIYoK0g" resolve="color" />
+                                    </node>
+                                    <node concept="2ShNRf" id="1O3benwjCtA" role="37vLTx">
+                                      <node concept="1pGfFk" id="1O3benwjCtB" role="2ShVmc">
+                                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                                        <node concept="10M0yZ" id="1O3benwjCtC" role="37wK5m">
+                                          <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
+                                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                        </node>
+                                        <node concept="10M0yZ" id="1O3benwjCtD" role="37wK5m">
+                                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                          <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
+                                        </node>
+                                      </node>
                                     </node>
                                   </node>
                                 </node>
@@ -1369,12 +1505,21 @@
                             </node>
                             <node concept="3clFbF" id="2AmZaIYoMMh" role="3cqZAp">
                               <node concept="37vLTI" id="2AmZaIYoMMi" role="3clFbG">
-                                <node concept="10M0yZ" id="2AmZaIYoMV3" role="37vLTx">
-                                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                                  <ref role="3cqZAo" to="z60i:~Color.orange" resolve="orange" />
-                                </node>
                                 <node concept="37vLTw" id="2AmZaIYoMMk" role="37vLTJ">
                                   <ref role="3cqZAo" node="2AmZaIYoK0g" resolve="color" />
+                                </node>
+                                <node concept="2ShNRf" id="1O3benwjDTn" role="37vLTx">
+                                  <node concept="1pGfFk" id="1O3benwjEPg" role="2ShVmc">
+                                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                                    <node concept="10M0yZ" id="2AmZaIYoMV3" role="37wK5m">
+                                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                      <ref role="3cqZAo" to="z60i:~Color.orange" resolve="orange" />
+                                    </node>
+                                    <node concept="10M0yZ" id="1O3benwjFfn" role="37wK5m">
+                                      <ref role="3cqZAo" to="z60i:~Color.orange" resolve="orange" />
+                                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                    </node>
+                                  </node>
                                 </node>
                               </node>
                             </node>
@@ -1415,12 +1560,21 @@
                         </node>
                         <node concept="3clFbF" id="2AmZaIYoNsw" role="3cqZAp">
                           <node concept="37vLTI" id="2AmZaIYoNsx" role="3clFbG">
-                            <node concept="10M0yZ" id="2AmZaIYoN_M" role="37vLTx">
-                              <ref role="3cqZAo" to="z60i:~Color.orange" resolve="orange" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            </node>
                             <node concept="37vLTw" id="2AmZaIYoNsz" role="37vLTJ">
                               <ref role="3cqZAo" node="2AmZaIYoK0g" resolve="color" />
+                            </node>
+                            <node concept="2ShNRf" id="1O3benwjFZH" role="37vLTx">
+                              <node concept="1pGfFk" id="1O3benwjFZI" role="2ShVmc">
+                                <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                                <node concept="10M0yZ" id="1O3benwjFZJ" role="37wK5m">
+                                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                  <ref role="3cqZAo" to="z60i:~Color.orange" resolve="orange" />
+                                </node>
+                                <node concept="10M0yZ" id="1O3benwjFZK" role="37wK5m">
+                                  <ref role="3cqZAo" to="z60i:~Color.orange" resolve="orange" />
+                                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                </node>
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -2429,9 +2583,18 @@
                                 <ref role="37wK5l" to="oq0c:4nY0kF82jiw" resolve="toString" />
                               </node>
                             </node>
-                            <node concept="10M0yZ" id="4nY0kF8vbPJ" role="37wK5m">
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                              <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                            <node concept="2ShNRf" id="1O3benwosXc" role="37wK5m">
+                              <node concept="1pGfFk" id="1O3benwotFW" role="2ShVmc">
+                                <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                                <node concept="10M0yZ" id="1O3benwouCj" role="37wK5m">
+                                  <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                </node>
+                                <node concept="10M0yZ" id="1O3benwov70" role="37wK5m">
+                                  <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                </node>
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -2805,9 +2968,18 @@
                         </node>
                         <node concept="liA8E" id="5avmkTFzVuU" role="2OqNvi">
                           <ref role="37wK5l" to="g51k:~EditorCell_Label.setTextColor(java.awt.Color)" resolve="setTextColor" />
-                          <node concept="10M0yZ" id="5avmkTFzWE7" role="37wK5m">
-                            <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <node concept="2ShNRf" id="1O3benwowLG" role="37wK5m">
+                            <node concept="1pGfFk" id="1O3benwoxvq" role="2ShVmc">
+                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                              <node concept="10M0yZ" id="5avmkTFzWE7" role="37wK5m">
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                              </node>
+                              <node concept="10M0yZ" id="1O3benwoxyF" role="37wK5m">
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -2840,9 +3012,18 @@
                           <node concept="1Z6Ecs" id="1CcsU$uSq$T" role="37wK5m">
                             <ref role="1Z6EpT" to="reoo:5PDTdguqQmB" resolve="shade-color" />
                           </node>
-                          <node concept="10M0yZ" id="5avmkTFyf4E" role="37wK5m">
-                            <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <node concept="2ShNRf" id="1O3benwoxE5" role="37wK5m">
+                            <node concept="1pGfFk" id="1O3benwoyqb" role="2ShVmc">
+                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                              <node concept="10M0yZ" id="5avmkTFyf4E" role="37wK5m">
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                              </node>
+                              <node concept="10M0yZ" id="1O3benwoyzu" role="37wK5m">
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -2862,9 +3043,18 @@
                             <ref role="3cqZAo" to="5ueo:~StyleAttributes.TEXT_COLOR" resolve="TEXT_COLOR" />
                             <ref role="1PxDUh" to="5ueo:~StyleAttributes" resolve="StyleAttributes" />
                           </node>
-                          <node concept="10M0yZ" id="5avmkTFyCvw" role="37wK5m">
-                            <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <node concept="2ShNRf" id="1O3benwoyB7" role="37wK5m">
+                            <node concept="1pGfFk" id="1O3benwoyB8" role="2ShVmc">
+                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                              <node concept="10M0yZ" id="1O3benwoyB9" role="37wK5m">
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                              </node>
+                              <node concept="10M0yZ" id="1O3benwoyBa" role="37wK5m">
+                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -2938,9 +3128,18 @@
                         </node>
                         <node concept="liA8E" id="5avmkTF$j60" role="2OqNvi">
                           <ref role="37wK5l" to="g51k:~EditorCell_Label.setTextColor(java.awt.Color)" resolve="setTextColor" />
-                          <node concept="10M0yZ" id="5avmkTF$j61" role="37wK5m">
-                            <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <node concept="2ShNRf" id="1O3benwoyIm" role="37wK5m">
+                            <node concept="1pGfFk" id="1O3benwoyIn" role="2ShVmc">
+                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                              <node concept="10M0yZ" id="1O3benwoyIo" role="37wK5m">
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                              </node>
+                              <node concept="10M0yZ" id="1O3benwoyIp" role="37wK5m">
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -2973,9 +3172,18 @@
                           <node concept="1Z6Ecs" id="5avmkTF9ZFn" role="37wK5m">
                             <ref role="1Z6EpT" to="reoo:5PDTdguqQmB" resolve="shade-color" />
                           </node>
-                          <node concept="10M0yZ" id="5avmkTFydtq" role="37wK5m">
-                            <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <node concept="2ShNRf" id="1O3benwoyMA" role="37wK5m">
+                            <node concept="1pGfFk" id="1O3benwoyMB" role="2ShVmc">
+                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                              <node concept="10M0yZ" id="1O3benwoyMC" role="37wK5m">
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                              </node>
+                              <node concept="10M0yZ" id="1O3benwoyMD" role="37wK5m">
+                                <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -2995,9 +3203,18 @@
                             <ref role="3cqZAo" to="5ueo:~StyleAttributes.TEXT_COLOR" resolve="TEXT_COLOR" />
                             <ref role="1PxDUh" to="5ueo:~StyleAttributes" resolve="StyleAttributes" />
                           </node>
-                          <node concept="10M0yZ" id="5avmkTFz3n3" role="37wK5m">
-                            <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <node concept="2ShNRf" id="1O3benwoyVA" role="37wK5m">
+                            <node concept="1pGfFk" id="1O3benwoyVB" role="2ShVmc">
+                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                              <node concept="10M0yZ" id="1O3benwoyVC" role="37wK5m">
+                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              </node>
+                              <node concept="10M0yZ" id="1O3benwoyVD" role="37wK5m">
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -3069,9 +3286,18 @@
             <node concept="3clFbJ" id="5avmkTF_XDU" role="3cqZAp">
               <node concept="3clFbS" id="5avmkTF_XDV" role="3clFbx">
                 <node concept="3cpWs6" id="5avmkTF_XDW" role="3cqZAp">
-                  <node concept="10M0yZ" id="5avmkTF_XYG" role="3cqZAk">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <node concept="2ShNRf" id="1O3benw7pNn" role="3cqZAk">
+                    <node concept="1pGfFk" id="1O3benw7qAS" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="5avmkTF_XYG" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="1O3benw7sFn" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -3087,10 +3313,19 @@
             </node>
             <node concept="3clFbJ" id="5avmkTFSZAd" role="3cqZAp">
               <node concept="3clFbS" id="5avmkTFSZAf" role="3clFbx">
-                <node concept="3cpWs6" id="5avmkTFT9A5" role="3cqZAp">
-                  <node concept="10M0yZ" id="5avmkTFTa9x" role="3cqZAk">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                <node concept="3cpWs6" id="1O3benw7rA0" role="3cqZAp">
+                  <node concept="2ShNRf" id="1O3benw7rA1" role="3cqZAk">
+                    <node concept="1pGfFk" id="1O3benw7rA2" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="1O3benw7rA3" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="1O3benw7sY7" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -3112,9 +3347,18 @@
               </node>
             </node>
             <node concept="3cpWs6" id="5avmkTFAIhe" role="3cqZAp">
-              <node concept="10M0yZ" id="5avmkTFAIhf" role="3cqZAk">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+              <node concept="2ShNRf" id="1O3benw7tnO" role="3cqZAk">
+                <node concept="1pGfFk" id="1O3benw7u6A" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="10M0yZ" id="1O3benw7uzh" role="37wK5m">
+                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  </node>
+                  <node concept="10M0yZ" id="1O3benw7v8n" role="37wK5m">
+                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -3126,10 +3370,19 @@
           <node concept="3clFbS" id="5avmkTFA1_m" role="2VODD2">
             <node concept="3clFbJ" id="5avmkTFA1_n" role="3cqZAp">
               <node concept="3clFbS" id="5avmkTFA1_o" role="3clFbx">
-                <node concept="3cpWs6" id="5avmkTFA1_p" role="3cqZAp">
-                  <node concept="10M0yZ" id="5avmkTFA1_q" role="3cqZAk">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                <node concept="3cpWs6" id="1O3benw9hhp" role="3cqZAp">
+                  <node concept="2ShNRf" id="1O3benw9hhq" role="3cqZAk">
+                    <node concept="1pGfFk" id="1O3benw9hhr" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="1O3benw9hhs" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                      </node>
+                      <node concept="10M0yZ" id="1O3benw9hht" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -3145,10 +3398,19 @@
             </node>
             <node concept="3clFbJ" id="5avmkTFTam3" role="3cqZAp">
               <node concept="3clFbS" id="5avmkTFTam4" role="3clFbx">
-                <node concept="3cpWs6" id="5avmkTFTam5" role="3cqZAp">
-                  <node concept="10M0yZ" id="5avmkTFTam6" role="3cqZAk">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                <node concept="3cpWs6" id="1O3benw9idH" role="3cqZAp">
+                  <node concept="2ShNRf" id="1O3benw9idI" role="3cqZAk">
+                    <node concept="1pGfFk" id="1O3benw9idJ" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="1O3benw9idK" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                      </node>
+                      <node concept="10M0yZ" id="1O3benw9idL" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -3169,10 +3431,19 @@
                 <node concept="3GX2aA" id="5avmkTFTame" role="2OqNvi" />
               </node>
             </node>
-            <node concept="3cpWs6" id="5avmkTFAIrs" role="3cqZAp">
-              <node concept="10M0yZ" id="5avmkTFAIrt" role="3cqZAk">
-                <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+            <node concept="3cpWs6" id="1O3benw9itq" role="3cqZAp">
+              <node concept="2ShNRf" id="1O3benw9itr" role="3cqZAk">
+                <node concept="1pGfFk" id="1O3benw9its" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="10M0yZ" id="1O3benw9itt" role="37wK5m">
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                  </node>
+                  <node concept="10M0yZ" id="1O3benw9itu" role="37wK5m">
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -3184,10 +3455,19 @@
           <node concept="3clFbS" id="5avmkTFA2L2" role="2VODD2">
             <node concept="3clFbJ" id="5avmkTFA2L3" role="3cqZAp">
               <node concept="3clFbS" id="5avmkTFA2L4" role="3clFbx">
-                <node concept="3cpWs6" id="5avmkTFA2L5" role="3cqZAp">
-                  <node concept="10M0yZ" id="5avmkTFA2L6" role="3cqZAk">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                <node concept="3cpWs6" id="1O3benw9iPx" role="3cqZAp">
+                  <node concept="2ShNRf" id="1O3benw9iPy" role="3cqZAk">
+                    <node concept="1pGfFk" id="1O3benw9iPz" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="1O3benw9iP$" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                      </node>
+                      <node concept="10M0yZ" id="1O3benw9iP_" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -3203,10 +3483,19 @@
             </node>
             <node concept="3clFbJ" id="5avmkTFTaJk" role="3cqZAp">
               <node concept="3clFbS" id="5avmkTFTaJl" role="3clFbx">
-                <node concept="3cpWs6" id="5avmkTFTaJm" role="3cqZAp">
-                  <node concept="10M0yZ" id="5avmkTFTaJn" role="3cqZAk">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                <node concept="3cpWs6" id="1O3benw9jd4" role="3cqZAp">
+                  <node concept="2ShNRf" id="1O3benw9jd5" role="3cqZAk">
+                    <node concept="1pGfFk" id="1O3benw9jd6" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="1O3benw9jd7" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                      </node>
+                      <node concept="10M0yZ" id="1O3benw9jd8" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -3227,10 +3516,19 @@
                 <node concept="3GX2aA" id="5avmkTFTaJv" role="2OqNvi" />
               </node>
             </node>
-            <node concept="3cpWs6" id="5avmkTFAI_M" role="3cqZAp">
-              <node concept="10M0yZ" id="5avmkTFAI_N" role="3cqZAk">
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+            <node concept="3cpWs6" id="1O3benw9jto" role="3cqZAp">
+              <node concept="2ShNRf" id="1O3benw9jtp" role="3cqZAk">
+                <node concept="1pGfFk" id="1O3benw9jtq" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="10M0yZ" id="1O3benw9jtr" role="37wK5m">
+                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  </node>
+                  <node concept="10M0yZ" id="1O3benw9jts" role="37wK5m">
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -3242,10 +3540,19 @@
           <node concept="3clFbS" id="5avmkTFA3SQ" role="2VODD2">
             <node concept="3clFbJ" id="5avmkTFA3SR" role="3cqZAp">
               <node concept="3clFbS" id="5avmkTFA3SS" role="3clFbx">
-                <node concept="3cpWs6" id="5avmkTFA3ST" role="3cqZAp">
-                  <node concept="10M0yZ" id="5avmkTFA3SU" role="3cqZAk">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                <node concept="3cpWs6" id="1O3benw9jQ6" role="3cqZAp">
+                  <node concept="2ShNRf" id="1O3benw9jQ7" role="3cqZAk">
+                    <node concept="1pGfFk" id="1O3benw9jQ8" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="1O3benw9jQ9" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                      </node>
+                      <node concept="10M0yZ" id="1O3benw9jQa" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -3261,10 +3568,19 @@
             </node>
             <node concept="3clFbJ" id="5avmkTFTbig" role="3cqZAp">
               <node concept="3clFbS" id="5avmkTFTbih" role="3clFbx">
-                <node concept="3cpWs6" id="5avmkTFTbii" role="3cqZAp">
-                  <node concept="10M0yZ" id="5avmkTFTbij" role="3cqZAk">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                <node concept="3cpWs6" id="1O3benw9keg" role="3cqZAp">
+                  <node concept="2ShNRf" id="1O3benw9keh" role="3cqZAk">
+                    <node concept="1pGfFk" id="1O3benw9kei" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="1O3benw9kej" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="1O3benw9kek" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -3285,10 +3601,19 @@
                 <node concept="3GX2aA" id="5avmkTFTbir" role="2OqNvi" />
               </node>
             </node>
-            <node concept="3cpWs6" id="5avmkTFA3T0" role="3cqZAp">
-              <node concept="10M0yZ" id="5avmkTFAHv6" role="3cqZAk">
-                <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+            <node concept="3cpWs6" id="1O3benw9kvb" role="3cqZAp">
+              <node concept="2ShNRf" id="1O3benw9kvc" role="3cqZAk">
+                <node concept="1pGfFk" id="1O3benw9kvd" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="10M0yZ" id="1O3benw9kve" role="37wK5m">
+                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  </node>
+                  <node concept="10M0yZ" id="1O3benw9kvf" role="37wK5m">
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -3301,17 +3626,36 @@
             <node concept="3clFbJ" id="5xEoEMrAWlV" role="3cqZAp">
               <node concept="3clFbS" id="5xEoEMrAWlX" role="3clFbx">
                 <node concept="3cpWs6" id="5xEoEMrB61a" role="3cqZAp">
-                  <node concept="2ShNRf" id="1mFXz_FZZV6" role="3cqZAk">
-                    <node concept="1pGfFk" id="1mFXz_FZZV5" role="2ShVmc">
-                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                      <node concept="3cmrfG" id="1mFXz_G00Sn" role="37wK5m">
-                        <property role="3cmrfH" value="255" />
+                  <node concept="2ShNRf" id="1O3benw5ZOD" role="3cqZAk">
+                    <node concept="1pGfFk" id="1O3benw6_Y3" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="2ShNRf" id="1mFXz_FZZV6" role="37wK5m">
+                        <node concept="1pGfFk" id="1mFXz_FZZV5" role="2ShVmc">
+                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                          <node concept="3cmrfG" id="1mFXz_G00Sn" role="37wK5m">
+                            <property role="3cmrfH" value="255" />
+                          </node>
+                          <node concept="3cmrfG" id="1mFXz_G01X0" role="37wK5m">
+                            <property role="3cmrfH" value="238" />
+                          </node>
+                          <node concept="3cmrfG" id="1mFXz_G03Us" role="37wK5m">
+                            <property role="3cmrfH" value="168" />
+                          </node>
+                        </node>
                       </node>
-                      <node concept="3cmrfG" id="1mFXz_G01X0" role="37wK5m">
-                        <property role="3cmrfH" value="238" />
-                      </node>
-                      <node concept="3cmrfG" id="1mFXz_G03Us" role="37wK5m">
-                        <property role="3cmrfH" value="168" />
+                      <node concept="2ShNRf" id="1O3benw6AV5" role="37wK5m">
+                        <node concept="1pGfFk" id="1O3benw6AV6" role="2ShVmc">
+                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                          <node concept="3cmrfG" id="1O3benw6AV7" role="37wK5m">
+                            <property role="3cmrfH" value="102" />
+                          </node>
+                          <node concept="3cmrfG" id="1O3benw6AV8" role="37wK5m">
+                            <property role="3cmrfH" value="82" />
+                          </node>
+                          <node concept="3cmrfG" id="1O3benw6DN_" role="37wK5m">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -3327,17 +3671,36 @@
             <node concept="3clFbJ" id="1mFXz_FYeVK" role="3cqZAp">
               <node concept="3clFbS" id="1mFXz_FYeVL" role="3clFbx">
                 <node concept="3cpWs6" id="1mFXz_FYeVM" role="3cqZAp">
-                  <node concept="2ShNRf" id="1mFXz_FYeVN" role="3cqZAk">
-                    <node concept="1pGfFk" id="1mFXz_FYeVO" role="2ShVmc">
-                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                      <node concept="3cmrfG" id="1mFXz_FYeVP" role="37wK5m">
-                        <property role="3cmrfH" value="224" />
+                  <node concept="2ShNRf" id="1O3benw6KOz" role="3cqZAk">
+                    <node concept="1pGfFk" id="1O3benw6LGx" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="2ShNRf" id="1mFXz_FYeVN" role="37wK5m">
+                        <node concept="1pGfFk" id="1mFXz_FYeVO" role="2ShVmc">
+                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                          <node concept="3cmrfG" id="1mFXz_FYeVP" role="37wK5m">
+                            <property role="3cmrfH" value="224" />
+                          </node>
+                          <node concept="3cmrfG" id="1mFXz_FYeVQ" role="37wK5m">
+                            <property role="3cmrfH" value="247" />
+                          </node>
+                          <node concept="3cmrfG" id="1mFXz_FYeVR" role="37wK5m">
+                            <property role="3cmrfH" value="255" />
+                          </node>
+                        </node>
                       </node>
-                      <node concept="3cmrfG" id="1mFXz_FYeVQ" role="37wK5m">
-                        <property role="3cmrfH" value="247" />
-                      </node>
-                      <node concept="3cmrfG" id="1mFXz_FYeVR" role="37wK5m">
-                        <property role="3cmrfH" value="255" />
+                      <node concept="2ShNRf" id="1O3benw6MFe" role="37wK5m">
+                        <node concept="1pGfFk" id="1O3benw6MFf" role="2ShVmc">
+                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                          <node concept="3cmrfG" id="1O3benw6O_r" role="37wK5m">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="3cmrfG" id="1O3benw6PIV" role="37wK5m">
+                            <property role="3cmrfH" value="96" />
+                          </node>
+                          <node concept="3cmrfG" id="1O3benw6PZ7" role="37wK5m">
+                            <property role="3cmrfH" value="128" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -3379,9 +3742,18 @@
                     <node concept="3clFbJ" id="5TsxM4BC0RS" role="3cqZAp">
                       <node concept="3clFbS" id="5TsxM4BC0RU" role="3clFbx">
                         <node concept="3cpWs6" id="5TsxM4BC4CL" role="3cqZAp">
-                          <node concept="10M0yZ" id="5TsxM4BC91o" role="3cqZAk">
-                            <ref role="3cqZAo" to="z60i:~Color.yellow" resolve="yellow" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <node concept="2ShNRf" id="1O3benw6RHy" role="3cqZAk">
+                            <node concept="1pGfFk" id="1O3benw6SVw" role="2ShVmc">
+                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                              <node concept="10M0yZ" id="5TsxM4BC91o" role="37wK5m">
+                                <ref role="3cqZAo" to="z60i:~Color.yellow" resolve="yellow" />
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              </node>
+                              <node concept="10M0yZ" id="1O3benw6Tbc" role="37wK5m">
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                <ref role="3cqZAo" to="z60i:~Color.yellow" resolve="yellow" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -3399,17 +3771,36 @@
                         <node concept="3clFbJ" id="5xEoEMrzh2v" role="3cqZAp">
                           <node concept="3clFbS" id="5xEoEMrzh2w" role="3clFbx">
                             <node concept="3cpWs6" id="5xEoEMrzh2x" role="3cqZAp">
-                              <node concept="2ShNRf" id="5xEoEMrzh2y" role="3cqZAk">
-                                <node concept="1pGfFk" id="ub9nkyNCaC" role="2ShVmc">
-                                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                                  <node concept="3cmrfG" id="ub9nkyNCaD" role="37wK5m">
-                                    <property role="3cmrfH" value="225" />
+                              <node concept="2ShNRf" id="1O3benw6UP6" role="3cqZAk">
+                                <node concept="1pGfFk" id="1O3benw6VID" role="2ShVmc">
+                                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                                  <node concept="2ShNRf" id="5xEoEMrzh2y" role="37wK5m">
+                                    <node concept="1pGfFk" id="ub9nkyNCaC" role="2ShVmc">
+                                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                                      <node concept="3cmrfG" id="ub9nkyNCaD" role="37wK5m">
+                                        <property role="3cmrfH" value="225" />
+                                      </node>
+                                      <node concept="3cmrfG" id="ub9nkyNCaE" role="37wK5m">
+                                        <property role="3cmrfH" value="252" />
+                                      </node>
+                                      <node concept="3cmrfG" id="ub9nkyNCaF" role="37wK5m">
+                                        <property role="3cmrfH" value="227" />
+                                      </node>
+                                    </node>
                                   </node>
-                                  <node concept="3cmrfG" id="ub9nkyNCaE" role="37wK5m">
-                                    <property role="3cmrfH" value="252" />
-                                  </node>
-                                  <node concept="3cmrfG" id="ub9nkyNCaF" role="37wK5m">
-                                    <property role="3cmrfH" value="227" />
+                                  <node concept="2ShNRf" id="1O3benw6Wzw" role="37wK5m">
+                                    <node concept="1pGfFk" id="1O3benw6XMx" role="2ShVmc">
+                                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                                      <node concept="3cmrfG" id="1O3benw6Y2W" role="37wK5m">
+                                        <property role="3cmrfH" value="11" />
+                                      </node>
+                                      <node concept="3cmrfG" id="1O3benw6Y39" role="37wK5m">
+                                        <property role="3cmrfH" value="116" />
+                                      </node>
+                                      <node concept="3cmrfG" id="1O3benw6ZcH" role="37wK5m">
+                                        <property role="3cmrfH" value="18" />
+                                      </node>
+                                    </node>
                                   </node>
                                 </node>
                               </node>
@@ -3426,17 +3817,36 @@
                           <node concept="9aQIb" id="5xEoEMrzh2E" role="9aQIa">
                             <node concept="3clFbS" id="5xEoEMrzh2F" role="9aQI4">
                               <node concept="3cpWs6" id="5xEoEMrzh2G" role="3cqZAp">
-                                <node concept="2ShNRf" id="5xEoEMrzh2H" role="3cqZAk">
-                                  <node concept="1pGfFk" id="5xEoEMrzh2I" role="2ShVmc">
-                                    <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                                    <node concept="3cmrfG" id="5xEoEMrzh2J" role="37wK5m">
-                                      <property role="3cmrfH" value="255" />
+                                <node concept="2ShNRf" id="1O3benw70Hl" role="3cqZAk">
+                                  <node concept="1pGfFk" id="1O3benw71C5" role="2ShVmc">
+                                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                                    <node concept="2ShNRf" id="5xEoEMrzh2H" role="37wK5m">
+                                      <node concept="1pGfFk" id="5xEoEMrzh2I" role="2ShVmc">
+                                        <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                                        <node concept="3cmrfG" id="5xEoEMrzh2J" role="37wK5m">
+                                          <property role="3cmrfH" value="255" />
+                                        </node>
+                                        <node concept="3cmrfG" id="5xEoEMrzh2K" role="37wK5m">
+                                          <property role="3cmrfH" value="219" />
+                                        </node>
+                                        <node concept="3cmrfG" id="5xEoEMrzh2L" role="37wK5m">
+                                          <property role="3cmrfH" value="227" />
+                                        </node>
+                                      </node>
                                     </node>
-                                    <node concept="3cmrfG" id="5xEoEMrzh2K" role="37wK5m">
-                                      <property role="3cmrfH" value="219" />
-                                    </node>
-                                    <node concept="3cmrfG" id="5xEoEMrzh2L" role="37wK5m">
-                                      <property role="3cmrfH" value="227" />
+                                    <node concept="2ShNRf" id="1O3benw733i" role="37wK5m">
+                                      <node concept="1pGfFk" id="1O3benw73Zx" role="2ShVmc">
+                                        <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                                        <node concept="3cmrfG" id="1O3benw74_8" role="37wK5m">
+                                          <property role="3cmrfH" value="179" />
+                                        </node>
+                                        <node concept="3cmrfG" id="1O3benw74Ax" role="37wK5m">
+                                          <property role="3cmrfH" value="0" />
+                                        </node>
+                                        <node concept="3cmrfG" id="1O3benw75lv" role="37wK5m">
+                                          <property role="3cmrfH" value="39" />
+                                        </node>
+                                      </node>
                                     </node>
                                   </node>
                                 </node>
@@ -3482,17 +3892,36 @@
             <node concept="3clFbJ" id="3_Nra3DSjWr" role="3cqZAp">
               <node concept="3clFbS" id="3_Nra3DSjWt" role="3clFbx">
                 <node concept="3cpWs6" id="3_Nra3DSlzD" role="3cqZAp">
-                  <node concept="2ShNRf" id="3_Nra3DSlzE" role="3cqZAk">
-                    <node concept="1pGfFk" id="3_Nra3DSlzF" role="2ShVmc">
-                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                      <node concept="3cmrfG" id="3_Nra3DSlzG" role="37wK5m">
-                        <property role="3cmrfH" value="227" />
+                  <node concept="2ShNRf" id="1O3benw774G" role="3cqZAk">
+                    <node concept="1pGfFk" id="1O3benw78kC" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="2ShNRf" id="3_Nra3DSlzE" role="37wK5m">
+                        <node concept="1pGfFk" id="3_Nra3DSlzF" role="2ShVmc">
+                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                          <node concept="3cmrfG" id="3_Nra3DSlzG" role="37wK5m">
+                            <property role="3cmrfH" value="227" />
+                          </node>
+                          <node concept="3cmrfG" id="3_Nra3DSlzH" role="37wK5m">
+                            <property role="3cmrfH" value="227" />
+                          </node>
+                          <node concept="3cmrfG" id="3_Nra3DSlzI" role="37wK5m">
+                            <property role="3cmrfH" value="227" />
+                          </node>
+                        </node>
                       </node>
-                      <node concept="3cmrfG" id="3_Nra3DSlzH" role="37wK5m">
-                        <property role="3cmrfH" value="227" />
-                      </node>
-                      <node concept="3cmrfG" id="3_Nra3DSlzI" role="37wK5m">
-                        <property role="3cmrfH" value="227" />
+                      <node concept="2ShNRf" id="1O3benw79LS" role="37wK5m">
+                        <node concept="1pGfFk" id="1O3benw7aJk" role="2ShVmc">
+                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                          <node concept="3cmrfG" id="1O3benw7bm8" role="37wK5m">
+                            <property role="3cmrfH" value="38" />
+                          </node>
+                          <node concept="3cmrfG" id="1O3benw7bXb" role="37wK5m">
+                            <property role="3cmrfH" value="38" />
+                          </node>
+                          <node concept="3cmrfG" id="1O3benw7bYC" role="37wK5m">
+                            <property role="3cmrfH" value="38" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -3508,17 +3937,36 @@
             <node concept="3clFbJ" id="7HzLUeHw_xw" role="3cqZAp">
               <node concept="3clFbS" id="7HzLUeHw_xx" role="3clFbx">
                 <node concept="3cpWs6" id="7HzLUeHw_xy" role="3cqZAp">
-                  <node concept="2ShNRf" id="7HzLUeHw_xz" role="3cqZAk">
-                    <node concept="1pGfFk" id="7HzLUeHw_x$" role="2ShVmc">
-                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                      <node concept="3cmrfG" id="7HzLUeHw_x_" role="37wK5m">
-                        <property role="3cmrfH" value="255" />
+                  <node concept="2ShNRf" id="1O3benw7fJ0" role="3cqZAk">
+                    <node concept="1pGfFk" id="1O3benw7gGa" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="2ShNRf" id="7HzLUeHw_xz" role="37wK5m">
+                        <node concept="1pGfFk" id="7HzLUeHw_x$" role="2ShVmc">
+                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                          <node concept="3cmrfG" id="7HzLUeHw_x_" role="37wK5m">
+                            <property role="3cmrfH" value="255" />
+                          </node>
+                          <node concept="3cmrfG" id="7HzLUeHw_xA" role="37wK5m">
+                            <property role="3cmrfH" value="246" />
+                          </node>
+                          <node concept="3cmrfG" id="7HzLUeHw_xB" role="37wK5m">
+                            <property role="3cmrfH" value="230" />
+                          </node>
+                        </node>
                       </node>
-                      <node concept="3cmrfG" id="7HzLUeHw_xA" role="37wK5m">
-                        <property role="3cmrfH" value="246" />
-                      </node>
-                      <node concept="3cmrfG" id="7HzLUeHw_xB" role="37wK5m">
-                        <property role="3cmrfH" value="230" />
+                      <node concept="2ShNRf" id="1O3benw7jvr" role="37wK5m">
+                        <node concept="1pGfFk" id="1O3benw7kM3" role="2ShVmc">
+                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                          <node concept="3cmrfG" id="1O3benw7lq4" role="37wK5m">
+                            <property role="3cmrfH" value="51" />
+                          </node>
+                          <node concept="3cmrfG" id="1O3benw7mEg" role="37wK5m">
+                            <property role="3cmrfH" value="32" />
+                          </node>
+                          <node concept="3cmrfG" id="1O3benw7n8O" role="37wK5m">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -3559,18 +4007,37 @@
                     </node>
                   </node>
                   <node concept="3clFbS" id="5avmkTFtJBu" role="3clFbx">
-                    <node concept="3cpWs6" id="5avmkTFtMF8" role="3cqZAp">
-                      <node concept="2ShNRf" id="5avmkTFtMF9" role="3cqZAk">
-                        <node concept="1pGfFk" id="5avmkTFtMFa" role="2ShVmc">
-                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                          <node concept="3cmrfG" id="5avmkTFtMFb" role="37wK5m">
-                            <property role="3cmrfH" value="227" />
+                    <node concept="3cpWs6" id="1O3benw7oeM" role="3cqZAp">
+                      <node concept="2ShNRf" id="1O3benw7oeN" role="3cqZAk">
+                        <node concept="1pGfFk" id="1O3benw7oeO" role="2ShVmc">
+                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                          <node concept="2ShNRf" id="1O3benw7oeP" role="37wK5m">
+                            <node concept="1pGfFk" id="1O3benw7oeQ" role="2ShVmc">
+                              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                              <node concept="3cmrfG" id="1O3benw7oeR" role="37wK5m">
+                                <property role="3cmrfH" value="227" />
+                              </node>
+                              <node concept="3cmrfG" id="1O3benw7oeS" role="37wK5m">
+                                <property role="3cmrfH" value="227" />
+                              </node>
+                              <node concept="3cmrfG" id="1O3benw7oeT" role="37wK5m">
+                                <property role="3cmrfH" value="227" />
+                              </node>
+                            </node>
                           </node>
-                          <node concept="3cmrfG" id="5avmkTFtMFc" role="37wK5m">
-                            <property role="3cmrfH" value="227" />
-                          </node>
-                          <node concept="3cmrfG" id="5avmkTFtMFd" role="37wK5m">
-                            <property role="3cmrfH" value="227" />
+                          <node concept="2ShNRf" id="1O3benw7oeU" role="37wK5m">
+                            <node concept="1pGfFk" id="1O3benw7oeV" role="2ShVmc">
+                              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                              <node concept="3cmrfG" id="1O3benw7oeW" role="37wK5m">
+                                <property role="3cmrfH" value="38" />
+                              </node>
+                              <node concept="3cmrfG" id="1O3benw7oeX" role="37wK5m">
+                                <property role="3cmrfH" value="38" />
+                              </node>
+                              <node concept="3cmrfG" id="1O3benw7oeY" role="37wK5m">
+                                <property role="3cmrfH" value="38" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -3605,18 +4072,37 @@
                     </node>
                   </node>
                   <node concept="3clFbS" id="2ufoZQJ_wrM" role="3clFbx">
-                    <node concept="3cpWs6" id="2ufoZQJ_wrN" role="3cqZAp">
-                      <node concept="2ShNRf" id="2ufoZQJ_wrO" role="3cqZAk">
-                        <node concept="1pGfFk" id="2ufoZQJ_wrP" role="2ShVmc">
-                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                          <node concept="3cmrfG" id="2ufoZQJ_wrQ" role="37wK5m">
-                            <property role="3cmrfH" value="227" />
+                    <node concept="3cpWs6" id="1O3benw7oT8" role="3cqZAp">
+                      <node concept="2ShNRf" id="1O3benw7oT9" role="3cqZAk">
+                        <node concept="1pGfFk" id="1O3benw7oTa" role="2ShVmc">
+                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                          <node concept="2ShNRf" id="1O3benw7oTb" role="37wK5m">
+                            <node concept="1pGfFk" id="1O3benw7oTc" role="2ShVmc">
+                              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                              <node concept="3cmrfG" id="1O3benw7oTd" role="37wK5m">
+                                <property role="3cmrfH" value="227" />
+                              </node>
+                              <node concept="3cmrfG" id="1O3benw7oTe" role="37wK5m">
+                                <property role="3cmrfH" value="227" />
+                              </node>
+                              <node concept="3cmrfG" id="1O3benw7oTf" role="37wK5m">
+                                <property role="3cmrfH" value="227" />
+                              </node>
+                            </node>
                           </node>
-                          <node concept="3cmrfG" id="2ufoZQJ_wrR" role="37wK5m">
-                            <property role="3cmrfH" value="227" />
-                          </node>
-                          <node concept="3cmrfG" id="2ufoZQJ_wrS" role="37wK5m">
-                            <property role="3cmrfH" value="227" />
+                          <node concept="2ShNRf" id="1O3benw7oTg" role="37wK5m">
+                            <node concept="1pGfFk" id="1O3benw7oTh" role="2ShVmc">
+                              <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                              <node concept="3cmrfG" id="1O3benw7oTi" role="37wK5m">
+                                <property role="3cmrfH" value="38" />
+                              </node>
+                              <node concept="3cmrfG" id="1O3benw7oTj" role="37wK5m">
+                                <property role="3cmrfH" value="38" />
+                              </node>
+                              <node concept="3cmrfG" id="1O3benw7oTk" role="37wK5m">
+                                <property role="3cmrfH" value="38" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -3984,7 +4470,25 @@
             <node concept="3F0ifn" id="3_Nra3DWScO" role="1j7Clw">
               <property role="3F0ifm" value="c|" />
               <node concept="VechU" id="3_Nra3DYkXB" role="3F10Kt">
-                <property role="Vb096" value="fLJRk5A/lightGray" />
+                <node concept="3ZlJ5R" id="1O3benwaZzf" role="VblUZ">
+                  <node concept="3clFbS" id="1O3benwaZzg" role="2VODD2">
+                    <node concept="3clFbF" id="1O3benwaZB7" role="3cqZAp">
+                      <node concept="2ShNRf" id="1O3benwaZB5" role="3clFbG">
+                        <node concept="1pGfFk" id="1O3benwb0lD" role="2ShVmc">
+                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                          <node concept="10M0yZ" id="1O3benwb0Iw" role="37wK5m">
+                            <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          </node>
+                          <node concept="10M0yZ" id="1O3benwcE0R" role="37wK5m">
+                            <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -4614,13 +5118,31 @@
                                     <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
                                   </node>
                                 </node>
-                                <node concept="10M0yZ" id="6GwlCCBaM$5" role="37wK5m">
-                                  <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                <node concept="2ShNRf" id="1O3benw9mbR" role="37wK5m">
+                                  <node concept="1pGfFk" id="1O3benw9niP" role="2ShVmc">
+                                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                                    <node concept="10M0yZ" id="6GwlCCBaM$5" role="37wK5m">
+                                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                      <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                                    </node>
+                                    <node concept="10M0yZ" id="1O3benw9otY" role="37wK5m">
+                                      <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                    </node>
+                                  </node>
                                 </node>
-                                <node concept="10M0yZ" id="2ufoZQJzKAa" role="37wK5m">
-                                  <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                <node concept="2ShNRf" id="1O3benw9pFo" role="37wK5m">
+                                  <node concept="1pGfFk" id="1O3benw9qNr" role="2ShVmc">
+                                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                                    <node concept="10M0yZ" id="2ufoZQJzKAa" role="37wK5m">
+                                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                      <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                                    </node>
+                                    <node concept="10M0yZ" id="1O3benw9sxF" role="37wK5m">
+                                      <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                    </node>
+                                  </node>
                                 </node>
                               </node>
                             </node>
@@ -5117,17 +5639,36 @@
             <node concept="3clFbJ" id="5avmkTFCmLP" role="3cqZAp">
               <node concept="3clFbS" id="5avmkTFCmLQ" role="3clFbx">
                 <node concept="3cpWs6" id="5avmkTFCmLR" role="3cqZAp">
-                  <node concept="2ShNRf" id="5avmkTFCmLS" role="3cqZAk">
-                    <node concept="1pGfFk" id="5avmkTFCmLT" role="2ShVmc">
-                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                      <node concept="3cmrfG" id="5avmkTFCmLU" role="37wK5m">
-                        <property role="3cmrfH" value="224" />
+                  <node concept="2ShNRf" id="1O3benwfQWx" role="3cqZAk">
+                    <node concept="1pGfFk" id="1O3benwfRCa" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="2ShNRf" id="5avmkTFCmLS" role="37wK5m">
+                        <node concept="1pGfFk" id="5avmkTFCmLT" role="2ShVmc">
+                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                          <node concept="3cmrfG" id="5avmkTFCmLU" role="37wK5m">
+                            <property role="3cmrfH" value="224" />
+                          </node>
+                          <node concept="3cmrfG" id="5avmkTFCmLV" role="37wK5m">
+                            <property role="3cmrfH" value="247" />
+                          </node>
+                          <node concept="3cmrfG" id="5avmkTFCmLW" role="37wK5m">
+                            <property role="3cmrfH" value="255" />
+                          </node>
+                        </node>
                       </node>
-                      <node concept="3cmrfG" id="5avmkTFCmLV" role="37wK5m">
-                        <property role="3cmrfH" value="247" />
-                      </node>
-                      <node concept="3cmrfG" id="5avmkTFCmLW" role="37wK5m">
-                        <property role="3cmrfH" value="255" />
+                      <node concept="2ShNRf" id="1O3benwfRTj" role="37wK5m">
+                        <node concept="1pGfFk" id="1O3benwfSB3" role="2ShVmc">
+                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                          <node concept="3cmrfG" id="1O3benwfT6h" role="37wK5m">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="3cmrfG" id="1O3benwhxsF" role="37wK5m">
+                            <property role="3cmrfH" value="77" />
+                          </node>
+                          <node concept="3cmrfG" id="1O3benwhxDQ" role="37wK5m">
+                            <property role="3cmrfH" value="102" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -5188,17 +5729,36 @@
             <node concept="3clFbJ" id="5avmkTFCpPd" role="3cqZAp">
               <node concept="3clFbS" id="5avmkTFCpPe" role="3clFbx">
                 <node concept="3cpWs6" id="5avmkTFCpPf" role="3cqZAp">
-                  <node concept="2ShNRf" id="5avmkTFCpPg" role="3cqZAk">
-                    <node concept="1pGfFk" id="5avmkTFCpPh" role="2ShVmc">
-                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                      <node concept="3cmrfG" id="5avmkTFCpPi" role="37wK5m">
-                        <property role="3cmrfH" value="224" />
+                  <node concept="2ShNRf" id="1O3benwjHEq" role="3cqZAk">
+                    <node concept="1pGfFk" id="1O3benwjImH" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="2ShNRf" id="5avmkTFCpPg" role="37wK5m">
+                        <node concept="1pGfFk" id="5avmkTFCpPh" role="2ShVmc">
+                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                          <node concept="3cmrfG" id="5avmkTFCpPi" role="37wK5m">
+                            <property role="3cmrfH" value="224" />
+                          </node>
+                          <node concept="3cmrfG" id="5avmkTFCpPj" role="37wK5m">
+                            <property role="3cmrfH" value="247" />
+                          </node>
+                          <node concept="3cmrfG" id="5avmkTFCpPk" role="37wK5m">
+                            <property role="3cmrfH" value="255" />
+                          </node>
+                        </node>
                       </node>
-                      <node concept="3cmrfG" id="5avmkTFCpPj" role="37wK5m">
-                        <property role="3cmrfH" value="247" />
-                      </node>
-                      <node concept="3cmrfG" id="5avmkTFCpPk" role="37wK5m">
-                        <property role="3cmrfH" value="255" />
+                      <node concept="2ShNRf" id="1O3benwjIGS" role="37wK5m">
+                        <node concept="1pGfFk" id="1O3benwjJAw" role="2ShVmc">
+                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                          <node concept="3cmrfG" id="1O3benwjK10" role="37wK5m">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="3cmrfG" id="1O3benwjKSo" role="37wK5m">
+                            <property role="3cmrfH" value="77" />
+                          </node>
+                          <node concept="3cmrfG" id="1O3benwjLhu" role="37wK5m">
+                            <property role="3cmrfH" value="102" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/editor.mps
@@ -2895,9 +2895,19 @@
                           <node concept="1Z6Ecs" id="1CcsU$uSq$T" role="37wK5m">
                             <ref role="1Z6EpT" to="reoo:5PDTdguqQmB" resolve="shade-color" />
                           </node>
-                          <node concept="10M0yZ" id="38mO9wgoxfW" role="37wK5m">
-                            <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
-                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                          <node concept="2ShNRf" id="6vTsSV__ibl" role="37wK5m">
+                            <node concept="1pGfFk" id="6vTsSV__kTE" role="2ShVmc">
+                              <property role="373rjd" value="true" />
+                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                              <node concept="10M0yZ" id="6vTsSV__kZA" role="37wK5m">
+                                <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              </node>
+                              <node concept="10M0yZ" id="6vTsSV__lmw" role="37wK5m">
+                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -2917,9 +2927,19 @@
                             <ref role="3cqZAo" to="5ueo:~StyleAttributes.TEXT_COLOR" resolve="TEXT_COLOR" />
                             <ref role="1PxDUh" to="5ueo:~StyleAttributes" resolve="StyleAttributes" />
                           </node>
-                          <node concept="10M0yZ" id="38mO9wgoxzx" role="37wK5m">
-                            <ref role="3cqZAo" to="lzb2:~JBColor.white" resolve="white" />
-                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                          <node concept="2ShNRf" id="6vTsSV__em_" role="37wK5m">
+                            <node concept="1pGfFk" id="6vTsSV__h5_" role="2ShVmc">
+                              <property role="373rjd" value="true" />
+                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                              <node concept="10M0yZ" id="6vTsSV__lbN" role="37wK5m">
+                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              </node>
+                              <node concept="10M0yZ" id="6vTsSV__hiz" role="37wK5m">
+                                <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -3028,9 +3048,19 @@
                           <node concept="1Z6Ecs" id="5avmkTF9ZFn" role="37wK5m">
                             <ref role="1Z6EpT" to="reoo:5PDTdguqQmB" resolve="shade-color" />
                           </node>
-                          <node concept="10M0yZ" id="38mO9wgoxVO" role="37wK5m">
-                            <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
-                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                          <node concept="2ShNRf" id="6vTsSV_Amg5" role="37wK5m">
+                            <node concept="1pGfFk" id="6vTsSV_Amg6" role="2ShVmc">
+                              <property role="373rjd" value="true" />
+                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                              <node concept="10M0yZ" id="6vTsSV_Amg7" role="37wK5m">
+                                <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              </node>
+                              <node concept="10M0yZ" id="6vTsSV_Amg8" role="37wK5m">
+                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -3050,9 +3080,19 @@
                             <ref role="3cqZAo" to="5ueo:~StyleAttributes.TEXT_COLOR" resolve="TEXT_COLOR" />
                             <ref role="1PxDUh" to="5ueo:~StyleAttributes" resolve="StyleAttributes" />
                           </node>
-                          <node concept="10M0yZ" id="38mO9wgoy32" role="37wK5m">
-                            <ref role="3cqZAo" to="lzb2:~JBColor.white" resolve="white" />
-                            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                          <node concept="2ShNRf" id="6vTsSV_AmpK" role="37wK5m">
+                            <node concept="1pGfFk" id="6vTsSV_AmpL" role="2ShVmc">
+                              <property role="373rjd" value="true" />
+                              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                              <node concept="10M0yZ" id="6vTsSV_AmpM" role="37wK5m">
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                              </node>
+                              <node concept="10M0yZ" id="6vTsSV_AmpN" role="37wK5m">
+                                <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -3424,11 +3464,11 @@
                           <node concept="3cmrfG" id="1O3benw6O_r" role="37wK5m">
                             <property role="3cmrfH" value="0" />
                           </node>
-                          <node concept="3cmrfG" id="1O3benw6PIV" role="37wK5m">
-                            <property role="3cmrfH" value="96" />
+                          <node concept="3cmrfG" id="6vTsSV_xW4l" role="37wK5m">
+                            <property role="3cmrfH" value="54" />
                           </node>
                           <node concept="3cmrfG" id="1O3benw6PZ7" role="37wK5m">
-                            <property role="3cmrfH" value="128" />
+                            <property role="3cmrfH" value="13" />
                           </node>
                         </node>
                       </node>
@@ -4193,10 +4233,20 @@
               <node concept="VechU" id="3_Nra3DYkXB" role="3F10Kt">
                 <node concept="3ZlJ5R" id="1O3benwaZzf" role="VblUZ">
                   <node concept="3clFbS" id="1O3benwaZzg" role="2VODD2">
-                    <node concept="3clFbF" id="1O3benwaZB7" role="3cqZAp">
-                      <node concept="10M0yZ" id="38mO9wgmy7o" role="3clFbG">
-                        <ref role="3cqZAo" to="lzb2:~JBColor.lightGray" resolve="lightGray" />
-                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                    <node concept="3cpWs6" id="6vTsSV_u2rp" role="3cqZAp">
+                      <node concept="2ShNRf" id="6vTsSV_u2ws" role="3cqZAk">
+                        <node concept="1pGfFk" id="6vTsSV_ukF4" role="2ShVmc">
+                          <property role="373rjd" value="true" />
+                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                          <node concept="10M0yZ" id="6vTsSV_ul6x" role="37wK5m">
+                            <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          </node>
+                          <node concept="10M0yZ" id="6vTsSV_vBuR" role="37wK5m">
+                            <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -5357,10 +5407,10 @@
                             <property role="3cmrfH" value="0" />
                           </node>
                           <node concept="3cmrfG" id="1O3benwhxsF" role="37wK5m">
-                            <property role="3cmrfH" value="77" />
+                            <property role="3cmrfH" value="54" />
                           </node>
                           <node concept="3cmrfG" id="1O3benwhxDQ" role="37wK5m">
-                            <property role="3cmrfH" value="102" />
+                            <property role="3cmrfH" value="13" />
                           </node>
                         </node>
                       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/models/org.iets3.core.expr.stringvalidation.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/models/org.iets3.core.expr.stringvalidation.editor.mps
@@ -10,8 +10,8 @@
   <imports>
     <import index="r4b4" ref="r:1784e088-20fd-4fdb-96b8-bc57f0056d94(com.mbeddr.core.base.editor)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
-    <import index="m999" ref="r:1d6bd88a-7393-4b32-b0e6-2d8b3094776e(org.iets3.core.expr.toplevel.editor)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
+    <import index="m999" ref="r:1d6bd88a-7393-4b32-b0e6-2d8b3094776e(org.iets3.core.expr.toplevel.editor)" />
     <import index="3r88" ref="r:0561db97-8a79-45b6-97f8-a5fd9b986b44(org.iets3.core.expr.stringvalidation.structure)" implicit="true" />
     <import index="itrz" ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
@@ -288,18 +288,9 @@
                 <node concept="1pGfFk" id="2LaXqmXzdoF" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:BsHjoDRDi8" resolve="OpeningBracketCell" />
                   <node concept="pncrf" id="2LaXqmXzdoG" role="37wK5m" />
-                  <node concept="2ShNRf" id="3frJLkOCj_J" role="37wK5m">
-                    <node concept="1pGfFk" id="3frJLkOCkiD" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="2LaXqmXzdoH" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                      </node>
-                      <node concept="10M0yZ" id="3frJLkOCk$Q" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wgjKy5" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -322,18 +313,9 @@
                 <node concept="1pGfFk" id="2LaXqmXzdoQ" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:4QhMqW2TWbb" resolve="ClosingBracketCell" />
                   <node concept="pncrf" id="2LaXqmXzdoR" role="37wK5m" />
-                  <node concept="2ShNRf" id="3frJLkOCkNK" role="37wK5m">
-                    <node concept="1pGfFk" id="3frJLkOCkNL" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="3frJLkOCkNM" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="3frJLkOCkNN" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wgjKOI" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/models/org.iets3.core.expr.stringvalidation.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/models/org.iets3.core.expr.stringvalidation.editor.mps
@@ -11,6 +11,7 @@
     <import index="r4b4" ref="r:1784e088-20fd-4fdb-96b8-bc57f0056d94(com.mbeddr.core.base.editor)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="m999" ref="r:1d6bd88a-7393-4b32-b0e6-2d8b3094776e(org.iets3.core.expr.toplevel.editor)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="3r88" ref="r:0561db97-8a79-45b6-97f8-a5fd9b986b44(org.iets3.core.expr.stringvalidation.structure)" implicit="true" />
     <import index="itrz" ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
@@ -134,9 +135,18 @@
                 <node concept="1pGfFk" id="6cw1FA3OUp_" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:BsHjoDRDi8" resolve="OpeningBracketCell" />
                   <node concept="pncrf" id="6cw1FA3OUub" role="37wK5m" />
-                  <node concept="10M0yZ" id="6cw1FA3REJN" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                  <node concept="2ShNRf" id="3frJLkOCkX1" role="37wK5m">
+                    <node concept="1pGfFk" id="3frJLkOCkX2" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="3frJLkOCkX3" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                      </node>
+                      <node concept="10M0yZ" id="3frJLkOCkX4" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -159,9 +169,18 @@
                 <node concept="1pGfFk" id="6cw1FA3OWnU" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:4QhMqW2TWbb" resolve="ClosingBracketCell" />
                   <node concept="pncrf" id="6cw1FA3OWnV" role="37wK5m" />
-                  <node concept="10M0yZ" id="6cw1FA3RFWe" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <node concept="2ShNRf" id="3frJLkOCl1V" role="37wK5m">
+                    <node concept="1pGfFk" id="3frJLkOCl1W" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="3frJLkOCl1X" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="3frJLkOCl1Y" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -269,9 +288,18 @@
                 <node concept="1pGfFk" id="2LaXqmXzdoF" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:BsHjoDRDi8" resolve="OpeningBracketCell" />
                   <node concept="pncrf" id="2LaXqmXzdoG" role="37wK5m" />
-                  <node concept="10M0yZ" id="2LaXqmXzdoH" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <node concept="2ShNRf" id="3frJLkOCj_J" role="37wK5m">
+                    <node concept="1pGfFk" id="3frJLkOCkiD" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="2LaXqmXzdoH" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                      </node>
+                      <node concept="10M0yZ" id="3frJLkOCk$Q" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -294,9 +322,18 @@
                 <node concept="1pGfFk" id="2LaXqmXzdoQ" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:4QhMqW2TWbb" resolve="ClosingBracketCell" />
                   <node concept="pncrf" id="2LaXqmXzdoR" role="37wK5m" />
-                  <node concept="10M0yZ" id="2LaXqmXzdoS" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                  <node concept="2ShNRf" id="3frJLkOCkNK" role="37wK5m">
+                    <node concept="1pGfFk" id="3frJLkOCkNL" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="3frJLkOCkNM" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="3frJLkOCkNN" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
@@ -1661,17 +1661,36 @@
           <node concept="3ZlJ5R" id="6HHp2Wn5LjG" role="VblUZ">
             <node concept="3clFbS" id="6HHp2Wn5LjH" role="2VODD2">
               <node concept="3clFbF" id="6HHp2Wn5LjI" role="3cqZAp">
-                <node concept="2ShNRf" id="6HHp2Wn5LjJ" role="3clFbG">
-                  <node concept="1pGfFk" id="6HHp2Wn5LjK" role="2ShVmc">
-                    <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                    <node concept="3cmrfG" id="6HHp2Wn5LjL" role="37wK5m">
-                      <property role="3cmrfH" value="168" />
+                <node concept="2ShNRf" id="3frJLkO_oP8" role="3clFbG">
+                  <node concept="1pGfFk" id="3frJLkO_pwO" role="2ShVmc">
+                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                    <node concept="2ShNRf" id="6HHp2Wn5LjJ" role="37wK5m">
+                      <node concept="1pGfFk" id="6HHp2Wn5LjK" role="2ShVmc">
+                        <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                        <node concept="3cmrfG" id="6HHp2Wn5LjL" role="37wK5m">
+                          <property role="3cmrfH" value="168" />
+                        </node>
+                        <node concept="3cmrfG" id="6HHp2Wn5LjM" role="37wK5m">
+                          <property role="3cmrfH" value="168" />
+                        </node>
+                        <node concept="3cmrfG" id="6HHp2Wn5LjN" role="37wK5m">
+                          <property role="3cmrfH" value="168" />
+                        </node>
+                      </node>
                     </node>
-                    <node concept="3cmrfG" id="6HHp2Wn5LjM" role="37wK5m">
-                      <property role="3cmrfH" value="168" />
-                    </node>
-                    <node concept="3cmrfG" id="6HHp2Wn5LjN" role="37wK5m">
-                      <property role="3cmrfH" value="168" />
+                    <node concept="2ShNRf" id="3frJLkO_pFq" role="37wK5m">
+                      <node concept="1pGfFk" id="3frJLkO_pFr" role="2ShVmc">
+                        <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                        <node concept="3cmrfG" id="3frJLkO_pFs" role="37wK5m">
+                          <property role="3cmrfH" value="168" />
+                        </node>
+                        <node concept="3cmrfG" id="3frJLkO_pFt" role="37wK5m">
+                          <property role="3cmrfH" value="168" />
+                        </node>
+                        <node concept="3cmrfG" id="3frJLkO_pFu" role="37wK5m">
+                          <property role="3cmrfH" value="168" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -2569,10 +2588,6 @@
             <node concept="3clFbS" id="RaqQlVWIKG" role="2VODD2">
               <node concept="3clFbF" id="RaqQlVWIRF" role="3cqZAp">
                 <node concept="3K4zz7" id="RaqQlVWNQ1" role="3clFbG">
-                  <node concept="10M0yZ" id="RaqQlVWO1u" role="3K4E3e">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
-                  </node>
                   <node concept="10Nm6u" id="RaqQlVWOlB" role="3K4GZi" />
                   <node concept="2OqwBi" id="RaqQlVWLsg" role="3K4Cdx">
                     <node concept="2OqwBi" id="RaqQlVWJ2b" role="2Oq$k0">
@@ -2585,6 +2600,19 @@
                       <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
                       <node concept="Xl_RD" id="RaqQlVWMbM" role="37wK5m">
                         <property role="Xl_RC" value="&lt;no value&gt;" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2ShNRf" id="3frJLkO_pWk" role="3K4E3e">
+                    <node concept="1pGfFk" id="3frJLkO_qIT" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="3frJLkO_qSi" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="3frJLkO_r6f" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
                       </node>
                     </node>
                   </node>
@@ -4698,11 +4726,23 @@
           <node concept="3ZlJ5R" id="3yVmeSjwpzU" role="VblUZ">
             <node concept="3clFbS" id="3yVmeSjwpzV" role="2VODD2">
               <node concept="3clFbF" id="3yVmeSjwpzW" role="3cqZAp">
-                <node concept="2YIFZM" id="3yVmeSjwpzX" role="3clFbG">
-                  <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                  <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                  <node concept="Xl_RD" id="3yVmeSjwpzY" role="37wK5m">
-                    <property role="Xl_RC" value="#FFE8ED" />
+                <node concept="2ShNRf" id="3frJLkO_rxD" role="3clFbG">
+                  <node concept="1pGfFk" id="3frJLkO_sdl" role="2ShVmc">
+                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                    <node concept="2YIFZM" id="3yVmeSjwpzX" role="37wK5m">
+                      <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                      <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                      <node concept="Xl_RD" id="3yVmeSjwpzY" role="37wK5m">
+                        <property role="Xl_RC" value="#FFE8ED" />
+                      </node>
+                    </node>
+                    <node concept="2YIFZM" id="3frJLkO_spB" role="37wK5m">
+                      <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                      <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                      <node concept="Xl_RD" id="3frJLkO_spC" role="37wK5m">
+                        <property role="Xl_RC" value="#FFE8ED" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -4714,9 +4754,18 @@
           <node concept="3sjG9q" id="3yVmeSjvwat" role="3tD6jU">
             <node concept="3clFbS" id="3yVmeSjvwau" role="2VODD2">
               <node concept="3clFbF" id="3yVmeSjvwav" role="3cqZAp">
-                <node concept="10M0yZ" id="3yVmeSjvwaw" role="3clFbG">
-                  <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                <node concept="2ShNRf" id="3frJLkO_sFR" role="3clFbG">
+                  <node concept="1pGfFk" id="3frJLkO_tnr" role="2ShVmc">
+                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                    <node concept="10M0yZ" id="3yVmeSjvwaw" role="37wK5m">
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
+                    </node>
+                    <node concept="10M0yZ" id="3frJLkO_tst" role="37wK5m">
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -4756,11 +4805,23 @@
           <node concept="3ZlJ5R" id="3yVmeSjvw_q" role="VblUZ">
             <node concept="3clFbS" id="3yVmeSjvw_r" role="2VODD2">
               <node concept="3clFbF" id="3yVmeSjvw_s" role="3cqZAp">
-                <node concept="2YIFZM" id="3yVmeSjvw_t" role="3clFbG">
-                  <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                  <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                  <node concept="Xl_RD" id="3yVmeSjvw_u" role="37wK5m">
-                    <property role="Xl_RC" value="#EBEBEB" />
+                <node concept="2ShNRf" id="3frJLkO_tUf" role="3clFbG">
+                  <node concept="1pGfFk" id="3frJLkO_u_V" role="2ShVmc">
+                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                    <node concept="2YIFZM" id="3yVmeSjvw_t" role="37wK5m">
+                      <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                      <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                      <node concept="Xl_RD" id="3yVmeSjvw_u" role="37wK5m">
+                        <property role="Xl_RC" value="#EBEBEB" />
+                      </node>
+                    </node>
+                    <node concept="2YIFZM" id="3frJLkO_uIQ" role="37wK5m">
+                      <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                      <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                      <node concept="Xl_RD" id="3frJLkO_uIR" role="37wK5m">
+                        <property role="Xl_RC" value="#EBEBEB" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -4772,9 +4833,18 @@
           <node concept="3sjG9q" id="3yVmeSjvw_w" role="3tD6jU">
             <node concept="3clFbS" id="3yVmeSjvw_x" role="2VODD2">
               <node concept="3clFbF" id="3yVmeSjvw_y" role="3cqZAp">
-                <node concept="10M0yZ" id="3yVmeSjvw_z" role="3clFbG">
-                  <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                  <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                <node concept="2ShNRf" id="3frJLkO_uL9" role="3clFbG">
+                  <node concept="1pGfFk" id="3frJLkO_vtC" role="2ShVmc">
+                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                    <node concept="10M0yZ" id="3yVmeSjvw_z" role="37wK5m">
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
+                    </node>
+                    <node concept="10M0yZ" id="3frJLkO_vDs" role="37wK5m">
+                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -6624,9 +6694,18 @@
                       <node concept="37vLTw" id="1gw9pCYi9uJ" role="37wK5m">
                         <ref role="3cqZAo" node="1gw9pCYi7yL" resolve="msg" />
                       </node>
-                      <node concept="10M0yZ" id="1gw9pCYm4un" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <node concept="2ShNRf" id="3frJLkO_yfH" role="37wK5m">
+                        <node concept="1pGfFk" id="3frJLkO_zhz" role="2ShVmc">
+                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                          <node concept="10M0yZ" id="1gw9pCYm4un" role="37wK5m">
+                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          </node>
+                          <node concept="10M0yZ" id="3frJLkO_$bX" role="37wK5m">
+                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          </node>
+                        </node>
                       </node>
                       <node concept="10Nm6u" id="1gw9pCYhyrX" role="37wK5m" />
                     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
@@ -2603,18 +2603,9 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="2ShNRf" id="3frJLkO_pWk" role="3K4E3e">
-                    <node concept="1pGfFk" id="3frJLkO_qIT" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="3frJLkO_qSi" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="3frJLkO_r6f" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.red" resolve="red" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wgk9D8" role="3K4E3e">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.red" resolve="red" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -4754,18 +4745,9 @@
           <node concept="3sjG9q" id="3yVmeSjvwat" role="3tD6jU">
             <node concept="3clFbS" id="3yVmeSjvwau" role="2VODD2">
               <node concept="3clFbF" id="3yVmeSjvwav" role="3cqZAp">
-                <node concept="2ShNRf" id="3frJLkO_sFR" role="3clFbG">
-                  <node concept="1pGfFk" id="3frJLkO_tnr" role="2ShVmc">
-                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                    <node concept="10M0yZ" id="3yVmeSjvwaw" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                    </node>
-                    <node concept="10M0yZ" id="3frJLkO_tst" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                    </node>
-                  </node>
+                <node concept="10M0yZ" id="38mO9wgkae0" role="3clFbG">
+                  <ref role="3cqZAo" to="lzb2:~JBColor.darkGray" resolve="darkGray" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                 </node>
               </node>
             </node>
@@ -4833,18 +4815,9 @@
           <node concept="3sjG9q" id="3yVmeSjvw_w" role="3tD6jU">
             <node concept="3clFbS" id="3yVmeSjvw_x" role="2VODD2">
               <node concept="3clFbF" id="3yVmeSjvw_y" role="3cqZAp">
-                <node concept="2ShNRf" id="3frJLkO_uL9" role="3clFbG">
-                  <node concept="1pGfFk" id="3frJLkO_vtC" role="2ShVmc">
-                    <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                    <node concept="10M0yZ" id="3yVmeSjvw_z" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                    </node>
-                    <node concept="10M0yZ" id="3frJLkO_vDs" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.darkGray" resolve="darkGray" />
-                    </node>
-                  </node>
+                <node concept="10M0yZ" id="38mO9wgkatf" role="3clFbG">
+                  <ref role="3cqZAo" to="lzb2:~JBColor.darkGray" resolve="darkGray" />
+                  <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                 </node>
               </node>
             </node>
@@ -6694,18 +6667,9 @@
                       <node concept="37vLTw" id="1gw9pCYi9uJ" role="37wK5m">
                         <ref role="3cqZAo" node="1gw9pCYi7yL" resolve="msg" />
                       </node>
-                      <node concept="2ShNRf" id="3frJLkO_yfH" role="37wK5m">
-                        <node concept="1pGfFk" id="3frJLkO_zhz" role="2ShVmc">
-                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                          <node concept="10M0yZ" id="1gw9pCYm4un" role="37wK5m">
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          </node>
-                          <node concept="10M0yZ" id="3frJLkO_$bX" role="37wK5m">
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          </node>
-                        </node>
+                      <node concept="10M0yZ" id="38mO9wgkbR_" role="37wK5m">
+                        <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                       </node>
                       <node concept="10Nm6u" id="1gw9pCYhyrX" role="37wK5m" />
                     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -26,21 +26,21 @@
     <import index="r4b4" ref="r:1784e088-20fd-4fdb-96b8-bc57f0056d94(com.mbeddr.core.base.editor)" />
     <import index="oq0c" ref="r:6c6155f0-4bbe-4af5-8c26-244d570e21e4(org.iets3.core.expr.base.plugin)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="buwp" ref="r:8405f486-53b5-4fe6-af3e-7f68358bd631(org.iets3.core.expr.base.editor)" />
     <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="q4oi" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellActions(MPS.Editor/)" />
+    <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
+    <import index="av1m" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.menus.style(MPS.Editor/)" />
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
     <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
-    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" />
     <import index="z0fb" ref="r:0b928dd6-dd7e-45a8-b309-a2e315b7877a(de.itemis.mps.editor.celllayout.styles.editor)" />
-    <import index="q4oi" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellActions(MPS.Editor/)" />
+    <import index="fulz" ref="r:6f792c44-2a5d-40e8-9f05-33f7d4ae26ec(jetbrains.mps.editor.runtime.completion)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
-    <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
-    <import index="av1m" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.menus.style(MPS.Editor/)" />
-    <import index="fulz" ref="r:6f792c44-2a5d-40e8-9f05-33f7d4ae26ec(jetbrains.mps.editor.runtime.completion)" />
-    <import index="buwp" ref="r:8405f486-53b5-4fe6-af3e-7f68358bd631(org.iets3.core.expr.base.editor)" />
     <import index="i6kd" ref="r:2261c766-d7b6-49d7-91bd-1207e471af0b(org.iets3.core.expr.lambda.editor)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
@@ -2705,9 +2705,18 @@
                 <node concept="1pGfFk" id="4tXyFaWwzSe" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakvelx" resolve="HorizLineCell" />
                   <node concept="pncrf" id="4tXyFaWwzSS" role="37wK5m" />
-                  <node concept="10M0yZ" id="4tXyFaWw$6n" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                  <node concept="2ShNRf" id="3frJLkOz53a" role="37wK5m">
+                    <node concept="1pGfFk" id="3frJLkOz5NG" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="4tXyFaWw$6n" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                      </node>
+                      <node concept="10M0yZ" id="3frJLkOz68f" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                   <node concept="3cmrfG" id="4tXyFaWw$bx" role="37wK5m">
                     <property role="3cmrfH" value="2" />
@@ -4923,6 +4932,13 @@
       <ref role="3uigEE" to="r4b4:4QhMqW2TcDm" resolve="AbstractBracketCell" />
     </node>
   </node>
+  <node concept="24kQdi" id="wlV$3lAU9R">
+    <property role="3GE5qa" value="enum" />
+    <ref role="1XX52x" to="yv47:wlV$3kt3Ry" resolve="AbstractEnumSortOrder" />
+    <node concept="PMmxH" id="6ww1tcsEGJG" role="2wV5jI">
+      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+    </node>
+  </node>
   <node concept="3dRTYf" id="6wzrxL3ayZ9">
     <property role="TrG5h" value="prioritizeEnum" />
     <node concept="3Tm1VV" id="6wzrxL3ayZa" role="1B3o_S" />
@@ -4955,13 +4971,6 @@
           <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
         </node>
       </node>
-    </node>
-  </node>
-  <node concept="24kQdi" id="wlV$3lAU9R">
-    <property role="3GE5qa" value="enum" />
-    <ref role="1XX52x" to="yv47:wlV$3kt3Ry" resolve="AbstractEnumSortOrder" />
-    <node concept="PMmxH" id="6ww1tcsEGJG" role="2wV5jI">
-      <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -29,6 +29,7 @@
     <import index="buwp" ref="r:8405f486-53b5-4fe6-af3e-7f68358bd631(org.iets3.core.expr.base.editor)" />
     <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="q4oi" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellActions(MPS.Editor/)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
@@ -39,7 +40,6 @@
     <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" />
     <import index="z0fb" ref="r:0b928dd6-dd7e-45a8-b309-a2e315b7877a(de.itemis.mps.editor.celllayout.styles.editor)" />
     <import index="fulz" ref="r:6f792c44-2a5d-40e8-9f05-33f7d4ae26ec(jetbrains.mps.editor.runtime.completion)" />
-    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
     <import index="i6kd" ref="r:2261c766-d7b6-49d7-91bd-1207e471af0b(org.iets3.core.expr.lambda.editor)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
@@ -2705,18 +2705,9 @@
                 <node concept="1pGfFk" id="4tXyFaWwzSe" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakvelx" resolve="HorizLineCell" />
                   <node concept="pncrf" id="4tXyFaWwzSS" role="37wK5m" />
-                  <node concept="2ShNRf" id="3frJLkOz53a" role="37wK5m">
-                    <node concept="1pGfFk" id="3frJLkOz5NG" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="4tXyFaWw$6n" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
-                      </node>
-                      <node concept="10M0yZ" id="3frJLkOz68f" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wghesq" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                   <node concept="3cmrfG" id="4tXyFaWw$bx" role="37wK5m">
                     <property role="3cmrfH" value="2" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tracing/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tracing/models/editor.mps
@@ -24,6 +24,7 @@
     <import index="pu3r" ref="r:9e94dd0f-9221-4302-af65-0a889986fe22(com.mbeddr.mpsutil.traceExplorer.plugin)" />
     <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
     <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="epcs" ref="b33d119e-196d-4497-977c-5c167b21fe33/r:b7f325a3-1f57-46bc-8b14-d2d7c5ff6714(com.mbeddr.mpsutil.framecell/com.mbeddr.mpsutil.framecell.editor)" implicit="true" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
@@ -152,6 +153,9 @@
       <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
         <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
       </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
@@ -235,6 +239,7 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
@@ -535,9 +540,18 @@
             <node concept="3ZlJ5R" id="7cNsFS_gJvf" role="VblUZ">
               <node concept="3clFbS" id="7cNsFS_gJvg" role="2VODD2">
                 <node concept="3clFbF" id="YcTL0w_x7" role="3cqZAp">
-                  <node concept="10M0yZ" id="5U8d23Qo_d5" role="3clFbG">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                  <node concept="2ShNRf" id="1O3benwqO7m" role="3clFbG">
+                    <node concept="1pGfFk" id="1O3benwqOPA" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="1O3benwqOUy" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="1O3benwqP19" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -623,9 +637,18 @@
             <node concept="3ZlJ5R" id="5U8d23Qpo46" role="VblUZ">
               <node concept="3clFbS" id="5U8d23Qpo47" role="2VODD2">
                 <node concept="3clFbF" id="5U8d23Qpo48" role="3cqZAp">
-                  <node concept="10M0yZ" id="5U8d23QpwrX" role="3clFbG">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <node concept="2ShNRf" id="1O3benwqP6D" role="3clFbG">
+                    <node concept="1pGfFk" id="1O3benwqPLb" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="5U8d23QpwrX" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                      </node>
+                      <node concept="10M0yZ" id="1O3benwqPWN" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -676,9 +699,18 @@
             <node concept="3ZlJ5R" id="5U8d23Qpo4v" role="VblUZ">
               <node concept="3clFbS" id="5U8d23Qpo4w" role="2VODD2">
                 <node concept="3clFbF" id="5U8d23Qpo4x" role="3cqZAp">
-                  <node concept="10M0yZ" id="5U8d23Qpo4y" role="3clFbG">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                  <node concept="2ShNRf" id="1O3benwqPZx" role="3clFbG">
+                    <node concept="1pGfFk" id="1O3benwqQHx" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="1O3benwqQMu" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="1O3benwqQU3" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -1479,13 +1511,26 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="2CFPPn7q67s" role="3cqZAp">
-          <node concept="AH0OO" id="2CFPPn7q6wI" role="3clFbG">
-            <node concept="37vLTw" id="2CFPPn7q6zc" role="AHEQo">
-              <ref role="3cqZAo" node="2CFPPn7pZru" resolve="s" />
-            </node>
-            <node concept="37vLTw" id="2CFPPn7q67q" role="AHHXb">
-              <ref role="3cqZAo" node="2CFPPn7pTKI" resolve="darkColors" />
+        <node concept="3clFbF" id="1O3benwqS0g" role="3cqZAp">
+          <node concept="2ShNRf" id="1O3benwqS0c" role="3clFbG">
+            <node concept="1pGfFk" id="1O3benwqSWA" role="2ShVmc">
+              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+              <node concept="AH0OO" id="1O3benwqTtu" role="37wK5m">
+                <node concept="37vLTw" id="1O3benwqTFR" role="AHEQo">
+                  <ref role="3cqZAo" node="2CFPPn7pZru" resolve="s" />
+                </node>
+                <node concept="37vLTw" id="1O3benwqT9N" role="AHHXb">
+                  <ref role="3cqZAo" node="2CFPPn7pTKI" resolve="darkColors" />
+                </node>
+              </node>
+              <node concept="AH0OO" id="1O3benwqUrU" role="37wK5m">
+                <node concept="37vLTw" id="1O3benwqUE_" role="AHEQo">
+                  <ref role="3cqZAo" node="2CFPPn7pZru" resolve="s" />
+                </node>
+                <node concept="37vLTw" id="1O3benwqU8q" role="AHHXb">
+                  <ref role="3cqZAo" node="5U8d23Qtb3T" resolve="brightColors" />
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1579,13 +1624,26 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="5U8d23QtcdU" role="3cqZAp">
-          <node concept="AH0OO" id="5U8d23QtcdV" role="3clFbG">
-            <node concept="37vLTw" id="5U8d23QtcdW" role="AHEQo">
-              <ref role="3cqZAo" node="5U8d23Qtcd$" resolve="s" />
-            </node>
-            <node concept="37vLTw" id="5U8d23Qtdhy" role="AHHXb">
-              <ref role="3cqZAo" node="5U8d23Qtb3T" resolve="brightColors" />
+        <node concept="3clFbF" id="1O3benwqVwH" role="3cqZAp">
+          <node concept="2ShNRf" id="1O3benwqVwD" role="3clFbG">
+            <node concept="1pGfFk" id="1O3benwqWrT" role="2ShVmc">
+              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+              <node concept="AH0OO" id="1O3benwqWVo" role="37wK5m">
+                <node concept="37vLTw" id="1O3benwqX8c" role="AHEQo">
+                  <ref role="3cqZAo" node="5U8d23Qtcd$" resolve="s" />
+                </node>
+                <node concept="37vLTw" id="1O3benwqWC0" role="AHHXb">
+                  <ref role="3cqZAo" node="5U8d23Qtb3T" resolve="brightColors" />
+                </node>
+              </node>
+              <node concept="AH0OO" id="1O3benwqXLD" role="37wK5m">
+                <node concept="37vLTw" id="1O3benwqXZS" role="AHEQo">
+                  <ref role="3cqZAo" node="5U8d23Qtcd$" resolve="s" />
+                </node>
+                <node concept="37vLTw" id="1O3benwqXvo" role="AHHXb">
+                  <ref role="3cqZAo" node="2CFPPn7pTKI" resolve="darkColors" />
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -1690,11 +1748,30 @@
             <node concept="3clFbJ" id="7IhZGc$Akj5" role="3cqZAp">
               <node concept="3clFbS" id="7IhZGc$Akj6" role="3clFbx">
                 <node concept="3cpWs6" id="7IhZGc$Akj7" role="3cqZAp">
-                  <node concept="2YIFZM" id="7IhZGc$AkMZ" role="3cqZAk">
-                    <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                    <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                    <node concept="Xl_RD" id="7IhZGc$Al1D" role="37wK5m">
-                      <property role="Xl_RC" value="#C4F0FF" />
+                  <node concept="2ShNRf" id="1O3benwqxMR" role="3cqZAk">
+                    <node concept="1pGfFk" id="1O3benwqyEt" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="2YIFZM" id="7IhZGc$AkMZ" role="37wK5m">
+                        <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                        <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                        <node concept="Xl_RD" id="7IhZGc$Al1D" role="37wK5m">
+                          <property role="Xl_RC" value="#C4F0FF" />
+                        </node>
+                      </node>
+                      <node concept="2ShNRf" id="1O3benwqzcz" role="37wK5m">
+                        <node concept="1pGfFk" id="1O3benwq_hY" role="2ShVmc">
+                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                          <node concept="3cmrfG" id="1O3benwq__U" role="37wK5m">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="3cmrfG" id="1O3benwqAE5" role="37wK5m">
+                            <property role="3cmrfH" value="96" />
+                          </node>
+                          <node concept="3cmrfG" id="1O3benwqBbU" role="37wK5m">
+                            <property role="3cmrfH" value="128" />
+                          </node>
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -1734,11 +1811,30 @@
             <node concept="3clFbJ" id="5U8d23QfXe2" role="3cqZAp">
               <node concept="3clFbS" id="5U8d23QfXe4" role="3clFbx">
                 <node concept="3cpWs6" id="5U8d23QfXS4" role="3cqZAp">
-                  <node concept="2YIFZM" id="7IhZGc$AmEZ" role="3cqZAk">
-                    <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                    <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                    <node concept="Xl_RD" id="7IhZGc$AmTy" role="37wK5m">
-                      <property role="Xl_RC" value="#D2FFC4" />
+                  <node concept="2ShNRf" id="1O3benwqCfR" role="3cqZAk">
+                    <node concept="1pGfFk" id="1O3benwqD9t" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="2YIFZM" id="7IhZGc$AmEZ" role="37wK5m">
+                        <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                        <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                        <node concept="Xl_RD" id="7IhZGc$AmTy" role="37wK5m">
+                          <property role="Xl_RC" value="#D2FFC4" />
+                        </node>
+                      </node>
+                      <node concept="2ShNRf" id="1O3benwqDIm" role="37wK5m">
+                        <node concept="1pGfFk" id="1O3benwqFTc" role="2ShVmc">
+                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                          <node concept="3cmrfG" id="1O3benwqGfg" role="37wK5m">
+                            <property role="3cmrfH" value="18" />
+                          </node>
+                          <node concept="3cmrfG" id="1O3benwqGXY" role="37wK5m">
+                            <property role="3cmrfH" value="77" />
+                          </node>
+                          <node concept="3cmrfG" id="1O3benwqHuN" role="37wK5m">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -1753,11 +1849,30 @@
             <node concept="3clFbJ" id="5U8d23QlKcc" role="3cqZAp">
               <node concept="3clFbS" id="5U8d23QlKce" role="3clFbx">
                 <node concept="3cpWs6" id="5U8d23QlSt$" role="3cqZAp">
-                  <node concept="2YIFZM" id="7IhZGc$AogA" role="3cqZAk">
-                    <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                    <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                    <node concept="Xl_RD" id="7IhZGc$Aov1" role="37wK5m">
-                      <property role="Xl_RC" value="#FFD3C4" />
+                  <node concept="2ShNRf" id="1O3benwqI_G" role="3cqZAk">
+                    <node concept="1pGfFk" id="1O3benwqJxg" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="2YIFZM" id="7IhZGc$AogA" role="37wK5m">
+                        <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                        <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                        <node concept="Xl_RD" id="7IhZGc$Aov1" role="37wK5m">
+                          <property role="Xl_RC" value="#FFD3C4" />
+                        </node>
+                      </node>
+                      <node concept="2ShNRf" id="1O3benwqK8L" role="37wK5m">
+                        <node concept="1pGfFk" id="1O3benwqL4y" role="2ShVmc">
+                          <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                          <node concept="3cmrfG" id="1O3benwqLrU" role="37wK5m">
+                            <property role="3cmrfH" value="77" />
+                          </node>
+                          <node concept="3cmrfG" id="1O3benwqLNq" role="37wK5m">
+                            <property role="3cmrfH" value="19" />
+                          </node>
+                          <node concept="3cmrfG" id="1O3benwqMKP" role="37wK5m">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/editor.mps
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:da55d8c4-8189-4ee0-9cbe-92f7143eed21(org.iets3.core.expr.util.editor)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells" version="2" />
     <use id="7e450f4e-1ac3-41ef-a851-4598161bdb94" name="de.slisson.mps.tables" version="0" />
-    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
     <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
@@ -40,6 +41,7 @@
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="5ueo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.style(MPS.Editor/)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="m999" ref="r:1d6bd88a-7393-4b32-b0e6-2d8b3094776e(org.iets3.core.expr.toplevel.editor)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
@@ -1670,9 +1672,18 @@
             <node concept="3sjG9q" id="3xnKElDuR_g" role="3tD6jU">
               <node concept="3clFbS" id="3xnKElDuR_h" role="2VODD2">
                 <node concept="3clFbF" id="3xnKElDuRD1" role="3cqZAp">
-                  <node concept="10M0yZ" id="3xnKElDuRDs" role="3clFbG">
-                    <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <node concept="2ShNRf" id="3frJLkOk5Xs" role="3clFbG">
+                    <node concept="1pGfFk" id="3frJLkOk6Gm" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="3xnKElDuRDs" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                      </node>
+                      <node concept="10M0yZ" id="3frJLkOk6Ld" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -1942,9 +1953,18 @@
                 <node concept="3clFbJ" id="wW2kvIoIrH" role="3cqZAp">
                   <node concept="3clFbS" id="wW2kvIoIrI" role="3clFbx">
                     <node concept="3cpWs6" id="wW2kvIoI$f" role="3cqZAp">
-                      <node concept="10M0yZ" id="wW2kvIoIAM" role="3cqZAk">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.blue" resolve="blue" />
+                      <node concept="2ShNRf" id="3frJLkOk756" role="3cqZAk">
+                        <node concept="1pGfFk" id="3frJLkOk7VV" role="2ShVmc">
+                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                          <node concept="10M0yZ" id="wW2kvIoIAM" role="37wK5m">
+                            <ref role="3cqZAo" to="z60i:~Color.blue" resolve="blue" />
+                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          </node>
+                          <node concept="10M0yZ" id="3frJLkOk873" role="37wK5m">
+                            <ref role="3cqZAo" to="z60i:~Color.blue" resolve="blue" />
+                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -1956,9 +1976,18 @@
                   </node>
                 </node>
                 <node concept="3cpWs6" id="wW2kvIoIFj" role="3cqZAp">
-                  <node concept="10M0yZ" id="wW2kvIoIGr" role="3cqZAk">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                  <node concept="2ShNRf" id="3frJLkOk8b1" role="3cqZAk">
+                    <node concept="1pGfFk" id="3frJLkOk93y" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="wW2kvIoIGr" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                      </node>
+                      <node concept="10M0yZ" id="3frJLkOk9tE" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -2069,9 +2098,18 @@
               <node concept="3sjG9q" id="3xnKElDwbyY" role="3tD6jU">
                 <node concept="3clFbS" id="3xnKElDwbyZ" role="2VODD2">
                   <node concept="3clFbF" id="3xnKElDwbz0" role="3cqZAp">
-                    <node concept="10M0yZ" id="3xnKElDwbz1" role="3clFbG">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                    <node concept="2ShNRf" id="3frJLkOlOCP" role="3clFbG">
+                      <node concept="1pGfFk" id="3frJLkOlPn3" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="10M0yZ" id="3xnKElDwbz1" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                        <node concept="10M0yZ" id="3frJLkOlPsG" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -2329,17 +2367,36 @@
               <node concept="3sjG9q" id="8XWEtergfg" role="3tD6jU">
                 <node concept="3clFbS" id="8XWEtergfh" role="2VODD2">
                   <node concept="3cpWs6" id="8XWEteq8I6" role="3cqZAp">
-                    <node concept="2ShNRf" id="8XWEteq8I7" role="3cqZAk">
-                      <node concept="1pGfFk" id="8XWEteq8I8" role="2ShVmc">
-                        <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                        <node concept="3cmrfG" id="8XWEteq8I9" role="37wK5m">
-                          <property role="3cmrfH" value="220" />
+                    <node concept="2ShNRf" id="3frJLkOirLF" role="3cqZAk">
+                      <node concept="1pGfFk" id="3frJLkOisw1" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="2ShNRf" id="8XWEteq8I7" role="37wK5m">
+                          <node concept="1pGfFk" id="8XWEteq8I8" role="2ShVmc">
+                            <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                            <node concept="3cmrfG" id="8XWEteq8I9" role="37wK5m">
+                              <property role="3cmrfH" value="220" />
+                            </node>
+                            <node concept="3cmrfG" id="8XWEteq8Ia" role="37wK5m">
+                              <property role="3cmrfH" value="220" />
+                            </node>
+                            <node concept="3cmrfG" id="8XWEteq8Ib" role="37wK5m">
+                              <property role="3cmrfH" value="220" />
+                            </node>
+                          </node>
                         </node>
-                        <node concept="3cmrfG" id="8XWEteq8Ia" role="37wK5m">
-                          <property role="3cmrfH" value="220" />
-                        </node>
-                        <node concept="3cmrfG" id="8XWEteq8Ib" role="37wK5m">
-                          <property role="3cmrfH" value="220" />
+                        <node concept="2ShNRf" id="3frJLkOisCO" role="37wK5m">
+                          <node concept="1pGfFk" id="3frJLkOitpl" role="2ShVmc">
+                            <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                            <node concept="3cmrfG" id="3frJLkOitvX" role="37wK5m">
+                              <property role="3cmrfH" value="30" />
+                            </node>
+                            <node concept="3cmrfG" id="3frJLkOitwa" role="37wK5m">
+                              <property role="3cmrfH" value="30" />
+                            </node>
+                            <node concept="3cmrfG" id="3frJLkOitxB" role="37wK5m">
+                              <property role="3cmrfH" value="30" />
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -2690,9 +2747,18 @@
         <node concept="3sjG9q" id="8XWEteklS3" role="3tD6jU">
           <node concept="3clFbS" id="8XWEteklS4" role="2VODD2">
             <node concept="3clFbF" id="8XWEteklS5" role="3cqZAp">
-              <node concept="10M0yZ" id="8XWEteklS6" role="3clFbG">
-                <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+              <node concept="2ShNRf" id="3frJLkOrGZh" role="3clFbG">
+                <node concept="1pGfFk" id="3frJLkOrGZi" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="10M0yZ" id="3frJLkOrGZj" role="37wK5m">
+                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  </node>
+                  <node concept="10M0yZ" id="3frJLkOrGZk" role="37wK5m">
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -2852,10 +2918,19 @@
         <ref role="3tD7wE" to="reoo:5PDTdguqQlF" resolve="border-left-color" />
         <node concept="3sjG9q" id="8XWEtekp37" role="3tD6jU">
           <node concept="3clFbS" id="8XWEtekp38" role="2VODD2">
-            <node concept="3clFbF" id="8XWEtekp39" role="3cqZAp">
-              <node concept="10M0yZ" id="8XWEtekp3a" role="3clFbG">
-                <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+            <node concept="3clFbF" id="3frJLkOgHZx" role="3cqZAp">
+              <node concept="2ShNRf" id="3frJLkOgHZv" role="3clFbG">
+                <node concept="1pGfFk" id="3frJLkOgK6n" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="10M0yZ" id="8XWEtekp3a" role="37wK5m">
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                  </node>
+                  <node concept="10M0yZ" id="3frJLkOgKrm" role="37wK5m">
+                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -3803,10 +3878,19 @@
         <ref role="3tD7wE" to="reoo:5PDTdguqQlF" resolve="border-left-color" />
         <node concept="3sjG9q" id="2U$lnbPo52t" role="3tD6jU">
           <node concept="3clFbS" id="2U$lnbPo52u" role="2VODD2">
-            <node concept="3clFbF" id="2U$lnbPo52v" role="3cqZAp">
-              <node concept="10M0yZ" id="2U$lnbPo52w" role="3clFbG">
-                <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+            <node concept="3clFbF" id="3frJLkOq2Du" role="3cqZAp">
+              <node concept="2ShNRf" id="3frJLkOq2Ds" role="3clFbG">
+                <node concept="1pGfFk" id="3frJLkOq3rb" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="10M0yZ" id="2U$lnbPo52w" role="37wK5m">
+                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  </node>
+                  <node concept="10M0yZ" id="3frJLkOq3KO" role="37wK5m">
+                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/editor.mps
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:da55d8c4-8189-4ee0-9cbe-92f7143eed21(org.iets3.core.expr.util.editor)">
   <persistence version="9" />
-  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells" version="2" />
@@ -173,6 +172,7 @@
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
+      <concept id="1176809959526" name="jetbrains.mps.lang.editor.structure.QueryFunction_Color" flags="in" index="3ZlJ5R" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
@@ -1445,9 +1445,30 @@
         </node>
         <node concept="3EZMnI" id="Nuz63eZ7ps" role="3EZMnx">
           <node concept="Veino" id="Nuz63f4PTA" role="3F10Kt">
-            <property role="Vb096" value="fLJRk5A/lightGray" />
-            <node concept="1iSF2X" id="Nuz63fa$af" role="VblUZ">
-              <property role="1iTho6" value="DDDDDD" />
+            <node concept="3ZlJ5R" id="38mO9wgafOO" role="VblUZ">
+              <node concept="3clFbS" id="38mO9wgafOP" role="2VODD2">
+                <node concept="3clFbF" id="38mO9wgdVpr" role="3cqZAp">
+                  <node concept="2ShNRf" id="38mO9wgdVps" role="3clFbG">
+                    <node concept="1pGfFk" id="38mO9wgdVpt" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="2YIFZM" id="38mO9wgdVpu" role="37wK5m">
+                        <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                        <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                        <node concept="Xl_RD" id="38mO9wgdVpv" role="37wK5m">
+                          <property role="Xl_RC" value="#dddddd" />
+                        </node>
+                      </node>
+                      <node concept="2YIFZM" id="38mO9wgdVpw" role="37wK5m">
+                        <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                        <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                        <node concept="Xl_RD" id="38mO9wgdVpx" role="37wK5m">
+                          <property role="Xl_RC" value="#1a1a1a" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
           <node concept="2iRfu4" id="Nuz63eZ7pt" role="2iSdaV" />
@@ -1495,9 +1516,30 @@
         </node>
         <node concept="3EZMnI" id="Nuz63f5Uhv" role="3EZMnx">
           <node concept="Veino" id="Nuz63f4Q5B" role="3F10Kt">
-            <property role="Vb096" value="fLJRk5A/lightGray" />
-            <node concept="1iSF2X" id="Nuz63fa$ah" role="VblUZ">
-              <property role="1iTho6" value="DDDDDD" />
+            <node concept="3ZlJ5R" id="38mO9wgcuaS" role="VblUZ">
+              <node concept="3clFbS" id="38mO9wgcuaT" role="2VODD2">
+                <node concept="3clFbF" id="38mO9wgcueI" role="3cqZAp">
+                  <node concept="2ShNRf" id="38mO9wgdDan" role="3clFbG">
+                    <node concept="1pGfFk" id="38mO9wgdUea" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="2YIFZM" id="38mO9wgdUtu" role="37wK5m">
+                        <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                        <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                        <node concept="Xl_RD" id="38mO9wgdUwo" role="37wK5m">
+                          <property role="Xl_RC" value="#dddddd" />
+                        </node>
+                      </node>
+                      <node concept="2YIFZM" id="38mO9wgdUXg" role="37wK5m">
+                        <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                        <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                        <node concept="Xl_RD" id="38mO9wgdV3m" role="37wK5m">
+                          <property role="Xl_RC" value="#1a1a1a" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
           <node concept="2iRfu4" id="Nuz63f5Uhw" role="2iSdaV" />
@@ -1672,18 +1714,9 @@
             <node concept="3sjG9q" id="3xnKElDuR_g" role="3tD6jU">
               <node concept="3clFbS" id="3xnKElDuR_h" role="2VODD2">
                 <node concept="3clFbF" id="3xnKElDuRD1" role="3cqZAp">
-                  <node concept="2ShNRf" id="3frJLkOk5Xs" role="3clFbG">
-                    <node concept="1pGfFk" id="3frJLkOk6Gm" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="3xnKElDuRDs" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                      </node>
-                      <node concept="10M0yZ" id="3frJLkOk6Ld" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wg87Mi" role="3clFbG">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -1953,18 +1986,9 @@
                 <node concept="3clFbJ" id="wW2kvIoIrH" role="3cqZAp">
                   <node concept="3clFbS" id="wW2kvIoIrI" role="3clFbx">
                     <node concept="3cpWs6" id="wW2kvIoI$f" role="3cqZAp">
-                      <node concept="2ShNRf" id="3frJLkOk756" role="3cqZAk">
-                        <node concept="1pGfFk" id="3frJLkOk7VV" role="2ShVmc">
-                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                          <node concept="10M0yZ" id="wW2kvIoIAM" role="37wK5m">
-                            <ref role="3cqZAo" to="z60i:~Color.blue" resolve="blue" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          </node>
-                          <node concept="10M0yZ" id="3frJLkOk873" role="37wK5m">
-                            <ref role="3cqZAo" to="z60i:~Color.blue" resolve="blue" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          </node>
-                        </node>
+                      <node concept="10M0yZ" id="38mO9wg881X" role="3cqZAk">
+                        <ref role="3cqZAo" to="lzb2:~JBColor.blue" resolve="blue" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                       </node>
                     </node>
                   </node>
@@ -1976,18 +2000,9 @@
                   </node>
                 </node>
                 <node concept="3cpWs6" id="wW2kvIoIFj" role="3cqZAp">
-                  <node concept="2ShNRf" id="3frJLkOk8b1" role="3cqZAk">
-                    <node concept="1pGfFk" id="3frJLkOk93y" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="wW2kvIoIGr" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                      </node>
-                      <node concept="10M0yZ" id="3frJLkOk9tE" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wg88cT" role="3cqZAk">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -2098,18 +2113,9 @@
               <node concept="3sjG9q" id="3xnKElDwbyY" role="3tD6jU">
                 <node concept="3clFbS" id="3xnKElDwbyZ" role="2VODD2">
                   <node concept="3clFbF" id="3xnKElDwbz0" role="3cqZAp">
-                    <node concept="2ShNRf" id="3frJLkOlOCP" role="3clFbG">
-                      <node concept="1pGfFk" id="3frJLkOlPn3" role="2ShVmc">
-                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                        <node concept="10M0yZ" id="3xnKElDwbz1" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                        <node concept="10M0yZ" id="3frJLkOlPsG" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="38mO9wg88lI" role="3clFbG">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                   </node>
                 </node>
@@ -2747,18 +2753,9 @@
         <node concept="3sjG9q" id="8XWEteklS3" role="3tD6jU">
           <node concept="3clFbS" id="8XWEteklS4" role="2VODD2">
             <node concept="3clFbF" id="8XWEteklS5" role="3cqZAp">
-              <node concept="2ShNRf" id="3frJLkOrGZh" role="3clFbG">
-                <node concept="1pGfFk" id="3frJLkOrGZi" role="2ShVmc">
-                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                  <node concept="10M0yZ" id="3frJLkOrGZj" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  </node>
-                  <node concept="10M0yZ" id="3frJLkOrGZk" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                  </node>
-                </node>
+              <node concept="10M0yZ" id="38mO9wg89jp" role="3clFbG">
+                <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
               </node>
             </node>
           </node>
@@ -2918,19 +2915,10 @@
         <ref role="3tD7wE" to="reoo:5PDTdguqQlF" resolve="border-left-color" />
         <node concept="3sjG9q" id="8XWEtekp37" role="3tD6jU">
           <node concept="3clFbS" id="8XWEtekp38" role="2VODD2">
-            <node concept="3clFbF" id="3frJLkOgHZx" role="3cqZAp">
-              <node concept="2ShNRf" id="3frJLkOgHZv" role="3clFbG">
-                <node concept="1pGfFk" id="3frJLkOgK6n" role="2ShVmc">
-                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                  <node concept="10M0yZ" id="8XWEtekp3a" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                  </node>
-                  <node concept="10M0yZ" id="3frJLkOgKrm" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  </node>
-                </node>
+            <node concept="3clFbF" id="38mO9wg83Im" role="3cqZAp">
+              <node concept="10M0yZ" id="38mO9wg83Mf" role="3clFbG">
+                <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
               </node>
             </node>
           </node>
@@ -3879,18 +3867,9 @@
         <node concept="3sjG9q" id="2U$lnbPo52t" role="3tD6jU">
           <node concept="3clFbS" id="2U$lnbPo52u" role="2VODD2">
             <node concept="3clFbF" id="3frJLkOq2Du" role="3cqZAp">
-              <node concept="2ShNRf" id="3frJLkOq2Ds" role="3clFbG">
-                <node concept="1pGfFk" id="3frJLkOq3rb" role="2ShVmc">
-                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                  <node concept="10M0yZ" id="2U$lnbPo52w" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  </node>
-                  <node concept="10M0yZ" id="3frJLkOq3KO" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  </node>
-                </node>
+              <node concept="10M0yZ" id="38mO9wg88OS" role="3clFbG">
+                <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.trace/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.trace/models/behavior.mps
@@ -11,6 +11,7 @@
     <import index="soq7" ref="r:4d48d56b-d670-4e5b-a763-2232bb0c4f2d(org.iets3.core.attributes.behavior)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -88,7 +89,9 @@
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
@@ -197,9 +200,28 @@
       <node concept="3Tm1VV" id="mhbzaHl1pv" role="1B3o_S" />
       <node concept="3clFbS" id="mhbzaHl1p$" role="3clF47">
         <node concept="3clFbF" id="mhbzaHl1pD" role="3cqZAp">
-          <node concept="10M0yZ" id="mhbzaHl1zU" role="3clFbG">
-            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-            <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
+          <node concept="2ShNRf" id="3frJLkOg9A8" role="3clFbG">
+            <node concept="1pGfFk" id="3frJLkOgaeq" role="2ShVmc">
+              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+              <node concept="10M0yZ" id="mhbzaHl1zU" role="37wK5m">
+                <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
+                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+              </node>
+              <node concept="2ShNRf" id="3frJLkOguwM" role="37wK5m">
+                <node concept="1pGfFk" id="3frJLkOguYH" role="2ShVmc">
+                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                  <node concept="3cmrfG" id="3frJLkOg_Lo" role="37wK5m">
+                    <property role="3cmrfH" value="0" />
+                  </node>
+                  <node concept="3cmrfG" id="3frJLkOgvit" role="37wK5m">
+                    <property role="3cmrfH" value="102" />
+                  </node>
+                  <node concept="3cmrfG" id="3frJLkOg_S1" role="37wK5m">
+                    <property role="3cmrfH" value="255" />
+                  </node>
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.trace/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.trace/models/behavior.mps
@@ -89,9 +89,7 @@
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
-        <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
@@ -199,29 +197,10 @@
       <ref role="13i0hy" to="soq7:4A8SzOVam5R" resolve="summaryColor" />
       <node concept="3Tm1VV" id="mhbzaHl1pv" role="1B3o_S" />
       <node concept="3clFbS" id="mhbzaHl1p$" role="3clF47">
-        <node concept="3clFbF" id="mhbzaHl1pD" role="3cqZAp">
-          <node concept="2ShNRf" id="3frJLkOg9A8" role="3clFbG">
-            <node concept="1pGfFk" id="3frJLkOgaeq" role="2ShVmc">
-              <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-              <node concept="10M0yZ" id="mhbzaHl1zU" role="37wK5m">
-                <ref role="3cqZAo" to="z60i:~Color.BLUE" resolve="BLUE" />
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-              </node>
-              <node concept="2ShNRf" id="3frJLkOguwM" role="37wK5m">
-                <node concept="1pGfFk" id="3frJLkOguYH" role="2ShVmc">
-                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                  <node concept="3cmrfG" id="3frJLkOg_Lo" role="37wK5m">
-                    <property role="3cmrfH" value="0" />
-                  </node>
-                  <node concept="3cmrfG" id="3frJLkOgvit" role="37wK5m">
-                    <property role="3cmrfH" value="102" />
-                  </node>
-                  <node concept="3cmrfG" id="3frJLkOg_S1" role="37wK5m">
-                    <property role="3cmrfH" value="255" />
-                  </node>
-                </node>
-              </node>
-            </node>
+        <node concept="3clFbF" id="38mO9wg7OU6" role="3cqZAp">
+          <node concept="10M0yZ" id="38mO9wg7OWv" role="3clFbG">
+            <ref role="3cqZAo" to="lzb2:~JBColor.blue" resolve="blue" />
+            <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.users/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.users/models/editor.mps
@@ -11,6 +11,7 @@
     <import index="r4b4" ref="r:1784e088-20fd-4fdb-96b8-bc57f0056d94(com.mbeddr.core.base.editor)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="cayy" ref="r:c1f7e681-4373-4429-b23f-337a1dd93658(org.iets3.core.users.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
@@ -219,9 +220,18 @@
                   <node concept="1pGfFk" id="7mG7sQPAivP" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                     <node concept="pncrf" id="7mG7sQPAivQ" role="37wK5m" />
-                    <node concept="10M0yZ" id="7mG7sQPAivR" role="37wK5m">
-                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                    <node concept="2ShNRf" id="3frJLkOa8vg" role="37wK5m">
+                      <node concept="1pGfFk" id="3frJLkOa8vh" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="10M0yZ" id="3frJLkOa8z4" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                        <node concept="10M0yZ" id="3frJLkOa8CK" role="37wK5m">
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.users/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.users/models/editor.mps
@@ -220,18 +220,9 @@
                   <node concept="1pGfFk" id="7mG7sQPAivP" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                     <node concept="pncrf" id="7mG7sQPAivQ" role="37wK5m" />
-                    <node concept="2ShNRf" id="3frJLkOa8vg" role="37wK5m">
-                      <node concept="1pGfFk" id="3frJLkOa8vh" role="2ShVmc">
-                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                        <node concept="10M0yZ" id="3frJLkOa8z4" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                        <node concept="10M0yZ" id="3frJLkOa8CK" role="37wK5m">
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="38mO9wg7O$8" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.users/org.iets3.core.users.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.users/org.iets3.core.users.mpl
@@ -14,6 +14,7 @@
   <sourcePath />
   <dependencies>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:e840b8ae-64d9-4b5b-b3b4-eca3f222d4da:com.mbeddr.mpsutil.iconchar" version="1" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.glossary/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.glossary/models/editor.mps
@@ -15,6 +15,7 @@
     <import index="tuf9" ref="r:7f8b53fb-2dfc-4e51-940a-0573ffa4389c(org.iets3.glossary.structure)" />
     <import index="tbr6" ref="r:6a005c26-87c0-43c4-8cf3-49ffba1099df(de.slisson.mps.richtext.behavior)" />
     <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="itrz" ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
@@ -376,9 +377,18 @@
                 <node concept="1pGfFk" id="4tXyFaWwuTW" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                   <node concept="pncrf" id="4tXyFaWwuTX" role="37wK5m" />
-                  <node concept="10M0yZ" id="4tXyFaWwuTY" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <node concept="2ShNRf" id="3frJLkO8tb8" role="37wK5m">
+                    <node concept="1pGfFk" id="3frJLkO96r$" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="7mG7sQPzhmL" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
+                      </node>
+                      <node concept="10M0yZ" id="3frJLkO96_9" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -461,9 +471,18 @@
                     <node concept="1pGfFk" id="6zaFu4oQBeg" role="2ShVmc">
                       <ref role="37wK5l" to="r4b4:6Ce4x7KQbw2" resolve="ColoredVerticalBarCell" />
                       <node concept="pncrf" id="6zaFu4oQBeU" role="37wK5m" />
-                      <node concept="10M0yZ" id="6zaFu4oQBiN" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      <node concept="2ShNRf" id="3frJLkOa8vg" role="37wK5m">
+                        <node concept="1pGfFk" id="3frJLkOa8vh" role="2ShVmc">
+                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                          <node concept="10M0yZ" id="3frJLkOa8z4" role="37wK5m">
+                            <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          </node>
+                          <node concept="10M0yZ" id="3frJLkOa8CK" role="37wK5m">
+                            <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          </node>
+                        </node>
                       </node>
                       <node concept="3cmrfG" id="6zaFu4oQBnP" role="37wK5m">
                         <property role="3cmrfH" value="-1" />
@@ -507,9 +526,18 @@
                       <node concept="1pGfFk" id="6zaFu4oPRTI" role="2ShVmc">
                         <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                         <node concept="pncrf" id="6zaFu4oPRUd" role="37wK5m" />
-                        <node concept="10M0yZ" id="6zaFu4oPS12" role="37wK5m">
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                        <node concept="2ShNRf" id="3frJLkOa8Nm" role="37wK5m">
+                          <node concept="1pGfFk" id="3frJLkOa8Nn" role="2ShVmc">
+                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                            <node concept="10M0yZ" id="3frJLkOa8No" role="37wK5m">
+                              <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            </node>
+                            <node concept="10M0yZ" id="3frJLkOa8Np" role="37wK5m">
+                              <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -798,9 +826,18 @@
                     <node concept="1pGfFk" id="6zaFu4oRD64" role="2ShVmc">
                       <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                       <node concept="pncrf" id="6zaFu4oRD65" role="37wK5m" />
-                      <node concept="10M0yZ" id="6zaFu4oRD66" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                      <node concept="2ShNRf" id="3frJLkOa8YJ" role="37wK5m">
+                        <node concept="1pGfFk" id="3frJLkOa8YK" role="2ShVmc">
+                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                          <node concept="10M0yZ" id="3frJLkOa8YL" role="37wK5m">
+                            <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          </node>
+                          <node concept="10M0yZ" id="3frJLkOa8YM" role="37wK5m">
+                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                            <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.glossary/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.glossary/models/editor.mps
@@ -377,18 +377,9 @@
                 <node concept="1pGfFk" id="4tXyFaWwuTW" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                   <node concept="pncrf" id="4tXyFaWwuTX" role="37wK5m" />
-                  <node concept="2ShNRf" id="3frJLkO8tb8" role="37wK5m">
-                    <node concept="1pGfFk" id="3frJLkO96r$" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="7mG7sQPzhmL" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
-                      </node>
-                      <node concept="10M0yZ" id="3frJLkO96_9" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wg7NiZ" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -471,18 +462,9 @@
                     <node concept="1pGfFk" id="6zaFu4oQBeg" role="2ShVmc">
                       <ref role="37wK5l" to="r4b4:6Ce4x7KQbw2" resolve="ColoredVerticalBarCell" />
                       <node concept="pncrf" id="6zaFu4oQBeU" role="37wK5m" />
-                      <node concept="2ShNRf" id="3frJLkOa8vg" role="37wK5m">
-                        <node concept="1pGfFk" id="3frJLkOa8vh" role="2ShVmc">
-                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                          <node concept="10M0yZ" id="3frJLkOa8z4" role="37wK5m">
-                            <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          </node>
-                          <node concept="10M0yZ" id="3frJLkOa8CK" role="37wK5m">
-                            <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          </node>
-                        </node>
+                      <node concept="10M0yZ" id="38mO9wg7N_U" role="37wK5m">
+                        <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                       </node>
                       <node concept="3cmrfG" id="6zaFu4oQBnP" role="37wK5m">
                         <property role="3cmrfH" value="-1" />
@@ -526,18 +508,9 @@
                       <node concept="1pGfFk" id="6zaFu4oPRTI" role="2ShVmc">
                         <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                         <node concept="pncrf" id="6zaFu4oPRUd" role="37wK5m" />
-                        <node concept="2ShNRf" id="3frJLkOa8Nm" role="37wK5m">
-                          <node concept="1pGfFk" id="3frJLkOa8Nn" role="2ShVmc">
-                            <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                            <node concept="10M0yZ" id="3frJLkOa8No" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            </node>
-                            <node concept="10M0yZ" id="3frJLkOa8Np" role="37wK5m">
-                              <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                              <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            </node>
-                          </node>
+                        <node concept="10M0yZ" id="38mO9wg7NLi" role="37wK5m">
+                          <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                         </node>
                       </node>
                     </node>
@@ -826,18 +799,9 @@
                     <node concept="1pGfFk" id="6zaFu4oRD64" role="2ShVmc">
                       <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                       <node concept="pncrf" id="6zaFu4oRD65" role="37wK5m" />
-                      <node concept="2ShNRf" id="3frJLkOa8YJ" role="37wK5m">
-                        <node concept="1pGfFk" id="3frJLkOa8YK" role="2ShVmc">
-                          <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                          <node concept="10M0yZ" id="3frJLkOa8YL" role="37wK5m">
-                            <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          </node>
-                          <node concept="10M0yZ" id="3frJLkOa8YM" role="37wK5m">
-                            <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                            <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          </node>
-                        </node>
+                      <node concept="10M0yZ" id="38mO9wg7O6T" role="37wK5m">
+                        <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                        <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                       </node>
                     </node>
                   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/editor.mps
@@ -32,6 +32,7 @@
     <import index="882r" ref="r:7c2726cf-5697-49bb-92f6-2986272fb311(com.mbeddr.doc.intentions)" />
     <import index="bemq" ref="r:4cfa8b0a-7754-4d3d-9e06-0ce9d427860c(org.iets3.req.core.behavior)" />
     <import index="ze1i" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.runtime(MPS.Core/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" implicit="true" />
@@ -943,9 +944,18 @@
                 <node concept="1pGfFk" id="4tXyFaWwzSe" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakvelx" resolve="HorizLineCell" />
                   <node concept="pncrf" id="4tXyFaWwzSS" role="37wK5m" />
-                  <node concept="10M0yZ" id="4tXyFaWw$6n" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                  <node concept="2ShNRf" id="3frJLkO97Wg" role="37wK5m">
+                    <node concept="1pGfFk" id="3frJLkO98GJ" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="4tXyFaWw$6n" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="3frJLkO98Vm" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                   <node concept="3cmrfG" id="4tXyFaWw$bx" role="37wK5m">
                     <property role="3cmrfH" value="2" />
@@ -1004,9 +1014,18 @@
                 <node concept="1pGfFk" id="4tXyFaWwuTW" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                   <node concept="pncrf" id="4tXyFaWwuTX" role="37wK5m" />
-                  <node concept="10M0yZ" id="4tXyFaWwuTY" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  <node concept="2ShNRf" id="3frJLkO9a1_" role="37wK5m">
+                    <node concept="1pGfFk" id="3frJLkO9a1A" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="3frJLkO9a1B" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="3frJLkO9a1C" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -1245,9 +1264,18 @@
                 <node concept="1pGfFk" id="7mG7sQPzhmJ" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                   <node concept="pncrf" id="7mG7sQPzhmK" role="37wK5m" />
-                  <node concept="10M0yZ" id="7mG7sQPzhmL" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
+                  <node concept="2ShNRf" id="3frJLkO8tb8" role="37wK5m">
+                    <node concept="1pGfFk" id="3frJLkO96r$" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="7mG7sQPzhmL" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
+                      </node>
+                      <node concept="10M0yZ" id="3frJLkO96_9" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -1445,9 +1473,18 @@
                   <node concept="1pGfFk" id="7mG7sQP$WEj" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:6Ce4x7KQbw2" resolve="ColoredVerticalBarCell" />
                     <node concept="pncrf" id="7mG7sQP$WEN" role="37wK5m" />
-                    <node concept="10M0yZ" id="7mG7sQP$WJD" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                    <node concept="2ShNRf" id="3frJLkO96HT" role="37wK5m">
+                      <node concept="1pGfFk" id="3frJLkO96HU" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="10M0yZ" id="3frJLkO96Qb" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                        <node concept="10M0yZ" id="3frJLkO96Zl" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                      </node>
                     </node>
                     <node concept="3cmrfG" id="7mG7sQP$WMI" role="37wK5m">
                       <property role="3cmrfH" value="2" />
@@ -1538,9 +1575,18 @@
                   <node concept="1pGfFk" id="7mG7sQP$WOv" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:6Ce4x7KQbw2" resolve="ColoredVerticalBarCell" />
                     <node concept="pncrf" id="7mG7sQP$WOw" role="37wK5m" />
-                    <node concept="10M0yZ" id="7mG7sQP$WOx" role="37wK5m">
-                      <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                    <node concept="2ShNRf" id="3frJLkO977g" role="37wK5m">
+                      <node concept="1pGfFk" id="3frJLkO977h" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="10M0yZ" id="3frJLkO977i" role="37wK5m">
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                        </node>
+                        <node concept="10M0yZ" id="3frJLkO977j" role="37wK5m">
+                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        </node>
+                      </node>
                     </node>
                     <node concept="3cmrfG" id="7mG7sQP$WOy" role="37wK5m">
                       <property role="3cmrfH" value="2" />
@@ -1563,9 +1609,18 @@
                 <node concept="1pGfFk" id="7Dcax7Ahwtp" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                   <node concept="pncrf" id="7Dcax7Ahwtq" role="37wK5m" />
-                  <node concept="10M0yZ" id="7Dcax7Ahwtr" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
+                  <node concept="2ShNRf" id="3frJLkO97f4" role="37wK5m">
+                    <node concept="1pGfFk" id="3frJLkO97f5" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="3frJLkO97f6" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                      </node>
+                      <node concept="10M0yZ" id="3frJLkO97f7" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -1983,9 +2038,18 @@
                 <node concept="1pGfFk" id="4Etk_BWvNKd" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakvelx" resolve="HorizLineCell" />
                   <node concept="pncrf" id="4Etk_BWvNKe" role="37wK5m" />
-                  <node concept="10M0yZ" id="4Etk_BWvNKf" role="37wK5m">
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                    <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                  <node concept="2ShNRf" id="3frJLkO99_C" role="37wK5m">
+                    <node concept="1pGfFk" id="3frJLkO99_D" role="2ShVmc">
+                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                      <node concept="10M0yZ" id="3frJLkO99_E" role="37wK5m">
+                        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                      </node>
+                      <node concept="10M0yZ" id="3frJLkO99_F" role="37wK5m">
+                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
+                      </node>
+                    </node>
                   </node>
                   <node concept="3cmrfG" id="4Etk_BWvNKg" role="37wK5m">
                     <property role="3cmrfH" value="2" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/editor.mps
@@ -31,8 +31,8 @@
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="882r" ref="r:7c2726cf-5697-49bb-92f6-2986272fb311(com.mbeddr.doc.intentions)" />
     <import index="bemq" ref="r:4cfa8b0a-7754-4d3d-9e06-0ce9d427860c(org.iets3.req.core.behavior)" />
-    <import index="ze1i" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.runtime(MPS.Core/)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
+    <import index="ze1i" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.runtime(MPS.Core/)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" implicit="true" />
@@ -944,18 +944,9 @@
                 <node concept="1pGfFk" id="4tXyFaWwzSe" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakvelx" resolve="HorizLineCell" />
                   <node concept="pncrf" id="4tXyFaWwzSS" role="37wK5m" />
-                  <node concept="2ShNRf" id="3frJLkO97Wg" role="37wK5m">
-                    <node concept="1pGfFk" id="3frJLkO98GJ" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="4tXyFaWw$6n" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="3frJLkO98Vm" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wg7LHb" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                   <node concept="3cmrfG" id="4tXyFaWw$bx" role="37wK5m">
                     <property role="3cmrfH" value="2" />
@@ -1014,18 +1005,9 @@
                 <node concept="1pGfFk" id="4tXyFaWwuTW" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                   <node concept="pncrf" id="4tXyFaWwuTX" role="37wK5m" />
-                  <node concept="2ShNRf" id="3frJLkO9a1_" role="37wK5m">
-                    <node concept="1pGfFk" id="3frJLkO9a1A" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="3frJLkO9a1B" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="3frJLkO9a1C" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wg7MHR" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -1264,18 +1246,9 @@
                 <node concept="1pGfFk" id="7mG7sQPzhmJ" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                   <node concept="pncrf" id="7mG7sQPzhmK" role="37wK5m" />
-                  <node concept="2ShNRf" id="3frJLkO8tb8" role="37wK5m">
-                    <node concept="1pGfFk" id="3frJLkO96r$" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="7mG7sQPzhmL" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
-                      </node>
-                      <node concept="10M0yZ" id="3frJLkO96_9" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.GRAY" resolve="GRAY" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wg7KQw" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -1473,18 +1446,9 @@
                   <node concept="1pGfFk" id="7mG7sQP$WEj" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:6Ce4x7KQbw2" resolve="ColoredVerticalBarCell" />
                     <node concept="pncrf" id="7mG7sQP$WEN" role="37wK5m" />
-                    <node concept="2ShNRf" id="3frJLkO96HT" role="37wK5m">
-                      <node concept="1pGfFk" id="3frJLkO96HU" role="2ShVmc">
-                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                        <node concept="10M0yZ" id="3frJLkO96Qb" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                        <node concept="10M0yZ" id="3frJLkO96Zl" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="38mO9wg7K_o" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                     <node concept="3cmrfG" id="7mG7sQP$WMI" role="37wK5m">
                       <property role="3cmrfH" value="2" />
@@ -1575,18 +1539,9 @@
                   <node concept="1pGfFk" id="7mG7sQP$WOv" role="2ShVmc">
                     <ref role="37wK5l" to="r4b4:6Ce4x7KQbw2" resolve="ColoredVerticalBarCell" />
                     <node concept="pncrf" id="7mG7sQP$WOw" role="37wK5m" />
-                    <node concept="2ShNRf" id="3frJLkO977g" role="37wK5m">
-                      <node concept="1pGfFk" id="3frJLkO977h" role="2ShVmc">
-                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                        <node concept="10M0yZ" id="3frJLkO977i" role="37wK5m">
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                        </node>
-                        <node concept="10M0yZ" id="3frJLkO977j" role="37wK5m">
-                          <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                          <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        </node>
-                      </node>
+                    <node concept="10M0yZ" id="38mO9wg7L1F" role="37wK5m">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                      <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                     <node concept="3cmrfG" id="7mG7sQP$WOy" role="37wK5m">
                       <property role="3cmrfH" value="2" />
@@ -1609,18 +1564,9 @@
                 <node concept="1pGfFk" id="7Dcax7Ahwtp" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakv6nY" resolve="HorizLineCell" />
                   <node concept="pncrf" id="7Dcax7Ahwtq" role="37wK5m" />
-                  <node concept="2ShNRf" id="3frJLkO97f4" role="37wK5m">
-                    <node concept="1pGfFk" id="3frJLkO97f5" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="3frJLkO97f6" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                      </node>
-                      <node concept="10M0yZ" id="3frJLkO97f7" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.gray" resolve="gray" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wg7Lfa" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.gray" resolve="gray" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                 </node>
               </node>
@@ -2038,18 +1984,9 @@
                 <node concept="1pGfFk" id="4Etk_BWvNKd" role="2ShVmc">
                   <ref role="37wK5l" to="r4b4:5gTlpakvelx" resolve="HorizLineCell" />
                   <node concept="pncrf" id="4Etk_BWvNKe" role="37wK5m" />
-                  <node concept="2ShNRf" id="3frJLkO99_C" role="37wK5m">
-                    <node concept="1pGfFk" id="3frJLkO99_D" role="2ShVmc">
-                      <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                      <node concept="10M0yZ" id="3frJLkO99_E" role="37wK5m">
-                        <ref role="3cqZAo" to="z60i:~Color.BLACK" resolve="BLACK" />
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                      </node>
-                      <node concept="10M0yZ" id="3frJLkO99_F" role="37wK5m">
-                        <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                        <ref role="3cqZAo" to="z60i:~Color.lightGray" resolve="lightGray" />
-                      </node>
-                    </node>
+                  <node concept="10M0yZ" id="38mO9wg7McF" role="37wK5m">
+                    <ref role="3cqZAo" to="lzb2:~JBColor.black" resolve="black" />
+                    <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                   </node>
                   <node concept="3cmrfG" id="4Etk_BWvNKg" role="37wK5m">
                     <property role="3cmrfH" value="2" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/models/plugin.mps
@@ -4767,18 +4767,9 @@
             </node>
             <node concept="liA8E" id="4yQfyMjgweN" role="2OqNvi">
               <ref role="37wK5l" to="dxuu:~JComponent.setBackground(java.awt.Color)" resolve="setBackground" />
-              <node concept="2ShNRf" id="1O3benwr_tV" role="37wK5m">
-                <node concept="1pGfFk" id="1O3benwrHiU" role="2ShVmc">
-                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
-                  <node concept="10M0yZ" id="1O3benwrNgm" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  </node>
-                  <node concept="10M0yZ" id="1O3benwrQHB" role="37wK5m">
-                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
-                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
-                  </node>
-                </node>
+              <node concept="10M0yZ" id="38mO9wg6jp_" role="37wK5m">
+                <ref role="3cqZAo" to="lzb2:~JBColor.white" resolve="white" />
+                <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/models/plugin.mps
@@ -1442,17 +1442,36 @@
                     <node concept="37vLTw" id="5U8d23PNr3A" role="37wK5m">
                       <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
                     </node>
-                    <node concept="2ShNRf" id="5U8d23PN24s" role="37wK5m">
-                      <node concept="1pGfFk" id="5U8d23PN24t" role="2ShVmc">
-                        <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                        <node concept="3cmrfG" id="5U8d23PN24u" role="37wK5m">
-                          <property role="3cmrfH" value="196" />
+                    <node concept="2ShNRf" id="1O3benwsdEd" role="37wK5m">
+                      <node concept="1pGfFk" id="1O3benwsgTj" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="2ShNRf" id="5U8d23PN24s" role="37wK5m">
+                          <node concept="1pGfFk" id="5U8d23PN24t" role="2ShVmc">
+                            <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                            <node concept="3cmrfG" id="5U8d23PN24u" role="37wK5m">
+                              <property role="3cmrfH" value="196" />
+                            </node>
+                            <node concept="3cmrfG" id="5U8d23PN24v" role="37wK5m">
+                              <property role="3cmrfH" value="107" />
+                            </node>
+                            <node concept="3cmrfG" id="5U8d23PN24w" role="37wK5m">
+                              <property role="3cmrfH" value="0" />
+                            </node>
+                          </node>
                         </node>
-                        <node concept="3cmrfG" id="5U8d23PN24v" role="37wK5m">
-                          <property role="3cmrfH" value="107" />
-                        </node>
-                        <node concept="3cmrfG" id="5U8d23PN24w" role="37wK5m">
-                          <property role="3cmrfH" value="0" />
+                        <node concept="2ShNRf" id="1O3benwsk0E" role="37wK5m">
+                          <node concept="1pGfFk" id="1O3benwsk0F" role="2ShVmc">
+                            <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                            <node concept="3cmrfG" id="1O3benwsk0G" role="37wK5m">
+                              <property role="3cmrfH" value="196" />
+                            </node>
+                            <node concept="3cmrfG" id="1O3benwsk0H" role="37wK5m">
+                              <property role="3cmrfH" value="107" />
+                            </node>
+                            <node concept="3cmrfG" id="1O3benwsk0I" role="37wK5m">
+                              <property role="3cmrfH" value="0" />
+                            </node>
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -1567,11 +1586,30 @@
                     <node concept="37vLTw" id="3vcWfImwaSo" role="37wK5m">
                       <ref role="3cqZAo" node="5U8d23PMIi5" resolve="bgColor" />
                     </node>
-                    <node concept="2YIFZM" id="3vcWfImvuoG" role="37wK5m">
-                      <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
-                      <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
-                      <node concept="Xl_RD" id="3vcWfImvw0T" role="37wK5m">
-                        <property role="Xl_RC" value="#228A00" />
+                    <node concept="2ShNRf" id="1O3benwslzR" role="37wK5m">
+                      <node concept="1pGfFk" id="1O3benwsoOz" role="2ShVmc">
+                        <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                        <node concept="2YIFZM" id="3vcWfImvuoG" role="37wK5m">
+                          <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
+                          <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
+                          <node concept="Xl_RD" id="3vcWfImvw0T" role="37wK5m">
+                            <property role="Xl_RC" value="#228A00" />
+                          </node>
+                        </node>
+                        <node concept="2ShNRf" id="1O3benwsvg_" role="37wK5m">
+                          <node concept="1pGfFk" id="1O3benwsytL" role="2ShVmc">
+                            <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                            <node concept="3cmrfG" id="1O3benws$uj" role="37wK5m">
+                              <property role="3cmrfH" value="45" />
+                            </node>
+                            <node concept="3cmrfG" id="1O3benwsCr0" role="37wK5m">
+                              <property role="3cmrfH" value="179" />
+                            </node>
+                            <node concept="3cmrfG" id="1O3benwsEEP" role="37wK5m">
+                              <property role="3cmrfH" value="0" />
+                            </node>
+                          </node>
+                        </node>
                       </node>
                     </node>
                     <node concept="10M0yZ" id="3vcWfImf5q_" role="37wK5m">
@@ -4729,9 +4767,18 @@
             </node>
             <node concept="liA8E" id="4yQfyMjgweN" role="2OqNvi">
               <ref role="37wK5l" to="dxuu:~JComponent.setBackground(java.awt.Color)" resolve="setBackground" />
-              <node concept="10M0yZ" id="4yQfyMjgwqm" role="37wK5m">
-                <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
-                <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+              <node concept="2ShNRf" id="1O3benwr_tV" role="37wK5m">
+                <node concept="1pGfFk" id="1O3benwrHiU" role="2ShVmc">
+                  <ref role="37wK5l" to="lzb2:~JBColor.&lt;init&gt;(java.awt.Color,java.awt.Color)" resolve="JBColor" />
+                  <node concept="10M0yZ" id="1O3benwrNgm" role="37wK5m">
+                    <ref role="3cqZAo" to="z60i:~Color.white" resolve="white" />
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  </node>
+                  <node concept="10M0yZ" id="1O3benwrQHB" role="37wK5m">
+                    <ref role="3cqZAo" to="z60i:~Color.black" resolve="black" />
+                    <ref role="1PxDUh" to="z60i:~Color" resolve="Color" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -8102,46 +8149,6 @@
     </node>
     <node concept="3Tm1VV" id="5rUl2R7OncG" role="1B3o_S" />
   </node>
-  <node concept="3HP615" id="kZqQ7ZZSl6">
-    <property role="TrG5h" value="ITraceTabOptionFactory" />
-    <node concept="3clFb_" id="kZqQ7ZZTVf" role="jymVt">
-      <property role="TrG5h" value="createTraceTabOption" />
-      <node concept="37vLTG" id="kZqQ800Lte" role="3clF46">
-        <property role="TrG5h" value="ideaProject" />
-        <node concept="3uibUv" id="kZqQ800Ltf" role="1tU5fm">
-          <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="kZqQ800CZ9" role="3clF46">
-        <property role="TrG5h" value="mpsProject" />
-        <node concept="3uibUv" id="kZqQ800CZa" role="1tU5fm">
-          <ref role="3uigEE" to="z1c3:~MPSProject" resolve="MPSProject" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="kZqQ800CZb" role="3clF46">
-        <property role="TrG5h" value="title" />
-        <node concept="17QB3L" id="kZqQ800CZc" role="1tU5fm" />
-      </node>
-      <node concept="37vLTG" id="kZqQ800CZd" role="3clF46">
-        <property role="TrG5h" value="icon" />
-        <node concept="3uibUv" id="kZqQ800CZe" role="1tU5fm">
-          <ref role="3uigEE" to="dxuu:~Icon" resolve="Icon" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="kZqQ800CUF" role="3clF46">
-        <property role="TrG5h" value="rootTraceRecord" />
-        <node concept="3uibUv" id="kZqQ800CUG" role="1tU5fm">
-          <ref role="3uigEE" to="pu3r:43aY2QmSq3e" resolve="ITraceRecord" />
-        </node>
-      </node>
-      <node concept="3clFbS" id="kZqQ7ZZTVi" role="3clF47" />
-      <node concept="3Tm1VV" id="kZqQ7ZZTVj" role="1B3o_S" />
-      <node concept="3uibUv" id="kZqQ7ZZTV0" role="3clF45">
-        <ref role="3uigEE" to="pu3r:43aY2QmUpUi" resolve="TraceTabOptions" />
-      </node>
-    </node>
-    <node concept="3Tm1VV" id="kZqQ7ZZSl7" role="1B3o_S" />
-  </node>
   <node concept="312cEu" id="kZqQ800dgq">
     <property role="TrG5h" value="DefaultTraceTabOptionsFactory" />
     <node concept="2tJIrI" id="kZqQ800dhE" role="jymVt" />
@@ -8460,6 +8467,460 @@
         </node>
       </node>
     </node>
+  </node>
+  <node concept="312cEu" id="3ApArNFARAE">
+    <property role="TrG5h" value="AbstractTraceExplorerAction" />
+    <property role="1sVAO0" value="true" />
+    <node concept="312cEg" id="3ApArNFASVW" role="jymVt">
+      <property role="TrG5h" value="ideaProject" />
+      <node concept="3Tmbuc" id="3ApArNFAZl5" role="1B3o_S" />
+      <node concept="3uibUv" id="3ApArNFASVY" role="1tU5fm">
+        <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+      </node>
+    </node>
+    <node concept="312cEg" id="3ApArNFASVZ" role="jymVt">
+      <property role="TrG5h" value="mpsProject" />
+      <node concept="3Tmbuc" id="3ApArNFAZvE" role="1B3o_S" />
+      <node concept="3uibUv" id="3ApArNFASW1" role="1tU5fm">
+        <ref role="3uigEE" to="z1c3:~MPSProject" resolve="MPSProject" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3ApArNFAS$I" role="jymVt" />
+    <node concept="2tJIrI" id="3ApArNFBgAL" role="jymVt" />
+    <node concept="3clFbW" id="3ApArNFASzH" role="jymVt">
+      <node concept="3cqZAl" id="3ApArNFASzJ" role="3clF45" />
+      <node concept="3Tm1VV" id="3ApArNFASzK" role="1B3o_S" />
+      <node concept="3clFbS" id="3ApArNFASzL" role="3clF47" />
+    </node>
+    <node concept="2tJIrI" id="3ApArNFATw0" role="jymVt" />
+    <node concept="3clFb_" id="3ApArNFDl1Z" role="jymVt">
+      <property role="TrG5h" value="initialize" />
+      <node concept="37vLTG" id="3ApArNFAS$7" role="3clF46">
+        <property role="TrG5h" value="ideaProject" />
+        <node concept="3uibUv" id="3ApArNFAS$8" role="1tU5fm">
+          <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3ApArNFAS$9" role="3clF46">
+        <property role="TrG5h" value="mpsProject" />
+        <node concept="3uibUv" id="3ApArNFAS$a" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~MPSProject" resolve="MPSProject" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="3ApArNFDl22" role="3clF47">
+        <node concept="3clFbF" id="3ApArNFATjD" role="3cqZAp">
+          <node concept="37vLTI" id="3ApArNFATjE" role="3clFbG">
+            <node concept="37vLTw" id="3ApArNFATjF" role="37vLTx">
+              <ref role="3cqZAo" node="3ApArNFAS$7" resolve="ideaProject" />
+            </node>
+            <node concept="2OqwBi" id="3ApArNFATjG" role="37vLTJ">
+              <node concept="Xjq3P" id="3ApArNFATjH" role="2Oq$k0" />
+              <node concept="2OwXpG" id="3ApArNFATjI" role="2OqNvi">
+                <ref role="2Oxat5" node="3ApArNFASVW" resolve="ideaProject" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3ApArNFATjL" role="3cqZAp">
+          <node concept="37vLTI" id="3ApArNFATjM" role="3clFbG">
+            <node concept="37vLTw" id="3ApArNFATjN" role="37vLTx">
+              <ref role="3cqZAo" node="3ApArNFAS$9" resolve="mpsProject" />
+            </node>
+            <node concept="2OqwBi" id="3ApArNFATjO" role="37vLTJ">
+              <node concept="Xjq3P" id="3ApArNFATjP" role="2Oq$k0" />
+              <node concept="2OwXpG" id="3ApArNFATjQ" role="2OqNvi">
+                <ref role="2Oxat5" node="3ApArNFASVZ" resolve="mpsProject" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3ApArNFDkuD" role="1B3o_S" />
+      <node concept="3cqZAl" id="3ApArNFDl1Q" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3ApArNFATFJ" role="jymVt" />
+    <node concept="3Tm1VV" id="3ApArNFARAF" role="1B3o_S" />
+  </node>
+  <node concept="3HP615" id="3ApArNFAIPt">
+    <property role="TrG5h" value="ITraceExplorerAction" />
+    <node concept="2tJIrI" id="3ApArNFBW5B" role="jymVt" />
+    <node concept="3clFb_" id="3ApArNFAK9d" role="jymVt">
+      <property role="TrG5h" value="getPriority" />
+      <node concept="3clFbS" id="3ApArNFAK9g" role="3clF47" />
+      <node concept="3Tm1VV" id="3ApArNFAK9h" role="1B3o_S" />
+      <node concept="10Oyi0" id="3ApArNFAK90" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3ApArNFBW52" role="jymVt" />
+    <node concept="3clFb_" id="3ApArNFD4pN" role="jymVt">
+      <property role="TrG5h" value="initialize" />
+      <node concept="37vLTG" id="3ApArNFD4AI" role="3clF46">
+        <property role="TrG5h" value="ideaProject" />
+        <node concept="3uibUv" id="3ApArNFD4AJ" role="1tU5fm">
+          <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3ApArNFD4AK" role="3clF46">
+        <property role="TrG5h" value="mpsProject" />
+        <node concept="3uibUv" id="3ApArNFD4AL" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~MPSProject" resolve="MPSProject" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="3ApArNFD4pQ" role="3clF47" />
+      <node concept="3Tm1VV" id="3ApArNFD4pR" role="1B3o_S" />
+      <node concept="3cqZAl" id="3ApArNFD4oV" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3ApArNFD4P2" role="jymVt" />
+    <node concept="3clFb_" id="3ApArNFJXkK" role="jymVt">
+      <property role="TrG5h" value="setNode" />
+      <node concept="3clFbS" id="3ApArNFJXkN" role="3clF47" />
+      <node concept="3Tm1VV" id="3ApArNFJXkO" role="1B3o_S" />
+      <node concept="3cqZAl" id="3ApArNFJXjs" role="3clF45" />
+      <node concept="37vLTG" id="3ApArNFJXTE" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="3ApArNFJXTD" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3ApArNFJWTz" role="jymVt" />
+    <node concept="3clFb_" id="3ApArNFD4Nv" role="jymVt">
+      <property role="TrG5h" value="isApplicable" />
+      <node concept="3clFbS" id="3ApArNFBSd8" role="3clF47" />
+      <node concept="37vLTG" id="3ApArNFBSdb" role="3clF46">
+        <property role="TrG5h" value="event" />
+        <node concept="3uibUv" id="3ApArNFBSdc" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
+        </node>
+      </node>
+      <node concept="10P_77" id="3ApArNFBSd6" role="3clF45" />
+      <node concept="3Tm1VV" id="3ApArNFBSdg" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="3ApArNFD4D1" role="jymVt" />
+    <node concept="3clFb_" id="3ApArNFBZx6" role="jymVt">
+      <property role="TrG5h" value="execute" />
+      <node concept="37vLTG" id="3ApArNFC20D" role="3clF46">
+        <property role="TrG5h" value="event" />
+        <node concept="3uibUv" id="3ApArNFC20E" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="3ApArNFBZx9" role="3clF47" />
+      <node concept="3Tm1VV" id="3ApArNFBZxa" role="1B3o_S" />
+      <node concept="3cqZAl" id="3ApArNFBZws" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3ApArNFAR3Z" role="jymVt" />
+    <node concept="3Tm1VV" id="3ApArNFAIPu" role="1B3o_S" />
+  </node>
+  <node concept="3HP615" id="kZqQ7ZZSl6">
+    <property role="TrG5h" value="ITraceTabOptionFactory" />
+    <node concept="3clFb_" id="kZqQ7ZZTVf" role="jymVt">
+      <property role="TrG5h" value="createTraceTabOption" />
+      <node concept="37vLTG" id="kZqQ800Lte" role="3clF46">
+        <property role="TrG5h" value="ideaProject" />
+        <node concept="3uibUv" id="kZqQ800Ltf" role="1tU5fm">
+          <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="kZqQ800CZ9" role="3clF46">
+        <property role="TrG5h" value="mpsProject" />
+        <node concept="3uibUv" id="kZqQ800CZa" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~MPSProject" resolve="MPSProject" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="kZqQ800CZb" role="3clF46">
+        <property role="TrG5h" value="title" />
+        <node concept="17QB3L" id="kZqQ800CZc" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="kZqQ800CZd" role="3clF46">
+        <property role="TrG5h" value="icon" />
+        <node concept="3uibUv" id="kZqQ800CZe" role="1tU5fm">
+          <ref role="3uigEE" to="dxuu:~Icon" resolve="Icon" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="kZqQ800CUF" role="3clF46">
+        <property role="TrG5h" value="rootTraceRecord" />
+        <node concept="3uibUv" id="kZqQ800CUG" role="1tU5fm">
+          <ref role="3uigEE" to="pu3r:43aY2QmSq3e" resolve="ITraceRecord" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="kZqQ7ZZTVi" role="3clF47" />
+      <node concept="3Tm1VV" id="kZqQ7ZZTVj" role="1B3o_S" />
+      <node concept="3uibUv" id="kZqQ7ZZTV0" role="3clF45">
+        <ref role="3uigEE" to="pu3r:43aY2QmUpUi" resolve="TraceTabOptions" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="kZqQ7ZZSl7" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="3ApArNFCbWK">
+    <property role="TrG5h" value="TraceExplorerActionHandlerResolver" />
+    <node concept="2tJIrI" id="3ApArNFCjPt" role="jymVt" />
+    <node concept="Wx3nA" id="3ApArNFDC35" role="jymVt">
+      <property role="TrG5h" value="traceExplorer" />
+      <node concept="3uibUv" id="3ApArNFDwOs" role="1tU5fm">
+        <ref role="3uigEE" node="3ApArNFAIPt" resolve="ITraceExplorerAction" />
+      </node>
+      <node concept="3Tm6S6" id="3ApArNFDx7L" role="1B3o_S" />
+      <node concept="10Nm6u" id="3ApArNFDBXT" role="33vP2m" />
+    </node>
+    <node concept="2tJIrI" id="3ApArNFDw5t" role="jymVt" />
+    <node concept="2YIFZL" id="3ApArNFDvMT" role="jymVt">
+      <property role="TrG5h" value="resolveTraceExplorer" />
+      <node concept="3clFbS" id="3ApArNFCcbB" role="3clF47">
+        <node concept="3clFbJ" id="3ApArNFD_2S" role="3cqZAp">
+          <node concept="3clFbS" id="3ApArNFD_2U" role="3clFbx">
+            <node concept="3cpWs8" id="3ApArNFCcKM" role="3cqZAp">
+              <node concept="3cpWsn" id="3ApArNFCcKP" role="3cpWs9">
+                <property role="TrG5h" value="ep" />
+                <node concept="Sf$Xq" id="3ApArNFCcKL" role="1tU5fm">
+                  <ref role="Sf$Xr" node="3ApArNFAAU0" resolve="TraceExplorerExtensionPoint" />
+                </node>
+                <node concept="2O5UvJ" id="3ApArNFCdir" role="33vP2m">
+                  <ref role="2O5UnU" node="3ApArNFAAU0" resolve="TraceExplorerExtensionPoint" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="3ApArNFCjJ$" role="3cqZAp">
+              <node concept="3cpWsn" id="3ApArNFCjJ_" role="3cpWs9">
+                <property role="TrG5h" value="action" />
+                <node concept="3uibUv" id="3ApArNFCjGV" role="1tU5fm">
+                  <ref role="3uigEE" node="3ApArNFAIPt" resolve="ITraceExplorerAction" />
+                </node>
+                <node concept="2OqwBi" id="3ApArNFCjJA" role="33vP2m">
+                  <node concept="2OqwBi" id="3ApArNFCjJB" role="2Oq$k0">
+                    <node concept="2OqwBi" id="3ApArNFCjJC" role="2Oq$k0">
+                      <node concept="37vLTw" id="3ApArNFCjJD" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3ApArNFCcKP" resolve="ep" />
+                      </node>
+                      <node concept="SfwO_" id="3ApArNFCjJE" role="2OqNvi" />
+                    </node>
+                    <node concept="2S7cBI" id="3ApArNFCjJF" role="2OqNvi">
+                      <node concept="1bVj0M" id="3ApArNFCjJG" role="23t8la">
+                        <node concept="3clFbS" id="3ApArNFCjJH" role="1bW5cS">
+                          <node concept="3clFbF" id="3ApArNFCjJI" role="3cqZAp">
+                            <node concept="2OqwBi" id="3ApArNFCjJJ" role="3clFbG">
+                              <node concept="37vLTw" id="3ApArNFCjJK" role="2Oq$k0">
+                                <ref role="3cqZAo" node="3ApArNFCjJM" resolve="it" />
+                              </node>
+                              <node concept="liA8E" id="3ApArNFCjJL" role="2OqNvi">
+                                <ref role="37wK5l" node="3ApArNFAK9d" resolve="getPriority" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="3ApArNFCjJM" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="3ApArNFCjJN" role="1tU5fm" />
+                        </node>
+                      </node>
+                      <node concept="1nlBCl" id="3ApArNFCjJO" role="2S7zOq" />
+                    </node>
+                  </node>
+                  <node concept="1uHKPH" id="3ApArNFCjJP" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="3ApArNFCl6K" role="3cqZAp">
+              <node concept="3clFbS" id="3ApArNFCl6M" role="3clFbx">
+                <node concept="3clFbF" id="3ApArNFDyM1" role="3cqZAp">
+                  <node concept="2OqwBi" id="3ApArNFDyYR" role="3clFbG">
+                    <node concept="37vLTw" id="3ApArNFDyLZ" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3ApArNFCjJ_" resolve="action" />
+                    </node>
+                    <node concept="liA8E" id="3ApArNFDzq$" role="2OqNvi">
+                      <ref role="37wK5l" node="3ApArNFD4pN" resolve="initialize" />
+                      <node concept="37vLTw" id="3ApArNFDzIf" role="37wK5m">
+                        <ref role="3cqZAo" node="3ApArNFD1hG" resolve="ideaProject" />
+                      </node>
+                      <node concept="37vLTw" id="3ApArNFDzIg" role="37wK5m">
+                        <ref role="3cqZAo" node="3ApArNFD1hI" resolve="mpsProject" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3y3z36" id="3ApArNFCmlC" role="3clFbw">
+                <node concept="10Nm6u" id="3ApArNFCmVX" role="3uHU7w" />
+                <node concept="37vLTw" id="3ApArNFCm1H" role="3uHU7B">
+                  <ref role="3cqZAo" node="3ApArNFCjJ_" resolve="action" />
+                </node>
+              </node>
+              <node concept="9aQIb" id="3ApArNFCn1_" role="9aQIa">
+                <node concept="3clFbS" id="3ApArNFCn1A" role="9aQI4">
+                  <node concept="3clFbF" id="3ApArNFCojz" role="3cqZAp">
+                    <node concept="37vLTI" id="3ApArNFCoAj" role="3clFbG">
+                      <node concept="2ShNRf" id="3ApArNFCoUx" role="37vLTx">
+                        <node concept="HV5vD" id="3ApArNFDunC" role="2ShVmc">
+                          <ref role="HV5vE" node="kZqQ808Ew6" resolve="DefaultTraceExplorerActionHandler" />
+                        </node>
+                      </node>
+                      <node concept="37vLTw" id="3ApArNFCojy" role="37vLTJ">
+                        <ref role="3cqZAo" node="3ApArNFCjJ_" resolve="action" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="3ApArNFDqbp" role="3cqZAp">
+                    <node concept="2OqwBi" id="3ApArNFDqnF" role="3clFbG">
+                      <node concept="37vLTw" id="3ApArNFDqbn" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3ApArNFCjJ_" resolve="action" />
+                      </node>
+                      <node concept="liA8E" id="3ApArNFDqLU" role="2OqNvi">
+                        <ref role="37wK5l" node="3ApArNFD4pN" resolve="initialize" />
+                        <node concept="37vLTw" id="3ApArNFD20B" role="37wK5m">
+                          <ref role="3cqZAo" node="3ApArNFD1hG" resolve="ideaProject" />
+                        </node>
+                        <node concept="37vLTw" id="3ApArNFD2yC" role="37wK5m">
+                          <ref role="3cqZAo" node="3ApArNFD1hI" resolve="mpsProject" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="3ApArNFDDCu" role="3cqZAp">
+              <node concept="37vLTI" id="3ApArNFDF8y" role="3clFbG">
+                <node concept="37vLTw" id="3ApArNFDFwi" role="37vLTx">
+                  <ref role="3cqZAo" node="3ApArNFCjJ_" resolve="action" />
+                </node>
+                <node concept="37vLTw" id="3ApArNFDDCz" role="37vLTJ">
+                  <ref role="3cqZAo" node="3ApArNFDC35" resolve="traceExplorer" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="3ApArNFDCq4" role="3clFbw">
+            <node concept="10Nm6u" id="3ApArNFDD3x" role="3uHU7w" />
+            <node concept="37vLTw" id="3ApArNFDG_M" role="3uHU7B">
+              <ref role="3cqZAo" node="3ApArNFDC35" resolve="traceExplorer" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3ApArNFD1hG" role="3clF46">
+        <property role="TrG5h" value="ideaProject" />
+        <node concept="3uibUv" id="3ApArNFD1hH" role="1tU5fm">
+          <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3ApArNFD1hI" role="3clF46">
+        <property role="TrG5h" value="mpsProject" />
+        <node concept="3uibUv" id="3ApArNFD1hJ" role="1tU5fm">
+          <ref role="3uigEE" to="z1c3:~MPSProject" resolve="MPSProject" />
+        </node>
+      </node>
+      <node concept="3cqZAl" id="3ApArNFM24$" role="3clF45" />
+      <node concept="3Tm1VV" id="3ApArNFDvWK" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="3ApArNFDIq5" role="jymVt" />
+    <node concept="2YIFZL" id="3ApArNFM15$" role="jymVt">
+      <property role="TrG5h" value="setNode" />
+      <node concept="3clFbS" id="3ApArNFLYWG" role="3clF47">
+        <node concept="3clFbJ" id="3ApArNFLZO$" role="3cqZAp">
+          <node concept="3clFbS" id="3ApArNFLZO_" role="3clFbx">
+            <node concept="3cpWs6" id="3ApArNFLZOA" role="3cqZAp" />
+          </node>
+          <node concept="3clFbC" id="3ApArNFLZOB" role="3clFbw">
+            <node concept="10Nm6u" id="3ApArNFLZOC" role="3uHU7w" />
+            <node concept="37vLTw" id="3ApArNFLZOH" role="3uHU7B">
+              <ref role="3cqZAo" node="3ApArNFDC35" resolve="traceExplorer" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3ApArNFLZOJ" role="3cqZAp">
+          <node concept="2OqwBi" id="3ApArNFLZOK" role="3clFbG">
+            <node concept="37vLTw" id="3ApArNFLZOR" role="2Oq$k0">
+              <ref role="3cqZAo" node="3ApArNFDC35" resolve="traceExplorer" />
+            </node>
+            <node concept="liA8E" id="3ApArNFM0hX" role="2OqNvi">
+              <ref role="37wK5l" node="3ApArNFJXkK" resolve="setNode" />
+              <node concept="37vLTw" id="3ApArNFM12t" role="37wK5m">
+                <ref role="3cqZAo" node="3ApArNFLZKW" resolve="node" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3ApArNFLZKW" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="3ApArNFLZKV" role="1tU5fm" />
+      </node>
+      <node concept="3cqZAl" id="3ApArNFLYRh" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3ApArNFM1cQ" role="jymVt" />
+    <node concept="2YIFZL" id="3ApArNFDMYO" role="jymVt">
+      <property role="TrG5h" value="isApplicable" />
+      <node concept="3clFbS" id="3ApArNFDJxk" role="3clF47">
+        <node concept="3clFbJ" id="3ApArNFDPLk" role="3cqZAp">
+          <node concept="3clFbS" id="3ApArNFDPLm" role="3clFbx">
+            <node concept="3cpWs6" id="3ApArNFDSQz" role="3cqZAp">
+              <node concept="3clFbT" id="3ApArNFDTCI" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="3clFbC" id="3ApArNFDR1t" role="3clFbw">
+            <node concept="10Nm6u" id="3ApArNFDRvG" role="3uHU7w" />
+            <node concept="37vLTw" id="3ApArNFDQCT" role="3uHU7B">
+              <ref role="3cqZAo" node="3ApArNFDC35" resolve="traceExplorer" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3ApArNFDMNW" role="3cqZAp">
+          <node concept="2OqwBi" id="3ApArNFDNkn" role="3clFbG">
+            <node concept="37vLTw" id="3ApArNFDMNV" role="2Oq$k0">
+              <ref role="3cqZAo" node="3ApArNFDC35" resolve="traceExplorer" />
+            </node>
+            <node concept="liA8E" id="3ApArNFDNKw" role="2OqNvi">
+              <ref role="37wK5l" node="3ApArNFD4Nv" resolve="isApplicable" />
+              <node concept="37vLTw" id="3ApArNFDOst" role="37wK5m">
+                <ref role="3cqZAo" node="3ApArNFDKUX" resolve="event" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3ApArNFDKUX" role="3clF46">
+        <property role="TrG5h" value="event" />
+        <node concept="3uibUv" id="3ApArNFDKUW" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
+        </node>
+      </node>
+      <node concept="10P_77" id="3ApArNFDJlV" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="3ApArNFDTMO" role="jymVt" />
+    <node concept="2YIFZL" id="3ApArNFE4Uk" role="jymVt">
+      <property role="TrG5h" value="execute" />
+      <node concept="3clFbS" id="3ApArNFDUEt" role="3clF47">
+        <node concept="3clFbJ" id="3ApArNFDV4w" role="3cqZAp">
+          <node concept="3clFbS" id="3ApArNFDV4x" role="3clFbx">
+            <node concept="3cpWs6" id="3ApArNFDV4y" role="3cqZAp" />
+          </node>
+          <node concept="3clFbC" id="3ApArNFDV4$" role="3clFbw">
+            <node concept="10Nm6u" id="3ApArNFDV4_" role="3uHU7w" />
+            <node concept="37vLTw" id="3ApArNFDV4D" role="3uHU7B">
+              <ref role="3cqZAo" node="3ApArNFDC35" resolve="traceExplorer" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3ApArNFDWuH" role="3cqZAp">
+          <node concept="2OqwBi" id="3ApArNFDWQy" role="3clFbG">
+            <node concept="37vLTw" id="3ApArNFDWuF" role="2Oq$k0">
+              <ref role="3cqZAo" node="3ApArNFDC35" resolve="traceExplorer" />
+            </node>
+            <node concept="liA8E" id="3ApArNFDXiO" role="2OqNvi">
+              <ref role="37wK5l" node="3ApArNFBZx6" resolve="execute" />
+              <node concept="37vLTw" id="3ApArNFDXZO" role="37wK5m">
+                <ref role="3cqZAo" node="3ApArNFDUUd" resolve="event" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3ApArNFDUUd" role="3clF46">
+        <property role="TrG5h" value="event" />
+        <node concept="3uibUv" id="3ApArNFDUUe" role="1tU5fm">
+          <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
+        </node>
+      </node>
+      <node concept="3cqZAl" id="3ApArNFDUtd" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="3ApArNFCbWL" role="1B3o_S" />
   </node>
   <node concept="312cEu" id="kZqQ808Ew6">
     <property role="TrG5h" value="DefaultTraceExplorerActionHandler" />
@@ -9636,420 +10097,6 @@
     <node concept="3uibUv" id="3ApArNFAWEE" role="1zkMxy">
       <ref role="3uigEE" node="3ApArNFARAE" resolve="AbstractTraceExplorerAction" />
     </node>
-  </node>
-  <node concept="3HP615" id="3ApArNFAIPt">
-    <property role="TrG5h" value="ITraceExplorerAction" />
-    <node concept="2tJIrI" id="3ApArNFBW5B" role="jymVt" />
-    <node concept="3clFb_" id="3ApArNFAK9d" role="jymVt">
-      <property role="TrG5h" value="getPriority" />
-      <node concept="3clFbS" id="3ApArNFAK9g" role="3clF47" />
-      <node concept="3Tm1VV" id="3ApArNFAK9h" role="1B3o_S" />
-      <node concept="10Oyi0" id="3ApArNFAK90" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="3ApArNFBW52" role="jymVt" />
-    <node concept="3clFb_" id="3ApArNFD4pN" role="jymVt">
-      <property role="TrG5h" value="initialize" />
-      <node concept="37vLTG" id="3ApArNFD4AI" role="3clF46">
-        <property role="TrG5h" value="ideaProject" />
-        <node concept="3uibUv" id="3ApArNFD4AJ" role="1tU5fm">
-          <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="3ApArNFD4AK" role="3clF46">
-        <property role="TrG5h" value="mpsProject" />
-        <node concept="3uibUv" id="3ApArNFD4AL" role="1tU5fm">
-          <ref role="3uigEE" to="z1c3:~MPSProject" resolve="MPSProject" />
-        </node>
-      </node>
-      <node concept="3clFbS" id="3ApArNFD4pQ" role="3clF47" />
-      <node concept="3Tm1VV" id="3ApArNFD4pR" role="1B3o_S" />
-      <node concept="3cqZAl" id="3ApArNFD4oV" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="3ApArNFD4P2" role="jymVt" />
-    <node concept="3clFb_" id="3ApArNFJXkK" role="jymVt">
-      <property role="TrG5h" value="setNode" />
-      <node concept="3clFbS" id="3ApArNFJXkN" role="3clF47" />
-      <node concept="3Tm1VV" id="3ApArNFJXkO" role="1B3o_S" />
-      <node concept="3cqZAl" id="3ApArNFJXjs" role="3clF45" />
-      <node concept="37vLTG" id="3ApArNFJXTE" role="3clF46">
-        <property role="TrG5h" value="node" />
-        <node concept="3Tqbb2" id="3ApArNFJXTD" role="1tU5fm" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="3ApArNFJWTz" role="jymVt" />
-    <node concept="3clFb_" id="3ApArNFD4Nv" role="jymVt">
-      <property role="TrG5h" value="isApplicable" />
-      <node concept="3clFbS" id="3ApArNFBSd8" role="3clF47" />
-      <node concept="37vLTG" id="3ApArNFBSdb" role="3clF46">
-        <property role="TrG5h" value="event" />
-        <node concept="3uibUv" id="3ApArNFBSdc" role="1tU5fm">
-          <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
-        </node>
-      </node>
-      <node concept="10P_77" id="3ApArNFBSd6" role="3clF45" />
-      <node concept="3Tm1VV" id="3ApArNFBSdg" role="1B3o_S" />
-    </node>
-    <node concept="2tJIrI" id="3ApArNFD4D1" role="jymVt" />
-    <node concept="3clFb_" id="3ApArNFBZx6" role="jymVt">
-      <property role="TrG5h" value="execute" />
-      <node concept="37vLTG" id="3ApArNFC20D" role="3clF46">
-        <property role="TrG5h" value="event" />
-        <node concept="3uibUv" id="3ApArNFC20E" role="1tU5fm">
-          <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
-        </node>
-      </node>
-      <node concept="3clFbS" id="3ApArNFBZx9" role="3clF47" />
-      <node concept="3Tm1VV" id="3ApArNFBZxa" role="1B3o_S" />
-      <node concept="3cqZAl" id="3ApArNFBZws" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="3ApArNFAR3Z" role="jymVt" />
-    <node concept="3Tm1VV" id="3ApArNFAIPu" role="1B3o_S" />
-  </node>
-  <node concept="312cEu" id="3ApArNFARAE">
-    <property role="TrG5h" value="AbstractTraceExplorerAction" />
-    <property role="1sVAO0" value="true" />
-    <node concept="312cEg" id="3ApArNFASVW" role="jymVt">
-      <property role="TrG5h" value="ideaProject" />
-      <node concept="3Tmbuc" id="3ApArNFAZl5" role="1B3o_S" />
-      <node concept="3uibUv" id="3ApArNFASVY" role="1tU5fm">
-        <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
-      </node>
-    </node>
-    <node concept="312cEg" id="3ApArNFASVZ" role="jymVt">
-      <property role="TrG5h" value="mpsProject" />
-      <node concept="3Tmbuc" id="3ApArNFAZvE" role="1B3o_S" />
-      <node concept="3uibUv" id="3ApArNFASW1" role="1tU5fm">
-        <ref role="3uigEE" to="z1c3:~MPSProject" resolve="MPSProject" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="3ApArNFAS$I" role="jymVt" />
-    <node concept="2tJIrI" id="3ApArNFBgAL" role="jymVt" />
-    <node concept="3clFbW" id="3ApArNFASzH" role="jymVt">
-      <node concept="3cqZAl" id="3ApArNFASzJ" role="3clF45" />
-      <node concept="3Tm1VV" id="3ApArNFASzK" role="1B3o_S" />
-      <node concept="3clFbS" id="3ApArNFASzL" role="3clF47" />
-    </node>
-    <node concept="2tJIrI" id="3ApArNFATw0" role="jymVt" />
-    <node concept="3clFb_" id="3ApArNFDl1Z" role="jymVt">
-      <property role="TrG5h" value="initialize" />
-      <node concept="37vLTG" id="3ApArNFAS$7" role="3clF46">
-        <property role="TrG5h" value="ideaProject" />
-        <node concept="3uibUv" id="3ApArNFAS$8" role="1tU5fm">
-          <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="3ApArNFAS$9" role="3clF46">
-        <property role="TrG5h" value="mpsProject" />
-        <node concept="3uibUv" id="3ApArNFAS$a" role="1tU5fm">
-          <ref role="3uigEE" to="z1c3:~MPSProject" resolve="MPSProject" />
-        </node>
-      </node>
-      <node concept="3clFbS" id="3ApArNFDl22" role="3clF47">
-        <node concept="3clFbF" id="3ApArNFATjD" role="3cqZAp">
-          <node concept="37vLTI" id="3ApArNFATjE" role="3clFbG">
-            <node concept="37vLTw" id="3ApArNFATjF" role="37vLTx">
-              <ref role="3cqZAo" node="3ApArNFAS$7" resolve="ideaProject" />
-            </node>
-            <node concept="2OqwBi" id="3ApArNFATjG" role="37vLTJ">
-              <node concept="Xjq3P" id="3ApArNFATjH" role="2Oq$k0" />
-              <node concept="2OwXpG" id="3ApArNFATjI" role="2OqNvi">
-                <ref role="2Oxat5" node="3ApArNFASVW" resolve="ideaProject" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="3ApArNFATjL" role="3cqZAp">
-          <node concept="37vLTI" id="3ApArNFATjM" role="3clFbG">
-            <node concept="37vLTw" id="3ApArNFATjN" role="37vLTx">
-              <ref role="3cqZAo" node="3ApArNFAS$9" resolve="mpsProject" />
-            </node>
-            <node concept="2OqwBi" id="3ApArNFATjO" role="37vLTJ">
-              <node concept="Xjq3P" id="3ApArNFATjP" role="2Oq$k0" />
-              <node concept="2OwXpG" id="3ApArNFATjQ" role="2OqNvi">
-                <ref role="2Oxat5" node="3ApArNFASVZ" resolve="mpsProject" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="3ApArNFDkuD" role="1B3o_S" />
-      <node concept="3cqZAl" id="3ApArNFDl1Q" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="3ApArNFATFJ" role="jymVt" />
-    <node concept="3Tm1VV" id="3ApArNFARAF" role="1B3o_S" />
-  </node>
-  <node concept="312cEu" id="3ApArNFCbWK">
-    <property role="TrG5h" value="TraceExplorerActionHandlerResolver" />
-    <node concept="2tJIrI" id="3ApArNFCjPt" role="jymVt" />
-    <node concept="Wx3nA" id="3ApArNFDC35" role="jymVt">
-      <property role="TrG5h" value="traceExplorer" />
-      <node concept="3uibUv" id="3ApArNFDwOs" role="1tU5fm">
-        <ref role="3uigEE" node="3ApArNFAIPt" resolve="ITraceExplorerAction" />
-      </node>
-      <node concept="3Tm6S6" id="3ApArNFDx7L" role="1B3o_S" />
-      <node concept="10Nm6u" id="3ApArNFDBXT" role="33vP2m" />
-    </node>
-    <node concept="2tJIrI" id="3ApArNFDw5t" role="jymVt" />
-    <node concept="2YIFZL" id="3ApArNFDvMT" role="jymVt">
-      <property role="TrG5h" value="resolveTraceExplorer" />
-      <node concept="3clFbS" id="3ApArNFCcbB" role="3clF47">
-        <node concept="3clFbJ" id="3ApArNFD_2S" role="3cqZAp">
-          <node concept="3clFbS" id="3ApArNFD_2U" role="3clFbx">
-            <node concept="3cpWs8" id="3ApArNFCcKM" role="3cqZAp">
-              <node concept="3cpWsn" id="3ApArNFCcKP" role="3cpWs9">
-                <property role="TrG5h" value="ep" />
-                <node concept="Sf$Xq" id="3ApArNFCcKL" role="1tU5fm">
-                  <ref role="Sf$Xr" node="3ApArNFAAU0" resolve="TraceExplorerExtensionPoint" />
-                </node>
-                <node concept="2O5UvJ" id="3ApArNFCdir" role="33vP2m">
-                  <ref role="2O5UnU" node="3ApArNFAAU0" resolve="TraceExplorerExtensionPoint" />
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="3ApArNFCjJ$" role="3cqZAp">
-              <node concept="3cpWsn" id="3ApArNFCjJ_" role="3cpWs9">
-                <property role="TrG5h" value="action" />
-                <node concept="3uibUv" id="3ApArNFCjGV" role="1tU5fm">
-                  <ref role="3uigEE" node="3ApArNFAIPt" resolve="ITraceExplorerAction" />
-                </node>
-                <node concept="2OqwBi" id="3ApArNFCjJA" role="33vP2m">
-                  <node concept="2OqwBi" id="3ApArNFCjJB" role="2Oq$k0">
-                    <node concept="2OqwBi" id="3ApArNFCjJC" role="2Oq$k0">
-                      <node concept="37vLTw" id="3ApArNFCjJD" role="2Oq$k0">
-                        <ref role="3cqZAo" node="3ApArNFCcKP" resolve="ep" />
-                      </node>
-                      <node concept="SfwO_" id="3ApArNFCjJE" role="2OqNvi" />
-                    </node>
-                    <node concept="2S7cBI" id="3ApArNFCjJF" role="2OqNvi">
-                      <node concept="1bVj0M" id="3ApArNFCjJG" role="23t8la">
-                        <node concept="3clFbS" id="3ApArNFCjJH" role="1bW5cS">
-                          <node concept="3clFbF" id="3ApArNFCjJI" role="3cqZAp">
-                            <node concept="2OqwBi" id="3ApArNFCjJJ" role="3clFbG">
-                              <node concept="37vLTw" id="3ApArNFCjJK" role="2Oq$k0">
-                                <ref role="3cqZAo" node="3ApArNFCjJM" resolve="it" />
-                              </node>
-                              <node concept="liA8E" id="3ApArNFCjJL" role="2OqNvi">
-                                <ref role="37wK5l" node="3ApArNFAK9d" resolve="getPriority" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="Rh6nW" id="3ApArNFCjJM" role="1bW2Oz">
-                          <property role="TrG5h" value="it" />
-                          <node concept="2jxLKc" id="3ApArNFCjJN" role="1tU5fm" />
-                        </node>
-                      </node>
-                      <node concept="1nlBCl" id="3ApArNFCjJO" role="2S7zOq" />
-                    </node>
-                  </node>
-                  <node concept="1uHKPH" id="3ApArNFCjJP" role="2OqNvi" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="3ApArNFCl6K" role="3cqZAp">
-              <node concept="3clFbS" id="3ApArNFCl6M" role="3clFbx">
-                <node concept="3clFbF" id="3ApArNFDyM1" role="3cqZAp">
-                  <node concept="2OqwBi" id="3ApArNFDyYR" role="3clFbG">
-                    <node concept="37vLTw" id="3ApArNFDyLZ" role="2Oq$k0">
-                      <ref role="3cqZAo" node="3ApArNFCjJ_" resolve="action" />
-                    </node>
-                    <node concept="liA8E" id="3ApArNFDzq$" role="2OqNvi">
-                      <ref role="37wK5l" node="3ApArNFD4pN" resolve="initialize" />
-                      <node concept="37vLTw" id="3ApArNFDzIf" role="37wK5m">
-                        <ref role="3cqZAo" node="3ApArNFD1hG" resolve="ideaProject" />
-                      </node>
-                      <node concept="37vLTw" id="3ApArNFDzIg" role="37wK5m">
-                        <ref role="3cqZAo" node="3ApArNFD1hI" resolve="mpsProject" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3y3z36" id="3ApArNFCmlC" role="3clFbw">
-                <node concept="10Nm6u" id="3ApArNFCmVX" role="3uHU7w" />
-                <node concept="37vLTw" id="3ApArNFCm1H" role="3uHU7B">
-                  <ref role="3cqZAo" node="3ApArNFCjJ_" resolve="action" />
-                </node>
-              </node>
-              <node concept="9aQIb" id="3ApArNFCn1_" role="9aQIa">
-                <node concept="3clFbS" id="3ApArNFCn1A" role="9aQI4">
-                  <node concept="3clFbF" id="3ApArNFCojz" role="3cqZAp">
-                    <node concept="37vLTI" id="3ApArNFCoAj" role="3clFbG">
-                      <node concept="2ShNRf" id="3ApArNFCoUx" role="37vLTx">
-                        <node concept="HV5vD" id="3ApArNFDunC" role="2ShVmc">
-                          <ref role="HV5vE" node="kZqQ808Ew6" resolve="DefaultTraceExplorerActionHandler" />
-                        </node>
-                      </node>
-                      <node concept="37vLTw" id="3ApArNFCojy" role="37vLTJ">
-                        <ref role="3cqZAo" node="3ApArNFCjJ_" resolve="action" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="3ApArNFDqbp" role="3cqZAp">
-                    <node concept="2OqwBi" id="3ApArNFDqnF" role="3clFbG">
-                      <node concept="37vLTw" id="3ApArNFDqbn" role="2Oq$k0">
-                        <ref role="3cqZAo" node="3ApArNFCjJ_" resolve="action" />
-                      </node>
-                      <node concept="liA8E" id="3ApArNFDqLU" role="2OqNvi">
-                        <ref role="37wK5l" node="3ApArNFD4pN" resolve="initialize" />
-                        <node concept="37vLTw" id="3ApArNFD20B" role="37wK5m">
-                          <ref role="3cqZAo" node="3ApArNFD1hG" resolve="ideaProject" />
-                        </node>
-                        <node concept="37vLTw" id="3ApArNFD2yC" role="37wK5m">
-                          <ref role="3cqZAo" node="3ApArNFD1hI" resolve="mpsProject" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="3ApArNFDDCu" role="3cqZAp">
-              <node concept="37vLTI" id="3ApArNFDF8y" role="3clFbG">
-                <node concept="37vLTw" id="3ApArNFDFwi" role="37vLTx">
-                  <ref role="3cqZAo" node="3ApArNFCjJ_" resolve="action" />
-                </node>
-                <node concept="37vLTw" id="3ApArNFDDCz" role="37vLTJ">
-                  <ref role="3cqZAo" node="3ApArNFDC35" resolve="traceExplorer" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbC" id="3ApArNFDCq4" role="3clFbw">
-            <node concept="10Nm6u" id="3ApArNFDD3x" role="3uHU7w" />
-            <node concept="37vLTw" id="3ApArNFDG_M" role="3uHU7B">
-              <ref role="3cqZAo" node="3ApArNFDC35" resolve="traceExplorer" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="3ApArNFD1hG" role="3clF46">
-        <property role="TrG5h" value="ideaProject" />
-        <node concept="3uibUv" id="3ApArNFD1hH" role="1tU5fm">
-          <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="3ApArNFD1hI" role="3clF46">
-        <property role="TrG5h" value="mpsProject" />
-        <node concept="3uibUv" id="3ApArNFD1hJ" role="1tU5fm">
-          <ref role="3uigEE" to="z1c3:~MPSProject" resolve="MPSProject" />
-        </node>
-      </node>
-      <node concept="3cqZAl" id="3ApArNFM24$" role="3clF45" />
-      <node concept="3Tm1VV" id="3ApArNFDvWK" role="1B3o_S" />
-    </node>
-    <node concept="2tJIrI" id="3ApArNFDIq5" role="jymVt" />
-    <node concept="2YIFZL" id="3ApArNFM15$" role="jymVt">
-      <property role="TrG5h" value="setNode" />
-      <node concept="3clFbS" id="3ApArNFLYWG" role="3clF47">
-        <node concept="3clFbJ" id="3ApArNFLZO$" role="3cqZAp">
-          <node concept="3clFbS" id="3ApArNFLZO_" role="3clFbx">
-            <node concept="3cpWs6" id="3ApArNFLZOA" role="3cqZAp" />
-          </node>
-          <node concept="3clFbC" id="3ApArNFLZOB" role="3clFbw">
-            <node concept="10Nm6u" id="3ApArNFLZOC" role="3uHU7w" />
-            <node concept="37vLTw" id="3ApArNFLZOH" role="3uHU7B">
-              <ref role="3cqZAo" node="3ApArNFDC35" resolve="traceExplorer" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="3ApArNFLZOJ" role="3cqZAp">
-          <node concept="2OqwBi" id="3ApArNFLZOK" role="3clFbG">
-            <node concept="37vLTw" id="3ApArNFLZOR" role="2Oq$k0">
-              <ref role="3cqZAo" node="3ApArNFDC35" resolve="traceExplorer" />
-            </node>
-            <node concept="liA8E" id="3ApArNFM0hX" role="2OqNvi">
-              <ref role="37wK5l" node="3ApArNFJXkK" resolve="setNode" />
-              <node concept="37vLTw" id="3ApArNFM12t" role="37wK5m">
-                <ref role="3cqZAo" node="3ApArNFLZKW" resolve="node" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="3ApArNFLZKW" role="3clF46">
-        <property role="TrG5h" value="node" />
-        <node concept="3Tqbb2" id="3ApArNFLZKV" role="1tU5fm" />
-      </node>
-      <node concept="3cqZAl" id="3ApArNFLYRh" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="3ApArNFM1cQ" role="jymVt" />
-    <node concept="2YIFZL" id="3ApArNFDMYO" role="jymVt">
-      <property role="TrG5h" value="isApplicable" />
-      <node concept="3clFbS" id="3ApArNFDJxk" role="3clF47">
-        <node concept="3clFbJ" id="3ApArNFDPLk" role="3cqZAp">
-          <node concept="3clFbS" id="3ApArNFDPLm" role="3clFbx">
-            <node concept="3cpWs6" id="3ApArNFDSQz" role="3cqZAp">
-              <node concept="3clFbT" id="3ApArNFDTCI" role="3cqZAk" />
-            </node>
-          </node>
-          <node concept="3clFbC" id="3ApArNFDR1t" role="3clFbw">
-            <node concept="10Nm6u" id="3ApArNFDRvG" role="3uHU7w" />
-            <node concept="37vLTw" id="3ApArNFDQCT" role="3uHU7B">
-              <ref role="3cqZAo" node="3ApArNFDC35" resolve="traceExplorer" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="3ApArNFDMNW" role="3cqZAp">
-          <node concept="2OqwBi" id="3ApArNFDNkn" role="3clFbG">
-            <node concept="37vLTw" id="3ApArNFDMNV" role="2Oq$k0">
-              <ref role="3cqZAo" node="3ApArNFDC35" resolve="traceExplorer" />
-            </node>
-            <node concept="liA8E" id="3ApArNFDNKw" role="2OqNvi">
-              <ref role="37wK5l" node="3ApArNFD4Nv" resolve="isApplicable" />
-              <node concept="37vLTw" id="3ApArNFDOst" role="37wK5m">
-                <ref role="3cqZAo" node="3ApArNFDKUX" resolve="event" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="3ApArNFDKUX" role="3clF46">
-        <property role="TrG5h" value="event" />
-        <node concept="3uibUv" id="3ApArNFDKUW" role="1tU5fm">
-          <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
-        </node>
-      </node>
-      <node concept="10P_77" id="3ApArNFDJlV" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="3ApArNFDTMO" role="jymVt" />
-    <node concept="2YIFZL" id="3ApArNFE4Uk" role="jymVt">
-      <property role="TrG5h" value="execute" />
-      <node concept="3clFbS" id="3ApArNFDUEt" role="3clF47">
-        <node concept="3clFbJ" id="3ApArNFDV4w" role="3cqZAp">
-          <node concept="3clFbS" id="3ApArNFDV4x" role="3clFbx">
-            <node concept="3cpWs6" id="3ApArNFDV4y" role="3cqZAp" />
-          </node>
-          <node concept="3clFbC" id="3ApArNFDV4$" role="3clFbw">
-            <node concept="10Nm6u" id="3ApArNFDV4_" role="3uHU7w" />
-            <node concept="37vLTw" id="3ApArNFDV4D" role="3uHU7B">
-              <ref role="3cqZAo" node="3ApArNFDC35" resolve="traceExplorer" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="3ApArNFDWuH" role="3cqZAp">
-          <node concept="2OqwBi" id="3ApArNFDWQy" role="3clFbG">
-            <node concept="37vLTw" id="3ApArNFDWuF" role="2Oq$k0">
-              <ref role="3cqZAo" node="3ApArNFDC35" resolve="traceExplorer" />
-            </node>
-            <node concept="liA8E" id="3ApArNFDXiO" role="2OqNvi">
-              <ref role="37wK5l" node="3ApArNFBZx6" resolve="execute" />
-              <node concept="37vLTw" id="3ApArNFDXZO" role="37wK5m">
-                <ref role="3cqZAo" node="3ApArNFDUUd" resolve="event" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="3ApArNFDUUd" role="3clF46">
-        <property role="TrG5h" value="event" />
-        <node concept="3uibUv" id="3ApArNFDUUe" role="1tU5fm">
-          <ref role="3uigEE" to="qkt:~AnActionEvent" resolve="AnActionEvent" />
-        </node>
-      </node>
-      <node concept="3cqZAl" id="3ApArNFDUtd" role="3clF45" />
-    </node>
-    <node concept="3Tm1VV" id="3ApArNFCbWL" role="1B3o_S" />
   </node>
   <node concept="vrV6u" id="3ApArNFAAU0">
     <property role="TrG5h" value="TraceExplorerExtensionPoint" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -1457,6 +1457,11 @@
             <ref role="3bR37D" node="4C_RnzfEE1P" resolve="org.iets3.core.expr.base.runtime" />
           </node>
         </node>
+        <node concept="1SiIV0" id="38mO9wfO5dj" role="3bR37C">
+          <node concept="3bR9La" id="38mO9wfO5dk" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="5QDPRL$oT7a" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -7140,6 +7145,11 @@
             <node concept="3qWCbU" id="1RMC8GHEwO9" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="38mO9wfO5nN" role="3bR37C">
+          <node concept="3bR9La" id="38mO9wfO5nO" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1ia2VB5guYy" resolve="MPS.IDEA" />
           </node>
         </node>
       </node>


### PR DESCRIPTION
This PR adds support for the dark themes by replacing plain occurrences of the `Color` class with calls to `new JBColor(.., ..)`. It implements #636. Each commit is annotated with the changed package and how the color choices have been tested. Some colors could notbe tested since their corresponding concepts has no usage in testcases.

**Note:** The PR builds on the work by @AlexeiQ and should only be merged once PR #625 has been merged.