### PR TITLE
Add error check for TemporalLiterals to identify slices with duplicate date.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelo
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
 
-## August 2023
+## September 2023
 
 ### Added
 
-- Temporal Literal shows an error if two slices use the same point in time. The check can handle date literals and (nested) references to constants with a date literal.
-- Temporal Literal shows a warning if the point in time of a slice cannot be unwrapped to a date literal, rendering the duplicates-check mentioned above ineffective.
+- Temporal Literal shows an error if two slices use the same point in time. The check can handle date literals and (nested) references to constants with a date literal. (See [PR 707](https://github.com/IETS3/iets3.opensource/pull/707))
+- Temporal Literal shows a warning if the point in time of a slice cannot be unwrapped to a date literal, rendering the duplicates-check mentioned above ineffective. (See [PR 707](https://github.com/IETS3/iets3.opensource/pull/707))
     
 
 ## July 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). 
+The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
+
+
+## August 2023
+
+### Added
+
+- Temporal Literal shows an error if two slices use the same point in time. The check can handle date literals and (nested) references to constants with a date literal.
+- Temporal Literal shows a warning if the point in time of a slice cannot be unwrapped to a date literal, rendering the duplicates-check mentioned above ineffective.
+    
+
+## July 2023
+
+### Fixed
+
+- Computation of the least-common-supertype for expressions with different return types has been fixed. The typesystem now correctly infers a join type (c.f. [original issue](https://github.com/IETS3/iets3.opensource/issues/505))
+- Naming constraint of IValidNamedConcept is customizable [original request](https://github.com/IETS3/iets3.opensource/pull/631)
+- Made transformation action [applyCommentsToIDocumentable](http://127.0.0.1:63320/node?ref=r%3A80fb0853-eb3b-4e84-aebd-cc7fdb011d97%28org.iets3.core.base.editor%29%2F5981628904839421072) only applicable if documentation is allowed [original request](https://github.com/IETS3/iets3.opensource/pull/626)
+
+### Added
+
+- Tuples are now handled within the typesystem.
+   Instead of allowing JoinTypes within tuples we merge different tuple types by JoinTypes.
+- Each subconcept of IValidNamedConcept can now contribute and customize naming constraints

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.datetime/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.datetime/models/behavior.mps
@@ -32,6 +32,7 @@
       <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -60,6 +61,7 @@
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
@@ -109,6 +111,9 @@
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
@@ -160,12 +165,23 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
       <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
         <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
       <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -670,6 +686,75 @@
           </node>
         </node>
       </node>
+    </node>
+    <node concept="13i0hz" id="3FK6iin2u1z" role="13h7CS">
+      <property role="TrG5h" value="isSameAs" />
+      <ref role="13i0hy" to="pbu6:7GwCuf2r4g6" resolve="isSameAs" />
+      <node concept="3Tm1VV" id="3FK6iin2u1$" role="1B3o_S" />
+      <node concept="3clFbS" id="3FK6iin2u1Z" role="3clF47">
+        <node concept="3clFbJ" id="7GwCuf2r4$s" role="3cqZAp">
+          <node concept="3clFbS" id="7GwCuf2r4$u" role="3clFbx">
+            <node concept="3cpWs6" id="7GwCuf2r4BB" role="3cqZAp">
+              <node concept="3clFbT" id="7GwCuf2r4BP" role="3cqZAk">
+                <property role="3clFbU" value="false" />
+              </node>
+            </node>
+          </node>
+          <node concept="22lmx$" id="3FK6iin1RrO" role="3clFbw">
+            <node concept="3fqX7Q" id="3FK6iin1RHV" role="3uHU7w">
+              <node concept="2OqwBi" id="3FK6iin1StC" role="3fr31v">
+                <node concept="37vLTw" id="3FK6iin1S00" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3FK6iin2u20" resolve="other" />
+                </node>
+                <node concept="1mIQ4w" id="3FK6iin1Tkm" role="2OqNvi">
+                  <node concept="chp4Y" id="3FK6iin1TpE" role="cj9EA">
+                    <ref role="cht4Q" to="mi3w:3nGzaxURa4h" resolve="DateLiteral" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbC" id="7GwCuf2r4B2" role="3uHU7B">
+              <node concept="37vLTw" id="7GwCuf2r4_u" role="3uHU7B">
+                <ref role="3cqZAo" node="3FK6iin2u20" resolve="other" />
+              </node>
+              <node concept="10Nm6u" id="7GwCuf2r4Bl" role="3uHU7w" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="7GwCuf2r4DP" role="3cqZAp">
+          <node concept="2OqwBi" id="3FK6iin3tHf" role="3cqZAk">
+            <node concept="2OqwBi" id="3FK6iin2wVW" role="2Oq$k0">
+              <node concept="13iPFW" id="7GwCuf2r4FV" role="2Oq$k0" />
+              <node concept="2qgKlT" id="3FK6iin2xor" role="2OqNvi">
+                <ref role="37wK5l" node="26CArgU4p85" resolve="toDate" />
+              </node>
+            </node>
+            <node concept="liA8E" id="3FK6iin3vbn" role="2OqNvi">
+              <ref role="37wK5l" to="28m1:~LocalDate.isEqual(java.time.chrono.ChronoLocalDate)" resolve="isEqual" />
+              <node concept="2OqwBi" id="3FK6iin2_rE" role="37wK5m">
+                <node concept="1PxgMI" id="3FK6iin2$22" role="2Oq$k0">
+                  <node concept="chp4Y" id="3FK6iin2$l$" role="3oSUPX">
+                    <ref role="cht4Q" to="mi3w:3nGzaxURa4h" resolve="DateLiteral" />
+                  </node>
+                  <node concept="37vLTw" id="7GwCuf2r4Jh" role="1m5AlR">
+                    <ref role="3cqZAo" node="3FK6iin2u20" resolve="other" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="3FK6iin2AD6" role="2OqNvi">
+                  <ref role="37wK5l" node="26CArgU4p85" resolve="toDate" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3FK6iin2u20" role="3clF46">
+        <property role="TrG5h" value="other" />
+        <node concept="3Tqbb2" id="3FK6iin2u21" role="1tU5fm">
+          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+        </node>
+      </node>
+      <node concept="10P_77" id="3FK6iin2u22" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="3nGzaxURzmT">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
@@ -24,6 +24,7 @@
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="yv47" ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
@@ -44,6 +45,12 @@
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
         <child id="1076505808688" name="condition" index="2$JKZa" />
+      </concept>
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
@@ -305,6 +312,9 @@
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1154546950173" name="jetbrains.mps.lang.smodel.structure.ConceptReference" flags="ng" index="3gn64h">
+        <reference id="1154546997487" name="concept" index="3gnhBz" />
+      </concept>
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
@@ -318,6 +328,15 @@
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
       <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
+      <concept id="5944356402132808749" name="jetbrains.mps.lang.smodel.structure.ConceptSwitchStatement" flags="nn" index="1_3QMa">
+        <child id="6039268229365417680" name="defaultBlock" index="1prKM_" />
+        <child id="5944356402132808753" name="case" index="1_3QMm" />
+        <child id="5944356402132808752" name="expression" index="1_3QMn" />
+      </concept>
+      <concept id="5944356402132808754" name="jetbrains.mps.lang.smodel.structure.SubconceptCase" flags="ng" index="1_3QMl">
+        <child id="1163670677455" name="concept" index="3Kbmr1" />
+        <child id="1163670683720" name="body" index="3Kbo56" />
+      </concept>
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
@@ -885,47 +904,21 @@
                     <node concept="3Tqbb2" id="5oaaToWY2jG" role="1tU5fm">
                       <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
                     </node>
-                    <node concept="2OqwBi" id="5oaaToWY2tU" role="33vP2m">
-                      <node concept="37vLTw" id="5oaaToWY2tV" role="2Oq$k0">
-                        <ref role="3cqZAo" node="6W4XqNw1Umu" resolve="slice" />
-                      </node>
-                      <node concept="3TrEf2" id="5oaaToWY2tW" role="2OqNvi">
-                        <ref role="3Tt5mk" to="l462:50smQ1V8QEi" resolve="pointInTime" />
+                    <node concept="2YIFZM" id="6belQKqlgMq" role="33vP2m">
+                      <ref role="37wK5l" node="6belQKqlgtP" resolve="unwrapToDateLiteral" />
+                      <ref role="1Pybhc" node="6belQKqkKUV" resolve="TemporalHelper" />
+                      <node concept="2OqwBi" id="7Ndb$5paR9y" role="37wK5m">
+                        <node concept="37vLTw" id="7Ndb$5paR9z" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6W4XqNw1Umu" resolve="slice" />
+                        </node>
+                        <node concept="3TrEf2" id="7Ndb$5paR9$" role="2OqNvi">
+                          <ref role="3Tt5mk" to="l462:50smQ1V8QEi" resolve="pointInTime" />
+                        </node>
                       </node>
                     </node>
                   </node>
                 </node>
                 <node concept="3clFbH" id="5oaaToWY2_W" role="3cqZAp" />
-                <node concept="3clFbJ" id="6belQKqkHCS" role="3cqZAp">
-                  <node concept="3clFbS" id="6belQKqkHCU" role="3clFbx">
-                    <node concept="3clFbF" id="6belQKqlfu0" role="3cqZAp">
-                      <node concept="37vLTI" id="6belQKqlfRC" role="3clFbG">
-                        <node concept="2YIFZM" id="6belQKqlgMq" role="37vLTx">
-                          <ref role="37wK5l" node="6belQKqlgtP" resolve="unwrapToDateLiteral" />
-                          <ref role="1Pybhc" node="6belQKqkKUV" resolve="TemporalHelper" />
-                          <node concept="37vLTw" id="6belQKqlhcq" role="37wK5m">
-                            <ref role="3cqZAo" node="5oaaToWY2tT" resolve="date" />
-                          </node>
-                        </node>
-                        <node concept="37vLTw" id="6belQKqlftY" role="37vLTJ">
-                          <ref role="3cqZAo" node="5oaaToWY2tT" resolve="date" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3fqX7Q" id="6belQKqkKwj" role="3clFbw">
-                    <node concept="2OqwBi" id="6belQKqkKwl" role="3fr31v">
-                      <node concept="37vLTw" id="6belQKqkKwm" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5oaaToWY2tT" resolve="date" />
-                      </node>
-                      <node concept="1mIQ4w" id="6belQKqkKwn" role="2OqNvi">
-                        <node concept="chp4Y" id="6belQKqkKwo" role="cj9EA">
-                          <ref role="cht4Q" to="mi3w:3nGzaxURa4h" resolve="DateLiteral" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
                 <node concept="3clFbJ" id="6belQKqlhIK" role="3cqZAp">
                   <node concept="3clFbS" id="6belQKqlhIM" role="3clFbx">
                     <node concept="a7r0C" id="6belQKqlkmr" role="3cqZAp">
@@ -948,58 +941,61 @@
                     </node>
                     <node concept="3w_OXm" id="6belQKqljEu" role="2OqNvi" />
                   </node>
-                </node>
-                <node concept="3clFbH" id="6belQKqkGaM" role="3cqZAp" />
-                <node concept="3cpWs8" id="5oaaToWY0BA" role="3cqZAp">
-                  <node concept="3cpWsn" id="5oaaToWY0BB" role="3cpWs9">
-                    <property role="TrG5h" value="readableDate" />
-                    <node concept="17QB3L" id="5oaaToWXWQx" role="1tU5fm" />
-                    <node concept="2OqwBi" id="5oaaToWY0BC" role="33vP2m">
-                      <node concept="37vLTw" id="5oaaToWY2tX" role="2Oq$k0">
-                        <ref role="3cqZAo" node="5oaaToWY2tT" resolve="pointInTime" />
-                      </node>
-                      <node concept="2qgKlT" id="5oaaToWY0BG" role="2OqNvi">
-                        <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="6W4XqNw201R" role="3cqZAp">
-                  <node concept="3clFbS" id="6W4XqNw201T" role="3clFbx">
-                    <node concept="2MkqsV" id="6W4XqNw24fs" role="3cqZAp">
-                      <node concept="Xl_RD" id="6W4XqNw24ny" role="2MkJ7o">
-                        <property role="Xl_RC" value="This date is already defined. Please remove this slice or select a different date." />
-                      </node>
-                      <node concept="2OqwBi" id="6belQKqo2Ua" role="1urrMF">
-                        <node concept="37vLTw" id="6W4XqNw255u" role="2Oq$k0">
-                          <ref role="3cqZAo" node="6W4XqNw1Umu" resolve="slice" />
-                        </node>
-                        <node concept="3TrEf2" id="6belQKqo3TC" role="2OqNvi">
-                          <ref role="3Tt5mk" to="l462:50smQ1V8QEi" resolve="pointInTime" />
+                  <node concept="9aQIb" id="7Ndb$5pb7Hl" role="9aQIa">
+                    <node concept="3clFbS" id="7Ndb$5pb7Hm" role="9aQI4">
+                      <node concept="3cpWs8" id="5oaaToWY0BA" role="3cqZAp">
+                        <node concept="3cpWsn" id="5oaaToWY0BB" role="3cpWs9">
+                          <property role="TrG5h" value="readableDate" />
+                          <node concept="17QB3L" id="5oaaToWXWQx" role="1tU5fm" />
+                          <node concept="2OqwBi" id="5oaaToWY0BC" role="33vP2m">
+                            <node concept="37vLTw" id="5oaaToWY2tX" role="2Oq$k0">
+                              <ref role="3cqZAo" node="5oaaToWY2tT" resolve="date" />
+                            </node>
+                            <node concept="2qgKlT" id="5oaaToWY0BG" role="2OqNvi">
+                              <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                            </node>
+                          </node>
                         </node>
                       </node>
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="6W4XqNw21G_" role="3clFbw">
-                    <node concept="37vLTw" id="6W4XqNw20C0" role="2Oq$k0">
-                      <ref role="3cqZAo" node="6W4XqNw1$zG" resolve="uniqueDates" />
-                    </node>
-                    <node concept="3JPx81" id="6W4XqNw22zO" role="2OqNvi">
-                      <node concept="37vLTw" id="5oaaToWY0BI" role="25WWJ7">
-                        <ref role="3cqZAo" node="5oaaToWY0BB" resolve="renderReadable" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="9aQIb" id="6W4XqNw27u3" role="9aQIa">
-                    <node concept="3clFbS" id="6W4XqNw27u4" role="9aQI4">
-                      <node concept="3clFbF" id="6W4XqNw27z7" role="3cqZAp">
-                        <node concept="2OqwBi" id="6W4XqNw28xK" role="3clFbG">
-                          <node concept="37vLTw" id="6W4XqNw27z6" role="2Oq$k0">
+                      <node concept="3clFbJ" id="6W4XqNw201R" role="3cqZAp">
+                        <node concept="3clFbS" id="6W4XqNw201T" role="3clFbx">
+                          <node concept="2MkqsV" id="6W4XqNw24fs" role="3cqZAp">
+                            <node concept="Xl_RD" id="6W4XqNw24ny" role="2MkJ7o">
+                              <property role="Xl_RC" value="This date is already defined. Please remove this slice or select a different date." />
+                            </node>
+                            <node concept="2OqwBi" id="6belQKqo2Ua" role="1urrMF">
+                              <node concept="37vLTw" id="6W4XqNw255u" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6W4XqNw1Umu" resolve="slice" />
+                              </node>
+                              <node concept="3TrEf2" id="6belQKqo3TC" role="2OqNvi">
+                                <ref role="3Tt5mk" to="l462:50smQ1V8QEi" resolve="pointInTime" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="6W4XqNw21G_" role="3clFbw">
+                          <node concept="37vLTw" id="6W4XqNw20C0" role="2Oq$k0">
                             <ref role="3cqZAo" node="6W4XqNw1$zG" resolve="uniqueDates" />
                           </node>
-                          <node concept="TSZUe" id="6W4XqNw29jU" role="2OqNvi">
-                            <node concept="37vLTw" id="5oaaToWY0BJ" role="25WWJ7">
-                              <ref role="3cqZAo" node="5oaaToWY0BB" resolve="renderReadable" />
+                          <node concept="3JPx81" id="6W4XqNw22zO" role="2OqNvi">
+                            <node concept="37vLTw" id="5oaaToWY0BI" role="25WWJ7">
+                              <ref role="3cqZAo" node="5oaaToWY0BB" resolve="readableDate" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="9aQIb" id="6W4XqNw27u3" role="9aQIa">
+                          <node concept="3clFbS" id="6W4XqNw27u4" role="9aQI4">
+                            <node concept="3clFbF" id="6W4XqNw27z7" role="3cqZAp">
+                              <node concept="2OqwBi" id="6W4XqNw28xK" role="3clFbG">
+                                <node concept="37vLTw" id="6W4XqNw27z6" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="6W4XqNw1$zG" resolve="uniqueDates" />
+                                </node>
+                                <node concept="TSZUe" id="6W4XqNw29jU" role="2OqNvi">
+                                  <node concept="37vLTw" id="5oaaToWY0BJ" role="25WWJ7">
+                                    <ref role="3cqZAo" node="5oaaToWY0BB" resolve="readableDate" />
+                                  </node>
+                                </node>
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -4520,54 +4516,129 @@
           </node>
         </node>
         <node concept="3clFbH" id="6belQKql3MH" role="3cqZAp" />
+        <node concept="3SKdUt" id="7Ndb$5pbxxI" role="3cqZAp">
+          <node concept="1PaTwC" id="7Ndb$5pbxxJ" role="1aUNEU">
+            <node concept="3oM_SD" id="7Ndb$5pby5o" role="1PaTwD">
+              <property role="3oM_SC" value="Unwraps" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pby5r" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pby5B" role="1PaTwD">
+              <property role="3oM_SC" value="given" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pby5O" role="1PaTwD">
+              <property role="3oM_SC" value="wrapper-expression" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pby6y" role="1PaTwD">
+              <property role="3oM_SC" value="until" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pby6D" role="1PaTwD">
+              <property role="3oM_SC" value="it" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pby6T" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pby7a" role="1PaTwD">
+              <property role="3oM_SC" value="either" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pby7s" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pby7B" role="1PaTwD">
+              <property role="3oM_SC" value="DateLiteral" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pby8j" role="1PaTwD">
+              <property role="3oM_SC" value="or" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pby9_" role="1PaTwD">
+              <property role="3oM_SC" value="it's" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pbya3" role="1PaTwD">
+              <property role="3oM_SC" value="unclear" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pbyay" role="1PaTwD">
+              <property role="3oM_SC" value="how" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pbyaU" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pbybj" role="1PaTwD">
+              <property role="3oM_SC" value="unwrap" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pbyhB" role="1PaTwD">
+              <property role="3oM_SC" value="it" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pbydt" role="1PaTwD">
+              <property role="3oM_SC" value="further," />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pbydS" role="1PaTwD">
+              <property role="3oM_SC" value="in" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pbyg6" role="1PaTwD">
+              <property role="3oM_SC" value="which" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pbygA" role="1PaTwD">
+              <property role="3oM_SC" value="case" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pbyek" role="1PaTwD">
+              <property role="3oM_SC" value="null" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pbyeL" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="7Ndb$5pbyh7" role="1PaTwD">
+              <property role="3oM_SC" value="returned" />
+            </node>
+          </node>
+        </node>
         <node concept="2$JKZl" id="6belQKql2Sn" role="3cqZAp">
           <node concept="3clFbS" id="6belQKql2Sp" role="2LFqv$">
-            <node concept="3clFbJ" id="6belQKql6sh" role="3cqZAp">
-              <node concept="2OqwBi" id="6belQKql6Hc" role="3clFbw">
-                <node concept="37vLTw" id="6belQKql6uP" role="2Oq$k0">
-                  <ref role="3cqZAo" node="6belQKql3Xk" resolve="unwrapped" />
+            <node concept="1_3QMa" id="7Ndb$5pbu2J" role="3cqZAp">
+              <node concept="1_3QMl" id="7Ndb$5pbvv8" role="1_3QMm">
+                <node concept="3gn64h" id="7Ndb$5pbvva" role="3Kbmr1">
+                  <ref role="3gnhBz" to="yv47:ub9nkyG$WT" resolve="ConstantRef" />
                 </node>
-                <node concept="1mIQ4w" id="6belQKql6X1" role="2OqNvi">
-                  <node concept="chp4Y" id="6belQKql70Y" role="cj9EA">
-                    <ref role="cht4Q" to="yv47:ub9nkyG$WT" resolve="ConstantRef" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbS" id="6belQKql6sj" role="3clFbx">
-                <node concept="3clFbF" id="6belQKql7n5" role="3cqZAp">
-                  <node concept="37vLTI" id="6belQKql7_r" role="3clFbG">
-                    <node concept="2OqwBi" id="6belQKqlazR" role="37vLTx">
-                      <node concept="2OqwBi" id="6belQKql8g6" role="2Oq$k0">
-                        <node concept="1PxgMI" id="6belQKql7T$" role="2Oq$k0">
-                          <node concept="chp4Y" id="6belQKql7VK" role="3oSUPX">
-                            <ref role="cht4Q" to="yv47:ub9nkyG$WT" resolve="ConstantRef" />
+                <node concept="3clFbS" id="7Ndb$5pbvvc" role="3Kbo56">
+                  <node concept="3clFbF" id="7Ndb$5pbvFm" role="3cqZAp">
+                    <node concept="37vLTI" id="7Ndb$5pbvFn" role="3clFbG">
+                      <node concept="2OqwBi" id="7Ndb$5pbvFo" role="37vLTx">
+                        <node concept="2OqwBi" id="7Ndb$5pbvFp" role="2Oq$k0">
+                          <node concept="1PxgMI" id="7Ndb$5pbvFq" role="2Oq$k0">
+                            <node concept="chp4Y" id="7Ndb$5pbvFr" role="3oSUPX">
+                              <ref role="cht4Q" to="yv47:ub9nkyG$WT" resolve="ConstantRef" />
+                            </node>
+                            <node concept="37vLTw" id="7Ndb$5pbvFs" role="1m5AlR">
+                              <ref role="3cqZAo" node="6belQKql3Xk" resolve="unwrapped" />
+                            </node>
                           </node>
-                          <node concept="37vLTw" id="6belQKql7F5" role="1m5AlR">
-                            <ref role="3cqZAo" node="6belQKql3Xk" resolve="unwrapped" />
+                          <node concept="3TrEf2" id="7Ndb$5pbvFt" role="2OqNvi">
+                            <ref role="3Tt5mk" to="yv47:ub9nkyG$WU" resolve="constant" />
                           </node>
                         </node>
-                        <node concept="3TrEf2" id="6belQKql9_a" role="2OqNvi">
-                          <ref role="3Tt5mk" to="yv47:ub9nkyG$WU" resolve="constant" />
+                        <node concept="3TrEf2" id="7Ndb$5pbvFu" role="2OqNvi">
+                          <ref role="3Tt5mk" to="yv47:69zaTr1HgRN" resolve="value" />
                         </node>
                       </node>
-                      <node concept="3TrEf2" id="6belQKqlbya" role="2OqNvi">
-                        <ref role="3Tt5mk" to="yv47:69zaTr1HgRN" resolve="value" />
-                      </node>
-                    </node>
-                    <node concept="37vLTw" id="6belQKql7n4" role="37vLTJ">
-                      <ref role="3cqZAo" node="6belQKql3Xk" resolve="unwrapped" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="9aQIb" id="6belQKqlbIV" role="9aQIa">
-                <node concept="3clFbS" id="6belQKqlbIW" role="9aQI4">
-                  <node concept="3clFbF" id="6belQKqlbUZ" role="3cqZAp">
-                    <node concept="37vLTI" id="6belQKqlc9j" role="3clFbG">
-                      <node concept="10Nm6u" id="6belQKqlcbJ" role="37vLTx" />
-                      <node concept="37vLTw" id="6belQKqlbUY" role="37vLTJ">
+                      <node concept="37vLTw" id="7Ndb$5pbvFv" role="37vLTJ">
                         <ref role="3cqZAo" node="6belQKql3Xk" resolve="unwrapped" />
                       </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7Ndb$5pbuqU" role="1_3QMn">
+                <node concept="37vLTw" id="7Ndb$5pbuaO" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6belQKql3Xk" resolve="unwrapped" />
+                </node>
+                <node concept="2yIwOk" id="7Ndb$5pbuQW" role="2OqNvi" />
+              </node>
+              <node concept="3clFbS" id="7Ndb$5pbuYg" role="1prKM_">
+                <node concept="3clFbF" id="7Ndb$5pbuYe" role="3cqZAp">
+                  <node concept="37vLTI" id="7Ndb$5pbvg0" role="3clFbG">
+                    <node concept="10Nm6u" id="7Ndb$5pbvnt" role="37vLTx" />
+                    <node concept="37vLTw" id="7Ndb$5pbuYd" role="37vLTJ">
+                      <ref role="3cqZAo" node="6belQKql3Xk" resolve="unwrapped" />
                     </node>
                   </node>
                 </node>
@@ -4646,6 +4717,9 @@
         <node concept="x79VA" id="6belQKqpx59" role="3nqlJM">
           <property role="x79VB" value="the unwrapped DateLiteral; otherwise null" />
         </node>
+      </node>
+      <node concept="2AHcQZ" id="7Ndb$5paPZS" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
       </node>
     </node>
     <node concept="2tJIrI" id="6belQKqkKXq" role="jymVt" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
@@ -4,6 +4,7 @@
   <languages>
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
   </languages>
   <imports>
@@ -22,6 +23,7 @@
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
+    <import index="yv47" ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
@@ -39,6 +41,10 @@
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
+        <child id="1076505808688" name="condition" index="2$JKZa" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -55,11 +61,13 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
@@ -72,6 +80,11 @@
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
       </concept>
       <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
@@ -112,6 +125,9 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
       <concept id="1171903916106" name="jetbrains.mps.baseLanguage.structure.UpperBoundType" flags="in" index="3qUE_q">
         <child id="1171903916107" name="bound" index="3qUE_r" />
       </concept>
@@ -124,18 +140,51 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
       <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
         <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
       </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5858074156537516430" name="jetbrains.mps.baseLanguage.javadoc.structure.ReturnBlockDocTag" flags="ng" index="x79VA">
+        <property id="5858074156537516431" name="text" index="x79VB" />
+      </concept>
+      <concept id="6832197706140518104" name="jetbrains.mps.baseLanguage.javadoc.structure.DocMethodParameterReference" flags="ng" index="zr_55" />
+      <concept id="6832197706140518103" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseParameterReference" flags="ng" index="zr_5a">
+        <reference id="6832197706140518108" name="param" index="zr_51" />
+      </concept>
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
+        <child id="5383422241790532083" name="tags" index="3nqlJM" />
+      </concept>
+      <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690881930" name="jetbrains.mps.baseLanguage.javadoc.structure.ParameterBlockDocTag" flags="ng" index="TUZQ0">
+        <property id="8465538089690881934" name="text" index="TUZQ4" />
+        <child id="6832197706140518123" name="parameter" index="zr_5Q" />
+      </concept>
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
       </concept>
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
@@ -286,6 +335,7 @@
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
@@ -300,6 +350,17 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
+        <child id="1226511765987" name="elementType" index="2hN53Y" />
+      </concept>
+      <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
       <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
         <child id="1153944400369" name="variable" index="2Gsz3X" />
         <child id="1153944424730" name="inputSequence" index="2GsD0m" />
@@ -308,10 +369,16 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
+      <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
     </language>
   </registry>
   <node concept="2sgARr" id="50smQ1V8pHj">
@@ -680,12 +747,11 @@
   <node concept="18kY7G" id="50smQ1Va0Ew">
     <property role="TrG5h" value="check_TemporalLiteral" />
     <node concept="3clFbS" id="50smQ1Va0Ex" role="18ibNy">
-      <node concept="3clFbH" id="7SY$c$i76FJ" role="3cqZAp" />
       <node concept="3clFbJ" id="50smQ1Va0EH" role="3cqZAp">
         <node concept="3clFbS" id="50smQ1Va0EJ" role="3clFbx">
           <node concept="2MkqsV" id="50smQ1Va57y" role="3cqZAp">
             <node concept="Xl_RD" id="50smQ1Va57I" role="2MkJ7o">
-              <property role="Xl_RC" value="at least one slice must be defined (alternatively the type constraint must be set)" />
+              <property role="Xl_RC" value="At least one slice must be defined (alternatively the type constraint must be set)" />
             </node>
             <node concept="1YBJjd" id="50smQ1Va58l" role="1urrMF">
               <ref role="1YBMHb" node="50smQ1Va0Ez" resolve="tl" />
@@ -753,6 +819,198 @@
                 <node concept="3TrEf2" id="2LepRDoTqMR" role="2OqNvi">
                   <ref role="3Tt5mk" to="l462:7SY$c$i5rRe" resolve="typeConstraint" />
                 </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="6W4XqNw1$2m" role="3cqZAp" />
+      <node concept="3SKdUt" id="6W4XqNw1$uV" role="3cqZAp">
+        <node concept="1PaTwC" id="6W4XqNw1$uW" role="1aUNEU">
+          <node concept="3oM_SD" id="6W4XqNw1$v_" role="1PaTwD">
+            <property role="3oM_SC" value="check" />
+          </node>
+          <node concept="3oM_SD" id="6W4XqNw1$vB" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="6W4XqNw1$vE" role="1PaTwD">
+            <property role="3oM_SC" value="slices" />
+          </node>
+          <node concept="3oM_SD" id="6belQKqqfRz" role="1PaTwD">
+            <property role="3oM_SC" value="with" />
+          </node>
+          <node concept="3oM_SD" id="6belQKqqfRF" role="1PaTwD">
+            <property role="3oM_SC" value="duplicate" />
+          </node>
+          <node concept="3oM_SD" id="6belQKqqfRW" role="1PaTwD">
+            <property role="3oM_SC" value="point" />
+          </node>
+          <node concept="3oM_SD" id="6belQKqqfS3" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6belQKqqfSb" role="1PaTwD">
+            <property role="3oM_SC" value="time" />
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="6W4XqNw1$zD" role="3cqZAp">
+        <node concept="3cpWsn" id="6W4XqNw1$zG" role="3cpWs9">
+          <property role="TrG5h" value="uniqueDates" />
+          <node concept="2hMVRd" id="6W4XqNw1$z_" role="1tU5fm">
+            <node concept="17QB3L" id="5oaaToWXqxh" role="2hN53Y" />
+          </node>
+          <node concept="2ShNRf" id="6W4XqNw1Nth" role="33vP2m">
+            <node concept="2i4dXS" id="6W4XqNw1P2S" role="2ShVmc">
+              <node concept="17QB3L" id="5oaaToWXqDw" role="HW$YZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbF" id="6W4XqNw1Pcd" role="3cqZAp">
+        <node concept="2OqwBi" id="6W4XqNw1RgM" role="3clFbG">
+          <node concept="2OqwBi" id="6W4XqNw1PrI" role="2Oq$k0">
+            <node concept="1YBJjd" id="6W4XqNw1Pcb" role="2Oq$k0">
+              <ref role="1YBMHb" node="50smQ1Va0Ez" resolve="tl" />
+            </node>
+            <node concept="3Tsc0h" id="6W4XqNw1PTd" role="2OqNvi">
+              <ref role="3TtcxE" to="l462:50smQ1V8QF$" resolve="slices" />
+            </node>
+          </node>
+          <node concept="2es0OD" id="6W4XqNw1Umq" role="2OqNvi">
+            <node concept="1bVj0M" id="6W4XqNw1Ums" role="23t8la">
+              <node concept="3clFbS" id="6W4XqNw1Umt" role="1bW5cS">
+                <node concept="3cpWs8" id="5oaaToWY2tS" role="3cqZAp">
+                  <node concept="3cpWsn" id="5oaaToWY2tT" role="3cpWs9">
+                    <property role="TrG5h" value="date" />
+                    <node concept="3Tqbb2" id="5oaaToWY2jG" role="1tU5fm">
+                      <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                    </node>
+                    <node concept="2OqwBi" id="5oaaToWY2tU" role="33vP2m">
+                      <node concept="37vLTw" id="5oaaToWY2tV" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6W4XqNw1Umu" resolve="slice" />
+                      </node>
+                      <node concept="3TrEf2" id="5oaaToWY2tW" role="2OqNvi">
+                        <ref role="3Tt5mk" to="l462:50smQ1V8QEi" resolve="pointInTime" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbH" id="5oaaToWY2_W" role="3cqZAp" />
+                <node concept="3clFbJ" id="6belQKqkHCS" role="3cqZAp">
+                  <node concept="3clFbS" id="6belQKqkHCU" role="3clFbx">
+                    <node concept="3clFbF" id="6belQKqlfu0" role="3cqZAp">
+                      <node concept="37vLTI" id="6belQKqlfRC" role="3clFbG">
+                        <node concept="2YIFZM" id="6belQKqlgMq" role="37vLTx">
+                          <ref role="37wK5l" node="6belQKqlgtP" resolve="unwrapToDateLiteral" />
+                          <ref role="1Pybhc" node="6belQKqkKUV" resolve="TemporalHelper" />
+                          <node concept="37vLTw" id="6belQKqlhcq" role="37wK5m">
+                            <ref role="3cqZAo" node="5oaaToWY2tT" resolve="date" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="6belQKqlftY" role="37vLTJ">
+                          <ref role="3cqZAo" node="5oaaToWY2tT" resolve="date" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3fqX7Q" id="6belQKqkKwj" role="3clFbw">
+                    <node concept="2OqwBi" id="6belQKqkKwl" role="3fr31v">
+                      <node concept="37vLTw" id="6belQKqkKwm" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5oaaToWY2tT" resolve="date" />
+                      </node>
+                      <node concept="1mIQ4w" id="6belQKqkKwn" role="2OqNvi">
+                        <node concept="chp4Y" id="6belQKqkKwo" role="cj9EA">
+                          <ref role="cht4Q" to="mi3w:3nGzaxURa4h" resolve="DateLiteral" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="6belQKqlhIK" role="3cqZAp">
+                  <node concept="3clFbS" id="6belQKqlhIM" role="3clFbx">
+                    <node concept="a7r0C" id="6belQKqlkmr" role="3cqZAp">
+                      <node concept="Xl_RD" id="6belQKqlkHR" role="a7wSD">
+                        <property role="Xl_RC" value="Slices point in time cannot be resolved to a date and thus cannot be checked for duplicates in this temporal literal." />
+                      </node>
+                      <node concept="2OqwBi" id="6belQKqlyc4" role="1urrMF">
+                        <node concept="37vLTw" id="6belQKqlxC7" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6W4XqNw1Umu" resolve="slice" />
+                        </node>
+                        <node concept="3TrEf2" id="6belQKqlz5j" role="2OqNvi">
+                          <ref role="3Tt5mk" to="l462:50smQ1V8QEi" resolve="pointInTime" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="6belQKqliFi" role="3clFbw">
+                    <node concept="37vLTw" id="6belQKqliax" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5oaaToWY2tT" resolve="date" />
+                    </node>
+                    <node concept="3w_OXm" id="6belQKqljEu" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="3clFbH" id="6belQKqkGaM" role="3cqZAp" />
+                <node concept="3cpWs8" id="5oaaToWY0BA" role="3cqZAp">
+                  <node concept="3cpWsn" id="5oaaToWY0BB" role="3cpWs9">
+                    <property role="TrG5h" value="readableDate" />
+                    <node concept="17QB3L" id="5oaaToWXWQx" role="1tU5fm" />
+                    <node concept="2OqwBi" id="5oaaToWY0BC" role="33vP2m">
+                      <node concept="37vLTw" id="5oaaToWY2tX" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5oaaToWY2tT" resolve="pointInTime" />
+                      </node>
+                      <node concept="2qgKlT" id="5oaaToWY0BG" role="2OqNvi">
+                        <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="6W4XqNw201R" role="3cqZAp">
+                  <node concept="3clFbS" id="6W4XqNw201T" role="3clFbx">
+                    <node concept="2MkqsV" id="6W4XqNw24fs" role="3cqZAp">
+                      <node concept="Xl_RD" id="6W4XqNw24ny" role="2MkJ7o">
+                        <property role="Xl_RC" value="This date is already defined. Please remove this slice or select a different date." />
+                      </node>
+                      <node concept="2OqwBi" id="6belQKqo2Ua" role="1urrMF">
+                        <node concept="37vLTw" id="6W4XqNw255u" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6W4XqNw1Umu" resolve="slice" />
+                        </node>
+                        <node concept="3TrEf2" id="6belQKqo3TC" role="2OqNvi">
+                          <ref role="3Tt5mk" to="l462:50smQ1V8QEi" resolve="pointInTime" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="6W4XqNw21G_" role="3clFbw">
+                    <node concept="37vLTw" id="6W4XqNw20C0" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6W4XqNw1$zG" resolve="uniqueDates" />
+                    </node>
+                    <node concept="3JPx81" id="6W4XqNw22zO" role="2OqNvi">
+                      <node concept="37vLTw" id="5oaaToWY0BI" role="25WWJ7">
+                        <ref role="3cqZAo" node="5oaaToWY0BB" resolve="renderReadable" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="9aQIb" id="6W4XqNw27u3" role="9aQIa">
+                    <node concept="3clFbS" id="6W4XqNw27u4" role="9aQI4">
+                      <node concept="3clFbF" id="6W4XqNw27z7" role="3cqZAp">
+                        <node concept="2OqwBi" id="6W4XqNw28xK" role="3clFbG">
+                          <node concept="37vLTw" id="6W4XqNw27z6" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6W4XqNw1$zG" resolve="uniqueDates" />
+                          </node>
+                          <node concept="TSZUe" id="6W4XqNw29jU" role="2OqNvi">
+                            <node concept="37vLTw" id="5oaaToWY0BJ" role="25WWJ7">
+                              <ref role="3cqZAo" node="5oaaToWY0BB" resolve="renderReadable" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="6W4XqNw1Umu" role="1bW2Oz">
+                <property role="TrG5h" value="slice" />
+                <node concept="2jxLKc" id="6W4XqNw1Umv" role="1tU5fm" />
               </node>
             </node>
           </node>
@@ -4243,6 +4501,155 @@
         </node>
       </node>
     </node>
+  </node>
+  <node concept="312cEu" id="6belQKqkKUV">
+    <property role="TrG5h" value="TemporalHelper" />
+    <node concept="2tJIrI" id="6belQKqkKX1" role="jymVt" />
+    <node concept="2YIFZL" id="6belQKqlgtP" role="jymVt">
+      <property role="TrG5h" value="unwrapToDateLiteral" />
+      <node concept="3clFbS" id="6belQKqkKXI" role="3clF47">
+        <node concept="3cpWs8" id="6belQKql3Xh" role="3cqZAp">
+          <node concept="3cpWsn" id="6belQKql3Xk" role="3cpWs9">
+            <property role="TrG5h" value="unwrapped" />
+            <node concept="3Tqbb2" id="6belQKql3Xf" role="1tU5fm">
+              <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+            </node>
+            <node concept="37vLTw" id="6belQKql4j8" role="33vP2m">
+              <ref role="3cqZAo" node="6belQKqkMye" resolve="wrapper" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6belQKql3MH" role="3cqZAp" />
+        <node concept="2$JKZl" id="6belQKql2Sn" role="3cqZAp">
+          <node concept="3clFbS" id="6belQKql2Sp" role="2LFqv$">
+            <node concept="3clFbJ" id="6belQKql6sh" role="3cqZAp">
+              <node concept="2OqwBi" id="6belQKql6Hc" role="3clFbw">
+                <node concept="37vLTw" id="6belQKql6uP" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6belQKql3Xk" resolve="unwrapped" />
+                </node>
+                <node concept="1mIQ4w" id="6belQKql6X1" role="2OqNvi">
+                  <node concept="chp4Y" id="6belQKql70Y" role="cj9EA">
+                    <ref role="cht4Q" to="yv47:ub9nkyG$WT" resolve="ConstantRef" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="6belQKql6sj" role="3clFbx">
+                <node concept="3clFbF" id="6belQKql7n5" role="3cqZAp">
+                  <node concept="37vLTI" id="6belQKql7_r" role="3clFbG">
+                    <node concept="2OqwBi" id="6belQKqlazR" role="37vLTx">
+                      <node concept="2OqwBi" id="6belQKql8g6" role="2Oq$k0">
+                        <node concept="1PxgMI" id="6belQKql7T$" role="2Oq$k0">
+                          <node concept="chp4Y" id="6belQKql7VK" role="3oSUPX">
+                            <ref role="cht4Q" to="yv47:ub9nkyG$WT" resolve="ConstantRef" />
+                          </node>
+                          <node concept="37vLTw" id="6belQKql7F5" role="1m5AlR">
+                            <ref role="3cqZAo" node="6belQKql3Xk" resolve="unwrapped" />
+                          </node>
+                        </node>
+                        <node concept="3TrEf2" id="6belQKql9_a" role="2OqNvi">
+                          <ref role="3Tt5mk" to="yv47:ub9nkyG$WU" resolve="constant" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="6belQKqlbya" role="2OqNvi">
+                        <ref role="3Tt5mk" to="yv47:69zaTr1HgRN" resolve="value" />
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="6belQKql7n4" role="37vLTJ">
+                      <ref role="3cqZAo" node="6belQKql3Xk" resolve="unwrapped" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="9aQIb" id="6belQKqlbIV" role="9aQIa">
+                <node concept="3clFbS" id="6belQKqlbIW" role="9aQI4">
+                  <node concept="3clFbF" id="6belQKqlbUZ" role="3cqZAp">
+                    <node concept="37vLTI" id="6belQKqlc9j" role="3clFbG">
+                      <node concept="10Nm6u" id="6belQKqlcbJ" role="37vLTx" />
+                      <node concept="37vLTw" id="6belQKqlbUY" role="37vLTJ">
+                        <ref role="3cqZAo" node="6belQKql3Xk" resolve="unwrapped" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1Wc70l" id="6belQKql5$Z" role="2$JKZa">
+            <node concept="2OqwBi" id="6belQKql5Zq" role="3uHU7w">
+              <node concept="37vLTw" id="6belQKql5NK" role="2Oq$k0">
+                <ref role="3cqZAo" node="6belQKql3Xk" resolve="unwrapped" />
+              </node>
+              <node concept="3x8VRR" id="6belQKql6nx" role="2OqNvi" />
+            </node>
+            <node concept="3fqX7Q" id="6belQKql5gJ" role="3uHU7B">
+              <node concept="2OqwBi" id="6belQKql5gL" role="3fr31v">
+                <node concept="37vLTw" id="6belQKql5gM" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6belQKql3Xk" resolve="unwrapped" />
+                </node>
+                <node concept="1mIQ4w" id="6belQKql5gN" role="2OqNvi">
+                  <node concept="chp4Y" id="6belQKql5gO" role="cj9EA">
+                    <ref role="cht4Q" to="mi3w:3nGzaxURa4h" resolve="DateLiteral" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6belQKql2Py" role="3cqZAp" />
+        <node concept="3cpWs6" id="6belQKqlcHe" role="3cqZAp">
+          <node concept="3K4zz7" id="6belQKqlek_" role="3cqZAk">
+            <node concept="1PxgMI" id="6belQKqleAc" role="3K4E3e">
+              <node concept="chp4Y" id="6belQKqleB9" role="3oSUPX">
+                <ref role="cht4Q" to="mi3w:3nGzaxURa4h" resolve="DateLiteral" />
+              </node>
+              <node concept="37vLTw" id="6belQKqlenp" role="1m5AlR">
+                <ref role="3cqZAo" node="6belQKql3Xk" resolve="unwrapped" />
+              </node>
+            </node>
+            <node concept="10Nm6u" id="6belQKqleIJ" role="3K4GZi" />
+            <node concept="2OqwBi" id="6belQKqld7O" role="3K4Cdx">
+              <node concept="37vLTw" id="6belQKqlcJs" role="2Oq$k0">
+                <ref role="3cqZAo" node="6belQKql3Xk" resolve="unwrapped" />
+              </node>
+              <node concept="3x8VRR" id="6belQKqldTD" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6belQKqkMye" role="3clF46">
+        <property role="TrG5h" value="wrapper" />
+        <node concept="3Tqbb2" id="6belQKqkMyd" role="1tU5fm">
+          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="6belQKqkMvm" role="3clF45">
+        <ref role="ehGHo" to="mi3w:3nGzaxURa4h" resolve="DateLiteral" />
+      </node>
+      <node concept="3Tm1VV" id="6belQKqkKXH" role="1B3o_S" />
+      <node concept="P$JXv" id="6belQKqpx53" role="lGtFl">
+        <node concept="TZ5HA" id="6belQKqpx54" role="TZ5H$">
+          <node concept="1dT_AC" id="6belQKqpx55" role="1dT_Ay">
+            <property role="1dT_AB" value="Unwraps a node, like ConstantRef, recursively until a DateLiteral is reached or unwrapping is not " />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="6belQKqpxzG" role="TZ5H$">
+          <node concept="1dT_AC" id="6belQKqpxzH" role="1dT_Ay">
+            <property role="1dT_AB" value="possible anymore, e.g. an unhandled concept is used for wrapping" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="6belQKqpx56" role="3nqlJM">
+          <property role="TUZQ4" value="the node that should be unwrapper to retrieve the DateLiteral" />
+          <node concept="zr_55" id="6belQKqpx58" role="zr_5Q">
+            <ref role="zr_51" node="6belQKqkMye" resolve="wrapper" />
+          </node>
+        </node>
+        <node concept="x79VA" id="6belQKqpx59" role="3nqlJM">
+          <property role="x79VB" value="the unwrapped DateLiteral; otherwise null" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6belQKqkKXq" role="jymVt" />
+    <node concept="3Tm1VV" id="6belQKqkKUW" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
@@ -388,6 +388,7 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
@@ -397,7 +398,6 @@
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
-      <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
     </language>
   </registry>
   <node concept="2sgARr" id="50smQ1V8pHj">
@@ -872,15 +872,19 @@
           </node>
         </node>
       </node>
-      <node concept="3cpWs8" id="6W4XqNw1$zD" role="3cqZAp">
-        <node concept="3cpWsn" id="6W4XqNw1$zG" role="3cpWs9">
-          <property role="TrG5h" value="uniqueDates" />
-          <node concept="2hMVRd" id="6W4XqNw1$z_" role="1tU5fm">
-            <node concept="17QB3L" id="5oaaToWXqxh" role="2hN53Y" />
+      <node concept="3cpWs8" id="1MJboh4Ntv4" role="3cqZAp">
+        <node concept="3cpWsn" id="1MJboh4Ntv7" role="3cpWs9">
+          <property role="TrG5h" value="dates" />
+          <node concept="2hMVRd" id="1MJboh4Ntv0" role="1tU5fm">
+            <node concept="3Tqbb2" id="1MJboh4Ntxl" role="2hN53Y">
+              <ref role="ehGHo" to="mi3w:3nGzaxURa4h" resolve="DateLiteral" />
+            </node>
           </node>
-          <node concept="2ShNRf" id="6W4XqNw1Nth" role="33vP2m">
-            <node concept="2i4dXS" id="6W4XqNw1P2S" role="2ShVmc">
-              <node concept="17QB3L" id="5oaaToWXqDw" role="HW$YZ" />
+          <node concept="2ShNRf" id="1MJboh4Nv8D" role="33vP2m">
+            <node concept="2i4dXS" id="1MJboh4NwDm" role="2ShVmc">
+              <node concept="3Tqbb2" id="1MJboh4NwL5" role="HW$YZ">
+                <ref role="ehGHo" to="mi3w:3nGzaxURa4h" resolve="DateLiteral" />
+              </node>
             </node>
           </node>
         </node>
@@ -902,7 +906,7 @@
                   <node concept="3cpWsn" id="5oaaToWY2tT" role="3cpWs9">
                     <property role="TrG5h" value="date" />
                     <node concept="3Tqbb2" id="5oaaToWY2jG" role="1tU5fm">
-                      <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                      <ref role="ehGHo" to="mi3w:3nGzaxURa4h" resolve="DateLiteral" />
                     </node>
                     <node concept="2YIFZM" id="6belQKqlgMq" role="33vP2m">
                       <ref role="37wK5l" node="6belQKqlgtP" resolve="unwrapToDateLiteral" />
@@ -918,7 +922,6 @@
                     </node>
                   </node>
                 </node>
-                <node concept="3clFbH" id="5oaaToWY2_W" role="3cqZAp" />
                 <node concept="3clFbJ" id="6belQKqlhIK" role="3cqZAp">
                   <node concept="3clFbS" id="6belQKqlhIM" role="3clFbx">
                     <node concept="a7r0C" id="6belQKqlkmr" role="3cqZAp">
@@ -943,20 +946,6 @@
                   </node>
                   <node concept="9aQIb" id="7Ndb$5pb7Hl" role="9aQIa">
                     <node concept="3clFbS" id="7Ndb$5pb7Hm" role="9aQI4">
-                      <node concept="3cpWs8" id="5oaaToWY0BA" role="3cqZAp">
-                        <node concept="3cpWsn" id="5oaaToWY0BB" role="3cpWs9">
-                          <property role="TrG5h" value="readableDate" />
-                          <node concept="17QB3L" id="5oaaToWXWQx" role="1tU5fm" />
-                          <node concept="2OqwBi" id="5oaaToWY0BC" role="33vP2m">
-                            <node concept="37vLTw" id="5oaaToWY2tX" role="2Oq$k0">
-                              <ref role="3cqZAo" node="5oaaToWY2tT" resolve="date" />
-                            </node>
-                            <node concept="2qgKlT" id="5oaaToWY0BG" role="2OqNvi">
-                              <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
                       <node concept="3clFbJ" id="6W4XqNw201R" role="3cqZAp">
                         <node concept="3clFbS" id="6W4XqNw201T" role="3clFbx">
                           <node concept="2MkqsV" id="6W4XqNw24fs" role="3cqZAp">
@@ -973,26 +962,44 @@
                             </node>
                           </node>
                         </node>
-                        <node concept="2OqwBi" id="6W4XqNw21G_" role="3clFbw">
-                          <node concept="37vLTw" id="6W4XqNw20C0" role="2Oq$k0">
-                            <ref role="3cqZAo" node="6W4XqNw1$zG" resolve="uniqueDates" />
+                        <node concept="2OqwBi" id="1MJboh4NXrW" role="3clFbw">
+                          <node concept="37vLTw" id="1MJboh4NW0c" role="2Oq$k0">
+                            <ref role="3cqZAo" node="1MJboh4Ntv7" resolve="dates" />
                           </node>
-                          <node concept="3JPx81" id="6W4XqNw22zO" role="2OqNvi">
-                            <node concept="37vLTw" id="5oaaToWY0BI" role="25WWJ7">
-                              <ref role="3cqZAo" node="5oaaToWY0BB" resolve="readableDate" />
+                          <node concept="2HwmR7" id="1MJboh4O57$" role="2OqNvi">
+                            <node concept="1bVj0M" id="1MJboh4O57A" role="23t8la">
+                              <node concept="3clFbS" id="1MJboh4O57B" role="1bW5cS">
+                                <node concept="3clFbF" id="1MJboh4O5Hy" role="3cqZAp">
+                                  <node concept="2OqwBi" id="1MJboh4O6xy" role="3clFbG">
+                                    <node concept="37vLTw" id="1MJboh4O5Hx" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="1MJboh4O57C" resolve="it" />
+                                    </node>
+                                    <node concept="2qgKlT" id="1MJboh4O9p7" role="2OqNvi">
+                                      <ref role="37wK5l" to="pbu6:7GwCuf2r4g6" resolve="isSameAs" />
+                                      <node concept="37vLTw" id="1MJboh4Oacz" role="37wK5m">
+                                        <ref role="3cqZAo" node="5oaaToWY2tT" resolve="date" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="Rh6nW" id="1MJboh4O57C" role="1bW2Oz">
+                                <property role="TrG5h" value="it" />
+                                <node concept="2jxLKc" id="1MJboh4O57D" role="1tU5fm" />
+                              </node>
                             </node>
                           </node>
                         </node>
                         <node concept="9aQIb" id="6W4XqNw27u3" role="9aQIa">
                           <node concept="3clFbS" id="6W4XqNw27u4" role="9aQI4">
-                            <node concept="3clFbF" id="6W4XqNw27z7" role="3cqZAp">
-                              <node concept="2OqwBi" id="6W4XqNw28xK" role="3clFbG">
-                                <node concept="37vLTw" id="6W4XqNw27z6" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="6W4XqNw1$zG" resolve="uniqueDates" />
+                            <node concept="3clFbF" id="1MJboh4OhMX" role="3cqZAp">
+                              <node concept="2OqwBi" id="1MJboh4OjrM" role="3clFbG">
+                                <node concept="37vLTw" id="1MJboh4OhMV" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1MJboh4Ntv7" resolve="dates" />
                                 </node>
-                                <node concept="TSZUe" id="6W4XqNw29jU" role="2OqNvi">
-                                  <node concept="37vLTw" id="5oaaToWY0BJ" role="25WWJ7">
-                                    <ref role="3cqZAo" node="5oaaToWY0BB" resolve="readableDate" />
+                                <node concept="TSZUe" id="1MJboh4OkRF" role="2OqNvi">
+                                  <node concept="37vLTw" id="1MJboh4Ol_V" role="25WWJ7">
+                                    <ref role="3cqZAo" node="5oaaToWY2tT" resolve="date" />
                                   </node>
                                 </node>
                               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/org.iets3.core.expr.temporal.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/org.iets3.core.expr.temporal.mpl
@@ -28,6 +28,7 @@
     <dependency reexport="false">957f018c-4561-4081-9ad3-b8618bf1160d(org.iets3.core.expr.datetime.runtime)</dependency>
     <dependency reexport="false">b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)</dependency>
     <dependency reexport="false">17ecc6b6-d106-4b60-87a9-3fde52f92301(org.iets3.core.expr.temporal.runtime)</dependency>
+    <dependency reexport="false">71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="2" />
@@ -132,9 +133,11 @@
     <module reference="289fb12b-7f53-4ef7-bc2e-1ed2c6a7c998(org.iets3.core.expr.datetime)" version="1" />
     <module reference="957f018c-4561-4081-9ad3-b8618bf1160d(org.iets3.core.expr.datetime.runtime)" version="0" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="0" />
+    <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="1" />
     <module reference="4621d3e3-b8a3-4bbe-b7ac-234b6e2d1d68(org.iets3.core.expr.temporal)" version="1" />
     <module reference="17ecc6b6-d106-4b60-87a9-3fde52f92301(org.iets3.core.expr.temporal.runtime)" version="0" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="2" />
   </dependencyVersions>
   <extendedLanguages>
     <extendedLanguage>9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)</extendedLanguage>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -6008,6 +6008,11 @@
             <ref role="3bR37D" node="2xddOZL74Qj" resolve="org.iets3.core.expr.datetime.runtime" />
           </node>
         </node>
+        <node concept="1SiIV0" id="6belQKqqIqr" role="3bR37C">
+          <node concept="3bR9La" id="6belQKqqIqs" role="1SiIV1">
+            <ref role="3bR37D" node="2uR5X5azttH" resolve="org.iets3.core.expr.toplevel" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="2xddOZL74Qf" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -12655,6 +12660,11 @@
       <node concept="1SiIV0" id="4PRpvcZJQ0m" role="3bR37C">
         <node concept="3bR9La" id="4PRpvcZJQ0n" role="1SiIV1">
           <ref role="3bR37D" node="cPLa7FuMZR" resolve="org.iets3.core.expr.data" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="6belQKqqIdM" role="3bR37C">
+        <node concept="3bR9La" id="6belQKqqIdN" role="1SiIV1">
+          <ref role="3bR37D" node="5zQvLw7dsP5" resolve="org.iets3.core.expr.temporal" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.temporal@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.temporal@tests.mps
@@ -11,16 +11,28 @@
     <use id="289fb12b-7f53-4ef7-bc2e-1ed2c6a7c998" name="org.iets3.core.expr.datetime" version="0" />
     <use id="9464fa06-5ab9-409b-9274-64ab29588457" name="org.iets3.core.expr.lambda" version="1" />
   </languages>
-  <imports />
+  <imports>
+    <import index="3ypn" ref="r:782cab7d-c30f-4797-991c-cb17d0274086(org.iets3.core.expr.temporal.typesystem)" />
+  </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="1215507671101" name="jetbrains.mps.lang.test.structure.NodeErrorCheckOperation" flags="ng" index="1TM$A" />
+      <concept id="1215507671101" name="jetbrains.mps.lang.test.structure.NodeErrorCheckOperation" flags="ng" index="1TM$A">
+        <child id="8489045168660938517" name="errorRef" index="3lydEf" />
+      </concept>
+      <concept id="1215511704609" name="jetbrains.mps.lang.test.structure.NodeWarningCheckOperation" flags="ng" index="29bkU">
+        <child id="8489045168660938635" name="warningRef" index="3lydCh" />
+      </concept>
       <concept id="1215603922101" name="jetbrains.mps.lang.test.structure.NodeOperationsContainer" flags="ng" index="7CXmI">
         <child id="1215604436604" name="nodeOperations" index="7EUXB" />
       </concept>
       <concept id="1215607067978" name="jetbrains.mps.lang.test.structure.CheckNodeForErrorMessagesOperation" flags="ng" index="7OXhh">
         <property id="3743352646565420194" name="includeSelf" index="GvXf4" />
       </concept>
+      <concept id="7691029917083872157" name="jetbrains.mps.lang.test.structure.IRuleReference" flags="ng" index="2u4UPC">
+        <reference id="8333855927540250453" name="declaration" index="39XzEq" />
+      </concept>
+      <concept id="4531408400486526326" name="jetbrains.mps.lang.test.structure.WarningStatementReference" flags="ng" index="2PQEqo" />
+      <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
       <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
       </concept>
@@ -31,12 +43,24 @@
         <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
       </concept>
     </language>
+    <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
+      <concept id="7554398283339850572" name="org.iets3.core.expr.collections.structure.FirstOp" flags="ng" index="3iB7TU" />
+      <concept id="7554398283339759319" name="org.iets3.core.expr.collections.structure.ListLiteral" flags="ng" index="3iBYfx">
+        <child id="7554398283339759320" name="elements" index="3iBYfI" />
+      </concept>
+    </language>
+    <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
+      <concept id="3693790620639876318" name="com.mbeddr.mpsutil.blutil.structure.BLDoc" flags="ng" index="2aEySx">
+        <child id="3693790620639876319" name="text" index="2aEySw" />
+      </concept>
+    </language>
     <language id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base">
       <concept id="7831630342157089621" name="org.iets3.core.base.structure.IDetectNeedToRunManually" flags="ng" index="0Rz4o">
         <property id="7831630342157089649" name="__hash" index="0Rz4W" />
       </concept>
     </language>
     <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
+      <concept id="2390066428848651932" name="org.iets3.core.expr.base.structure.BangOp" flags="ng" index="wdKpt" />
       <concept id="7071042522334260296" name="org.iets3.core.expr.base.structure.ITyped" flags="ng" index="2_iKZX">
         <child id="8811147530085329321" name="type" index="2S399n" />
       </concept>
@@ -239,9 +263,33 @@
             <node concept="OjmMv" id="6N7p0lWyjbG" role="1w35rA">
               <node concept="19SGf9" id="6N7p0lWyjbH" role="OjmMu">
                 <node concept="19SUe$" id="6N7p0lWyjbI" role="19SJt6">
-                  <property role="19SUeA" value="Test binary equality expression with records and temporals. &#10;Since in the temporal language, behavior of the typesystem for the BinaryEqualityExpression isoverridden, the plain case is also tested here.  &#10;" />
+                  <property role="19SUeA" value="Test binary equality expression with records and temporals. &#10;Since in the temporal language, behavior of the typesystem for the BinaryEqualityExpression is overridden, the plain case is also tested here.  &#10;" />
                 </node>
               </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="6W4XqNw1HHh" role="_iOnB">
+          <property role="TrG5h" value="date1" />
+          <node concept="1fc2QT" id="6W4XqNw1HNS" role="2zPyp_">
+            <property role="1fc2QW" value="02" />
+            <property role="1fc2QX" value="02" />
+            <property role="1fc2QY" value="2000" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="6belQKqmgEj" role="_iOnB">
+          <property role="TrG5h" value="date1Ref" />
+          <node concept="_emDc" id="6belQKqmgNR" role="2zPyp_">
+            <ref role="_emDf" node="6W4XqNw1HHh" resolve="date1" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="6belQKqmk8l" role="_iOnB">
+          <property role="TrG5h" value="dateList" />
+          <node concept="3iBYfx" id="6belQKqmnyK" role="2zPyp_">
+            <node concept="1fc2QT" id="6belQKqmodb" role="3iBYfI">
+              <property role="1fc2QW" value="01" />
+              <property role="1fc2QX" value="01" />
+              <property role="1fc2QY" value="2000" />
             </node>
           </node>
         </node>
@@ -294,7 +342,11 @@
               <ref role="_emDf" node="6N7p0lWtErk" resolve="point1" />
             </node>
             <node concept="7CXmI" id="6N7p0lWyiMy" role="lGtFl">
-              <node concept="1TM$A" id="6N7p0lWyiMz" role="7EUXB" />
+              <node concept="1TM$A" id="6belQKqkoVv" role="7EUXB">
+                <node concept="2PYRI3" id="6belQKqkoVw" role="3lydEf">
+                  <ref role="39XzEq" to="3ypn:6xvNSEj8hpl" />
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -331,12 +383,234 @@
               <ref role="_emDf" node="6N7p0lWuM1Z" resolve="tempPoint" />
             </node>
             <node concept="7CXmI" id="6N7p0lWyiQT" role="lGtFl">
-              <node concept="1TM$A" id="6N7p0lWyiQU" role="7EUXB" />
+              <node concept="1TM$A" id="6belQKqksGW" role="7EUXB">
+                <node concept="2PYRI3" id="6belQKqksGX" role="3lydEf">
+                  <ref role="39XzEq" to="3ypn:6xvNSEj8hpl" />
+                </node>
+              </node>
             </node>
           </node>
         </node>
         <node concept="_ixoA" id="4Uid4MjTKwo" role="_iOnB" />
-        <node concept="_ixoA" id="4Uid4MjTK5W" role="_iOnB" />
+        <node concept="2zPypq" id="6W4XqNw1sFZ" role="_iOnB">
+          <property role="TrG5h" value="uniqueTimeSlices" />
+          <node concept="FfN7I" id="6W4XqNw1sLS" role="2zPyp_">
+            <node concept="FfN7L" id="6W4XqNw1sMc" role="FfN64">
+              <node concept="_emDc" id="6W4XqNw1sMb" role="FfN7M">
+                <ref role="_emDf" node="7aRvJQErc4O" resolve="date0" />
+              </node>
+              <node concept="_emDc" id="6W4XqNw1sMO" role="FfN7O">
+                <ref role="_emDf" node="6N7p0lWtErk" resolve="point1" />
+              </node>
+            </node>
+            <node concept="FfN7L" id="6W4XqNw1sRL" role="FfN64">
+              <node concept="_emDc" id="6W4XqNw1sWW" role="FfN7M">
+                <ref role="_emDf" node="6W4XqNw1HHh" resolve="date1" />
+              </node>
+              <node concept="_emDc" id="6W4XqNw1t1L" role="FfN7O">
+                <ref role="_emDf" node="6N7p0lWtErk" resolve="point1" />
+              </node>
+            </node>
+            <node concept="7CXmI" id="6W4XqNwcz16" role="lGtFl">
+              <node concept="7OXhh" id="6W4XqNwcz6W" role="7EUXB">
+                <property role="GvXf4" value="true" />
+              </node>
+              <node concept="2aEySx" id="6W4XqNwczcM" role="lGtFl">
+                <node concept="19SGf9" id="6W4XqNwczcN" role="2aEySw">
+                  <node concept="19SUe$" id="6W4XqNwczcO" role="19SJt6">
+                    <property role="19SUeA" value="TT with unique dates in slices shows no errors" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="6W4XqNwbQ6a" role="_iOnB">
+          <property role="TrG5h" value="duplicateTimeSlice" />
+          <node concept="FfN7I" id="6W4XqNwbQ6b" role="2zPyp_">
+            <node concept="FfN7L" id="6W4XqNwbQ6c" role="FfN64">
+              <node concept="_emDc" id="6W4XqNwbQ6e" role="FfN7O">
+                <ref role="_emDf" node="6N7p0lWtErk" resolve="point1" />
+              </node>
+              <node concept="1fc2QT" id="5oaaToWWCTk" role="FfN7M">
+                <property role="1fc2QY" value="2013" />
+                <property role="1fc2QX" value="01" />
+                <property role="1fc2QW" value="01" />
+              </node>
+            </node>
+            <node concept="FfN7L" id="6W4XqNwbQ6f" role="FfN64">
+              <node concept="_emDc" id="6W4XqNwbQ6h" role="FfN7O">
+                <ref role="_emDf" node="6N7p0lWtErk" resolve="point1" />
+              </node>
+              <node concept="1fc2QT" id="5oaaToWWP6j" role="FfN7M">
+                <property role="1fc2QY" value="2013" />
+                <property role="1fc2QX" value="01" />
+                <property role="1fc2QW" value="01" />
+                <node concept="7CXmI" id="6belQKqogu1" role="lGtFl">
+                  <node concept="1TM$A" id="6belQKqoh2H" role="7EUXB">
+                    <node concept="2PYRI3" id="6belQKqoh2I" role="3lydEf">
+                      <ref role="39XzEq" to="3ypn:6W4XqNw24fs" />
+                    </node>
+                  </node>
+                  <node concept="2aEySx" id="6belQKqohci" role="lGtFl">
+                    <node concept="19SGf9" id="6belQKqohcj" role="2aEySw">
+                      <node concept="19SUe$" id="6belQKqohck" role="19SJt6">
+                        <property role="19SUeA" value="TT with duplicate point in time; DateLiteral vs DateLiteral " />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5oaaToWXX91" role="_iOnB">
+          <property role="TrG5h" value="duplicateTimeSlice2" />
+          <node concept="FfN7I" id="5oaaToWXX92" role="2zPyp_">
+            <node concept="FfN7L" id="5oaaToWXX93" role="FfN64">
+              <node concept="_emDc" id="5oaaToWXX94" role="FfN7O">
+                <ref role="_emDf" node="6N7p0lWtErk" resolve="point1" />
+              </node>
+              <node concept="1fc2QT" id="5oaaToWXXoI" role="FfN7M">
+                <property role="1fc2QY" value="2000" />
+                <property role="1fc2QX" value="01" />
+                <property role="1fc2QW" value="01" />
+              </node>
+            </node>
+            <node concept="FfN7L" id="5oaaToWXX96" role="FfN64">
+              <node concept="_emDc" id="5oaaToWXX97" role="FfN7O">
+                <ref role="_emDf" node="6N7p0lWtErk" resolve="point1" />
+              </node>
+              <node concept="_emDc" id="5oaaToWXX98" role="FfN7M">
+                <ref role="_emDf" node="7aRvJQErc4O" resolve="date0" />
+                <node concept="7CXmI" id="6belQKqohGU" role="lGtFl">
+                  <node concept="1TM$A" id="6belQKqoihA" role="7EUXB">
+                    <node concept="2PYRI3" id="6belQKqoihB" role="3lydEf">
+                      <ref role="39XzEq" to="3ypn:6W4XqNw24fs" />
+                    </node>
+                  </node>
+                  <node concept="2aEySx" id="6belQKqoirr" role="lGtFl">
+                    <node concept="19SGf9" id="6belQKqoirs" role="2aEySw">
+                      <node concept="19SUe$" id="6belQKqoirt" role="19SJt6">
+                        <property role="19SUeA" value="TT with duplicate point in time; DateLiteral vs DateConstantRef" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5oaaToWXMCy" role="_iOnB">
+          <property role="TrG5h" value="duplicateTimeSlice3" />
+          <node concept="FfN7I" id="5oaaToWXMCz" role="2zPyp_">
+            <node concept="FfN7L" id="5oaaToWXMC$" role="FfN64">
+              <node concept="_emDc" id="5oaaToWXMC_" role="FfN7O">
+                <ref role="_emDf" node="6N7p0lWtErk" resolve="point1" />
+              </node>
+              <node concept="_emDc" id="5oaaToWXMXF" role="FfN7M">
+                <ref role="_emDf" node="7aRvJQErc4O" resolve="date0" />
+              </node>
+            </node>
+            <node concept="FfN7L" id="5oaaToWXMCB" role="FfN64">
+              <node concept="_emDc" id="5oaaToWXMCC" role="FfN7O">
+                <ref role="_emDf" node="6N7p0lWtErk" resolve="point1" />
+              </node>
+              <node concept="_emDc" id="5oaaToWXNav" role="FfN7M">
+                <ref role="_emDf" node="7aRvJQErc4O" resolve="date0" />
+                <node concept="7CXmI" id="6belQKqoiIN" role="lGtFl">
+                  <node concept="1TM$A" id="6belQKqojjv" role="7EUXB">
+                    <node concept="2PYRI3" id="6belQKqojjw" role="3lydEf">
+                      <ref role="39XzEq" to="3ypn:6W4XqNw24fs" />
+                    </node>
+                  </node>
+                  <node concept="2aEySx" id="6belQKqojt4" role="lGtFl">
+                    <node concept="19SGf9" id="6belQKqojt5" role="2aEySw">
+                      <node concept="19SUe$" id="6belQKqojt6" role="19SJt6">
+                        <property role="19SUeA" value="TT with duplicate point in time; DateConstantRef vs DateConstantRef" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="6belQKqmhzY" role="_iOnB">
+          <property role="TrG5h" value="duplicateTimeSlice4" />
+          <node concept="FfN7I" id="6belQKqmhzZ" role="2zPyp_">
+            <node concept="FfN7L" id="6belQKqmh$0" role="FfN64">
+              <node concept="_emDc" id="6belQKqmh$1" role="FfN7O">
+                <ref role="_emDf" node="6N7p0lWtErk" resolve="point1" />
+              </node>
+              <node concept="_emDc" id="6belQKqmh$2" role="FfN7M">
+                <ref role="_emDf" node="6W4XqNw1HHh" resolve="date1" />
+              </node>
+            </node>
+            <node concept="FfN7L" id="6belQKqmh$3" role="FfN64">
+              <node concept="_emDc" id="6belQKqmh$4" role="FfN7O">
+                <ref role="_emDf" node="6N7p0lWtErk" resolve="point1" />
+              </node>
+              <node concept="_emDc" id="6belQKqmh$5" role="FfN7M">
+                <ref role="_emDf" node="6belQKqmgEj" resolve="date1Ref" />
+                <node concept="7CXmI" id="6belQKqojKs" role="lGtFl">
+                  <node concept="1TM$A" id="6belQKqokl8" role="7EUXB">
+                    <node concept="2PYRI3" id="6belQKqokl9" role="3lydEf">
+                      <ref role="39XzEq" to="3ypn:6W4XqNw24fs" />
+                    </node>
+                  </node>
+                  <node concept="2aEySx" id="6belQKqokuH" role="lGtFl">
+                    <node concept="19SGf9" id="6belQKqokuI" role="2aEySw">
+                      <node concept="19SUe$" id="6belQKqokuJ" role="19SJt6">
+                        <property role="19SUeA" value="TT with duplicate point in time; DateConstantRef vs DateConstantRef-Ref" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="6belQKqmjyP" role="_iOnB">
+          <property role="TrG5h" value="duplicateTimeSlice5" />
+          <node concept="FfN7I" id="6belQKqmjyQ" role="2zPyp_">
+            <node concept="FfN7L" id="6belQKqmjyR" role="FfN64">
+              <node concept="_emDc" id="6belQKqmjyS" role="FfN7O">
+                <ref role="_emDf" node="6N7p0lWtErk" resolve="point1" />
+              </node>
+              <node concept="_emDc" id="6belQKqmjyT" role="FfN7M">
+                <ref role="_emDf" node="6W4XqNw1HHh" resolve="date1" />
+              </node>
+            </node>
+            <node concept="FfN7L" id="6belQKqmjyU" role="FfN64">
+              <node concept="_emDc" id="6belQKqmjyV" role="FfN7O">
+                <ref role="_emDf" node="6N7p0lWtErk" resolve="point1" />
+              </node>
+              <node concept="wdKpt" id="6belQKqnTYn" role="FfN7M">
+                <node concept="1QScDb" id="6belQKqmkRE" role="30czhm">
+                  <node concept="3iB7TU" id="6belQKqml6$" role="1QScD9" />
+                  <node concept="_emDc" id="6belQKqmjyW" role="30czhm">
+                    <ref role="_emDf" node="6belQKqmk8l" resolve="dateList" />
+                  </node>
+                </node>
+                <node concept="7CXmI" id="6belQKqnUQH" role="lGtFl">
+                  <node concept="29bkU" id="6belQKqnVrp" role="7EUXB">
+                    <node concept="2PQEqo" id="6belQKqnVrq" role="3lydCh">
+                      <ref role="39XzEq" to="3ypn:6belQKqlkmr" />
+                    </node>
+                  </node>
+                  <node concept="2aEySx" id="6belQKqnV_e" role="lGtFl">
+                    <node concept="19SGf9" id="6belQKqnV_f" role="2aEySw">
+                      <node concept="19SUe$" id="6belQKqnV_g" role="19SJt6">
+                        <property role="19SUeA" value="If a reference cannot be unwrapped, the duplicate check doesn't work. The user should be aware of it." />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -35,6 +35,7 @@
     <import index="b1h1" ref="r:ac5f749f-6179-4d4f-ad24-ad9edbd8077b(org.iets3.core.expr.simpleTypes.behavior)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
+    <import index="mi3w" ref="r:9ec53fca-e669-4a18-ba8b-6c9f4f1cb361(org.iets3.core.expr.datetime.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -644,6 +645,12 @@
         <child id="8427750732757990724" name="expected" index="3tpDZB" />
       </concept>
       <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1172073500303" name="jetbrains.mps.baseLanguage.unitTest.structure.Message" flags="ng" index="3_1$Yv">
+        <child id="1172073511101" name="message" index="3_1BAH" />
+      </concept>
+      <concept id="1172075514136" name="jetbrains.mps.baseLanguage.unitTest.structure.MessageHolder" flags="ng" index="3_9gw8">
+        <child id="1172075534298" name="message" index="3_9lra" />
+      </concept>
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
       <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
@@ -15015,6 +15022,119 @@
   </node>
   <node concept="1lH9Xt" id="7aRvJQEkOc$">
     <property role="TrG5h" value="dateStuff" />
+    <node concept="1LZb2c" id="3FK6iin2JaJ" role="1SL9yI">
+      <property role="TrG5h" value="isSame" />
+      <node concept="3cqZAl" id="3FK6iin2JaK" role="3clF45" />
+      <node concept="3clFbS" id="3FK6iin2JaO" role="3clF47">
+        <node concept="3cpWs8" id="3FK6iin2Jgi" role="3cqZAp">
+          <node concept="3cpWsn" id="3FK6iin2Jgl" role="3cpWs9">
+            <property role="TrG5h" value="jan_1_2000" />
+            <node concept="3Tqbb2" id="3FK6iin2Jgh" role="1tU5fm">
+              <ref role="ehGHo" to="mi3w:3nGzaxURa4h" resolve="DateLiteral" />
+            </node>
+            <node concept="2c44tf" id="3FK6iin2K8w" role="33vP2m">
+              <node concept="1fc2QT" id="3FK6iin2Kaz" role="2c44tc">
+                <property role="1fc2QW" value="01" />
+                <property role="1fc2QX" value="01" />
+                <property role="1fc2QY" value="2000" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3FK6iin6Ya2" role="3cqZAp">
+          <node concept="3cpWsn" id="3FK6iin6Ya3" role="3cpWs9">
+            <property role="TrG5h" value="jan_1_2000_copy" />
+            <node concept="3Tqbb2" id="3FK6iin6Ya4" role="1tU5fm">
+              <ref role="ehGHo" to="mi3w:3nGzaxURa4h" resolve="DateLiteral" />
+            </node>
+            <node concept="2c44tf" id="3FK6iin6Ya5" role="33vP2m">
+              <node concept="1fc2QT" id="3FK6iin6Ya6" role="2c44tc">
+                <property role="1fc2QW" value="01" />
+                <property role="1fc2QX" value="01" />
+                <property role="1fc2QY" value="2000" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3FK6iin2K6y" role="3cqZAp">
+          <node concept="3cpWsn" id="3FK6iin2K6z" role="3cpWs9">
+            <property role="TrG5h" value="jan_2_2000" />
+            <node concept="3Tqbb2" id="3FK6iin2K6p" role="1tU5fm">
+              <ref role="ehGHo" to="mi3w:3nGzaxURa4h" resolve="DateLiteral" />
+            </node>
+            <node concept="2c44tf" id="3FK6iin2K6$" role="33vP2m">
+              <node concept="1fc2QT" id="3FK6iin2K6_" role="2c44tc">
+                <property role="1fc2QW" value="02" />
+                <property role="1fc2QX" value="01" />
+                <property role="1fc2QY" value="2000" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3FK6iin2JhT" role="3cqZAp" />
+        <node concept="3vlDli" id="3FK6iin2Kf4" role="3cqZAp">
+          <node concept="3clFbT" id="3FK6iin45u_" role="3tpDZB">
+            <property role="3clFbU" value="true" />
+          </node>
+          <node concept="2OqwBi" id="3FK6iin2Kpb" role="3tpDZA">
+            <node concept="37vLTw" id="3FK6iin2Kfx" role="2Oq$k0">
+              <ref role="3cqZAo" node="3FK6iin2Jgl" resolve="date1" />
+            </node>
+            <node concept="2qgKlT" id="3FK6iin2KQt" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:7GwCuf2r4g6" resolve="isSameAs" />
+              <node concept="37vLTw" id="3FK6iin2KXz" role="37wK5m">
+                <ref role="3cqZAo" node="3FK6iin2Jgl" resolve="date1" />
+              </node>
+            </node>
+          </node>
+          <node concept="3_1$Yv" id="3FK6iin7yJJ" role="3_9lra">
+            <node concept="Xl_RD" id="3FK6iin7yQi" role="3_1BAH">
+              <property role="Xl_RC" value="date literal equals itself" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="3FK6iin2La6" role="3cqZAp">
+          <node concept="2OqwBi" id="3FK6iin2La7" role="3tpDZA">
+            <node concept="37vLTw" id="3FK6iin2La8" role="2Oq$k0">
+              <ref role="3cqZAo" node="3FK6iin2Jgl" resolve="date1" />
+            </node>
+            <node concept="2qgKlT" id="3FK6iin2La9" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:7GwCuf2r4g6" resolve="isSameAs" />
+              <node concept="37vLTw" id="3FK6iin2Laa" role="37wK5m">
+                <ref role="3cqZAo" node="3FK6iin2K6z" resolve="date2" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbT" id="3FK6iin47pv" role="3tpDZB" />
+          <node concept="3_1$Yv" id="3FK6iin7zEg" role="3_9lra">
+            <node concept="Xl_RD" id="3FK6iin7zKN" role="3_1BAH">
+              <property role="Xl_RC" value="date literal equals a date literal with a different date" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vlDli" id="3FK6iin6Ynw" role="3cqZAp">
+          <node concept="2OqwBi" id="3FK6iin6Ynx" role="3tpDZA">
+            <node concept="37vLTw" id="3FK6iin6Yny" role="2Oq$k0">
+              <ref role="3cqZAo" node="3FK6iin2Jgl" resolve="date1" />
+            </node>
+            <node concept="2qgKlT" id="3FK6iin6Ynz" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:7GwCuf2r4g6" resolve="isSameAs" />
+              <node concept="37vLTw" id="3FK6iin6Yn$" role="37wK5m">
+                <ref role="3cqZAo" node="3FK6iin6Ya3" resolve="date3" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbT" id="3FK6iin7$A8" role="3tpDZB">
+            <property role="3clFbU" value="true" />
+          </node>
+          <node concept="3_1$Yv" id="3FK6iin7kEP" role="3_9lra">
+            <node concept="Xl_RD" id="3FK6iin7l7q" role="3_1BAH">
+              <property role="Xl_RC" value="two date literals of the same date are equal" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="1qefOq" id="7aRvJQEkOc_" role="1SKRRt">
       <node concept="_iOnV" id="7aRvJQEkOcA" role="1qenE9">
         <property role="TrG5h" value="dateStuf" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
@@ -30,6 +30,7 @@
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
     <dependency reexport="false">7a5dda62-9140-4668-ab76-d5ed1746f2b2(jetbrains.mps.lang.typesystem)</dependency>
     <dependency reexport="false">b25b8ad1-4d3d-4e45-8c78-72091b39fdda(org.iets3.core.expr.data)</dependency>
+    <dependency reexport="false">4621d3e3-b8a3-4bbe-b7ac-234b6e2d1d68(org.iets3.core.expr.temporal)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
@@ -143,6 +144,7 @@
     <module reference="1157d4c9-6175-4550-96aa-aae0a9fdc06f(org.iets3.core.expr.repl.plugin)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="1" />
     <module reference="197e2a32-ff26-4358-af5c-731ae2b35f83(org.iets3.core.expr.simpleTypes.interpreter)" version="0" />
+    <module reference="4621d3e3-b8a3-4bbe-b7ac-234b6e2d1d68(org.iets3.core.expr.temporal)" version="1" />
     <module reference="7a4a0378-45ed-4612-99b5-b72416acc630(org.iets3.core.expr.tests.interpreter)" version="0" />
     <module reference="6effa8ea-ddf9-441a-a29e-80a73b7d0fc7(org.iets3.core.expr.tests.rt)" version="0" />
     <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="2" />


### PR DESCRIPTION
`TemporalLiterals` may have multiple slices with different values at different points in time. Slices with the same point in time are forbidden, because it can lead to nondeterministic behaviour. 
Thus a check is introduced to show an error on each slices point in time, if the date is a duplicate, i.e. the date is already used in another slice. The check retrieves the date literals in the slices' point in time and compares them against each other. It can handle date literals and (nested) references to constants defining a date via a date literal. 

If a point in time cannot be unwrapped to a date literal, e.g. the date literal is part of a list, then a warning is shown, that the date literal couldn't be retrieved. This indicates, that the duplicates-check  cannot be applied to this slice and its point in time.