### PR TITLE
Add a cycle check to the unit definition + use correct conversion specifier when converting units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented in this file.
 
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). 
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
+
+## November 2023
+
+### Fixes
+
+- Unit definitions are now checked for cycles.
+- When units are converted, the specified conversion specifier is used, instead of the first one.
+
 ## October 2023
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 ### Fixes
 
 - Unit definitions are now checked for cycles.
-- When units are converted, the specified conversion specifier is used, instead of the first one.
+- Units now provide an extension point to configure which conversion specifier is used per default.
+  Per default the first available one is used as in older versions. The extension point supports using the one specified in the conversion expression.
 
 ## October 2023
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/behavior.mps
@@ -1409,6 +1409,102 @@
       </node>
       <node concept="17QB3L" id="49jLf4T793V" role="3clF45" />
     </node>
+    <node concept="13i0hz" id="9MvF2i49cL" role="13h7CS">
+      <property role="TrG5h" value="getDependenciesRelevantForCycleDetection" />
+      <ref role="13i0hy" to="hwgx:59HbAIOYveX" resolve="getDependenciesRelevantForCycleDetection" />
+      <node concept="3Tm1VV" id="9MvF2i49cM" role="1B3o_S" />
+      <node concept="3clFbS" id="9MvF2i49cQ" role="3clF47">
+        <node concept="3clFbF" id="RIvadv1enL" role="3cqZAp">
+          <node concept="2OqwBi" id="RIvadv1l_X" role="3clFbG">
+            <node concept="2OqwBi" id="RIvadv1fk6" role="2Oq$k0">
+              <node concept="2OqwBi" id="RIvadv1e_E" role="2Oq$k0">
+                <node concept="13iPFW" id="RIvadv1enK" role="2Oq$k0" />
+                <node concept="3TrEf2" id="2Fd5B1gxgPb" role="2OqNvi">
+                  <ref role="3Tt5mk" to="b0gq:7eOyx9r3k4r" resolve="specification" />
+                </node>
+              </node>
+              <node concept="2Rf3mk" id="RIvadv1fxA" role="2OqNvi">
+                <node concept="1xMEDy" id="RIvadv1fxC" role="1xVPHs">
+                  <node concept="chp4Y" id="2Fd5B1gxdiC" role="ri$Ld">
+                    <ref role="cht4Q" to="b0gq:7eOyx9r3kR5" resolve="UnitReference" />
+                  </node>
+                </node>
+                <node concept="1xIGOp" id="RIvadv2xVe" role="1xVPHs" />
+              </node>
+            </node>
+            <node concept="3$u5V9" id="RIvadv2InJ" role="2OqNvi">
+              <node concept="1bVj0M" id="RIvadv2InL" role="23t8la">
+                <node concept="3clFbS" id="RIvadv2InM" role="1bW5cS">
+                  <node concept="3clFbF" id="RIvadv2Ivk" role="3cqZAp">
+                    <node concept="2OqwBi" id="RIvadv2IDr" role="3clFbG">
+                      <node concept="37vLTw" id="RIvadv2Ivj" role="2Oq$k0">
+                        <ref role="3cqZAo" node="RIvadv2InN" resolve="it" />
+                      </node>
+                      <node concept="3TrEf2" id="2Fd5B1gxdCm" role="2OqNvi">
+                        <ref role="3Tt5mk" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="RIvadv2InN" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="RIvadv2InO" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="9MvF2i49cR" role="3clF45">
+        <node concept="3Tqbb2" id="9MvF2i49cS" role="A3Ik2">
+          <ref role="ehGHo" to="vs0r:59HbAIOYkEn" resolve="IDetectCycle" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="74SLKElqaGy" role="13h7CS">
+      <property role="TrG5h" value="traceBackElementInCycle" />
+      <ref role="13i0hy" to="hwgx:17fjvcLF7UR" resolve="traceBackElementInCycle" />
+      <node concept="3Tm1VV" id="74SLKElqaG_" role="1B3o_S" />
+      <node concept="3clFbS" id="74SLKElqaGR" role="3clF47">
+        <node concept="3cpWs8" id="4ISByPoXvbq" role="3cqZAp">
+          <node concept="3cpWsn" id="4ISByPoXvbt" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="2hMVRd" id="4ISByPoXvbm" role="1tU5fm">
+              <node concept="3Tqbb2" id="4ISByPoXvbO" role="2hN53Y" />
+            </node>
+            <node concept="2ShNRf" id="4ISByPoXveP" role="33vP2m">
+              <node concept="2i4dXS" id="4ISByPoXvdV" role="2ShVmc">
+                <node concept="3Tqbb2" id="4ISByPoXvdW" role="HW$YZ" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5eKs1GS7ScI" role="3cqZAp">
+          <node concept="2OqwBi" id="5eKs1GS7SMZ" role="3clFbG">
+            <node concept="TSZUe" id="1D8fMMrKjdJ" role="2OqNvi">
+              <node concept="13iPFW" id="1D8fMMrKjdI" role="25WWJ7" />
+            </node>
+            <node concept="37vLTw" id="5eKs1GS7ScG" role="2Oq$k0">
+              <ref role="3cqZAo" node="4ISByPoXvbt" resolve="result" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="17fjvcLFaIv" role="3cqZAp">
+          <node concept="37vLTw" id="4ISByPoXvZk" role="3cqZAk">
+            <ref role="3cqZAo" node="4ISByPoXvbt" resolve="result" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="74SLKElqaGS" role="3clF46">
+        <property role="TrG5h" value="dependency" />
+        <node concept="3Tqbb2" id="74SLKElqaGT" role="1tU5fm">
+          <ref role="ehGHo" to="vs0r:59HbAIOYkEn" resolve="IDetectCycle" />
+        </node>
+      </node>
+      <node concept="2hMVRd" id="74SLKElqaGU" role="3clF45">
+        <node concept="3Tqbb2" id="74SLKElqaGV" role="2hN53Y" />
+      </node>
+    </node>
   </node>
   <node concept="13h7C7" id="6Mx2Tmonp$n">
     <property role="3GE5qa" value="definition" />
@@ -6210,460 +6306,18 @@
       <property role="od$2w" value="false" />
       <property role="DiZV1" value="false" />
       <node concept="3clFbS" id="2Jcs$lv2BiG" role="3clF47">
-        <node concept="3cpWs8" id="2Jcs$lv2FCJ" role="3cqZAp">
-          <node concept="3cpWsn" id="2Jcs$lv2FCK" role="3cpWs9">
-            <property role="TrG5h" value="queue" />
-            <node concept="3O6Q9H" id="2Jcs$lv2FCL" role="1tU5fm">
-              <node concept="3Tqbb2" id="2Jcs$lv2H_6" role="3O5elw">
-                <ref role="ehGHo" to="b0gq:7eOyx9r3k3e" resolve="IUnit" />
+        <node concept="3clFbF" id="74SLKElmfj1" role="3cqZAp">
+          <node concept="2OqwBi" id="74SLKElmkq3" role="3clFbG">
+            <node concept="2OqwBi" id="74SLKElmfV9" role="2Oq$k0">
+              <node concept="37vLTw" id="74SLKElmfiZ" role="2Oq$k0">
+                <ref role="3cqZAo" node="2Jcs$lv2DQ5" resolve="unit" />
+              </node>
+              <node concept="2qgKlT" id="74SLKElmiYd" role="2OqNvi">
+                <ref role="37wK5l" to="hwgx:17fjvcLFUH5" resolve="getCyclicDependencyElements" />
               </node>
             </node>
-            <node concept="2ShNRf" id="2Jcs$lv2JnJ" role="33vP2m">
-              <node concept="2Jqq0_" id="2Jcs$lv2JnD" role="2ShVmc">
-                <node concept="3Tqbb2" id="2Jcs$lv2JnE" role="HW$YZ">
-                  <ref role="ehGHo" to="b0gq:7eOyx9r3k3e" resolve="IUnit" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="2Jcs$lv2NPU" role="3cqZAp">
-          <node concept="2OqwBi" id="2Jcs$lv2Q_w" role="3clFbG">
-            <node concept="2OqwBi" id="2Jcs$lv2Pm_" role="2Oq$k0">
-              <node concept="2OqwBi" id="2Jcs$lv2O1P" role="2Oq$k0">
-                <node concept="37vLTw" id="2Jcs$lv2NPS" role="2Oq$k0">
-                  <ref role="3cqZAo" node="2Jcs$lv2DQ5" resolve="unit" />
-                </node>
-                <node concept="2qgKlT" id="1KUmgSF_Ih1" role="2OqNvi">
-                  <ref role="37wK5l" node="1KUmgSF_6QP" resolve="specification" />
-                </node>
-              </node>
-              <node concept="2qgKlT" id="1KUmgSF_IMo" role="2OqNvi">
-                <ref role="37wK5l" node="1KUmgSF_6Sp" resolve="components" />
-              </node>
-            </node>
-            <node concept="2es0OD" id="2Jcs$lv2S_j" role="2OqNvi">
-              <node concept="1bVj0M" id="2Jcs$lv2S_l" role="23t8la">
-                <node concept="3clFbS" id="2Jcs$lv2S_m" role="1bW5cS">
-                  <node concept="3clFbF" id="2Jcs$lv2SFm" role="3cqZAp">
-                    <node concept="2OqwBi" id="2Jcs$lv2SZA" role="3clFbG">
-                      <node concept="37vLTw" id="2Jcs$lv2SFl" role="2Oq$k0">
-                        <ref role="3cqZAo" node="2Jcs$lv2FCK" resolve="queue" />
-                      </node>
-                      <node concept="2Ke9KJ" id="2Jcs$lv2Uqt" role="2OqNvi">
-                        <node concept="2OqwBi" id="2Jcs$lv2UBK" role="25WWJ7">
-                          <node concept="37vLTw" id="2Jcs$lv2Uyj" role="2Oq$k0">
-                            <ref role="3cqZAo" node="2Jcs$lv2S_n" resolve="it" />
-                          </node>
-                          <node concept="3TrEf2" id="6Lx6lqAkDs" role="2OqNvi">
-                            <ref role="3Tt5mk" to="b0gq:7eOyx9r3qFW" resolve="unit" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="Rh6nW" id="2Jcs$lv2S_n" role="1bW2Oz">
-                  <property role="TrG5h" value="it" />
-                  <node concept="2jxLKc" id="2Jcs$lv2S_o" role="1tU5fm" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="2Jcs$lvqUlv" role="3cqZAp" />
-        <node concept="3SKdUt" id="2Jcs$lvqU_U" role="3cqZAp">
-          <node concept="1PaTwC" id="17Nm8oCo8FD" role="1aUNEU">
-            <node concept="3oM_SD" id="17Nm8oCo8FE" role="1PaTwD">
-              <property role="3oM_SC" value="it" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FF" role="1PaTwD">
-              <property role="3oM_SC" value="is" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FG" role="1PaTwD">
-              <property role="3oM_SC" value="better" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FH" role="1PaTwD">
-              <property role="3oM_SC" value="to" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FI" role="1PaTwD">
-              <property role="3oM_SC" value="collect" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FJ" role="1PaTwD">
-              <property role="3oM_SC" value="all" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FK" role="1PaTwD">
-              <property role="3oM_SC" value="the" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FL" role="1PaTwD">
-              <property role="3oM_SC" value="seen" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FM" role="1PaTwD">
-              <property role="3oM_SC" value="units" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FN" role="1PaTwD">
-              <property role="3oM_SC" value="instead" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FO" role="1PaTwD">
-              <property role="3oM_SC" value="of" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FP" role="1PaTwD">
-              <property role="3oM_SC" value="checking" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FQ" role="1PaTwD">
-              <property role="3oM_SC" value="at" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FR" role="1PaTwD">
-              <property role="3oM_SC" value="the" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FS" role="1PaTwD">
-              <property role="3oM_SC" value="place" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FT" role="1PaTwD">
-              <property role="3oM_SC" value="of" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FU" role="1PaTwD">
-              <property role="3oM_SC" value="addition" />
-            </node>
-          </node>
-        </node>
-        <node concept="3SKdUt" id="2Jcs$lvqUX8" role="3cqZAp">
-          <node concept="1PaTwC" id="17Nm8oCo8FV" role="1aUNEU">
-            <node concept="3oM_SD" id="17Nm8oCo8FW" role="1PaTwD">
-              <property role="3oM_SC" value="whether" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FX" role="1PaTwD">
-              <property role="3oM_SC" value="the" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FY" role="1PaTwD">
-              <property role="3oM_SC" value="unit" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8FZ" role="1PaTwD">
-              <property role="3oM_SC" value="is" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8G0" role="1PaTwD">
-              <property role="3oM_SC" value="the" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8G1" role="1PaTwD">
-              <property role="3oM_SC" value="same" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8G2" role="1PaTwD">
-              <property role="3oM_SC" value="as" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8G3" role="1PaTwD">
-              <property role="3oM_SC" value="the" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8G4" role="1PaTwD">
-              <property role="3oM_SC" value="to-be-added" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8G5" role="1PaTwD">
-              <property role="3oM_SC" value="one," />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8G6" role="1PaTwD">
-              <property role="3oM_SC" value="because" />
-            </node>
-          </node>
-        </node>
-        <node concept="3SKdUt" id="2Jcs$lvqVjh" role="3cqZAp">
-          <node concept="1PaTwC" id="17Nm8oCo8G7" role="1aUNEU">
-            <node concept="3oM_SD" id="17Nm8oCo8G8" role="1PaTwD">
-              <property role="3oM_SC" value="there" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8G9" role="1PaTwD">
-              <property role="3oM_SC" value="may" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Ga" role="1PaTwD">
-              <property role="3oM_SC" value="be" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gb" role="1PaTwD">
-              <property role="3oM_SC" value="a" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gc" role="1PaTwD">
-              <property role="3oM_SC" value="circular" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gd" role="1PaTwD">
-              <property role="3oM_SC" value="dependency" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Ge" role="1PaTwD">
-              <property role="3oM_SC" value="between" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gf" role="1PaTwD">
-              <property role="3oM_SC" value="other" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gg" role="1PaTwD">
-              <property role="3oM_SC" value="units" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gh" role="1PaTwD">
-              <property role="3oM_SC" value="and" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gi" role="1PaTwD">
-              <property role="3oM_SC" value="then" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gj" role="1PaTwD">
-              <property role="3oM_SC" value="we" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gk" role="1PaTwD">
-              <property role="3oM_SC" value="will" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gl" role="1PaTwD">
-              <property role="3oM_SC" value="end" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gm" role="1PaTwD">
-              <property role="3oM_SC" value="up" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gn" role="1PaTwD">
-              <property role="3oM_SC" value="in" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Go" role="1PaTwD">
-              <property role="3oM_SC" value="an" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gp" role="1PaTwD">
-              <property role="3oM_SC" value="infinite" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gq" role="1PaTwD">
-              <property role="3oM_SC" value="loop" />
-            </node>
-          </node>
-        </node>
-        <node concept="3SKdUt" id="2Jcs$lvqVEA" role="3cqZAp">
-          <node concept="1PaTwC" id="17Nm8oCo8Gr" role="1aUNEU">
-            <node concept="3oM_SD" id="17Nm8oCo8Gs" role="1PaTwD">
-              <property role="3oM_SC" value="nevertheless" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gt" role="1PaTwD">
-              <property role="3oM_SC" value="we" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gu" role="1PaTwD">
-              <property role="3oM_SC" value="can" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gv" role="1PaTwD">
-              <property role="3oM_SC" value="apply" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gw" role="1PaTwD">
-              <property role="3oM_SC" value="early-exit" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gx" role="1PaTwD">
-              <property role="3oM_SC" value="when" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gy" role="1PaTwD">
-              <property role="3oM_SC" value="we" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8Gz" role="1PaTwD">
-              <property role="3oM_SC" value="have" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8G$" role="1PaTwD">
-              <property role="3oM_SC" value="found" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8G_" role="1PaTwD">
-              <property role="3oM_SC" value="the" />
-            </node>
-            <node concept="3oM_SD" id="17Nm8oCo8GA" role="1PaTwD">
-              <property role="3oM_SC" value="match" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="2Jcs$lv35yB" role="3cqZAp">
-          <node concept="3cpWsn" id="2Jcs$lv35yE" role="3cpWs9">
-            <property role="TrG5h" value="seenUnits" />
-            <node concept="2hMVRd" id="2Jcs$lv35yz" role="1tU5fm">
-              <node concept="3Tqbb2" id="2Jcs$lv36ri" role="2hN53Y">
-                <ref role="ehGHo" to="b0gq:7eOyx9r3k3e" resolve="IUnit" />
-              </node>
-            </node>
-            <node concept="2ShNRf" id="2Jcs$lv36wY" role="33vP2m">
-              <node concept="2i4dXS" id="2Jcs$lv36wL" role="2ShVmc">
-                <node concept="3Tqbb2" id="2Jcs$lv36wM" role="HW$YZ">
-                  <ref role="ehGHo" to="b0gq:7eOyx9r3k3e" resolve="IUnit" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="2Jcs$lv36xW" role="3cqZAp" />
-        <node concept="2$JKZl" id="2Jcs$lv2Yid" role="3cqZAp">
-          <node concept="3clFbS" id="2Jcs$lv2Yie" role="2LFqv$">
-            <node concept="3cpWs8" id="2Jcs$lv30eQ" role="3cqZAp">
-              <node concept="3cpWsn" id="2Jcs$lv30eT" role="3cpWs9">
-                <property role="TrG5h" value="head" />
-                <node concept="3Tqbb2" id="2Jcs$lv30eO" role="1tU5fm">
-                  <ref role="ehGHo" to="b0gq:7eOyx9r3k3e" resolve="IUnit" />
-                </node>
-                <node concept="2OqwBi" id="2Jcs$lv31d9" role="33vP2m">
-                  <node concept="37vLTw" id="2Jcs$lv30Sh" role="2Oq$k0">
-                    <ref role="3cqZAo" node="2Jcs$lv2FCK" resolve="queue" />
-                  </node>
-                  <node concept="2Kt2Hk" id="2Jcs$lv3461" role="2OqNvi" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="2Jcs$lvwltX" role="3cqZAp">
-              <node concept="3clFbS" id="2Jcs$lvwlu0" role="3clFbx">
-                <node concept="3cpWs6" id="2Jcs$lvwlNC" role="3cqZAp">
-                  <node concept="3clFbT" id="2Jcs$lvwlPa" role="3cqZAk">
-                    <property role="3clFbU" value="true" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbC" id="2Jcs$lvwlDu" role="3clFbw">
-                <node concept="37vLTw" id="2Jcs$lvwlKa" role="3uHU7w">
-                  <ref role="3cqZAo" node="2Jcs$lv2DQ5" resolve="unit" />
-                </node>
-                <node concept="37vLTw" id="2Jcs$lvwl_B" role="3uHU7B">
-                  <ref role="3cqZAo" node="2Jcs$lv30eT" resolve="head" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="2Jcs$lv2Yiz" role="3cqZAp">
-              <node concept="2OqwBi" id="2Jcs$lv2Yi$" role="3clFbG">
-                <node concept="37vLTw" id="2Jcs$lv2Yi_" role="2Oq$k0">
-                  <ref role="3cqZAo" node="2Jcs$lv35yE" resolve="seenUnits" />
-                </node>
-                <node concept="TSZUe" id="2Jcs$lv2YiA" role="2OqNvi">
-                  <node concept="37vLTw" id="2Jcs$lv3emO" role="25WWJ7">
-                    <ref role="3cqZAo" node="2Jcs$lv30eT" resolve="head" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbH" id="2Jcs$lv2YiE" role="3cqZAp" />
-            <node concept="3clFbJ" id="2Jcs$lv2YiF" role="3cqZAp">
-              <node concept="3clFbS" id="2Jcs$lv2YiG" role="3clFbx">
-                <node concept="2Gpval" id="2Jcs$lv3wuH" role="3cqZAp">
-                  <node concept="2GrKxI" id="2Jcs$lv3wuI" role="2Gsz3X">
-                    <property role="TrG5h" value="component" />
-                  </node>
-                  <node concept="3clFbS" id="2Jcs$lv3wuJ" role="2LFqv$">
-                    <node concept="3SKdUt" id="2Jcs$lv3wuK" role="3cqZAp">
-                      <node concept="1PaTwC" id="17Nm8oCo8GB" role="1aUNEU">
-                        <node concept="3oM_SD" id="17Nm8oCo8GC" role="1PaTwD">
-                          <property role="3oM_SC" value="this" />
-                        </node>
-                        <node concept="3oM_SD" id="17Nm8oCo8GD" role="1PaTwD">
-                          <property role="3oM_SC" value="check" />
-                        </node>
-                        <node concept="3oM_SD" id="17Nm8oCo8GE" role="1PaTwD">
-                          <property role="3oM_SC" value="is" />
-                        </node>
-                        <node concept="3oM_SD" id="17Nm8oCo8GF" role="1PaTwD">
-                          <property role="3oM_SC" value="needed" />
-                        </node>
-                        <node concept="3oM_SD" id="17Nm8oCo8GG" role="1PaTwD">
-                          <property role="3oM_SC" value="to" />
-                        </node>
-                        <node concept="3oM_SD" id="17Nm8oCo8GH" role="1PaTwD">
-                          <property role="3oM_SC" value="handle" />
-                        </node>
-                        <node concept="3oM_SD" id="17Nm8oCo8GI" role="1PaTwD">
-                          <property role="3oM_SC" value="circular" />
-                        </node>
-                        <node concept="3oM_SD" id="17Nm8oCo8GJ" role="1PaTwD">
-                          <property role="3oM_SC" value="unit" />
-                        </node>
-                        <node concept="3oM_SD" id="17Nm8oCo8GK" role="1PaTwD">
-                          <property role="3oM_SC" value="specifications" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbJ" id="2Jcs$lv3wuM" role="3cqZAp">
-                      <node concept="3clFbS" id="2Jcs$lv3wuN" role="3clFbx">
-                        <node concept="3clFbF" id="2Jcs$lv3wuO" role="3cqZAp">
-                          <node concept="2OqwBi" id="2Jcs$lv3wuP" role="3clFbG">
-                            <node concept="37vLTw" id="2Jcs$lv3wuQ" role="2Oq$k0">
-                              <ref role="3cqZAo" node="2Jcs$lv2FCK" resolve="queue" />
-                            </node>
-                            <node concept="2Ke9KJ" id="2Jcs$lv3wuR" role="2OqNvi">
-                              <node concept="2OqwBi" id="2Jcs$lv3D65" role="25WWJ7">
-                                <node concept="2GrUjf" id="2Jcs$lv3D1p" role="2Oq$k0">
-                                  <ref role="2Gs0qQ" node="2Jcs$lv3wuI" resolve="component" />
-                                </node>
-                                <node concept="3TrEf2" id="6Lx6lqAmQi" role="2OqNvi">
-                                  <ref role="3Tt5mk" to="b0gq:7eOyx9r3qFW" resolve="unit" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="22lmx$" id="55c6fL3cMXf" role="3clFbw">
-                        <node concept="1rXfSq" id="55c6fL3d1CP" role="3uHU7w">
-                          <ref role="37wK5l" node="55c6fL3cQYS" resolve="isAtomicUnit" />
-                          <node concept="2OqwBi" id="55c6fL3d1TW" role="37wK5m">
-                            <node concept="2GrUjf" id="55c6fL3d1LC" role="2Oq$k0">
-                              <ref role="2Gs0qQ" node="2Jcs$lv3wuI" resolve="component" />
-                            </node>
-                            <node concept="3TrEf2" id="6Lx6lqAmFn" role="2OqNvi">
-                              <ref role="3Tt5mk" to="b0gq:7eOyx9r3qFW" resolve="unit" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3fqX7Q" id="2Jcs$lv3wuY" role="3uHU7B">
-                          <node concept="2OqwBi" id="2Jcs$lv3wuZ" role="3fr31v">
-                            <node concept="37vLTw" id="2Jcs$lv3wv0" role="2Oq$k0">
-                              <ref role="3cqZAo" node="2Jcs$lv35yE" resolve="seenUnits" />
-                            </node>
-                            <node concept="3JPx81" id="2Jcs$lv3wv1" role="2OqNvi">
-                              <node concept="2OqwBi" id="2Jcs$lv3wv2" role="25WWJ7">
-                                <node concept="2GrUjf" id="2Jcs$lv3wv3" role="2Oq$k0">
-                                  <ref role="2Gs0qQ" node="2Jcs$lv3wuI" resolve="component" />
-                                </node>
-                                <node concept="3TrEf2" id="6Lx6lqAmyq" role="2OqNvi">
-                                  <ref role="3Tt5mk" to="b0gq:7eOyx9r3qFW" resolve="unit" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="2Jcs$lv3$bf" role="2GsD0m">
-                    <node concept="2OqwBi" id="2Jcs$lv3yxZ" role="2Oq$k0">
-                      <node concept="37vLTw" id="2Jcs$lv3xRY" role="2Oq$k0">
-                        <ref role="3cqZAo" node="2Jcs$lv30eT" resolve="head" />
-                      </node>
-                      <node concept="2qgKlT" id="1KUmgSF_UeF" role="2OqNvi">
-                        <ref role="37wK5l" node="1KUmgSF_6QP" resolve="specification" />
-                      </node>
-                    </node>
-                    <node concept="2qgKlT" id="1KUmgSF_UUM" role="2OqNvi">
-                      <ref role="37wK5l" node="1KUmgSF_6Sp" resolve="components" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3y3z36" id="2Jcs$lv3vVW" role="3clFbw">
-                <node concept="10Nm6u" id="2Jcs$lv3wbf" role="3uHU7w" />
-                <node concept="2OqwBi" id="2Jcs$lv3uiV" role="3uHU7B">
-                  <node concept="2OqwBi" id="2Jcs$lv3sq3" role="2Oq$k0">
-                    <node concept="37vLTw" id="2Jcs$lv3rFd" role="2Oq$k0">
-                      <ref role="3cqZAo" node="2Jcs$lv30eT" resolve="head" />
-                    </node>
-                    <node concept="2qgKlT" id="1KUmgSF_Nk7" role="2OqNvi">
-                      <ref role="37wK5l" node="1KUmgSF_6QP" resolve="specification" />
-                    </node>
-                  </node>
-                  <node concept="2qgKlT" id="1KUmgSF_NE1" role="2OqNvi">
-                    <ref role="37wK5l" node="1KUmgSF_6Sp" resolve="components" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="2OqwBi" id="2Jcs$lv2YjR" role="2$JKZa">
-            <node concept="37vLTw" id="2Jcs$lv2YjS" role="2Oq$k0">
-              <ref role="3cqZAo" node="2Jcs$lv2FCK" resolve="queue" />
-            </node>
-            <node concept="3GX2aA" id="2Jcs$lv2YjT" role="2OqNvi" />
-          </node>
-        </node>
-        <node concept="3clFbH" id="2Jcs$lv2XIQ" role="3cqZAp" />
-        <node concept="3cpWs6" id="2Jcs$lv2WD$" role="3cqZAp">
-          <node concept="2OqwBi" id="2Jcs$lv54S4" role="3cqZAk">
-            <node concept="37vLTw" id="2Jcs$lv540m" role="2Oq$k0">
-              <ref role="3cqZAo" node="2Jcs$lv35yE" resolve="seenUnits" />
-            </node>
-            <node concept="3JPx81" id="2Jcs$lv5785" role="2OqNvi">
-              <node concept="37vLTw" id="2Jcs$lv57hS" role="25WWJ7">
+            <node concept="3JPx81" id="74SLKElmqAb" role="2OqNvi">
+              <node concept="37vLTw" id="74SLKElmu6Z" role="25WWJ7">
                 <ref role="3cqZAo" node="2Jcs$lv2DQ5" resolve="unit" />
               </node>
             </node>
@@ -6704,6 +6358,32 @@
                 <node concept="3Tqbb2" id="lqDNwvrYSx" role="3rHrn6">
                   <ref role="ehGHo" to="b0gq:7eOyx9r3k3e" resolve="IUnit" />
                 </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="7b$SURZ4aLX" role="3cqZAp">
+          <node concept="3clFbS" id="7b$SURZ4aLZ" role="3clFbx">
+            <node concept="3cpWs6" id="7b$SURZ4_JD" role="3cqZAp">
+              <node concept="37vLTw" id="7b$SURZ4Are" role="3cqZAk">
+                <ref role="3cqZAo" node="4jkbLB5XHt2" resolve="result" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7b$SURZ4uv0" role="3clFbw">
+            <node concept="2qgKlT" id="7b$SURZ4xXs" role="2OqNvi">
+              <ref role="37wK5l" to="hwgx:59HbAIOYtvQ" resolve="isInvolvedInCycle" />
+            </node>
+            <node concept="1PxgMI" id="7b$SURZ4omX" role="2Oq$k0">
+              <property role="1BlNFB" value="true" />
+              <node concept="chp4Y" id="7b$SURZ4rk8" role="3oSUPX">
+                <ref role="cht4Q" to="b0gq:7eOyx9r3jsZ" resolve="Unit" />
+              </node>
+              <node concept="2OqwBi" id="7b$SURZ4ihT" role="1m5AlR">
+                <node concept="37vLTw" id="7b$SURZ4f9P" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1GIWTDBlX2u" resolve="specification" />
+                </node>
+                <node concept="1mfA1w" id="7b$SURZ4lpQ" role="2OqNvi" />
               </node>
             </node>
           </node>
@@ -7014,48 +6694,6 @@
                   </node>
                 </node>
               </node>
-              <node concept="9aQIb" id="4jkbLB5XseR" role="9aQIa">
-                <node concept="3clFbS" id="4jkbLB5XseS" role="9aQI4">
-                  <node concept="2Gpval" id="4jkbLB5WCOr" role="3cqZAp">
-                    <node concept="2GrKxI" id="4jkbLB5WCOt" role="2Gsz3X">
-                      <property role="TrG5h" value="component" />
-                    </node>
-                    <node concept="3clFbS" id="4jkbLB5WCOx" role="2LFqv$">
-                      <node concept="3clFbF" id="5rl0a66_MzE" role="3cqZAp">
-                        <node concept="2OqwBi" id="5rl0a66_N47" role="3clFbG">
-                          <node concept="37vLTw" id="5rl0a66_MzC" role="2Oq$k0">
-                            <ref role="3cqZAo" node="5rl0a66xc17" resolve="queue" />
-                          </node>
-                          <node concept="2Ke9KJ" id="5rl0a66_Pn4" role="2OqNvi">
-                            <node concept="1Ls8ON" id="5rl0a66_PvU" role="25WWJ7">
-                              <node concept="2GrUjf" id="5rl0a66_PKt" role="1Lso8e">
-                                <ref role="2Gs0qQ" node="4jkbLB5WCOt" resolve="component" />
-                              </node>
-                              <node concept="2OqwBi" id="5dSoB2LU4PU" role="1Lso8e">
-                                <node concept="1rXfSq" id="5rl0a66_Qj2" role="2Oq$k0">
-                                  <ref role="37wK5l" node="4jkbLB68OYa" resolve="getExponent" />
-                                  <node concept="2GrUjf" id="5rl0a66_Qj3" role="37wK5m">
-                                    <ref role="2Gs0qQ" node="4jkbLB5WCOt" resolve="component" />
-                                  </node>
-                                </node>
-                                <node concept="liA8E" id="5dSoB2LU5z0" role="2OqNvi">
-                                  <ref role="37wK5l" node="5dSoB2LN99N" resolve="multiply" />
-                                  <node concept="37vLTw" id="2d0sr0BICVY" role="37wK5m">
-                                    <ref role="3cqZAo" node="5rl0a66zvH$" resolve="headExponent" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="37vLTw" id="4jkbLB5XucM" role="2GsD0m">
-                      <ref role="3cqZAo" node="4jkbLB5XgpJ" resolve="components" />
-                    </node>
-                  </node>
-                </node>
-              </node>
               <node concept="22lmx$" id="4jkbLB5XmkY" role="3clFbw">
                 <node concept="2OqwBi" id="4jkbLB5Xn7K" role="3uHU7w">
                   <node concept="37vLTw" id="4jkbLB5Xmnc" role="2Oq$k0">
@@ -7068,6 +6706,63 @@
                     <ref role="3cqZAo" node="4jkbLB5XgpJ" resolve="components" />
                   </node>
                   <node concept="10Nm6u" id="4jkbLB5Xmk3" role="3uHU7w" />
+                </node>
+              </node>
+              <node concept="3eNFk2" id="74SLKElldT0" role="3eNLev">
+                <node concept="3clFbS" id="74SLKElldT1" role="3eOfB_">
+                  <node concept="2Gpval" id="74SLKElldT2" role="3cqZAp">
+                    <node concept="2GrKxI" id="74SLKElldT3" role="2Gsz3X">
+                      <property role="TrG5h" value="component" />
+                    </node>
+                    <node concept="3clFbS" id="74SLKElldT4" role="2LFqv$">
+                      <node concept="3clFbF" id="74SLKElldT5" role="3cqZAp">
+                        <node concept="2OqwBi" id="74SLKElldT6" role="3clFbG">
+                          <node concept="37vLTw" id="74SLKElldT7" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5rl0a66xc17" resolve="queue" />
+                          </node>
+                          <node concept="2Ke9KJ" id="74SLKElldT8" role="2OqNvi">
+                            <node concept="1Ls8ON" id="74SLKElldT9" role="25WWJ7">
+                              <node concept="2GrUjf" id="74SLKElldTa" role="1Lso8e">
+                                <ref role="2Gs0qQ" node="74SLKElldT3" resolve="component" />
+                              </node>
+                              <node concept="2OqwBi" id="74SLKElldTb" role="1Lso8e">
+                                <node concept="1rXfSq" id="74SLKElldTc" role="2Oq$k0">
+                                  <ref role="37wK5l" node="4jkbLB68OYa" resolve="getExponent" />
+                                  <node concept="2GrUjf" id="74SLKElldTd" role="37wK5m">
+                                    <ref role="2Gs0qQ" node="74SLKElldT3" resolve="component" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="74SLKElldTe" role="2OqNvi">
+                                  <ref role="37wK5l" node="5dSoB2LN99N" resolve="multiply" />
+                                  <node concept="37vLTw" id="74SLKElldTf" role="37wK5m">
+                                    <ref role="3cqZAo" node="5rl0a66zvH$" resolve="headExponent" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="74SLKElldTg" role="2GsD0m">
+                      <ref role="3cqZAo" node="4jkbLB5XgpJ" resolve="components" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3fqX7Q" id="74SLKElm2xB" role="3eO9$A">
+                  <node concept="2OqwBi" id="74SLKElm2xD" role="3fr31v">
+                    <node concept="2OqwBi" id="74SLKElm2xE" role="2Oq$k0">
+                      <node concept="37vLTw" id="74SLKElm2xF" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5rl0a66yo1W" resolve="headReference" />
+                      </node>
+                      <node concept="3TrEf2" id="74SLKElm2xG" role="2OqNvi">
+                        <ref role="3Tt5mk" to="b0gq:7eOyx9r3qFW" resolve="unit" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="74SLKElm2xH" role="2OqNvi">
+                      <ref role="37wK5l" to="hwgx:59HbAIOYtvQ" resolve="isInvolvedInCycle" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -7165,6 +6860,24 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbJ" id="5TRhfIcb1_3" role="3cqZAp">
+          <node concept="3clFbS" id="5TRhfIcb1_5" role="3clFbx">
+            <node concept="3cpWs6" id="5TRhfIcbbqp" role="3cqZAp">
+              <node concept="37vLTw" id="5TRhfIcbxhc" role="3cqZAk">
+                <ref role="3cqZAo" node="3$KQaHcbl4m" resolve="result" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="5TRhfIcb567" role="3clFbw">
+            <node concept="37vLTw" id="5TRhfIcb4B_" role="2Oq$k0">
+              <ref role="3cqZAo" node="3$KQaHcb8UG" resolve="unit" />
+            </node>
+            <node concept="2qgKlT" id="5TRhfIcb8aw" role="2OqNvi">
+              <ref role="37wK5l" to="hwgx:59HbAIOYtvQ" resolve="isInvolvedInCycle" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5TRhfIcbmn_" role="3cqZAp" />
         <node concept="3cpWs8" id="3$KQaHcbl4K" role="3cqZAp">
           <node concept="3cpWsn" id="3$KQaHcbl4L" role="3cpWs9">
             <property role="TrG5h" value="components" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/org.iets3.core.expr.typetags.units.plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/org.iets3.core.expr.typetags.units.plugin.mps
@@ -1489,6 +1489,31 @@
             </node>
           </node>
         </node>
+        <node concept="3SKdUt" id="3bE2i5JypcP" role="3cqZAp">
+          <node concept="1PaTwC" id="3bE2i5JypcQ" role="1aUNEU">
+            <node concept="3oM_SD" id="3bE2i5Jypff" role="1PaTwD">
+              <property role="3oM_SC" value="null" />
+            </node>
+            <node concept="3oM_SD" id="3bE2i5JypCM" role="1PaTwD">
+              <property role="3oM_SC" value="case" />
+            </node>
+            <node concept="3oM_SD" id="3bE2i5JypD8" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="3bE2i5JypDv" role="1PaTwD">
+              <property role="3oM_SC" value="fallback," />
+            </node>
+            <node concept="3oM_SD" id="3bE2i5Jypfh" role="1PaTwD">
+              <property role="3oM_SC" value="should" />
+            </node>
+            <node concept="3oM_SD" id="3bE2i5Jypfk" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="3bE2i5Jypfo" role="1PaTwD">
+              <property role="3oM_SC" value="happen" />
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="4qv99IrBJoK" role="3cqZAp">
           <node concept="3K4zz7" id="4qv99IrBK2L" role="3clFbG">
             <node concept="2ShNRf" id="4qv99IrBK8j" role="3K4E3e">
@@ -1515,6 +1540,40 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="4qv99IrBkzF" role="1B3o_S" />
+  </node>
+  <node concept="1lYeZD" id="3bE2i5JxRVg">
+    <property role="TrG5h" value="DefaultUnitLangConfigExtension" />
+    <ref role="1lYe$Y" node="4qv99IryjZk" resolve="UnitLangConfig" />
+    <node concept="3Tm1VV" id="3bE2i5JxRVh" role="1B3o_S" />
+    <node concept="2tJIrI" id="3bE2i5JxRVi" role="jymVt" />
+    <node concept="3tTeZs" id="3bE2i5JxRVj" role="jymVt">
+      <property role="3tTeZt" value="activate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0CPy" resolve="activate" />
+    </node>
+    <node concept="3tTeZs" id="3bE2i5JxRVk" role="jymVt">
+      <property role="3tTeZt" value="deactivate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+    </node>
+    <node concept="2tJIrI" id="3bE2i5JxRVl" role="jymVt" />
+    <node concept="q3mfD" id="3bE2i5JxRVm" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="3bE2i5JxRVo" role="1B3o_S" />
+      <node concept="3clFbS" id="3bE2i5JxRVq" role="3clF47">
+        <node concept="3cpWs6" id="3bE2i5Jy5ae" role="3cqZAp">
+          <node concept="2ShNRf" id="3bE2i5Jy5cB" role="3cqZAk">
+            <node concept="HV5vD" id="3bE2i5JyoxM" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="HV5vE" node="4qv99IrzTI8" resolve="DefaultUnitLangConfig" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="3bE2i5JxRVr" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="3bE2i5JxRVm" resolve="get" />
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/org.iets3.core.expr.typetags.units.plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/org.iets3.core.expr.typetags.units.plugin.mps
@@ -53,6 +53,14 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1083245097125" name="jetbrains.mps.baseLanguage.structure.EnumClass" flags="ig" index="Qs71p">
+        <child id="1083245396908" name="enumConstant" index="Qtgdg" />
+      </concept>
+      <concept id="1083245299891" name="jetbrains.mps.baseLanguage.structure.EnumConstantDeclaration" flags="ig" index="QsSxf" />
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
+      </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
@@ -67,13 +75,18 @@
         <child id="1081256993305" name="classType" index="2ZW6by" />
         <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <child id="1095933932569" name="implementedInterface" index="EKbjA" />
         <child id="1165602531693" name="superclass" index="1zkMxy" />
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -102,7 +115,9 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
@@ -146,6 +161,12 @@
       <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
         <child id="1144230900587" name="variable" index="1Duv9x" />
       </concept>
+      <concept id="1107796713796" name="jetbrains.mps.baseLanguage.structure.Interface" flags="ig" index="3HP615" />
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
@@ -154,6 +175,13 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
+      <concept id="3729007189729192406" name="jetbrains.mps.lang.extension.structure.ExtensionPointDeclaration" flags="ng" index="vrV6u">
+        <child id="8029776554053057803" name="objectType" index="luc8K" />
+      </concept>
+      <concept id="6626851894249711936" name="jetbrains.mps.lang.extension.structure.ExtensionPointExpression" flags="nn" index="2O5UvJ">
+        <reference id="6626851894249712469" name="extensionPoint" index="2O5UnU" />
+      </concept>
+      <concept id="3175313036448560967" name="jetbrains.mps.lang.extension.structure.GetExtensionObjectsOperation" flags="nn" index="SfwO_" />
       <concept id="126958800891274162" name="jetbrains.mps.lang.extension.structure.Extension" flags="ig" index="1lYeZD">
         <reference id="126958800891274597" name="extensionPoint" index="1lYe$Y" />
       </concept>
@@ -260,13 +288,18 @@
       <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
       <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1205679737078" name="jetbrains.mps.baseLanguage.collections.structure.SortOperation" flags="nn" index="2S7cBI">
+        <child id="1205679832066" name="ascending" index="2S7zOq" />
+      </concept>
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
         <child id="1240687658305" name="delimiter" index="3uJOhx" />
       </concept>
+      <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
     </language>
@@ -1325,6 +1358,163 @@
     <node concept="2tJIrI" id="7WxTcH$fO1Y" role="jymVt" />
     <node concept="2tJIrI" id="7WxTcH$fO24" role="jymVt" />
     <node concept="3Tm1VV" id="7WxTcH$fNQZ" role="1B3o_S" />
+  </node>
+  <node concept="vrV6u" id="4qv99IryjZk">
+    <property role="TrG5h" value="UnitLangConfig" />
+    <node concept="3uibUv" id="4qv99IrzfFk" role="luc8K">
+      <ref role="3uigEE" node="4qv99IryjZo" resolve="IUnitLangConfig" />
+    </node>
+  </node>
+  <node concept="3HP615" id="4qv99IryjZo">
+    <property role="TrG5h" value="IUnitLangConfig" />
+    <node concept="2tJIrI" id="4qv99IrykmM" role="jymVt" />
+    <node concept="2tJIrI" id="4qv99IryRZ6" role="jymVt" />
+    <node concept="Qs71p" id="4qv99IrykBs" role="jymVt">
+      <property role="TrG5h" value="ConversionSpecifierSelection" />
+      <node concept="3Tm1VV" id="4qv99IrykBt" role="1B3o_S" />
+      <node concept="QsSxf" id="4qv99IrykGi" role="Qtgdg">
+        <property role="TrG5h" value="FIRST_APPLICABLE" />
+        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
+      </node>
+      <node concept="QsSxf" id="4qv99IrykKI" role="Qtgdg">
+        <property role="TrG5h" value="DEFINED_IN_CONVERT_EXPESSION" />
+        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4qv99Irykn3" role="jymVt" />
+    <node concept="3clFb_" id="26cjRACVSeU" role="jymVt">
+      <property role="TrG5h" value="getPriorityLevel" />
+      <node concept="10Oyi0" id="26cjRACVSeV" role="3clF45" />
+      <node concept="3Tm1VV" id="26cjRACVSeW" role="1B3o_S" />
+      <node concept="3clFbS" id="26cjRACVSeY" role="3clF47" />
+    </node>
+    <node concept="2tJIrI" id="4qv99IrzPzw" role="jymVt" />
+    <node concept="3clFb_" id="4qv99Irylny" role="jymVt">
+      <property role="TrG5h" value="getConversionSpecifierSelection" />
+      <node concept="3clFbS" id="4qv99Iryln_" role="3clF47" />
+      <node concept="3Tm1VV" id="4qv99IrylnA" role="1B3o_S" />
+      <node concept="3uibUv" id="4qv99IryllQ" role="3clF45">
+        <ref role="3uigEE" node="4qv99IrykBs" resolve="ConversionSpecifierSelection" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="4qv99IryjZp" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="4qv99IrzTI8">
+    <property role="TrG5h" value="DefaultUnitLangConfig" />
+    <node concept="2tJIrI" id="4qv99IrzUd2" role="jymVt" />
+    <node concept="3clFb_" id="4qv99IrzQ79" role="jymVt">
+      <property role="TrG5h" value="getPriorityLevel" />
+      <node concept="10Oyi0" id="4qv99IrzQ7a" role="3clF45" />
+      <node concept="3Tm1VV" id="4qv99IrzQ7b" role="1B3o_S" />
+      <node concept="3clFbS" id="4qv99IrzQ7e" role="3clF47">
+        <node concept="3clFbF" id="4qv99IrzQ7h" role="3cqZAp">
+          <node concept="3cmrfG" id="4qv99IrzQ7g" role="3clFbG">
+            <property role="3cmrfH" value="0" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="4qv99IrzQ7f" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4qv99IrzU0b" role="jymVt" />
+    <node concept="3clFb_" id="4qv99IrzP4v" role="jymVt">
+      <property role="TrG5h" value="getConversionSpecifierSelection" />
+      <node concept="3Tm1VV" id="4qv99IrzP4x" role="1B3o_S" />
+      <node concept="3uibUv" id="4qv99IrzP4y" role="3clF45">
+        <ref role="3uigEE" node="4qv99IrykBs" resolve="ConversionSpecifierSelection" />
+      </node>
+      <node concept="3clFbS" id="4qv99IrzP4$" role="3clF47">
+        <node concept="3clFbF" id="4qv99IrylCC" role="3cqZAp">
+          <node concept="Rm8GO" id="4qv99IrylHL" role="3clFbG">
+            <ref role="Rm8GQ" node="4qv99IrykGi" resolve="FIRST_APPLICABLE" />
+            <ref role="1Px2BO" node="4qv99IrykBs" resolve="ConversionSpecifierSelection" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="4qv99IrzP4_" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4qv99IrzTTd" role="jymVt" />
+    <node concept="3Tm1VV" id="4qv99IrzTI9" role="1B3o_S" />
+    <node concept="3uibUv" id="4qv99IrzTNO" role="EKbjA">
+      <ref role="3uigEE" node="4qv99IryjZo" resolve="IUnitLangConfig" />
+    </node>
+  </node>
+  <node concept="312cEu" id="4qv99IrBkzE">
+    <property role="TrG5h" value="UnitLangConfigHelper" />
+    <node concept="2YIFZL" id="4qv99IrBnzk" role="jymVt">
+      <property role="TrG5h" value="getConfig" />
+      <node concept="3clFbS" id="4qv99IrBnzn" role="3clF47">
+        <node concept="3cpWs8" id="4qv99IrBJ3T" role="3cqZAp">
+          <node concept="3cpWsn" id="4qv99IrBJ3U" role="3cpWs9">
+            <property role="TrG5h" value="config" />
+            <node concept="3uibUv" id="4qv99IrBJ1H" role="1tU5fm">
+              <ref role="3uigEE" node="4qv99IryjZo" resolve="IUnitLangConfig" />
+            </node>
+            <node concept="2OqwBi" id="4qv99IrBJ3V" role="33vP2m">
+              <node concept="2OqwBi" id="4qv99IrBJ3W" role="2Oq$k0">
+                <node concept="2OqwBi" id="4qv99IrBJ3X" role="2Oq$k0">
+                  <node concept="2O5UvJ" id="4qv99IrBJ3Y" role="2Oq$k0">
+                    <ref role="2O5UnU" node="4qv99IryjZk" resolve="UnitLangConfig" />
+                  </node>
+                  <node concept="SfwO_" id="4qv99IrBJ3Z" role="2OqNvi" />
+                </node>
+                <node concept="2S7cBI" id="4qv99IrBJ40" role="2OqNvi">
+                  <node concept="1bVj0M" id="4qv99IrBJ41" role="23t8la">
+                    <node concept="3clFbS" id="4qv99IrBJ42" role="1bW5cS">
+                      <node concept="3clFbF" id="4qv99IrBJ43" role="3cqZAp">
+                        <node concept="2OqwBi" id="4qv99IrBJ44" role="3clFbG">
+                          <node concept="37vLTw" id="4qv99IrBJ45" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4qv99IrBJ47" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="4qv99IrBJ46" role="2OqNvi">
+                            <ref role="37wK5l" node="26cjRACVSeU" resolve="getPriorityLevel" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="4qv99IrBJ47" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="4qv99IrBJ48" role="1tU5fm" />
+                    </node>
+                  </node>
+                  <node concept="1nlBCl" id="4qv99IrBJ49" role="2S7zOq">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1yVyf7" id="4qv99IrBJ4a" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4qv99IrBJoK" role="3cqZAp">
+          <node concept="3K4zz7" id="4qv99IrBK2L" role="3clFbG">
+            <node concept="2ShNRf" id="4qv99IrBK8j" role="3K4E3e">
+              <node concept="HV5vD" id="4qv99IrBMfR" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" node="4qv99IrzTI8" resolve="DefaultUnitLangConfig" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="4qv99IrBMks" role="3K4GZi">
+              <ref role="3cqZAo" node="4qv99IrBJ3U" resolve="config" />
+            </node>
+            <node concept="3clFbC" id="4qv99IrBJNT" role="3K4Cdx">
+              <node concept="10Nm6u" id="4qv99IrBJTZ" role="3uHU7w" />
+              <node concept="37vLTw" id="4qv99IrBJoI" role="3uHU7B">
+                <ref role="3cqZAo" node="4qv99IrBJ3U" resolve="config" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4qv99IrBkRE" role="1B3o_S" />
+      <node concept="3uibUv" id="4qv99IrBo4U" role="3clF45">
+        <ref role="3uigEE" node="4qv99IryjZo" resolve="IUnitLangConfig" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="4qv99IrBkzF" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/structure.mps
@@ -80,6 +80,9 @@
     <node concept="PrWs8" id="2JXkwhJfSCx" role="PrDN$">
       <ref role="PrY4T" to="4kwy:cJpacq5T0O" resolve="IValidNamedConcept" />
     </node>
+    <node concept="PrWs8" id="9MvF2i4gt7" role="PrDN$">
+      <ref role="PrY4T" to="vs0r:59HbAIOYkEn" resolve="IDetectCycle" />
+    </node>
   </node>
   <node concept="1TIwiD" id="7eOyx9r3jsZ">
     <property role="TrG5h" value="Unit" />
@@ -115,6 +118,9 @@
     </node>
     <node concept="PrWs8" id="3WnwFDbcwDv" role="PzmwI">
       <ref role="PrY4T" to="tpck:69Qfsw3InJo" resolve="ISmartReferent" />
+    </node>
+    <node concept="PrWs8" id="9MvF2i48Ez" role="PzmwI">
+      <ref role="PrY4T" to="vs0r:59HbAIOYkEn" resolve="IDetectCycle" />
     </node>
   </node>
   <node concept="1TIwiD" id="7eOyx9r3k4t">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/typesystem.mps
@@ -7,6 +7,7 @@
     <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil" version="1" />
+    <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
     <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
   </languages>
   <imports>
@@ -69,6 +70,10 @@
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
       </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
@@ -172,6 +177,7 @@
         <child id="8276990574895933172" name="throwable" index="1zc67B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
@@ -185,6 +191,14 @@
       <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
         <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
         <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
+      <concept id="1163670490218" name="jetbrains.mps.baseLanguage.structure.SwitchStatement" flags="nn" index="3KaCP$">
+        <child id="1163670766145" name="expression" index="3KbGdf" />
+        <child id="1163670772911" name="case" index="3KbHQx" />
+      </concept>
+      <concept id="1163670641947" name="jetbrains.mps.baseLanguage.structure.SwitchCase" flags="ng" index="3KbdKl">
+        <child id="1163670677455" name="expression" index="3Kbmr1" />
+        <child id="1163670683720" name="body" index="3Kbo56" />
       </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
@@ -3316,8 +3330,75 @@
                   <node concept="liA8E" id="52UOzzPp0Rp" role="2OqNvi">
                     <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
                     <node concept="Xl_RD" id="yGiRIEWwlX" role="37wK5m">
-                      <property role="Xl_RC" value="Multiple matching conversion specifiers have been found" />
+                      <property role="Xl_RC" value="Multiple matching conversion specifiers have been found." />
                     </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="4qv99Irzl5n" role="3cqZAp">
+                <node concept="3cpWsn" id="4qv99Irzl5o" role="3cpWs9">
+                  <property role="TrG5h" value="config" />
+                  <node concept="3uibUv" id="4qv99Irzl1t" role="1tU5fm">
+                    <ref role="3uigEE" to="zdxd:4qv99IryjZo" resolve="IUnitLangConfig" />
+                  </node>
+                  <node concept="2YIFZM" id="4qv99IrBAXj" role="33vP2m">
+                    <ref role="37wK5l" to="zdxd:4qv99IrBnzk" resolve="getConfig" />
+                    <ref role="1Pybhc" to="zdxd:4qv99IrBkzE" resolve="UnitLangConfigHelper" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbH" id="4qv99IrBSVk" role="3cqZAp" />
+              <node concept="3KaCP$" id="4qv99Irzn8d" role="3cqZAp">
+                <node concept="2OqwBi" id="4qv99Irzm7o" role="3KbGdf">
+                  <node concept="37vLTw" id="4qv99Irzm1b" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4qv99Irzl5o" resolve="config" />
+                  </node>
+                  <node concept="liA8E" id="4qv99IrzmhT" role="2OqNvi">
+                    <ref role="37wK5l" to="zdxd:4qv99Irylny" resolve="getConversionSpecifierSelection" />
+                  </node>
+                </node>
+                <node concept="3KbdKl" id="4qv99Irzsw5" role="3KbHQx">
+                  <node concept="Rm8GO" id="4qv99IrzsAO" role="3Kbmr1">
+                    <ref role="Rm8GQ" to="zdxd:4qv99IrykKI" resolve="DEFINED_IN_CONVERT_EXPESSION" />
+                    <ref role="1Px2BO" to="zdxd:4qv99IrykBs" resolve="ConversionSpecifierSelection" />
+                  </node>
+                  <node concept="3clFbS" id="4qv99IrzsEt" role="3Kbo56">
+                    <node concept="3clFbF" id="4qv99IrAHPr" role="3cqZAp">
+                      <node concept="2OqwBi" id="4qv99IrAJ6t" role="3clFbG">
+                        <node concept="37vLTw" id="4qv99IrAHPp" role="2Oq$k0">
+                          <ref role="3cqZAo" node="52UOzzPoZFv" resolve="builder" />
+                        </node>
+                        <node concept="liA8E" id="4qv99IrAKGA" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                          <node concept="Xl_RD" id="4qv99IrALwF" role="37wK5m">
+                            <property role="Xl_RC" value=" For conversions, the selected specifier will be used" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3zACq4" id="4qv99IrzsZA" role="3cqZAp" />
+                  </node>
+                </node>
+                <node concept="3KbdKl" id="4qv99IrzneS" role="3KbHQx">
+                  <node concept="Rm8GO" id="4qv99Irznk1" role="3Kbmr1">
+                    <ref role="Rm8GQ" to="zdxd:4qv99IrykGi" resolve="FIRST_APPLICABLE" />
+                    <ref role="1Px2BO" to="zdxd:4qv99IrykBs" resolve="ConversionSpecifierSelection" />
+                  </node>
+                  <node concept="3clFbS" id="4qv99Irznkz" role="3Kbo56">
+                    <node concept="3clFbF" id="4qv99IrAV70" role="3cqZAp">
+                      <node concept="2OqwBi" id="4qv99IrAV71" role="3clFbG">
+                        <node concept="37vLTw" id="4qv99IrAV72" role="2Oq$k0">
+                          <ref role="3cqZAo" node="52UOzzPoZFv" resolve="builder" />
+                        </node>
+                        <node concept="liA8E" id="4qv99IrAV73" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                          <node concept="Xl_RD" id="4qv99IrAV74" role="37wK5m">
+                            <property role="Xl_RC" value=" For conversions, the first applicable specifier will be used" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3zACq4" id="4qv99Irzsu_" role="3cqZAp" />
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.units.interpreter/models/org.iets3.core.expr.typetags.units.interpreter.plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.units.interpreter/models/org.iets3.core.expr.typetags.units.interpreter.plugin.mps
@@ -8,6 +8,7 @@
     <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="47f075a6-558e-4640-a606-7ce0236c8023" name="com.mbeddr.mpsutil.interpreter" version="1" />
+    <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
   </languages>
   <imports>
     <import index="b0gq" ref="r:1eb914ff-b91c-4cbc-93c6-3ecde7821894(org.iets3.core.expr.typetags.units.structure)" />
@@ -15,6 +16,7 @@
     <import index="dntf" ref="r:5d67260e-ef2e-4f51-9a4f-b005e241d989(org.iets3.core.expr.typetags.units.behavior)" />
     <import index="rxpb" ref="r:31fd8edf-66c5-44d7-84a8-5940badb4d17(org.iets3.core.expr.base.interpreter.plugin)" />
     <import index="km5y" ref="r:78e88ebb-2d27-4b89-867f-623c50619338(org.iets3.core.expr.simpleTypes.interpreter.plugin)" />
+    <import index="zdxd" ref="r:8397e61b-8602-4a1e-97b1-3469618bad2d(org.iets3.core.expr.typetags.units.plugin)" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
     <import index="w1hl" ref="r:04b74a30-84ff-4d44-89e3-8084278f9c79(org.iets3.core.expr.typetags.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
@@ -28,18 +30,27 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
+      </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
       <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
@@ -79,8 +90,17 @@
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
+      <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1163670490218" name="jetbrains.mps.baseLanguage.structure.SwitchStatement" flags="nn" index="3KaCP$">
+        <child id="1163670766145" name="expression" index="3KbGdf" />
+        <child id="1163670772911" name="case" index="3KbHQx" />
+      </concept>
+      <concept id="1163670641947" name="jetbrains.mps.baseLanguage.structure.SwitchCase" flags="ng" index="3KbdKl">
+        <child id="1163670677455" name="expression" index="3Kbmr1" />
+        <child id="1163670683720" name="body" index="3Kbo56" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
@@ -153,20 +173,81 @@
       <node concept="3dA_Gj" id="3xzP2_mBv9J" role="3vQZUl">
         <node concept="9aQIb" id="3xzP2_mBv9L" role="3vcmbn">
           <node concept="3clFbS" id="3xzP2_mBv9N" role="9aQI4">
+            <node concept="3cpWs8" id="4qv99Irzl5n" role="3cqZAp">
+              <node concept="3cpWsn" id="4qv99Irzl5o" role="3cpWs9">
+                <property role="TrG5h" value="config" />
+                <node concept="3uibUv" id="4qv99Irzl1t" role="1tU5fm">
+                  <ref role="3uigEE" to="zdxd:4qv99IryjZo" resolve="IUnitLangConfig" />
+                </node>
+                <node concept="2YIFZM" id="4qv99IrBUee" role="33vP2m">
+                  <ref role="37wK5l" to="zdxd:4qv99IrBnzk" resolve="getConfig" />
+                  <ref role="1Pybhc" to="zdxd:4qv99IrBkzE" resolve="UnitLangConfigHelper" />
+                </node>
+              </node>
+            </node>
             <node concept="3cpWs8" id="3xzP2_mBvmh" role="3cqZAp">
               <node concept="3cpWsn" id="3xzP2_mBvmk" role="3cpWs9">
                 <property role="TrG5h" value="conversionSpecifier" />
                 <node concept="3Tqbb2" id="3xzP2_mBvmg" role="1tU5fm">
                   <ref role="ehGHo" to="b0gq:1wGuEUvU$lO" resolve="ConversionSpecifier" />
                 </node>
-                <node concept="2OqwBi" id="3xzP2_mBxiM" role="33vP2m">
-                  <node concept="2OqwBi" id="3xzP2_mBvuz" role="2Oq$k0">
-                    <node concept="oxGPV" id="3xzP2_mBvmL" role="2Oq$k0" />
-                    <node concept="2qgKlT" id="3xzP2_mBvE9" role="2OqNvi">
-                      <ref role="37wK5l" to="dntf:3_TFq$0_vSx" resolve="getApplicableConversionSpecifiers" />
+                <node concept="10Nm6u" id="4qv99IrzvxN" role="33vP2m" />
+              </node>
+            </node>
+            <node concept="3KaCP$" id="4qv99Irzn8d" role="3cqZAp">
+              <node concept="2OqwBi" id="4qv99Irzm7o" role="3KbGdf">
+                <node concept="37vLTw" id="4qv99Irzm1b" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4qv99Irzl5o" resolve="config" />
+                </node>
+                <node concept="liA8E" id="4qv99IrzmhT" role="2OqNvi">
+                  <ref role="37wK5l" to="zdxd:4qv99Irylny" resolve="getConversionSpecifierSelection" />
+                </node>
+              </node>
+              <node concept="3KbdKl" id="4qv99Irzsw5" role="3KbHQx">
+                <node concept="Rm8GO" id="4qv99IrzsAO" role="3Kbmr1">
+                  <ref role="Rm8GQ" to="zdxd:4qv99IrykKI" resolve="DEFINED_IN_CONVERT_EXPESSION" />
+                  <ref role="1Px2BO" to="zdxd:4qv99IrykBs" resolve="ConversionSpecifierSelection" />
+                </node>
+                <node concept="3clFbS" id="4qv99IrzsEt" role="3Kbo56">
+                  <node concept="3clFbF" id="4qv99IrzsGq" role="3cqZAp">
+                    <node concept="37vLTI" id="4qv99IrzlBC" role="3clFbG">
+                      <node concept="2OqwBi" id="3xzP2_mBvuz" role="37vLTx">
+                        <node concept="oxGPV" id="3xzP2_mBvmL" role="2Oq$k0" />
+                        <node concept="2qgKlT" id="3xzP2_mBvE9" role="2OqNvi">
+                          <ref role="37wK5l" to="dntf:7SygLIkR36w" resolve="getConversionSpecifier" />
+                        </node>
+                      </node>
+                      <node concept="37vLTw" id="4qv99IrzlBG" role="37vLTJ">
+                        <ref role="3cqZAo" node="3xzP2_mBvmk" resolve="conversionSpecifier" />
+                      </node>
                     </node>
                   </node>
-                  <node concept="1uHKPH" id="3xzP2_mBzKm" role="2OqNvi" />
+                  <node concept="3zACq4" id="4qv99IrzsZA" role="3cqZAp" />
+                </node>
+              </node>
+              <node concept="3KbdKl" id="4qv99IrzneS" role="3KbHQx">
+                <node concept="Rm8GO" id="4qv99Irznk1" role="3Kbmr1">
+                  <ref role="Rm8GQ" to="zdxd:4qv99IrykGi" resolve="FIRST_APPLICABLE" />
+                  <ref role="1Px2BO" to="zdxd:4qv99IrykBs" resolve="ConversionSpecifierSelection" />
+                </node>
+                <node concept="3clFbS" id="4qv99Irznkz" role="3Kbo56">
+                  <node concept="3clFbF" id="4qv99IrznE_" role="3cqZAp">
+                    <node concept="37vLTI" id="4qv99IrznNv" role="3clFbG">
+                      <node concept="2OqwBi" id="4qv99IrzpJX" role="37vLTx">
+                        <node concept="2OqwBi" id="4qv99IrznVY" role="2Oq$k0">
+                          <node concept="oxGPV" id="4qv99IrznNW" role="2Oq$k0" />
+                          <node concept="2qgKlT" id="4qv99Irzo9w" role="2OqNvi">
+                            <ref role="37wK5l" to="dntf:3_TFq$0_vSx" resolve="getApplicableConversionSpecifiers" />
+                          </node>
+                        </node>
+                        <node concept="1uHKPH" id="4qv99Irzscq" role="2OqNvi" />
+                      </node>
+                      <node concept="37vLTw" id="4qv99IrznEz" role="37vLTJ">
+                        <ref role="3cqZAo" node="3xzP2_mBvmk" resolve="conversionSpecifier" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3zACq4" id="4qv99Irzsu_" role="3cqZAp" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -12529,9 +12529,9 @@
           <ref role="3bR37D" node="5zQvLw7dx1X" resolve="org.iets3.core.expr.datetime" />
         </node>
       </node>
-      <node concept="1SiIV0" id="193tnjlVdcJ" role="3bR37C">
-        <node concept="3bR9La" id="193tnjlVdcK" role="1SiIV1">
-          <ref role="3bR37D" node="OJuIQp$d7j" resolve="test.in.expr.os" />
+      <node concept="1SiIV0" id="4qv99IrCRzl" role="3bR37C">
+        <node concept="3bR9La" id="4qv99IrCRzm" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:7Kfy9QB6L5O" resolve="jetbrains.mps.lang.extension" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.plugin.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.plugin.mps
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:df6d55ea-0ac0-4364-9581-8cb45ef224d6(test.ts.expr.os.plugin)">
+  <persistence version="9" />
+  <languages>
+    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="5" />
+    <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
+    <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+    <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
+  </languages>
+  <imports>
+    <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" />
+    <import index="zdxd" ref="r:8397e61b-8602-4a1e-97b1-3469618bad2d(org.iets3.core.expr.typetags.units.plugin)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone">
+      <concept id="7520713872864775836" name="jetbrains.mps.lang.plugin.standalone.structure.StandalonePluginDescriptor" flags="ng" index="2DaZZR" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+        <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
+        <reference id="1144432896254" name="enumClass" index="1Px2BO" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
+      </concept>
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+      </concept>
+    </language>
+    <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
+      <concept id="126958800891274162" name="jetbrains.mps.lang.extension.structure.Extension" flags="ig" index="1lYeZD">
+        <reference id="126958800891274597" name="extensionPoint" index="1lYe$Y" />
+      </concept>
+    </language>
+    <language id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl">
+      <concept id="3751132065236767083" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.DependentTypeInstance" flags="ig" index="q3mfm">
+        <reference id="3751132065236767084" name="decl" index="q3mfh" />
+        <reference id="9097849371505568270" name="point" index="1QQUv3" />
+      </concept>
+      <concept id="3751132065236767060" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MethodInstance" flags="ig" index="q3mfD">
+        <reference id="19209059688387895" name="decl" index="2VtyIY" />
+      </concept>
+      <concept id="6478870542308703666" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MemberPlaceholder" flags="ng" index="3tTeZs">
+        <property id="6478870542308703667" name="caption" index="3tTeZt" />
+        <reference id="6478870542308703669" name="decl" index="3tTeZr" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1lYeZD" id="4qv99Ir$9$F">
+    <property role="TrG5h" value="UnitLangConfigExtensionNewBehaviors" />
+    <ref role="1lYe$Y" to="zdxd:4qv99IryjZk" resolve="UnitLangConfig" />
+    <node concept="3Tm1VV" id="4qv99Ir$9$G" role="1B3o_S" />
+    <node concept="2tJIrI" id="4qv99Ir$9$H" role="jymVt" />
+    <node concept="3tTeZs" id="4qv99Ir$9$I" role="jymVt">
+      <property role="3tTeZt" value="activate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0CPy" resolve="activate" />
+    </node>
+    <node concept="3tTeZs" id="4qv99Ir$9$J" role="jymVt">
+      <property role="3tTeZt" value="deactivate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+    </node>
+    <node concept="2tJIrI" id="4qv99Ir$9$K" role="jymVt" />
+    <node concept="q3mfD" id="4qv99Ir$9$L" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="4qv99Ir$9$N" role="1B3o_S" />
+      <node concept="3clFbS" id="4qv99Ir$9$P" role="3clF47">
+        <node concept="3clFbF" id="4qv99Ir$9RV" role="3cqZAp">
+          <node concept="2ShNRf" id="4qv99Ir$9RT" role="3clFbG">
+            <node concept="YeOm9" id="4qv99Ir$ks5" role="2ShVmc">
+              <node concept="1Y3b0j" id="4qv99Ir$ks8" role="YeSDq">
+                <property role="2bfB8j" value="true" />
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
+                <ref role="1Y3XeK" to="zdxd:4qv99IryjZo" resolve="IUnitLangConfig" />
+                <node concept="3Tm1VV" id="4qv99Ir$ks9" role="1B3o_S" />
+                <node concept="3clFb_" id="4qv99Ir$kud" role="jymVt">
+                  <property role="TrG5h" value="getPriorityLevel" />
+                  <node concept="10Oyi0" id="4qv99Ir$kue" role="3clF45" />
+                  <node concept="3Tm1VV" id="4qv99Ir$kuf" role="1B3o_S" />
+                  <node concept="3clFbS" id="4qv99Ir$kui" role="3clF47">
+                    <node concept="3clFbF" id="4qv99Ir$kul" role="3cqZAp">
+                      <node concept="3cmrfG" id="4qv99Ir$kuk" role="3clFbG">
+                        <property role="3cmrfH" value="-1" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="4qv99Ir$kuj" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" />
+                  </node>
+                </node>
+                <node concept="3clFb_" id="4qv99Ir$kum" role="jymVt">
+                  <property role="TrG5h" value="getConversionSpecifierSelection" />
+                  <node concept="3Tm1VV" id="4qv99Ir$kuo" role="1B3o_S" />
+                  <node concept="3uibUv" id="4qv99Ir$kup" role="3clF45">
+                    <ref role="3uigEE" to="zdxd:4qv99IrykBs" resolve="ConversionSpecifierSelection" />
+                  </node>
+                  <node concept="3clFbS" id="4qv99Ir$kur" role="3clF47">
+                    <node concept="3clFbF" id="4qv99Ir$kOA" role="3cqZAp">
+                      <node concept="Rm8GO" id="4qv99Ir$kRL" role="3clFbG">
+                        <ref role="Rm8GQ" to="zdxd:4qv99IrykKI" resolve="DEFINED_IN_CONVERT_EXPESSION" />
+                        <ref role="1Px2BO" to="zdxd:4qv99IrykBs" resolve="ConversionSpecifierSelection" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2AHcQZ" id="4qv99Ir$kus" role="2AJF6D">
+                    <ref role="2AI5Lk" to="wyt6:~Override" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="4qv99Ir$9$Q" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="4qv99Ir$9$L" resolve="get" />
+      </node>
+    </node>
+  </node>
+  <node concept="2DaZZR" id="C0WcYEphgd" />
+</model>
+

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.plugin.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.plugin.mps
@@ -6,6 +6,7 @@
     <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
     <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
   </languages>
   <imports>
     <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" />
@@ -24,6 +25,9 @@
       <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
         <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
         <reference id="1144432896254" name="enumClass" index="1Px2BO" />
@@ -31,12 +35,22 @@
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
-      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
-        <child id="1182160096073" name="cls" index="YeSDq" />
-      </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <child id="1095933932569" name="implementedInterface" index="EKbjA" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
       <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
       <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
         <child id="1068580123133" name="returnType" index="3clF45" />
@@ -52,11 +66,10 @@
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
-        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
-        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
@@ -65,10 +78,10 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
-      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
-      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
-        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
     <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
       <concept id="126958800891274162" name="jetbrains.mps.lang.extension.structure.Extension" flags="ig" index="1lYeZD">
@@ -93,6 +106,14 @@
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
   </registry>
   <node concept="1lYeZD" id="4qv99Ir$9$F">
     <property role="TrG5h" value="UnitLangConfigExtensionNewBehaviors" />
@@ -113,49 +134,11 @@
       <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
       <node concept="3Tm1VV" id="4qv99Ir$9$N" role="1B3o_S" />
       <node concept="3clFbS" id="4qv99Ir$9$P" role="3clF47">
-        <node concept="3clFbF" id="4qv99Ir$9RV" role="3cqZAp">
-          <node concept="2ShNRf" id="4qv99Ir$9RT" role="3clFbG">
-            <node concept="YeOm9" id="4qv99Ir$ks5" role="2ShVmc">
-              <node concept="1Y3b0j" id="4qv99Ir$ks8" role="YeSDq">
-                <property role="2bfB8j" value="true" />
-                <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
-                <ref role="1Y3XeK" to="zdxd:4qv99IryjZo" resolve="IUnitLangConfig" />
-                <node concept="3Tm1VV" id="4qv99Ir$ks9" role="1B3o_S" />
-                <node concept="3clFb_" id="4qv99Ir$kud" role="jymVt">
-                  <property role="TrG5h" value="getPriorityLevel" />
-                  <node concept="10Oyi0" id="4qv99Ir$kue" role="3clF45" />
-                  <node concept="3Tm1VV" id="4qv99Ir$kuf" role="1B3o_S" />
-                  <node concept="3clFbS" id="4qv99Ir$kui" role="3clF47">
-                    <node concept="3clFbF" id="4qv99Ir$kul" role="3cqZAp">
-                      <node concept="3cmrfG" id="4qv99Ir$kuk" role="3clFbG">
-                        <property role="3cmrfH" value="-1" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2AHcQZ" id="4qv99Ir$kuj" role="2AJF6D">
-                    <ref role="2AI5Lk" to="wyt6:~Override" />
-                  </node>
-                </node>
-                <node concept="3clFb_" id="4qv99Ir$kum" role="jymVt">
-                  <property role="TrG5h" value="getConversionSpecifierSelection" />
-                  <node concept="3Tm1VV" id="4qv99Ir$kuo" role="1B3o_S" />
-                  <node concept="3uibUv" id="4qv99Ir$kup" role="3clF45">
-                    <ref role="3uigEE" to="zdxd:4qv99IrykBs" resolve="ConversionSpecifierSelection" />
-                  </node>
-                  <node concept="3clFbS" id="4qv99Ir$kur" role="3clF47">
-                    <node concept="3clFbF" id="4qv99Ir$kOA" role="3cqZAp">
-                      <node concept="Rm8GO" id="4qv99Ir$kRL" role="3clFbG">
-                        <ref role="Rm8GQ" to="zdxd:4qv99IrykKI" resolve="DEFINED_IN_CONVERT_EXPESSION" />
-                        <ref role="1Px2BO" to="zdxd:4qv99IrykBs" resolve="ConversionSpecifierSelection" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2AHcQZ" id="4qv99Ir$kus" role="2AJF6D">
-                    <ref role="2AI5Lk" to="wyt6:~Override" />
-                  </node>
-                </node>
-              </node>
+        <node concept="3cpWs6" id="3bE2i5JyvFp" role="3cqZAp">
+          <node concept="2ShNRf" id="3bE2i5JyvGp" role="3cqZAk">
+            <node concept="HV5vD" id="3bE2i5Jyw7W" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="HV5vE" node="3bE2i5JypU2" resolve="NewBehaviorUnitLangConfig" />
             </node>
           </node>
         </node>
@@ -167,5 +150,81 @@
     </node>
   </node>
   <node concept="2DaZZR" id="C0WcYEphgd" />
+  <node concept="312cEu" id="3bE2i5JypU2">
+    <property role="TrG5h" value="NewBehaviorUnitLangConfig" />
+    <node concept="3Tm1VV" id="3bE2i5JypU3" role="1B3o_S" />
+    <node concept="3uibUv" id="3bE2i5JypWI" role="EKbjA">
+      <ref role="3uigEE" to="zdxd:4qv99IryjZo" resolve="IUnitLangConfig" />
+    </node>
+    <node concept="2tJIrI" id="3bE2i5JyqOJ" role="jymVt" />
+    <node concept="2tJIrI" id="3bE2i5JyuU4" role="jymVt" />
+    <node concept="Wx3nA" id="3bE2i5JyurL" role="jymVt">
+      <property role="TrG5h" value="PRIORITY" />
+      <node concept="3Tm1VV" id="3bE2i5Jyrj5" role="1B3o_S" />
+      <node concept="10Oyi0" id="3bE2i5JyupV" role="1tU5fm" />
+      <node concept="3cmrfG" id="3bE2i5Jyuve" role="33vP2m">
+        <property role="3cmrfH" value="-1" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3bE2i5JyqUG" role="jymVt" />
+    <node concept="3clFb_" id="3bE2i5JypXj" role="jymVt">
+      <property role="TrG5h" value="getPriorityLevel" />
+      <node concept="10Oyi0" id="3bE2i5JypXk" role="3clF45" />
+      <node concept="3Tm1VV" id="3bE2i5JypXl" role="1B3o_S" />
+      <node concept="3clFbS" id="3bE2i5JypXn" role="3clF47">
+        <node concept="3SKdUt" id="3bE2i5Jyvqi" role="3cqZAp">
+          <node concept="1PaTwC" id="3bE2i5Jyvqj" role="1aUNEU">
+            <node concept="3oM_SD" id="3bE2i5Jyvqq" role="1PaTwD">
+              <property role="3oM_SC" value="To" />
+            </node>
+            <node concept="3oM_SD" id="3bE2i5Jyvtd" role="1PaTwD">
+              <property role="3oM_SC" value="allow" />
+            </node>
+            <node concept="3oM_SD" id="3bE2i5Jyvtg" role="1PaTwD">
+              <property role="3oM_SC" value="dynamic" />
+            </node>
+            <node concept="3oM_SD" id="3bE2i5Jyvt$" role="1PaTwD">
+              <property role="3oM_SC" value="reconfiguration" />
+            </node>
+            <node concept="3oM_SD" id="3bE2i5Jyvup" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="3bE2i5JyvuJ" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="3bE2i5JyvuQ" role="1PaTwD">
+              <property role="3oM_SC" value="priority" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="3bE2i5JyuOr" role="3cqZAp">
+          <node concept="37vLTw" id="3bE2i5JyuRg" role="3cqZAk">
+            <ref role="3cqZAo" node="3bE2i5JyurL" resolve="PRIORITY" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="3bE2i5JypXo" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="3bE2i5JypZB" role="jymVt">
+      <property role="TrG5h" value="getConversionSpecifierSelection" />
+      <node concept="3Tm1VV" id="3bE2i5JypZD" role="1B3o_S" />
+      <node concept="3uibUv" id="3bE2i5JypZE" role="3clF45">
+        <ref role="3uigEE" to="zdxd:4qv99IrykBs" resolve="ConversionSpecifierSelection" />
+      </node>
+      <node concept="3clFbS" id="3bE2i5JypZF" role="3clF47">
+        <node concept="3clFbF" id="3bE2i5Jyqh9" role="3cqZAp">
+          <node concept="Rm8GO" id="3bE2i5Jyqha" role="3clFbG">
+            <ref role="Rm8GQ" to="zdxd:4qv99IrykKI" resolve="DEFINED_IN_CONVERT_EXPESSION" />
+            <ref role="1Px2BO" to="zdxd:4qv99IrykBs" resolve="ConversionSpecifierSelection" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="3bE2i5JypZG" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
@@ -29,12 +29,15 @@
     <import index="tpd4" ref="r:00000000-0000-4000-0000-011c895902b4(jetbrains.mps.lang.typesystem.structure)" />
     <import index="63ih" ref="r:8b224ec5-7a3e-45b9-8341-eb73ff942246(org.iets3.core.expr.math.typesystem)" />
     <import index="9zoj" ref="r:1b0f275e-bd62-4f6e-8c4b-51b05d651a63(com.mbeddr.core.base.typesystem)" />
+    <import index="cp9o" ref="r:df6d55ea-0ac0-4364-9581-8cb45ef224d6(test.ts.expr.os.plugin)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="2325284917965760583" name="jetbrains.mps.lang.test.structure.BeforeTestsMethod" flags="ig" index="0EjCn" />
+      <concept id="2325284917965760584" name="jetbrains.mps.lang.test.structure.AfterTestsMethod" flags="ig" index="0EjCo" />
       <concept id="1215507671101" name="jetbrains.mps.lang.test.structure.NodeErrorCheckOperation" flags="ng" index="1TM$A">
         <child id="8489045168660938517" name="errorRef" index="3lydEf" />
       </concept>
@@ -56,6 +59,8 @@
       </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="2325284917965993569" name="beforeTests" index="0EEgL" />
+        <child id="2325284917965993580" name="afterTests" index="0EEgW" />
         <child id="1216993439383" name="methods" index="1qtyYc" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
         <child id="1217501895093" name="testMethods" index="1SL9yI" />
@@ -73,6 +78,10 @@
       <concept id="1219920932475" name="jetbrains.mps.baseLanguage.structure.VariableArityType" flags="in" index="8X2XB">
         <child id="1219921048460" name="componentType" index="8Xvag" />
       </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
@@ -85,11 +94,17 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
@@ -100,6 +115,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -7424,6 +7440,37 @@
         </node>
         <node concept="_ixoA" id="74SLKEls$c1" role="_iOnC" />
         <node concept="_ixoA" id="74SLKElsygs" role="_iOnC" />
+      </node>
+    </node>
+    <node concept="0EjCn" id="3bE2i5JyBzb" role="0EEgL">
+      <node concept="3clFbS" id="3bE2i5JyBzc" role="2VODD2">
+        <node concept="3clFbF" id="3bE2i5JyBzu" role="3cqZAp">
+          <node concept="37vLTI" id="3bE2i5JyCp7" role="3clFbG">
+            <node concept="10M0yZ" id="3bE2i5JyCqc" role="37vLTx">
+              <ref role="3cqZAo" to="wyt6:~Integer.MAX_VALUE" resolve="MAX_VALUE" />
+              <ref role="1PxDUh" to="wyt6:~Integer" resolve="Integer" />
+            </node>
+            <node concept="10M0yZ" id="3bE2i5JyBzN" role="37vLTJ">
+              <ref role="3cqZAo" to="cp9o:3bE2i5JyurL" resolve="PRIORITY" />
+              <ref role="1PxDUh" to="cp9o:3bE2i5JypU2" resolve="NewBehaviorUnitLangConfig" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="0EjCo" id="3bE2i5JOcCe" role="0EEgW">
+      <node concept="3clFbS" id="3bE2i5JOcCf" role="2VODD2">
+        <node concept="3clFbF" id="3bE2i5JOcDc" role="3cqZAp">
+          <node concept="37vLTI" id="3bE2i5JOdvS" role="3clFbG">
+            <node concept="3cmrfG" id="3bE2i5JOdwh" role="37vLTx">
+              <property role="3cmrfH" value="-1" />
+            </node>
+            <node concept="10M0yZ" id="3bE2i5JOcEF" role="37vLTJ">
+              <ref role="3cqZAo" to="cp9o:3bE2i5JyurL" resolve="PRIORITY" />
+              <ref role="1PxDUh" to="cp9o:3bE2i5JypU2" resolve="NewBehaviorUnitLangConfig" />
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
@@ -30,6 +30,8 @@
     <import index="63ih" ref="r:8b224ec5-7a3e-45b9-8341-eb73ff942246(org.iets3.core.expr.math.typesystem)" />
     <import index="9zoj" ref="r:1b0f275e-bd62-4f6e-8c4b-51b05d651a63(com.mbeddr.core.base.typesystem)" />
     <import index="cp9o" ref="r:df6d55ea-0ac0-4364-9581-8cb45ef224d6(test.ts.expr.os.plugin)" />
+    <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
+    <import index="xlxw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.math(JDK/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
@@ -108,6 +110,10 @@
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
@@ -125,6 +131,7 @@
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -144,10 +151,19 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
       <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
+      <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="nn" index="1gVbGN">
+        <child id="1160998896846" name="condition" index="1gVkn0" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -7474,99 +7490,333 @@
       </node>
     </node>
   </node>
-  <node concept="_iOnU" id="74SLKElsxe3">
-    <property role="1XBH2A" value="true" />
+  <node concept="1lH9Xt" id="31BxekZWy2w">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
     <property role="TrG5h" value="TestInterpreterForUnitConversionCyclic" />
-    <ref role="2HwdWd" node="5XaocLWHGMs" resolve="CyclicUnits" />
-    <node concept="_fkuM" id="74SLKElsxe4" role="_iOnB">
-      <property role="TrG5h" value="testConversionInterpreterCyclic" />
-      <node concept="_fkuZ" id="74SLKElsxe5" role="_fkp5">
-        <node concept="_fku$" id="74SLKElsxe6" role="_fkur" />
-        <node concept="1PfFCI" id="74SLKElsxe7" role="_fkuY">
-          <ref role="1Pfwd7" node="74SLKElses0" resolve="b" />
-          <ref role="2yhJs8" node="74SLKElsygQ" resolve="conversion_a_b (any)" />
-          <node concept="1YnStw" id="74SLKElsxe8" role="30czhm">
-            <node concept="CIsGf" id="74SLKElsxe9" role="2c7tTI">
-              <node concept="CIsvn" id="74SLKElsxea" role="CIi4h">
-                <ref role="CIi3I" node="5XaocLWHSS4" resolve="a" />
+    <node concept="1LZb2c" id="31BxekZWABh" role="1SL9yI">
+      <property role="TrG5h" value="cyclicConversion1" />
+      <node concept="3cqZAl" id="31BxekZWABi" role="3clF45" />
+      <node concept="3clFbS" id="31BxekZWABm" role="3clF47">
+        <node concept="3cpWs8" id="31Bxel01qHC" role="3cqZAp">
+          <node concept="3cpWsn" id="31Bxel01qHD" role="3cpWs9">
+            <property role="TrG5h" value="evaluate" />
+            <node concept="3uibUv" id="31Bxel01iNS" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+            </node>
+            <node concept="2YIFZM" id="31Bxel01qHE" role="33vP2m">
+              <ref role="37wK5l" to="pbu6:3xDNhgd54rl" resolve="evaluate" />
+              <ref role="1Pybhc" to="pbu6:3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
+              <node concept="3xONca" id="31Bxel01qHF" role="37wK5m">
+                <ref role="3xOPvv" node="31BxekZX$Xj" resolve="test1" />
               </node>
             </node>
-            <node concept="30bXRB" id="74SLKElsDuu" role="1YnStB">
-              <property role="30bXRw" value="1" />
-            </node>
           </node>
         </node>
-        <node concept="30bXRB" id="74SLKElsxec" role="_fkuS">
-          <property role="30bXRw" value="1000" />
-        </node>
-      </node>
-      <node concept="_fkuZ" id="74SLKElsCVT" role="_fkp5">
-        <node concept="_fku$" id="74SLKElsCVU" role="_fkur" />
-        <node concept="1PfFCI" id="74SLKElsCVV" role="_fkuY">
-          <ref role="1Pfwd7" node="5XaocLWHSS4" resolve="a" />
-          <ref role="2yhJs8" node="74SLKElsIWE" resolve="conversion_b_a (any)" />
-          <node concept="1YnStw" id="74SLKElsCVW" role="30czhm">
-            <node concept="CIsGf" id="74SLKElsCVX" role="2c7tTI">
-              <node concept="CIsvn" id="74SLKElsCVY" role="CIi4h">
-                <ref role="CIi3I" node="74SLKElses0" resolve="b" />
+        <node concept="1gVbGN" id="31Bxel01qQS" role="3cqZAp">
+          <node concept="3clFbC" id="31Bxel01qTh" role="1gVkn0">
+            <node concept="3cmrfG" id="31Bxel01qTi" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+            <node concept="2OqwBi" id="31Bxel01qTj" role="3uHU7B">
+              <node concept="1eOMI4" id="31Bxel01qTk" role="2Oq$k0">
+                <node concept="10QFUN" id="31Bxel01qTl" role="1eOMHV">
+                  <node concept="37vLTw" id="31Bxel01qTm" role="10QFUP">
+                    <ref role="3cqZAo" node="31Bxel01qHD" resolve="evaluate" />
+                  </node>
+                  <node concept="3uibUv" id="31Bxel01qTn" role="10QFUM">
+                    <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="31Bxel01qTo" role="2OqNvi">
+                <ref role="37wK5l" to="xlxw:~BigInteger.compareTo(java.math.BigInteger)" resolve="compareTo" />
+                <node concept="2YIFZM" id="31Bxel01qTp" role="37wK5m">
+                  <ref role="37wK5l" to="xlxw:~BigInteger.valueOf(long)" resolve="valueOf" />
+                  <ref role="1Pybhc" to="xlxw:~BigInteger" resolve="BigInteger" />
+                  <node concept="3cmrfG" id="31Bxel01qTq" role="37wK5m">
+                    <property role="3cmrfH" value="1000" />
+                  </node>
+                </node>
               </node>
             </node>
-            <node concept="30bXRB" id="74SLKElsDHt" role="1YnStB">
-              <property role="30bXRw" value="1000" />
-            </node>
           </node>
-        </node>
-        <node concept="30bXRB" id="74SLKElsCW0" role="_fkuS">
-          <property role="30bXRw" value="1" />
-        </node>
-      </node>
-      <node concept="3dYjL0" id="74SLKElsxey" role="_fkp5" />
-      <node concept="_fkuZ" id="74SLKElsxez" role="_fkp5">
-        <node concept="_fku$" id="74SLKElsxe$" role="_fkur" />
-        <node concept="1QScDb" id="74SLKElsxe_" role="_fkuY">
-          <node concept="3EXbTZ" id="74SLKElsxeA" role="1QScD9">
-            <ref role="3EXiBN" node="74SLKElses0" resolve="b" />
-            <ref role="3EXiBM" node="74SLKElsygQ" resolve="conversion_a_b (any)" />
-          </node>
-          <node concept="1YnStw" id="74SLKElsxeB" role="30czhm">
-            <node concept="CIsGf" id="74SLKElsxeC" role="2c7tTI">
-              <node concept="CIsvn" id="74SLKElsxeD" role="CIi4h">
-                <ref role="CIi3I" node="5XaocLWHSS4" resolve="a" />
-              </node>
-            </node>
-            <node concept="30bXRB" id="74SLKElsxeE" role="1YnStB">
-              <property role="30bXRw" value="5" />
-            </node>
-          </node>
-        </node>
-        <node concept="30bXRB" id="74SLKElsxeF" role="_fkuS">
-          <property role="30bXRw" value="5000" />
-        </node>
-      </node>
-      <node concept="_fkuZ" id="74SLKElsDat" role="_fkp5">
-        <node concept="_fku$" id="74SLKElsDau" role="_fkur" />
-        <node concept="1QScDb" id="74SLKElsDav" role="_fkuY">
-          <node concept="3EXbTZ" id="74SLKElsDaw" role="1QScD9">
-            <ref role="3EXiBN" node="5XaocLWHSS4" resolve="a" />
-            <ref role="3EXiBM" node="74SLKElsIWE" resolve="conversion_b_a (any)" />
-          </node>
-          <node concept="1YnStw" id="74SLKElsDax" role="30czhm">
-            <node concept="CIsGf" id="74SLKElsDay" role="2c7tTI">
-              <node concept="CIsvn" id="74SLKElsDaz" role="CIi4h">
-                <ref role="CIi3I" node="74SLKElses0" resolve="b" />
-              </node>
-            </node>
-            <node concept="30bXRB" id="74SLKElsDa$" role="1YnStB">
-              <property role="30bXRw" value="1000" />
-            </node>
-          </node>
-        </node>
-        <node concept="30bXRB" id="74SLKElsDa_" role="_fkuS">
-          <property role="30bXRw" value="1" />
         </node>
       </node>
     </node>
-    <node concept="_ixoA" id="74SLKElsxeY" role="_iOnB" />
+    <node concept="1LZb2c" id="31BxekZYbOA" role="1SL9yI">
+      <property role="TrG5h" value="cyclicConversion2" />
+      <node concept="3cqZAl" id="31BxekZYbOB" role="3clF45" />
+      <node concept="3clFbS" id="31BxekZYbOF" role="3clF47">
+        <node concept="3cpWs8" id="31BxekZYVPN" role="3cqZAp">
+          <node concept="3cpWsn" id="31BxekZYVPO" role="3cpWs9">
+            <property role="TrG5h" value="evaluate" />
+            <node concept="3uibUv" id="31BxekZYSWr" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+            </node>
+            <node concept="2YIFZM" id="31BxekZYVPP" role="33vP2m">
+              <ref role="37wK5l" to="pbu6:3xDNhgd54rl" resolve="evaluate" />
+              <ref role="1Pybhc" to="pbu6:3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
+              <node concept="3xONca" id="31BxekZYVPQ" role="37wK5m">
+                <ref role="3xOPvv" node="31BxekZXQ0w" resolve="test2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1gVbGN" id="31Bxel00H8z" role="3cqZAp">
+          <node concept="3clFbC" id="31Bxel00K4f" role="1gVkn0">
+            <node concept="3cmrfG" id="31Bxel00KCG" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+            <node concept="2OqwBi" id="31Bxel00HG7" role="3uHU7B">
+              <node concept="1eOMI4" id="31Bxel00HiR" role="2Oq$k0">
+                <node concept="10QFUN" id="31Bxel00HiQ" role="1eOMHV">
+                  <node concept="37vLTw" id="31Bxel00HiP" role="10QFUP">
+                    <ref role="3cqZAo" node="31BxekZYVPO" resolve="evaluate" />
+                  </node>
+                  <node concept="3uibUv" id="31Bxel00Hnr" role="10QFUM">
+                    <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="31Bxel00IwC" role="2OqNvi">
+                <ref role="37wK5l" to="xlxw:~BigDecimal.compareTo(java.math.BigDecimal)" resolve="compareTo" />
+                <node concept="2YIFZM" id="31Bxel00J2a" role="37wK5m">
+                  <ref role="37wK5l" to="xlxw:~BigDecimal.valueOf(long)" resolve="valueOf" />
+                  <ref role="1Pybhc" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+                  <node concept="3cmrfG" id="31Bxel00J6r" role="37wK5m">
+                    <property role="3cmrfH" value="1" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="31BxekZYc1X" role="1SL9yI">
+      <property role="TrG5h" value="cyclicConversion3" />
+      <node concept="3cqZAl" id="31BxekZYc1Y" role="3clF45" />
+      <node concept="3clFbS" id="31BxekZYc22" role="3clF47">
+        <node concept="3cpWs8" id="31Bxel01rk5" role="3cqZAp">
+          <node concept="3cpWsn" id="31Bxel01rk6" role="3cpWs9">
+            <property role="TrG5h" value="evaluate" />
+            <node concept="3uibUv" id="31Bxel01rk7" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+            </node>
+            <node concept="2YIFZM" id="31Bxel01rk8" role="33vP2m">
+              <ref role="37wK5l" to="pbu6:3xDNhgd54rl" resolve="evaluate" />
+              <ref role="1Pybhc" to="pbu6:3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
+              <node concept="3xONca" id="31Bxel01rk9" role="37wK5m">
+                <ref role="3xOPvv" node="31BxekZXR26" resolve="test3" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1gVbGN" id="31Bxel01rka" role="3cqZAp">
+          <node concept="3clFbC" id="31Bxel01rkb" role="1gVkn0">
+            <node concept="3cmrfG" id="31Bxel01rkc" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+            <node concept="2OqwBi" id="31Bxel01rkd" role="3uHU7B">
+              <node concept="1eOMI4" id="31Bxel01rke" role="2Oq$k0">
+                <node concept="10QFUN" id="31Bxel01rkf" role="1eOMHV">
+                  <node concept="37vLTw" id="31Bxel01rkg" role="10QFUP">
+                    <ref role="3cqZAo" node="31Bxel01rk6" resolve="evaluate" />
+                  </node>
+                  <node concept="3uibUv" id="31Bxel01rkh" role="10QFUM">
+                    <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="31Bxel01rki" role="2OqNvi">
+                <ref role="37wK5l" to="xlxw:~BigInteger.compareTo(java.math.BigInteger)" resolve="compareTo" />
+                <node concept="2YIFZM" id="31Bxel01rkj" role="37wK5m">
+                  <ref role="37wK5l" to="xlxw:~BigInteger.valueOf(long)" resolve="valueOf" />
+                  <ref role="1Pybhc" to="xlxw:~BigInteger" resolve="BigInteger" />
+                  <node concept="3cmrfG" id="31Bxel01rkk" role="37wK5m">
+                    <property role="3cmrfH" value="5000" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="31BxekZYcfq" role="1SL9yI">
+      <property role="TrG5h" value="cyclicConversion4" />
+      <node concept="3cqZAl" id="31BxekZYcfr" role="3clF45" />
+      <node concept="3clFbS" id="31BxekZYcfv" role="3clF47">
+        <node concept="3cpWs8" id="31Bxel01rGX" role="3cqZAp">
+          <node concept="3cpWsn" id="31Bxel01rGY" role="3cpWs9">
+            <property role="TrG5h" value="evaluate" />
+            <node concept="3uibUv" id="31Bxel01rGZ" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+            </node>
+            <node concept="2YIFZM" id="31Bxel01rH0" role="33vP2m">
+              <ref role="37wK5l" to="pbu6:3xDNhgd54rl" resolve="evaluate" />
+              <ref role="1Pybhc" to="pbu6:3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
+              <node concept="3xONca" id="31Bxel01rH1" role="37wK5m">
+                <ref role="3xOPvv" node="31BxekZXS46" resolve="test4" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1gVbGN" id="31Bxel01rH2" role="3cqZAp">
+          <node concept="3clFbC" id="31Bxel01rH3" role="1gVkn0">
+            <node concept="3cmrfG" id="31Bxel01rH4" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+            <node concept="2OqwBi" id="31Bxel01rH5" role="3uHU7B">
+              <node concept="1eOMI4" id="31Bxel01rH6" role="2Oq$k0">
+                <node concept="10QFUN" id="31Bxel01rH7" role="1eOMHV">
+                  <node concept="37vLTw" id="31Bxel01rH8" role="10QFUP">
+                    <ref role="3cqZAo" node="31Bxel01rGY" resolve="evaluate" />
+                  </node>
+                  <node concept="3uibUv" id="31Bxel01rH9" role="10QFUM">
+                    <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="31Bxel01rHa" role="2OqNvi">
+                <ref role="37wK5l" to="xlxw:~BigDecimal.compareTo(java.math.BigDecimal)" resolve="compareTo" />
+                <node concept="2YIFZM" id="31Bxel01rHb" role="37wK5m">
+                  <ref role="37wK5l" to="xlxw:~BigDecimal.valueOf(long)" resolve="valueOf" />
+                  <ref role="1Pybhc" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+                  <node concept="3cmrfG" id="31Bxel01rHc" role="37wK5m">
+                    <property role="3cmrfH" value="1" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="31BxekZWy2x" role="1SKRRt">
+      <node concept="_iOnV" id="31BxekZWy2_" role="1qenE9">
+        <property role="TrG5h" value="TestCyclicConversion" />
+        <node concept="2zPypq" id="31BxekZWykv" role="_iOnC">
+          <property role="TrG5h" value="test1" />
+          <node concept="1PfFCI" id="31BxekZX$$G" role="2zPyp_">
+            <ref role="1Pfwd7" node="74SLKElses0" resolve="b" />
+            <ref role="2yhJs8" node="74SLKElsygQ" resolve="conversion_a_b (any)" />
+            <node concept="1YnStw" id="31BxekZX$$H" role="30czhm">
+              <node concept="CIsGf" id="31BxekZX$$I" role="2c7tTI">
+                <node concept="CIsvn" id="31BxekZX$$J" role="CIi4h">
+                  <ref role="CIi3I" node="5XaocLWHSS4" resolve="a" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="31BxekZX$$K" role="1YnStB">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="3xLA65" id="31BxekZX$Xj" role="lGtFl">
+              <property role="TrG5h" value="test1" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="31BxekZWynz" role="_iOnC">
+          <property role="TrG5h" value="test2" />
+          <node concept="1PfFCI" id="31BxekZXPHn" role="2zPyp_">
+            <ref role="1Pfwd7" node="5XaocLWHSS4" resolve="a" />
+            <ref role="2yhJs8" node="74SLKElsIWE" resolve="conversion_b_a (any)" />
+            <node concept="1YnStw" id="31BxekZXPHo" role="30czhm">
+              <node concept="CIsGf" id="31BxekZXPHp" role="2c7tTI">
+                <node concept="CIsvn" id="31BxekZXPHq" role="CIi4h">
+                  <ref role="CIi3I" node="74SLKElses0" resolve="b" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="31BxekZXPHr" role="1YnStB">
+                <property role="30bXRw" value="1000" />
+              </node>
+            </node>
+            <node concept="3xLA65" id="31BxekZXQ0w" role="lGtFl">
+              <property role="TrG5h" value="test2" />
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="31BxekZWyrd" role="_iOnC" />
+        <node concept="2zPypq" id="31BxekZWyrG" role="_iOnC">
+          <property role="TrG5h" value="test3" />
+          <node concept="1QScDb" id="31BxekZXQDK" role="2zPyp_">
+            <node concept="3EXbTZ" id="31BxekZXQDL" role="1QScD9">
+              <ref role="3EXiBN" node="74SLKElses0" resolve="b" />
+              <ref role="3EXiBM" node="74SLKElsygQ" resolve="conversion_a_b (any)" />
+            </node>
+            <node concept="1YnStw" id="31BxekZXQDM" role="30czhm">
+              <node concept="CIsGf" id="31BxekZXQDN" role="2c7tTI">
+                <node concept="CIsvn" id="31BxekZXQDO" role="CIi4h">
+                  <ref role="CIi3I" node="5XaocLWHSS4" resolve="a" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="31BxekZXQDP" role="1YnStB">
+                <property role="30bXRw" value="5" />
+              </node>
+            </node>
+            <node concept="3xLA65" id="31BxekZXR26" role="lGtFl">
+              <property role="TrG5h" value="test3" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="31BxekZWysm" role="_iOnC">
+          <property role="TrG5h" value="test4" />
+          <node concept="1QScDb" id="31BxekZXRGT" role="2zPyp_">
+            <node concept="3EXbTZ" id="31BxekZXRGU" role="1QScD9">
+              <ref role="3EXiBN" node="5XaocLWHSS4" resolve="a" />
+              <ref role="3EXiBM" node="74SLKElsIWE" resolve="conversion_b_a (any)" />
+            </node>
+            <node concept="1YnStw" id="31BxekZXRGV" role="30czhm">
+              <node concept="CIsGf" id="31BxekZXRGW" role="2c7tTI">
+                <node concept="CIsvn" id="31BxekZXRGX" role="CIi4h">
+                  <ref role="CIi3I" node="74SLKElses0" resolve="b" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="31BxekZXRGY" role="1YnStB">
+                <property role="30bXRw" value="1000" />
+              </node>
+            </node>
+            <node concept="3xLA65" id="31BxekZXS46" role="lGtFl">
+              <property role="TrG5h" value="test4" />
+            </node>
+          </node>
+        </node>
+        <node concept="3GEVxB" id="31BxekZWykp" role="3i6evy">
+          <ref role="3GEb4d" node="5XaocLWHGMs" resolve="CyclicUnits" />
+        </node>
+      </node>
+    </node>
+    <node concept="0EjCn" id="31BxekZWAps" role="0EEgL">
+      <node concept="3clFbS" id="31BxekZWApt" role="2VODD2">
+        <node concept="3clFbF" id="31BxekZWApw" role="3cqZAp">
+          <node concept="37vLTI" id="31BxekZWApx" role="3clFbG">
+            <node concept="10M0yZ" id="31BxekZWApy" role="37vLTx">
+              <ref role="3cqZAo" to="wyt6:~Integer.MAX_VALUE" resolve="MAX_VALUE" />
+              <ref role="1PxDUh" to="wyt6:~Integer" resolve="Integer" />
+            </node>
+            <node concept="10M0yZ" id="31BxekZWApz" role="37vLTJ">
+              <ref role="3cqZAo" to="cp9o:3bE2i5JyurL" resolve="PRIORITY" />
+              <ref role="1PxDUh" to="cp9o:3bE2i5JypU2" resolve="NewBehaviorUnitLangConfig" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="0EjCo" id="31BxekZWA$R" role="0EEgW">
+      <node concept="3clFbS" id="31BxekZWA$S" role="2VODD2">
+        <node concept="3clFbF" id="31BxekZWA_3" role="3cqZAp">
+          <node concept="37vLTI" id="31BxekZWA_4" role="3clFbG">
+            <node concept="10M0yZ" id="31BxekZWA_6" role="37vLTJ">
+              <ref role="3cqZAo" to="cp9o:3bE2i5JyurL" resolve="PRIORITY" />
+              <ref role="1PxDUh" to="cp9o:3bE2i5JypU2" resolve="NewBehaviorUnitLangConfig" />
+            </node>
+            <node concept="3cmrfG" id="31BxekZWAAp" role="37vLTx">
+              <property role="3cmrfH" value="-1" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
@@ -28,6 +28,7 @@
     <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" />
     <import index="tpd4" ref="r:00000000-0000-4000-0000-011c895902b4(jetbrains.mps.lang.typesystem.structure)" />
     <import index="63ih" ref="r:8b224ec5-7a3e-45b9-8341-eb73ff942246(org.iets3.core.expr.math.typesystem)" />
+    <import index="9zoj" ref="r:1b0f275e-bd62-4f6e-8c4b-51b05d651a63(com.mbeddr.core.base.typesystem)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
@@ -347,6 +348,9 @@
       </concept>
       <concept id="7740953487936184022" name="org.iets3.core.expr.toplevel.structure.TypedefType" flags="ng" index="1WbbFT">
         <reference id="7740953487936184023" name="typedef" index="1WbbFS" />
+      </concept>
+      <concept id="7740953487933794886" name="org.iets3.core.expr.toplevel.structure.SectionMarker" flags="ng" index="1Ws0TD">
+        <property id="7740953487933876080" name="label" index="1WsWdv" />
       </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
@@ -7329,6 +7333,193 @@
     <node concept="CIrOH" id="2UZH4PMT5J8" role="_iOnC">
       <property role="TrG5h" value="s" />
     </node>
+  </node>
+  <node concept="1lH9Xt" id="74SLKElsaBA">
+    <property role="TrG5h" value="Cycles" />
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <node concept="1qefOq" id="74SLKElsaCF" role="1SKRRt">
+      <node concept="_iOnV" id="5XaocLWHGMs" role="1qenE9">
+        <property role="TrG5h" value="CyclicUnits" />
+        <node concept="Rn5op" id="1KUmgSFvJUk" role="_iOnC">
+          <property role="TrG5h" value="quantityA" />
+        </node>
+        <node concept="Rn5op" id="74SLKEltgH7" role="_iOnC">
+          <property role="TrG5h" value="quantityB" />
+        </node>
+        <node concept="_ixoA" id="_I$tx9G_Hy" role="_iOnC" />
+        <node concept="1Ws0TD" id="_I$tx9G_GS" role="_iOnC">
+          <property role="1WsWdv" value="SI Units" />
+        </node>
+        <node concept="CIrOH" id="5XaocLWHSS4" role="_iOnC">
+          <property role="TrG5h" value="a" />
+          <ref role="Rn5ok" node="1KUmgSFvJUk" resolve="quantity" />
+          <node concept="7CXmI" id="74SLKElsesQ" role="lGtFl">
+            <node concept="1TM$A" id="74SLKElsesR" role="7EUXB">
+              <node concept="2PYRI3" id="74SLKElsesS" role="3lydEf">
+                <ref role="39XzEq" to="9zoj:17fjvcLFfFc" />
+              </node>
+            </node>
+          </node>
+          <node concept="CIsGf" id="74SLKEltDZZ" role="CIsG9">
+            <node concept="CIsvn" id="74SLKEltDZY" role="CIi4h">
+              <ref role="CIi3I" node="74SLKElses0" resolve="b" />
+            </node>
+          </node>
+        </node>
+        <node concept="CIrOH" id="74SLKElses0" role="_iOnC">
+          <property role="TrG5h" value="b" />
+          <ref role="Rn5ok" node="74SLKEltgH7" resolve="quantityB" />
+          <node concept="7CXmI" id="74SLKElseOd" role="lGtFl">
+            <node concept="1TM$A" id="74SLKElseOe" role="7EUXB">
+              <node concept="2PYRI3" id="74SLKElseOf" role="3lydEf">
+                <ref role="39XzEq" to="9zoj:17fjvcLFfFc" />
+              </node>
+            </node>
+          </node>
+          <node concept="CIsGf" id="74SLKEltvex" role="CIsG9">
+            <node concept="CIsvn" id="74SLKEltvew" role="CIi4h">
+              <ref role="CIi3I" node="5XaocLWHSS4" resolve="a" />
+            </node>
+          </node>
+        </node>
+        <node concept="CIrOH" id="74SLKElses$" role="_iOnC">
+          <property role="TrG5h" value="c" />
+          <node concept="CIsGf" id="74SLKElsesM" role="CIsG9">
+            <node concept="CIsvn" id="74SLKElsesL" role="CIi4h">
+              <ref role="CIi3I" node="74SLKElses$" resolve="c" />
+            </node>
+          </node>
+          <node concept="7CXmI" id="74SLKElseOv" role="lGtFl">
+            <node concept="1TM$A" id="74SLKElseOw" role="7EUXB">
+              <node concept="2PYRI3" id="74SLKElseOx" role="3lydEf">
+                <ref role="39XzEq" to="9zoj:17fjvcLFfFc" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="74SLKElsyg4" role="_iOnC" />
+        <node concept="TRoc0" id="74SLKElsygP" role="_iOnC">
+          <ref role="27Q$ZR" node="74SLKElses0" resolve="b" />
+          <ref role="27Q$ZQ" node="5XaocLWHSS4" resolve="a" />
+          <node concept="27LzZq" id="74SLKElsygQ" role="27P04L">
+            <node concept="30dDTi" id="74SLKElsygS" role="27K$mF">
+              <node concept="30bXRB" id="74SLKElsygT" role="30dEs_">
+                <property role="30bXRw" value="1000" />
+              </node>
+              <node concept="2m5Cep" id="74SLKElsygU" role="30dEsF" />
+            </node>
+          </node>
+        </node>
+        <node concept="TRoc0" id="74SLKElsIWD" role="_iOnC">
+          <ref role="27Q$ZR" node="5XaocLWHSS4" resolve="a" />
+          <ref role="27Q$ZQ" node="74SLKElses0" resolve="b" />
+          <node concept="27LzZq" id="74SLKElsIWE" role="27P04L">
+            <node concept="30dvO6" id="74SLKElsIZW" role="27K$mF">
+              <node concept="30bXRB" id="74SLKElsJ0h" role="30dEs_">
+                <property role="30bXRw" value="1000" />
+              </node>
+              <node concept="2m5Cep" id="74SLKElsIWH" role="30dEsF" />
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="74SLKEls$c1" role="_iOnC" />
+        <node concept="_ixoA" id="74SLKElsygs" role="_iOnC" />
+      </node>
+    </node>
+  </node>
+  <node concept="_iOnU" id="74SLKElsxe3">
+    <property role="1XBH2A" value="true" />
+    <property role="TrG5h" value="TestInterpreterForUnitConversionCyclic" />
+    <ref role="2HwdWd" node="5XaocLWHGMs" resolve="CyclicUnits" />
+    <node concept="_fkuM" id="74SLKElsxe4" role="_iOnB">
+      <property role="TrG5h" value="testConversionInterpreterCyclic" />
+      <node concept="_fkuZ" id="74SLKElsxe5" role="_fkp5">
+        <node concept="_fku$" id="74SLKElsxe6" role="_fkur" />
+        <node concept="1PfFCI" id="74SLKElsxe7" role="_fkuY">
+          <ref role="1Pfwd7" node="74SLKElses0" resolve="b" />
+          <ref role="2yhJs8" node="74SLKElsygQ" resolve="conversion_a_b (any)" />
+          <node concept="1YnStw" id="74SLKElsxe8" role="30czhm">
+            <node concept="CIsGf" id="74SLKElsxe9" role="2c7tTI">
+              <node concept="CIsvn" id="74SLKElsxea" role="CIi4h">
+                <ref role="CIi3I" node="5XaocLWHSS4" resolve="a" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="74SLKElsDuu" role="1YnStB">
+              <property role="30bXRw" value="1" />
+            </node>
+          </node>
+        </node>
+        <node concept="30bXRB" id="74SLKElsxec" role="_fkuS">
+          <property role="30bXRw" value="1000" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="74SLKElsCVT" role="_fkp5">
+        <node concept="_fku$" id="74SLKElsCVU" role="_fkur" />
+        <node concept="1PfFCI" id="74SLKElsCVV" role="_fkuY">
+          <ref role="1Pfwd7" node="5XaocLWHSS4" resolve="a" />
+          <ref role="2yhJs8" node="74SLKElsIWE" resolve="conversion_b_a (any)" />
+          <node concept="1YnStw" id="74SLKElsCVW" role="30czhm">
+            <node concept="CIsGf" id="74SLKElsCVX" role="2c7tTI">
+              <node concept="CIsvn" id="74SLKElsCVY" role="CIi4h">
+                <ref role="CIi3I" node="74SLKElses0" resolve="b" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="74SLKElsDHt" role="1YnStB">
+              <property role="30bXRw" value="1000" />
+            </node>
+          </node>
+        </node>
+        <node concept="30bXRB" id="74SLKElsCW0" role="_fkuS">
+          <property role="30bXRw" value="1" />
+        </node>
+      </node>
+      <node concept="3dYjL0" id="74SLKElsxey" role="_fkp5" />
+      <node concept="_fkuZ" id="74SLKElsxez" role="_fkp5">
+        <node concept="_fku$" id="74SLKElsxe$" role="_fkur" />
+        <node concept="1QScDb" id="74SLKElsxe_" role="_fkuY">
+          <node concept="3EXbTZ" id="74SLKElsxeA" role="1QScD9">
+            <ref role="3EXiBN" node="74SLKElses0" resolve="b" />
+            <ref role="3EXiBM" node="74SLKElsygQ" resolve="conversion_a_b (any)" />
+          </node>
+          <node concept="1YnStw" id="74SLKElsxeB" role="30czhm">
+            <node concept="CIsGf" id="74SLKElsxeC" role="2c7tTI">
+              <node concept="CIsvn" id="74SLKElsxeD" role="CIi4h">
+                <ref role="CIi3I" node="5XaocLWHSS4" resolve="a" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="74SLKElsxeE" role="1YnStB">
+              <property role="30bXRw" value="5" />
+            </node>
+          </node>
+        </node>
+        <node concept="30bXRB" id="74SLKElsxeF" role="_fkuS">
+          <property role="30bXRw" value="5000" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="74SLKElsDat" role="_fkp5">
+        <node concept="_fku$" id="74SLKElsDau" role="_fkur" />
+        <node concept="1QScDb" id="74SLKElsDav" role="_fkuY">
+          <node concept="3EXbTZ" id="74SLKElsDaw" role="1QScD9">
+            <ref role="3EXiBN" node="5XaocLWHSS4" resolve="a" />
+            <ref role="3EXiBM" node="74SLKElsIWE" resolve="conversion_b_a (any)" />
+          </node>
+          <node concept="1YnStw" id="74SLKElsDax" role="30czhm">
+            <node concept="CIsGf" id="74SLKElsDay" role="2c7tTI">
+              <node concept="CIsvn" id="74SLKElsDaz" role="CIi4h">
+                <ref role="CIi3I" node="74SLKElses0" resolve="b" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="74SLKElsDa$" role="1YnStB">
+              <property role="30bXRw" value="1000" />
+            </node>
+          </node>
+        </node>
+        <node concept="30bXRB" id="74SLKElsDa_" role="_fkuS">
+          <property role="30bXRw" value="1" />
+        </node>
+      </node>
+    </node>
+    <node concept="_ixoA" id="74SLKElsxeY" role="_iOnB" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
@@ -28,6 +28,7 @@
     <dependency reexport="false">a2242e6f-d308-41e6-ac06-28b0a2a4ad79(test.ts.expr.os.validNameConcept)</dependency>
     <dependency reexport="false">4621d3e3-b8a3-4bbe-b7ac-234b6e2d1d68(org.iets3.core.expr.temporal)</dependency>
     <dependency reexport="false">289fb12b-7f53-4ef7-bc2e-1ed2c6a7c998(org.iets3.core.expr.datetime)</dependency>
+    <dependency reexport="false">c0080a47-7e37-4558-bee9-9ae18e690549(jetbrains.mps.lang.extension)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
@@ -44,10 +44,14 @@
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:c0080a47-7e37-4558-bee9-9ae18e690549:jetbrains.mps.lang.extension" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="5" />
+    <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
@@ -113,6 +117,7 @@
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="c0080a47-7e37-4558-bee9-9ae18e690549(jetbrains.mps.lang.extension)" version="0" />
     <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
     <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
     <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />


### PR DESCRIPTION
This PR fixes https://github.com/IETS3/iets3.opensource/issues/728. In addition, the automatically set conversion specifier of the `convert` expression and the `convertTo`  target is now used instead of the first applicable conversion specifier. This way, the converting even works with those cyclic definitions. The editor also shouldn't freeze anymore when using cyclic definitions. Example:
                      
```
quantity quantityA                                          
quantity quantityB                                          
                                                                               
unit a := b for quantityA
unit b := a for quantityB
unit c := c
                                                            
conversion a -> b {                                         
val as <no type> -> val * 1000                              
}                                                           
conversion b -> a {                                         
val as <no type> -> val / 1000                              
}                                                           

test case testConversionInterpreterCyclic [incomplete] {    
  assert convert[1 a -> b] equals 1000
  assert convert[1000 b -> a] equals 1
                                                            
  assert 5 a.convertTo(b)equals 5000
  assert 1000 b.convertTo(a)equals 1
}           
```                                                
                                                            
                                                            