### PR TITLE
Don't call the interpreter with computation trace enabled with it is not necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 - The `all` and `any` operation of collections now also support the `index` expression. The concepts `AllWithIndexOp` and `AnyWithIndexOp` are therefore deprecated.
 
+### Changed
+
+- The class `IETS3ExprEvalHelper` was deprecated and a new class `IETS3ExprEvaluator` was introduced that can also influence the creation of the computation trace.
+
 ## November 2023
 
 ### Added

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -22951,17 +22951,32 @@
                     </node>
                     <node concept="3Tm1VV" id="5IR_boHRmen" role="1B3o_S" />
                     <node concept="3clFbS" id="5IR_boHRmeo" role="3clF47">
-                      <node concept="3cpWs8" id="5IR_boHUFHp" role="3cqZAp">
-                        <node concept="3cpWsn" id="5IR_boHUFHq" role="3cpWs9">
-                          <property role="TrG5h" value="r" />
-                          <node concept="3uibUv" id="5IR_boHUFHl" role="1tU5fm">
-                            <ref role="3uigEE" node="7lHetQyBI3r" resolve="ValueAndTrace" />
+                      <node concept="3cpWs8" id="5af9jCuJP7w" role="3cqZAp">
+                        <node concept="3cpWsn" id="5af9jCuJP7x" role="3cpWs9">
+                          <property role="TrG5h" value="result" />
+                          <node concept="3uibUv" id="5af9jCuJOZj" role="1tU5fm">
+                            <ref role="3uigEE" node="4Pi6J8Cccqb" resolve="ValueAndTraceAndEnv" />
                           </node>
-                          <node concept="2YIFZM" id="5IR_boHUFHr" role="33vP2m">
-                            <ref role="37wK5l" node="7obiejCzIm_" resolve="evaluateWithTrace" />
-                            <ref role="1Pybhc" node="3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
-                            <node concept="37vLTw" id="5IR_boHUFHt" role="37wK5m">
-                              <ref role="3cqZAo" node="5IR_boHRjde" resolve="n" />
+                          <node concept="2OqwBi" id="5af9jCuJP7y" role="33vP2m">
+                            <node concept="2OqwBi" id="5af9jCuJP7z" role="2Oq$k0">
+                              <node concept="2ShNRf" id="5af9jCuJP7$" role="2Oq$k0">
+                                <node concept="HV5vD" id="5af9jCuJP7_" role="2ShVmc">
+                                  <property role="373rjd" value="true" />
+                                  <ref role="HV5vE" node="2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="5af9jCuJP7A" role="2OqNvi">
+                                <ref role="37wK5l" node="2nydsCfvLxS" resolve="withComputationTrace" />
+                                <node concept="3clFbT" id="5af9jCuJP7B" role="37wK5m">
+                                  <property role="3clFbU" value="true" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="5af9jCuJP7C" role="2OqNvi">
+                              <ref role="37wK5l" node="2nydsCfz7eH" resolve="evaluate" />
+                              <node concept="37vLTw" id="5af9jCuJP7D" role="37wK5m">
+                                <ref role="3cqZAo" node="5IR_boHRjde" resolve="n" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -22974,7 +22989,7 @@
                           </node>
                           <node concept="2OqwBi" id="5IR_boHR_I9" role="33vP2m">
                             <node concept="37vLTw" id="5IR_boHUGWC" role="2Oq$k0">
-                              <ref role="3cqZAo" node="5IR_boHUFHq" resolve="r" />
+                              <ref role="3cqZAo" node="5af9jCuJP7x" resolve="result" />
                             </node>
                             <node concept="2OwXpG" id="5IR_boHUHYf" role="2OqNvi">
                               <ref role="2Oxat5" node="7lHetQyBz4T" resolve="trace" />
@@ -26611,6 +26626,86 @@
       <node concept="3uibUv" id="2nydsCfArt3" role="3clF45">
         <ref role="3uigEE" to="2ahs:50LzNoSxDO3" resolve="InterpreterEvaluationHelper" />
       </node>
+    </node>
+    <node concept="2tJIrI" id="7gBavbyuNv1" role="jymVt" />
+    <node concept="3clFb_" id="7gBavbyuRAy" role="jymVt">
+      <property role="TrG5h" value="evaluateAndThrowConstraintFailures" />
+      <node concept="3clFbS" id="7gBavbyuRA$" role="3clF47">
+        <node concept="3J1_TO" id="7gBavbyuRA_" role="3cqZAp">
+          <node concept="3uVAMA" id="7gBavbyuRAA" role="1zxBo5">
+            <node concept="XOnhg" id="7gBavbyuRAB" role="1zc67B">
+              <property role="3TUv4t" value="false" />
+              <property role="TrG5h" value="cfe" />
+              <node concept="nSUau" id="7gBavbyuRAC" role="1tU5fm">
+                <node concept="3uibUv" id="7gBavbyuRAD" role="nSUat">
+                  <ref role="3uigEE" to="oq0c:3Y6fbK1oSAh" resolve="ConstraintFailedException" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="7gBavbyuRAE" role="1zc67A">
+              <node concept="YS8fn" id="7gBavbyuRAF" role="3cqZAp">
+                <node concept="37vLTw" id="7gBavbyuRAG" role="YScLw">
+                  <ref role="3cqZAo" node="7gBavbyuRAB" resolve="cfe" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3uVAMA" id="7gBavbyuRAH" role="1zxBo5">
+            <node concept="XOnhg" id="7gBavbyuRAI" role="1zc67B">
+              <property role="3TUv4t" value="false" />
+              <property role="TrG5h" value="stopEx" />
+              <node concept="nSUau" id="7gBavbyuRAJ" role="1tU5fm">
+                <node concept="3uibUv" id="7gBavbyuRAK" role="nSUat">
+                  <ref role="3uigEE" to="2ahs:6MNhNeUeNix" resolve="StopAndReturnException" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="7gBavbyuRAL" role="1zc67A">
+              <node concept="3cpWs6" id="7gBavbyuRAM" role="3cqZAp">
+                <node concept="2OqwBi" id="7gBavbyuRAN" role="3cqZAk">
+                  <node concept="37vLTw" id="7gBavbyuRAO" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7gBavbyuRAI" resolve="stopEx" />
+                  </node>
+                  <node concept="liA8E" id="7gBavbyuRAP" role="2OqNvi">
+                    <ref role="37wK5l" to="2ahs:6MNhNeUeYe3" resolve="value" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="7gBavbyuRAQ" role="1zxBo7">
+            <node concept="3cpWs6" id="7gBavbyuRAR" role="3cqZAp">
+              <node concept="2OqwBi" id="7gBavbyuRAS" role="3cqZAk">
+                <node concept="2OqwBi" id="7gBavbyuRAT" role="2Oq$k0">
+                  <node concept="2ShNRf" id="7gBavbyuRAU" role="2Oq$k0">
+                    <node concept="HV5vD" id="7gBavbyuRAV" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="HV5vE" node="2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="7gBavbyuRAW" role="2OqNvi">
+                    <ref role="37wK5l" node="2nydsCfz7eH" resolve="evaluate" />
+                    <node concept="37vLTw" id="7gBavbyuRAX" role="37wK5m">
+                      <ref role="3cqZAo" node="7gBavbyuRB1" resolve="expr" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OwXpG" id="7gBavbyuRAY" role="2OqNvi">
+                  <ref role="2Oxat5" node="7lHetQyBz3x" resolve="value" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="7gBavbyuRB0" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+      </node>
+      <node concept="37vLTG" id="7gBavbyuRB1" role="3clF46">
+        <property role="TrG5h" value="expr" />
+        <node concept="3Tqbb2" id="7gBavbyuRB2" role="1tU5fm" />
+      </node>
+      <node concept="3Tm1VV" id="7gBavbyuRAZ" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="2nydsCf$GYl" role="jymVt" />
     <node concept="3clFb_" id="2nydsCfz7eH" role="jymVt">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -8371,17 +8371,12 @@
                         <ref role="37wK5l" to="2ahs:6MNhNeUeYe3" resolve="value" />
                       </node>
                     </node>
-                    <node concept="2OqwBi" id="7obiejCzU08" role="37wK5m">
-                      <node concept="2OqwBi" id="2nydsCfAy$j" role="2Oq$k0">
-                        <node concept="37vLTw" id="7obiejCzU09" role="2Oq$k0">
-                          <ref role="3cqZAo" node="2nydsCfAuHQ" resolve="evaluator" />
-                        </node>
-                        <node concept="liA8E" id="2nydsCfAzdp" role="2OqNvi">
-                          <ref role="37wK5l" node="2nydsCfAryl" resolve="getInternalHelper" />
-                        </node>
+                    <node concept="2OqwBi" id="2nydsCfAy$j" role="37wK5m">
+                      <node concept="37vLTw" id="7obiejCzU09" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2nydsCfAuHQ" resolve="evaluator" />
                       </node>
-                      <node concept="liA8E" id="7obiejCzU0a" role="2OqNvi">
-                        <ref role="37wK5l" to="2ahs:7obiejCzFIg" resolve="getLastLog" />
+                      <node concept="liA8E" id="2nydsCfAzdp" role="2OqNvi">
+                        <ref role="37wK5l" node="7obiejCzFIg" resolve="getLastLog" />
                       </node>
                     </node>
                   </node>
@@ -8666,17 +8661,12 @@
                         <ref role="37wK5l" to="2ahs:6MNhNeUeYe3" resolve="value" />
                       </node>
                     </node>
-                    <node concept="2OqwBi" id="2nydsCfA_Pk" role="37wK5m">
-                      <node concept="2OqwBi" id="2nydsCfA_Pl" role="2Oq$k0">
-                        <node concept="37vLTw" id="2nydsCfA_Pm" role="2Oq$k0">
-                          <ref role="3cqZAo" node="2nydsCfA_P3" resolve="evaluator" />
-                        </node>
-                        <node concept="liA8E" id="2nydsCfA_Pn" role="2OqNvi">
-                          <ref role="37wK5l" node="2nydsCfAryl" resolve="getInternalHelper" />
-                        </node>
+                    <node concept="2OqwBi" id="2nydsCfA_Pl" role="37wK5m">
+                      <node concept="37vLTw" id="2nydsCfA_Pm" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2nydsCfA_P3" resolve="evaluator" />
                       </node>
-                      <node concept="liA8E" id="2nydsCfA_Po" role="2OqNvi">
-                        <ref role="37wK5l" to="2ahs:7obiejCzFIg" resolve="getLastLog" />
+                      <node concept="liA8E" id="2nydsCfA_Pn" role="2OqNvi">
+                        <ref role="37wK5l" node="7obiejCzFIg" resolve="getLastLog" />
                       </node>
                     </node>
                     <node concept="2OqwBi" id="2nydsCfAKCm" role="37wK5m">
@@ -26613,19 +26603,30 @@
       </node>
     </node>
     <node concept="2tJIrI" id="2nydsCfApRm" role="jymVt" />
-    <node concept="3clFb_" id="2nydsCfAryl" role="jymVt">
-      <property role="TrG5h" value="getInternalHelper" />
-      <node concept="3clFbS" id="2nydsCfAryo" role="3clF47">
-        <node concept="3clFbF" id="2nydsCfAswY" role="3cqZAp">
-          <node concept="37vLTw" id="2nydsCfAswX" role="3clFbG">
-            <ref role="3cqZAo" node="2nydsCfAaTv" resolve="helper" />
+    <node concept="3clFb_" id="7obiejCzFIg" role="jymVt">
+      <property role="TrG5h" value="getLastLog" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="7obiejCzFIi" role="3clF47">
+        <node concept="3clFbF" id="7obiejCzFIj" role="3cqZAp">
+          <node concept="2OqwBi" id="5cJmxjBjCia" role="3clFbG">
+            <node concept="2OqwBi" id="7obiejCzFIk" role="2Oq$k0">
+              <node concept="Xjq3P" id="7obiejCzFIl" role="2Oq$k0" />
+              <node concept="2OwXpG" id="7obiejCzFIm" role="2OqNvi">
+                <ref role="2Oxat5" node="2nydsCfAaTv" resolve="helper" />
+              </node>
+            </node>
+            <node concept="liA8E" id="5cJmxjBjCU$" role="2OqNvi">
+              <ref role="37wK5l" to="2ahs:7obiejCzFIg" resolve="getLastLog" />
+            </node>
           </node>
         </node>
       </node>
-      <node concept="3Tm1VV" id="2nydsCfAqHB" role="1B3o_S" />
-      <node concept="3uibUv" id="2nydsCfArt3" role="3clF45">
-        <ref role="3uigEE" to="2ahs:50LzNoSxDO3" resolve="InterpreterEvaluationHelper" />
+      <node concept="3uibUv" id="7obiejCzFIn" role="3clF45">
+        <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
       </node>
+      <node concept="3Tm1VV" id="7obiejCzFIo" role="1B3o_S" />
     </node>
     <node concept="2tJIrI" id="7gBavbyuNv1" role="jymVt" />
     <node concept="3clFb_" id="7gBavbyuRAy" role="jymVt">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -180,6 +180,9 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -374,6 +377,7 @@
       <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
         <property id="8970989240999019144" name="text" index="1dT_AB" />
       </concept>
+      <concept id="2068944020170241612" name="jetbrains.mps.baseLanguage.javadoc.structure.ClassifierDocComment" flags="ng" index="3UR2Jj" />
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
@@ -8038,11 +8042,11 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm1VV" id="rJR8WZSdV5" role="1B3o_S" />
       <node concept="17QB3L" id="50LzNoSyDIb" role="1tU5fm" />
-      <node concept="Xl_RD" id="50LzNoSyDIT" role="33vP2m">
-        <property role="Xl_RC" value="arithmetic" />
+      <node concept="10M0yZ" id="2nydsCfzIcW" role="33vP2m">
+        <ref role="3cqZAo" node="2nydsCfz2XE" resolve="INTERPRETER_CATEGORY" />
+        <ref role="1PxDUh" node="2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
       </node>
     </node>
-    <node concept="2tJIrI" id="50LzNoSyDHy" role="jymVt" />
     <node concept="2tJIrI" id="7obiejCl3Uu" role="jymVt" />
     <node concept="2YIFZL" id="3xDNhgd54rl" role="jymVt">
       <property role="TrG5h" value="evaluate" />
@@ -8132,7 +8136,7 @@
         <node concept="3Tqbb2" id="Qsaevo33zN" role="1tU5fm" />
       </node>
       <node concept="37vLTG" id="Qsaevo35yg" role="3clF46">
-        <property role="TrG5h" value="ctx" />
+        <property role="TrG5h" value="context" />
         <node concept="3uibUv" id="Qsaevo3aM_" role="1tU5fm">
           <ref role="3uigEE" node="6iqfHNC0mHl" resolve="IETS3ExprContext" />
         </node>
@@ -8169,7 +8173,7 @@
         <node concept="3Tqbb2" id="5ElQ4Z$IM$" role="1tU5fm" />
       </node>
       <node concept="37vLTG" id="5ElQ4Z$J$R" role="3clF46">
-        <property role="TrG5h" value="ctx" />
+        <property role="TrG5h" value="context" />
         <node concept="3uibUv" id="5ElQ4Z$J$S" role="1tU5fm">
           <ref role="3uigEE" node="6iqfHNC0mHl" resolve="IETS3ExprContext" />
         </node>
@@ -8182,66 +8186,64 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="5ElQ4Zyzn5" role="3clF47">
-        <node concept="3J1_TO" id="5ElQ4Zyznb" role="3cqZAp">
-          <node concept="3uVAMA" id="5ElQ4Zyznc" role="1zxBo5">
-            <node concept="XOnhg" id="5ElQ4Zyznd" role="1zc67B">
-              <property role="3TUv4t" value="false" />
+        <node concept="3J1_TO" id="2nydsCf$2LP" role="3cqZAp">
+          <node concept="3uVAMA" id="2nydsCf$6tZ" role="1zxBo5">
+            <node concept="XOnhg" id="2nydsCf$6u0" role="1zc67B">
               <property role="TrG5h" value="stopEx" />
-              <node concept="nSUau" id="5ElQ4Zyzne" role="1tU5fm">
-                <node concept="3uibUv" id="5ElQ4Zyznf" role="nSUat">
+              <node concept="nSUau" id="2nydsCf$6u1" role="1tU5fm">
+                <node concept="3uibUv" id="2nydsCf$7h3" role="nSUat">
                   <ref role="3uigEE" to="2ahs:6MNhNeUeNix" resolve="StopAndReturnException" />
                 </node>
               </node>
             </node>
-            <node concept="3clFbS" id="5ElQ4Zyzng" role="1zc67A">
-              <node concept="3cpWs6" id="5ElQ4Zyznh" role="3cqZAp">
-                <node concept="2OqwBi" id="5ElQ4Zyzni" role="3cqZAk">
-                  <node concept="37vLTw" id="5ElQ4Zyznj" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5ElQ4Zyznd" resolve="stopEx" />
+            <node concept="3clFbS" id="2nydsCf$6u2" role="1zc67A">
+              <node concept="3cpWs6" id="2nydsCf$9wN" role="3cqZAp">
+                <node concept="2OqwBi" id="2nydsCf$bGI" role="3cqZAk">
+                  <node concept="37vLTw" id="2nydsCf$bca" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2nydsCf$6u0" resolve="stopEx" />
                   </node>
-                  <node concept="liA8E" id="5ElQ4Zyznk" role="2OqNvi">
+                  <node concept="liA8E" id="2nydsCf$cFe" role="2OqNvi">
                     <ref role="37wK5l" to="2ahs:6MNhNeUeYe3" resolve="value" />
                   </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="3clFbS" id="5ElQ4ZyznZ" role="1zxBo7">
-            <node concept="3cpWs8" id="5ElQ4Zyzo0" role="3cqZAp">
-              <node concept="3cpWsn" id="5ElQ4Zyzo1" role="3cpWs9">
-                <property role="TrG5h" value="helper" />
-                <node concept="3uibUv" id="5ElQ4Zyzo2" role="1tU5fm">
-                  <ref role="3uigEE" to="2ahs:50LzNoSxDO3" resolve="InterpreterEvaluationHelper" />
-                </node>
-                <node concept="2ShNRf" id="5ElQ4Zyzo3" role="33vP2m">
-                  <node concept="1pGfFk" id="5ElQ4Zyzo4" role="2ShVmc">
-                    <ref role="37wK5l" to="2ahs:50LzNoSxJpU" resolve="InterpreterEvaluationHelper" />
-                    <node concept="37vLTw" id="5ElQ4Zyzpc" role="37wK5m">
-                      <ref role="3cqZAo" node="50LzNoSyDId" resolve="INTERPRETER_CATEGORY" />
+          <node concept="3clFbS" id="2nydsCf$2LR" role="1zxBo7">
+            <node concept="3cpWs6" id="2nydsCfB9os" role="3cqZAp">
+              <node concept="2OqwBi" id="2nydsCfBa4Y" role="3cqZAk">
+                <node concept="2OqwBi" id="2nydsCf$fXR" role="2Oq$k0">
+                  <node concept="2OqwBi" id="2nydsCf$fXS" role="2Oq$k0">
+                    <node concept="2OqwBi" id="2nydsCf$fXT" role="2Oq$k0">
+                      <node concept="2ShNRf" id="2nydsCf$fXU" role="2Oq$k0">
+                        <node concept="HV5vD" id="2nydsCf$fXV" role="2ShVmc">
+                          <property role="373rjd" value="true" />
+                          <ref role="HV5vE" node="2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="2nydsCf$fXW" role="2OqNvi">
+                        <ref role="37wK5l" node="2nydsCfvv5Z" resolve="withContext" />
+                        <node concept="37vLTw" id="2nydsCf$fXX" role="37wK5m">
+                          <ref role="3cqZAo" node="5ElQ4Zyzog" resolve="context" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="2nydsCf$fXY" role="2OqNvi">
+                      <ref role="37wK5l" node="2nydsCfw1oG" resolve="withCoverAnalyzer" />
+                      <node concept="37vLTw" id="2nydsCf$fXZ" role="37wK5m">
+                        <ref role="3cqZAo" node="5ElQ4ZyMvG" resolve="coverage" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="2nydsCf$fY0" role="2OqNvi">
+                    <ref role="37wK5l" node="2nydsCfz7eH" resolve="evaluate" />
+                    <node concept="37vLTw" id="2nydsCf$fY1" role="37wK5m">
+                      <ref role="3cqZAo" node="5ElQ4Zyzoe" resolve="expr" />
                     </node>
                   </node>
                 </node>
-              </node>
-            </node>
-            <node concept="3cpWs6" id="5ElQ4Zyzo5" role="3cqZAp">
-              <node concept="2OqwBi" id="5ElQ4Zyzo6" role="3cqZAk">
-                <node concept="37vLTw" id="5ElQ4Zyzo7" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5ElQ4Zyzo1" resolve="helper" />
-                </node>
-                <node concept="liA8E" id="5ElQ4Zyzo8" role="2OqNvi">
-                  <ref role="37wK5l" to="2ahs:14DmiwrcwYd" resolve="evaluateWithContextAndCoverage" />
-                  <node concept="37vLTw" id="5ElQ4Zyzo9" role="37wK5m">
-                    <ref role="3cqZAo" node="5ElQ4Zyzoe" resolve="expr" />
-                  </node>
-                  <node concept="1rXfSq" id="5ElQ4Zyzoa" role="37wK5m">
-                    <ref role="37wK5l" node="50LzNoSyDOv" resolve="getInterpreter" />
-                  </node>
-                  <node concept="37vLTw" id="5ElQ4Zyzob" role="37wK5m">
-                    <ref role="3cqZAo" node="5ElQ4Zyzog" resolve="ctx" />
-                  </node>
-                  <node concept="37vLTw" id="5ElQ4Zyzoc" role="37wK5m">
-                    <ref role="3cqZAo" node="5ElQ4ZyMvG" resolve="coverage" />
-                  </node>
+                <node concept="2OwXpG" id="2nydsCfBaNa" role="2OqNvi">
+                  <ref role="2Oxat5" node="7lHetQyBz3x" resolve="value" />
                 </node>
               </node>
             </node>
@@ -8256,7 +8258,7 @@
         <node concept="3Tqbb2" id="5ElQ4Zyzof" role="1tU5fm" />
       </node>
       <node concept="37vLTG" id="5ElQ4Zyzog" role="3clF46">
-        <property role="TrG5h" value="ctx" />
+        <property role="TrG5h" value="context" />
         <node concept="3uibUv" id="5ElQ4Zyzoh" role="1tU5fm">
           <ref role="3uigEE" node="6iqfHNC0mHl" resolve="IETS3ExprContext" />
         </node>
@@ -8330,35 +8332,21 @@
     <node concept="2YIFZL" id="5ElQ4Zz6HL" role="jymVt">
       <property role="TrG5h" value="evaluateWithTraceInternal" />
       <node concept="3clFbS" id="5ElQ4Zz6HO" role="3clF47">
-        <node concept="3cpWs8" id="7obiejCzImB" role="3cqZAp">
-          <node concept="3cpWsn" id="7obiejCzImC" role="3cpWs9">
-            <property role="TrG5h" value="ctx" />
-            <node concept="3uibUv" id="7obiejCzImD" role="1tU5fm">
-              <ref role="3uigEE" node="6iqfHNC0mHl" resolve="IETS3ExprContext" />
+        <node concept="3cpWs8" id="2nydsCfAuHP" role="3cqZAp">
+          <node concept="3cpWsn" id="2nydsCfAuHQ" role="3cpWs9">
+            <property role="TrG5h" value="evaluator" />
+            <node concept="3uibUv" id="2nydsCfAuae" role="1tU5fm">
+              <ref role="3uigEE" node="2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
             </node>
-            <node concept="2ShNRf" id="7obiejCzImE" role="33vP2m">
-              <node concept="HV5vD" id="7obiejCzImF" role="2ShVmc">
-                <ref role="HV5vE" node="6iqfHNC0mHl" resolve="IETS3ExprContext" />
+            <node concept="2ShNRf" id="2nydsCfAuHR" role="33vP2m">
+              <node concept="HV5vD" id="2nydsCfAuHS" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" node="2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="7obiejCzImN" role="3cqZAp">
-          <node concept="3cpWsn" id="7obiejCzImO" role="3cpWs9">
-            <property role="TrG5h" value="helper" />
-            <node concept="3uibUv" id="7obiejCzImP" role="1tU5fm">
-              <ref role="3uigEE" to="2ahs:50LzNoSxDO3" resolve="InterpreterEvaluationHelper" />
-            </node>
-            <node concept="2ShNRf" id="7obiejCzImQ" role="33vP2m">
-              <node concept="1pGfFk" id="7obiejCzImR" role="2ShVmc">
-                <ref role="37wK5l" to="2ahs:50LzNoSxJpU" resolve="InterpreterEvaluationHelper" />
-                <node concept="37vLTw" id="5ElQ4Zz9sq" role="37wK5m">
-                  <ref role="3cqZAo" node="50LzNoSyDId" resolve="INTERPRETER_CATEGORY" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
+        <node concept="3clFbH" id="2nydsCfAvUx" role="3cqZAp" />
         <node concept="3J1_TO" id="7obiejCzImL" role="3cqZAp">
           <node concept="3uVAMA" id="7obiejCzIn1" role="1zxBo5">
             <node concept="XOnhg" id="7obiejCzIn2" role="1zc67B">
@@ -8384,8 +8372,13 @@
                       </node>
                     </node>
                     <node concept="2OqwBi" id="7obiejCzU08" role="37wK5m">
-                      <node concept="37vLTw" id="7obiejCzU09" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7obiejCzImO" resolve="helper" />
+                      <node concept="2OqwBi" id="2nydsCfAy$j" role="2Oq$k0">
+                        <node concept="37vLTw" id="7obiejCzU09" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2nydsCfAuHQ" resolve="evaluator" />
+                        </node>
+                        <node concept="liA8E" id="2nydsCfAzdp" role="2OqNvi">
+                          <ref role="37wK5l" node="2nydsCfAryl" resolve="getInternalHelper" />
+                        </node>
                       </node>
                       <node concept="liA8E" id="7obiejCzU0a" role="2OqNvi">
                         <ref role="37wK5l" to="2ahs:7obiejCzFIg" resolve="getLastLog" />
@@ -8397,59 +8390,29 @@
             </node>
           </node>
           <node concept="3clFbS" id="7obiejCzImM" role="1zxBo7">
-            <node concept="3cpWs8" id="7obiejCzMo_" role="3cqZAp">
-              <node concept="3cpWsn" id="7obiejCzMoA" role="3cpWs9">
-                <property role="TrG5h" value="res" />
-                <node concept="3uibUv" id="7obiejCzMot" role="1tU5fm">
-                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+            <node concept="3cpWs8" id="2nydsCf_Wsh" role="3cqZAp">
+              <node concept="3cpWsn" id="2nydsCf_Wsi" role="3cpWs9">
+                <property role="TrG5h" value="result" />
+                <node concept="3uibUv" id="2nydsCf_MbZ" role="1tU5fm">
+                  <ref role="3uigEE" node="4Pi6J8Cccqb" resolve="ValueAndTraceAndEnv" />
                 </node>
-                <node concept="2OqwBi" id="7obiejCzMoB" role="33vP2m">
-                  <node concept="37vLTw" id="7obiejCzMoC" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7obiejCzImO" resolve="helper" />
+                <node concept="2OqwBi" id="2nydsCf_Wsj" role="33vP2m">
+                  <node concept="2OqwBi" id="2nydsCf_Wsk" role="2Oq$k0">
+                    <node concept="37vLTw" id="2nydsCfAuHT" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2nydsCfAuHQ" resolve="evaluator" />
+                    </node>
+                    <node concept="liA8E" id="2nydsCf_Wsn" role="2OqNvi">
+                      <ref role="37wK5l" node="2nydsCfw1oG" resolve="withCoverAnalyzer" />
+                      <node concept="37vLTw" id="2nydsCf_Wso" role="37wK5m">
+                        <ref role="3cqZAo" node="5ElQ4Zz8pK" resolve="coverage" />
+                      </node>
+                    </node>
                   </node>
-                  <node concept="liA8E" id="7obiejCzMoD" role="2OqNvi">
-                    <ref role="37wK5l" to="2ahs:14DmiwrcwYd" resolve="evaluateWithContextAndCoverage" />
-                    <node concept="37vLTw" id="7obiejCzMoE" role="37wK5m">
+                  <node concept="liA8E" id="2nydsCf_Wsp" role="2OqNvi">
+                    <ref role="37wK5l" node="2nydsCfz7eH" resolve="evaluate" />
+                    <node concept="37vLTw" id="2nydsCf_Wsq" role="37wK5m">
                       <ref role="3cqZAo" node="5ElQ4Zz7wT" resolve="expr" />
                     </node>
-                    <node concept="1rXfSq" id="7obiejCzMoF" role="37wK5m">
-                      <ref role="37wK5l" node="50LzNoSyDOv" resolve="getInterpreter" />
-                    </node>
-                    <node concept="37vLTw" id="7obiejCzMoG" role="37wK5m">
-                      <ref role="3cqZAo" node="7obiejCzImC" resolve="ctx" />
-                    </node>
-                    <node concept="37vLTw" id="7obiejCzMoH" role="37wK5m">
-                      <ref role="3cqZAo" node="5ElQ4Zz8pK" resolve="coverage" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="7obiejCzOkc" role="3cqZAp">
-              <node concept="3cpWsn" id="7obiejCzOkd" role="3cpWs9">
-                <property role="TrG5h" value="trace" />
-                <node concept="3uibUv" id="7obiejCzOk7" role="1tU5fm">
-                  <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
-                </node>
-                <node concept="2OqwBi" id="7obiejCzOke" role="33vP2m">
-                  <node concept="37vLTw" id="7obiejCzOkf" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7obiejCzImO" resolve="helper" />
-                  </node>
-                  <node concept="liA8E" id="7obiejCzOkg" role="2OqNvi">
-                    <ref role="37wK5l" to="2ahs:7obiejCzFIg" resolve="getLastLog" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="2kg0xI3rSTN" role="3cqZAp">
-              <node concept="2OqwBi" id="2kg0xI3rTki" role="3clFbG">
-                <node concept="37vLTw" id="2kg0xI3rSTL" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7obiejCzOkd" resolve="trace" />
-                </node>
-                <node concept="liA8E" id="2kg0xI3rTNA" role="2OqNvi">
-                  <ref role="37wK5l" to="2ahs:7obiejAu3TD" resolve="setValue" />
-                  <node concept="37vLTw" id="2kg0xI3rTUO" role="37wK5m">
-                    <ref role="3cqZAo" node="7obiejCzMoA" resolve="res" />
                   </node>
                 </node>
               </node>
@@ -8458,11 +8421,21 @@
               <node concept="2ShNRf" id="7lHetQyB_k6" role="3cqZAk">
                 <node concept="1pGfFk" id="7lHetQyBA7W" role="2ShVmc">
                   <ref role="37wK5l" node="7lHetQyByYS" resolve="ValueAndTrace" />
-                  <node concept="37vLTw" id="7lHetQyBAzA" role="37wK5m">
-                    <ref role="3cqZAo" node="7obiejCzMoA" resolve="res" />
+                  <node concept="2OqwBi" id="2nydsCf_ZCS" role="37wK5m">
+                    <node concept="37vLTw" id="7lHetQyBAzA" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2nydsCf_Wsi" resolve="result" />
+                    </node>
+                    <node concept="2OwXpG" id="2nydsCfA0s6" role="2OqNvi">
+                      <ref role="2Oxat5" node="7lHetQyBz3x" resolve="value" />
+                    </node>
                   </node>
-                  <node concept="37vLTw" id="7lHetQyBAZu" role="37wK5m">
-                    <ref role="3cqZAo" node="7obiejCzOkd" resolve="trace" />
+                  <node concept="2OqwBi" id="2nydsCfA2eu" role="37wK5m">
+                    <node concept="37vLTw" id="7lHetQyBAZu" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2nydsCf_Wsi" resolve="result" />
+                    </node>
+                    <node concept="2OwXpG" id="2nydsCfA2y9" role="2OqNvi">
+                      <ref role="2Oxat5" node="7lHetQyBz4T" resolve="trace" />
+                    </node>
                   </node>
                 </node>
               </node>
@@ -8566,7 +8539,7 @@
         <node concept="3Tqbb2" id="7p_bE3JctZx" role="1tU5fm" />
       </node>
       <node concept="37vLTG" id="7p_bE3Jcw0b" role="3clF46">
-        <property role="TrG5h" value="stuffForEnv" />
+        <property role="TrG5h" value="environmentContent" />
         <node concept="3rvAFt" id="7p_bE3JcwNr" role="1tU5fm">
           <node concept="3Tqbb2" id="7p_bE3Jcx57" role="3rvQeY" />
           <node concept="3uibUv" id="7p_bE3Jcxmc" role="3rvSg0">
@@ -8608,7 +8581,7 @@
         <node concept="3Tqbb2" id="5ElQ4Z_71X" role="1tU5fm" />
       </node>
       <node concept="37vLTG" id="5ElQ4Z_71Y" role="3clF46">
-        <property role="TrG5h" value="stuffForEnv" />
+        <property role="TrG5h" value="environmentContent" />
         <node concept="3rvAFt" id="5ElQ4Z_71Z" role="1tU5fm">
           <node concept="3Tqbb2" id="5ElQ4Z_720" role="3rvQeY" />
           <node concept="3uibUv" id="5ElQ4Z_721" role="3rvSg0">
@@ -8626,7 +8599,7 @@
         <node concept="3Tqbb2" id="5ElQ4ZzYvu" role="1tU5fm" />
       </node>
       <node concept="37vLTG" id="5ElQ4ZzZbv" role="3clF46">
-        <property role="TrG5h" value="stuffForEnv" />
+        <property role="TrG5h" value="environmentContent" />
         <node concept="3rvAFt" id="5ElQ4ZzZqd" role="1tU5fm">
           <node concept="3Tqbb2" id="5ElQ4ZzZqe" role="3rvQeY" />
           <node concept="3uibUv" id="5ElQ4ZzZqf" role="3rvSg0">
@@ -8641,102 +8614,80 @@
         </node>
       </node>
       <node concept="3clFbS" id="5ElQ4ZziRj" role="3clF47">
-        <node concept="3cpWs8" id="7p_bE3JctXR" role="3cqZAp">
-          <node concept="3cpWsn" id="7p_bE3JctXS" role="3cpWs9">
-            <property role="TrG5h" value="ctx" />
-            <node concept="3uibUv" id="7p_bE3JctXT" role="1tU5fm">
+        <node concept="3cpWs8" id="2nydsCfA_P2" role="3cqZAp">
+          <node concept="3cpWsn" id="2nydsCfA_P3" role="3cpWs9">
+            <property role="TrG5h" value="evaluator" />
+            <node concept="3uibUv" id="2nydsCfA_P4" role="1tU5fm">
+              <ref role="3uigEE" node="2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+            </node>
+            <node concept="2ShNRf" id="2nydsCfA_P5" role="33vP2m">
+              <node concept="HV5vD" id="2nydsCfA_P6" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" node="2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2nydsCfAEtk" role="3cqZAp">
+          <node concept="3cpWsn" id="2nydsCfAEtl" role="3cpWs9">
+            <property role="TrG5h" value="context" />
+            <node concept="3uibUv" id="2nydsCfAEtm" role="1tU5fm">
               <ref role="3uigEE" node="6iqfHNC0mHl" resolve="IETS3ExprContext" />
             </node>
-            <node concept="2ShNRf" id="7p_bE3JctXU" role="33vP2m">
-              <node concept="HV5vD" id="7p_bE3JctXV" role="2ShVmc">
+            <node concept="2ShNRf" id="2nydsCfAEtn" role="33vP2m">
+              <node concept="HV5vD" id="2nydsCfAEto" role="2ShVmc">
                 <ref role="HV5vE" node="6iqfHNC0mHl" resolve="IETS3ExprContext" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbJ" id="7p_bE3Jd5CJ" role="3cqZAp">
-          <node concept="3clFbS" id="7p_bE3Jd5CL" role="3clFbx">
-            <node concept="3clFbF" id="7p_bE3Jd9ig" role="3cqZAp">
-              <node concept="2OqwBi" id="7p_bE3Jd9y0" role="3clFbG">
-                <node concept="37vLTw" id="7p_bE3Jd9ie" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7p_bE3JctXS" resolve="ctx" />
-                </node>
-                <node concept="liA8E" id="7p_bE3Jd9Q5" role="2OqNvi">
-                  <ref role="37wK5l" to="2ahs:2pAf7L4EsIf" resolve="pushEnvironment" />
-                  <node concept="37vLTw" id="7p_bE3JdbZz" role="37wK5m">
-                    <ref role="3cqZAo" node="5ElQ4ZzYvt" resolve="expr" />
-                  </node>
-                  <node concept="37vLTw" id="7p_bE3Jdco$" role="37wK5m">
-                    <ref role="3cqZAo" node="5ElQ4ZzZbv" resolve="stuffForEnv" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3y3z36" id="7p_bE3Jd7RB" role="3clFbw">
-            <node concept="10Nm6u" id="7p_bE3Jd8bF" role="3uHU7w" />
-            <node concept="37vLTw" id="7p_bE3Jd75X" role="3uHU7B">
-              <ref role="3cqZAo" node="5ElQ4ZzZbv" resolve="stuffForEnv" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="7p_bE3JctY1" role="3cqZAp">
-          <node concept="3cpWsn" id="7p_bE3JctY2" role="3cpWs9">
-            <property role="TrG5h" value="helper" />
-            <node concept="3uibUv" id="7p_bE3JctY3" role="1tU5fm">
-              <ref role="3uigEE" to="2ahs:50LzNoSxDO3" resolve="InterpreterEvaluationHelper" />
-            </node>
-            <node concept="2ShNRf" id="7p_bE3JctY4" role="33vP2m">
-              <node concept="1pGfFk" id="7p_bE3JctY5" role="2ShVmc">
-                <ref role="37wK5l" to="2ahs:50LzNoSxJpU" resolve="InterpreterEvaluationHelper" />
-                <node concept="37vLTw" id="5ElQ4Z$2yS" role="37wK5m">
-                  <ref role="3cqZAo" node="50LzNoSyDId" resolve="INTERPRETER_CATEGORY" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3J1_TO" id="7p_bE3JctY7" role="3cqZAp">
-          <node concept="3uVAMA" id="7p_bE3JctYA" role="1zxBo5">
-            <node concept="XOnhg" id="7p_bE3JctYB" role="1zc67B">
+        <node concept="3clFbH" id="2nydsCfA_P7" role="3cqZAp" />
+        <node concept="3J1_TO" id="2nydsCfA_P8" role="3cqZAp">
+          <node concept="3uVAMA" id="2nydsCfA_P9" role="1zxBo5">
+            <node concept="XOnhg" id="2nydsCfA_Pa" role="1zc67B">
               <property role="3TUv4t" value="false" />
               <property role="TrG5h" value="stopEx" />
-              <node concept="nSUau" id="2HIRAZRxf$8" role="1tU5fm">
-                <node concept="3uibUv" id="7p_bE3JctYC" role="nSUat">
+              <node concept="nSUau" id="2nydsCfA_Pb" role="1tU5fm">
+                <node concept="3uibUv" id="2nydsCfA_Pc" role="nSUat">
                   <ref role="3uigEE" to="2ahs:6MNhNeUeNix" resolve="StopAndReturnException" />
                 </node>
               </node>
             </node>
-            <node concept="3clFbS" id="7p_bE3JctYD" role="1zc67A">
-              <node concept="3cpWs6" id="7p_bE3JctYE" role="3cqZAp">
-                <node concept="2ShNRf" id="7p_bE3JctYF" role="3cqZAk">
-                  <node concept="1pGfFk" id="7p_bE3JctYG" role="2ShVmc">
+            <node concept="3clFbS" id="2nydsCfA_Pd" role="1zc67A">
+              <node concept="3cpWs6" id="2nydsCfA_Pe" role="3cqZAp">
+                <node concept="2ShNRf" id="2nydsCfA_Pf" role="3cqZAk">
+                  <node concept="1pGfFk" id="2nydsCfA_Pg" role="2ShVmc">
                     <ref role="37wK5l" node="2ns1RQRO9uL" resolve="ValueAndTraceAndEnv" />
-                    <node concept="2OqwBi" id="7p_bE3JctYH" role="37wK5m">
-                      <node concept="37vLTw" id="7p_bE3JctYI" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7p_bE3JctYB" resolve="stopEx" />
+                    <node concept="2OqwBi" id="2nydsCfA_Ph" role="37wK5m">
+                      <node concept="37vLTw" id="2nydsCfA_Pi" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2nydsCfA_Pa" resolve="stopEx" />
                       </node>
-                      <node concept="liA8E" id="7p_bE3JctYJ" role="2OqNvi">
+                      <node concept="liA8E" id="2nydsCfA_Pj" role="2OqNvi">
                         <ref role="37wK5l" to="2ahs:6MNhNeUeYe3" resolve="value" />
                       </node>
                     </node>
-                    <node concept="2OqwBi" id="7p_bE3JctYK" role="37wK5m">
-                      <node concept="37vLTw" id="7p_bE3JctYL" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7p_bE3JctY2" resolve="helper" />
+                    <node concept="2OqwBi" id="2nydsCfA_Pk" role="37wK5m">
+                      <node concept="2OqwBi" id="2nydsCfA_Pl" role="2Oq$k0">
+                        <node concept="37vLTw" id="2nydsCfA_Pm" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2nydsCfA_P3" resolve="evaluator" />
+                        </node>
+                        <node concept="liA8E" id="2nydsCfA_Pn" role="2OqNvi">
+                          <ref role="37wK5l" node="2nydsCfAryl" resolve="getInternalHelper" />
+                        </node>
                       </node>
-                      <node concept="liA8E" id="7p_bE3JctYM" role="2OqNvi">
+                      <node concept="liA8E" id="2nydsCfA_Po" role="2OqNvi">
                         <ref role="37wK5l" to="2ahs:7obiejCzFIg" resolve="getLastLog" />
                       </node>
                     </node>
-                    <node concept="2OqwBi" id="7p_bE3JctYN" role="37wK5m">
-                      <node concept="37vLTw" id="7p_bE3JctYO" role="2Oq$k0">
-                        <ref role="3cqZAo" node="7p_bE3JctXS" resolve="ctx" />
+                    <node concept="2OqwBi" id="2nydsCfAKCm" role="37wK5m">
+                      <node concept="37vLTw" id="2nydsCfAK8w" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2nydsCfAEtl" resolve="context" />
                       </node>
-                      <node concept="liA8E" id="7p_bE3JctYP" role="2OqNvi">
+                      <node concept="liA8E" id="2nydsCfALDL" role="2OqNvi">
                         <ref role="37wK5l" to="2ahs:2X4$XGmeuKp" resolve="getEnvironment" />
                       </node>
                     </node>
-                    <node concept="37vLTw" id="4kdJi32PpbP" role="37wK5m">
+                    <node concept="37vLTw" id="2nydsCfAMxm" role="37wK5m">
                       <ref role="3cqZAo" node="5ElQ4Z$1k6" resolve="coverage" />
                     </node>
                   </node>
@@ -8744,84 +8695,40 @@
               </node>
             </node>
           </node>
-          <node concept="3clFbS" id="7p_bE3JctY8" role="1zxBo7">
-            <node concept="3cpWs8" id="7p_bE3JctY9" role="3cqZAp">
-              <node concept="3cpWsn" id="7p_bE3JctYa" role="3cpWs9">
-                <property role="TrG5h" value="res" />
-                <node concept="3uibUv" id="7p_bE3JctYb" role="1tU5fm">
-                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                </node>
-                <node concept="2OqwBi" id="7p_bE3JctYc" role="33vP2m">
-                  <node concept="37vLTw" id="7p_bE3JctYd" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7p_bE3JctY2" resolve="helper" />
-                  </node>
-                  <node concept="liA8E" id="7p_bE3JctYe" role="2OqNvi">
-                    <ref role="37wK5l" to="2ahs:14DmiwrcwYd" resolve="evaluateWithContextAndCoverage" />
-                    <node concept="37vLTw" id="7p_bE3JctYf" role="37wK5m">
-                      <ref role="3cqZAo" node="5ElQ4ZzYvt" resolve="expr" />
+          <node concept="3clFbS" id="2nydsCfA_Pp" role="1zxBo7">
+            <node concept="3cpWs6" id="2nydsCfACSf" role="3cqZAp">
+              <node concept="2OqwBi" id="2nydsCfA_Pt" role="3cqZAk">
+                <node concept="2OqwBi" id="2nydsCfAPSn" role="2Oq$k0">
+                  <node concept="2OqwBi" id="2nydsCfAFvM" role="2Oq$k0">
+                    <node concept="2OqwBi" id="2nydsCfA_Pu" role="2Oq$k0">
+                      <node concept="37vLTw" id="2nydsCfA_Pv" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2nydsCfA_P3" resolve="evaluator" />
+                      </node>
+                      <node concept="liA8E" id="2nydsCfA_Pw" role="2OqNvi">
+                        <ref role="37wK5l" node="2nydsCfw1oG" resolve="withCoverAnalyzer" />
+                        <node concept="37vLTw" id="2nydsCfA_Px" role="37wK5m">
+                          <ref role="3cqZAo" node="5ElQ4Z$1k6" resolve="coverage" />
+                        </node>
+                      </node>
                     </node>
-                    <node concept="1rXfSq" id="7p_bE3JctYg" role="37wK5m">
-                      <ref role="37wK5l" node="50LzNoSyDOv" resolve="getInterpreter" />
-                    </node>
-                    <node concept="37vLTw" id="7p_bE3JctYh" role="37wK5m">
-                      <ref role="3cqZAo" node="7p_bE3JctXS" resolve="ctx" />
-                    </node>
-                    <node concept="37vLTw" id="7p_bE3JctYi" role="37wK5m">
-                      <ref role="3cqZAo" node="5ElQ4Z$1k6" resolve="coverage" />
+                    <node concept="liA8E" id="2nydsCfAGnV" role="2OqNvi">
+                      <ref role="37wK5l" node="2nydsCfvv5Z" resolve="withContext" />
+                      <node concept="37vLTw" id="2nydsCfAItD" role="37wK5m">
+                        <ref role="3cqZAo" node="2nydsCfAEtl" resolve="context" />
+                      </node>
                     </node>
                   </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="7p_bE3JctYj" role="3cqZAp">
-              <node concept="3cpWsn" id="7p_bE3JctYk" role="3cpWs9">
-                <property role="TrG5h" value="trace" />
-                <node concept="3uibUv" id="7p_bE3JctYl" role="1tU5fm">
-                  <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
-                </node>
-                <node concept="2OqwBi" id="7p_bE3JctYm" role="33vP2m">
-                  <node concept="37vLTw" id="7p_bE3JctYn" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7p_bE3JctY2" resolve="helper" />
-                  </node>
-                  <node concept="liA8E" id="7p_bE3JctYo" role="2OqNvi">
-                    <ref role="37wK5l" to="2ahs:7obiejCzFIg" resolve="getLastLog" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="7p_bE3JctYp" role="3cqZAp">
-              <node concept="2OqwBi" id="7p_bE3JctYq" role="3clFbG">
-                <node concept="37vLTw" id="7p_bE3JctYr" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7p_bE3JctYk" resolve="trace" />
-                </node>
-                <node concept="liA8E" id="7p_bE3JctYs" role="2OqNvi">
-                  <ref role="37wK5l" to="2ahs:7obiejAu3TD" resolve="setValue" />
-                  <node concept="37vLTw" id="7p_bE3JctYt" role="37wK5m">
-                    <ref role="3cqZAo" node="7p_bE3JctYa" resolve="res" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs6" id="7p_bE3JctYu" role="3cqZAp">
-              <node concept="2ShNRf" id="7p_bE3JctYv" role="3cqZAk">
-                <node concept="1pGfFk" id="7p_bE3JctYw" role="2ShVmc">
-                  <ref role="37wK5l" node="2ns1RQRO9uL" resolve="ValueAndTraceAndEnv" />
-                  <node concept="37vLTw" id="7p_bE3JctYx" role="37wK5m">
-                    <ref role="3cqZAo" node="7p_bE3JctYa" resolve="res" />
-                  </node>
-                  <node concept="37vLTw" id="7p_bE3JctYy" role="37wK5m">
-                    <ref role="3cqZAo" node="7p_bE3JctYk" resolve="trace" />
-                  </node>
-                  <node concept="2OqwBi" id="7p_bE3JctYz" role="37wK5m">
-                    <node concept="37vLTw" id="7p_bE3JctY$" role="2Oq$k0">
-                      <ref role="3cqZAo" node="7p_bE3JctXS" resolve="ctx" />
-                    </node>
-                    <node concept="liA8E" id="7p_bE3JctY_" role="2OqNvi">
-                      <ref role="37wK5l" to="2ahs:2X4$XGmeuKp" resolve="getEnvironment" />
+                  <node concept="liA8E" id="2nydsCfAQMF" role="2OqNvi">
+                    <ref role="37wK5l" node="2nydsCf$H0v" resolve="withEnvironmentContent" />
+                    <node concept="37vLTw" id="2nydsCfAS1p" role="37wK5m">
+                      <ref role="3cqZAo" node="5ElQ4ZzZbv" resolve="stuffForEnv" />
                     </node>
                   </node>
-                  <node concept="37vLTw" id="4kdJi32PdWt" role="37wK5m">
-                    <ref role="3cqZAo" node="5ElQ4Z$1k6" resolve="coverage" />
+                </node>
+                <node concept="liA8E" id="2nydsCfA_Py" role="2OqNvi">
+                  <ref role="37wK5l" node="2nydsCfz7eH" resolve="evaluate" />
+                  <node concept="37vLTw" id="2nydsCfA_Pz" role="37wK5m">
+                    <ref role="3cqZAo" node="5ElQ4ZzYvt" resolve="expr" />
                   </node>
                 </node>
               </node>
@@ -8895,19 +8802,6 @@
     <node concept="2YIFZL" id="5ElQ4Z$cXx" role="jymVt">
       <property role="TrG5h" value="evaluateAndThrowConstraintFailuresInternal" />
       <node concept="3clFbS" id="5ElQ4Z$cX$" role="3clF47">
-        <node concept="3cpWs8" id="5ElQ4Z$eyv" role="3cqZAp">
-          <node concept="3cpWsn" id="5ElQ4Z$eyw" role="3cpWs9">
-            <property role="TrG5h" value="ctx" />
-            <node concept="3uibUv" id="5ElQ4Z$eyx" role="1tU5fm">
-              <ref role="3uigEE" node="6iqfHNC0mHl" resolve="IETS3ExprContext" />
-            </node>
-            <node concept="2ShNRf" id="5ElQ4Z$eyy" role="33vP2m">
-              <node concept="HV5vD" id="5ElQ4Z$eyz" role="2ShVmc">
-                <ref role="HV5vE" node="6iqfHNC0mHl" resolve="IETS3ExprContext" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3J1_TO" id="5ElQ4Z$eyD" role="3cqZAp">
           <node concept="3uVAMA" id="5ElQ4Z$eyE" role="1zxBo5">
             <node concept="XOnhg" id="5ElQ4Z$eyF" role="1zc67B">
@@ -8951,41 +8845,32 @@
             </node>
           </node>
           <node concept="3clFbS" id="5ElQ4Z$ez$" role="1zxBo7">
-            <node concept="3cpWs8" id="5ElQ4Z$ez_" role="3cqZAp">
-              <node concept="3cpWsn" id="5ElQ4Z$ezA" role="3cpWs9">
-                <property role="TrG5h" value="helper" />
-                <node concept="3uibUv" id="5ElQ4Z$ezB" role="1tU5fm">
-                  <ref role="3uigEE" to="2ahs:50LzNoSxDO3" resolve="InterpreterEvaluationHelper" />
-                </node>
-                <node concept="2ShNRf" id="5ElQ4Z$ezC" role="33vP2m">
-                  <node concept="1pGfFk" id="5ElQ4Z$ezD" role="2ShVmc">
-                    <ref role="37wK5l" to="2ahs:50LzNoSxJpU" resolve="InterpreterEvaluationHelper" />
-                    <node concept="37vLTw" id="5ElQ4Z$e_j" role="37wK5m">
-                      <ref role="3cqZAo" node="50LzNoSyDId" resolve="INTERPRETER_CATEGORY" />
+            <node concept="3cpWs6" id="2nydsCfAXOo" role="3cqZAp">
+              <node concept="2OqwBi" id="2nydsCfB4SG" role="3cqZAk">
+                <node concept="2OqwBi" id="2nydsCfB2JJ" role="2Oq$k0">
+                  <node concept="2OqwBi" id="2nydsCfB0sQ" role="2Oq$k0">
+                    <node concept="2ShNRf" id="2nydsCfAZ1L" role="2Oq$k0">
+                      <node concept="HV5vD" id="2nydsCfAZSo" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="HV5vE" node="2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="2nydsCfB130" role="2OqNvi">
+                      <ref role="37wK5l" node="2nydsCfw1oG" resolve="withCoverAnalyzer" />
+                      <node concept="37vLTw" id="2nydsCfB2bs" role="37wK5m">
+                        <ref role="3cqZAo" node="5ElQ4Z$pOr" resolve="coverage" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="2nydsCfB3pg" role="2OqNvi">
+                    <ref role="37wK5l" node="2nydsCfz7eH" resolve="evaluate" />
+                    <node concept="37vLTw" id="2nydsCfB4bn" role="37wK5m">
+                      <ref role="3cqZAo" node="5ElQ4Z$dPc" resolve="expr" />
                     </node>
                   </node>
                 </node>
-              </node>
-            </node>
-            <node concept="3cpWs6" id="5ElQ4Z$ezF" role="3cqZAp">
-              <node concept="2OqwBi" id="5ElQ4Z$ezG" role="3cqZAk">
-                <node concept="37vLTw" id="5ElQ4Z$ezH" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5ElQ4Z$ezA" resolve="helper" />
-                </node>
-                <node concept="liA8E" id="5ElQ4Z$ezI" role="2OqNvi">
-                  <ref role="37wK5l" to="2ahs:14DmiwrcwYd" resolve="evaluateWithContextAndCoverage" />
-                  <node concept="37vLTw" id="5ElQ4Z$ezJ" role="37wK5m">
-                    <ref role="3cqZAo" node="5ElQ4Z$dPc" resolve="expr" />
-                  </node>
-                  <node concept="1rXfSq" id="5ElQ4Z$ezK" role="37wK5m">
-                    <ref role="37wK5l" node="50LzNoSyDOv" resolve="getInterpreter" />
-                  </node>
-                  <node concept="37vLTw" id="5ElQ4Z$ezL" role="37wK5m">
-                    <ref role="3cqZAo" node="5ElQ4Z$eyw" resolve="ctx" />
-                  </node>
-                  <node concept="37vLTw" id="5ElQ4Z$ezM" role="37wK5m">
-                    <ref role="3cqZAo" node="5ElQ4Z$pOr" resolve="coverage" />
-                  </node>
+                <node concept="2OwXpG" id="2nydsCfB5F1" role="2OqNvi">
+                  <ref role="2Oxat5" node="7lHetQyBz3x" resolve="value" />
                 </node>
               </node>
             </node>
@@ -9014,13 +8899,10 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <node concept="3clFbS" id="50LzNoSyDOy" role="3clF47">
-        <node concept="3clFbF" id="48h5VLcja_l" role="3cqZAp">
-          <node concept="2YIFZM" id="50LzNoSyJ0O" role="3clFbG">
-            <ref role="1Pybhc" to="2ahs:50LzNoSxDO3" resolve="InterpreterEvaluationHelper" />
-            <ref role="37wK5l" to="2ahs:50LzNoSyEfI" resolve="getInterpreter" />
-            <node concept="37vLTw" id="48h5VLcja_q" role="37wK5m">
-              <ref role="3cqZAo" node="50LzNoSyDId" resolve="INTERPRETER_CATEGORY" />
-            </node>
+        <node concept="3clFbF" id="2nydsCfzukp" role="3cqZAp">
+          <node concept="2YIFZM" id="2nydsCfzvmS" role="3clFbG">
+            <ref role="37wK5l" node="2nydsCfzrJq" resolve="getInterpreter" />
+            <ref role="1Pybhc" node="2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
           </node>
         </node>
       </node>
@@ -9030,6 +8912,18 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="3xDNhgd53EA" role="1B3o_S" />
+    <node concept="3UR2Jj" id="2nydsCfyZ7A" role="lGtFl">
+      <node concept="TZ5HI" id="2nydsCfyZ7B" role="3nqlJM">
+        <node concept="TZ5HA" id="2nydsCfyZ7C" role="3HnX3l">
+          <node concept="1dT_AC" id="2nydsCfz0f1" role="1dT_Ay">
+            <property role="1dT_AB" value="use the class IETS3ExprEvaluator instead" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2AHcQZ" id="2nydsCfyZ7D" role="2AJF6D">
+      <ref role="2AI5Lk" to="wyt6:~Deprecated" />
+    </node>
   </node>
   <node concept="312cEu" id="6iqfHNBVsSc">
     <property role="TrG5h" value="IETS3ExprContextProvider" />
@@ -26475,6 +26369,551 @@
       </node>
       <node concept="10P_77" id="7k6A8Wfp8Fi" role="3clF45" />
     </node>
+  </node>
+  <node concept="312cEu" id="2nydsCfyYD0">
+    <property role="TrG5h" value="IETS3ExprEvaluator" />
+    <node concept="Wx3nA" id="2nydsCfz2XE" role="jymVt">
+      <property role="2dlcS1" value="false" />
+      <property role="2dld4O" value="false" />
+      <property role="TrG5h" value="INTERPRETER_CATEGORY" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm1VV" id="2nydsCfz2XF" role="1B3o_S" />
+      <node concept="17QB3L" id="2nydsCfz2XG" role="1tU5fm" />
+      <node concept="Xl_RD" id="2nydsCfz2XH" role="33vP2m">
+        <property role="Xl_RC" value="arithmetic" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2nydsCfz2Qv" role="jymVt" />
+    <node concept="312cEg" id="2nydsCftMQC" role="jymVt">
+      <property role="TrG5h" value="context" />
+      <node concept="3uibUv" id="2nydsCftMDR" role="1tU5fm">
+        <ref role="3uigEE" to="2ahs:4X7QcQ31ENp" resolve="IContext" />
+      </node>
+      <node concept="3Tm6S6" id="2nydsCftN3q" role="1B3o_S" />
+      <node concept="10Nm6u" id="2nydsCfzmCk" role="33vP2m" />
+    </node>
+    <node concept="312cEg" id="2nydsCftO1R" role="jymVt">
+      <property role="TrG5h" value="createComputationTrace" />
+      <node concept="3Tm6S6" id="2nydsCftNyC" role="1B3o_S" />
+      <node concept="10P_77" id="2nydsCftO1G" role="1tU5fm" />
+      <node concept="3clFbT" id="2nydsCftOLh" role="33vP2m">
+        <property role="3clFbU" value="true" />
+      </node>
+    </node>
+    <node concept="312cEg" id="2nydsCftPdm" role="jymVt">
+      <property role="TrG5h" value="coverageAnalyzer" />
+      <node concept="3uibUv" id="2nydsCftP0y" role="1tU5fm">
+        <ref role="3uigEE" to="2ahs:4_qY3E5ifTh" resolve="ICoverageAnalyzer" />
+      </node>
+      <node concept="3Tm6S6" id="2nydsCftPqf" role="1B3o_S" />
+      <node concept="10Nm6u" id="2nydsCfuJVp" role="33vP2m" />
+    </node>
+    <node concept="312cEg" id="2nydsCfx9Qs" role="jymVt">
+      <property role="TrG5h" value="interpreter" />
+      <node concept="3Tm6S6" id="2nydsCfx86T" role="1B3o_S" />
+      <node concept="3uibUv" id="2nydsCfx9DV" role="1tU5fm">
+        <ref role="3uigEE" to="2ahs:4X7QcQ36WR7" resolve="IInterpreter" />
+      </node>
+      <node concept="10Nm6u" id="2nydsCfznb5" role="33vP2m" />
+    </node>
+    <node concept="312cEg" id="2nydsCf$Ggh" role="jymVt">
+      <property role="TrG5h" value="environmentContent" />
+      <node concept="3Tm6S6" id="2nydsCf$Ggi" role="1B3o_S" />
+      <node concept="3rvAFt" id="2nydsCf$Ggk" role="1tU5fm">
+        <node concept="3Tqbb2" id="2nydsCf$Ggl" role="3rvQeY" />
+        <node concept="3uibUv" id="2nydsCf$Ggm" role="3rvSg0">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+      </node>
+      <node concept="10Nm6u" id="2nydsCf$GVm" role="33vP2m" />
+    </node>
+    <node concept="2tJIrI" id="2nydsCfA8CX" role="jymVt" />
+    <node concept="312cEg" id="2nydsCfAaTv" role="jymVt">
+      <property role="TrG5h" value="helper" />
+      <node concept="3Tm6S6" id="2nydsCfAa6R" role="1B3o_S" />
+      <node concept="3uibUv" id="2nydsCfAaOh" role="1tU5fm">
+        <ref role="3uigEE" to="2ahs:50LzNoSxDO3" resolve="InterpreterEvaluationHelper" />
+      </node>
+      <node concept="10Nm6u" id="2nydsCfApqJ" role="33vP2m" />
+    </node>
+    <node concept="2tJIrI" id="2nydsCfz1ly" role="jymVt" />
+    <node concept="3clFb_" id="2nydsCfvv5Z" role="jymVt">
+      <property role="TrG5h" value="withContext" />
+      <node concept="3clFbS" id="2nydsCfvv62" role="3clF47">
+        <node concept="3clFbF" id="2nydsCfvyPm" role="3cqZAp">
+          <node concept="37vLTI" id="2nydsCfvBm3" role="3clFbG">
+            <node concept="37vLTw" id="2nydsCfvDYs" role="37vLTx">
+              <ref role="3cqZAo" node="2nydsCfvwIL" resolve="context" />
+            </node>
+            <node concept="2OqwBi" id="2nydsCfv$zP" role="37vLTJ">
+              <node concept="Xjq3P" id="2nydsCfvyPl" role="2Oq$k0" />
+              <node concept="2OwXpG" id="2nydsCfv_Nt" role="2OqNvi">
+                <ref role="2Oxat5" node="2nydsCftMQC" resolve="context" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2nydsCfvHg_" role="3cqZAp">
+          <node concept="Xjq3P" id="2nydsCfvHgz" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2nydsCfvta5" role="1B3o_S" />
+      <node concept="3uibUv" id="2nydsCfvuPo" role="3clF45">
+        <ref role="3uigEE" node="2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+      </node>
+      <node concept="37vLTG" id="2nydsCfvwIL" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <node concept="3uibUv" id="2nydsCfvwIK" role="1tU5fm">
+          <ref role="3uigEE" to="2ahs:4X7QcQ31ENp" resolve="IContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2nydsCfvLtN" role="jymVt" />
+    <node concept="3clFb_" id="2nydsCfvLxS" role="jymVt">
+      <property role="TrG5h" value="withComputationTrace" />
+      <node concept="3clFbS" id="2nydsCfvLxT" role="3clF47">
+        <node concept="3clFbF" id="2nydsCfvLxU" role="3cqZAp">
+          <node concept="37vLTI" id="2nydsCfvLxV" role="3clFbG">
+            <node concept="37vLTw" id="2nydsCfvLxW" role="37vLTx">
+              <ref role="3cqZAo" node="2nydsCfvLy4" resolve="flag" />
+            </node>
+            <node concept="2OqwBi" id="2nydsCfvLxX" role="37vLTJ">
+              <node concept="Xjq3P" id="2nydsCfvLxY" role="2Oq$k0" />
+              <node concept="2OwXpG" id="2nydsCfvLxZ" role="2OqNvi">
+                <ref role="2Oxat5" node="2nydsCftO1R" resolve="createComputationTrace" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2nydsCfvLy0" role="3cqZAp">
+          <node concept="Xjq3P" id="2nydsCfvLy1" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2nydsCfvLy2" role="1B3o_S" />
+      <node concept="3uibUv" id="2nydsCfvLy3" role="3clF45">
+        <ref role="3uigEE" node="2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+      </node>
+      <node concept="37vLTG" id="2nydsCfvLy4" role="3clF46">
+        <property role="TrG5h" value="flag" />
+        <node concept="10P_77" id="2nydsCfvRCi" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2nydsCfvLvP" role="jymVt" />
+    <node concept="3clFb_" id="2nydsCfw1oG" role="jymVt">
+      <property role="TrG5h" value="withCoverAnalyzer" />
+      <node concept="3clFbS" id="2nydsCfw1oJ" role="3clF47">
+        <node concept="3clFbF" id="2nydsCfwaqU" role="3cqZAp">
+          <node concept="37vLTI" id="2nydsCfweCD" role="3clFbG">
+            <node concept="37vLTw" id="2nydsCfwgRt" role="37vLTx">
+              <ref role="3cqZAo" node="2nydsCfw33i" resolve="coverageAnalyzer" />
+            </node>
+            <node concept="2OqwBi" id="2nydsCfwbDh" role="37vLTJ">
+              <node concept="Xjq3P" id="2nydsCfwaqT" role="2Oq$k0" />
+              <node concept="2OwXpG" id="2nydsCfwdib" role="2OqNvi">
+                <ref role="2Oxat5" node="2nydsCftPdm" resolve="coverageAnalyzer" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2nydsCfwjTt" role="3cqZAp">
+          <node concept="Xjq3P" id="2nydsCfwjTr" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2nydsCfvZt3" role="1B3o_S" />
+      <node concept="3uibUv" id="2nydsCfw185" role="3clF45">
+        <ref role="3uigEE" node="2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+      </node>
+      <node concept="37vLTG" id="2nydsCfw33i" role="3clF46">
+        <property role="TrG5h" value="coverageAnalyzer" />
+        <node concept="3uibUv" id="2nydsCfw33h" role="1tU5fm">
+          <ref role="3uigEE" to="2ahs:4_qY3E5ifTh" resolve="ICoverageAnalyzer" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2nydsCfxbnf" role="jymVt" />
+    <node concept="3clFb_" id="2nydsCfxfV8" role="jymVt">
+      <property role="TrG5h" value="withInterpreter" />
+      <node concept="3clFbS" id="2nydsCfxfVb" role="3clF47">
+        <node concept="3clFbF" id="2nydsCfxjFm" role="3cqZAp">
+          <node concept="37vLTI" id="2nydsCfxnOM" role="3clFbG">
+            <node concept="37vLTw" id="2nydsCfxqqp" role="37vLTx">
+              <ref role="3cqZAo" node="2nydsCfxhIs" resolve="interpreter" />
+            </node>
+            <node concept="2OqwBi" id="2nydsCfxkPB" role="37vLTJ">
+              <node concept="Xjq3P" id="2nydsCfxjFl" role="2Oq$k0" />
+              <node concept="2OwXpG" id="2nydsCfxmlh" role="2OqNvi">
+                <ref role="2Oxat5" node="2nydsCfx9Qs" resolve="interpreter" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2nydsCfxt19" role="3cqZAp">
+          <node concept="Xjq3P" id="2nydsCfxt17" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2nydsCfxeb0" role="1B3o_S" />
+      <node concept="3uibUv" id="2nydsCfxfIa" role="3clF45">
+        <ref role="3uigEE" node="2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+      </node>
+      <node concept="37vLTG" id="2nydsCfxhIs" role="3clF46">
+        <property role="TrG5h" value="interpreter" />
+        <node concept="3uibUv" id="2nydsCfxhIr" role="1tU5fm">
+          <ref role="3uigEE" to="2ahs:4X7QcQ36WR7" resolve="IInterpreter" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2nydsCf$GWc" role="jymVt" />
+    <node concept="3clFb_" id="2nydsCf$H0v" role="jymVt">
+      <property role="TrG5h" value="withEnvironmentContent" />
+      <node concept="3clFbS" id="2nydsCf$H0w" role="3clF47">
+        <node concept="3clFbF" id="2nydsCf$H0x" role="3cqZAp">
+          <node concept="37vLTI" id="2nydsCf$H0y" role="3clFbG">
+            <node concept="37vLTw" id="2nydsCf$H0z" role="37vLTx">
+              <ref role="3cqZAo" node="2nydsCf$H0F" resolve="interpreter" />
+            </node>
+            <node concept="2OqwBi" id="2nydsCf$H0$" role="37vLTJ">
+              <node concept="Xjq3P" id="2nydsCf$H0_" role="2Oq$k0" />
+              <node concept="2OwXpG" id="2nydsCf$H0A" role="2OqNvi">
+                <ref role="2Oxat5" node="2nydsCf$Ggh" resolve="environment" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2nydsCf$H0B" role="3cqZAp">
+          <node concept="Xjq3P" id="2nydsCf$H0C" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2nydsCf$H0D" role="1B3o_S" />
+      <node concept="3uibUv" id="2nydsCf$H0E" role="3clF45">
+        <ref role="3uigEE" node="2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+      </node>
+      <node concept="37vLTG" id="2nydsCf$H0F" role="3clF46">
+        <property role="TrG5h" value="environmentContent" />
+        <node concept="3rvAFt" id="2nydsCf$I$v" role="1tU5fm">
+          <node concept="3Tqbb2" id="2nydsCf$I$w" role="3rvQeY" />
+          <node concept="3uibUv" id="2nydsCf$I$x" role="3rvSg0">
+            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2nydsCfApRm" role="jymVt" />
+    <node concept="3clFb_" id="2nydsCfAryl" role="jymVt">
+      <property role="TrG5h" value="getInternalHelper" />
+      <node concept="3clFbS" id="2nydsCfAryo" role="3clF47">
+        <node concept="3clFbF" id="2nydsCfAswY" role="3cqZAp">
+          <node concept="37vLTw" id="2nydsCfAswX" role="3clFbG">
+            <ref role="3cqZAo" node="2nydsCfAaTv" resolve="helper" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2nydsCfAqHB" role="1B3o_S" />
+      <node concept="3uibUv" id="2nydsCfArt3" role="3clF45">
+        <ref role="3uigEE" to="2ahs:50LzNoSxDO3" resolve="InterpreterEvaluationHelper" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2nydsCf$GYl" role="jymVt" />
+    <node concept="3clFb_" id="2nydsCfz7eH" role="jymVt">
+      <property role="TrG5h" value="evaluate" />
+      <node concept="3clFbS" id="2nydsCfz7eK" role="3clF47">
+        <node concept="3clFbJ" id="2nydsCf$Yvz" role="3cqZAp">
+          <node concept="3clFbS" id="2nydsCf$Yv_" role="3clFbx">
+            <node concept="3clFbF" id="2nydsCf_1g4" role="3cqZAp">
+              <node concept="37vLTI" id="2nydsCf_1N1" role="3clFbG">
+                <node concept="2ShNRf" id="2nydsCf_28Z" role="37vLTx">
+                  <node concept="HV5vD" id="2nydsCf_2Tq" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="HV5vE" node="6iqfHNC0mHl" resolve="IETS3ExprContext" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="2nydsCf_1g2" role="37vLTJ">
+                  <ref role="3cqZAo" node="2nydsCftMQC" resolve="context" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="2nydsCf$ZWd" role="3clFbw">
+            <node concept="10Nm6u" id="2nydsCf_0zF" role="3uHU7w" />
+            <node concept="37vLTw" id="2nydsCf$Zob" role="3uHU7B">
+              <ref role="3cqZAo" node="2nydsCftMQC" resolve="context" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2nydsCf_3m5" role="3cqZAp" />
+        <node concept="3clFbJ" id="2nydsCf_50M" role="3cqZAp">
+          <node concept="3clFbS" id="2nydsCf_50O" role="3clFbx">
+            <node concept="3clFbF" id="2nydsCf_8gw" role="3cqZAp">
+              <node concept="2OqwBi" id="2nydsCf_8Dc" role="3clFbG">
+                <node concept="37vLTw" id="2nydsCf_8gu" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2nydsCftMQC" resolve="context" />
+                </node>
+                <node concept="liA8E" id="2nydsCf_99i" role="2OqNvi">
+                  <ref role="37wK5l" to="2ahs:2pAf7L4El8y" resolve="pushEnvironment" />
+                  <node concept="37vLTw" id="2nydsCf_9Hi" role="37wK5m">
+                    <ref role="3cqZAo" node="2nydsCfz7pp" resolve="expr" />
+                  </node>
+                  <node concept="37vLTw" id="2nydsCf_aku" role="37wK5m">
+                    <ref role="3cqZAo" node="2nydsCf$Ggh" resolve="environment" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="2nydsCf_6QE" role="3clFbw">
+            <node concept="10Nm6u" id="2nydsCf_7_K" role="3uHU7w" />
+            <node concept="37vLTw" id="2nydsCf_631" role="3uHU7B">
+              <ref role="3cqZAo" node="2nydsCf$Ggh" resolve="environment" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2nydsCf_e4j" role="3cqZAp" />
+        <node concept="3clFbJ" id="2nydsCf_eNp" role="3cqZAp">
+          <node concept="3clFbS" id="2nydsCf_eNr" role="3clFbx">
+            <node concept="3clFbF" id="2nydsCf_h9p" role="3cqZAp">
+              <node concept="37vLTI" id="2nydsCf_hGl" role="3clFbG">
+                <node concept="1rXfSq" id="2nydsCf_i9_" role="37vLTx">
+                  <ref role="37wK5l" node="2nydsCfzrJq" resolve="getInterpreter" />
+                </node>
+                <node concept="37vLTw" id="2nydsCf_h9n" role="37vLTJ">
+                  <ref role="3cqZAo" node="2nydsCfx9Qs" resolve="interpreter" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="2nydsCf_fZO" role="3clFbw">
+            <node concept="10Nm6u" id="2nydsCf_gGp" role="3uHU7w" />
+            <node concept="37vLTw" id="2nydsCf_fs0" role="3uHU7B">
+              <ref role="3cqZAo" node="2nydsCfx9Qs" resolve="interpreter" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2nydsCf$XIN" role="3cqZAp" />
+        <node concept="3J1_TO" id="2nydsCf$KLL" role="3cqZAp">
+          <node concept="3uVAMA" id="2nydsCf$KLM" role="1zxBo5">
+            <node concept="XOnhg" id="2nydsCf$KLN" role="1zc67B">
+              <property role="3TUv4t" value="false" />
+              <property role="TrG5h" value="stopEx" />
+              <node concept="nSUau" id="2nydsCf$KLO" role="1tU5fm">
+                <node concept="3uibUv" id="2nydsCf$KLP" role="nSUat">
+                  <ref role="3uigEE" to="2ahs:6MNhNeUeNix" resolve="StopAndReturnException" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="2nydsCf$KLQ" role="1zc67A">
+              <node concept="3cpWs6" id="2nydsCf$KLR" role="3cqZAp">
+                <node concept="2ShNRf" id="2nydsCf$KLS" role="3cqZAk">
+                  <node concept="1pGfFk" id="2nydsCf$KLT" role="2ShVmc">
+                    <ref role="37wK5l" node="2ns1RQRO9uL" resolve="ValueAndTraceAndEnv" />
+                    <node concept="2OqwBi" id="2nydsCf$KLU" role="37wK5m">
+                      <node concept="37vLTw" id="2nydsCf$KLV" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2nydsCf$KLN" resolve="stopEx" />
+                      </node>
+                      <node concept="liA8E" id="2nydsCf$KLW" role="2OqNvi">
+                        <ref role="37wK5l" to="2ahs:6MNhNeUeYe3" resolve="value" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="2nydsCf$KLX" role="37wK5m">
+                      <node concept="37vLTw" id="2nydsCf$KLY" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2nydsCfAaTv" resolve="helper" />
+                      </node>
+                      <node concept="liA8E" id="2nydsCf$KLZ" role="2OqNvi">
+                        <ref role="37wK5l" to="2ahs:7obiejCzFIg" resolve="getLastLog" />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="2nydsCf$KM0" role="37wK5m">
+                      <node concept="37vLTw" id="2nydsCf$KM1" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2nydsCftMQC" resolve="context" />
+                      </node>
+                      <node concept="liA8E" id="2nydsCf$KM2" role="2OqNvi">
+                        <ref role="37wK5l" to="2ahs:2X4$XGmeh8R" resolve="getEnvironment" />
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="2nydsCf$KM3" role="37wK5m">
+                      <ref role="3cqZAo" node="2nydsCftPdm" resolve="coverageAnalyzer" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="2nydsCf$KM4" role="1zxBo7">
+            <node concept="3clFbF" id="2nydsCfAget" role="3cqZAp">
+              <node concept="37vLTI" id="2nydsCfAgVF" role="3clFbG">
+                <node concept="37vLTw" id="2nydsCfAger" role="37vLTJ">
+                  <ref role="3cqZAo" node="2nydsCfAaTv" resolve="helper" />
+                </node>
+                <node concept="2ShNRf" id="2nydsCfAiG2" role="37vLTx">
+                  <node concept="1pGfFk" id="2nydsCfAiG3" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="2ahs:50LzNoSxJpU" resolve="InterpreterEvaluationHelper" />
+                    <node concept="37vLTw" id="2nydsCfAiGh" role="37wK5m">
+                      <ref role="3cqZAo" node="2nydsCfz2XE" resolve="INTERPRETER_CATEGORY" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="2nydsCf$KM5" role="3cqZAp">
+              <node concept="3cpWsn" id="2nydsCf$KM6" role="3cpWs9">
+                <property role="TrG5h" value="res" />
+                <node concept="3uibUv" id="2nydsCf$KM7" role="1tU5fm">
+                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                </node>
+                <node concept="2OqwBi" id="2nydsCf_jcd" role="33vP2m">
+                  <node concept="2OqwBi" id="2nydsCf$WIR" role="2Oq$k0">
+                    <node concept="2OqwBi" id="2nydsCf$V6I" role="2Oq$k0">
+                      <node concept="2OqwBi" id="2nydsCf$RNc" role="2Oq$k0">
+                        <node concept="2OqwBi" id="2nydsCf$Pr6" role="2Oq$k0">
+                          <node concept="2OqwBi" id="2nydsCf$NVK" role="2Oq$k0">
+                            <node concept="37vLTw" id="2nydsCfAjLf" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2nydsCfAaTv" resolve="helper" />
+                            </node>
+                            <node concept="liA8E" id="2nydsCf$Oqh" role="2OqNvi">
+                              <ref role="37wK5l" to="2ahs:2nydsCfuiP4" resolve="evaluateWithOptions" />
+                              <node concept="37vLTw" id="2nydsCf$OXG" role="37wK5m">
+                                <ref role="3cqZAo" node="2nydsCfz7pp" resolve="expr" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="2nydsCf$QRT" role="2OqNvi">
+                            <ref role="37wK5l" to="2ahs:2nydsCfvv5Z" resolve="withContext" />
+                            <node concept="37vLTw" id="2nydsCf$Rkc" role="37wK5m">
+                              <ref role="3cqZAo" node="2nydsCftMQC" resolve="context" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="2nydsCf$U9o" role="2OqNvi">
+                          <ref role="37wK5l" to="2ahs:2nydsCfvLxS" resolve="withComputationTrace" />
+                          <node concept="37vLTw" id="2nydsCf$UB1" role="37wK5m">
+                            <ref role="3cqZAo" node="2nydsCftO1R" resolve="createComputationTrace" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="2nydsCf$VJp" role="2OqNvi">
+                        <ref role="37wK5l" to="2ahs:2nydsCfw1oG" resolve="withCoverAnalyzer" />
+                        <node concept="37vLTw" id="2nydsCf$Wew" role="37wK5m">
+                          <ref role="3cqZAo" node="2nydsCftPdm" resolve="coverageAnalyzer" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="2nydsCf$XmQ" role="2OqNvi">
+                      <ref role="37wK5l" to="2ahs:2nydsCfxfV8" resolve="withInterpreter" />
+                      <node concept="37vLTw" id="2nydsCf_iBv" role="37wK5m">
+                        <ref role="3cqZAo" node="2nydsCfx9Qs" resolve="interpreter" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="2nydsCf_jSb" role="2OqNvi">
+                    <ref role="37wK5l" to="2ahs:2nydsCfuljQ" resolve="execute" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="2nydsCf$KMf" role="3cqZAp">
+              <node concept="3cpWsn" id="2nydsCf$KMg" role="3cpWs9">
+                <property role="TrG5h" value="trace" />
+                <node concept="3uibUv" id="2nydsCf$KMh" role="1tU5fm">
+                  <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
+                </node>
+                <node concept="10Nm6u" id="2nydsCf_S$X" role="33vP2m" />
+              </node>
+            </node>
+            <node concept="3clFbH" id="2nydsCf_VsC" role="3cqZAp" />
+            <node concept="3clFbJ" id="2nydsCf_NMx" role="3cqZAp">
+              <node concept="3clFbS" id="2nydsCf_NMz" role="3clFbx">
+                <node concept="3clFbF" id="2nydsCf_RtS" role="3cqZAp">
+                  <node concept="37vLTI" id="2nydsCf_RtU" role="3clFbG">
+                    <node concept="2OqwBi" id="2nydsCf$KMi" role="37vLTx">
+                      <node concept="37vLTw" id="2nydsCf$KMj" role="2Oq$k0">
+                        <ref role="3cqZAo" node="2nydsCfAaTv" resolve="helper" />
+                      </node>
+                      <node concept="liA8E" id="2nydsCf$KMk" role="2OqNvi">
+                        <ref role="37wK5l" to="2ahs:7obiejCzFIg" resolve="getLastLog" />
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="2nydsCf_RtY" role="37vLTJ">
+                      <ref role="3cqZAo" node="2nydsCf$KMg" resolve="trace" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="2nydsCf$KMl" role="3cqZAp">
+                  <node concept="2OqwBi" id="2nydsCf$KMm" role="3clFbG">
+                    <node concept="37vLTw" id="2nydsCf$KMn" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2nydsCf$KMg" resolve="trace" />
+                    </node>
+                    <node concept="liA8E" id="2nydsCf$KMo" role="2OqNvi">
+                      <ref role="37wK5l" to="2ahs:7obiejAu3TD" resolve="setValue" />
+                      <node concept="37vLTw" id="2nydsCf$KMp" role="37wK5m">
+                        <ref role="3cqZAo" node="2nydsCf$KM6" resolve="res" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTw" id="2nydsCf_OqY" role="3clFbw">
+                <ref role="3cqZAo" node="2nydsCftO1R" resolve="createComputationTrace" />
+              </node>
+            </node>
+            <node concept="3clFbH" id="2nydsCf_Tsh" role="3cqZAp" />
+            <node concept="3cpWs6" id="2nydsCf$KMq" role="3cqZAp">
+              <node concept="2ShNRf" id="2nydsCf$KMr" role="3cqZAk">
+                <node concept="1pGfFk" id="2nydsCf$KMs" role="2ShVmc">
+                  <ref role="37wK5l" node="2ns1RQRO9uL" resolve="ValueAndTraceAndEnv" />
+                  <node concept="37vLTw" id="2nydsCf$KMt" role="37wK5m">
+                    <ref role="3cqZAo" node="2nydsCf$KM6" resolve="res" />
+                  </node>
+                  <node concept="37vLTw" id="2nydsCf$KMu" role="37wK5m">
+                    <ref role="3cqZAo" node="2nydsCf$KMg" resolve="trace" />
+                  </node>
+                  <node concept="2OqwBi" id="2nydsCf$KMv" role="37wK5m">
+                    <node concept="37vLTw" id="2nydsCf$KMw" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2nydsCftMQC" resolve="context" />
+                    </node>
+                    <node concept="liA8E" id="2nydsCf$KMx" role="2OqNvi">
+                      <ref role="37wK5l" to="2ahs:2X4$XGmeh8R" resolve="getEnvironment" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="2nydsCf_owl" role="37wK5m">
+                    <ref role="3cqZAo" node="2nydsCftPdm" resolve="coverageAnalyzer" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2nydsCfz68L" role="1B3o_S" />
+      <node concept="3uibUv" id="2nydsCfz6Ga" role="3clF45">
+        <ref role="3uigEE" node="4Pi6J8Cccqb" resolve="ValueAndTraceAndEnv" />
+      </node>
+      <node concept="37vLTG" id="2nydsCfz7pp" role="3clF46">
+        <property role="TrG5h" value="expr" />
+        <node concept="3Tqbb2" id="2nydsCfz7po" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2nydsCfzzQc" role="jymVt" />
+    <node concept="2YIFZL" id="2nydsCfzrJq" role="jymVt">
+      <property role="TrG5h" value="getInterpreter" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="2nydsCfzrJr" role="3clF47">
+        <node concept="3clFbF" id="2nydsCfzrJs" role="3cqZAp">
+          <node concept="2YIFZM" id="2nydsCfzrJt" role="3clFbG">
+            <ref role="1Pybhc" to="2ahs:50LzNoSxDO3" resolve="InterpreterEvaluationHelper" />
+            <ref role="37wK5l" to="2ahs:50LzNoSyEfI" resolve="getInterpreter" />
+            <node concept="37vLTw" id="2nydsCfzwB8" role="37wK5m">
+              <ref role="3cqZAo" node="2nydsCfz2XE" resolve="INTERPRETER_CATEGORY" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2nydsCfzrJu" role="1B3o_S" />
+      <node concept="3uibUv" id="2nydsCfzrJv" role="3clF45">
+        <ref role="3uigEE" to="2ahs:4X7QcQ36WR7" resolve="IInterpreter" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="2nydsCfyYD1" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/behavior.mps
@@ -1721,8 +1721,8 @@
             <node concept="3clFbF" id="7bd8pklcd$P" role="3cqZAp">
               <node concept="37vLTI" id="7bd8pklcd$Q" role="3clFbG">
                 <node concept="2YIFZM" id="7bd8pklcd$R" role="37vLTx">
-                  <ref role="37wK5l" to="pbu6:50LzNoSyDOv" resolve="getInterpreter" />
-                  <ref role="1Pybhc" to="pbu6:3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
+                  <ref role="1Pybhc" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                  <ref role="37wK5l" to="pbu6:2nydsCfzrJq" resolve="getInterpreter" />
                 </node>
                 <node concept="37vLTw" id="7bd8pklcd$S" role="37vLTJ">
                   <ref role="3cqZAo" node="7bd8pklbYCn" resolve="i" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/editor.mps
@@ -238,6 +238,9 @@
       <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
         <child id="1239714902950" name="expression" index="2$L3a6" />
       </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -281,6 +284,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -4059,18 +4065,31 @@
                   <node concept="1HfYo3" id="5avmkTFwB_q" role="1HlULh">
                     <node concept="3TQlhw" id="5avmkTFwB_r" role="1Hhtcw">
                       <node concept="3clFbS" id="5avmkTFwB_s" role="2VODD2">
-                        <node concept="3clFbF" id="5avmkTFwB_t" role="3cqZAp">
-                          <node concept="3cpWs3" id="5avmkTFwB_u" role="3clFbG">
-                            <node concept="Xl_RD" id="5avmkTFwB_v" role="3uHU7w">
+                        <node concept="3clFbF" id="5af9jCuPpkh" role="3cqZAp">
+                          <node concept="3cpWs3" id="5af9jCuPECl" role="3clFbG">
+                            <node concept="Xl_RD" id="5af9jCuPECp" role="3uHU7w">
                               <property role="Xl_RC" value="" />
                             </node>
-                            <node concept="2YIFZM" id="5avmkTFwB_w" role="3uHU7B">
-                              <ref role="1Pybhc" to="pbu6:3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
-                              <ref role="37wK5l" to="pbu6:3xDNhgd54rl" resolve="evaluate" />
-                              <node concept="2OqwBi" id="5avmkTFwB_x" role="37wK5m">
-                                <node concept="pncrf" id="5avmkTFwB_y" role="2Oq$k0" />
-                                <node concept="3TrEf2" id="5avmkTFwB_z" role="2OqNvi">
-                                  <ref role="3Tt5mk" to="wtll:5xEoEMrmiVo" resolve="expr" />
+                            <node concept="2OqwBi" id="5af9jCuPDtl" role="3uHU7B">
+                              <node concept="2OqwBi" id="5af9jCuPCOe" role="2Oq$k0">
+                                <node concept="2ShNRf" id="5af9jCuPpkd" role="2Oq$k0">
+                                  <node concept="HV5vD" id="5af9jCuPB5n" role="2ShVmc">
+                                    <property role="373rjd" value="true" />
+                                    <ref role="HV5vE" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="5af9jCuPDb6" role="2OqNvi">
+                                  <ref role="37wK5l" to="pbu6:2nydsCfvLxS" resolve="withComputationTrace" />
+                                  <node concept="3clFbT" id="5af9jCuPDeu" role="37wK5m" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="5af9jCuPDIc" role="2OqNvi">
+                                <ref role="37wK5l" to="pbu6:2nydsCfz7eH" resolve="evaluate" />
+                                <node concept="2OqwBi" id="5af9jCuPE18" role="37wK5m">
+                                  <node concept="pncrf" id="5af9jCuPDMB" role="2Oq$k0" />
+                                  <node concept="3TrEf2" id="5af9jCuPErD" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="wtll:5xEoEMrmiVo" resolve="expr" />
+                                  </node>
                                 </node>
                               </node>
                             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/typesystem.mps
@@ -67,6 +67,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -1388,7 +1391,7 @@
         <node concept="3clFbS" id="5avmkTFxQiD" role="3clFbx">
           <node concept="3cpWs8" id="7HzLUeHnBt2" role="3cqZAp">
             <node concept="3cpWsn" id="7HzLUeHnBt3" role="3cpWs9">
-              <property role="TrG5h" value="ctx" />
+              <property role="TrG5h" value="context" />
               <node concept="3uibUv" id="7HzLUeHnBt0" role="1tU5fm">
                 <ref role="3uigEE" to="pbu6:6iqfHNC0mHl" resolve="IETS3ExprContext" />
               </node>
@@ -1432,24 +1435,42 @@
               <node concept="3uibUv" id="7HzLUeHnEEX" role="1tU5fm">
                 <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
               </node>
-              <node concept="2YIFZM" id="7HzLUeHnEF7" role="33vP2m">
-                <ref role="37wK5l" to="pbu6:Qsaevo33yK" resolve="evaluateWithContext" />
-                <ref role="1Pybhc" to="pbu6:3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
-                <node concept="2OqwBi" id="7HzLUeHnEF8" role="37wK5m">
-                  <node concept="2OqwBi" id="7HzLUeHnEF9" role="2Oq$k0">
-                    <node concept="1YBJjd" id="7HzLUeHnEFa" role="2Oq$k0">
-                      <ref role="1YBMHb" node="3_Nra3EaXXG" resolve="cell" />
+              <node concept="2OqwBi" id="5af9jCuPLD$" role="33vP2m">
+                <node concept="2OqwBi" id="5af9jCuRFe3" role="2Oq$k0">
+                  <node concept="2OqwBi" id="5af9jCuPKVE" role="2Oq$k0">
+                    <node concept="2ShNRf" id="5af9jCuPKr6" role="2Oq$k0">
+                      <node concept="HV5vD" id="5af9jCuPKSF" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="HV5vE" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                      </node>
                     </node>
-                    <node concept="3TrEf2" id="7HzLUeHnEFb" role="2OqNvi">
-                      <ref role="3Tt5mk" to="wtll:3_Nra3DTfmI" resolve="constraint" />
+                    <node concept="liA8E" id="5af9jCuPL0W" role="2OqNvi">
+                      <ref role="37wK5l" to="pbu6:2nydsCfvv5Z" resolve="withContext" />
+                      <node concept="37vLTw" id="5af9jCuPL1K" role="37wK5m">
+                        <ref role="3cqZAo" node="7HzLUeHnBt3" resolve="context" />
+                      </node>
                     </node>
                   </node>
-                  <node concept="3TrEf2" id="7HzLUeHnEFc" role="2OqNvi">
-                    <ref role="3Tt5mk" to="wtll:3_Nra3DTaT2" resolve="constraint" />
+                  <node concept="liA8E" id="5af9jCuRFMV" role="2OqNvi">
+                    <ref role="37wK5l" to="pbu6:2nydsCfvLxS" resolve="withComputationTrace" />
+                    <node concept="3clFbT" id="5af9jCuRG1D" role="37wK5m" />
                   </node>
                 </node>
-                <node concept="37vLTw" id="7HzLUeHnEFd" role="37wK5m">
-                  <ref role="3cqZAo" node="7HzLUeHnBt3" resolve="ctx" />
+                <node concept="liA8E" id="5af9jCuPLI0" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:2nydsCfz7eH" resolve="evaluate" />
+                  <node concept="2OqwBi" id="5af9jCuPLK2" role="37wK5m">
+                    <node concept="2OqwBi" id="5af9jCuPLK3" role="2Oq$k0">
+                      <node concept="1YBJjd" id="5af9jCuPLK4" role="2Oq$k0">
+                        <ref role="1YBMHb" node="3_Nra3EaXXG" resolve="cell" />
+                      </node>
+                      <node concept="3TrEf2" id="5af9jCuPLK5" role="2OqNvi">
+                        <ref role="3Tt5mk" to="wtll:3_Nra3DTfmI" resolve="constraint" />
+                      </node>
+                    </node>
+                    <node concept="3TrEf2" id="5af9jCuPLK6" role="2OqNvi">
+                      <ref role="3Tt5mk" to="wtll:3_Nra3DTaT2" resolve="constraint" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -195,6 +195,9 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -3287,8 +3290,8 @@
       <node concept="3clFbS" id="uGVYUilnJi" role="3clF47">
         <node concept="3clFbF" id="uGVYUilnU5" role="3cqZAp">
           <node concept="2YIFZM" id="ub9nkyNsfK" role="3clFbG">
-            <ref role="1Pybhc" to="pbu6:3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
-            <ref role="37wK5l" to="pbu6:50LzNoSyDOv" resolve="getInterpreter" />
+            <ref role="1Pybhc" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+            <ref role="37wK5l" to="pbu6:2nydsCfzrJq" resolve="getInterpreter" />
           </node>
         </node>
       </node>
@@ -3316,12 +3319,25 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="7obiejCz$G$" role="3cqZAp">
-          <node concept="2YIFZM" id="6BSYN9m74xu" role="3clFbG">
-            <ref role="37wK5l" to="pbu6:3xDNhgd54rl" resolve="evaluate" />
-            <ref role="1Pybhc" to="pbu6:3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
-            <node concept="37vLTw" id="6BSYN9m74xv" role="37wK5m">
-              <ref role="3cqZAo" node="uGVYUilG_a" resolve="n" />
+        <node concept="3clFbF" id="5af9jCuTE37" role="3cqZAp">
+          <node concept="2OqwBi" id="5af9jCuTFrn" role="3clFbG">
+            <node concept="2OqwBi" id="5af9jCuTFil" role="2Oq$k0">
+              <node concept="2ShNRf" id="5af9jCuTE33" role="2Oq$k0">
+                <node concept="HV5vD" id="5af9jCuTFfi" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="HV5vE" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                </node>
+              </node>
+              <node concept="liA8E" id="5af9jCuTFnn" role="2OqNvi">
+                <ref role="37wK5l" to="pbu6:2nydsCfvLxS" resolve="withComputationTrace" />
+                <node concept="3clFbT" id="5af9jCuTFnq" role="37wK5m" />
+              </node>
+            </node>
+            <node concept="liA8E" id="5af9jCuTGxr" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:2nydsCfz7eH" resolve="evaluate" />
+              <node concept="37vLTw" id="5af9jCuTG$K" role="37wK5m">
+                <ref role="3cqZAo" node="uGVYUilG_a" resolve="n" />
+              </node>
             </node>
           </node>
         </node>
@@ -3351,12 +3367,19 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="7obiejCzWM6" role="3cqZAp">
-          <node concept="2YIFZM" id="4Pi6J8Ccshm" role="3clFbG">
-            <ref role="37wK5l" to="pbu6:4Pi6J8Ccg1L" resolve="evaluateWithTraceAndEnv" />
-            <ref role="1Pybhc" to="pbu6:3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
-            <node concept="37vLTw" id="4Pi6J8Ccshn" role="37wK5m">
-              <ref role="3cqZAo" node="7obiejCzVLL" resolve="n" />
+        <node concept="3clFbF" id="5af9jCuTGIN" role="3cqZAp">
+          <node concept="2OqwBi" id="5af9jCuTHfg" role="3clFbG">
+            <node concept="2ShNRf" id="5af9jCuTGIJ" role="2Oq$k0">
+              <node concept="HV5vD" id="5af9jCuTHaF" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+              </node>
+            </node>
+            <node concept="liA8E" id="5af9jCuTHpJ" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:2nydsCfz7eH" resolve="evaluate" />
+              <node concept="37vLTw" id="5af9jCuTHzY" role="37wK5m">
+                <ref role="3cqZAo" node="7obiejCzVLL" resolve="n" />
+              </node>
             </node>
           </node>
         </node>
@@ -3655,12 +3678,25 @@
         </node>
         <node concept="3clFbJ" id="4KZjPKUdF$1" role="3cqZAp">
           <node concept="3clFbS" id="4KZjPKUdF$2" role="3clFbx">
-            <node concept="3clFbF" id="1cd9HYW_IC8" role="3cqZAp">
-              <node concept="2YIFZM" id="1cd9HYW_IC9" role="3clFbG">
-                <ref role="1Pybhc" to="pbu6:3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
-                <ref role="37wK5l" to="pbu6:4Pi6J8Ccg1L" resolve="evaluateWithTraceAndEnv" />
-                <node concept="37vLTw" id="4KZjPKUfBNt" role="37wK5m">
-                  <ref role="3cqZAo" node="4KZjPKUdFzS" resolve="su" />
+            <node concept="3clFbF" id="5af9jCuTJT3" role="3cqZAp">
+              <node concept="2OqwBi" id="5af9jCuTLaw" role="3clFbG">
+                <node concept="2OqwBi" id="5af9jCuTMzC" role="2Oq$k0">
+                  <node concept="2ShNRf" id="5af9jCuTJSZ" role="2Oq$k0">
+                    <node concept="HV5vD" id="5af9jCuTKGX" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="HV5vE" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="5af9jCuTN0B" role="2OqNvi">
+                    <ref role="37wK5l" to="pbu6:2nydsCfvLxS" resolve="withComputationTrace" />
+                    <node concept="3clFbT" id="5af9jCuTN0E" role="37wK5m" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="5af9jCuTLD4" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:2nydsCfz7eH" resolve="evaluate" />
+                  <node concept="37vLTw" id="5af9jCuTM50" role="37wK5m">
+                    <ref role="3cqZAo" node="4KZjPKUdFzS" resolve="su" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -9884,11 +9920,24 @@
                     <node concept="37vLTw" id="4945UtSiyZg" role="37vLTJ">
                       <ref role="3cqZAo" node="4945UtSiwdl" resolve="actualVal" />
                     </node>
-                    <node concept="2YIFZM" id="4945UtStEjX" role="37vLTx">
-                      <ref role="37wK5l" to="pbu6:4945UtStyFA" resolve="evaluateAndThrowConstraintFailures" />
-                      <ref role="1Pybhc" to="pbu6:3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
-                      <node concept="37vLTw" id="4945UtStEjY" role="37wK5m">
-                        <ref role="3cqZAo" node="5AG05XYAt5x" resolve="call" />
+                    <node concept="2OqwBi" id="5af9jCuTXkX" role="37vLTx">
+                      <node concept="2OqwBi" id="5af9jCuTVYl" role="2Oq$k0">
+                        <node concept="2ShNRf" id="5af9jCuTUiF" role="2Oq$k0">
+                          <node concept="HV5vD" id="5af9jCuTVkD" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="HV5vE" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="5af9jCuTWEk" role="2OqNvi">
+                          <ref role="37wK5l" to="pbu6:2nydsCfvLxS" resolve="withComputationTrace" />
+                          <node concept="3clFbT" id="5af9jCuTWEn" role="37wK5m" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="5af9jCuTY0S" role="2OqNvi">
+                        <ref role="37wK5l" to="pbu6:7gBavbyuRAy" resolve="evaluateAndThrowConstraintFailures" />
+                        <node concept="37vLTw" id="5af9jCuTYEO" role="37wK5m">
+                          <ref role="3cqZAo" node="5AG05XYAt5x" resolve="call" />
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -10173,16 +10222,34 @@
                 <node concept="3uibUv" id="1vJWYavhGRl" role="1tU5fm">
                   <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
                 </node>
-                <node concept="2YIFZM" id="1vJWYavhGRm" role="33vP2m">
-                  <ref role="1Pybhc" to="pbu6:3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
-                  <ref role="37wK5l" to="pbu6:3xDNhgd54rl" resolve="evaluate" />
-                  <node concept="2OqwBi" id="1vJWYavikeb" role="37wK5m">
-                    <node concept="37vLTw" id="1vJWYavhKcd" role="2Oq$k0">
-                      <ref role="3cqZAo" node="1vJWYavhGG8" resolve="exp" />
+                <node concept="2OqwBi" id="7gBavbyGrIU" role="33vP2m">
+                  <node concept="2OqwBi" id="5af9jCuU0CS" role="2Oq$k0">
+                    <node concept="2OqwBi" id="5af9jCuU0CT" role="2Oq$k0">
+                      <node concept="2ShNRf" id="5af9jCuU0CU" role="2Oq$k0">
+                        <node concept="HV5vD" id="5af9jCuU0CV" role="2ShVmc">
+                          <property role="373rjd" value="true" />
+                          <ref role="HV5vE" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="5af9jCuU0CW" role="2OqNvi">
+                        <ref role="37wK5l" to="pbu6:2nydsCfvLxS" resolve="withComputationTrace" />
+                        <node concept="3clFbT" id="5af9jCuU0CX" role="37wK5m" />
+                      </node>
                     </node>
-                    <node concept="3TrEf2" id="1vJWYaviklh" role="2OqNvi">
-                      <ref role="3Tt5mk" to="av4b:1bwJEEgicnC" resolve="value" />
+                    <node concept="liA8E" id="5af9jCuU0CY" role="2OqNvi">
+                      <ref role="37wK5l" to="pbu6:2nydsCfz7eH" resolve="evaluate" />
+                      <node concept="2OqwBi" id="5af9jCuU1Tl" role="37wK5m">
+                        <node concept="37vLTw" id="5af9jCuU0CZ" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1vJWYavhGG8" resolve="exp" />
+                        </node>
+                        <node concept="3TrEf2" id="5af9jCuU2JS" role="2OqNvi">
+                          <ref role="3Tt5mk" to="av4b:1bwJEEgicnC" resolve="value" />
+                        </node>
+                      </node>
                     </node>
+                  </node>
+                  <node concept="2OwXpG" id="7gBavbyGs$a" role="2OqNvi">
+                    <ref role="2Oxat5" to="pbu6:7lHetQyBz3x" resolve="value" />
                   </node>
                 </node>
               </node>


### PR DESCRIPTION
The class `IETS3ExprEvalHelper` was deprecated and a new class `IETS3ExprEvaluator` was introduced that can also influence the creation of the computation trace. The interpreter doesn't automatically create a computation trace anymore that is discarded anyway.
The performance improvements are unfortunately only minimal and are only noticeable for larger computations e.g.
`10.upto(500).map(|it: number{0} => it * 2|).where(|it >= 50|).size` now sometimes takes 125 ms instead of 130 ms.