### PR TITLE
Unify end cell of multitab, builder expression and validate string

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/generator/template/org.iets3.core.expr.genjava.toplevel@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/generator/template/org.iets3.core.expr.genjava.toplevel@generator.mps
@@ -15,7 +15,7 @@
     <import index="rw5i" ref="r:4243557f-1c7a-4d6b-953a-807576e4bee7(org.iets3.core.expr.genjava.base@generator)" />
     <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" />
     <import index="vsv5" ref="r:7df3c033-0c27-4a50-97c3-f940e7dd27c2(org.iets3.core.expr.genjava.base.rt.rt)" />
-    <import index="wfax" ref="r:5d67e954-7960-4214-97d1-8f5d3823a964(org.iets3.core.expr.genjava.simpleTypes.rt.rt)" />
+    <import index="wfax" ref="r:5d67e954-7960-4214-97d1-8f5d3823a964(org.iets3.core.expr.collections.rt.rt)" />
     <import index="b1h1" ref="r:ac5f749f-6179-4d4f-ad24-ad9edbd8077b(org.iets3.core.expr.simpleTypes.behavior)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="pq1l" ref="r:93cd1fe8-b296-405c-a6e6-040c940ccfa1(org.iets3.core.expr.toplevel.plugin)" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lookup/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lookup/models/editor.mps
@@ -164,7 +164,7 @@
       </concept>
     </language>
     <language id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells">
-      <concept id="9041925471455857605" name="com.mbeddr.mpsutil.grammarcells.structure.Cell_DescriptionText" flags="ng" index="uPpia" />
+      <concept id="9041925471455857605" name="com.mbeddr.mpsutil.grammarcells.structure.Cell_DescriptionText" flags="ig" index="uPpia" />
       <concept id="5083944728298846680" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell" flags="ng" index="_tjkj">
         <child id="5083944728298846681" name="option" index="_tjki" />
       </concept>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/models/org.iets3.core.expr.stringvalidation.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/models/org.iets3.core.expr.stringvalidation.editor.mps
@@ -10,6 +10,7 @@
   <imports>
     <import index="r4b4" ref="r:1784e088-20fd-4fdb-96b8-bc57f0056d94(com.mbeddr.core.base.editor)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="m999" ref="r:1d6bd88a-7393-4b32-b0e6-2d8b3094776e(org.iets3.core.expr.toplevel.editor)" />
     <import index="3r88" ref="r:0561db97-8a79-45b6-97f8-a5fd9b986b44(org.iets3.core.expr.stringvalidation.structure)" implicit="true" />
     <import index="itrz" ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
@@ -168,10 +169,18 @@
           </node>
         </node>
       </node>
-      <node concept="3F0ifn" id="3dTPcTThWRr" role="3EZMnx">
-        <property role="3F0ifm" value="|" />
-        <node concept="11L4FC" id="3dTPcTTiuK9" role="3F10Kt">
-          <property role="VOm3f" value="true" />
+      <node concept="gc7cB" id="68WEpgCMwU8" role="3EZMnx">
+        <node concept="3VJUX4" id="68WEpgCMwUb" role="3YsKMw">
+          <node concept="3clFbS" id="68WEpgCMwUe" role="2VODD2">
+            <node concept="3clFbF" id="68WEpgCMwZw" role="3cqZAp">
+              <node concept="2ShNRf" id="68WEpgCMwZu" role="3clFbG">
+                <node concept="1pGfFk" id="68WEpgCMyVZ" role="2ShVmc">
+                  <ref role="37wK5l" to="m999:1F0U9H74l9q" resolve="EndCell" />
+                  <node concept="pncrf" id="68WEpgCMyZg" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -11,6 +11,7 @@
     <use id="3bdedd09-792a-4e15-a4db-83970df3ee86" name="de.itemis.mps.editor.collapsible" version="-1" />
     <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="-1" />
     <use id="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" name="com.mbeddr.mpsutil.editor.querylist" version="0" />
+    <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -26,13 +27,21 @@
     <import index="r4b4" ref="r:1784e088-20fd-4fdb-96b8-bc57f0056d94(com.mbeddr.core.base.editor)" />
     <import index="oq0c" ref="r:6c6155f0-4bbe-4af5-8c26-244d570e21e4(org.iets3.core.expr.base.plugin)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
-    <import index="buwp" ref="r:8405f486-53b5-4fe6-af3e-7f68358bd631(org.iets3.core.expr.base.editor)" />
     <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
     <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
+    <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="lwvz" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.selection(MPS.Editor/)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="z0fb" ref="r:0b928dd6-dd7e-45a8-b309-a2e315b7877a(de.itemis.mps.editor.celllayout.styles.editor)" />
+    <import index="q4oi" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellActions(MPS.Editor/)" />
+    <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
+    <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="i6kd" ref="r:2261c766-d7b6-49d7-91bd-1207e471af0b(org.iets3.core.expr.lambda.editor)" implicit="true" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -290,13 +299,27 @@
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
       <concept id="3903367331818357915" name="jetbrains.mps.lang.editor.structure.StyledTextType" flags="in" index="1YN$XN" />
+      <concept id="6029276237631252951" name="jetbrains.mps.lang.editor.structure.StyleAttributeReferenceExpression" flags="ng" index="1Z6Ecs">
+        <reference id="6029276237631253682" name="attributeDeclaration" index="1Z6EpT" />
+      </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -304,12 +327,21 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
+      </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1070475587102" name="jetbrains.mps.baseLanguage.structure.SuperConstructorInvocation" flags="nn" index="XkiVB" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
@@ -326,7 +358,12 @@
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
       </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <child id="1095933932569" name="implementedInterface" index="EKbjA" />
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
@@ -334,6 +371,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -342,9 +380,14 @@
         <property id="1113006610751" name="value" index="$nhwW" />
       </concept>
       <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <property id="4276006055363816570" name="isSynchronized" index="od$2w" />
+        <property id="1181808852946" name="isFinal" index="DiZV1" />
         <child id="1068580123133" name="returnType" index="3clF45" />
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_">
+        <property id="1178608670077" name="isAbstract" index="1EzhhJ" />
       </concept>
       <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
@@ -362,6 +405,7 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
@@ -372,6 +416,7 @@
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
+      <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
@@ -386,6 +431,11 @@
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
@@ -411,6 +461,7 @@
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
@@ -2939,7 +2990,7 @@
                   <node concept="3cpWs6" id="BsHjoDRLSE" role="3cqZAp">
                     <node concept="2ShNRf" id="BsHjoDRLSF" role="3cqZAk">
                       <node concept="1pGfFk" id="BsHjoDRLSG" role="2ShVmc">
-                        <ref role="37wK5l" to="r4b4:1F0U9H74l9y" resolve="CRHelperCell" />
+                        <ref role="37wK5l" node="1F0U9H74l9y" resolve="EndCell" />
                         <node concept="pncrf" id="BsHjoDRLSH" role="37wK5m" />
                         <node concept="37vLTw" id="5HxjapwgH2Q" role="37wK5m">
                           <ref role="3cqZAo" node="BsHjoDRLS$" resolve="color" />
@@ -2953,7 +3004,7 @@
                     <node concept="3cpWs6" id="BsHjoDRLSL" role="3cqZAp">
                       <node concept="2ShNRf" id="BsHjoDRLSM" role="3cqZAk">
                         <node concept="1pGfFk" id="BsHjoDRLSN" role="2ShVmc">
-                          <ref role="37wK5l" to="r4b4:1F0U9H74l9q" resolve="CRHelperCell" />
+                          <ref role="37wK5l" node="1F0U9H74l9q" resolve="EndCell" />
                           <node concept="pncrf" id="BsHjoDRLSO" role="37wK5m" />
                         </node>
                       </node>
@@ -4282,6 +4333,519 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="4db20qfqb8U">
+    <property role="TrG5h" value="EndCell" />
+    <node concept="3clFbW" id="1F0U9H74l9q" role="jymVt">
+      <node concept="3cqZAl" id="1F0U9H74l9r" role="3clF45" />
+      <node concept="3Tm1VV" id="1F0U9H74l9s" role="1B3o_S" />
+      <node concept="3clFbS" id="1F0U9H74l9t" role="3clF47">
+        <node concept="XkiVB" id="1F0U9H74l9u" role="3cqZAp">
+          <ref role="37wK5l" to="r4b4:4QhMqW2Tfln" resolve="AbstractBracketCell" />
+          <node concept="37vLTw" id="1F0U9H74l9v" role="37wK5m">
+            <ref role="3cqZAo" node="1F0U9H74l9w" resolve="node" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="1F0U9H74l9w" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="1F0U9H74l9x" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="3clFbW" id="1F0U9H74l9y" role="jymVt">
+      <node concept="3cqZAl" id="1F0U9H74l9z" role="3clF45" />
+      <node concept="3Tm1VV" id="1F0U9H74l9$" role="1B3o_S" />
+      <node concept="3clFbS" id="1F0U9H74l9_" role="3clF47">
+        <node concept="XkiVB" id="1F0U9H74l9A" role="3cqZAp">
+          <ref role="37wK5l" to="r4b4:4QhMqW2Tfl$" resolve="AbstractBracketCell" />
+          <node concept="37vLTw" id="1F0U9H74l9B" role="37wK5m">
+            <ref role="3cqZAo" node="1F0U9H74l9D" resolve="node" />
+          </node>
+          <node concept="37vLTw" id="1F0U9H74l9C" role="37wK5m">
+            <ref role="3cqZAo" node="68WEpgCCy7e" resolve="c" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="1F0U9H74l9D" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="1F0U9H74l9E" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="68WEpgCCy7e" role="3clF46">
+        <property role="TrG5h" value="c" />
+        <node concept="3uibUv" id="68WEpgCCy7f" role="1tU5fm">
+          <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1F0U9H74l9H" role="jymVt" />
+    <node concept="3clFb_" id="1F0U9H74l9I" role="jymVt">
+      <property role="1EzhhJ" value="false" />
+      <property role="TrG5h" value="createEditorCell" />
+      <property role="DiZV1" value="false" />
+      <node concept="3Tm1VV" id="1F0U9H74l9J" role="1B3o_S" />
+      <node concept="3uibUv" id="1F0U9H74l9K" role="3clF45">
+        <ref role="3uigEE" to="g51k:~EditorCell" resolve="EditorCell" />
+      </node>
+      <node concept="37vLTG" id="1F0U9H74l9L" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="7XIXMBMXnxa" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="1F0U9H74l9N" role="3clF47">
+        <node concept="3cpWs8" id="1F0U9H74l9O" role="3cqZAp">
+          <node concept="3cpWsn" id="1F0U9H74l9P" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="3uibUv" id="1F0U9H74l9Q" role="1tU5fm">
+              <ref role="3uigEE" to="g51k:~EditorCell_Basic" resolve="EditorCell_Basic" />
+            </node>
+            <node concept="2ShNRf" id="1F0U9H74l9R" role="33vP2m">
+              <node concept="1pGfFk" id="7x0eTkxyBX" role="2ShVmc">
+                <ref role="37wK5l" node="68WEpgCCRht" resolve="EndCell.Cell" />
+                <node concept="37vLTw" id="1F0U9H74l9V" role="37wK5m">
+                  <ref role="3cqZAo" node="1F0U9H74l9L" resolve="context" />
+                </node>
+                <node concept="1rXfSq" id="16ADmNZ6ocj" role="37wK5m">
+                  <ref role="37wK5l" to="exr9:~AbstractCellProvider.getSNode()" resolve="getSNode" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="1F0U9H74lbz" role="3cqZAp">
+          <node concept="37vLTw" id="1F0U9H74lb$" role="3cqZAk">
+            <ref role="3cqZAo" node="1F0U9H74l9P" resolve="result" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="68WEpgCCHZl" role="jymVt" />
+    <node concept="312cEu" id="7x0eTkxfOs" role="jymVt">
+      <property role="2bfB8j" value="true" />
+      <property role="TrG5h" value="Cell" />
+      <node concept="2tJIrI" id="7x0eTkxk5b" role="jymVt" />
+      <node concept="3clFbW" id="68WEpgCCRht" role="jymVt">
+        <node concept="3cqZAl" id="68WEpgCCRhu" role="3clF45" />
+        <node concept="3Tm1VV" id="68WEpgCCRhv" role="1B3o_S" />
+        <node concept="3clFbS" id="68WEpgCCRhw" role="3clF47">
+          <node concept="XkiVB" id="68WEpgCCRhx" role="3cqZAp">
+            <ref role="37wK5l" to="g51k:~EditorCell_Basic.&lt;init&gt;(jetbrains.mps.openapi.editor.EditorContext,org.jetbrains.mps.openapi.model.SNode)" resolve="EditorCell_Basic" />
+            <node concept="37vLTw" id="68WEpgCCRhy" role="37wK5m">
+              <ref role="3cqZAo" node="68WEpgCCRhQ" resolve="context" />
+            </node>
+            <node concept="37vLTw" id="68WEpgCCRhz" role="37wK5m">
+              <ref role="3cqZAo" node="68WEpgCCRhT" resolve="node" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="68WEpgCCRh$" role="3cqZAp">
+            <node concept="2OqwBi" id="68WEpgCCRh_" role="3clFbG">
+              <node concept="1rXfSq" id="68WEpgCCRhA" role="2Oq$k0">
+                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getStyle()" resolve="getStyle" />
+              </node>
+              <node concept="liA8E" id="68WEpgCCRhB" role="2OqNvi">
+                <ref role="37wK5l" to="hox0:~Style.set(jetbrains.mps.openapi.editor.style.StyleAttribute,java.lang.Object)" resolve="set" />
+                <node concept="1Z6Ecs" id="68WEpgCCRhC" role="37wK5m">
+                  <ref role="1Z6EpT" to="z0fb:7lS0O5066tg" resolve="_grow-y" />
+                </node>
+                <node concept="3clFbT" id="68WEpgCCRhD" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="3AY9Typr_xR" role="3cqZAp">
+            <node concept="2OqwBi" id="3AY9Typr_xS" role="3clFbG">
+              <node concept="1rXfSq" id="3AY9Typr_xT" role="2Oq$k0">
+                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getStyle()" resolve="getStyle" />
+              </node>
+              <node concept="liA8E" id="3AY9Typr_xU" role="2OqNvi">
+                <ref role="37wK5l" to="hox0:~Style.set(jetbrains.mps.openapi.editor.style.StyleAttribute,java.lang.Object)" resolve="set" />
+                <node concept="1Z6Ecs" id="3AY9Typr_xV" role="37wK5m">
+                  <ref role="1Z6EpT" to="z0fb:7lS0O5066uD" resolve="_push-y" />
+                </node>
+                <node concept="3clFbT" id="3AY9Typr_xW" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="3AY9TypibfP" role="3cqZAp" />
+          <node concept="3clFbF" id="68WEpgCCRhE" role="3cqZAp">
+            <node concept="1rXfSq" id="68WEpgCCRhF" role="3clFbG">
+              <ref role="37wK5l" to="g51k:~EditorCell_Basic.setAction(jetbrains.mps.openapi.editor.cells.CellActionType,jetbrains.mps.openapi.editor.cells.CellAction)" resolve="setAction" />
+              <node concept="Rm8GO" id="68WEpgCCRhG" role="37wK5m">
+                <ref role="1Px2BO" to="f4zo:~CellActionType" resolve="CellActionType" />
+                <ref role="Rm8GQ" to="f4zo:~CellActionType.DELETE" resolve="DELETE" />
+              </node>
+              <node concept="2ShNRf" id="68WEpgCCRhH" role="37wK5m">
+                <node concept="1pGfFk" id="68WEpgCCRhI" role="2ShVmc">
+                  <ref role="37wK5l" to="q4oi:~CellAction_DeleteNode.&lt;init&gt;(org.jetbrains.mps.openapi.model.SNode)" resolve="CellAction_DeleteNode" />
+                  <node concept="37vLTw" id="68WEpgCCRhJ" role="37wK5m">
+                    <ref role="3cqZAo" node="68WEpgCCRhT" resolve="node" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="68WEpgCCRhK" role="3cqZAp">
+            <node concept="1rXfSq" id="68WEpgCCRhL" role="3clFbG">
+              <ref role="37wK5l" to="g51k:~EditorCell_Basic.setAction(jetbrains.mps.openapi.editor.cells.CellActionType,jetbrains.mps.openapi.editor.cells.CellAction)" resolve="setAction" />
+              <node concept="Rm8GO" id="68WEpgCCRhM" role="37wK5m">
+                <ref role="1Px2BO" to="f4zo:~CellActionType" resolve="CellActionType" />
+                <ref role="Rm8GQ" to="f4zo:~CellActionType.BACKSPACE" resolve="BACKSPACE" />
+              </node>
+              <node concept="2ShNRf" id="68WEpgCCRhN" role="37wK5m">
+                <node concept="1pGfFk" id="68WEpgCCRhO" role="2ShVmc">
+                  <ref role="37wK5l" to="q4oi:~CellAction_DeleteNode.&lt;init&gt;(org.jetbrains.mps.openapi.model.SNode)" resolve="CellAction_DeleteNode" />
+                  <node concept="37vLTw" id="68WEpgCCRhP" role="37wK5m">
+                    <ref role="3cqZAo" node="68WEpgCCRhT" resolve="node" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="37vLTG" id="68WEpgCCRhQ" role="3clF46">
+          <property role="TrG5h" value="context" />
+          <node concept="3uibUv" id="68WEpgCCRhR" role="1tU5fm">
+            <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+          </node>
+          <node concept="2AHcQZ" id="68WEpgCCRhS" role="2AJF6D">
+            <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="68WEpgCCRhT" role="3clF46">
+          <property role="TrG5h" value="node" />
+          <node concept="3uibUv" id="68WEpgCCRhU" role="1tU5fm">
+            <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+          </node>
+        </node>
+      </node>
+      <node concept="2tJIrI" id="7x0eTkxjtE" role="jymVt" />
+      <node concept="3clFb_" id="1F0U9H74l9Z" role="jymVt">
+        <property role="1EzhhJ" value="false" />
+        <property role="TrG5h" value="paintContent" />
+        <node concept="3Tm1VV" id="1F0U9H74la0" role="1B3o_S" />
+        <node concept="3cqZAl" id="1F0U9H74la1" role="3clF45" />
+        <node concept="37vLTG" id="1F0U9H74la2" role="3clF46">
+          <property role="TrG5h" value="g" />
+          <node concept="3uibUv" id="1F0U9H74la3" role="1tU5fm">
+            <ref role="3uigEE" to="z60i:~Graphics" resolve="Graphics" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="1F0U9H74la4" role="3clF46">
+          <property role="TrG5h" value="parentSettings" />
+          <node concept="3uibUv" id="1F0U9H74la5" role="1tU5fm">
+            <ref role="3uigEE" to="g51k:~ParentSettings" resolve="ParentSettings" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="1F0U9H74la6" role="3clF47">
+          <node concept="3clFbJ" id="1F0U9H74la7" role="3cqZAp">
+            <node concept="3clFbS" id="1F0U9H74la8" role="3clFbx">
+              <node concept="3clFbJ" id="4QhMqW2Tvhv" role="3cqZAp">
+                <node concept="3clFbS" id="4QhMqW2Tvhw" role="3clFbx">
+                  <node concept="3clFbF" id="4QhMqW2Tvhx" role="3cqZAp">
+                    <node concept="2OqwBi" id="4QhMqW2Tvhy" role="3clFbG">
+                      <node concept="37vLTw" id="4QhMqW2Tvhz" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1F0U9H74la2" resolve="g" />
+                      </node>
+                      <node concept="liA8E" id="4QhMqW2Tvh$" role="2OqNvi">
+                        <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
+                        <node concept="37vLTw" id="4QhMqW2Tvh_" role="37wK5m">
+                          <ref role="3cqZAo" to="r4b4:4QhMqW2Tflk" resolve="color" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3y3z36" id="4QhMqW2TvhA" role="3clFbw">
+                  <node concept="10Nm6u" id="4QhMqW2TvhB" role="3uHU7w" />
+                  <node concept="37vLTw" id="4QhMqW2TvhC" role="3uHU7B">
+                    <ref role="3cqZAo" to="r4b4:4QhMqW2Tflk" resolve="color" />
+                  </node>
+                </node>
+                <node concept="9aQIb" id="4QhMqW2TvhD" role="9aQIa">
+                  <node concept="3clFbS" id="4QhMqW2TvhE" role="9aQI4">
+                    <node concept="3clFbF" id="4QhMqW2TvhF" role="3cqZAp">
+                      <node concept="2OqwBi" id="4QhMqW2TvhG" role="3clFbG">
+                        <node concept="37vLTw" id="4QhMqW2TvhH" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1F0U9H74la2" resolve="g" />
+                        </node>
+                        <node concept="liA8E" id="4QhMqW2TvhI" role="2OqNvi">
+                          <ref role="37wK5l" to="z60i:~Graphics.setColor(java.awt.Color)" resolve="setColor" />
+                          <node concept="2YIFZM" id="3AY9Typqd1t" role="37wK5m">
+                            <ref role="37wK5l" to="lzb2:~ColorUtil.withAlpha(java.awt.Color,double)" resolve="withAlpha" />
+                            <ref role="1Pybhc" to="lzb2:~ColorUtil" resolve="ColorUtil" />
+                            <node concept="10M0yZ" id="3AY9Typqe9o" role="37wK5m">
+                              <ref role="3cqZAo" to="lzb2:~JBColor.BLACK" resolve="BLACK" />
+                              <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
+                            </node>
+                            <node concept="3b6qkQ" id="3AY9Typqfgn" role="37wK5m">
+                              <property role="$nhwW" value="0.12" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="7gVrg_0tvFG" role="3cqZAp">
+                <node concept="3cpWsn" id="7gVrg_0tvFH" role="3cpWs9">
+                  <property role="TrG5h" value="parent" />
+                  <node concept="3uibUv" id="7gVrg_0tvFI" role="1tU5fm">
+                    <ref role="3uigEE" to="g51k:~EditorCell_Collection" resolve="EditorCell_Collection" />
+                  </node>
+                  <node concept="2OqwBi" id="7gVrg_0tvFJ" role="33vP2m">
+                    <node concept="liA8E" id="7gVrg_0tvFK" role="2OqNvi">
+                      <ref role="37wK5l" to="g51k:~EditorCell_Basic.getParent()" resolve="getParent" />
+                    </node>
+                    <node concept="Xjq3P" id="7gVrg_0tvFL" role="2Oq$k0" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="7gVrg_0tvFM" role="3cqZAp">
+                <node concept="3cpWsn" id="7gVrg_0tvFN" role="3cpWs9">
+                  <property role="TrG5h" value="x" />
+                  <node concept="10Oyi0" id="7gVrg_0tvFO" role="1tU5fm" />
+                  <node concept="3cpWs3" id="3AY9Typkntc" role="33vP2m">
+                    <node concept="1rXfSq" id="3AY9Typkof1" role="3uHU7w">
+                      <ref role="37wK5l" to="g51k:~EditorCell_Basic.getLeftGap()" resolve="getLeftGap" />
+                    </node>
+                    <node concept="37vLTw" id="3AY9TypsVqr" role="3uHU7B">
+                      <ref role="3cqZAo" to="g51k:~EditorCell_Basic.myX" resolve="myX" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="7gVrg_0tvFQ" role="3cqZAp">
+                <node concept="3cpWsn" id="7gVrg_0tvFR" role="3cpWs9">
+                  <property role="TrG5h" value="y" />
+                  <node concept="10Oyi0" id="7gVrg_0tvFS" role="1tU5fm" />
+                  <node concept="2OqwBi" id="7gVrg_0tvFT" role="33vP2m">
+                    <node concept="37vLTw" id="7gVrg_0tvFU" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7gVrg_0tvFH" resolve="parent" />
+                    </node>
+                    <node concept="liA8E" id="7gVrg_0tvFV" role="2OqNvi">
+                      <ref role="37wK5l" to="g51k:~EditorCell_Basic.getY()" resolve="getY" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="7gVrg_0tvFW" role="3cqZAp">
+                <node concept="3cpWsn" id="7gVrg_0tvFX" role="3cpWs9">
+                  <property role="TrG5h" value="height" />
+                  <node concept="10Oyi0" id="7gVrg_0tvFY" role="1tU5fm" />
+                  <node concept="3cpWsd" id="7gVrg_0tvFZ" role="33vP2m">
+                    <node concept="2OqwBi" id="7gVrg_0tvG0" role="3uHU7B">
+                      <node concept="37vLTw" id="5HxjapwgHo4" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7gVrg_0tvFH" resolve="parent" />
+                      </node>
+                      <node concept="liA8E" id="7gVrg_0tvG2" role="2OqNvi">
+                        <ref role="37wK5l" to="g51k:~EditorCell_Basic.getHeight()" resolve="getHeight" />
+                      </node>
+                    </node>
+                    <node concept="3cmrfG" id="7gVrg_0tvG3" role="3uHU7w">
+                      <property role="3cmrfH" value="2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="7gVrg_0tvG4" role="3cqZAp">
+                <node concept="2OqwBi" id="7gVrg_0tvG5" role="3clFbG">
+                  <node concept="37vLTw" id="7gVrg_0tvG6" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1F0U9H74la2" resolve="g" />
+                  </node>
+                  <node concept="liA8E" id="7gVrg_0tvG7" role="2OqNvi">
+                    <ref role="37wK5l" to="z60i:~Graphics.fillRect(int,int,int,int)" resolve="fillRect" />
+                    <node concept="37vLTw" id="7gVrg_0tvG8" role="37wK5m">
+                      <ref role="3cqZAo" node="7gVrg_0tvFN" resolve="x" />
+                    </node>
+                    <node concept="3cpWs3" id="7gVrg_0tvG9" role="37wK5m">
+                      <node concept="3cmrfG" id="7gVrg_0tvGa" role="3uHU7w">
+                        <property role="3cmrfH" value="2" />
+                      </node>
+                      <node concept="37vLTw" id="7gVrg_0tvGb" role="3uHU7B">
+                        <ref role="3cqZAo" node="7gVrg_0tvFR" resolve="y" />
+                      </node>
+                    </node>
+                    <node concept="3cmrfG" id="7gVrg_0tvGc" role="37wK5m">
+                      <property role="3cmrfH" value="2" />
+                    </node>
+                    <node concept="37vLTw" id="7gVrg_0tvGd" role="37wK5m">
+                      <ref role="3cqZAo" node="7gVrg_0tvFX" resolve="height" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1rXfSq" id="1F0U9H74lb9" role="3clFbw">
+              <ref role="37wK5l" to="r4b4:4QhMqW2T_0a" resolve="shouldPaintBracket" />
+              <node concept="1rXfSq" id="7x0eTkxxBu" role="37wK5m">
+                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getContext()" resolve="getContext" />
+              </node>
+              <node concept="Xjq3P" id="1F0U9H74lbb" role="37wK5m" />
+              <node concept="37vLTw" id="1F0U9H74lbc" role="37wK5m">
+                <ref role="3cqZAo" node="1F0U9H74la4" resolve="parentSettings" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2tJIrI" id="3VQE5sAUr6e" role="jymVt" />
+      <node concept="3clFb_" id="1F0U9H74lbd" role="jymVt">
+        <property role="TrG5h" value="relayoutImpl" />
+        <node concept="3cqZAl" id="1F0U9H74lbe" role="3clF45" />
+        <node concept="3Tm1VV" id="1F0U9H74lbf" role="1B3o_S" />
+        <node concept="3clFbS" id="1F0U9H74lbg" role="3clF47">
+          <node concept="3clFbF" id="1F0U9H74lbh" role="3cqZAp">
+            <node concept="37vLTI" id="1F0U9H74lbi" role="3clFbG">
+              <node concept="2OqwBi" id="1F0U9H74lbk" role="37vLTJ">
+                <node concept="2OwXpG" id="1F0U9H74lbl" role="2OqNvi">
+                  <ref role="2Oxat5" to="g51k:~EditorCell_Basic.myWidth" resolve="myWidth" />
+                </node>
+                <node concept="Xjq3P" id="1F0U9H74lbm" role="2Oq$k0" />
+              </node>
+              <node concept="3cmrfG" id="68WEpgCImnS" role="37vLTx">
+                <property role="3cmrfH" value="2" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="1F0U9H74lbn" role="3cqZAp">
+            <node concept="37vLTI" id="1F0U9H74lbo" role="3clFbG">
+              <node concept="2OqwBi" id="1F0U9H74lbp" role="37vLTJ">
+                <node concept="2OwXpG" id="1F0U9H74lbq" role="2OqNvi">
+                  <ref role="2Oxat5" to="g51k:~EditorCell_Basic.myHeight" resolve="myHeight" />
+                </node>
+                <node concept="Xjq3P" id="1F0U9H74lbr" role="2Oq$k0" />
+              </node>
+              <node concept="3cmrfG" id="1F0U9H74lbs" role="37vLTx">
+                <property role="3cmrfH" value="20" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2tJIrI" id="7x0eTkxaRF" role="jymVt" />
+      <node concept="3Tm1VV" id="7x0eTkxfOt" role="1B3o_S" />
+      <node concept="3uibUv" id="264ij5_0Qye" role="1zkMxy">
+        <ref role="3uigEE" to="g51k:~EditorCell_Basic" resolve="EditorCell_Basic" />
+      </node>
+      <node concept="3uibUv" id="7x0eTkxzL2" role="EKbjA">
+        <ref role="3uigEE" to="lwvz:~SelectionListener" resolve="SelectionListener" />
+      </node>
+      <node concept="3clFb_" id="7x0eTkx9nV" role="jymVt">
+        <property role="1EzhhJ" value="false" />
+        <property role="TrG5h" value="onAdd" />
+        <property role="DiZV1" value="false" />
+        <property role="od$2w" value="false" />
+        <node concept="3Tm1VV" id="7x0eTkx9nW" role="1B3o_S" />
+        <node concept="3cqZAl" id="7x0eTkx9nY" role="3clF45" />
+        <node concept="3clFbS" id="7x0eTkx9o0" role="3clF47">
+          <node concept="3clFbF" id="7x0eTkxcRr" role="3cqZAp">
+            <node concept="2OqwBi" id="7x0eTkxd02" role="3clFbG">
+              <node concept="2OqwBi" id="7x0eTkxcTY" role="2Oq$k0">
+                <node concept="1rXfSq" id="7x0eTkxcRq" role="2Oq$k0">
+                  <ref role="37wK5l" to="g51k:~EditorCell_Basic.getEditorComponent()" resolve="getEditorComponent" />
+                </node>
+                <node concept="liA8E" id="7x0eTkxcZ8" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorComponent.getSelectionManager()" resolve="getSelectionManager" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7x0eTkxd3Y" role="2OqNvi">
+                <ref role="37wK5l" to="lwvz:~SelectionManager.addSelectionListener(jetbrains.mps.openapi.editor.selection.SelectionListener)" resolve="addSelectionListener" />
+                <node concept="Xjq3P" id="7x0eTkxdj0" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="7x0eTkx9o1" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="3AY9Typi9bc" role="jymVt" />
+      <node concept="3clFb_" id="7x0eTkxa7c" role="jymVt">
+        <property role="1EzhhJ" value="false" />
+        <property role="TrG5h" value="onRemove" />
+        <property role="DiZV1" value="false" />
+        <property role="od$2w" value="false" />
+        <node concept="3Tm1VV" id="7x0eTkxa7d" role="1B3o_S" />
+        <node concept="3cqZAl" id="7x0eTkxa7f" role="3clF45" />
+        <node concept="3clFbS" id="7x0eTkxa7h" role="3clF47">
+          <node concept="3clFbF" id="7x0eTkxATT" role="3cqZAp">
+            <node concept="2OqwBi" id="7x0eTkxATU" role="3clFbG">
+              <node concept="2OqwBi" id="7x0eTkxATV" role="2Oq$k0">
+                <node concept="1rXfSq" id="7x0eTkxATW" role="2Oq$k0">
+                  <ref role="37wK5l" to="g51k:~EditorCell_Basic.getEditorComponent()" resolve="getEditorComponent" />
+                </node>
+                <node concept="liA8E" id="7x0eTkxATX" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorComponent.getSelectionManager()" resolve="getSelectionManager" />
+                </node>
+              </node>
+              <node concept="liA8E" id="7x0eTkxATY" role="2OqNvi">
+                <ref role="37wK5l" to="lwvz:~SelectionManager.removeSelectionListener(jetbrains.mps.openapi.editor.selection.SelectionListener)" resolve="removeSelectionListener" />
+                <node concept="Xjq3P" id="7x0eTkxATZ" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="7x0eTkxa7i" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+        </node>
+      </node>
+      <node concept="2tJIrI" id="7x0eTkxgWA" role="jymVt" />
+      <node concept="3clFb_" id="3AY9Typi9bd" role="jymVt">
+        <property role="1EzhhJ" value="false" />
+        <property role="TrG5h" value="selectionChanged" />
+        <property role="DiZV1" value="false" />
+        <property role="od$2w" value="false" />
+        <node concept="3Tm1VV" id="3AY9Typi9be" role="1B3o_S" />
+        <node concept="3cqZAl" id="3AY9Typi9bf" role="3clF45" />
+        <node concept="37vLTG" id="3AY9Typi9bg" role="3clF46">
+          <property role="TrG5h" value="component" />
+          <node concept="3uibUv" id="3AY9Typi9bh" role="1tU5fm">
+            <ref role="3uigEE" to="cj4x:~EditorComponent" resolve="EditorComponent" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="3AY9Typi9bi" role="3clF46">
+          <property role="TrG5h" value="selection" />
+          <node concept="3uibUv" id="3AY9Typi9bj" role="1tU5fm">
+            <ref role="3uigEE" to="lwvz:~Selection" resolve="Selection" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="3AY9Typi9bk" role="3clF46">
+          <property role="TrG5h" value="selection1" />
+          <node concept="3uibUv" id="3AY9Typi9bl" role="1tU5fm">
+            <ref role="3uigEE" to="lwvz:~Selection" resolve="Selection" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="3AY9Typi9bm" role="3clF47">
+          <node concept="3clFbF" id="7x0eTkx_za" role="3cqZAp">
+            <node concept="2OqwBi" id="7x0eTkx_Z5" role="3clFbG">
+              <node concept="1eOMI4" id="7x0eTkx_IA" role="2Oq$k0">
+                <node concept="10QFUN" id="7x0eTkx_IB" role="1eOMHV">
+                  <node concept="1rXfSq" id="7x0eTkx_I_" role="10QFUP">
+                    <ref role="37wK5l" to="g51k:~EditorCell_Basic.getEditorComponent()" resolve="getEditorComponent" />
+                  </node>
+                  <node concept="3uibUv" id="7x0eTkx_Vf" role="10QFUM">
+                    <ref role="3uigEE" to="exr9:~EditorComponent" resolve="EditorComponent" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="7x0eTkxAEJ" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.repaint(jetbrains.mps.openapi.editor.cells.EditorCell)" resolve="repaint" />
+                <node concept="Xjq3P" id="7x0eTkxARf" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="4db20qfqb8V" role="1B3o_S" />
+    <node concept="3uibUv" id="68WEpgCCy0n" role="1zkMxy">
+      <ref role="3uigEE" to="r4b4:4QhMqW2TcDm" resolve="AbstractBracketCell" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/org.iets3.core.expr.toplevel.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/org.iets3.core.expr.toplevel.mpl
@@ -31,6 +31,8 @@
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
     <dependency reexport="false">6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)</dependency>
     <dependency reexport="false">34e84b8f-afa8-4364-abcd-a279fddddbe7(jetbrains.mps.editor.runtime)</dependency>
+    <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
+    <dependency reexport="false">24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:677f00fb-4488-405e-9885-abb75d472fd1:com.mbeddr.mpsutil.contextactions" version="0" />
@@ -41,7 +43,6 @@
     <language slang="l:309e0004-4976-4416-b947-ec02ae4ecef2:com.mbeddr.mpsutil.modellisteners" version="0" />
     <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
     <language slang="l:3bdedd09-792a-4e15-a4db-83970df3ee86:de.itemis.mps.editor.collapsible" version="0" />
-    <language slang="l:52733268-be24-4f5f-ab84-a73b7c0c03b0:de.slisson.mps.richtext.customcell" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
     <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/editor.mps
@@ -40,6 +40,7 @@
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="5ueo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.style(MPS.Editor/)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
+    <import index="m999" ref="r:1d6bd88a-7393-4b32-b0e6-2d8b3094776e(org.iets3.core.expr.toplevel.editor)" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="epcs" ref="b33d119e-196d-4497-977c-5c167b21fe33/r:b7f325a3-1f57-46bc-8b14-d2d7c5ff6714(com.mbeddr.mpsutil.framecell/com.mbeddr.mpsutil.framecell.editor)" implicit="true" />
@@ -3266,115 +3267,118 @@
             </node>
           </node>
         </node>
-        <node concept="2rfBfz" id="8XWEtdXA0W" role="3EZMny">
-          <node concept="2r3Xtq" id="5hullqu1Kmh" role="2rfbqz">
-            <node concept="1A0rlU" id="5hullqu5Vbi" role="uCobI">
-              <node concept="3F0ifn" id="5hullqu5WMQ" role="1A0rbF">
-                <node concept="VPM3Z" id="5hullqu5WMU" role="3F10Kt">
-                  <property role="VOm3f" value="false" />
-                </node>
-                <node concept="3tD6jV" id="5hullqu5WN0" role="3F10Kt">
-                  <ref role="3tD7wE" to="reoo:5PDTdguqQlC" resolve="border-top-width" />
-                  <node concept="3sjG9q" id="5hullqu5WN1" role="3tD6jU">
-                    <node concept="3clFbS" id="5hullqu5WN2" role="2VODD2">
-                      <node concept="3clFbF" id="5hullqu5X41" role="3cqZAp">
-                        <node concept="3cmrfG" id="5hullqu5X40" role="3clFbG">
-                          <property role="3cmrfH" value="0" />
+        <node concept="3EZMnI" id="264ij5$S4n3" role="3EZMny">
+          <node concept="2iRfu4" id="264ij5$S4n4" role="2iSdaV" />
+          <node concept="2rfBfz" id="8XWEtdXA0W" role="3EZMnx">
+            <node concept="2r3Xtq" id="5hullqu1Kmh" role="2rfbqz">
+              <node concept="1A0rlU" id="5hullqu5Vbi" role="uCobI">
+                <node concept="3F0ifn" id="5hullqu5WMQ" role="1A0rbF">
+                  <node concept="VPM3Z" id="5hullqu5WMU" role="3F10Kt">
+                    <property role="VOm3f" value="false" />
+                  </node>
+                  <node concept="3tD6jV" id="5hullqu5WN0" role="3F10Kt">
+                    <ref role="3tD7wE" to="reoo:5PDTdguqQlC" resolve="border-top-width" />
+                    <node concept="3sjG9q" id="5hullqu5WN1" role="3tD6jU">
+                      <node concept="3clFbS" id="5hullqu5WN2" role="2VODD2">
+                        <node concept="3clFbF" id="5hullqu5X41" role="3cqZAp">
+                          <node concept="3cmrfG" id="5hullqu5X40" role="3clFbG">
+                            <property role="3cmrfH" value="0" />
+                          </node>
                         </node>
                       </node>
                     </node>
                   </node>
-                </node>
-                <node concept="3tD6jV" id="5hullqu5Xll" role="3F10Kt">
-                  <ref role="3tD7wE" to="reoo:5PDTdguqQlv" resolve="border-left-width" />
-                  <node concept="3sjG9q" id="5hullqu5Xln" role="3tD6jU">
-                    <node concept="3clFbS" id="5hullqu5Xlp" role="2VODD2">
-                      <node concept="3clFbF" id="5hullqu5XAz" role="3cqZAp">
-                        <node concept="3cmrfG" id="5hullqu5XAy" role="3clFbG">
-                          <property role="3cmrfH" value="0" />
+                  <node concept="3tD6jV" id="5hullqu5Xll" role="3F10Kt">
+                    <ref role="3tD7wE" to="reoo:5PDTdguqQlv" resolve="border-left-width" />
+                    <node concept="3sjG9q" id="5hullqu5Xln" role="3tD6jU">
+                      <node concept="3clFbS" id="5hullqu5Xlp" role="2VODD2">
+                        <node concept="3clFbF" id="5hullqu5XAz" role="3cqZAp">
+                          <node concept="3cmrfG" id="5hullqu5XAy" role="3clFbG">
+                            <property role="3cmrfH" value="0" />
+                          </node>
                         </node>
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-            </node>
-            <node concept="2r3VGE" id="5hullqu1Kmj" role="uCobI">
-              <property role="TrG5h" value="cols" />
-              <node concept="3clFbS" id="5hullqu1Kmk" role="2VODD2">
-                <node concept="3clFbF" id="5hullqu1Kml" role="3cqZAp">
-                  <node concept="2OqwBi" id="5hullqu1Kmm" role="3clFbG">
-                    <node concept="2r2w_c" id="5hullqu1Kmn" role="2Oq$k0" />
-                    <node concept="3Tsc0h" id="5hullqu1Kmo" role="2OqNvi">
-                      <ref role="3TtcxE" to="kfo3:7FuUjk_57Cw" resolve="colDefs" />
+              <node concept="2r3VGE" id="5hullqu1Kmj" role="uCobI">
+                <property role="TrG5h" value="cols" />
+                <node concept="3clFbS" id="5hullqu1Kmk" role="2VODD2">
+                  <node concept="3clFbF" id="5hullqu1Kml" role="3cqZAp">
+                    <node concept="2OqwBi" id="5hullqu1Kmm" role="3clFbG">
+                      <node concept="2r2w_c" id="5hullqu1Kmn" role="2Oq$k0" />
+                      <node concept="3Tsc0h" id="5hullqu1Kmo" role="2OqNvi">
+                        <ref role="3TtcxE" to="kfo3:7FuUjk_57Cw" resolve="colDefs" />
+                      </node>
                     </node>
                   </node>
                 </node>
-              </node>
-              <node concept="10boU0" id="5hullqu1Kmp" role="10bivc">
-                <node concept="3clFbS" id="5hullqu1Kmq" role="2VODD2">
-                  <node concept="3clFbJ" id="5hullqu1Kmr" role="3cqZAp">
-                    <node concept="3clFbS" id="5hullqu1Kms" role="3clFbx">
-                      <node concept="3clFbF" id="5hullqu1Kmt" role="3cqZAp">
-                        <node concept="2OqwBi" id="5hullqu1Kmu" role="3clFbG">
-                          <node concept="2OqwBi" id="5hullqu1Kmv" role="2Oq$k0">
-                            <node concept="2r2w_c" id="5hullqu1Kmw" role="2Oq$k0" />
-                            <node concept="3Tsc0h" id="5hullqu1Kmx" role="2OqNvi">
+                <node concept="10boU0" id="5hullqu1Kmp" role="10bivc">
+                  <node concept="3clFbS" id="5hullqu1Kmq" role="2VODD2">
+                    <node concept="3clFbJ" id="5hullqu1Kmr" role="3cqZAp">
+                      <node concept="3clFbS" id="5hullqu1Kms" role="3clFbx">
+                        <node concept="3clFbF" id="5hullqu1Kmt" role="3cqZAp">
+                          <node concept="2OqwBi" id="5hullqu1Kmu" role="3clFbG">
+                            <node concept="2OqwBi" id="5hullqu1Kmv" role="2Oq$k0">
+                              <node concept="2r2w_c" id="5hullqu1Kmw" role="2Oq$k0" />
+                              <node concept="3Tsc0h" id="5hullqu1Kmx" role="2OqNvi">
+                                <ref role="3TtcxE" to="kfo3:7FuUjk_57Cw" resolve="colDefs" />
+                              </node>
+                            </node>
+                            <node concept="1sK_Qi" id="5hullqu1Kmy" role="2OqNvi">
+                              <node concept="10bopy" id="5hullqu1Kmz" role="1sKJu8" />
+                              <node concept="2ShNRf" id="5hullqu1Km$" role="1sKFgg">
+                                <node concept="3zrR0B" id="5hullqu1Km_" role="2ShVmc">
+                                  <node concept="3Tqbb2" id="5hullqu1KmA" role="3zrR0E">
+                                    <ref role="ehGHo" to="kfo3:5GPhrsV2kb8" resolve="TopLevelColDef" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="5hullqu1KmB" role="3clFbw">
+                        <node concept="2OqwBi" id="5hullqu1KmC" role="2Oq$k0">
+                          <node concept="2OqwBi" id="5hullqu1KmD" role="2Oq$k0">
+                            <node concept="2r2w_c" id="5hullqu1KmE" role="2Oq$k0" />
+                            <node concept="3Tsc0h" id="5hullqu1KmF" role="2OqNvi">
                               <ref role="3TtcxE" to="kfo3:7FuUjk_57Cw" resolve="colDefs" />
                             </node>
                           </node>
-                          <node concept="1sK_Qi" id="5hullqu1Kmy" role="2OqNvi">
-                            <node concept="10bopy" id="5hullqu1Kmz" role="1sKJu8" />
-                            <node concept="2ShNRf" id="5hullqu1Km$" role="1sKFgg">
-                              <node concept="3zrR0B" id="5hullqu1Km_" role="2ShVmc">
-                                <node concept="3Tqbb2" id="5hullqu1KmA" role="3zrR0E">
-                                  <ref role="ehGHo" to="kfo3:5GPhrsV2kb8" resolve="TopLevelColDef" />
+                          <node concept="34jXtK" id="5hullqu1KmG" role="2OqNvi">
+                            <node concept="3cpWsd" id="5hullqu1KmH" role="25WWJ7">
+                              <node concept="3cmrfG" id="5hullqu1KmI" role="3uHU7w">
+                                <property role="3cmrfH" value="1" />
+                              </node>
+                              <node concept="10bopy" id="5hullqu1KmJ" role="3uHU7B" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="1mIQ4w" id="5hullqu1KmK" role="2OqNvi">
+                          <node concept="chp4Y" id="5hullqu1KmL" role="cj9EA">
+                            <ref role="cht4Q" to="kfo3:5GPhrsV2kb8" resolve="TopLevelColDef" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="9aQIb" id="5hullqu1KmM" role="9aQIa">
+                        <node concept="3clFbS" id="5hullqu1KmN" role="9aQI4">
+                          <node concept="3clFbF" id="5hullqu1KmO" role="3cqZAp">
+                            <node concept="2OqwBi" id="5hullqu1KmP" role="3clFbG">
+                              <node concept="2OqwBi" id="5hullqu1KmQ" role="2Oq$k0">
+                                <node concept="2r2w_c" id="5hullqu1KmR" role="2Oq$k0" />
+                                <node concept="3Tsc0h" id="5hullqu1KmS" role="2OqNvi">
+                                  <ref role="3TtcxE" to="kfo3:7FuUjk_57Cw" resolve="colDefs" />
                                 </node>
                               </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2OqwBi" id="5hullqu1KmB" role="3clFbw">
-                      <node concept="2OqwBi" id="5hullqu1KmC" role="2Oq$k0">
-                        <node concept="2OqwBi" id="5hullqu1KmD" role="2Oq$k0">
-                          <node concept="2r2w_c" id="5hullqu1KmE" role="2Oq$k0" />
-                          <node concept="3Tsc0h" id="5hullqu1KmF" role="2OqNvi">
-                            <ref role="3TtcxE" to="kfo3:7FuUjk_57Cw" resolve="colDefs" />
-                          </node>
-                        </node>
-                        <node concept="34jXtK" id="5hullqu1KmG" role="2OqNvi">
-                          <node concept="3cpWsd" id="5hullqu1KmH" role="25WWJ7">
-                            <node concept="3cmrfG" id="5hullqu1KmI" role="3uHU7w">
-                              <property role="3cmrfH" value="1" />
-                            </node>
-                            <node concept="10bopy" id="5hullqu1KmJ" role="3uHU7B" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="1mIQ4w" id="5hullqu1KmK" role="2OqNvi">
-                        <node concept="chp4Y" id="5hullqu1KmL" role="cj9EA">
-                          <ref role="cht4Q" to="kfo3:5GPhrsV2kb8" resolve="TopLevelColDef" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="9aQIb" id="5hullqu1KmM" role="9aQIa">
-                      <node concept="3clFbS" id="5hullqu1KmN" role="9aQI4">
-                        <node concept="3clFbF" id="5hullqu1KmO" role="3cqZAp">
-                          <node concept="2OqwBi" id="5hullqu1KmP" role="3clFbG">
-                            <node concept="2OqwBi" id="5hullqu1KmQ" role="2Oq$k0">
-                              <node concept="2r2w_c" id="5hullqu1KmR" role="2Oq$k0" />
-                              <node concept="3Tsc0h" id="5hullqu1KmS" role="2OqNvi">
-                                <ref role="3TtcxE" to="kfo3:7FuUjk_57Cw" resolve="colDefs" />
-                              </node>
-                            </node>
-                            <node concept="1sK_Qi" id="5hullqu1KmT" role="2OqNvi">
-                              <node concept="10bopy" id="5hullqu1KmU" role="1sKJu8" />
-                              <node concept="2ShNRf" id="5hullqu1KmV" role="1sKFgg">
-                                <node concept="3zrR0B" id="5hullqu1KmW" role="2ShVmc">
-                                  <node concept="3Tqbb2" id="5hullqu1KmX" role="3zrR0E">
-                                    <ref role="ehGHo" to="kfo3:6OunYCeYf_8" resolve="AbstractResultColDef" />
+                              <node concept="1sK_Qi" id="5hullqu1KmT" role="2OqNvi">
+                                <node concept="10bopy" id="5hullqu1KmU" role="1sKJu8" />
+                                <node concept="2ShNRf" id="5hullqu1KmV" role="1sKFgg">
+                                  <node concept="3zrR0B" id="5hullqu1KmW" role="2ShVmc">
+                                    <node concept="3Tqbb2" id="5hullqu1KmX" role="3zrR0E">
+                                      <ref role="ehGHo" to="kfo3:6OunYCeYf_8" resolve="AbstractResultColDef" />
+                                    </node>
                                   </node>
                                 </node>
                               </node>
@@ -3385,247 +3389,247 @@
                     </node>
                   </node>
                 </node>
-              </node>
-              <node concept="3x7d0o" id="5hullqu1KmY" role="3x7fTB">
-                <node concept="3clFbS" id="5hullqu1KmZ" role="2VODD2">
-                  <node concept="3cpWs8" id="5hullqu1Kn0" role="3cqZAp">
-                    <node concept="3cpWsn" id="5hullqu1Kn1" role="3cpWs9">
-                      <property role="TrG5h" value="h" />
-                      <node concept="3Tqbb2" id="5hullqu1Kn2" role="1tU5fm">
-                        <ref role="ehGHo" to="kfo3:8XWEtdYdD1" resolve="ColDef" />
-                      </node>
-                      <node concept="2OqwBi" id="5hullqu1Kn3" role="33vP2m">
-                        <node concept="2OqwBi" id="5hullqu1Kn4" role="2Oq$k0">
-                          <node concept="2r2w_c" id="5hullqu1Kn5" role="2Oq$k0" />
-                          <node concept="3Tsc0h" id="5hullqu1Kn6" role="2OqNvi">
-                            <ref role="3TtcxE" to="kfo3:7FuUjk_57Cw" resolve="colDefs" />
-                          </node>
+                <node concept="3x7d0o" id="5hullqu1KmY" role="3x7fTB">
+                  <node concept="3clFbS" id="5hullqu1KmZ" role="2VODD2">
+                    <node concept="3cpWs8" id="5hullqu1Kn0" role="3cqZAp">
+                      <node concept="3cpWsn" id="5hullqu1Kn1" role="3cpWs9">
+                        <property role="TrG5h" value="h" />
+                        <node concept="3Tqbb2" id="5hullqu1Kn2" role="1tU5fm">
+                          <ref role="ehGHo" to="kfo3:8XWEtdYdD1" resolve="ColDef" />
                         </node>
-                        <node concept="34jXtK" id="5hullqu1Kn7" role="2OqNvi">
-                          <node concept="10bopy" id="5hullqu1Kn8" role="25WWJ7" />
+                        <node concept="2OqwBi" id="5hullqu1Kn3" role="33vP2m">
+                          <node concept="2OqwBi" id="5hullqu1Kn4" role="2Oq$k0">
+                            <node concept="2r2w_c" id="5hullqu1Kn5" role="2Oq$k0" />
+                            <node concept="3Tsc0h" id="5hullqu1Kn6" role="2OqNvi">
+                              <ref role="3TtcxE" to="kfo3:7FuUjk_57Cw" resolve="colDefs" />
+                            </node>
+                          </node>
+                          <node concept="34jXtK" id="5hullqu1Kn7" role="2OqNvi">
+                            <node concept="10bopy" id="5hullqu1Kn8" role="25WWJ7" />
+                          </node>
                         </node>
                       </node>
                     </node>
-                  </node>
-                  <node concept="3clFbF" id="5hullqu1Kn9" role="3cqZAp">
-                    <node concept="2OqwBi" id="5hullqu1Kna" role="3clFbG">
-                      <node concept="2OqwBi" id="5hullqu1Knb" role="2Oq$k0">
-                        <node concept="2r2w_c" id="5hullqu1Knc" role="2Oq$k0" />
-                        <node concept="3Tsc0h" id="5hullqu1Knd" role="2OqNvi">
-                          <ref role="3TtcxE" to="kfo3:7FuUjk_57K$" resolve="rows" />
+                    <node concept="3clFbF" id="5hullqu1Kn9" role="3cqZAp">
+                      <node concept="2OqwBi" id="5hullqu1Kna" role="3clFbG">
+                        <node concept="2OqwBi" id="5hullqu1Knb" role="2Oq$k0">
+                          <node concept="2r2w_c" id="5hullqu1Knc" role="2Oq$k0" />
+                          <node concept="3Tsc0h" id="5hullqu1Knd" role="2OqNvi">
+                            <ref role="3TtcxE" to="kfo3:7FuUjk_57K$" resolve="rows" />
+                          </node>
                         </node>
-                      </node>
-                      <node concept="2es0OD" id="5hullqu1Kne" role="2OqNvi">
-                        <node concept="1bVj0M" id="5hullqu1Knf" role="23t8la">
-                          <node concept="3clFbS" id="5hullqu1Kng" role="1bW5cS">
-                            <node concept="3clFbF" id="5hullqu1Knh" role="3cqZAp">
-                              <node concept="2OqwBi" id="5hullqu1Kni" role="3clFbG">
-                                <node concept="2OqwBi" id="5hullqu1Knj" role="2Oq$k0">
-                                  <node concept="2OqwBi" id="5hullqu1Knk" role="2Oq$k0">
-                                    <node concept="37vLTw" id="5hullqu1Knl" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="5hullqu1KnF" resolve="row" />
+                        <node concept="2es0OD" id="5hullqu1Kne" role="2OqNvi">
+                          <node concept="1bVj0M" id="5hullqu1Knf" role="23t8la">
+                            <node concept="3clFbS" id="5hullqu1Kng" role="1bW5cS">
+                              <node concept="3clFbF" id="5hullqu1Knh" role="3cqZAp">
+                                <node concept="2OqwBi" id="5hullqu1Kni" role="3clFbG">
+                                  <node concept="2OqwBi" id="5hullqu1Knj" role="2Oq$k0">
+                                    <node concept="2OqwBi" id="5hullqu1Knk" role="2Oq$k0">
+                                      <node concept="37vLTw" id="5hullqu1Knl" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="5hullqu1KnF" resolve="row" />
+                                      </node>
+                                      <node concept="3Tsc0h" id="5hullqu1Knm" role="2OqNvi">
+                                        <ref role="3TtcxE" to="kfo3:8XWEtdYkjq" resolve="contents" />
+                                      </node>
                                     </node>
-                                    <node concept="3Tsc0h" id="5hullqu1Knm" role="2OqNvi">
-                                      <ref role="3TtcxE" to="kfo3:8XWEtdYkjq" resolve="contents" />
-                                    </node>
-                                  </node>
-                                  <node concept="3zZkjj" id="5hullqu1Knn" role="2OqNvi">
-                                    <node concept="1bVj0M" id="5hullqu1Kno" role="23t8la">
-                                      <node concept="3clFbS" id="5hullqu1Knp" role="1bW5cS">
-                                        <node concept="3clFbF" id="5hullqu1Knq" role="3cqZAp">
-                                          <node concept="3clFbC" id="5hullqu1Knr" role="3clFbG">
-                                            <node concept="37vLTw" id="5hullqu1Kns" role="3uHU7w">
-                                              <ref role="3cqZAo" node="5hullqu1Kn1" resolve="h" />
-                                            </node>
-                                            <node concept="2OqwBi" id="5hullqu1Knt" role="3uHU7B">
-                                              <node concept="37vLTw" id="5hullqu1Knu" role="2Oq$k0">
-                                                <ref role="3cqZAo" node="5hullqu1Knw" resolve="c" />
+                                    <node concept="3zZkjj" id="5hullqu1Knn" role="2OqNvi">
+                                      <node concept="1bVj0M" id="5hullqu1Kno" role="23t8la">
+                                        <node concept="3clFbS" id="5hullqu1Knp" role="1bW5cS">
+                                          <node concept="3clFbF" id="5hullqu1Knq" role="3cqZAp">
+                                            <node concept="3clFbC" id="5hullqu1Knr" role="3clFbG">
+                                              <node concept="37vLTw" id="5hullqu1Kns" role="3uHU7w">
+                                                <ref role="3cqZAo" node="5hullqu1Kn1" resolve="h" />
                                               </node>
-                                              <node concept="3TrEf2" id="5hullqu1Knv" role="2OqNvi">
-                                                <ref role="3Tt5mk" to="kfo3:8XWEtdYkmU" resolve="col" />
+                                              <node concept="2OqwBi" id="5hullqu1Knt" role="3uHU7B">
+                                                <node concept="37vLTw" id="5hullqu1Knu" role="2Oq$k0">
+                                                  <ref role="3cqZAo" node="5hullqu1Knw" resolve="c" />
+                                                </node>
+                                                <node concept="3TrEf2" id="5hullqu1Knv" role="2OqNvi">
+                                                  <ref role="3Tt5mk" to="kfo3:8XWEtdYkmU" resolve="col" />
+                                                </node>
                                               </node>
                                             </node>
                                           </node>
                                         </node>
+                                        <node concept="Rh6nW" id="5hullqu1Knw" role="1bW2Oz">
+                                          <property role="TrG5h" value="c" />
+                                          <node concept="2jxLKc" id="5hullqu1Knx" role="1tU5fm" />
+                                        </node>
                                       </node>
-                                      <node concept="Rh6nW" id="5hullqu1Knw" role="1bW2Oz">
+                                    </node>
+                                  </node>
+                                  <node concept="2es0OD" id="5hullqu1Kny" role="2OqNvi">
+                                    <node concept="1bVj0M" id="5hullqu1Knz" role="23t8la">
+                                      <node concept="3clFbS" id="5hullqu1Kn$" role="1bW5cS">
+                                        <node concept="3clFbF" id="5hullqu1Kn_" role="3cqZAp">
+                                          <node concept="2OqwBi" id="5hullqu1KnA" role="3clFbG">
+                                            <node concept="37vLTw" id="5hullqu1KnB" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="5hullqu1KnD" resolve="c" />
+                                            </node>
+                                            <node concept="3YRAZt" id="5hullqu1KnC" role="2OqNvi" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="Rh6nW" id="5hullqu1KnD" role="1bW2Oz">
                                         <property role="TrG5h" value="c" />
-                                        <node concept="2jxLKc" id="5hullqu1Knx" role="1tU5fm" />
+                                        <node concept="2jxLKc" id="5hullqu1KnE" role="1tU5fm" />
                                       </node>
                                     </node>
                                   </node>
                                 </node>
-                                <node concept="2es0OD" id="5hullqu1Kny" role="2OqNvi">
-                                  <node concept="1bVj0M" id="5hullqu1Knz" role="23t8la">
-                                    <node concept="3clFbS" id="5hullqu1Kn$" role="1bW5cS">
-                                      <node concept="3clFbF" id="5hullqu1Kn_" role="3cqZAp">
-                                        <node concept="2OqwBi" id="5hullqu1KnA" role="3clFbG">
-                                          <node concept="37vLTw" id="5hullqu1KnB" role="2Oq$k0">
-                                            <ref role="3cqZAo" node="5hullqu1KnD" resolve="c" />
-                                          </node>
-                                          <node concept="3YRAZt" id="5hullqu1KnC" role="2OqNvi" />
-                                        </node>
-                                      </node>
-                                    </node>
-                                    <node concept="Rh6nW" id="5hullqu1KnD" role="1bW2Oz">
-                                      <property role="TrG5h" value="c" />
-                                      <node concept="2jxLKc" id="5hullqu1KnE" role="1tU5fm" />
-                                    </node>
-                                  </node>
-                                </node>
                               </node>
                             </node>
-                          </node>
-                          <node concept="Rh6nW" id="5hullqu1KnF" role="1bW2Oz">
-                            <property role="TrG5h" value="row" />
-                            <node concept="2jxLKc" id="5hullqu1KnG" role="1tU5fm" />
+                            <node concept="Rh6nW" id="5hullqu1KnF" role="1bW2Oz">
+                              <property role="TrG5h" value="row" />
+                              <node concept="2jxLKc" id="5hullqu1KnG" role="1tU5fm" />
+                            </node>
                           </node>
                         </node>
                       </node>
                     </node>
-                  </node>
-                  <node concept="3clFbF" id="5hullqu1KnH" role="3cqZAp">
-                    <node concept="2OqwBi" id="5hullqu1KnI" role="3clFbG">
-                      <node concept="37vLTw" id="5hullqu1KnJ" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5hullqu1Kn1" resolve="h" />
+                    <node concept="3clFbF" id="5hullqu1KnH" role="3cqZAp">
+                      <node concept="2OqwBi" id="5hullqu1KnI" role="3clFbG">
+                        <node concept="37vLTw" id="5hullqu1KnJ" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5hullqu1Kn1" resolve="h" />
+                        </node>
+                        <node concept="3YRAZt" id="5hullqu1KnK" role="2OqNvi" />
                       </node>
-                      <node concept="3YRAZt" id="5hullqu1KnK" role="2OqNvi" />
                     </node>
                   </node>
                 </node>
-              </node>
-              <node concept="1g0IQG" id="5hullqu1KnL" role="1geGt4">
-                <node concept="3hWdHu" id="5hullqu1KnM" role="3hTmz4">
-                  <property role="Vb097" value="fLJRk5B/darkGray" />
-                </node>
-                <node concept="3hShVS" id="5hullqu1KnN" role="3hTmz4">
-                  <property role="3hSBKY" value="3" />
-                </node>
-                <node concept="3hWdWw" id="5hullqu1KnO" role="3hTmz4">
-                  <property role="Vb097" value="fLJRk5A/lightGray" />
-                  <node concept="3hZENJ" id="5hullqu1KnP" role="3hZOwg">
-                    <node concept="3clFbS" id="5hullqu1KnQ" role="2VODD2">
-                      <node concept="3cpWs8" id="8xLOUty5cV" role="3cqZAp">
-                        <node concept="3cpWsn" id="8xLOUty5cW" role="3cpWs9">
-                          <property role="TrG5h" value="color" />
-                          <node concept="3uibUv" id="8xLOUty5cX" role="1tU5fm">
-                            <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbJ" id="5hullqu1KnR" role="3cqZAp">
-                        <node concept="2OqwBi" id="5hullqu1KnS" role="3clFbw">
-                          <node concept="2OqwBi" id="5hullqu1KnT" role="2Oq$k0">
-                            <node concept="2OqwBi" id="5hullqu1KnU" role="2Oq$k0">
-                              <node concept="2r2w_c" id="5hullqu1KnV" role="2Oq$k0" />
-                              <node concept="3Tsc0h" id="5hullqu1KnW" role="2OqNvi">
-                                <ref role="3TtcxE" to="kfo3:7FuUjk_57Cw" resolve="colDefs" />
-                              </node>
-                            </node>
-                            <node concept="34jXtK" id="5hullqu1KnX" role="2OqNvi">
-                              <node concept="Xuyhr" id="5hullqu1KnY" role="25WWJ7" />
-                            </node>
-                          </node>
-                          <node concept="1mIQ4w" id="5hullqu1KnZ" role="2OqNvi">
-                            <node concept="chp4Y" id="6OunYCf1wE_" role="cj9EA">
-                              <ref role="cht4Q" to="kfo3:6OunYCeYf_8" resolve="AbstractResultColDef" />
+                <node concept="1g0IQG" id="5hullqu1KnL" role="1geGt4">
+                  <node concept="3hWdHu" id="5hullqu1KnM" role="3hTmz4">
+                    <property role="Vb097" value="fLJRk5B/darkGray" />
+                  </node>
+                  <node concept="3hShVS" id="5hullqu1KnN" role="3hTmz4">
+                    <property role="3hSBKY" value="3" />
+                  </node>
+                  <node concept="3hWdWw" id="5hullqu1KnO" role="3hTmz4">
+                    <property role="Vb097" value="fLJRk5A/lightGray" />
+                    <node concept="3hZENJ" id="5hullqu1KnP" role="3hZOwg">
+                      <node concept="3clFbS" id="5hullqu1KnQ" role="2VODD2">
+                        <node concept="3cpWs8" id="8xLOUty5cV" role="3cqZAp">
+                          <node concept="3cpWsn" id="8xLOUty5cW" role="3cpWs9">
+                            <property role="TrG5h" value="color" />
+                            <node concept="3uibUv" id="8xLOUty5cX" role="1tU5fm">
+                              <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
                             </node>
                           </node>
                         </node>
-                        <node concept="3clFbS" id="5hullqu1Ko1" role="3clFbx">
-                          <node concept="3clFbF" id="8xLOUty5NS" role="3cqZAp">
-                            <node concept="37vLTI" id="8xLOUty5Ux" role="3clFbG">
-                              <node concept="37vLTw" id="8xLOUty5NQ" role="37vLTJ">
-                                <ref role="3cqZAo" node="8xLOUty5cW" resolve="color" />
-                              </node>
-                              <node concept="2ShNRf" id="55_6bv_ftJ0" role="37vLTx">
-                                <node concept="1pGfFk" id="55_6bv_ftJ1" role="2ShVmc">
-                                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                                  <node concept="3cmrfG" id="55_6bv_ftJ2" role="37wK5m">
-                                    <property role="3cmrfH" value="230" />
-                                  </node>
-                                  <node concept="3cmrfG" id="55_6bv_ftJ3" role="37wK5m">
-                                    <property role="3cmrfH" value="230" />
-                                  </node>
-                                  <node concept="3cmrfG" id="55_6bv_ftJ4" role="37wK5m">
-                                    <property role="3cmrfH" value="230" />
-                                  </node>
+                        <node concept="3clFbJ" id="5hullqu1KnR" role="3cqZAp">
+                          <node concept="2OqwBi" id="5hullqu1KnS" role="3clFbw">
+                            <node concept="2OqwBi" id="5hullqu1KnT" role="2Oq$k0">
+                              <node concept="2OqwBi" id="5hullqu1KnU" role="2Oq$k0">
+                                <node concept="2r2w_c" id="5hullqu1KnV" role="2Oq$k0" />
+                                <node concept="3Tsc0h" id="5hullqu1KnW" role="2OqNvi">
+                                  <ref role="3TtcxE" to="kfo3:7FuUjk_57Cw" resolve="colDefs" />
                                 </node>
                               </node>
+                              <node concept="34jXtK" id="5hullqu1KnX" role="2OqNvi">
+                                <node concept="Xuyhr" id="5hullqu1KnY" role="25WWJ7" />
+                              </node>
+                            </node>
+                            <node concept="1mIQ4w" id="5hullqu1KnZ" role="2OqNvi">
+                              <node concept="chp4Y" id="6OunYCf1wE_" role="cj9EA">
+                                <ref role="cht4Q" to="kfo3:6OunYCeYf_8" resolve="AbstractResultColDef" />
+                              </node>
                             </node>
                           </node>
-                        </node>
-                        <node concept="9aQIb" id="5hullqu1Ko8" role="9aQIa">
-                          <node concept="3clFbS" id="5hullqu1Ko9" role="9aQI4">
-                            <node concept="3clFbF" id="8xLOUty6zW" role="3cqZAp">
-                              <node concept="37vLTI" id="8xLOUty6DA" role="3clFbG">
-                                <node concept="37vLTw" id="8xLOUty6zU" role="37vLTJ">
+                          <node concept="3clFbS" id="5hullqu1Ko1" role="3clFbx">
+                            <node concept="3clFbF" id="8xLOUty5NS" role="3cqZAp">
+                              <node concept="37vLTI" id="8xLOUty5Ux" role="3clFbG">
+                                <node concept="37vLTw" id="8xLOUty5NQ" role="37vLTJ">
                                   <ref role="3cqZAo" node="8xLOUty5cW" resolve="color" />
                                 </node>
-                                <node concept="2ShNRf" id="5hullqu1Ko3" role="37vLTx">
-                                  <node concept="1pGfFk" id="5hullqu1Ko4" role="2ShVmc">
+                                <node concept="2ShNRf" id="55_6bv_ftJ0" role="37vLTx">
+                                  <node concept="1pGfFk" id="55_6bv_ftJ1" role="2ShVmc">
                                     <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
-                                    <node concept="3cmrfG" id="5hullqu1Ko5" role="37wK5m">
-                                      <property role="3cmrfH" value="190" />
+                                    <node concept="3cmrfG" id="55_6bv_ftJ2" role="37wK5m">
+                                      <property role="3cmrfH" value="230" />
                                     </node>
-                                    <node concept="3cmrfG" id="5hullqu1Ko6" role="37wK5m">
-                                      <property role="3cmrfH" value="190" />
+                                    <node concept="3cmrfG" id="55_6bv_ftJ3" role="37wK5m">
+                                      <property role="3cmrfH" value="230" />
                                     </node>
-                                    <node concept="3cmrfG" id="5hullqu1Ko7" role="37wK5m">
-                                      <property role="3cmrfH" value="190" />
+                                    <node concept="3cmrfG" id="55_6bv_ftJ4" role="37wK5m">
+                                      <property role="3cmrfH" value="230" />
                                     </node>
                                   </node>
                                 </node>
                               </node>
                             </node>
                           </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbJ" id="8xLOUty7vL" role="3cqZAp">
-                        <node concept="3clFbS" id="8xLOUty7vN" role="3clFbx">
-                          <node concept="3cpWs8" id="8xLOUtyflb" role="3cqZAp">
-                            <node concept="3cpWsn" id="8xLOUtyfle" role="3cpWs9">
-                              <property role="TrG5h" value="neg" />
-                              <node concept="10Oyi0" id="8xLOUtyfl9" role="1tU5fm" />
-                              <node concept="3cpWsd" id="8xLOUtygFR" role="33vP2m">
-                                <node concept="2OqwBi" id="8xLOUtyhbS" role="3uHU7w">
-                                  <node concept="37vLTw" id="8xLOUtygSq" role="2Oq$k0">
+                          <node concept="9aQIb" id="5hullqu1Ko8" role="9aQIa">
+                            <node concept="3clFbS" id="5hullqu1Ko9" role="9aQI4">
+                              <node concept="3clFbF" id="8xLOUty6zW" role="3cqZAp">
+                                <node concept="37vLTI" id="8xLOUty6DA" role="3clFbG">
+                                  <node concept="37vLTw" id="8xLOUty6zU" role="37vLTJ">
                                     <ref role="3cqZAo" node="8xLOUty5cW" resolve="color" />
                                   </node>
-                                  <node concept="liA8E" id="8xLOUtyhyX" role="2OqNvi">
-                                    <ref role="37wK5l" to="z60i:~Color.getRGB()" resolve="getRGB" />
-                                  </node>
-                                </node>
-                                <node concept="2nou5x" id="8xLOUtyfBw" role="3uHU7B">
-                                  <property role="2noCCI" value="FFFFFF" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="3clFbF" id="8xLOUtydEh" role="3cqZAp">
-                            <node concept="37vLTI" id="8xLOUtydJT" role="3clFbG">
-                              <node concept="37vLTw" id="8xLOUtydEf" role="37vLTJ">
-                                <ref role="3cqZAo" node="8xLOUty5cW" resolve="color" />
-                              </node>
-                              <node concept="2ShNRf" id="8xLOUtyi0u" role="37vLTx">
-                                <node concept="1pGfFk" id="8xLOUtyjet" role="2ShVmc">
-                                  <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int)" resolve="Color" />
-                                  <node concept="37vLTw" id="8xLOUtyjKf" role="37wK5m">
-                                    <ref role="3cqZAo" node="8xLOUtyfle" resolve="neg" />
+                                  <node concept="2ShNRf" id="5hullqu1Ko3" role="37vLTx">
+                                    <node concept="1pGfFk" id="5hullqu1Ko4" role="2ShVmc">
+                                      <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
+                                      <node concept="3cmrfG" id="5hullqu1Ko5" role="37wK5m">
+                                        <property role="3cmrfH" value="190" />
+                                      </node>
+                                      <node concept="3cmrfG" id="5hullqu1Ko6" role="37wK5m">
+                                        <property role="3cmrfH" value="190" />
+                                      </node>
+                                      <node concept="3cmrfG" id="5hullqu1Ko7" role="37wK5m">
+                                        <property role="3cmrfH" value="190" />
+                                      </node>
+                                    </node>
                                   </node>
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
-                        <node concept="2YIFZM" id="8xLOUtydnN" role="3clFbw">
-                          <ref role="37wK5l" to="g1qu:~UIUtil.isUnderDarcula()" resolve="isUnderDarcula" />
-                          <ref role="1Pybhc" to="g1qu:~UIUtil" resolve="UIUtil" />
+                        <node concept="3clFbJ" id="8xLOUty7vL" role="3cqZAp">
+                          <node concept="3clFbS" id="8xLOUty7vN" role="3clFbx">
+                            <node concept="3cpWs8" id="8xLOUtyflb" role="3cqZAp">
+                              <node concept="3cpWsn" id="8xLOUtyfle" role="3cpWs9">
+                                <property role="TrG5h" value="neg" />
+                                <node concept="10Oyi0" id="8xLOUtyfl9" role="1tU5fm" />
+                                <node concept="3cpWsd" id="8xLOUtygFR" role="33vP2m">
+                                  <node concept="2OqwBi" id="8xLOUtyhbS" role="3uHU7w">
+                                    <node concept="37vLTw" id="8xLOUtygSq" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="8xLOUty5cW" resolve="color" />
+                                    </node>
+                                    <node concept="liA8E" id="8xLOUtyhyX" role="2OqNvi">
+                                      <ref role="37wK5l" to="z60i:~Color.getRGB()" resolve="getRGB" />
+                                    </node>
+                                  </node>
+                                  <node concept="2nou5x" id="8xLOUtyfBw" role="3uHU7B">
+                                    <property role="2noCCI" value="FFFFFF" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="8xLOUtydEh" role="3cqZAp">
+                              <node concept="37vLTI" id="8xLOUtydJT" role="3clFbG">
+                                <node concept="37vLTw" id="8xLOUtydEf" role="37vLTJ">
+                                  <ref role="3cqZAo" node="8xLOUty5cW" resolve="color" />
+                                </node>
+                                <node concept="2ShNRf" id="8xLOUtyi0u" role="37vLTx">
+                                  <node concept="1pGfFk" id="8xLOUtyjet" role="2ShVmc">
+                                    <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int)" resolve="Color" />
+                                    <node concept="37vLTw" id="8xLOUtyjKf" role="37wK5m">
+                                      <ref role="3cqZAo" node="8xLOUtyfle" resolve="neg" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2YIFZM" id="8xLOUtydnN" role="3clFbw">
+                            <ref role="37wK5l" to="g1qu:~UIUtil.isUnderDarcula()" resolve="isUnderDarcula" />
+                            <ref role="1Pybhc" to="g1qu:~UIUtil" resolve="UIUtil" />
+                          </node>
                         </node>
-                      </node>
-                      <node concept="3clFbF" id="8xLOUtyjYm" role="3cqZAp">
-                        <node concept="37vLTw" id="8xLOUtyjYk" role="3clFbG">
-                          <ref role="3cqZAo" node="8xLOUty5cW" resolve="color" />
+                        <node concept="3clFbF" id="8xLOUtyjYm" role="3cqZAp">
+                          <node concept="37vLTw" id="8xLOUtyjYk" role="3clFbG">
+                            <ref role="3cqZAo" node="8xLOUty5cW" resolve="color" />
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -3633,87 +3637,87 @@
                 </node>
               </node>
             </node>
+            <node concept="2reSaE" id="4_sn_QHs_5X" role="2rf8GZ">
+              <ref role="2reCK$" to="kfo3:7FuUjk_57K$" resolve="rows" />
+            </node>
           </node>
-          <node concept="2reSaE" id="4_sn_QHs_5X" role="2rf8GZ">
-            <ref role="2reCK$" to="kfo3:7FuUjk_57K$" resolve="rows" />
+          <node concept="gc7cB" id="264ij5$S6wY" role="3EZMnx">
+            <node concept="3VJUX4" id="264ij5$S6wZ" role="3YsKMw">
+              <node concept="3clFbS" id="264ij5$S6x0" role="2VODD2">
+                <node concept="3cpWs8" id="264ij5$S6x1" role="3cqZAp">
+                  <node concept="3cpWsn" id="264ij5$S6x2" role="3cpWs9">
+                    <property role="TrG5h" value="pp" />
+                    <node concept="3Tqbb2" id="264ij5$S6x3" role="1tU5fm" />
+                    <node concept="2OqwBi" id="264ij5$S6x4" role="33vP2m">
+                      <node concept="pncrf" id="264ij5$S6x5" role="2Oq$k0" />
+                      <node concept="1mfA1w" id="264ij5$S6x6" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="264ij5$S6x7" role="3cqZAp">
+                  <node concept="2OqwBi" id="264ij5$S6x8" role="3clFbw">
+                    <node concept="37vLTw" id="264ij5$S6x9" role="2Oq$k0">
+                      <ref role="3cqZAo" node="264ij5$S6x2" resolve="pp" />
+                    </node>
+                    <node concept="1mIQ4w" id="264ij5$S6xa" role="2OqNvi">
+                      <node concept="chp4Y" id="264ij5$S6xb" role="cj9EA">
+                        <ref role="cht4Q" to="vs0r:7uLL3Mf3udZ" resolve="ITextBlockOwner" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="264ij5$S6xc" role="3clFbx">
+                    <node concept="3cpWs8" id="264ij5$S6xd" role="3cqZAp">
+                      <node concept="3cpWsn" id="264ij5$S6xe" role="3cpWs9">
+                        <property role="TrG5h" value="color" />
+                        <node concept="3uibUv" id="264ij5$S6xf" role="1tU5fm">
+                          <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
+                        </node>
+                        <node concept="2OqwBi" id="264ij5$S6xg" role="33vP2m">
+                          <node concept="1PxgMI" id="264ij5$S6xh" role="2Oq$k0">
+                            <node concept="37vLTw" id="264ij5$S6xi" role="1m5AlR">
+                              <ref role="3cqZAo" node="264ij5$S6x2" resolve="pp" />
+                            </node>
+                            <node concept="chp4Y" id="264ij5$S6xj" role="3oSUPX">
+                              <ref role="cht4Q" to="vs0r:7uLL3Mf3udZ" resolve="ITextBlockOwner" />
+                            </node>
+                          </node>
+                          <node concept="2qgKlT" id="264ij5$S6xk" role="2OqNvi">
+                            <ref role="37wK5l" to="hwgx:BsHjoDQZaR" resolve="getTextColor" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs6" id="264ij5$S6xl" role="3cqZAp">
+                      <node concept="2ShNRf" id="264ij5$S6xm" role="3cqZAk">
+                        <node concept="1pGfFk" id="264ij5$S6xn" role="2ShVmc">
+                          <ref role="37wK5l" to="m999:1F0U9H74l9y" resolve="EndCell" />
+                          <node concept="pncrf" id="264ij5$S6xo" role="37wK5m" />
+                          <node concept="37vLTw" id="264ij5$S6xp" role="37wK5m">
+                            <ref role="3cqZAo" node="264ij5$S6xe" resolve="color" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="9aQIb" id="264ij5$S6xq" role="9aQIa">
+                    <node concept="3clFbS" id="264ij5$S6xr" role="9aQI4">
+                      <node concept="3cpWs6" id="264ij5$S6xs" role="3cqZAp">
+                        <node concept="2ShNRf" id="264ij5$S6xt" role="3cqZAk">
+                          <node concept="1pGfFk" id="264ij5$S6xu" role="2ShVmc">
+                            <ref role="37wK5l" to="m999:1F0U9H74l9q" resolve="EndCell" />
+                            <node concept="pncrf" id="264ij5$S6xv" role="37wK5m" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
       <node concept="2iRfu4" id="2d3TE9ezQcY" role="2iSdaV" />
-      <node concept="gc7cB" id="7gVrg_0tw6K" role="3EZMnx">
-        <node concept="3VJUX4" id="7gVrg_0tw6L" role="3YsKMw">
-          <node concept="3clFbS" id="7gVrg_0tw6M" role="2VODD2">
-            <node concept="3cpWs8" id="BsHjoDRLSl" role="3cqZAp">
-              <node concept="3cpWsn" id="BsHjoDRLSm" role="3cpWs9">
-                <property role="TrG5h" value="pp" />
-                <node concept="3Tqbb2" id="BsHjoDRLSn" role="1tU5fm" />
-                <node concept="2OqwBi" id="BsHjoDRLSp" role="33vP2m">
-                  <node concept="pncrf" id="BsHjoDRLSq" role="2Oq$k0" />
-                  <node concept="1mfA1w" id="BsHjoDRLSr" role="2OqNvi" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="BsHjoDRLSt" role="3cqZAp">
-              <node concept="2OqwBi" id="BsHjoDRLSu" role="3clFbw">
-                <node concept="37vLTw" id="BsHjoDRLSv" role="2Oq$k0">
-                  <ref role="3cqZAo" node="BsHjoDRLSm" resolve="pp" />
-                </node>
-                <node concept="1mIQ4w" id="BsHjoDRLSw" role="2OqNvi">
-                  <node concept="chp4Y" id="BsHjoDRLSx" role="cj9EA">
-                    <ref role="cht4Q" to="vs0r:7uLL3Mf3udZ" resolve="ITextBlockOwner" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbS" id="BsHjoDRLSy" role="3clFbx">
-                <node concept="3cpWs8" id="BsHjoDRLSz" role="3cqZAp">
-                  <node concept="3cpWsn" id="BsHjoDRLS$" role="3cpWs9">
-                    <property role="TrG5h" value="color" />
-                    <node concept="3uibUv" id="BsHjoDRLS_" role="1tU5fm">
-                      <ref role="3uigEE" to="z60i:~Color" resolve="Color" />
-                    </node>
-                    <node concept="2OqwBi" id="BsHjoDRLSA" role="33vP2m">
-                      <node concept="1PxgMI" id="BsHjoDRLSB" role="2Oq$k0">
-                        <node concept="37vLTw" id="BsHjoDRLSC" role="1m5AlR">
-                          <ref role="3cqZAo" node="BsHjoDRLSm" resolve="pp" />
-                        </node>
-                        <node concept="chp4Y" id="79i$vAY5P5Z" role="3oSUPX">
-                          <ref role="cht4Q" to="vs0r:7uLL3Mf3udZ" resolve="ITextBlockOwner" />
-                        </node>
-                      </node>
-                      <node concept="2qgKlT" id="BsHjoDRLSD" role="2OqNvi">
-                        <ref role="37wK5l" to="hwgx:BsHjoDQZaR" resolve="getTextColor" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs6" id="BsHjoDRLSE" role="3cqZAp">
-                  <node concept="2ShNRf" id="BsHjoDRLSF" role="3cqZAk">
-                    <node concept="1pGfFk" id="BsHjoDRLSG" role="2ShVmc">
-                      <ref role="37wK5l" to="r4b4:1F0U9H74l9y" resolve="CRHelperCell" />
-                      <node concept="pncrf" id="BsHjoDRLSH" role="37wK5m" />
-                      <node concept="37vLTw" id="5HxjapwgH2Q" role="37wK5m">
-                        <ref role="3cqZAo" node="BsHjoDRLS$" resolve="color" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="9aQIb" id="BsHjoDRLSJ" role="9aQIa">
-                <node concept="3clFbS" id="BsHjoDRLSK" role="9aQI4">
-                  <node concept="3cpWs6" id="BsHjoDRLSL" role="3cqZAp">
-                    <node concept="2ShNRf" id="BsHjoDRLSM" role="3cqZAk">
-                      <node concept="1pGfFk" id="BsHjoDRLSN" role="2ShVmc">
-                        <ref role="37wK5l" to="r4b4:1F0U9H74l9q" resolve="CRHelperCell" />
-                        <node concept="pncrf" id="BsHjoDRLSO" role="37wK5m" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
     </node>
   </node>
   <node concept="24kQdi" id="1yFVafcItV$">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -3813,6 +3813,16 @@
             <ref role="3bR37D" to="ffeo:3MI1gu0QouH" resolve="jetbrains.mps.editor.runtime" />
           </node>
         </node>
+        <node concept="1SiIV0" id="3AY9Typvp2a" role="3bR37C">
+          <node concept="3bR9La" id="3AY9Typvp2b" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3AY9Typvp2c" role="3bR37C">
+          <node concept="3bR9La" id="3AY9Typvp2d" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:6SVXTgIel8z" resolve="de.itemis.mps.editor.celllayout.styles" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="5a_u3OzLedQ" role="2G$12L">
         <property role="BnDLt" value="true" />


### PR DESCRIPTION
This was a customer request. All three concepts used different custom cells to denote the end of the editor. I've attached some screenshots that showcase how the newly introduced end cell looks like. It is modeled after the end cell of table rows. If you are unhappy with the look (e.g. the thickness, color), please amend the commit yourself. There is also no way to show the cursor in a good way, the same way it is done for the table rows.
![Screenshot 2023-03-30 at 08 31 09](https://user-images.githubusercontent.com/88385944/228752251-7cf02f80-e25e-44ac-87d7-a758366df23d.png)

![Screenshot 2023-03-30 at 08 38 44](https://user-images.githubusercontent.com/88385944/228752274-60539497-3e08-472e-b959-2bc5e86a105c.png)

![Screenshot 2023-03-30 at 08 37 59](https://user-images.githubusercontent.com/88385944/228752610-65546cef-fc45-4101-bf28-3db28c316610.png)

![Screenshot 2023-03-30 at 08 45 15](https://user-images.githubusercontent.com/88385944/228752331-2efa95ee-2543-4110-a5f8-f09e1de2e421.png)

The vertical line gets the highlight color when it is selected:

![Screenshot 2023-03-30 at 08 51 30](https://user-images.githubusercontent.com/88385944/228753310-7f6e490c-0df5-453f-8b45-95926fcd7c78.png)

![Screenshot 2023-03-30 at 08 52 28](https://user-images.githubusercontent.com/88385944/228753477-49fdeecb-06de-4c3b-a7e1-7bb16bb4c30e.png)
