### PR TITLE
Set different priorities for the conditional editors

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
@@ -3525,7 +3525,7 @@
     </node>
   </node>
   <node concept="RtYIR" id="1WlYLwX1DOp">
-    <property role="Rtri_" value="100" />
+    <property role="Rtri_" value="200" />
     <property role="3NULOk" value="ModelCoverage_Coloring" />
     <property role="3GE5qa" value="coverage" />
     <ref role="1XX52x" to="tpck:gw2VY9q" resolve="BaseConcept" />
@@ -5733,7 +5733,7 @@
     </node>
   </node>
   <node concept="RtYIR" id="3TIaSh$92nT">
-    <property role="Rtri_" value="100" />
+    <property role="Rtri_" value="210" />
     <property role="3GE5qa" value="coverageHighlighter" />
     <property role="3NULOk" value="coverageAnnotation" />
     <ref role="1XX52x" to="tpck:gw2VY9q" resolve="BaseConcept" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tracing/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tracing/models/editor.mps
@@ -333,7 +333,7 @@
     </language>
   </registry>
   <node concept="RtYIR" id="1rUbSenML5">
-    <property role="Rtri_" value="100" />
+    <property role="Rtri_" value="240" />
     <property role="3NULOk" value="Tracing" />
     <ref role="1XX52x" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="RtMap" id="1rUbSenNEl" role="RtEXV">
@@ -752,7 +752,7 @@
     <node concept="Rtstu" id="1OitGwf5Zbs" role="6VMZX" />
   </node>
   <node concept="RtYIR" id="2CFPPn7pH83">
-    <property role="Rtri_" value="100" />
+    <property role="Rtri_" value="250" />
     <property role="3NULOk" value="Tracing" />
     <ref role="1XX52x" to="hm2y:6sdnDbSla17" resolve="Expression" />
     <node concept="RtMap" id="2CFPPn7pH84" role="RtEXV">
@@ -1603,7 +1603,7 @@
     <node concept="3Tm1VV" id="2CFPPn7pTGr" role="1B3o_S" />
   </node>
   <node concept="RtYIR" id="5U8d23PW4kf">
-    <property role="Rtri_" value="100" />
+    <property role="Rtri_" value="230" />
     <property role="3NULOk" value="Coloring" />
     <ref role="1XX52x" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="RtMap" id="5U8d23PW4kg" role="RtEXV">


### PR DESCRIPTION
I'm not sure if there should be a specific order. I've used priorities from the 200er range because the 100er range is used by mbeddr. The original error message comes from mps itself:
`
 ERROR - actEditorHintsSpecificRegistry - Additional editor class org.iets3.core.expr.tracing.editor.BaseConcept_conditionalEditor_Editor_Tracing is applicable to the current context (de.slisson.mps.conditionalEditor.hints.editor.conditionalEditorHints.conditionalEditor_doNotUseThisHint, de.slisson.mps.conditionalEditor.hints.editor.conditionalEditorHints.conditionalEditor). Skipping this editor, using class org.iets3.core.expr.tracing.editor.BaseConcept_conditionalEditor_Editor_Coloring.`

