### PR TITLE
Make the function runSolver virtual to overwrite it where necessary

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/behavior.mps
@@ -1332,6 +1332,7 @@
     </node>
     <node concept="13i0hz" id="7QODtLw3SMH" role="13h7CS">
       <property role="TrG5h" value="runSolver" />
+      <property role="13i0it" value="true" />
       <node concept="3Tm1VV" id="7QODtLw3SMI" role="1B3o_S" />
       <node concept="3uibUv" id="7QODtLw3VBg" role="3clF45">
         <ref role="3uigEE" to="gdgh:5zG5$Lyex1G" resolve="IResult" />


### PR DESCRIPTION
This PR makes the function `runSolver` in the Behavior of the `ISolvable` concept virtual such that it can be overwritten in dependencies.

**Known Issues**

If the function is implicitly overwritten in sub-concepts, the reflective editor must be used to add the overriding information manually. This is only required if the function should properly overwrite the `runSolver`  method from the `ISolvable`. 

_No changes are required if the two functions can be kept separate._
