### PR TITLE
Add no-wrap property to additional expressions.

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -741,19 +741,13 @@
             <property role="VOm3f" value="true" />
           </node>
         </node>
-        <node concept="3F2HdR" id="49WTic8f4u3" role="3EZMnx">
+        <node concept="3F2HdR" id="4Lmaxwvn71o" role="3EZMnx">
           <property role="2czwfO" value="," />
-          <ref role="1ERwB7" node="2KGel$SrnV0" resolve="deleteFunParens" />
           <ref role="1NtTu8" to="zzzn:49WTic8eSCZ" resolve="args" />
-          <node concept="2iRfu4" id="49WTic8f4u5" role="2czzBx" />
-          <node concept="3F0ifn" id="49WTic8f4uY" role="2czzBI">
-            <property role="3F0ifm" value="" />
-            <node concept="VPxyj" id="49WTic8f4vO" role="3F10Kt">
-              <property role="VOm3f" value="true" />
-            </node>
-          </node>
+          <ref role="1ERwB7" node="2KGel$SrnV0" resolve="deleteFunParens" />
+          <node concept="l2Vlx" id="4Lmaxwvn71q" role="2czzBx" />
         </node>
-        <node concept="2iRfu4" id="1tPb0nsiq3O" role="2iSdaV" />
+        <node concept="l2Vlx" id="4LmaxwvxJ98" role="2iSdaV" />
         <node concept="3F0ifn" id="49WTic8f4ui" role="3EZMnx">
           <property role="3F0ifm" value=")" />
           <ref role="1ERwB7" node="2KGel$SrnV0" resolve="deleteFunParens" />
@@ -761,51 +755,51 @@
             <property role="VOm3f" value="true" />
           </node>
         </node>
-      </node>
-      <node concept="_tjkj" id="69zaTr1GaRE" role="3EZMnx">
-        <node concept="3EZMnI" id="69zaTr1GaWu" role="_tjki">
-          <node concept="3F0ifn" id="69zaTr1GaWB" role="3EZMnx">
-            <property role="3F0ifm" value=":" />
+        <node concept="_tjkj" id="69zaTr1GaRE" role="3EZMnx">
+          <node concept="3EZMnI" id="69zaTr1GaWu" role="_tjki">
+            <node concept="3F0ifn" id="69zaTr1GaWB" role="3EZMnx">
+              <property role="3F0ifm" value=":" />
+            </node>
+            <node concept="3F1sOY" id="69zaTr1GaWH" role="3EZMnx">
+              <ref role="1NtTu8" to="hm2y:69zaTr1EKHX" resolve="type" />
+            </node>
+            <node concept="2iRfu4" id="69zaTr1GaWx" role="2iSdaV" />
+            <node concept="VPM3Z" id="69zaTr1GaWy" role="3F10Kt">
+              <property role="VOm3f" value="false" />
+            </node>
+            <node concept="11L4FC" id="2KGel$SqWxl" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
           </node>
-          <node concept="3F1sOY" id="69zaTr1GaWH" role="3EZMnx">
-            <ref role="1NtTu8" to="hm2y:69zaTr1EKHX" resolve="type" />
-          </node>
-          <node concept="2iRfu4" id="69zaTr1GaWx" role="2iSdaV" />
-          <node concept="VPM3Z" id="69zaTr1GaWy" role="3F10Kt">
-            <property role="VOm3f" value="false" />
-          </node>
-          <node concept="11L4FC" id="2KGel$SqWxl" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-        </node>
-        <node concept="uPpia" id="1ZlHRbgqWuB" role="1djCvC">
-          <node concept="3clFbS" id="1ZlHRbgqWuC" role="2VODD2">
-            <node concept="3clFbF" id="1ZlHRbgqWv1" role="3cqZAp">
-              <node concept="Xl_RD" id="1ZlHRbgqWv0" role="3clFbG">
-                <property role="Xl_RC" value="a type for the function" />
+          <node concept="uPpia" id="1ZlHRbgqWuB" role="1djCvC">
+            <node concept="3clFbS" id="1ZlHRbgqWuC" role="2VODD2">
+              <node concept="3clFbF" id="1ZlHRbgqWv1" role="3cqZAp">
+                <node concept="Xl_RD" id="1ZlHRbgqWv0" role="3clFbG">
+                  <property role="Xl_RC" value="a type for the function" />
+                </node>
               </node>
             </node>
           </node>
         </node>
-      </node>
-      <node concept="_tjkj" id="KaZMgyebXJ" role="3EZMnx">
-        <node concept="3F1sOY" id="KaZMgyec5r" role="_tjki">
-          <ref role="1NtTu8" to="hm2y:KaZMgy4Ily" resolve="contract" />
-        </node>
-        <node concept="ZYGn8" id="KaZMgyec5v" role="ZWbT9">
-          <node concept="3clFbS" id="KaZMgyec5w" role="2VODD2">
-            <node concept="3clFbF" id="KaZMgyec6b" role="3cqZAp">
-              <node concept="Xl_RD" id="KaZMgyec6a" role="3clFbG">
-                <property role="Xl_RC" value="where" />
+        <node concept="_tjkj" id="KaZMgyebXJ" role="3EZMnx">
+          <node concept="3F1sOY" id="KaZMgyec5r" role="_tjki">
+            <ref role="1NtTu8" to="hm2y:KaZMgy4Ily" resolve="contract" />
+          </node>
+          <node concept="ZYGn8" id="KaZMgyec5v" role="ZWbT9">
+            <node concept="3clFbS" id="KaZMgyec5w" role="2VODD2">
+              <node concept="3clFbF" id="KaZMgyec6b" role="3cqZAp">
+                <node concept="Xl_RD" id="KaZMgyec6a" role="3clFbG">
+                  <property role="Xl_RC" value="where" />
+                </node>
               </node>
             </node>
           </node>
-        </node>
-        <node concept="uPpia" id="1ZlHRbgqW$O" role="1djCvC">
-          <node concept="3clFbS" id="1ZlHRbgqW$P" role="2VODD2">
-            <node concept="3clFbF" id="1ZlHRbgqW$W" role="3cqZAp">
-              <node concept="Xl_RD" id="1ZlHRbgqW$V" role="3clFbG">
-                <property role="Xl_RC" value="a contract for the function" />
+          <node concept="uPpia" id="1ZlHRbgqW$O" role="1djCvC">
+            <node concept="3clFbS" id="1ZlHRbgqW$P" role="2VODD2">
+              <node concept="3clFbF" id="1ZlHRbgqW$W" role="3cqZAp">
+                <node concept="Xl_RD" id="1ZlHRbgqW$V" role="3clFbG">
+                  <property role="Xl_RC" value="a contract for the function" />
+                </node>
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags/models/org/iets3/core/expr/typetags/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags/models/org/iets3/core/expr/typetags/editor.mps
@@ -636,6 +636,9 @@
         </node>
       </node>
       <node concept="l2Vlx" id="7eOyx9r3D2u" role="2iSdaV" />
+      <node concept="34QqEe" id="1JH3t3Wf$KC" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
     </node>
   </node>
   <node concept="3INDKC" id="3cUcim$6q3Z">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags/models/org/iets3/core/expr/typetags/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags/models/org/iets3/core/expr/typetags/editor.mps
@@ -636,7 +636,7 @@
         </node>
       </node>
       <node concept="l2Vlx" id="7eOyx9r3D2u" role="2iSdaV" />
-      <node concept="34QqEe" id="1JH3t3Wf$KC" role="3F10Kt">
+      <node concept="34QqEe" id="4Lmaxwvrdv7" role="3F10Kt">
         <property role="VOm3f" value="true" />
       </node>
     </node>


### PR DESCRIPTION
The previous PR #661 was still missing some cases, where the number tags where not properly using the `indent-layout-no-wrap` property to prevent odd line breaks.

Before:
![Screenshot_20230418_154332](https://user-images.githubusercontent.com/3237993/233913636-bbf47d5b-febb-4d59-b7c4-ef16ac17839a.png)
(notice the overlong line for the function parameters, going beyond the grey cell width marker)

After:
![Screenshot_20230418_154201](https://user-images.githubusercontent.com/3237993/233913702-e71190a5-3c70-44bc-b381-c024fa4401fb.png)


The PR also adds the `indent-layout-no-wrap` property to tagged expressions. In a customer project those are currently being wrapped too, but this was tricky to replicate here.