### PR TITLE
Minor fix for ComponentInstances.

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/structure.mps
@@ -383,9 +383,6 @@
         <property role="YLQ7P" value="The link was moved to concept &quot;org.iets3.components.core.structure.AbstractComponentInstanceWithRef&quot;" />
       </node>
     </node>
-    <node concept="PrWs8" id="siw10FiR6l" role="PzmwI">
-      <ref role="PrY4T" node="siw10FiR6c" resolve="ISubstructureContent" />
-    </node>
     <node concept="PrWs8" id="6Z4vEhQZ6sI" role="PzmwI">
       <ref role="PrY4T" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
     </node>
@@ -1439,9 +1436,6 @@
       <property role="20kJfa" value="component" />
       <property role="20lbJX" value="fLJekj4/_1" />
       <ref role="20lvS9" node="6LfBX8Yi4o1" resolve="Component" />
-    </node>
-    <node concept="PrWs8" id="77HYM7HosV8" role="PzmwI">
-      <ref role="PrY4T" node="siw10FiR6c" resolve="ISubstructureContent" />
     </node>
     <node concept="PrWs8" id="77HYM7HosVn" role="PzmwI">
       <ref role="PrY4T" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/structure.mps
@@ -1422,6 +1422,9 @@
     <node concept="PrWs8" id="2QRlyxOgRVg" role="PzmwI">
       <ref role="PrY4T" to="4kwy:cJpacq5T0O" resolve="IValidNamedConcept" />
     </node>
+    <node concept="PrWs8" id="2_GRxqhsLR7" role="PzmwI">
+      <ref role="PrY4T" node="siw10FiR6c" resolve="ISubstructureContent" />
+    </node>
   </node>
   <node concept="1TIwiD" id="77HYM7HnhfK">
     <property role="EcuMT" value="8209493818901074928" />


### PR DESCRIPTION
Add ISubstructureContent interface to AbstractComponentInterface. This change fixes a warning in dependent projects.