### PR TITLE
Remove ugly empty symbol in function editor

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -748,6 +748,7 @@
           <ref role="1NtTu8" to="zzzn:49WTic8eSCZ" resolve="args" />
           <ref role="1ERwB7" node="2KGel$SrnV0" resolve="deleteFunParens" />
           <node concept="l2Vlx" id="4Lmaxwvn71q" role="2czzBx" />
+          <node concept="3F0ifn" id="7joYtgBM8Bt" role="2czzBI" />
         </node>
         <node concept="3F0ifn" id="49WTic8f4ui" role="3EZMnx">
           <property role="3F0ifm" value=")" />


### PR DESCRIPTION
This PR only changes the editor of functions in iets3 when no argument is given.

Before:
![Screenshot_20231117_105605](https://github.com/IETS3/iets3.opensource/assets/3237993/2f4f2096-6efc-4413-bd95-5cfb53ec6799)

After:
![Screenshot_20231117_105706](https://github.com/IETS3/iets3.opensource/assets/3237993/1e9969c2-8c13-4d07-89e8-f6c1e2270e69)

