### PR TITLE
Bugfix/correct sum op

### DIFF
--- a/code/languages/org.iets3.opensource/.mps/modules.xml
+++ b/code/languages/org.iets3.opensource/.mps/modules.xml
@@ -82,6 +82,7 @@
       <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.base.runtime/org.iets3.core.expr.base.runtime.msd" folder="expr.lang-core" />
       <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.base.shared.runtime/org.iets3.core.expr.base.shared.runtime.msd" folder="expr.lang-core" />
       <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.collections.interpreter/org.iets3.core.expr.collections.interpreter.msd" folder="expr.lang-core" />
+      <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.collections.rt/org.iets3.core.expr.collections.rt.msd" folder="expr.lang-core" />
       <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.data.interpreter/org.iets3.core.expr.data.interpreter.msd" folder="expr.lang-advanced" />
       <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.dataflow.interpreter/org.iets3.core.expr.dataflow.interpreter.msd" folder="expr.lang-advanced" />
       <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.datetime.interpreter/org.iets3.core.expr.datetime.interpreter.msd" folder="expr.lang-advanced" />
@@ -92,7 +93,6 @@
       <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.genjava.core.genplan/org.iets3.core.expr.genjava.core.genplan.msd" folder="expr.genjava" />
       <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.genjava.functionalJava/org.iets3.core.expr.genjava.functionalJava.msd" folder="expr.genjava" />
       <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.genjava.messages.rt/org.iets3.core.expr.genjava.messages.rt.msd" folder="expr.genjava" />
-      <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.genjava.simpleTypes.rt/org.iets3.core.expr.genjava.simpleTypes.rt.msd" folder="expr.genjava" />
       <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.genjava.stateMachineExample.genplan/org.iets3.core.expr.genjava.stateMachineExample.genplan.msd" folder="expr.genjava.stateMachineExample" />
       <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.genjava.temporal.rt/org.iets3.core.expr.genjava.temporal.rt.msd" folder="expr.genjava" />
       <modulePath path="$PROJECT_DIR$/solutions/org.iets3.core.expr.genjava.tests.rt/org.iets3.core.expr.genjava.tests.rt.msd" folder="expr.genjava" />

--- a/code/languages/org.iets3.opensource/devkits/org.iets3.core.expr.genjava.core.devkit/org.iets3.core.expr.genjava.core.devkit.devkit
+++ b/code/languages/org.iets3.opensource/devkits/org.iets3.core.expr.genjava.core.devkit/org.iets3.core.expr.genjava.core.devkit.devkit
@@ -8,7 +8,6 @@
   <exported-solutions>
     <exported-solution>3a6ebc02-087e-4791-9854-65244ce22d8d(org.iets3.core.expr.genjava.base.rt)</exported-solution>
     <exported-solution>708a03ad-8699-43c9-821a-6cd00b68e9f8(org.iets3.core.expr.genjava.functionalJava)</exported-solution>
-    <exported-solution>272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.genjava.simpleTypes.rt)</exported-solution>
     <exported-solution>fde59617-0336-493b-a7ec-21148c3507f1(org.iets3.core.expr.genjava.temporal.rt)</exported-solution>
     <exported-solution>68da6d9d-3ccf-4255-b4f7-37603cd89090(org.iets3.core.expr.genjava.tests.rt)</exported-solution>
     <exported-solution>336cc7f4-18d3-473b-81a1-d8df1c0ad27a(org.iets3.core.expr.genjava.toplevel.rt)</exported-solution>
@@ -17,6 +16,7 @@
     <exported-solution>b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)</exported-solution>
     <exported-solution>52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)</exported-solution>
     <exported-solution>00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)</exported-solution>
+    <exported-solution>272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.collections.rt)</exported-solution>
   </exported-solutions>
   <generation-plan model="r:44582398-dfcf-40ad-bb09-b88bb3cc5de2(org.iets3.core.expr.genjava.core.genplan.genplan)" />
 </dev-kit>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.simpleTypes/org.iets3.core.expr.genjava.simpleTypes.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.simpleTypes/org.iets3.core.expr.genjava.simpleTypes.mpl
@@ -30,7 +30,7 @@
         <dependency reexport="false">6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)</dependency>
         <dependency reexport="false">cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</dependency>
         <dependency reexport="false">4517af98-2eaa-4f19-a962-92df60010094(org.iets3.core.expr.genjava.base#8286534136181746510)</dependency>
-        <dependency reexport="false">272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.genjava.simpleTypes.rt)</dependency>
+        <dependency reexport="false">272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.collections.rt)</dependency>
         <dependency reexport="false">2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)</dependency>
         <dependency reexport="false">b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)</dependency>
         <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
@@ -97,10 +97,10 @@
         <module reference="b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)" version="0" />
         <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
         <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="5" />
+        <module reference="272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.collections.rt)" version="0" />
         <module reference="4517af98-2eaa-4f19-a962-92df60010094(org.iets3.core.expr.genjava.base#8286534136181746510)" version="0" />
         <module reference="5a0b0b9c-ca67-4d27-9caa-ec974d9cfa40(org.iets3.core.expr.genjava.simpleTypes)" version="0" />
         <module reference="0ab6f947-2451-4a3a-80a3-33b77e399874(org.iets3.core.expr.genjava.simpleTypes#8286534136182342700)" version="0" />
-        <module reference="272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.genjava.simpleTypes.rt)" version="0" />
         <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="0" />
         <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="1" />
         <module reference="52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)" version="0" />
@@ -174,8 +174,8 @@
     <module reference="5a0b0b9c-ca67-4d27-9caa-ec974d9cfa40(org.iets3.core.expr.genjava.simpleTypes)" version="0" />
   </dependencyVersions>
   <runtime>
-    <dependency reexport="false">272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.genjava.simpleTypes.rt)</dependency>
     <dependency reexport="false">52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)</dependency>
+    <dependency reexport="false">272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.collections.rt)</dependency>
   </runtime>
   <extendedLanguages />
 </language>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.stateMachineExample/sandbox/org.iets3.core.expr.genjava.stateMachineExample.sandbox.msd
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.stateMachineExample/sandbox/org.iets3.core.expr.genjava.stateMachineExample.sandbox.msd
@@ -36,6 +36,7 @@
     <language slang="l:752cf1d3-84d1-4f2b-bbf5-4ef076a62ec7:org.iets3.core.expr.genjava.messages" version="0" />
     <language slang="l:5a0b0b9c-ca67-4d27-9caa-ec974d9cfa40:org.iets3.core.expr.genjava.simpleTypes" version="0" />
     <language slang="l:a15685d6-531e-45b7-9e72-af80302071ea:org.iets3.core.expr.genjava.stateMachineExample" version="0" />
+    <language slang="l:f9bb00ab-1f7e-40ab-9ec0-b11e02d84d0f:org.iets3.core.expr.genjava.stringvalidation" version="0" />
     <language slang="l:4453335f-7c63-4874-b3b1-ece8c37e6d9b:org.iets3.core.expr.genjava.temporal" version="0" />
     <language slang="l:e75207bb-7b13-40bd-b80b-c8fe625c4ee2:org.iets3.core.expr.genjava.tests" version="0" />
     <language slang="l:ddeeec5e-aa31-4c44-bc40-319cd452626e:org.iets3.core.expr.genjava.toplevel" version="-1" />
@@ -48,18 +49,19 @@
     <module reference="b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)" version="0" />
     <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
     <module reference="00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)" version="0" />
+    <module reference="272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.collections.rt)" version="0" />
     <module reference="a37d732b-a361-4dba-bc6f-f8e645007559(org.iets3.core.expr.genjava.advanced.genplan)" version="0" />
     <module reference="3a6ebc02-087e-4791-9854-65244ce22d8d(org.iets3.core.expr.genjava.base.rt)" version="0" />
     <module reference="72f3ce09-f244-46a5-88ca-7b98cd2dfb22(org.iets3.core.expr.genjava.core.genplan)" version="0" />
     <module reference="708a03ad-8699-43c9-821a-6cd00b68e9f8(org.iets3.core.expr.genjava.functionalJava)" version="0" />
     <module reference="646d63c6-d580-4c19-8759-e3a3123f5424(org.iets3.core.expr.genjava.messages.rt)" version="0" />
-    <module reference="272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.genjava.simpleTypes.rt)" version="0" />
     <module reference="889f307c-31c8-4d64-9e24-a83f15c85f02(org.iets3.core.expr.genjava.stateMachineExample.genplan)" version="0" />
     <module reference="6b5eff48-8eaa-4e24-9818-9fbfa6c3532c(org.iets3.core.expr.genjava.stateMachineExample.sandbox)" version="0" />
     <module reference="fde59617-0336-493b-a7ec-21148c3507f1(org.iets3.core.expr.genjava.temporal.rt)" version="0" />
     <module reference="68da6d9d-3ccf-4255-b4f7-37603cd89090(org.iets3.core.expr.genjava.tests.rt)" version="0" />
     <module reference="336cc7f4-18d3-473b-81a1-d8df1c0ad27a(org.iets3.core.expr.genjava.toplevel.rt)" version="0" />
     <module reference="52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)" version="0" />
+    <module reference="f38b69a3-1d33-4f9b-84e0-ac1095df2998(org.iets3.core.expr.stringvalidation.runtime)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.tests/org.iets3.core.expr.genjava.tests.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.tests/org.iets3.core.expr.genjava.tests.mpl
@@ -28,7 +28,7 @@
         <dependency reexport="false">d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)</dependency>
         <dependency reexport="false">49808fad-9d41-4b96-83fa-9231640f6b2b(JUnit)</dependency>
         <dependency reexport="false">4517af98-2eaa-4f19-a962-92df60010094(org.iets3.core.expr.genjava.base#8286534136181746510)</dependency>
-        <dependency reexport="false">272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.genjava.simpleTypes.rt)</dependency>
+        <dependency reexport="false">272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.collections.rt)</dependency>
         <dependency reexport="false">3a6ebc02-087e-4791-9854-65244ce22d8d(org.iets3.core.expr.genjava.base.rt)</dependency>
         <dependency reexport="false">68da6d9d-3ccf-4255-b4f7-37603cd89090(org.iets3.core.expr.genjava.tests.rt)</dependency>
         <dependency reexport="false">6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)</dependency>
@@ -100,9 +100,9 @@
         <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
         <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="3" />
         <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="5" />
+        <module reference="272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.collections.rt)" version="0" />
         <module reference="4517af98-2eaa-4f19-a962-92df60010094(org.iets3.core.expr.genjava.base#8286534136181746510)" version="0" />
         <module reference="3a6ebc02-087e-4791-9854-65244ce22d8d(org.iets3.core.expr.genjava.base.rt)" version="0" />
-        <module reference="272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.genjava.simpleTypes.rt)" version="0" />
         <module reference="e75207bb-7b13-40bd-b80b-c8fe625c4ee2(org.iets3.core.expr.genjava.tests)" version="0" />
         <module reference="d8b3dc54-37d4-4d4c-a903-50fe428a2dd5(org.iets3.core.expr.genjava.tests#8286534136181927906)" version="0" />
         <module reference="68da6d9d-3ccf-4255-b4f7-37603cd89090(org.iets3.core.expr.genjava.tests.rt)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/org.iets3.core.expr.genjava.toplevel.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/org.iets3.core.expr.genjava.toplevel.mpl
@@ -32,7 +32,7 @@
         <dependency reexport="false">6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)</dependency>
         <dependency reexport="false">3a6ebc02-087e-4791-9854-65244ce22d8d(org.iets3.core.expr.genjava.base.rt)</dependency>
         <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
-        <dependency reexport="false">272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.genjava.simpleTypes.rt)</dependency>
+        <dependency reexport="false">272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.collections.rt)</dependency>
         <dependency reexport="false">fbba5118-5fc6-49ff-9c3b-0b4469830440(org.iets3.core.expr.mutable)</dependency>
         <dependency reexport="false">336cc7f4-18d3-473b-81a1-d8df1c0ad27a(org.iets3.core.expr.genjava.toplevel.rt)</dependency>
         <dependency reexport="false">c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)</dependency>
@@ -102,9 +102,9 @@
         <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="3" />
         <module reference="b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)" version="0" />
         <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="5" />
+        <module reference="272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.collections.rt)" version="0" />
         <module reference="4517af98-2eaa-4f19-a962-92df60010094(org.iets3.core.expr.genjava.base#8286534136181746510)" version="0" />
         <module reference="3a6ebc02-087e-4791-9854-65244ce22d8d(org.iets3.core.expr.genjava.base.rt)" version="0" />
-        <module reference="272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.genjava.simpleTypes.rt)" version="0" />
         <module reference="ddeeec5e-aa31-4c44-bc40-319cd452626e(org.iets3.core.expr.genjava.toplevel)" version="0" />
         <module reference="26a1be67-8b63-4e59-b200-8e35002e091e(org.iets3.core.expr.genjava.toplevel#1899408283182158123)" version="0" />
         <module reference="336cc7f4-18d3-473b-81a1-d8df1c0ad27a(org.iets3.core.expr.genjava.toplevel.rt)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.interpreter/models/plugin.mps
@@ -25,6 +25,7 @@
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="j10v" ref="b76a0f63-5959-456b-993a-c796cc0d0c13/java:org.pcollections(org.iets3.core.expr.base.collections.stubs/)" />
     <import index="ppzb" ref="r:5db517a0-f62d-4841-a421-11bb7269799d(org.iets3.core.expr.base.shared.runtime)" />
+    <import index="wfax" ref="r:5d67e954-7960-4214-97d1-8f5d3823a964(org.iets3.core.expr.collections.rt.rt)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -81,7 +82,6 @@
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
-      <concept id="1070534513062" name="jetbrains.mps.baseLanguage.structure.DoubleType" flags="in" index="10P55v" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
@@ -3881,7 +3881,7 @@
                       <node concept="3cpWsn" id="4Q4DxjD$vJY" role="3cpWs9">
                         <property role="TrG5h" value="coll" />
                         <node concept="3uibUv" id="46cplYx_Uer" role="1tU5fm">
-                          <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+                          <ref role="3uigEE" to="j10v:~PCollection" resolve="PCollection" />
                         </node>
                         <node concept="1eOMI4" id="4Q4DxjD$vK0" role="33vP2m">
                           <node concept="10QFUN" id="4Q4DxjD$vK1" role="1eOMHV">
@@ -3895,7 +3895,7 @@
                               <node concept="TvHiN" id="4Q4DxjD$vK6" role="3ElQJh" />
                             </node>
                             <node concept="3uibUv" id="46cplYx_UCM" role="10QFUM">
-                              <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+                              <ref role="3uigEE" to="j10v:~PCollection" resolve="PCollection" />
                             </node>
                           </node>
                         </node>
@@ -3907,102 +3907,15 @@
                         <ref role="3cqZAo" node="4Q4DxjD$vJY" resolve="coll" />
                       </node>
                     </node>
-                    <node concept="3cpWs8" id="4Q4DxjD$vK8" role="3cqZAp">
-                      <node concept="3cpWsn" id="4Q4DxjD$vK9" role="3cpWs9">
-                        <property role="TrG5h" value="iterator" />
-                        <node concept="3uibUv" id="4Q4DxjD$vKa" role="1tU5fm">
-                          <ref role="3uigEE" to="33ny:~Iterator" resolve="Iterator" />
-                          <node concept="3uibUv" id="4Q4DxjD$vKb" role="11_B2D">
-                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                          </node>
-                        </node>
-                        <node concept="2OqwBi" id="4Q4DxjD$vKc" role="33vP2m">
-                          <node concept="37vLTw" id="4Q4DxjD$vKd" role="2Oq$k0">
-                            <ref role="3cqZAo" node="4Q4DxjD$vJY" resolve="coll" />
-                          </node>
-                          <node concept="liA8E" id="4Q4DxjD$vKe" role="2OqNvi">
-                            <ref role="37wK5l" to="33ny:~Collection.iterator()" resolve="iterator" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3cpWs8" id="4Q4DxjD$vKf" role="3cqZAp">
-                      <node concept="3cpWsn" id="4Q4DxjD$vKg" role="3cpWs9">
-                        <property role="TrG5h" value="sum" />
-                        <node concept="3cpWsb" id="4Q4DxjD$vKh" role="1tU5fm" />
-                        <node concept="3cmrfG" id="4Q4DxjD$vKi" role="33vP2m">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2$JKZl" id="4Q4DxjD$vKj" role="3cqZAp">
-                      <node concept="3clFbS" id="4Q4DxjD$vKk" role="2LFqv$">
-                        <node concept="3cpWs8" id="4Q4DxjD$vKl" role="3cqZAp">
-                          <node concept="3cpWsn" id="4Q4DxjD$vKm" role="3cpWs9">
-                            <property role="TrG5h" value="next" />
-                            <node concept="3uibUv" id="4Q4DxjD$vKn" role="1tU5fm">
-                              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                            </node>
-                            <node concept="2OqwBi" id="4Q4DxjD$vKo" role="33vP2m">
-                              <node concept="37vLTw" id="4Q4DxjD$vKp" role="2Oq$k0">
-                                <ref role="3cqZAo" node="4Q4DxjD$vK9" resolve="iterator" />
-                              </node>
-                              <node concept="liA8E" id="4Q4DxjD$vKq" role="2OqNvi">
-                                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3cpWs8" id="4Q4DxjD$vKr" role="3cqZAp">
-                          <node concept="3cpWsn" id="4Q4DxjD$vKs" role="3cpWs9">
-                            <property role="TrG5h" value="i" />
-                            <node concept="3cpWsb" id="4Q4DxjD$vKt" role="1tU5fm" />
-                            <node concept="2OqwBi" id="4Q4DxjD$vKu" role="33vP2m">
-                              <node concept="1eOMI4" id="4Q4DxjD$vKv" role="2Oq$k0">
-                                <node concept="10QFUN" id="4Q4DxjD$vKw" role="1eOMHV">
-                                  <node concept="3uibUv" id="s2V0$5WkZi" role="10QFUM">
-                                    <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
-                                  </node>
-                                  <node concept="37vLTw" id="4Q4DxjD$vKx" role="10QFUP">
-                                    <ref role="3cqZAo" node="4Q4DxjD$vKm" resolve="next" />
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="liA8E" id="4Q4DxjD$vKz" role="2OqNvi">
-                                <ref role="37wK5l" to="wyt6:~Number.longValue()" resolve="longValue" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3clFbF" id="4Q4DxjD$we$" role="3cqZAp">
-                          <node concept="d57v9" id="4Q4DxjD$wl7" role="3clFbG">
-                            <node concept="37vLTw" id="4Q4DxjD$wlm" role="37vLTx">
-                              <ref role="3cqZAo" node="4Q4DxjD$vKs" resolve="i" />
-                            </node>
-                            <node concept="37vLTw" id="4Q4DxjD$wey" role="37vLTJ">
-                              <ref role="3cqZAo" node="4Q4DxjD$vKg" resolve="sum" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="4Q4DxjD$vKH" role="2$JKZa">
-                        <node concept="37vLTw" id="4Q4DxjD$vKI" role="2Oq$k0">
-                          <ref role="3cqZAo" node="4Q4DxjD$vK9" resolve="iterator" />
-                        </node>
-                        <node concept="liA8E" id="4Q4DxjD$vKJ" role="2OqNvi">
-                          <ref role="37wK5l" to="33ny:~Iterator.hasNext()" resolve="hasNext" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3YmQ6b" id="18$bUx5VEz3" role="3cqZAp">
+                    <node concept="3YmQ6b" id="5Nr2ndjTrPE" role="3cqZAp">
                       <ref role="1nYgiw" node="18$bUx5VCpM" resolve="intCase" />
                     </node>
-                    <node concept="3cpWs6" id="4Q4DxjD$vKK" role="3cqZAp">
-                      <node concept="2YIFZM" id="s2V0$66OZW" role="3cqZAk">
-                        <ref role="37wK5l" to="xlxw:~BigInteger.valueOf(long)" resolve="valueOf" />
-                        <ref role="1Pybhc" to="xlxw:~BigInteger" resolve="BigInteger" />
-                        <node concept="37vLTw" id="s2V0$66P0a" role="37wK5m">
-                          <ref role="3cqZAo" node="4Q4DxjD$vKg" resolve="sum" />
+                    <node concept="3cpWs6" id="5Nr2ndjTseI" role="3cqZAp">
+                      <node concept="2YIFZM" id="5Nr2ndjTruw" role="3cqZAk">
+                        <ref role="37wK5l" to="wfax:7nYU6yJ0$7s" resolve="sumAsBigInteger" />
+                        <ref role="1Pybhc" to="wfax:4lRNjFWGzDc" resolve="CollectionHelper" />
+                        <node concept="37vLTw" id="5Nr2ndjTD2W" role="37wK5m">
+                          <ref role="3cqZAo" node="4Q4DxjD$vJY" resolve="coll" />
                         </node>
                       </node>
                     </node>
@@ -4052,102 +3965,15 @@
                         <ref role="3cqZAo" node="4Q4DxjD$vKV" resolve="coll" />
                       </node>
                     </node>
-                    <node concept="3cpWs8" id="4Q4DxjD$vL5" role="3cqZAp">
-                      <node concept="3cpWsn" id="4Q4DxjD$vL6" role="3cpWs9">
-                        <property role="TrG5h" value="iterator" />
-                        <node concept="3uibUv" id="4Q4DxjD$vL7" role="1tU5fm">
-                          <ref role="3uigEE" to="33ny:~Iterator" resolve="Iterator" />
-                          <node concept="3uibUv" id="4Q4DxjD$vL8" role="11_B2D">
-                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                          </node>
-                        </node>
-                        <node concept="2OqwBi" id="4Q4DxjD$vL9" role="33vP2m">
-                          <node concept="37vLTw" id="4Q4DxjD$vLa" role="2Oq$k0">
-                            <ref role="3cqZAo" node="4Q4DxjD$vKV" resolve="coll" />
-                          </node>
-                          <node concept="liA8E" id="4Q4DxjD$vLb" role="2OqNvi">
-                            <ref role="37wK5l" to="33ny:~Collection.iterator()" resolve="iterator" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3cpWs8" id="4Q4DxjD$vLc" role="3cqZAp">
-                      <node concept="3cpWsn" id="4Q4DxjD$vLd" role="3cpWs9">
-                        <property role="TrG5h" value="sum" />
-                        <node concept="10P55v" id="4Q4DxjD$vLe" role="1tU5fm" />
-                        <node concept="3cmrfG" id="4Q4DxjD$vLf" role="33vP2m">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2$JKZl" id="4Q4DxjD$vLg" role="3cqZAp">
-                      <node concept="3clFbS" id="4Q4DxjD$vLh" role="2LFqv$">
-                        <node concept="3cpWs8" id="4Q4DxjD$vLi" role="3cqZAp">
-                          <node concept="3cpWsn" id="4Q4DxjD$vLj" role="3cpWs9">
-                            <property role="TrG5h" value="next" />
-                            <node concept="3uibUv" id="4Q4DxjD$vLk" role="1tU5fm">
-                              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                            </node>
-                            <node concept="2OqwBi" id="4Q4DxjD$vLl" role="33vP2m">
-                              <node concept="37vLTw" id="4Q4DxjD$vLm" role="2Oq$k0">
-                                <ref role="3cqZAo" node="4Q4DxjD$vL6" resolve="iterator" />
-                              </node>
-                              <node concept="liA8E" id="4Q4DxjD$vLn" role="2OqNvi">
-                                <ref role="37wK5l" to="33ny:~Iterator.next()" resolve="next" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3cpWs8" id="4Q4DxjD$vLo" role="3cqZAp">
-                          <node concept="3cpWsn" id="4Q4DxjD$vLp" role="3cpWs9">
-                            <property role="TrG5h" value="i" />
-                            <node concept="10P55v" id="4Q4DxjD$vLq" role="1tU5fm" />
-                            <node concept="2OqwBi" id="4Q4DxjD$vLr" role="33vP2m">
-                              <node concept="1eOMI4" id="4Q4DxjD$vLs" role="2Oq$k0">
-                                <node concept="10QFUN" id="4Q4DxjD$vLt" role="1eOMHV">
-                                  <node concept="3uibUv" id="s2V0$5WkT7" role="10QFUM">
-                                    <ref role="3uigEE" to="wyt6:~Number" resolve="Number" />
-                                  </node>
-                                  <node concept="37vLTw" id="4Q4DxjD$vLu" role="10QFUP">
-                                    <ref role="3cqZAo" node="4Q4DxjD$vLj" resolve="next" />
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="liA8E" id="4Q4DxjD$vLw" role="2OqNvi">
-                                <ref role="37wK5l" to="wyt6:~Number.doubleValue()" resolve="doubleValue" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3clFbF" id="4Q4DxjD$wx9" role="3cqZAp">
-                          <node concept="d57v9" id="4Q4DxjD$w$r" role="3clFbG">
-                            <node concept="37vLTw" id="4Q4DxjD$w$E" role="37vLTx">
-                              <ref role="3cqZAo" node="4Q4DxjD$vLp" resolve="i" />
-                            </node>
-                            <node concept="37vLTw" id="4Q4DxjD$wx7" role="37vLTJ">
-                              <ref role="3cqZAo" node="4Q4DxjD$vLd" resolve="sum" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="4Q4DxjD$vLE" role="2$JKZa">
-                        <node concept="37vLTw" id="4Q4DxjD$vLF" role="2Oq$k0">
-                          <ref role="3cqZAo" node="4Q4DxjD$vL6" resolve="iterator" />
-                        </node>
-                        <node concept="liA8E" id="4Q4DxjD$vLG" role="2OqNvi">
-                          <ref role="37wK5l" to="33ny:~Iterator.hasNext()" resolve="hasNext" />
-                        </node>
-                      </node>
-                    </node>
                     <node concept="3YmQ6b" id="18$bUx5VFEI" role="3cqZAp">
                       <ref role="1nYgiw" node="18$bUx5VCpN" resolve="floatCase" />
                     </node>
-                    <node concept="3cpWs6" id="4Q4DxjD$vLH" role="3cqZAp">
-                      <node concept="2YIFZM" id="s2V0$66P0E" role="3cqZAk">
-                        <ref role="37wK5l" to="xlxw:~BigDecimal.valueOf(double)" resolve="valueOf" />
-                        <ref role="1Pybhc" to="xlxw:~BigDecimal" resolve="BigDecimal" />
-                        <node concept="37vLTw" id="s2V0$66P0S" role="37wK5m">
-                          <ref role="3cqZAo" node="4Q4DxjD$vLd" resolve="sum" />
+                    <node concept="3cpWs6" id="5Nr2ndjTH9c" role="3cqZAp">
+                      <node concept="2YIFZM" id="5Nr2ndjTHqG" role="3cqZAk">
+                        <ref role="37wK5l" to="wfax:4lRNjFWSwEt" resolve="sumAsBigDecimal" />
+                        <ref role="1Pybhc" to="wfax:4lRNjFWGzDc" resolve="CollectionHelper" />
+                        <node concept="37vLTw" id="5Nr2ndjTHqY" role="37wK5m">
+                          <ref role="3cqZAo" node="4Q4DxjD$vKV" resolve="coll" />
                         </node>
                       </node>
                     </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.interpreter/org.iets3.core.expr.collections.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.interpreter/org.iets3.core.expr.collections.interpreter.msd
@@ -21,6 +21,7 @@
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
     <dependency reexport="false">b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)</dependency>
     <dependency reexport="false">00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)</dependency>
+    <dependency reexport="false">272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.collections.rt)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:47f075a6-558e-4640-a606-7ce0236c8023:com.mbeddr.mpsutil.interpreter" version="1" />
@@ -76,6 +77,7 @@
     <module reference="00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)" version="0" />
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="5" />
     <module reference="07f696b4-29e7-4878-aefb-39cac5e8c6cc(org.iets3.core.expr.collections.interpreter)" version="0" />
+    <module reference="272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.collections.rt)" version="0" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="0" />
     <module reference="8ba65567-1c8a-4983-beb8-0482324d7e44(org.iets3.core.expr.lambda.interpreter)" version="0" />
   </dependencyVersions>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.rt/models/org.iets3.core.expr.collections.rt.rt.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.rt/models/org.iets3.core.expr.collections.rt.rt.mps
@@ -3,6 +3,7 @@
   <persistence version="9" />
   <attribute name="doNotGenerate" value="false" />
   <languages>
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -120,6 +121,9 @@
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
+      <concept id="1171903916106" name="jetbrains.mps.baseLanguage.structure.UpperBoundType" flags="in" index="3qUE_q">
+        <child id="1171903916107" name="bound" index="3qUE_r" />
+      </concept>
       <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
         <property id="8355037393041754995" name="isNative" index="2aFKle" />
       </concept>
@@ -155,6 +159,103 @@
   </registry>
   <node concept="312cEu" id="4lRNjFWGzDc">
     <property role="TrG5h" value="CollectionHelper" />
+    <node concept="2YIFZL" id="3A3G7ASlgFu" role="jymVt">
+      <property role="TrG5h" value="flatten" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="3A3G7ASlgFx" role="3clF47">
+        <node concept="3cpWs8" id="3A3G7ASlXHG" role="3cqZAp">
+          <node concept="3cpWsn" id="3A3G7ASlXHH" role="3cpWs9">
+            <property role="TrG5h" value="r" />
+            <node concept="3uibUv" id="3A3G7ASlXHE" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~List" resolve="List" />
+              <node concept="3uibUv" id="3A3G7ASlXIj" role="11_B2D">
+                <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="3A3G7ASq3$X" role="33vP2m">
+              <node concept="1pGfFk" id="3A3G7ASq492" role="2ShVmc">
+                <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;()" resolve="ArrayList" />
+                <node concept="3uibUv" id="3A3G7ASq58F" role="1pMfVU">
+                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="3A3G7ASlX$O" role="3cqZAp">
+          <node concept="2GrKxI" id="3A3G7ASlX$P" role="2Gsz3X">
+            <property role="TrG5h" value="coll" />
+          </node>
+          <node concept="37vLTw" id="3A3G7ASlXBp" role="2GsD0m">
+            <ref role="3cqZAo" node="3A3G7ASlgKy" resolve="vec" />
+          </node>
+          <node concept="3clFbS" id="3A3G7ASlX$R" role="2LFqv$">
+            <node concept="3clFbF" id="3A3G7ASq68Z" role="3cqZAp">
+              <node concept="2OqwBi" id="3A3G7ASq6U9" role="3clFbG">
+                <node concept="37vLTw" id="3A3G7ASq68X" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3A3G7ASlXHH" resolve="r" />
+                </node>
+                <node concept="liA8E" id="3A3G7ASq8SI" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~List.addAll(java.util.Collection)" resolve="addAll" />
+                  <node concept="2GrUjf" id="3A3G7ASq9gy" role="37wK5m">
+                    <ref role="2Gs0qQ" node="3A3G7ASlX$P" resolve="coll" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3A3G7ASqaYH" role="3cqZAp">
+          <node concept="3cpWsn" id="3A3G7ASqaYI" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="3uibUv" id="3A3G7ASqaYF" role="1tU5fm">
+              <ref role="3uigEE" to="j10v:~PVector" resolve="PVector" />
+              <node concept="3uibUv" id="3A3G7ASqbpU" role="11_B2D">
+                <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+              </node>
+            </node>
+            <node concept="2YIFZM" id="3A3G7ASqbXy" role="33vP2m">
+              <ref role="1Pybhc" to="j10v:~TreePVector" resolve="TreePVector" />
+              <ref role="37wK5l" to="j10v:~TreePVector.from(java.util.Collection)" resolve="from" />
+              <node concept="37vLTw" id="3A3G7ASqc7S" role="37wK5m">
+                <ref role="3cqZAo" node="3A3G7ASlXHH" resolve="r" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2VjxpUAJMJm" role="3cqZAp" />
+        <node concept="3cpWs6" id="3A3G7ASm7ln" role="3cqZAp">
+          <node concept="37vLTw" id="3A3G7ASqcqg" role="3cqZAk">
+            <ref role="3cqZAo" node="3A3G7ASqaYI" resolve="result" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3A3G7ASlgAr" role="1B3o_S" />
+      <node concept="3uibUv" id="3A3G7ASlgFl" role="3clF45">
+        <ref role="3uigEE" to="j10v:~PVector" resolve="PVector" />
+        <node concept="3uibUv" id="3A3G7ASlXAH" role="11_B2D">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3A3G7ASlgKy" role="3clF46">
+        <property role="TrG5h" value="vec" />
+        <node concept="3uibUv" id="3A3G7ASlX$8" role="1tU5fm">
+          <ref role="3uigEE" to="j10v:~PCollection" resolve="PCollection" />
+          <node concept="3qUE_q" id="$9KWJq6Bh3" role="11_B2D">
+            <node concept="3uibUv" id="3A3G7ASm3IQ" role="3qUE_r">
+              <ref role="3uigEE" to="j10v:~PCollection" resolve="PCollection" />
+              <node concept="3qUE_q" id="$9KWJq5KyH" role="11_B2D">
+                <node concept="3uibUv" id="$9KWJq5KQR" role="3qUE_r">
+                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="4lRNjFWGzDY" role="jymVt" />
     <node concept="2YIFZL" id="4lRNjFWSiFT" role="jymVt">
       <property role="TrG5h" value="min" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.rt/models/org.iets3.core.expr.collections.rt.rt.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.rt/models/org.iets3.core.expr.collections.rt.rt.mps
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:5d67e954-7960-4214-97d1-8f5d3823a964(org.iets3.core.expr.genjava.simpleTypes.rt.rt)">
+<model ref="r:5d67e954-7960-4214-97d1-8f5d3823a964(org.iets3.core.expr.collections.rt.rt)">
   <persistence version="9" />
   <attribute name="doNotGenerate" value="false" />
   <languages>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.rt/org.iets3.core.expr.collections.rt.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.rt/org.iets3.core.expr.collections.rt.msd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="org.iets3.core.expr.collections.rt" uuid="272bf1ac-d70c-4dac-96a3-976884f641b8" moduleVersion="0" pluginKind="PLUGIN_OTHER" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)</dependency>
+    <dependency reexport="false">52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)" version="0" />
+    <module reference="272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.collections.rt)" version="0" />
+    <module reference="52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.genjava.base.rt/models/rt.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.genjava.base.rt/models/rt.mps
@@ -35,9 +35,6 @@
       <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
         <reference id="2820489544401957798" name="classifier" index="HV5vE" />
       </concept>
-      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
-        <child id="1154032183016" name="body" index="2LFqv$" />
-      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -130,10 +127,6 @@
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
-      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
-        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
-      </concept>
-      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
@@ -145,9 +138,6 @@
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
-      </concept>
-      <concept id="1171903916106" name="jetbrains.mps.baseLanguage.structure.UpperBoundType" flags="in" index="3qUE_q">
-        <child id="1171903916107" name="bound" index="3qUE_r" />
       </concept>
       <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
         <property id="8355037393041754995" name="isNative" index="2aFKle" />
@@ -180,14 +170,6 @@
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
       <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
-      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
-        <child id="1153944400369" name="variable" index="2Gsz3X" />
-        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
-      </concept>
-      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
-      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
-        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
-      </concept>
       <concept id="1240325842691" name="jetbrains.mps.baseLanguage.collections.structure.AsSequenceOperation" flags="nn" index="39bAoz" />
     </language>
   </registry>
@@ -422,110 +404,6 @@
     <node concept="3uibUv" id="10wUh3OyTyI" role="1zkMxy">
       <ref role="3uigEE" to="wyt6:~RuntimeException" resolve="RuntimeException" />
     </node>
-  </node>
-  <node concept="312cEu" id="4lRNjFWGzDc">
-    <property role="TrG5h" value="CollectionHelper" />
-    <node concept="2tJIrI" id="4lRNjFWXTdZ" role="jymVt" />
-    <node concept="2tJIrI" id="3A3G7ASlgsV" role="jymVt" />
-    <node concept="2YIFZL" id="3A3G7ASlgFu" role="jymVt">
-      <property role="TrG5h" value="flatten" />
-      <property role="od$2w" value="false" />
-      <property role="DiZV1" value="false" />
-      <property role="2aFKle" value="false" />
-      <node concept="3clFbS" id="3A3G7ASlgFx" role="3clF47">
-        <node concept="3cpWs8" id="3A3G7ASlXHG" role="3cqZAp">
-          <node concept="3cpWsn" id="3A3G7ASlXHH" role="3cpWs9">
-            <property role="TrG5h" value="r" />
-            <node concept="3uibUv" id="3A3G7ASlXHE" role="1tU5fm">
-              <ref role="3uigEE" to="33ny:~List" resolve="List" />
-              <node concept="3uibUv" id="3A3G7ASlXIj" role="11_B2D">
-                <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-              </node>
-            </node>
-            <node concept="2ShNRf" id="3A3G7ASq3$X" role="33vP2m">
-              <node concept="1pGfFk" id="3A3G7ASq492" role="2ShVmc">
-                <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;()" resolve="ArrayList" />
-                <node concept="3uibUv" id="3A3G7ASq58F" role="1pMfVU">
-                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2Gpval" id="3A3G7ASlX$O" role="3cqZAp">
-          <node concept="2GrKxI" id="3A3G7ASlX$P" role="2Gsz3X">
-            <property role="TrG5h" value="coll" />
-          </node>
-          <node concept="37vLTw" id="3A3G7ASlXBp" role="2GsD0m">
-            <ref role="3cqZAo" node="3A3G7ASlgKy" resolve="vec" />
-          </node>
-          <node concept="3clFbS" id="3A3G7ASlX$R" role="2LFqv$">
-            <node concept="3clFbF" id="3A3G7ASq68Z" role="3cqZAp">
-              <node concept="2OqwBi" id="3A3G7ASq6U9" role="3clFbG">
-                <node concept="37vLTw" id="3A3G7ASq68X" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3A3G7ASlXHH" resolve="r" />
-                </node>
-                <node concept="liA8E" id="3A3G7ASq8SI" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~List.addAll(java.util.Collection)" resolve="addAll" />
-                  <node concept="2GrUjf" id="3A3G7ASq9gy" role="37wK5m">
-                    <ref role="2Gs0qQ" node="3A3G7ASlX$P" resolve="coll" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="3A3G7ASqaYH" role="3cqZAp">
-          <node concept="3cpWsn" id="3A3G7ASqaYI" role="3cpWs9">
-            <property role="TrG5h" value="result" />
-            <node concept="3uibUv" id="3A3G7ASqaYF" role="1tU5fm">
-              <ref role="3uigEE" to="j10v:~PVector" resolve="PVector" />
-              <node concept="3uibUv" id="3A3G7ASqbpU" role="11_B2D">
-                <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-              </node>
-            </node>
-            <node concept="2YIFZM" id="3A3G7ASqbXy" role="33vP2m">
-              <ref role="1Pybhc" to="j10v:~TreePVector" resolve="TreePVector" />
-              <ref role="37wK5l" to="j10v:~TreePVector.from(java.util.Collection)" resolve="from" />
-              <node concept="37vLTw" id="3A3G7ASqc7S" role="37wK5m">
-                <ref role="3cqZAo" node="3A3G7ASlXHH" resolve="r" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="2VjxpUAJMJm" role="3cqZAp" />
-        <node concept="3cpWs6" id="3A3G7ASm7ln" role="3cqZAp">
-          <node concept="37vLTw" id="3A3G7ASqcqg" role="3cqZAk">
-            <ref role="3cqZAo" node="3A3G7ASqaYI" resolve="result" />
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="3A3G7ASlgAr" role="1B3o_S" />
-      <node concept="3uibUv" id="3A3G7ASlgFl" role="3clF45">
-        <ref role="3uigEE" to="j10v:~PVector" resolve="PVector" />
-        <node concept="3uibUv" id="3A3G7ASlXAH" role="11_B2D">
-          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="3A3G7ASlgKy" role="3clF46">
-        <property role="TrG5h" value="vec" />
-        <node concept="3uibUv" id="3A3G7ASlX$8" role="1tU5fm">
-          <ref role="3uigEE" to="j10v:~PCollection" resolve="PCollection" />
-          <node concept="3qUE_q" id="$9KWJq6Bh3" role="11_B2D">
-            <node concept="3uibUv" id="3A3G7ASm3IQ" role="3qUE_r">
-              <ref role="3uigEE" to="j10v:~PCollection" resolve="PCollection" />
-              <node concept="3qUE_q" id="$9KWJq5KyH" role="11_B2D">
-                <node concept="3uibUv" id="$9KWJq5KQR" role="3qUE_r">
-                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="4lRNjFWX$nu" role="jymVt" />
-    <node concept="3Tm1VV" id="4lRNjFWGzDd" role="1B3o_S" />
   </node>
   <node concept="312cEu" id="2VjxpU_Tpwv">
     <property role="TrG5h" value="AlternativesException" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.stringvalidation.interpreter/models/org.iets3.core.expr.stringvalidation.interpreter.plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.stringvalidation.interpreter/models/org.iets3.core.expr.stringvalidation.interpreter.plugin.mps
@@ -142,7 +142,7 @@
     <property role="UYu25" value="arithmetic" />
     <node concept="qq9P1" id="3dTPcTTj0Qq" role="qq9xR">
       <property role="2TnfIJ" value="true" />
-      <ref role="qq9wM" to="3r88:3dTPcTThCWF" resolve="StringResultMessagesOp" />
+      <ref role="qq9wM" to="3r88:3dTPcTThCWF" resolve="ValidateStringResultErrorsOp" />
       <node concept="3vetai" id="3dTPcTTj3FI" role="3vQZUl">
         <node concept="3EllGN" id="3dTPcTTj3FW" role="3vdyny">
           <node concept="2OqwBi" id="3dTPcTTj3FX" role="3ElVtu">
@@ -157,7 +157,7 @@
     </node>
     <node concept="qq9P1" id="3dTPcTTiSTh" role="qq9xR">
       <property role="2TnfIJ" value="true" />
-      <ref role="qq9wM" to="3r88:3dTPcTThmny" resolve="StringResultOkOp" />
+      <ref role="qq9wM" to="3r88:3dTPcTThmny" resolve="ValidateStringResultOkOp" />
       <node concept="3vetai" id="3dTPcTTiVuM" role="3vQZUl">
         <node concept="2OqwBi" id="3dTPcTTiWYo" role="3vdyny">
           <node concept="1eOMI4" id="3dTPcTTiWyo" role="2Oq$k0">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -2839,6 +2839,76 @@
           </node>
         </node>
       </node>
+      <node concept="1E1JtA" id="5Nr2ndjUDzy" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="org.iets3.core.expr.collections.rt" />
+        <property role="3LESm3" value="272bf1ac-d70c-4dac-96a3-976884f641b8" />
+        <node concept="398BVA" id="5Nr2ndjUDzQ" role="3LF7KH">
+          <ref role="398BVh" node="5wLtKNeTaqD" resolve="iets3.lang.opensource" />
+          <node concept="2Ry0Ak" id="5Nr2ndjUDzU" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="5Nr2ndjUDzu" role="2Ry0An">
+              <property role="2Ry0Am" value="org.iets3.core.expr.collections.rt" />
+              <node concept="2Ry0Ak" id="5Nr2ndjUDzA" role="2Ry0An">
+                <property role="2Ry0Am" value="org.iets3.core.expr.collections.rt.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5Nr2ndjUDzM" role="3bR37C">
+          <node concept="3bR9La" id="5Nr2ndjUDzO" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="5Nr2ndjUDzG" role="3bR31x">
+          <node concept="3LXTmp" id="5Nr2ndjUDzs" role="3rtmxm">
+            <node concept="3qWCbU" id="5Nr2ndjUDzC" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="5Nr2ndjUDzS" role="3LXTmr">
+              <ref role="398BVh" node="5wLtKNeTaqD" resolve="iets3.lang.opensource" />
+              <node concept="2Ry0Ak" id="5Nr2ndjUDzo" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="5Nr2ndjUDz$" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.iets3.core.expr.genjava.simpleTypes.rt" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5Nr2ndjUDzI" role="3bR37C">
+          <node concept="3bR9La" id="5Nr2ndjUDzK" role="1SiIV1">
+            <ref role="3bR37D" node="5khwDRKS378" resolve="org.iets3.core.expr.base.collections.stubs" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="5Nr2ndjUDzE" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="5Nr2ndjTrq3" role="1HemKq">
+            <node concept="398BVA" id="5Nr2ndjTrpS" role="3LXTmr">
+              <ref role="398BVh" node="5wLtKNeTaqD" resolve="iets3.lang.opensource" />
+              <node concept="2Ry0Ak" id="5Nr2ndjTrpT" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="5Nr2ndjTrpU" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.iets3.core.expr.collections.rt" />
+                  <node concept="2Ry0Ak" id="5Nr2ndjTrpV" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="5Nr2ndjTrq4" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5Nr2ndjUDzw" role="3bR37C">
+          <node concept="3bR9La" id="5Nr2ndjUDzq" role="1SiIV1">
+            <ref role="3bR37D" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
+          </node>
+        </node>
+      </node>
       <node concept="1E1JtA" id="44TucI396ft" role="2G$12L">
         <property role="BnDLt" value="true" />
         <property role="3LESm3" value="07f696b4-29e7-4878-aefb-39cac5e8c6cc" />
@@ -2936,6 +3006,11 @@
         <node concept="1SiIV0" id="3qKzW8QJ_Az" role="3bR37C">
           <node concept="3bR9La" id="3qKzW8QJ_A$" role="1SiIV1">
             <ref role="3bR37D" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2IeAAg0yrpb" role="3bR37C">
+          <node concept="3bR9La" id="2IeAAg0yrpc" role="1SiIV1">
+            <ref role="3bR37D" node="5Nr2ndjUDzy" resolve="org.iets3.core.expr.collections.rt" />
           </node>
         </node>
       </node>
@@ -9277,11 +9352,6 @@
               <ref role="3bR37D" node="6JPXQMQs0pX" resolve="org.iets3.core.expr.collections" />
             </node>
           </node>
-          <node concept="1SiIV0" id="26tZ$Z4s7fC" role="3bR37C">
-            <node concept="3bR9La" id="26tZ$Z4s7fD" role="1SiIV1">
-              <ref role="3bR37D" node="26tZ$Z4rpVd" resolve="org.iets3.core.expr.genjava.simpleTypes.rt" />
-            </node>
-          </node>
           <node concept="1SiIV0" id="26tZ$Z4s7fE" role="3bR37C">
             <node concept="3bR9La" id="26tZ$Z4s7fF" role="1SiIV1">
               <ref role="3bR37D" node="26tZ$Z4rnV1" resolve="org.iets3.core.expr.genjava.base#8286534136181746510" />
@@ -9332,9 +9402,14 @@
               <ref role="3bR37D" node="4C_RnzfEE1P" resolve="org.iets3.core.expr.base.runtime" />
             </node>
           </node>
+          <node concept="1SiIV0" id="2IeAAg0yr_n" role="3bR37C">
+            <node concept="3bR9La" id="2IeAAg0yr_o" role="1SiIV1">
+              <ref role="3bR37D" node="5Nr2ndjUDzy" resolve="org.iets3.core.expr.collections.rt" />
+            </node>
+          </node>
         </node>
         <node concept="1E0d5M" id="26tZ$Z4s7fB" role="1E1XAP">
-          <ref role="1E0d5P" node="26tZ$Z4rpVd" resolve="org.iets3.core.expr.genjava.simpleTypes.rt" />
+          <ref role="1E0d5P" node="5Nr2ndjUDzy" resolve="org.iets3.core.expr.collections.rt" />
         </node>
         <node concept="3rtmxn" id="ojgKi0VOoC" role="3bR31x">
           <node concept="3LXTmp" id="ojgKi0VOoD" role="3rtmxm">
@@ -9376,6 +9451,9 @@
         </node>
         <node concept="1E0d5M" id="2xddOZL76P6" role="1E1XAP">
           <ref role="1E0d5P" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
+        </node>
+        <node concept="1E0d5M" id="2IeAAg0yr_m" role="1E1XAP">
+          <ref role="1E0d5P" node="5Nr2ndjUDzy" resolve="org.iets3.core.expr.collections.rt" />
         </node>
       </node>
       <node concept="1E1JtD" id="26tZ$Z4qWbm" role="2G$12L">
@@ -9428,11 +9506,6 @@
               <ref role="3bR37D" node="26tZ$Z4roBX" resolve="org.iets3.core.expr.genjava.base.rt" />
             </node>
           </node>
-          <node concept="1SiIV0" id="26tZ$Z4s7g6" role="3bR37C">
-            <node concept="3bR9La" id="26tZ$Z4s7g7" role="1SiIV1">
-              <ref role="3bR37D" node="26tZ$Z4rpVd" resolve="org.iets3.core.expr.genjava.simpleTypes.rt" />
-            </node>
-          </node>
           <node concept="1SiIV0" id="26tZ$Z4s7g8" role="3bR37C">
             <node concept="3bR9La" id="26tZ$Z4s7g9" role="1SiIV1">
               <ref role="3bR37D" node="26tZ$Z4rnV1" resolve="org.iets3.core.expr.genjava.base#8286534136181746510" />
@@ -9476,6 +9549,11 @@
               <node concept="3qWCbU" id="1RMC8GHEwUG" role="3LXTna">
                 <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
               </node>
+            </node>
+          </node>
+          <node concept="1SiIV0" id="2IeAAg0yr_L" role="3bR37C">
+            <node concept="3bR9La" id="2IeAAg0yr_M" role="1SiIV1">
+              <ref role="3bR37D" node="5Nr2ndjUDzy" resolve="org.iets3.core.expr.collections.rt" />
             </node>
           </node>
         </node>
@@ -9567,11 +9645,6 @@
               <ref role="3bR37D" node="26tZ$Z4rreH" resolve="org.iets3.core.expr.genjava.toplevel.rt" />
             </node>
           </node>
-          <node concept="1SiIV0" id="26tZ$Z4s7gA" role="3bR37C">
-            <node concept="3bR9La" id="26tZ$Z4s7gB" role="1SiIV1">
-              <ref role="3bR37D" node="26tZ$Z4rpVd" resolve="org.iets3.core.expr.genjava.simpleTypes.rt" />
-            </node>
-          </node>
           <node concept="1SiIV0" id="26tZ$Z4s7gC" role="3bR37C">
             <node concept="3bR9La" id="26tZ$Z4s7gD" role="1SiIV1">
               <ref role="3bR37D" node="26tZ$Z4rnV1" resolve="org.iets3.core.expr.genjava.base#8286534136181746510" />
@@ -9625,6 +9698,11 @@
           <node concept="1SiIV0" id="vWSpXPrMdq" role="3bR37C">
             <node concept="3bR9La" id="vWSpXPrMdp" role="1SiIV1">
               <ref role="3bR37D" node="26tZ$Z4rnV1" resolve="org.iets3.core.expr.genjava.base#8286534136181746510" />
+            </node>
+          </node>
+          <node concept="1SiIV0" id="2IeAAg0yrAb" role="3bR37C">
+            <node concept="3bR9La" id="2IeAAg0yrAc" role="1SiIV1">
+              <ref role="3bR37D" node="5Nr2ndjUDzy" resolve="org.iets3.core.expr.collections.rt" />
             </node>
           </node>
         </node>
@@ -9741,11 +9819,6 @@
           </node>
           <node concept="1SiIV0" id="4PBkCCBc3d9" role="3bR37C">
             <node concept="3bR9La" id="4PBkCCBc3da" role="1SiIV1">
-              <ref role="3bR37D" node="26tZ$Z4rnV1" resolve="org.iets3.core.expr.genjava.base#8286534136181746510" />
-            </node>
-          </node>
-          <node concept="1SiIV0" id="4PBkCCBc3dp" role="3bR37C">
-            <node concept="3bR9La" id="4PBkCCBc3do" role="1SiIV1">
               <ref role="3bR37D" node="26tZ$Z4rnV1" resolve="org.iets3.core.expr.genjava.base#8286534136181746510" />
             </node>
           </node>
@@ -10247,76 +10320,6 @@
           </node>
         </node>
       </node>
-      <node concept="1E1JtA" id="26tZ$Z4rpVd" role="2G$12L">
-        <property role="BnDLt" value="true" />
-        <property role="TrG5h" value="org.iets3.core.expr.genjava.simpleTypes.rt" />
-        <property role="3LESm3" value="272bf1ac-d70c-4dac-96a3-976884f641b8" />
-        <node concept="398BVA" id="26tZ$Z4rzH0" role="3LF7KH">
-          <ref role="398BVh" node="5wLtKNeTaqD" resolve="iets3.lang.opensource" />
-          <node concept="2Ry0Ak" id="26tZ$Z4r$Vy" role="iGT6I">
-            <property role="2Ry0Am" value="solutions" />
-            <node concept="2Ry0Ak" id="26tZ$Z4r_yP" role="2Ry0An">
-              <property role="2Ry0Am" value="org.iets3.core.expr.genjava.simpleTypes.rt" />
-              <node concept="2Ry0Ak" id="26tZ$Z4rAa8" role="2Ry0An">
-                <property role="2Ry0Am" value="org.iets3.core.expr.genjava.simpleTypes.rt.msd" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="26tZ$Z4s7hS" role="3bR37C">
-          <node concept="3bR9La" id="26tZ$Z4s7hT" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-          </node>
-        </node>
-        <node concept="3rtmxn" id="ojgKi0VVIf" role="3bR31x">
-          <node concept="3LXTmp" id="ojgKi0VVIg" role="3rtmxm">
-            <node concept="3qWCbU" id="ojgKi0VX3G" role="3LXTna">
-              <property role="3qWCbO" value="icons/**, resources/**" />
-            </node>
-            <node concept="398BVA" id="ojgKi0VW3_" role="3LXTmr">
-              <ref role="398BVh" node="5wLtKNeTaqD" resolve="iets3.lang.opensource" />
-              <node concept="2Ry0Ak" id="ojgKi0VWoV" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="ojgKi0VX3E" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.iets3.core.expr.genjava.simpleTypes.rt" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="3MqEfsXeLmI" role="3bR37C">
-          <node concept="3bR9La" id="3MqEfsXeLmJ" role="1SiIV1">
-            <ref role="3bR37D" node="5khwDRKS378" resolve="org.iets3.core.expr.base.collections.stubs" />
-          </node>
-        </node>
-        <node concept="1BupzO" id="1RMC8GHEwXB" role="3bR31x">
-          <property role="3ZfqAx" value="models" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="1RMC8GHEwXC" role="1HemKq">
-            <node concept="398BVA" id="1RMC8GHEwXs" role="3LXTmr">
-              <ref role="398BVh" node="5wLtKNeTaqD" resolve="iets3.lang.opensource" />
-              <node concept="2Ry0Ak" id="1RMC8GHEwXt" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="1RMC8GHEwXu" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.iets3.core.expr.genjava.simpleTypes.rt" />
-                  <node concept="2Ry0Ak" id="1RMC8GHEwXv" role="2Ry0An">
-                    <property role="2Ry0Am" value="models" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="1RMC8GHEwXD" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
-        <node concept="1SiIV0" id="2xddOZL76RR" role="3bR37C">
-          <node concept="3bR9La" id="2xddOZL76RS" role="1SiIV1">
-            <ref role="3bR37D" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
-          </node>
-        </node>
-      </node>
       <node concept="1E1JtA" id="5v$Gz_MUO6K" role="2G$12L">
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="org.iets3.core.expr.genjava.tests.rt" />
@@ -10781,9 +10784,6 @@
         <node concept="3LEDTM" id="2zpAVpC$Bhi" role="3LEDUa">
           <ref role="3LEDTN" node="26tZ$Z4rphz" resolve="org.iets3.core.expr.genjava.functionalJava" />
         </node>
-        <node concept="3LEDTM" id="2zpAVpC$Bhj" role="3LEDUa">
-          <ref role="3LEDTN" node="26tZ$Z4rpVd" resolve="org.iets3.core.expr.genjava.simpleTypes.rt" />
-        </node>
         <node concept="3LEDTM" id="2zpAVpC$Bhk" role="3LEDUa">
           <ref role="3LEDTN" node="7sID8G9t7pW" resolve="org.iets3.core.expr.genjava.temporal.rt" />
         </node>
@@ -10819,6 +10819,9 @@
         </node>
         <node concept="3LEDTy" id="3HiHZeyCpa4" role="3LEDUa">
           <ref role="3LEDTV" to="ffeo:7Kfy9QB6KZG" resolve="jetbrains.mps.baseLanguage.closures" />
+        </node>
+        <node concept="3LEDTM" id="2IeAAg0yrDk" role="3LEDUa">
+          <ref role="3LEDTN" node="5Nr2ndjUDzy" resolve="org.iets3.core.expr.collections.rt" />
         </node>
       </node>
       <node concept="3LEwk6" id="2zpAVpC$OJa" role="2G$12L">

--- a/code/languages/org.iets3.opensource/solutions/test.ex.core.expr.genjava/test.ex.core.expr.genjava.msd
+++ b/code/languages/org.iets3.opensource/solutions/test.ex.core.expr.genjava/test.ex.core.expr.genjava.msd
@@ -39,6 +39,7 @@
     <language slang="l:cc59a077-028a-42b0-ad86-6a1d71258691:org.iets3.core.expr.genjava.datetime" version="0" />
     <language slang="l:752cf1d3-84d1-4f2b-bbf5-4ef076a62ec7:org.iets3.core.expr.genjava.messages" version="-1" />
     <language slang="l:5a0b0b9c-ca67-4d27-9caa-ec974d9cfa40:org.iets3.core.expr.genjava.simpleTypes" version="0" />
+    <language slang="l:f9bb00ab-1f7e-40ab-9ec0-b11e02d84d0f:org.iets3.core.expr.genjava.stringvalidation" version="0" />
     <language slang="l:4453335f-7c63-4874-b3b1-ece8c37e6d9b:org.iets3.core.expr.genjava.temporal" version="0" />
     <language slang="l:e75207bb-7b13-40bd-b80b-c8fe625c4ee2:org.iets3.core.expr.genjava.tests" version="0" />
     <language slang="l:ddeeec5e-aa31-4c44-bc40-319cd452626e:org.iets3.core.expr.genjava.toplevel" version="0" />
@@ -56,16 +57,17 @@
     <module reference="b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)" version="0" />
     <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
     <module reference="00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)" version="0" />
+    <module reference="272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.collections.rt)" version="0" />
     <module reference="a37d732b-a361-4dba-bc6f-f8e645007559(org.iets3.core.expr.genjava.advanced.genplan)" version="0" />
     <module reference="3a6ebc02-087e-4791-9854-65244ce22d8d(org.iets3.core.expr.genjava.base.rt)" version="0" />
     <module reference="72f3ce09-f244-46a5-88ca-7b98cd2dfb22(org.iets3.core.expr.genjava.core.genplan)" version="0" />
     <module reference="708a03ad-8699-43c9-821a-6cd00b68e9f8(org.iets3.core.expr.genjava.functionalJava)" version="0" />
     <module reference="646d63c6-d580-4c19-8759-e3a3123f5424(org.iets3.core.expr.genjava.messages.rt)" version="0" />
-    <module reference="272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.genjava.simpleTypes.rt)" version="0" />
     <module reference="fde59617-0336-493b-a7ec-21148c3507f1(org.iets3.core.expr.genjava.temporal.rt)" version="0" />
     <module reference="68da6d9d-3ccf-4255-b4f7-37603cd89090(org.iets3.core.expr.genjava.tests.rt)" version="0" />
     <module reference="336cc7f4-18d3-473b-81a1-d8df1c0ad27a(org.iets3.core.expr.genjava.toplevel.rt)" version="0" />
     <module reference="52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)" version="0" />
+    <module reference="f38b69a3-1d33-4f9b-84e0-ac1095df2998(org.iets3.core.expr.stringvalidation.runtime)" version="0" />
     <module reference="0a68022c-4e89-4403-a717-1caf19c68980(test.ex.core.expr.genjava)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/test.in.expr.os.msd
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/test.in.expr.os.msd
@@ -133,6 +133,7 @@
     <module reference="00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)" version="0" />
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="5" />
     <module reference="07f696b4-29e7-4878-aefb-39cac5e8c6cc(org.iets3.core.expr.collections.interpreter)" version="0" />
+    <module reference="272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.collections.rt)" version="0" />
     <module reference="3a79aca0-f4b1-40f1-a3e9-259162afa77b(org.iets3.core.expr.dataflow.interpreter)" version="0" />
     <module reference="289fb12b-7f53-4ef7-bc2e-1ed2c6a7c998(org.iets3.core.expr.datetime)" version="1" />
     <module reference="356f24c7-748b-463e-a9e4-7973abbf5b8f(org.iets3.core.expr.datetime.interpreter)" version="0" />
@@ -143,7 +144,6 @@
     <module reference="72f3ce09-f244-46a5-88ca-7b98cd2dfb22(org.iets3.core.expr.genjava.core.genplan)" version="0" />
     <module reference="708a03ad-8699-43c9-821a-6cd00b68e9f8(org.iets3.core.expr.genjava.functionalJava)" version="0" />
     <module reference="646d63c6-d580-4c19-8759-e3a3123f5424(org.iets3.core.expr.genjava.messages.rt)" version="0" />
-    <module reference="272bf1ac-d70c-4dac-96a3-976884f641b8(org.iets3.core.expr.genjava.simpleTypes.rt)" version="0" />
     <module reference="fde59617-0336-493b-a7ec-21148c3507f1(org.iets3.core.expr.genjava.temporal.rt)" version="0" />
     <module reference="68da6d9d-3ccf-4255-b4f7-37603cd89090(org.iets3.core.expr.genjava.tests.rt)" version="0" />
     <module reference="336cc7f4-18d3-473b-81a1-d8df1c0ad27a(org.iets3.core.expr.genjava.toplevel.rt)" version="0" />


### PR DESCRIPTION
Fix for issue #639.

Move the `org.iets3.core.expr.genjava.collections.rt` package into `org.iets3.core.expr.collections.rt` such that it can be reused in both the interpreter and the generator. Reuse collection helper in interpreter implementation of `SumOp`.