### PR TITLE
Expression eval helper methods without coverage

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -8049,6 +8049,33 @@
       </node>
       <node concept="3Tm1VV" id="uGVYUiloqA" role="1B3o_S" />
     </node>
+    <node concept="2tJIrI" id="5ElQ4Z$vuE" role="jymVt" />
+    <node concept="2YIFZL" id="5ElQ4Z$xNf" role="jymVt">
+      <property role="TrG5h" value="evaluateWithoutCoverage" />
+      <node concept="3clFbS" id="5ElQ4Z$xNi" role="3clF47">
+        <node concept="3cpWs6" id="5ElQ4Z$NtH" role="3cqZAp">
+          <node concept="1rXfSq" id="5ElQ4Z$On5" role="3cqZAk">
+            <ref role="37wK5l" node="5ElQ4Z$HSq" resolve="evaluateWithContextWithoutCoverage" />
+            <node concept="37vLTw" id="5ElQ4Z$Pg1" role="37wK5m">
+              <ref role="3cqZAo" node="5ElQ4Z$yBW" resolve="expr" />
+            </node>
+            <node concept="2ShNRf" id="5ElQ4Z$Q92" role="37wK5m">
+              <node concept="HV5vD" id="5ElQ4Z$QSV" role="2ShVmc">
+                <ref role="HV5vE" node="6iqfHNC0mHl" resolve="IETS3ExprContext" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5ElQ4Z$wgz" role="1B3o_S" />
+      <node concept="3uibUv" id="5ElQ4Z$xdD" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+      </node>
+      <node concept="37vLTG" id="5ElQ4Z$yBW" role="3clF46">
+        <property role="TrG5h" value="expr" />
+        <node concept="3Tqbb2" id="5ElQ4Z$yBV" role="1tU5fm" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="Qsaevo34dw" role="jymVt" />
     <node concept="2YIFZL" id="Qsaevo33yK" role="jymVt">
       <property role="TrG5h" value="evaluateWithContext" />
@@ -8056,188 +8083,18 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="Qsaevo33yL" role="3clF47">
-        <node concept="3cpWs8" id="Qsaevo33yR" role="3cqZAp">
-          <node concept="3cpWsn" id="Qsaevo33yS" role="3cpWs9">
-            <property role="TrG5h" value="coverage" />
-            <node concept="3uibUv" id="Qsaevo33yT" role="1tU5fm">
-              <ref role="3uigEE" node="4_qY3E5IXRD" resolve="DefaultCoverageAnalyzer" />
+        <node concept="3clFbF" id="5ElQ4ZyRVX" role="3cqZAp">
+          <node concept="1rXfSq" id="5ElQ4ZyRVV" role="3clFbG">
+            <ref role="37wK5l" node="5ElQ4Zyzn4" resolve="evaluateWithContextInternal" />
+            <node concept="37vLTw" id="5ElQ4ZySUD" role="37wK5m">
+              <ref role="3cqZAo" node="Qsaevo33zM" resolve="expr" />
             </node>
-            <node concept="2ShNRf" id="Qsaevo33yU" role="33vP2m">
-              <node concept="1pGfFk" id="2ns1RQRNMXO" role="2ShVmc">
+            <node concept="37vLTw" id="5ElQ4ZyUIl" role="37wK5m">
+              <ref role="3cqZAo" node="Qsaevo35yg" resolve="ctx" />
+            </node>
+            <node concept="2ShNRf" id="5ElQ4Zz096" role="37wK5m">
+              <node concept="1pGfFk" id="5ElQ4Zz3WU" role="2ShVmc">
                 <ref role="37wK5l" node="7ezRWquAAWk" resolve="DefaultCoverageAnalyzer" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3J1_TO" id="Qsaevo33yW" role="3cqZAp">
-          <node concept="3uVAMA" id="Qsaevo33zc" role="1zxBo5">
-            <node concept="XOnhg" id="Qsaevo33zd" role="1zc67B">
-              <property role="3TUv4t" value="false" />
-              <property role="TrG5h" value="stopEx" />
-              <node concept="nSUau" id="dMsOI6pZNvt" role="1tU5fm">
-                <node concept="3uibUv" id="Qsaevo33ze" role="nSUat">
-                  <ref role="3uigEE" to="2ahs:6MNhNeUeNix" resolve="StopAndReturnException" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbS" id="Qsaevo33zf" role="1zc67A">
-              <node concept="3cpWs6" id="Qsaevo33zg" role="3cqZAp">
-                <node concept="2OqwBi" id="Qsaevo33zh" role="3cqZAk">
-                  <node concept="37vLTw" id="Qsaevo33zi" role="2Oq$k0">
-                    <ref role="3cqZAo" node="Qsaevo33zd" resolve="stopEx" />
-                  </node>
-                  <node concept="liA8E" id="Qsaevo33zj" role="2OqNvi">
-                    <ref role="37wK5l" to="2ahs:6MNhNeUeYe3" resolve="value" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3uVAMA" id="Qsaevo33zk" role="1zxBo5">
-            <node concept="XOnhg" id="Qsaevo33zl" role="1zc67B">
-              <property role="3TUv4t" value="false" />
-              <property role="TrG5h" value="ex" />
-              <node concept="nSUau" id="dMsOI6pZNvH" role="1tU5fm">
-                <node concept="3uibUv" id="Qsaevo33zm" role="nSUat">
-                  <ref role="3uigEE" to="2ahs:9nJ_zCA_CM" resolve="InterpreterRuntimeException" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbS" id="Qsaevo33zn" role="1zc67A">
-              <node concept="3cpWs8" id="6LLJO$vZzEM" role="3cqZAp">
-                <node concept="3cpWsn" id="6LLJO$vZzEN" role="3cpWs9">
-                  <property role="TrG5h" value="failureTrace" />
-                  <node concept="3uibUv" id="6LLJO$vZzEI" role="1tU5fm">
-                    <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
-                  </node>
-                  <node concept="2OqwBi" id="6LLJO$vZzEO" role="33vP2m">
-                    <node concept="37vLTw" id="6LLJO$vZzEP" role="2Oq$k0">
-                      <ref role="3cqZAo" node="Qsaevo33zl" resolve="ex" />
-                    </node>
-                    <node concept="liA8E" id="6LLJO$vZzEQ" role="2OqNvi">
-                      <ref role="37wK5l" to="2ahs:6LLJO$vY_c_" resolve="getFailureTrace" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbJ" id="6LLJO$vZzls" role="3cqZAp">
-                <node concept="3clFbS" id="6LLJO$vZzlu" role="3clFbx">
-                  <node concept="3clFbF" id="Qsaevo33zo" role="3cqZAp">
-                    <node concept="2OqwBi" id="Qsaevo33zp" role="3clFbG">
-                      <node concept="10M0yZ" id="Qsaevo33zq" role="2Oq$k0">
-                        <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-                        <ref role="3cqZAo" to="wyt6:~System.err" resolve="err" />
-                      </node>
-                      <node concept="liA8E" id="Qsaevo33zr" role="2OqNvi">
-                        <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
-                        <node concept="3cpWs3" id="Qsaevo33zs" role="37wK5m">
-                          <node concept="2OqwBi" id="6LLJO$vYEI0" role="3uHU7w">
-                            <node concept="37vLTw" id="6LLJO$vZzER" role="2Oq$k0">
-                              <ref role="3cqZAo" node="6LLJO$vZzEN" resolve="failureTrace" />
-                            </node>
-                            <node concept="liA8E" id="6LLJO$vYFtf" role="2OqNvi">
-                              <ref role="37wK5l" to="2ahs:6LLJO$vYHbj" resolve="createStackTraceToThisOneAsString" />
-                              <node concept="3clFbT" id="6LLJO$vYFNP" role="37wK5m">
-                                <property role="3clFbU" value="true" />
-                              </node>
-                              <node concept="3cmrfG" id="6LLJO$vZwyz" role="37wK5m">
-                                <property role="3cmrfH" value="2" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="Xl_RD" id="Qsaevo33zx" role="3uHU7B">
-                            <property role="Xl_RC" value="Interpreter failed when running " />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3y3z36" id="6LLJO$vZ_is" role="3clFbw">
-                  <node concept="10Nm6u" id="6LLJO$vZ__h" role="3uHU7w" />
-                  <node concept="37vLTw" id="6LLJO$vZ$Mw" role="3uHU7B">
-                    <ref role="3cqZAo" node="6LLJO$vZzEN" resolve="failureTrace" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbF" id="Qsaevo33zy" role="3cqZAp">
-                <node concept="2OqwBi" id="Qsaevo33zz" role="3clFbG">
-                  <node concept="10M0yZ" id="Qsaevo33z$" role="2Oq$k0">
-                    <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-                    <ref role="3cqZAo" to="wyt6:~System.err" resolve="err" />
-                  </node>
-                  <node concept="liA8E" id="Qsaevo33z_" role="2OqNvi">
-                    <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
-                    <node concept="3cpWs3" id="Qsaevo33zA" role="37wK5m">
-                      <node concept="2OqwBi" id="Qsaevo33zB" role="3uHU7w">
-                        <node concept="37vLTw" id="Qsaevo33zC" role="2Oq$k0">
-                          <ref role="3cqZAo" node="Qsaevo33zl" resolve="ex" />
-                        </node>
-                        <node concept="liA8E" id="Qsaevo33zD" role="2OqNvi">
-                          <ref role="37wK5l" to="2ahs:9nJ_zCAH8C" resolve="getMessage" />
-                        </node>
-                      </node>
-                      <node concept="Xl_RD" id="Qsaevo33zE" role="3uHU7B">
-                        <property role="Xl_RC" value="Exception: " />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbF" id="Qsaevo33zF" role="3cqZAp">
-                <node concept="2OqwBi" id="Qsaevo33zG" role="3clFbG">
-                  <node concept="37vLTw" id="Qsaevo33zH" role="2Oq$k0">
-                    <ref role="3cqZAo" node="Qsaevo33zl" resolve="ex" />
-                  </node>
-                  <node concept="liA8E" id="Qsaevo33zI" role="2OqNvi">
-                    <ref role="37wK5l" to="wyt6:~Throwable.printStackTrace()" resolve="printStackTrace" />
-                  </node>
-                </node>
-              </node>
-              <node concept="YS8fn" id="7EYe2PMkuMo" role="3cqZAp">
-                <node concept="37vLTw" id="7EYe2PMkv9P" role="YScLw">
-                  <ref role="3cqZAo" node="Qsaevo33zl" resolve="ex" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbS" id="Qsaevo33yX" role="1zxBo7">
-            <node concept="3cpWs8" id="Qsaevo33yY" role="3cqZAp">
-              <node concept="3cpWsn" id="Qsaevo33yZ" role="3cpWs9">
-                <property role="TrG5h" value="helper" />
-                <node concept="3uibUv" id="Qsaevo33z0" role="1tU5fm">
-                  <ref role="3uigEE" to="2ahs:50LzNoSxDO3" resolve="InterpreterEvaluationHelper" />
-                </node>
-                <node concept="2ShNRf" id="Qsaevo33z1" role="33vP2m">
-                  <node concept="1pGfFk" id="Qsaevo33z2" role="2ShVmc">
-                    <ref role="37wK5l" to="2ahs:50LzNoSxJpU" resolve="InterpreterEvaluationHelper" />
-                    <node concept="37vLTw" id="Qsaevo33z3" role="37wK5m">
-                      <ref role="3cqZAo" node="50LzNoSyDId" resolve="INTERPRETER_CATEGORY" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs6" id="Qsaevo33z4" role="3cqZAp">
-              <node concept="2OqwBi" id="Qsaevo33z5" role="3cqZAk">
-                <node concept="37vLTw" id="Qsaevo33z6" role="2Oq$k0">
-                  <ref role="3cqZAo" node="Qsaevo33yZ" resolve="helper" />
-                </node>
-                <node concept="liA8E" id="Qsaevo33z7" role="2OqNvi">
-                  <ref role="37wK5l" to="2ahs:14DmiwrcwYd" resolve="evaluateWithContextAndCoverage" />
-                  <node concept="37vLTw" id="Qsaevo33z8" role="37wK5m">
-                    <ref role="3cqZAo" node="Qsaevo33zM" resolve="expr" />
-                  </node>
-                  <node concept="1rXfSq" id="Qsaevo33z9" role="37wK5m">
-                    <ref role="37wK5l" node="50LzNoSyDOv" resolve="getInterpreter" />
-                  </node>
-                  <node concept="37vLTw" id="Qsaevo33za" role="37wK5m">
-                    <ref role="3cqZAo" node="Qsaevo35yg" resolve="ctx" />
-                  </node>
-                  <node concept="37vLTw" id="Qsaevo33zb" role="37wK5m">
-                    <ref role="3cqZAo" node="Qsaevo33yS" resolve="coverage" />
-                  </node>
-                </node>
               </node>
             </node>
           </node>
@@ -8258,6 +8115,244 @@
       </node>
       <node concept="3Tm1VV" id="Qsaevo33zO" role="1B3o_S" />
     </node>
+    <node concept="2tJIrI" id="5ElQ4Z$ET0" role="jymVt" />
+    <node concept="2YIFZL" id="5ElQ4Z$HSq" role="jymVt">
+      <property role="TrG5h" value="evaluateWithContextWithoutCoverage" />
+      <node concept="3clFbS" id="5ElQ4Z$HSt" role="3clF47">
+        <node concept="3clFbF" id="5ElQ4Z$JZh" role="3cqZAp">
+          <node concept="1rXfSq" id="5ElQ4Z$JZi" role="3clFbG">
+            <ref role="37wK5l" node="5ElQ4Zyzn4" resolve="evaluateWithContextInternal" />
+            <node concept="37vLTw" id="5ElQ4Z$JZj" role="37wK5m">
+              <ref role="3cqZAo" node="5ElQ4Z$IM_" resolve="expr" />
+            </node>
+            <node concept="37vLTw" id="5ElQ4Z$JZk" role="37wK5m">
+              <ref role="3cqZAo" node="5ElQ4Z$J$R" resolve="ctx" />
+            </node>
+            <node concept="2ShNRf" id="5ElQ4Z$LEv" role="37wK5m">
+              <node concept="HV5vD" id="5ElQ4Z$Mqs" role="2ShVmc">
+                <ref role="HV5vE" to="2ahs:4_qY3E6qZJh" resolve="NullCoverageAnalyzer" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5ElQ4Z$FYM" role="1B3o_S" />
+      <node concept="3uibUv" id="5ElQ4Z$Hc$" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+      </node>
+      <node concept="37vLTG" id="5ElQ4Z$IM_" role="3clF46">
+        <property role="TrG5h" value="expr" />
+        <node concept="3Tqbb2" id="5ElQ4Z$IM$" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="5ElQ4Z$J$R" role="3clF46">
+        <property role="TrG5h" value="ctx" />
+        <node concept="3uibUv" id="5ElQ4Z$J$S" role="1tU5fm">
+          <ref role="3uigEE" node="6iqfHNC0mHl" resolve="IETS3ExprContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5ElQ4Zy_tc" role="jymVt" />
+    <node concept="2YIFZL" id="5ElQ4Zyzn4" role="jymVt">
+      <property role="TrG5h" value="evaluateWithContextInternal" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="5ElQ4Zyzn5" role="3clF47">
+        <node concept="3J1_TO" id="5ElQ4Zyznb" role="3cqZAp">
+          <node concept="3uVAMA" id="5ElQ4Zyznc" role="1zxBo5">
+            <node concept="XOnhg" id="5ElQ4Zyznd" role="1zc67B">
+              <property role="3TUv4t" value="false" />
+              <property role="TrG5h" value="stopEx" />
+              <node concept="nSUau" id="5ElQ4Zyzne" role="1tU5fm">
+                <node concept="3uibUv" id="5ElQ4Zyznf" role="nSUat">
+                  <ref role="3uigEE" to="2ahs:6MNhNeUeNix" resolve="StopAndReturnException" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="5ElQ4Zyzng" role="1zc67A">
+              <node concept="3cpWs6" id="5ElQ4Zyznh" role="3cqZAp">
+                <node concept="2OqwBi" id="5ElQ4Zyzni" role="3cqZAk">
+                  <node concept="37vLTw" id="5ElQ4Zyznj" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5ElQ4Zyznd" resolve="stopEx" />
+                  </node>
+                  <node concept="liA8E" id="5ElQ4Zyznk" role="2OqNvi">
+                    <ref role="37wK5l" to="2ahs:6MNhNeUeYe3" resolve="value" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3uVAMA" id="5ElQ4Zyznl" role="1zxBo5">
+            <node concept="XOnhg" id="5ElQ4Zyznm" role="1zc67B">
+              <property role="3TUv4t" value="false" />
+              <property role="TrG5h" value="ex" />
+              <node concept="nSUau" id="5ElQ4Zyznn" role="1tU5fm">
+                <node concept="3uibUv" id="5ElQ4Zyzno" role="nSUat">
+                  <ref role="3uigEE" to="2ahs:9nJ_zCA_CM" resolve="InterpreterRuntimeException" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="5ElQ4Zyznp" role="1zc67A">
+              <node concept="3cpWs8" id="5ElQ4Zyznq" role="3cqZAp">
+                <node concept="3cpWsn" id="5ElQ4Zyznr" role="3cpWs9">
+                  <property role="TrG5h" value="failureTrace" />
+                  <node concept="3uibUv" id="5ElQ4Zyzns" role="1tU5fm">
+                    <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
+                  </node>
+                  <node concept="2OqwBi" id="5ElQ4Zyznt" role="33vP2m">
+                    <node concept="37vLTw" id="5ElQ4Zyznu" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5ElQ4Zyznm" resolve="ex" />
+                    </node>
+                    <node concept="liA8E" id="5ElQ4Zyznv" role="2OqNvi">
+                      <ref role="37wK5l" to="2ahs:6LLJO$vY_c_" resolve="getFailureTrace" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="5ElQ4Zyznw" role="3cqZAp">
+                <node concept="3clFbS" id="5ElQ4Zyznx" role="3clFbx">
+                  <node concept="3clFbF" id="5ElQ4Zyzny" role="3cqZAp">
+                    <node concept="2OqwBi" id="5ElQ4Zyznz" role="3clFbG">
+                      <node concept="10M0yZ" id="5ElQ4Zyzn$" role="2Oq$k0">
+                        <ref role="3cqZAo" to="wyt6:~System.err" resolve="err" />
+                        <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                      </node>
+                      <node concept="liA8E" id="5ElQ4Zyzn_" role="2OqNvi">
+                        <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                        <node concept="3cpWs3" id="5ElQ4ZyznA" role="37wK5m">
+                          <node concept="2OqwBi" id="5ElQ4ZyznB" role="3uHU7w">
+                            <node concept="37vLTw" id="5ElQ4ZyznC" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5ElQ4Zyznr" resolve="failureTrace" />
+                            </node>
+                            <node concept="liA8E" id="5ElQ4ZyznD" role="2OqNvi">
+                              <ref role="37wK5l" to="2ahs:6LLJO$vYHbj" resolve="createStackTraceToThisOneAsString" />
+                              <node concept="3clFbT" id="5ElQ4ZyznE" role="37wK5m">
+                                <property role="3clFbU" value="true" />
+                              </node>
+                              <node concept="3cmrfG" id="5ElQ4ZyznF" role="37wK5m">
+                                <property role="3cmrfH" value="2" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Xl_RD" id="5ElQ4ZyznG" role="3uHU7B">
+                            <property role="Xl_RC" value="Interpreter failed when running " />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3y3z36" id="5ElQ4ZyznH" role="3clFbw">
+                  <node concept="10Nm6u" id="5ElQ4ZyznI" role="3uHU7w" />
+                  <node concept="37vLTw" id="5ElQ4ZyznJ" role="3uHU7B">
+                    <ref role="3cqZAo" node="5ElQ4Zyznr" resolve="failureTrace" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="5ElQ4ZyznK" role="3cqZAp">
+                <node concept="2OqwBi" id="5ElQ4ZyznL" role="3clFbG">
+                  <node concept="10M0yZ" id="5ElQ4ZyznM" role="2Oq$k0">
+                    <ref role="3cqZAo" to="wyt6:~System.err" resolve="err" />
+                    <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                  </node>
+                  <node concept="liA8E" id="5ElQ4ZyznN" role="2OqNvi">
+                    <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                    <node concept="3cpWs3" id="5ElQ4ZyznO" role="37wK5m">
+                      <node concept="2OqwBi" id="5ElQ4ZyznP" role="3uHU7w">
+                        <node concept="37vLTw" id="5ElQ4ZyznQ" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5ElQ4Zyznm" resolve="ex" />
+                        </node>
+                        <node concept="liA8E" id="5ElQ4ZyznR" role="2OqNvi">
+                          <ref role="37wK5l" to="2ahs:9nJ_zCAH8C" resolve="getMessage" />
+                        </node>
+                      </node>
+                      <node concept="Xl_RD" id="5ElQ4ZyznS" role="3uHU7B">
+                        <property role="Xl_RC" value="Exception: " />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="5ElQ4ZyznT" role="3cqZAp">
+                <node concept="2OqwBi" id="5ElQ4ZyznU" role="3clFbG">
+                  <node concept="37vLTw" id="5ElQ4ZyznV" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5ElQ4Zyznm" resolve="ex" />
+                  </node>
+                  <node concept="liA8E" id="5ElQ4ZyznW" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Throwable.printStackTrace()" resolve="printStackTrace" />
+                  </node>
+                </node>
+              </node>
+              <node concept="YS8fn" id="5ElQ4ZyznX" role="3cqZAp">
+                <node concept="37vLTw" id="5ElQ4ZyznY" role="YScLw">
+                  <ref role="3cqZAo" node="5ElQ4Zyznm" resolve="ex" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="5ElQ4ZyznZ" role="1zxBo7">
+            <node concept="3cpWs8" id="5ElQ4Zyzo0" role="3cqZAp">
+              <node concept="3cpWsn" id="5ElQ4Zyzo1" role="3cpWs9">
+                <property role="TrG5h" value="helper" />
+                <node concept="3uibUv" id="5ElQ4Zyzo2" role="1tU5fm">
+                  <ref role="3uigEE" to="2ahs:50LzNoSxDO3" resolve="InterpreterEvaluationHelper" />
+                </node>
+                <node concept="2ShNRf" id="5ElQ4Zyzo3" role="33vP2m">
+                  <node concept="1pGfFk" id="5ElQ4Zyzo4" role="2ShVmc">
+                    <ref role="37wK5l" to="2ahs:50LzNoSxJpU" resolve="InterpreterEvaluationHelper" />
+                    <node concept="37vLTw" id="5ElQ4Zyzpc" role="37wK5m">
+                      <ref role="3cqZAo" node="50LzNoSyDId" resolve="INTERPRETER_CATEGORY" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="5ElQ4Zyzo5" role="3cqZAp">
+              <node concept="2OqwBi" id="5ElQ4Zyzo6" role="3cqZAk">
+                <node concept="37vLTw" id="5ElQ4Zyzo7" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5ElQ4Zyzo1" resolve="helper" />
+                </node>
+                <node concept="liA8E" id="5ElQ4Zyzo8" role="2OqNvi">
+                  <ref role="37wK5l" to="2ahs:14DmiwrcwYd" resolve="evaluateWithContextAndCoverage" />
+                  <node concept="37vLTw" id="5ElQ4Zyzo9" role="37wK5m">
+                    <ref role="3cqZAo" node="5ElQ4Zyzoe" resolve="expr" />
+                  </node>
+                  <node concept="1rXfSq" id="5ElQ4Zyzoa" role="37wK5m">
+                    <ref role="37wK5l" node="50LzNoSyDOv" resolve="getInterpreter" />
+                  </node>
+                  <node concept="37vLTw" id="5ElQ4Zyzob" role="37wK5m">
+                    <ref role="3cqZAo" node="5ElQ4Zyzog" resolve="ctx" />
+                  </node>
+                  <node concept="37vLTw" id="5ElQ4Zyzoc" role="37wK5m">
+                    <ref role="3cqZAo" node="5ElQ4ZyMvG" resolve="coverage" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="5ElQ4Zyzod" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+      </node>
+      <node concept="37vLTG" id="5ElQ4Zyzoe" role="3clF46">
+        <property role="TrG5h" value="expr" />
+        <node concept="3Tqbb2" id="5ElQ4Zyzof" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="5ElQ4Zyzog" role="3clF46">
+        <property role="TrG5h" value="ctx" />
+        <node concept="3uibUv" id="5ElQ4Zyzoh" role="1tU5fm">
+          <ref role="3uigEE" node="6iqfHNC0mHl" resolve="IETS3ExprContext" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="5ElQ4ZyMvG" role="3clF46">
+        <property role="TrG5h" value="coverage" />
+        <node concept="3uibUv" id="5ElQ4ZyN1e" role="1tU5fm">
+          <ref role="3uigEE" to="2ahs:4_qY3E5ifTh" resolve="ICoverageAnalyzer" />
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="5ElQ4ZyAdc" role="1B3o_S" />
+    </node>
     <node concept="2tJIrI" id="50LzNoSyDMa" role="jymVt" />
     <node concept="2YIFZL" id="7obiejCzIm_" role="jymVt">
       <property role="TrG5h" value="evaluateWithTrace" />
@@ -8265,6 +8360,60 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="7obiejCzImA" role="3clF47">
+        <node concept="3clFbF" id="5ElQ4Zzblh" role="3cqZAp">
+          <node concept="1rXfSq" id="5ElQ4Zzblg" role="3clFbG">
+            <ref role="37wK5l" node="5ElQ4Zz6HL" resolve="evaluateWithTraceInternal" />
+            <node concept="37vLTw" id="5ElQ4ZzcmB" role="37wK5m">
+              <ref role="3cqZAo" node="7obiejCzInB" resolve="expr" />
+            </node>
+            <node concept="2ShNRf" id="5ElQ4ZzdXx" role="37wK5m">
+              <node concept="1pGfFk" id="5ElQ4Zzf4L" role="2ShVmc">
+                <ref role="37wK5l" node="7ezRWquAAWk" resolve="DefaultCoverageAnalyzer" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="7lHetQyBJ7k" role="3clF45">
+        <ref role="3uigEE" node="7lHetQyBI3r" resolve="ValueAndTrace" />
+      </node>
+      <node concept="37vLTG" id="7obiejCzInB" role="3clF46">
+        <property role="TrG5h" value="expr" />
+        <node concept="3Tqbb2" id="7obiejCzInC" role="1tU5fm" />
+      </node>
+      <node concept="3Tm1VV" id="7obiejCzInD" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="5ElQ4Z$Rkc" role="jymVt" />
+    <node concept="2YIFZL" id="5ElQ4Z$TPU" role="jymVt">
+      <property role="TrG5h" value="evaluateWithTraceWithoutCoverage" />
+      <node concept="3clFbS" id="5ElQ4Z$TPX" role="3clF47">
+        <node concept="3clFbF" id="5ElQ4Z$VxQ" role="3cqZAp">
+          <node concept="1rXfSq" id="5ElQ4Z$VxR" role="3clFbG">
+            <ref role="37wK5l" node="5ElQ4Zz6HL" resolve="evaluateWithTraceInternal" />
+            <node concept="37vLTw" id="5ElQ4Z$VxS" role="37wK5m">
+              <ref role="3cqZAo" node="5ElQ4Z$UHd" resolve="expr" />
+            </node>
+            <node concept="2ShNRf" id="5ElQ4Z$Xdn" role="37wK5m">
+              <node concept="HV5vD" id="5ElQ4Z$XYz" role="2ShVmc">
+                <ref role="HV5vE" to="2ahs:4_qY3E6qZJh" resolve="NullCoverageAnalyzer" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5ElQ4Z$SrF" role="1B3o_S" />
+      <node concept="3uibUv" id="5ElQ4Z$Tsp" role="3clF45">
+        <ref role="3uigEE" node="7lHetQyBI3r" resolve="ValueAndTrace" />
+      </node>
+      <node concept="37vLTG" id="5ElQ4Z$UHd" role="3clF46">
+        <property role="TrG5h" value="expr" />
+        <node concept="3Tqbb2" id="5ElQ4Z$UHc" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5ElQ4Zz4jg" role="jymVt" />
+    <node concept="2YIFZL" id="5ElQ4Zz6HL" role="jymVt">
+      <property role="TrG5h" value="evaluateWithTraceInternal" />
+      <node concept="3clFbS" id="5ElQ4Zz6HO" role="3clF47">
         <node concept="3cpWs8" id="7obiejCzImB" role="3cqZAp">
           <node concept="3cpWsn" id="7obiejCzImC" role="3cpWs9">
             <property role="TrG5h" value="ctx" />
@@ -8278,19 +8427,6 @@
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="7obiejCzImG" role="3cqZAp">
-          <node concept="3cpWsn" id="7obiejCzImH" role="3cpWs9">
-            <property role="TrG5h" value="coverage" />
-            <node concept="3uibUv" id="7obiejCzImI" role="1tU5fm">
-              <ref role="3uigEE" node="4_qY3E5IXRD" resolve="DefaultCoverageAnalyzer" />
-            </node>
-            <node concept="2ShNRf" id="7obiejCzImJ" role="33vP2m">
-              <node concept="1pGfFk" id="2ns1RQRNMXR" role="2ShVmc">
-                <ref role="37wK5l" node="7ezRWquAAWk" resolve="DefaultCoverageAnalyzer" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3cpWs8" id="7obiejCzImN" role="3cqZAp">
           <node concept="3cpWsn" id="7obiejCzImO" role="3cpWs9">
             <property role="TrG5h" value="helper" />
@@ -8300,8 +8436,7 @@
             <node concept="2ShNRf" id="7obiejCzImQ" role="33vP2m">
               <node concept="1pGfFk" id="7obiejCzImR" role="2ShVmc">
                 <ref role="37wK5l" to="2ahs:50LzNoSxJpU" resolve="InterpreterEvaluationHelper" />
-                <node concept="10M0yZ" id="64w0Iq2zOrf" role="37wK5m">
-                  <ref role="1PxDUh" node="3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
+                <node concept="37vLTw" id="5ElQ4Zz9sq" role="37wK5m">
                   <ref role="3cqZAo" node="50LzNoSyDId" resolve="INTERPRETER_CATEGORY" />
                 </node>
               </node>
@@ -8415,8 +8550,8 @@
               <node concept="3clFbF" id="1CNpG_haYkj" role="3cqZAp">
                 <node concept="2OqwBi" id="1CNpG_haYkk" role="3clFbG">
                   <node concept="10M0yZ" id="1CNpG_haYkl" role="2Oq$k0">
-                    <ref role="3cqZAo" to="wyt6:~System.err" resolve="err" />
                     <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                    <ref role="3cqZAo" to="wyt6:~System.err" resolve="err" />
                   </node>
                   <node concept="liA8E" id="1CNpG_haYkm" role="2OqNvi">
                     <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
@@ -8467,7 +8602,7 @@
                   <node concept="liA8E" id="7obiejCzMoD" role="2OqNvi">
                     <ref role="37wK5l" to="2ahs:14DmiwrcwYd" resolve="evaluateWithContextAndCoverage" />
                     <node concept="37vLTw" id="7obiejCzMoE" role="37wK5m">
-                      <ref role="3cqZAo" node="7obiejCzInB" resolve="expr" />
+                      <ref role="3cqZAo" node="5ElQ4Zz7wT" resolve="expr" />
                     </node>
                     <node concept="1rXfSq" id="7obiejCzMoF" role="37wK5m">
                       <ref role="37wK5l" node="50LzNoSyDOv" resolve="getInterpreter" />
@@ -8476,7 +8611,7 @@
                       <ref role="3cqZAo" node="7obiejCzImC" resolve="ctx" />
                     </node>
                     <node concept="37vLTw" id="7obiejCzMoH" role="37wK5m">
-                      <ref role="3cqZAo" node="7obiejCzImH" resolve="coverage" />
+                      <ref role="3cqZAo" node="5ElQ4Zz8pK" resolve="coverage" />
                     </node>
                   </node>
                 </node>
@@ -8527,14 +8662,20 @@
           </node>
         </node>
       </node>
-      <node concept="3uibUv" id="7lHetQyBJ7k" role="3clF45">
+      <node concept="3Tm6S6" id="5ElQ4Zz7W4" role="1B3o_S" />
+      <node concept="3uibUv" id="5ElQ4Zz6wU" role="3clF45">
         <ref role="3uigEE" node="7lHetQyBI3r" resolve="ValueAndTrace" />
       </node>
-      <node concept="37vLTG" id="7obiejCzInB" role="3clF46">
+      <node concept="37vLTG" id="5ElQ4Zz7wT" role="3clF46">
         <property role="TrG5h" value="expr" />
-        <node concept="3Tqbb2" id="7obiejCzInC" role="1tU5fm" />
+        <node concept="3Tqbb2" id="5ElQ4Zz7wS" role="1tU5fm" />
       </node>
-      <node concept="3Tm1VV" id="7obiejCzInD" role="1B3o_S" />
+      <node concept="37vLTG" id="5ElQ4Zz8pK" role="3clF46">
+        <property role="TrG5h" value="coverage" />
+        <node concept="3uibUv" id="5ElQ4Zz8pL" role="1tU5fm">
+          <ref role="3uigEE" to="2ahs:4_qY3E5ifTh" resolve="ICoverageAnalyzer" />
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="4Pi6J8CcoPf" role="jymVt" />
     <node concept="2YIFZL" id="4Pi6J8Ccg1L" role="jymVt">
@@ -8562,6 +8703,29 @@
       </node>
       <node concept="3Tm1VV" id="4Pi6J8Ccg3o" role="1B3o_S" />
     </node>
+    <node concept="2tJIrI" id="5ElQ4Z$Yul" role="jymVt" />
+    <node concept="2YIFZL" id="5ElQ4Z_3XW" role="jymVt">
+      <property role="TrG5h" value="evaluateWithTraceAndEnvWithoutCoverage" />
+      <node concept="3clFbS" id="5ElQ4Z_3XZ" role="3clF47">
+        <node concept="3clFbF" id="5ElQ4Z_52r" role="3cqZAp">
+          <node concept="1rXfSq" id="5ElQ4Z_52s" role="3clFbG">
+            <ref role="37wK5l" node="5ElQ4Z_71N" resolve="evaluateWithTraceAndEnvWithoutCoverage" />
+            <node concept="37vLTw" id="5ElQ4Z_52t" role="37wK5m">
+              <ref role="3cqZAo" node="5ElQ4Z_5BV" resolve="expr" />
+            </node>
+            <node concept="10Nm6u" id="5ElQ4Z_52u" role="37wK5m" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5ElQ4Z_0vv" role="1B3o_S" />
+      <node concept="3uibUv" id="5ElQ4Z_1MS" role="3clF45">
+        <ref role="3uigEE" node="4Pi6J8Cccqb" resolve="ValueAndTraceAndEnv" />
+      </node>
+      <node concept="37vLTG" id="5ElQ4Z_5BV" role="3clF46">
+        <property role="TrG5h" value="expr" />
+        <node concept="3Tqbb2" id="5ElQ4Z_5BU" role="1tU5fm" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="7p_bE3JczfP" role="jymVt" />
     <node concept="2YIFZL" id="7p_bE3JctXP" role="jymVt">
       <property role="TrG5h" value="evaluateWithTraceAndEnv" />
@@ -8569,6 +8733,106 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="7p_bE3JctXQ" role="3clF47">
+        <node concept="3clFbF" id="5ElQ4Z$5q8" role="3cqZAp">
+          <node concept="1rXfSq" id="5ElQ4Z$5q7" role="3clFbG">
+            <ref role="37wK5l" node="5ElQ4ZziRg" resolve="evaluateWithTraceAndEnvInternal" />
+            <node concept="37vLTw" id="5ElQ4Z$6y$" role="37wK5m">
+              <ref role="3cqZAo" node="7p_bE3JctZw" resolve="expr" />
+            </node>
+            <node concept="37vLTw" id="5ElQ4Z$7xl" role="37wK5m">
+              <ref role="3cqZAo" node="7p_bE3Jcw0b" resolve="stuffForEnv" />
+            </node>
+            <node concept="2ShNRf" id="5zuMBsCJxu8" role="37wK5m">
+              <node concept="1pGfFk" id="5zuMBsCJxrk" role="2ShVmc">
+                <ref role="37wK5l" node="7ezRWquAAWk" resolve="DefaultCoverageAnalyzer" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="7p_bE3JctZv" role="3clF45">
+        <ref role="3uigEE" node="4Pi6J8Cccqb" resolve="ValueAndTraceAndEnv" />
+      </node>
+      <node concept="37vLTG" id="7p_bE3JctZw" role="3clF46">
+        <property role="TrG5h" value="expr" />
+        <node concept="3Tqbb2" id="7p_bE3JctZx" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="7p_bE3Jcw0b" role="3clF46">
+        <property role="TrG5h" value="stuffForEnv" />
+        <node concept="3rvAFt" id="7p_bE3JcwNr" role="1tU5fm">
+          <node concept="3Tqbb2" id="7p_bE3Jcx57" role="3rvQeY" />
+          <node concept="3uibUv" id="7p_bE3Jcxmc" role="3rvSg0">
+            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7p_bE3JctZy" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="5ElQ4Z_8Xz" role="jymVt" />
+    <node concept="2YIFZL" id="5ElQ4Z_71N" role="jymVt">
+      <property role="TrG5h" value="evaluateWithTraceAndEnvWithoutCoverage" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="5ElQ4Z_71O" role="3clF47">
+        <node concept="3clFbF" id="5ElQ4Z_71P" role="3cqZAp">
+          <node concept="1rXfSq" id="5ElQ4Z_71Q" role="3clFbG">
+            <ref role="37wK5l" node="5ElQ4ZziRg" resolve="evaluateWithTraceAndEnvInternal" />
+            <node concept="37vLTw" id="5ElQ4Z_71R" role="37wK5m">
+              <ref role="3cqZAo" node="5ElQ4Z_71W" resolve="expr" />
+            </node>
+            <node concept="37vLTw" id="5ElQ4Z_71S" role="37wK5m">
+              <ref role="3cqZAo" node="5ElQ4Z_71Y" resolve="stuffForEnv" />
+            </node>
+            <node concept="2ShNRf" id="5ElQ4Z_cKW" role="37wK5m">
+              <node concept="HV5vD" id="5ElQ4Z_dIx" role="2ShVmc">
+                <ref role="HV5vE" to="2ahs:4_qY3E6qZJh" resolve="NullCoverageAnalyzer" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="5ElQ4Z_71V" role="3clF45">
+        <ref role="3uigEE" node="4Pi6J8Cccqb" resolve="ValueAndTraceAndEnv" />
+      </node>
+      <node concept="37vLTG" id="5ElQ4Z_71W" role="3clF46">
+        <property role="TrG5h" value="expr" />
+        <node concept="3Tqbb2" id="5ElQ4Z_71X" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="5ElQ4Z_71Y" role="3clF46">
+        <property role="TrG5h" value="stuffForEnv" />
+        <node concept="3rvAFt" id="5ElQ4Z_71Z" role="1tU5fm">
+          <node concept="3Tqbb2" id="5ElQ4Z_720" role="3rvQeY" />
+          <node concept="3uibUv" id="5ElQ4Z_721" role="3rvSg0">
+            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5ElQ4Z_722" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="5ElQ4ZzgQ2" role="jymVt" />
+    <node concept="2YIFZL" id="5ElQ4ZziRg" role="jymVt">
+      <property role="TrG5h" value="evaluateWithTraceAndEnvInternal" />
+      <node concept="37vLTG" id="5ElQ4ZzYvt" role="3clF46">
+        <property role="TrG5h" value="expr" />
+        <node concept="3Tqbb2" id="5ElQ4ZzYvu" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="5ElQ4ZzZbv" role="3clF46">
+        <property role="TrG5h" value="stuffForEnv" />
+        <node concept="3rvAFt" id="5ElQ4ZzZqd" role="1tU5fm">
+          <node concept="3Tqbb2" id="5ElQ4ZzZqe" role="3rvQeY" />
+          <node concept="3uibUv" id="5ElQ4ZzZqf" role="3rvSg0">
+            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5ElQ4Z$1k6" role="3clF46">
+        <property role="TrG5h" value="coverage" />
+        <node concept="3uibUv" id="5ElQ4Z$1k7" role="1tU5fm">
+          <ref role="3uigEE" to="2ahs:4_qY3E5ifTh" resolve="ICoverageAnalyzer" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="5ElQ4ZziRj" role="3clF47">
         <node concept="3cpWs8" id="7p_bE3JctXR" role="3cqZAp">
           <node concept="3cpWsn" id="7p_bE3JctXS" role="3cpWs9">
             <property role="TrG5h" value="ctx" />
@@ -8578,19 +8842,6 @@
             <node concept="2ShNRf" id="7p_bE3JctXU" role="33vP2m">
               <node concept="HV5vD" id="7p_bE3JctXV" role="2ShVmc">
                 <ref role="HV5vE" node="6iqfHNC0mHl" resolve="IETS3ExprContext" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="7p_bE3JctXW" role="3cqZAp">
-          <node concept="3cpWsn" id="7p_bE3JctXX" role="3cpWs9">
-            <property role="TrG5h" value="coverage" />
-            <node concept="3uibUv" id="7p_bE3JctXY" role="1tU5fm">
-              <ref role="3uigEE" node="4_qY3E5IXRD" resolve="DefaultCoverageAnalyzer" />
-            </node>
-            <node concept="2ShNRf" id="5zuMBsCJxu8" role="33vP2m">
-              <node concept="1pGfFk" id="5zuMBsCJxrk" role="2ShVmc">
-                <ref role="37wK5l" node="7ezRWquAAWk" resolve="DefaultCoverageAnalyzer" />
               </node>
             </node>
           </node>
@@ -8605,10 +8856,10 @@
                 <node concept="liA8E" id="7p_bE3Jd9Q5" role="2OqNvi">
                   <ref role="37wK5l" to="2ahs:2pAf7L4EsIf" resolve="pushEnvironment" />
                   <node concept="37vLTw" id="7p_bE3JdbZz" role="37wK5m">
-                    <ref role="3cqZAo" node="7p_bE3JctZw" resolve="expr" />
+                    <ref role="3cqZAo" node="5ElQ4ZzYvt" resolve="expr" />
                   </node>
                   <node concept="37vLTw" id="7p_bE3Jdco$" role="37wK5m">
-                    <ref role="3cqZAo" node="7p_bE3Jcw0b" resolve="stuffForEnv" />
+                    <ref role="3cqZAo" node="5ElQ4ZzZbv" resolve="stuffForEnv" />
                   </node>
                 </node>
               </node>
@@ -8617,7 +8868,7 @@
           <node concept="3y3z36" id="7p_bE3Jd7RB" role="3clFbw">
             <node concept="10Nm6u" id="7p_bE3Jd8bF" role="3uHU7w" />
             <node concept="37vLTw" id="7p_bE3Jd75X" role="3uHU7B">
-              <ref role="3cqZAo" node="7p_bE3Jcw0b" resolve="stuffForEnv" />
+              <ref role="3cqZAo" node="5ElQ4ZzZbv" resolve="stuffForEnv" />
             </node>
           </node>
         </node>
@@ -8630,8 +8881,7 @@
             <node concept="2ShNRf" id="7p_bE3JctY4" role="33vP2m">
               <node concept="1pGfFk" id="7p_bE3JctY5" role="2ShVmc">
                 <ref role="37wK5l" to="2ahs:50LzNoSxJpU" resolve="InterpreterEvaluationHelper" />
-                <node concept="10M0yZ" id="7p_bE3JctY6" role="37wK5m">
-                  <ref role="1PxDUh" node="3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
+                <node concept="37vLTw" id="5ElQ4Z$2yS" role="37wK5m">
                   <ref role="3cqZAo" node="50LzNoSyDId" resolve="INTERPRETER_CATEGORY" />
                 </node>
               </node>
@@ -8679,7 +8929,7 @@
                       </node>
                     </node>
                     <node concept="37vLTw" id="4kdJi32PpbP" role="37wK5m">
-                      <ref role="3cqZAo" node="7p_bE3JctXX" resolve="coverage" />
+                      <ref role="3cqZAo" node="5ElQ4Z$1k6" resolve="coverage" />
                     </node>
                   </node>
                 </node>
@@ -8808,7 +9058,7 @@
                   <node concept="liA8E" id="7p_bE3JctYe" role="2OqNvi">
                     <ref role="37wK5l" to="2ahs:14DmiwrcwYd" resolve="evaluateWithContextAndCoverage" />
                     <node concept="37vLTw" id="7p_bE3JctYf" role="37wK5m">
-                      <ref role="3cqZAo" node="7p_bE3JctZw" resolve="expr" />
+                      <ref role="3cqZAo" node="5ElQ4ZzYvt" resolve="expr" />
                     </node>
                     <node concept="1rXfSq" id="7p_bE3JctYg" role="37wK5m">
                       <ref role="37wK5l" node="50LzNoSyDOv" resolve="getInterpreter" />
@@ -8817,7 +9067,7 @@
                       <ref role="3cqZAo" node="7p_bE3JctXS" resolve="ctx" />
                     </node>
                     <node concept="37vLTw" id="7p_bE3JctYi" role="37wK5m">
-                      <ref role="3cqZAo" node="7p_bE3JctXX" resolve="coverage" />
+                      <ref role="3cqZAo" node="5ElQ4Z$1k6" resolve="coverage" />
                     </node>
                   </node>
                 </node>
@@ -8871,7 +9121,7 @@
                     </node>
                   </node>
                   <node concept="37vLTw" id="4kdJi32PdWt" role="37wK5m">
-                    <ref role="3cqZAo" node="7p_bE3JctXX" resolve="coverage" />
+                    <ref role="3cqZAo" node="5ElQ4Z$1k6" resolve="coverage" />
                   </node>
                 </node>
               </node>
@@ -8879,23 +9129,10 @@
           </node>
         </node>
       </node>
-      <node concept="3uibUv" id="7p_bE3JctZv" role="3clF45">
+      <node concept="3Tm6S6" id="5ElQ4ZzYeG" role="1B3o_S" />
+      <node concept="3uibUv" id="5ElQ4ZziDp" role="3clF45">
         <ref role="3uigEE" node="4Pi6J8Cccqb" resolve="ValueAndTraceAndEnv" />
       </node>
-      <node concept="37vLTG" id="7p_bE3JctZw" role="3clF46">
-        <property role="TrG5h" value="expr" />
-        <node concept="3Tqbb2" id="7p_bE3JctZx" role="1tU5fm" />
-      </node>
-      <node concept="37vLTG" id="7p_bE3Jcw0b" role="3clF46">
-        <property role="TrG5h" value="stuffForEnv" />
-        <node concept="3rvAFt" id="7p_bE3JcwNr" role="1tU5fm">
-          <node concept="3Tqbb2" id="7p_bE3Jcx57" role="3rvQeY" />
-          <node concept="3uibUv" id="7p_bE3Jcxmc" role="3rvSg0">
-            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="7p_bE3JctZy" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="4945UtStzlF" role="jymVt" />
     <node concept="2YIFZL" id="4945UtStyFA" role="jymVt">
@@ -8904,220 +9141,15 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="4945UtStyFB" role="3clF47">
-        <node concept="3cpWs8" id="4945UtStyFC" role="3cqZAp">
-          <node concept="3cpWsn" id="4945UtStyFD" role="3cpWs9">
-            <property role="TrG5h" value="ctx" />
-            <node concept="3uibUv" id="4945UtStyFE" role="1tU5fm">
-              <ref role="3uigEE" node="6iqfHNC0mHl" resolve="IETS3ExprContext" />
+        <node concept="3clFbF" id="5ElQ4Z$ltH" role="3cqZAp">
+          <node concept="1rXfSq" id="5ElQ4Z$ltG" role="3clFbG">
+            <ref role="37wK5l" node="5ElQ4Z$cXx" resolve="evaluateAndThrowConstraintFailuresInternal" />
+            <node concept="37vLTw" id="5ElQ4Z$mES" role="37wK5m">
+              <ref role="3cqZAo" node="4945UtStyGC" resolve="expr" />
             </node>
-            <node concept="2ShNRf" id="4945UtStyFF" role="33vP2m">
-              <node concept="HV5vD" id="4945UtStyFG" role="2ShVmc">
-                <ref role="HV5vE" node="6iqfHNC0mHl" resolve="IETS3ExprContext" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="4945UtStyFH" role="3cqZAp">
-          <node concept="3cpWsn" id="4945UtStyFI" role="3cpWs9">
-            <property role="TrG5h" value="coverage" />
-            <node concept="3uibUv" id="4945UtStyFJ" role="1tU5fm">
-              <ref role="3uigEE" node="4_qY3E5IXRD" resolve="DefaultCoverageAnalyzer" />
-            </node>
-            <node concept="2ShNRf" id="4945UtStyFK" role="33vP2m">
+            <node concept="2ShNRf" id="4945UtStyFK" role="37wK5m">
               <node concept="1pGfFk" id="2ns1RQRNMXI" role="2ShVmc">
                 <ref role="37wK5l" node="7ezRWquAAWk" resolve="DefaultCoverageAnalyzer" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3J1_TO" id="4945UtStyFM" role="3cqZAp">
-          <node concept="3uVAMA" id="4945UtStBr8" role="1zxBo5">
-            <node concept="XOnhg" id="4945UtStBr9" role="1zc67B">
-              <property role="3TUv4t" value="false" />
-              <property role="TrG5h" value="cfe" />
-              <node concept="nSUau" id="4cGF63p2UJk" role="1tU5fm">
-                <node concept="3uibUv" id="4945UtStBP5" role="nSUat">
-                  <ref role="3uigEE" to="oq0c:3Y6fbK1oSAh" resolve="ConstraintFailedException" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbS" id="4945UtStBrb" role="1zc67A">
-              <node concept="YS8fn" id="4945UtStCoj" role="3cqZAp">
-                <node concept="37vLTw" id="4945UtStCxr" role="YScLw">
-                  <ref role="3cqZAo" node="4945UtStBr9" resolve="cfe" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3uVAMA" id="4945UtStyG2" role="1zxBo5">
-            <node concept="XOnhg" id="4945UtStyG3" role="1zc67B">
-              <property role="3TUv4t" value="false" />
-              <property role="TrG5h" value="stopEx" />
-              <node concept="nSUau" id="4cGF63p2L10" role="1tU5fm">
-                <node concept="3uibUv" id="4945UtStyG4" role="nSUat">
-                  <ref role="3uigEE" to="2ahs:6MNhNeUeNix" resolve="StopAndReturnException" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbS" id="4945UtStyG5" role="1zc67A">
-              <node concept="3cpWs6" id="4945UtStyG6" role="3cqZAp">
-                <node concept="2OqwBi" id="4945UtStyG7" role="3cqZAk">
-                  <node concept="37vLTw" id="4945UtStyG8" role="2Oq$k0">
-                    <ref role="3cqZAo" node="4945UtStyG3" resolve="stopEx" />
-                  </node>
-                  <node concept="liA8E" id="4945UtStyG9" role="2OqNvi">
-                    <ref role="37wK5l" to="2ahs:6MNhNeUeYe3" resolve="value" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3uVAMA" id="4945UtStyGa" role="1zxBo5">
-            <node concept="XOnhg" id="4945UtStyGb" role="1zc67B">
-              <property role="3TUv4t" value="false" />
-              <property role="TrG5h" value="ex" />
-              <node concept="nSUau" id="4cGF63p2L1g" role="1tU5fm">
-                <node concept="3uibUv" id="4945UtStyGc" role="nSUat">
-                  <ref role="3uigEE" to="2ahs:9nJ_zCA_CM" resolve="InterpreterRuntimeException" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbS" id="4945UtStyGd" role="1zc67A">
-              <node concept="3cpWs8" id="1CNpG_haZHs" role="3cqZAp">
-                <node concept="3cpWsn" id="1CNpG_haZHt" role="3cpWs9">
-                  <property role="TrG5h" value="failureTrace" />
-                  <node concept="3uibUv" id="1CNpG_haZHu" role="1tU5fm">
-                    <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
-                  </node>
-                  <node concept="2OqwBi" id="1CNpG_haZHv" role="33vP2m">
-                    <node concept="37vLTw" id="1CNpG_haZHw" role="2Oq$k0">
-                      <ref role="3cqZAo" node="4945UtStyGb" resolve="ex" />
-                    </node>
-                    <node concept="liA8E" id="1CNpG_haZHx" role="2OqNvi">
-                      <ref role="37wK5l" to="2ahs:6LLJO$vY_c_" resolve="getFailureTrace" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbJ" id="1CNpG_haZHy" role="3cqZAp">
-                <node concept="3clFbS" id="1CNpG_haZHz" role="3clFbx">
-                  <node concept="3clFbF" id="1CNpG_haZH$" role="3cqZAp">
-                    <node concept="2OqwBi" id="1CNpG_haZH_" role="3clFbG">
-                      <node concept="10M0yZ" id="1CNpG_haZHA" role="2Oq$k0">
-                        <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-                        <ref role="3cqZAo" to="wyt6:~System.err" resolve="err" />
-                      </node>
-                      <node concept="liA8E" id="1CNpG_haZHB" role="2OqNvi">
-                        <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
-                        <node concept="3cpWs3" id="1CNpG_haZHC" role="37wK5m">
-                          <node concept="2OqwBi" id="1CNpG_haZHD" role="3uHU7w">
-                            <node concept="37vLTw" id="1CNpG_haZHE" role="2Oq$k0">
-                              <ref role="3cqZAo" node="1CNpG_haZHt" resolve="failureTrace" />
-                            </node>
-                            <node concept="liA8E" id="1CNpG_haZHF" role="2OqNvi">
-                              <ref role="37wK5l" to="2ahs:6LLJO$vYHbj" resolve="createStackTraceToThisOneAsString" />
-                              <node concept="3clFbT" id="1CNpG_haZHG" role="37wK5m">
-                                <property role="3clFbU" value="true" />
-                              </node>
-                              <node concept="3cmrfG" id="1CNpG_haZHH" role="37wK5m">
-                                <property role="3cmrfH" value="2" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="Xl_RD" id="1CNpG_haZHI" role="3uHU7B">
-                            <property role="Xl_RC" value="Interpreter failed when running " />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3y3z36" id="1CNpG_haZHJ" role="3clFbw">
-                  <node concept="10Nm6u" id="1CNpG_haZHK" role="3uHU7w" />
-                  <node concept="37vLTw" id="1CNpG_haZHL" role="3uHU7B">
-                    <ref role="3cqZAo" node="1CNpG_haZHt" resolve="failureTrace" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbF" id="1CNpG_haZHT" role="3cqZAp">
-                <node concept="2OqwBi" id="1CNpG_haZHU" role="3clFbG">
-                  <node concept="10M0yZ" id="1CNpG_haZHV" role="2Oq$k0">
-                    <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-                    <ref role="3cqZAo" to="wyt6:~System.err" resolve="err" />
-                  </node>
-                  <node concept="liA8E" id="1CNpG_haZHW" role="2OqNvi">
-                    <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
-                    <node concept="3cpWs3" id="1CNpG_haZHX" role="37wK5m">
-                      <node concept="2OqwBi" id="1CNpG_haZHY" role="3uHU7w">
-                        <node concept="37vLTw" id="1CNpG_haZHZ" role="2Oq$k0">
-                          <ref role="3cqZAo" node="4945UtStyGb" resolve="ex" />
-                        </node>
-                        <node concept="liA8E" id="1CNpG_haZI0" role="2OqNvi">
-                          <ref role="37wK5l" to="2ahs:9nJ_zCAH8C" resolve="getMessage" />
-                        </node>
-                      </node>
-                      <node concept="Xl_RD" id="1CNpG_haZI1" role="3uHU7B">
-                        <property role="Xl_RC" value="Exception: " />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbF" id="4945UtStyGx" role="3cqZAp">
-                <node concept="2OqwBi" id="4945UtStyGy" role="3clFbG">
-                  <node concept="37vLTw" id="4945UtStyGz" role="2Oq$k0">
-                    <ref role="3cqZAo" node="4945UtStyGb" resolve="ex" />
-                  </node>
-                  <node concept="liA8E" id="4945UtStyG$" role="2OqNvi">
-                    <ref role="37wK5l" to="wyt6:~Throwable.printStackTrace()" resolve="printStackTrace" />
-                  </node>
-                </node>
-              </node>
-              <node concept="YS8fn" id="7EYe2PMkrQu" role="3cqZAp">
-                <node concept="37vLTw" id="7EYe2PMksdZ" role="YScLw">
-                  <ref role="3cqZAo" node="4945UtStyGb" resolve="ex" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbS" id="4945UtStyFN" role="1zxBo7">
-            <node concept="3cpWs8" id="4945UtStyFO" role="3cqZAp">
-              <node concept="3cpWsn" id="4945UtStyFP" role="3cpWs9">
-                <property role="TrG5h" value="helper" />
-                <node concept="3uibUv" id="4945UtStyFQ" role="1tU5fm">
-                  <ref role="3uigEE" to="2ahs:50LzNoSxDO3" resolve="InterpreterEvaluationHelper" />
-                </node>
-                <node concept="2ShNRf" id="4945UtStyFR" role="33vP2m">
-                  <node concept="1pGfFk" id="4945UtStyFS" role="2ShVmc">
-                    <ref role="37wK5l" to="2ahs:50LzNoSxJpU" resolve="InterpreterEvaluationHelper" />
-                    <node concept="10M0yZ" id="64w0Iq2zOrg" role="37wK5m">
-                      <ref role="1PxDUh" node="3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
-                      <ref role="3cqZAo" node="50LzNoSyDId" resolve="INTERPRETER_CATEGORY" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs6" id="4945UtStyFU" role="3cqZAp">
-              <node concept="2OqwBi" id="4945UtStyFV" role="3cqZAk">
-                <node concept="37vLTw" id="4945UtStyFW" role="2Oq$k0">
-                  <ref role="3cqZAo" node="4945UtStyFP" resolve="helper" />
-                </node>
-                <node concept="liA8E" id="4945UtStyFX" role="2OqNvi">
-                  <ref role="37wK5l" to="2ahs:14DmiwrcwYd" resolve="evaluateWithContextAndCoverage" />
-                  <node concept="37vLTw" id="4945UtStyFY" role="37wK5m">
-                    <ref role="3cqZAo" node="4945UtStyGC" resolve="expr" />
-                  </node>
-                  <node concept="1rXfSq" id="4945UtStyFZ" role="37wK5m">
-                    <ref role="37wK5l" node="50LzNoSyDOv" resolve="getInterpreter" />
-                  </node>
-                  <node concept="37vLTw" id="4945UtStyG0" role="37wK5m">
-                    <ref role="3cqZAo" node="4945UtStyFD" resolve="ctx" />
-                  </node>
-                  <node concept="37vLTw" id="4945UtStyG1" role="37wK5m">
-                    <ref role="3cqZAo" node="4945UtStyFI" resolve="coverage" />
-                  </node>
-                </node>
               </node>
             </node>
           </node>
@@ -9131,6 +9163,257 @@
         <node concept="3Tqbb2" id="4945UtStyGD" role="1tU5fm" />
       </node>
       <node concept="3Tm1VV" id="4945UtStyGE" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="5ElQ4Z_eo1" role="jymVt" />
+    <node concept="2YIFZL" id="5ElQ4Z_hIL" role="jymVt">
+      <property role="TrG5h" value="evaluateAndThrowConstraintFailuresWithoutCoverage" />
+      <node concept="3clFbS" id="5ElQ4Z_hIO" role="3clF47">
+        <node concept="3clFbF" id="5ElQ4Z_kdg" role="3cqZAp">
+          <node concept="1rXfSq" id="5ElQ4Z_kdh" role="3clFbG">
+            <ref role="37wK5l" node="5ElQ4Z$cXx" resolve="evaluateAndThrowConstraintFailuresInternal" />
+            <node concept="37vLTw" id="5ElQ4Z_kdi" role="37wK5m">
+              <ref role="3cqZAo" node="5ElQ4Z_iVW" resolve="expr" />
+            </node>
+            <node concept="2ShNRf" id="5ElQ4Z_kdj" role="37wK5m">
+              <node concept="HV5vD" id="5ElQ4Z_m5G" role="2ShVmc">
+                <ref role="HV5vE" to="2ahs:4_qY3E6qZJh" resolve="NullCoverageAnalyzer" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5ElQ4Z_fGD" role="1B3o_S" />
+      <node concept="3uibUv" id="5ElQ4Z_gUI" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+      </node>
+      <node concept="37vLTG" id="5ElQ4Z_iVW" role="3clF46">
+        <property role="TrG5h" value="expr" />
+        <node concept="3Tqbb2" id="5ElQ4Z_iVV" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5ElQ4Z$agN" role="jymVt" />
+    <node concept="2YIFZL" id="5ElQ4Z$cXx" role="jymVt">
+      <property role="TrG5h" value="evaluateAndThrowConstraintFailuresInternal" />
+      <node concept="3clFbS" id="5ElQ4Z$cX$" role="3clF47">
+        <node concept="3cpWs8" id="5ElQ4Z$eyv" role="3cqZAp">
+          <node concept="3cpWsn" id="5ElQ4Z$eyw" role="3cpWs9">
+            <property role="TrG5h" value="ctx" />
+            <node concept="3uibUv" id="5ElQ4Z$eyx" role="1tU5fm">
+              <ref role="3uigEE" node="6iqfHNC0mHl" resolve="IETS3ExprContext" />
+            </node>
+            <node concept="2ShNRf" id="5ElQ4Z$eyy" role="33vP2m">
+              <node concept="HV5vD" id="5ElQ4Z$eyz" role="2ShVmc">
+                <ref role="HV5vE" node="6iqfHNC0mHl" resolve="IETS3ExprContext" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3J1_TO" id="5ElQ4Z$eyD" role="3cqZAp">
+          <node concept="3uVAMA" id="5ElQ4Z$eyE" role="1zxBo5">
+            <node concept="XOnhg" id="5ElQ4Z$eyF" role="1zc67B">
+              <property role="3TUv4t" value="false" />
+              <property role="TrG5h" value="cfe" />
+              <node concept="nSUau" id="5ElQ4Z$eyG" role="1tU5fm">
+                <node concept="3uibUv" id="5ElQ4Z$eyH" role="nSUat">
+                  <ref role="3uigEE" to="oq0c:3Y6fbK1oSAh" resolve="ConstraintFailedException" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="5ElQ4Z$eyI" role="1zc67A">
+              <node concept="YS8fn" id="5ElQ4Z$eyJ" role="3cqZAp">
+                <node concept="37vLTw" id="5ElQ4Z$eyK" role="YScLw">
+                  <ref role="3cqZAo" node="5ElQ4Z$eyF" resolve="cfe" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3uVAMA" id="5ElQ4Z$eyL" role="1zxBo5">
+            <node concept="XOnhg" id="5ElQ4Z$eyM" role="1zc67B">
+              <property role="3TUv4t" value="false" />
+              <property role="TrG5h" value="stopEx" />
+              <node concept="nSUau" id="5ElQ4Z$eyN" role="1tU5fm">
+                <node concept="3uibUv" id="5ElQ4Z$eyO" role="nSUat">
+                  <ref role="3uigEE" to="2ahs:6MNhNeUeNix" resolve="StopAndReturnException" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="5ElQ4Z$eyP" role="1zc67A">
+              <node concept="3cpWs6" id="5ElQ4Z$eyQ" role="3cqZAp">
+                <node concept="2OqwBi" id="5ElQ4Z$eyR" role="3cqZAk">
+                  <node concept="37vLTw" id="5ElQ4Z$eyS" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5ElQ4Z$eyM" resolve="stopEx" />
+                  </node>
+                  <node concept="liA8E" id="5ElQ4Z$eyT" role="2OqNvi">
+                    <ref role="37wK5l" to="2ahs:6MNhNeUeYe3" resolve="value" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3uVAMA" id="5ElQ4Z$eyU" role="1zxBo5">
+            <node concept="XOnhg" id="5ElQ4Z$eyV" role="1zc67B">
+              <property role="3TUv4t" value="false" />
+              <property role="TrG5h" value="ex" />
+              <node concept="nSUau" id="5ElQ4Z$eyW" role="1tU5fm">
+                <node concept="3uibUv" id="5ElQ4Z$eyX" role="nSUat">
+                  <ref role="3uigEE" to="2ahs:9nJ_zCA_CM" resolve="InterpreterRuntimeException" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="5ElQ4Z$eyY" role="1zc67A">
+              <node concept="3cpWs8" id="5ElQ4Z$eyZ" role="3cqZAp">
+                <node concept="3cpWsn" id="5ElQ4Z$ez0" role="3cpWs9">
+                  <property role="TrG5h" value="failureTrace" />
+                  <node concept="3uibUv" id="5ElQ4Z$ez1" role="1tU5fm">
+                    <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
+                  </node>
+                  <node concept="2OqwBi" id="5ElQ4Z$ez2" role="33vP2m">
+                    <node concept="37vLTw" id="5ElQ4Z$ez3" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5ElQ4Z$eyV" resolve="ex" />
+                    </node>
+                    <node concept="liA8E" id="5ElQ4Z$ez4" role="2OqNvi">
+                      <ref role="37wK5l" to="2ahs:6LLJO$vY_c_" resolve="getFailureTrace" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="5ElQ4Z$ez5" role="3cqZAp">
+                <node concept="3clFbS" id="5ElQ4Z$ez6" role="3clFbx">
+                  <node concept="3clFbF" id="5ElQ4Z$ez7" role="3cqZAp">
+                    <node concept="2OqwBi" id="5ElQ4Z$ez8" role="3clFbG">
+                      <node concept="10M0yZ" id="5ElQ4Z$ez9" role="2Oq$k0">
+                        <ref role="3cqZAo" to="wyt6:~System.err" resolve="err" />
+                        <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                      </node>
+                      <node concept="liA8E" id="5ElQ4Z$eza" role="2OqNvi">
+                        <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                        <node concept="3cpWs3" id="5ElQ4Z$ezb" role="37wK5m">
+                          <node concept="2OqwBi" id="5ElQ4Z$ezc" role="3uHU7w">
+                            <node concept="37vLTw" id="5ElQ4Z$ezd" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5ElQ4Z$ez0" resolve="failureTrace" />
+                            </node>
+                            <node concept="liA8E" id="5ElQ4Z$eze" role="2OqNvi">
+                              <ref role="37wK5l" to="2ahs:6LLJO$vYHbj" resolve="createStackTraceToThisOneAsString" />
+                              <node concept="3clFbT" id="5ElQ4Z$ezf" role="37wK5m">
+                                <property role="3clFbU" value="true" />
+                              </node>
+                              <node concept="3cmrfG" id="5ElQ4Z$ezg" role="37wK5m">
+                                <property role="3cmrfH" value="2" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Xl_RD" id="5ElQ4Z$ezh" role="3uHU7B">
+                            <property role="Xl_RC" value="Interpreter failed when running " />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3y3z36" id="5ElQ4Z$ezi" role="3clFbw">
+                  <node concept="10Nm6u" id="5ElQ4Z$ezj" role="3uHU7w" />
+                  <node concept="37vLTw" id="5ElQ4Z$ezk" role="3uHU7B">
+                    <ref role="3cqZAo" node="5ElQ4Z$ez0" resolve="failureTrace" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="5ElQ4Z$ezl" role="3cqZAp">
+                <node concept="2OqwBi" id="5ElQ4Z$ezm" role="3clFbG">
+                  <node concept="10M0yZ" id="5ElQ4Z$ezn" role="2Oq$k0">
+                    <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+                    <ref role="3cqZAo" to="wyt6:~System.err" resolve="err" />
+                  </node>
+                  <node concept="liA8E" id="5ElQ4Z$ezo" role="2OqNvi">
+                    <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                    <node concept="3cpWs3" id="5ElQ4Z$ezp" role="37wK5m">
+                      <node concept="2OqwBi" id="5ElQ4Z$ezq" role="3uHU7w">
+                        <node concept="37vLTw" id="5ElQ4Z$ezr" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5ElQ4Z$eyV" resolve="ex" />
+                        </node>
+                        <node concept="liA8E" id="5ElQ4Z$ezs" role="2OqNvi">
+                          <ref role="37wK5l" to="2ahs:9nJ_zCAH8C" resolve="getMessage" />
+                        </node>
+                      </node>
+                      <node concept="Xl_RD" id="5ElQ4Z$ezt" role="3uHU7B">
+                        <property role="Xl_RC" value="Exception: " />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="5ElQ4Z$ezu" role="3cqZAp">
+                <node concept="2OqwBi" id="5ElQ4Z$ezv" role="3clFbG">
+                  <node concept="37vLTw" id="5ElQ4Z$ezw" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5ElQ4Z$eyV" resolve="ex" />
+                  </node>
+                  <node concept="liA8E" id="5ElQ4Z$ezx" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Throwable.printStackTrace()" resolve="printStackTrace" />
+                  </node>
+                </node>
+              </node>
+              <node concept="YS8fn" id="5ElQ4Z$ezy" role="3cqZAp">
+                <node concept="37vLTw" id="5ElQ4Z$ezz" role="YScLw">
+                  <ref role="3cqZAo" node="5ElQ4Z$eyV" resolve="ex" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="5ElQ4Z$ez$" role="1zxBo7">
+            <node concept="3cpWs8" id="5ElQ4Z$ez_" role="3cqZAp">
+              <node concept="3cpWsn" id="5ElQ4Z$ezA" role="3cpWs9">
+                <property role="TrG5h" value="helper" />
+                <node concept="3uibUv" id="5ElQ4Z$ezB" role="1tU5fm">
+                  <ref role="3uigEE" to="2ahs:50LzNoSxDO3" resolve="InterpreterEvaluationHelper" />
+                </node>
+                <node concept="2ShNRf" id="5ElQ4Z$ezC" role="33vP2m">
+                  <node concept="1pGfFk" id="5ElQ4Z$ezD" role="2ShVmc">
+                    <ref role="37wK5l" to="2ahs:50LzNoSxJpU" resolve="InterpreterEvaluationHelper" />
+                    <node concept="37vLTw" id="5ElQ4Z$e_j" role="37wK5m">
+                      <ref role="3cqZAo" node="50LzNoSyDId" resolve="INTERPRETER_CATEGORY" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="5ElQ4Z$ezF" role="3cqZAp">
+              <node concept="2OqwBi" id="5ElQ4Z$ezG" role="3cqZAk">
+                <node concept="37vLTw" id="5ElQ4Z$ezH" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5ElQ4Z$ezA" resolve="helper" />
+                </node>
+                <node concept="liA8E" id="5ElQ4Z$ezI" role="2OqNvi">
+                  <ref role="37wK5l" to="2ahs:14DmiwrcwYd" resolve="evaluateWithContextAndCoverage" />
+                  <node concept="37vLTw" id="5ElQ4Z$ezJ" role="37wK5m">
+                    <ref role="3cqZAo" node="5ElQ4Z$dPc" resolve="expr" />
+                  </node>
+                  <node concept="1rXfSq" id="5ElQ4Z$ezK" role="37wK5m">
+                    <ref role="37wK5l" node="50LzNoSyDOv" resolve="getInterpreter" />
+                  </node>
+                  <node concept="37vLTw" id="5ElQ4Z$ezL" role="37wK5m">
+                    <ref role="3cqZAo" node="5ElQ4Z$eyw" resolve="ctx" />
+                  </node>
+                  <node concept="37vLTw" id="5ElQ4Z$ezM" role="37wK5m">
+                    <ref role="3cqZAo" node="5ElQ4Z$pOr" resolve="coverage" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="5ElQ4Z$bbn" role="1B3o_S" />
+      <node concept="3uibUv" id="5ElQ4Z$ckb" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+      </node>
+      <node concept="37vLTG" id="5ElQ4Z$dPc" role="3clF46">
+        <property role="TrG5h" value="expr" />
+        <node concept="3Tqbb2" id="5ElQ4Z$dPb" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="5ElQ4Z$pOr" role="3clF46">
+        <property role="TrG5h" value="coverage" />
+        <node concept="3uibUv" id="5ElQ4Z$pOs" role="1tU5fm">
+          <ref role="3uigEE" to="2ahs:4_qY3E5ifTh" resolve="ICoverageAnalyzer" />
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="64w0Iq2zOrh" role="jymVt" />
     <node concept="2YIFZL" id="50LzNoSyDOv" role="jymVt">


### PR DESCRIPTION
This PR adds complementary helper methods to IETS3ExprEvalHelper, so you can call the methods without the default coverage analyzer. In some cases, e.g. when invoking the other methods too often or maybe from the generator, the default (global) coverage analyzer needs too much memory and the coverage information is not even needed.