### PR TITLE
Implement named tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 ### Changed
 
 - The class `IETS3ExprEvalHelper` was deprecated and a new class `IETS3ExprEvaluator` was introduced that can also influence the creation of the computation trace.
+- Multi-decision tables now return an internal stored named tuple instead of a tuple. The new return type is compatible with the old type.
 
 ## November 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 ### Fixed
 
 - The `index` expression in collections operations now works correctly in nested expressions in the interpreter and generator.
-- Generation of nested short lambda expression now use the correct type for "it" as a variable.
+- Generation of nested short lambda expression now uses the correct type for "it" as a variable.
 - Collections: The index expression now works with collection types in the generator.
 
 ### Added
 
 - The `all` and `any` operation of collections now also support the `index` expression. The concepts `AllWithIndexOp` and `AnyWithIndexOp` are therefore deprecated.
-- Named tuples were added. The can be declared at the top level with the keywords `named tuple`. Fields can be accessed witht the `.` expression.
+- Named tuples were added. They can be declared at the top level with the keywords `named tuple`. Fields can be accessed witht the `.` expression.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 ### Added
 
 - The `all` and `any` operation of collections now also support the `index` expression. The concepts `AllWithIndexOp` and `AnyWithIndexOp` are therefore deprecated.
+- Named tuples were added. The can be declared at the top level with the keywords `named tuple`. Fields can be accessed witht the `.` expression.
 
 ### Changed
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -454,6 +454,9 @@
       <concept id="3562215692195599741" name="jetbrains.mps.lang.smodel.structure.SLinkImplicitSelect" flags="nn" index="13MTOL">
         <reference id="3562215692195600259" name="link" index="13MTZf" />
       </concept>
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz">
         <reference id="6677504323281689839" name="conceptDeclaraton" index="3bZ5Sy" />
       </concept>
@@ -10232,6 +10235,26 @@
       </node>
       <node concept="10P_77" id="5L2mTKmB19J" role="3clF45" />
     </node>
+    <node concept="13i0hz" id="4ZbdskT1$aE" role="13h7CS">
+      <property role="TrG5h" value="getElementTypes" />
+      <ref role="13i0hy" node="4ZbdskT1yfk" resolve="getElementTypes" />
+      <node concept="3Tm1VV" id="4ZbdskT1$aF" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskT1$aJ" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskT1_2o" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskT1_gc" role="3clFbG">
+            <node concept="13iPFW" id="4ZbdskT1_2n" role="2Oq$k0" />
+            <node concept="3Tsc0h" id="4ZbdskT1_zc" role="2OqNvi">
+              <ref role="3TtcxE" to="hm2y:S$tO8ocniV" resolve="elementTypes" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="4ZbdskT1$aK" role="3clF45">
+        <node concept="3Tqbb2" id="4ZbdskT1$aL" role="_ZDj9">
+          <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="13h7C7" id="S$tO8ocQNQ">
     <property role="3GE5qa" value="tuples" />
@@ -10350,6 +10373,41 @@
         </node>
       </node>
       <node concept="10P_77" id="7b6J31DlkYd" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="4ZbdskSW5Qo" role="13h7CS">
+      <property role="TrG5h" value="getValues" />
+      <ref role="13i0hy" node="4ZbdskSW3D7" resolve="getValues" />
+      <node concept="3Tm1VV" id="4ZbdskSW5Qp" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskSW5Qt" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskSW6fF" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskSW6vv" role="3clFbG">
+            <node concept="13iPFW" id="4ZbdskSW6fE" role="2Oq$k0" />
+            <node concept="3Tsc0h" id="4ZbdskSW6QH" role="2OqNvi">
+              <ref role="3TtcxE" to="hm2y:S$tO8ocnpr" resolve="values" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="4ZbdskSW5Qu" role="3clF45">
+        <node concept="3Tqbb2" id="4ZbdskSW5Qv" role="_ZDj9">
+          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4ZbdskSXXFu" role="13h7CS">
+      <property role="TrG5h" value="getConceptOfType" />
+      <ref role="13i0hy" node="4ZbdskSXUP5" resolve="getConceptOfType" />
+      <node concept="3Tm1VV" id="4ZbdskSXXFv" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskSXXFz" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskSXY9Q" role="3cqZAp">
+          <node concept="35c_gC" id="4ZbdskSXY9P" role="3clFbG">
+            <ref role="35c_gD" to="hm2y:S$tO8ocniU" resolve="TupleType" />
+          </node>
+        </node>
+      </node>
+      <node concept="3bZ5Sz" id="4ZbdskSXXF_" role="3clF45">
+        <ref role="3bZ5Sy" to="hm2y:6sdnDbSlaok" resolve="Type" />
+      </node>
     </node>
     <node concept="13i0hz" id="7b6J31Dl_dD" role="13h7CS">
       <property role="13i0iv" value="false" />
@@ -27010,6 +27068,54 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="2nydsCfyYD1" role="1B3o_S" />
+  </node>
+  <node concept="13h7C7" id="4ZbdskSW2Nh">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="13h7C2" to="hm2y:4ZbdskSW2Ng" resolve="ITupleValue" />
+    <node concept="13i0hz" id="4ZbdskSW3D7" role="13h7CS">
+      <property role="13i0iv" value="true" />
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="getValues" />
+      <node concept="3Tm1VV" id="4ZbdskSW3D8" role="1B3o_S" />
+      <node concept="_YKpA" id="4ZbdskSW3Dn" role="3clF45">
+        <node concept="3Tqbb2" id="4ZbdskSW3Dz" role="_ZDj9">
+          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="4ZbdskSW3Da" role="3clF47" />
+    </node>
+    <node concept="13i0hz" id="4ZbdskSXUP5" role="13h7CS">
+      <property role="13i0iv" value="true" />
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="getConceptOfType" />
+      <node concept="3Tm1VV" id="4ZbdskSXUP6" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskSXUP8" role="3clF47" />
+      <node concept="3bZ5Sz" id="4ZbdskSXXxU" role="3clF45">
+        <ref role="3bZ5Sy" to="hm2y:6sdnDbSlaok" resolve="Type" />
+      </node>
+    </node>
+    <node concept="13hLZK" id="4ZbdskSW2Ni" role="13h7CW">
+      <node concept="3clFbS" id="4ZbdskSW2Nj" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4ZbdskT1yf9">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="13h7C2" to="hm2y:4ZbdskT0qlt" resolve="ITupleType" />
+    <node concept="13i0hz" id="4ZbdskT1yfk" role="13h7CS">
+      <property role="13i0iv" value="true" />
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="getElementTypes" />
+      <node concept="3Tm1VV" id="4ZbdskT1yfl" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskT1yfn" role="3clF47" />
+      <node concept="_YKpA" id="4ZbdskT1yfV" role="3clF45">
+        <node concept="3Tqbb2" id="4ZbdskT1yg7" role="_ZDj9">
+          <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="4ZbdskT1yfa" role="13h7CW">
+      <node concept="3clFbS" id="4ZbdskT1yfb" role="2VODD2" />
+    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -8121,7 +8121,7 @@
               <ref role="3cqZAo" node="Qsaevo33zM" resolve="expr" />
             </node>
             <node concept="37vLTw" id="5ElQ4ZyUIl" role="37wK5m">
-              <ref role="3cqZAo" node="Qsaevo35yg" resolve="ctx" />
+              <ref role="3cqZAo" node="Qsaevo35yg" resolve="context" />
             </node>
             <node concept="2ShNRf" id="5ElQ4Zz096" role="37wK5m">
               <node concept="1pGfFk" id="5ElQ4Zz3WU" role="2ShVmc">
@@ -8157,7 +8157,7 @@
               <ref role="3cqZAo" node="5ElQ4Z$IM_" resolve="expr" />
             </node>
             <node concept="37vLTw" id="5ElQ4Z$JZk" role="37wK5m">
-              <ref role="3cqZAo" node="5ElQ4Z$J$R" resolve="ctx" />
+              <ref role="3cqZAo" node="5ElQ4Z$J$R" resolve="context" />
             </node>
             <node concept="2ShNRf" id="5ElQ4Z$LEv" role="37wK5m">
               <node concept="HV5vD" id="5ElQ4Z$Mqs" role="2ShVmc">
@@ -8519,7 +8519,7 @@
               <ref role="3cqZAo" node="7p_bE3JctZw" resolve="expr" />
             </node>
             <node concept="37vLTw" id="5ElQ4Z$7xl" role="37wK5m">
-              <ref role="3cqZAo" node="7p_bE3Jcw0b" resolve="stuffForEnv" />
+              <ref role="3cqZAo" node="7p_bE3Jcw0b" resolve="environmentContent" />
             </node>
             <node concept="2ShNRf" id="5zuMBsCJxu8" role="37wK5m">
               <node concept="1pGfFk" id="5zuMBsCJxrk" role="2ShVmc">
@@ -8561,7 +8561,7 @@
               <ref role="3cqZAo" node="5ElQ4Z_71W" resolve="expr" />
             </node>
             <node concept="37vLTw" id="5ElQ4Z_71S" role="37wK5m">
-              <ref role="3cqZAo" node="5ElQ4Z_71Y" resolve="stuffForEnv" />
+              <ref role="3cqZAo" node="5ElQ4Z_71Y" resolve="environmentContent" />
             </node>
             <node concept="2ShNRf" id="5ElQ4Z_cKW" role="37wK5m">
               <node concept="HV5vD" id="5ElQ4Z_dIx" role="2ShVmc">
@@ -8714,7 +8714,7 @@
                   <node concept="liA8E" id="2nydsCfAQMF" role="2OqNvi">
                     <ref role="37wK5l" node="2nydsCf$H0v" resolve="withEnvironmentContent" />
                     <node concept="37vLTw" id="2nydsCfAS1p" role="37wK5m">
-                      <ref role="3cqZAo" node="5ElQ4ZzZbv" resolve="stuffForEnv" />
+                      <ref role="3cqZAo" node="5ElQ4ZzZbv" resolve="environmentContent" />
                     </node>
                   </node>
                 </node>
@@ -8915,7 +8915,7 @@
       </node>
     </node>
     <node concept="2AHcQZ" id="2nydsCfyZ7D" role="2AJF6D">
-      <ref role="2AI5Lk" to="wyt6:~Deprecated" />
+      <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
     </node>
   </node>
   <node concept="312cEu" id="6iqfHNBVsSc">
@@ -26632,12 +26632,12 @@
         <node concept="3clFbF" id="2nydsCf$H0x" role="3cqZAp">
           <node concept="37vLTI" id="2nydsCf$H0y" role="3clFbG">
             <node concept="37vLTw" id="2nydsCf$H0z" role="37vLTx">
-              <ref role="3cqZAo" node="2nydsCf$H0F" resolve="interpreter" />
+              <ref role="3cqZAo" node="2nydsCf$H0F" resolve="environmentContent" />
             </node>
             <node concept="2OqwBi" id="2nydsCf$H0$" role="37vLTJ">
               <node concept="Xjq3P" id="2nydsCf$H0_" role="2Oq$k0" />
               <node concept="2OwXpG" id="2nydsCf$H0A" role="2OqNvi">
-                <ref role="2Oxat5" node="2nydsCf$Ggh" resolve="environment" />
+                <ref role="2Oxat5" node="2nydsCf$Ggh" resolve="environmentContent" />
               </node>
             </node>
           </node>
@@ -26807,7 +26807,7 @@
                     <ref role="3cqZAo" node="2nydsCfz7pp" resolve="expr" />
                   </node>
                   <node concept="37vLTw" id="2nydsCf_aku" role="37wK5m">
-                    <ref role="3cqZAo" node="2nydsCf$Ggh" resolve="environment" />
+                    <ref role="3cqZAo" node="2nydsCf$Ggh" resolve="environmentContent" />
                   </node>
                 </node>
               </node>
@@ -26816,7 +26816,7 @@
           <node concept="3y3z36" id="2nydsCf_6QE" role="3clFbw">
             <node concept="10Nm6u" id="2nydsCf_7_K" role="3uHU7w" />
             <node concept="37vLTw" id="2nydsCf_631" role="3uHU7B">
-              <ref role="3cqZAo" node="2nydsCf$Ggh" resolve="environment" />
+              <ref role="3cqZAo" node="2nydsCf$Ggh" resolve="environmentContent" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/constraints.mps
@@ -9,7 +9,6 @@
   <imports>
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
-    <import index="oq0c" ref="r:6c6155f0-4bbe-4af5-8c26-244d570e21e4(org.iets3.core.expr.base.plugin)" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
     <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
     <import index="4kwy" ref="r:657c9fde-2f36-4e61-ae17-20f02b8630ad(org.iets3.core.base.structure)" />
@@ -1094,6 +1093,58 @@
               </node>
             </node>
             <node concept="3x8VRR" id="7RXj7bkw0Sy" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="672JozYJSwX">
+    <property role="3GE5qa" value="nix" />
+    <ref role="1M2myG" to="hm2y:3nVyItrZk9z" resolve="HasValueOp" />
+    <node concept="9S07l" id="672JozYJSwY" role="9Vyp8">
+      <node concept="3clFbS" id="672JozYJSwZ" role="2VODD2">
+        <node concept="3cpWs8" id="672JozYJS$X" role="3cqZAp">
+          <node concept="3cpWsn" id="6XBPhggEzuo" role="3cpWs9">
+            <property role="TrG5h" value="tt" />
+            <node concept="3Tqbb2" id="6XBPhggEzup" role="1tU5fm" />
+            <node concept="2OqwBi" id="6XBPhggEzuq" role="33vP2m">
+              <node concept="2OqwBi" id="6XBPhggEzur" role="2Oq$k0">
+                <node concept="1PxgMI" id="6XBPhggEzus" role="2Oq$k0">
+                  <node concept="nLn13" id="6XBPhggEzut" role="1m5AlR" />
+                  <node concept="chp4Y" id="6XBPhggEzx8" role="3oSUPX">
+                    <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+                  </node>
+                </node>
+                <node concept="3TrEf2" id="6XBPhggEzuu" role="2OqNvi">
+                  <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                </node>
+              </node>
+              <node concept="3JvlWi" id="6XBPhggEzuv" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="672JozYGA3d" role="3cqZAp">
+          <node concept="3clFbS" id="672JozYGA3e" role="3clFbx">
+            <node concept="3cpWs6" id="672JozYGA3f" role="3cqZAp">
+              <node concept="3clFbT" id="672JozYGA3g" role="3cqZAk">
+                <property role="3clFbU" value="false" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="672JozYGA3h" role="3clFbw">
+            <node concept="37vLTw" id="672JozYGA3i" role="2Oq$k0">
+              <ref role="3cqZAo" node="6XBPhggEzuo" resolve="tt" />
+            </node>
+            <node concept="1mIQ4w" id="672JozYGA3j" role="2OqNvi">
+              <node concept="chp4Y" id="672JozYJT52" role="cj9EA">
+                <ref role="cht4Q" to="hm2y:4ZbdskT0qlt" resolve="ITupleType" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="672JozYJTfx" role="3cqZAp">
+          <node concept="3clFbT" id="672JozYJTg2" role="3cqZAk">
+            <property role="3clFbU" value="true" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/constraints.mps
@@ -3,6 +3,7 @@
   <persistence version="9" />
   <languages>
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="6" />
     <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
   </languages>
   <imports>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/structure.mps
@@ -1114,6 +1114,9 @@
       <property role="IQ2ns" value="1019070541450015931" />
       <ref role="20lvS9" node="6sdnDbSlaok" resolve="Type" />
     </node>
+    <node concept="PrWs8" id="4ZbdskT0ql$" role="PzmwI">
+      <ref role="PrY4T" node="4ZbdskT0qlt" resolve="ITupleType" />
+    </node>
   </node>
   <node concept="1TIwiD" id="S$tO8ocnpq">
     <property role="TrG5h" value="TupleValue" />
@@ -1122,6 +1125,9 @@
     <property role="EcuMT" value="1019070541450016346" />
     <property role="R4oN_" value="a n-ary tuple value" />
     <ref role="1TJDcQ" node="6sdnDbSla17" resolve="Expression" />
+    <node concept="PrWs8" id="4ZbdskSW3CO" role="PzmwI">
+      <ref role="PrY4T" node="4ZbdskSW2Ng" resolve="ITupleValue" />
+    </node>
     <node concept="PrWs8" id="4qVjx3kr2pf" role="PzmwI">
       <ref role="PrY4T" node="6KxoTHgLv_I" resolve="IMayHaveEffect" />
     </node>
@@ -2188,6 +2194,16 @@
   <node concept="PlHQZ" id="6xvNSEj6BMb">
     <property role="EcuMT" value="7520958096812440715" />
     <property role="TrG5h" value="IComplexTypeSupportsEquals" />
+  </node>
+  <node concept="PlHQZ" id="4ZbdskSW2Ng">
+    <property role="EcuMT" value="5749748470448663760" />
+    <property role="3GE5qa" value="tuples" />
+    <property role="TrG5h" value="ITupleValue" />
+  </node>
+  <node concept="PlHQZ" id="4ZbdskT0qlt">
+    <property role="EcuMT" value="5749748470449808733" />
+    <property role="3GE5qa" value="tuples" />
+    <property role="TrG5h" value="ITupleType" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/constraints.mps
@@ -1028,6 +1028,25 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbJ" id="672JozYGA3d" role="3cqZAp">
+          <node concept="3clFbS" id="672JozYGA3e" role="3clFbx">
+            <node concept="3cpWs6" id="672JozYGA3f" role="3cqZAp">
+              <node concept="3clFbT" id="672JozYGA3g" role="3cqZAk">
+                <property role="3clFbU" value="false" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="672JozYGA3h" role="3clFbw">
+            <node concept="37vLTw" id="672JozYGA3i" role="2Oq$k0">
+              <ref role="3cqZAo" node="6XBPhggEzuo" resolve="tt" />
+            </node>
+            <node concept="1mIQ4w" id="672JozYGA3j" role="2OqNvi">
+              <node concept="chp4Y" id="672JozYJTtr" role="cj9EA">
+                <ref role="cht4Q" to="hm2y:4ZbdskT0qlt" resolve="ITupleType" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbJ" id="6XBPhggEzuC" role="3cqZAp">
           <node concept="3clFbS" id="6XBPhggEzuD" role="3clFbx">
             <node concept="3cpWs6" id="6XBPhggEzuE" role="3cqZAp">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/org.iets3.core.expr.collections.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/org.iets3.core.expr.collections.mpl
@@ -22,6 +22,7 @@
     <dependency reexport="false">6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)</dependency>
     <dependency reexport="false">9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)</dependency>
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
+    <dependency reexport="false">71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
@@ -127,7 +128,9 @@
     <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="5" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="0" />
+    <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="6b277d9a-d52d-416f-a209-1919bd737f50(org.iets3.core.expr.simpleTypes)" version="1" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="2" />
   </dependencyVersions>
   <extendedLanguages>
     <extendedLanguage>9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)</extendedLanguage>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
@@ -32,6 +32,7 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="j10v" ref="b76a0f63-5959-456b-993a-c796cc0d0c13/java:org.pcollections(org.iets3.core.expr.base.collections.stubs/)" />
     <import index="ppzb" ref="r:5db517a0-f62d-4841-a421-11bb7269799d(org.iets3.core.expr.base.shared.runtime)" />
+    <import index="nu60" ref="r:cfd59c48-ecc8-4b0c-8ae8-6d876c46ebbb(org.iets3.core.expr.toplevel.behavior)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
     <import index="4kwy" ref="r:657c9fde-2f36-4e61-ae17-20f02b8630ad(org.iets3.core.base.structure)" implicit="true" />
     <import index="5s8v" ref="r:06389a24-a77a-450d-bc88-bccec0aae7d8(org.iets3.core.expr.lambda.behavior)" implicit="true" />
@@ -370,6 +371,9 @@
       <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1204834851141" name="jetbrains.mps.lang.smodel.structure.PoundExpression" flags="ng" index="25Kdxt">
+        <child id="1204834868751" name="expression" index="25KhWn" />
+      </concept>
       <concept id="1179168000618" name="jetbrains.mps.lang.smodel.structure.Node_GetIndexInParentOperation" flags="nn" index="2bSWHS" />
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
@@ -9954,7 +9958,7 @@
               </node>
               <node concept="1mIQ4w" id="1mDdTGWJjm" role="2OqNvi">
                 <node concept="chp4Y" id="1mDdTGWJAd" role="cj9EA">
-                  <ref role="cht4Q" to="hm2y:S$tO8ocniU" resolve="TupleType" />
+                  <ref role="cht4Q" to="hm2y:4ZbdskT0qlt" resolve="ITupleType" />
                 </node>
               </node>
             </node>
@@ -10006,7 +10010,7 @@
                                       <node concept="2OqwBi" id="3mvkonGaCT3" role="2Oq$k0">
                                         <node concept="1PxgMI" id="3mvkonGa_ov" role="2Oq$k0">
                                           <node concept="chp4Y" id="3mvkonGaB4h" role="3oSUPX">
-                                            <ref role="cht4Q" to="hm2y:S$tO8ocniU" resolve="TupleType" />
+                                            <ref role="cht4Q" to="hm2y:4ZbdskT0qlt" resolve="ITupleType" />
                                           </node>
                                           <node concept="2OqwBi" id="3mvkonG87Tz" role="1m5AlR">
                                             <node concept="1PxgMI" id="3mvkonG87T$" role="2Oq$k0">
@@ -10020,8 +10024,8 @@
                                             </node>
                                           </node>
                                         </node>
-                                        <node concept="3Tsc0h" id="3mvkonGaF5d" role="2OqNvi">
-                                          <ref role="3TtcxE" to="hm2y:S$tO8ocniV" resolve="elementTypes" />
+                                        <node concept="2qgKlT" id="4ZbdskT30jw" role="2OqNvi">
+                                          <ref role="37wK5l" to="pbu6:4ZbdskT1yfk" resolve="getElementTypes" />
                                         </node>
                                       </node>
                                       <node concept="liA8E" id="3mvkonGaSqF" role="2OqNvi">
@@ -10045,7 +10049,7 @@
                                       <node concept="2OqwBi" id="3mvkonGb8Rh" role="2Oq$k0">
                                         <node concept="1PxgMI" id="3mvkonGb8Ri" role="2Oq$k0">
                                           <node concept="chp4Y" id="3mvkonGb8Rj" role="3oSUPX">
-                                            <ref role="cht4Q" to="hm2y:S$tO8ocniU" resolve="TupleType" />
+                                            <ref role="cht4Q" to="hm2y:4ZbdskT0qlt" resolve="ITupleType" />
                                           </node>
                                           <node concept="2OqwBi" id="3mvkonGb8Rk" role="1m5AlR">
                                             <node concept="1PxgMI" id="3mvkonGb8Rl" role="2Oq$k0">
@@ -10059,8 +10063,8 @@
                                             </node>
                                           </node>
                                         </node>
-                                        <node concept="3Tsc0h" id="3mvkonGb8Rp" role="2OqNvi">
-                                          <ref role="3TtcxE" to="hm2y:S$tO8ocniV" resolve="elementTypes" />
+                                        <node concept="2qgKlT" id="4ZbdskT3dUS" role="2OqNvi">
+                                          <ref role="37wK5l" to="pbu6:4ZbdskT1yfk" resolve="getElementTypes" />
                                         </node>
                                       </node>
                                       <node concept="liA8E" id="3mvkonGb8Rq" role="2OqNvi">
@@ -10123,7 +10127,7 @@
                                                 <node concept="2OqwBi" id="3mvkonGbUho" role="2Oq$k0">
                                                   <node concept="1PxgMI" id="3mvkonGbUhp" role="2Oq$k0">
                                                     <node concept="chp4Y" id="3mvkonGbUhq" role="3oSUPX">
-                                                      <ref role="cht4Q" to="hm2y:S$tO8ocniU" resolve="TupleType" />
+                                                      <ref role="cht4Q" to="hm2y:4ZbdskT0qlt" resolve="ITupleType" />
                                                     </node>
                                                     <node concept="2OqwBi" id="3mvkonGbUhr" role="1m5AlR">
                                                       <node concept="1PxgMI" id="3mvkonGbUhs" role="2Oq$k0">
@@ -10137,8 +10141,8 @@
                                                       </node>
                                                     </node>
                                                   </node>
-                                                  <node concept="3Tsc0h" id="3mvkonGbUhw" role="2OqNvi">
-                                                    <ref role="3TtcxE" to="hm2y:S$tO8ocniV" resolve="elementTypes" />
+                                                  <node concept="2qgKlT" id="4ZbdskT29bo" role="2OqNvi">
+                                                    <ref role="37wK5l" to="pbu6:4ZbdskT1yfk" resolve="getElementTypes" />
                                                   </node>
                                                 </node>
                                                 <node concept="liA8E" id="3mvkonGbUhx" role="2OqNvi">
@@ -10177,7 +10181,7 @@
                                                 <node concept="2OqwBi" id="3mvkonGce8Y" role="2Oq$k0">
                                                   <node concept="1PxgMI" id="3mvkonGce8Z" role="2Oq$k0">
                                                     <node concept="chp4Y" id="3mvkonGce90" role="3oSUPX">
-                                                      <ref role="cht4Q" to="hm2y:S$tO8ocniU" resolve="TupleType" />
+                                                      <ref role="cht4Q" to="hm2y:4ZbdskT0qlt" resolve="ITupleType" />
                                                     </node>
                                                     <node concept="2OqwBi" id="3mvkonGce91" role="1m5AlR">
                                                       <node concept="1PxgMI" id="3mvkonGce92" role="2Oq$k0">
@@ -10191,8 +10195,8 @@
                                                       </node>
                                                     </node>
                                                   </node>
-                                                  <node concept="3Tsc0h" id="3mvkonGce96" role="2OqNvi">
-                                                    <ref role="3TtcxE" to="hm2y:S$tO8ocniV" resolve="elementTypes" />
+                                                  <node concept="2qgKlT" id="4ZbdskT2MGp" role="2OqNvi">
+                                                    <ref role="37wK5l" to="pbu6:4ZbdskT1yfk" resolve="getElementTypes" />
                                                   </node>
                                                 </node>
                                                 <node concept="liA8E" id="3mvkonGce97" role="2OqNvi">
@@ -12903,6 +12907,39 @@
         </node>
       </node>
     </node>
+    <node concept="3aamgX" id="4ZbdskRGtLD" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="yv47:4ZbdskRDGLl" resolve="NamedTupleValue" />
+      <node concept="30G5F_" id="4ZbdskRGtLE" role="30HLyM">
+        <node concept="3clFbS" id="4ZbdskRGtLF" role="2VODD2">
+          <node concept="3clFbF" id="4ZbdskRGtLG" role="3cqZAp">
+            <node concept="2OqwBi" id="4ZbdskRGtLH" role="3clFbG">
+              <node concept="2OqwBi" id="4ZbdskRGtLI" role="2Oq$k0">
+                <node concept="30H73N" id="4ZbdskRGtLJ" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="4ZbdskRGtLK" role="2OqNvi">
+                  <ref role="3TtcxE" to="yv47:4ZbdskRDGMh" resolve="values" />
+                </node>
+              </node>
+              <node concept="1v1jN8" id="4ZbdskRGtLL" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="gft3U" id="4ZbdskRGtLM" role="1lVwrX">
+        <node concept="2YIFZM" id="4ZbdskRGtLN" role="gfFT$">
+          <ref role="1Pybhc" to="j10v:~TreePVector" resolve="TreePVector" />
+          <ref role="37wK5l" to="j10v:~TreePVector.from(java.util.Collection)" resolve="from" />
+          <node concept="2ShNRf" id="4ZbdskRGtLO" role="37wK5m">
+            <node concept="1pGfFk" id="4ZbdskRGtLP" role="2ShVmc">
+              <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;()" resolve="ArrayList" />
+              <node concept="3uibUv" id="4ZbdskRGtLQ" role="1pMfVU">
+                <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="3aamgX" id="2ICvjplP2UJ" role="3aUrZf">
       <property role="36QftV" value="true" />
       <ref role="30HIoZ" to="hm2y:S$tO8ocnpq" resolve="TupleValue" />
@@ -12952,6 +12989,60 @@
             </node>
           </node>
           <node concept="3uibUv" id="3vaYGVXUy4c" role="3PaCim">
+            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="4ZbdskRJZAD" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="yv47:4ZbdskRDGLl" resolve="NamedTupleValue" />
+      <node concept="30G5F_" id="4ZbdskRJZAE" role="30HLyM">
+        <node concept="3clFbS" id="4ZbdskRJZAF" role="2VODD2">
+          <node concept="3clFbF" id="4ZbdskRJZAG" role="3cqZAp">
+            <node concept="3fqX7Q" id="4ZbdskRJZAH" role="3clFbG">
+              <node concept="2OqwBi" id="4ZbdskRJZAI" role="3fr31v">
+                <node concept="2OqwBi" id="4ZbdskRJZAJ" role="2Oq$k0">
+                  <node concept="30H73N" id="4ZbdskRJZAK" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="4ZbdskRJZAL" role="2OqNvi">
+                    <ref role="3TtcxE" to="yv47:4ZbdskRDGMh" resolve="values" />
+                  </node>
+                </node>
+                <node concept="1v1jN8" id="4ZbdskRJZAM" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="gft3U" id="4ZbdskRJZAN" role="1lVwrX">
+        <node concept="2YIFZM" id="4ZbdskRJZAO" role="gfFT$">
+          <ref role="1Pybhc" to="j10v:~TreePVector" resolve="TreePVector" />
+          <ref role="37wK5l" to="j10v:~TreePVector.from(java.util.Collection)" resolve="from" />
+          <node concept="2YIFZM" id="4ZbdskRJZAP" role="37wK5m">
+            <ref role="1Pybhc" to="33ny:~Arrays" resolve="Arrays" />
+            <ref role="37wK5l" to="33ny:~Arrays.asList(java.lang.Object...)" resolve="asList" />
+            <node concept="Xl_RD" id="4ZbdskRJZAQ" role="37wK5m">
+              <property role="Xl_RC" value="s" />
+              <node concept="2b32R4" id="4ZbdskRJZAR" role="lGtFl">
+                <node concept="3JmXsc" id="4ZbdskRJZAS" role="2P8S$">
+                  <node concept="3clFbS" id="4ZbdskRJZAT" role="2VODD2">
+                    <node concept="3clFbF" id="4ZbdskRNKC2" role="3cqZAp">
+                      <node concept="2OqwBi" id="4ZbdskRNKQz" role="3clFbG">
+                        <node concept="30H73N" id="4ZbdskRNKC1" role="2Oq$k0" />
+                        <node concept="2qgKlT" id="4ZbdskRNLjU" role="2OqNvi">
+                          <ref role="37wK5l" to="nu60:4ZbdskRO1Cc" resolve="getIndexSortedValues" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3uibUv" id="4ZbdskRJZAY" role="3PaCim">
+              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+            </node>
+          </node>
+          <node concept="3uibUv" id="4ZbdskRJZAZ" role="3PaCim">
             <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
           </node>
         </node>
@@ -16436,6 +16527,34 @@
         </node>
       </node>
     </node>
+    <node concept="3aamgX" id="4ZbdskSSZPN" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="yv47:4ZbdskRgu$y" resolve="NamedTupleType" />
+      <node concept="1Koe21" id="4ZbdskSSZPO" role="1lVwrX">
+        <node concept="3clFb_" id="4ZbdskSSZPP" role="1Koe22">
+          <property role="DiZV1" value="false" />
+          <property role="od$2w" value="false" />
+          <property role="2aFKle" value="false" />
+          <property role="TrG5h" value="foo" />
+          <node concept="3Tm1VV" id="4ZbdskSSZPQ" role="1B3o_S" />
+          <node concept="3cqZAl" id="4ZbdskSSZPR" role="3clF45" />
+          <node concept="3clFbS" id="4ZbdskSSZPS" role="3clF47">
+            <node concept="3cpWs8" id="4ZbdskSSZPT" role="3cqZAp">
+              <node concept="3cpWsn" id="4ZbdskSSZPU" role="3cpWs9">
+                <property role="TrG5h" value="l" />
+                <node concept="3uibUv" id="4ZbdskSSZPV" role="1tU5fm">
+                  <ref role="3uigEE" to="j10v:~PVector" resolve="PVector" />
+                  <node concept="3uibUv" id="4ZbdskSSZPW" role="11_B2D">
+                    <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                  </node>
+                  <node concept="raruj" id="4ZbdskSSZPX" role="lGtFl" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="3aamgX" id="2ICvjpm0spc" role="3aUrZf">
       <ref role="30HIoZ" to="hm2y:5BNZGjBtUbJ" resolve="AttemptType" />
       <node concept="1Koe21" id="5gxCh1pibTF" role="1lVwrX">
@@ -18681,8 +18800,24 @@
                   <node concept="3JvlWi" id="4ORV4ylbmuR" role="2OqNvi" />
                 </node>
                 <node concept="1mIQ4w" id="4ORV4ylbogM" role="2OqNvi">
-                  <node concept="chp4Y" id="4ORV4ylboyC" role="cj9EA">
-                    <ref role="cht4Q" to="hm2y:S$tO8ocniU" resolve="TupleType" />
+                  <node concept="25Kdxt" id="4ZbdskSZRw$" role="cj9EA">
+                    <node concept="2OqwBi" id="4ZbdskSZUuP" role="25KhWn">
+                      <node concept="1PxgMI" id="4ZbdskSZTSD" role="2Oq$k0">
+                        <property role="1BlNFB" value="true" />
+                        <node concept="chp4Y" id="4ZbdskSZU8v" role="3oSUPX">
+                          <ref role="cht4Q" to="hm2y:4ZbdskSW2Ng" resolve="ITupleValue" />
+                        </node>
+                        <node concept="2OqwBi" id="4ZbdskSZS7g" role="1m5AlR">
+                          <node concept="30H73N" id="4ZbdskSZRGC" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="4ZbdskSZSK3" role="2OqNvi">
+                            <ref role="3Tt5mk" to="hm2y:4rZeNQ6MpKm" resolve="left" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2qgKlT" id="4ZbdskSZURM" role="2OqNvi">
+                        <ref role="37wK5l" to="pbu6:4ZbdskSXUP5" resolve="getConceptOfType" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -18695,7 +18830,7 @@
                 </node>
                 <node concept="1mIQ4w" id="4ORV4ylb2Bh" role="2OqNvi">
                   <node concept="chp4Y" id="4ORV4ylb2O3" role="cj9EA">
-                    <ref role="cht4Q" to="hm2y:S$tO8ocnpq" resolve="TupleValue" />
+                    <ref role="cht4Q" to="hm2y:4ZbdskSW2Ng" resolve="ITupleValue" />
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
@@ -12917,7 +12917,7 @@
               <node concept="2OqwBi" id="4ZbdskRGtLI" role="2Oq$k0">
                 <node concept="30H73N" id="4ZbdskRGtLJ" role="2Oq$k0" />
                 <node concept="3Tsc0h" id="4ZbdskRGtLK" role="2OqNvi">
-                  <ref role="3TtcxE" to="yv47:4ZbdskRDGMh" resolve="values" />
+                  <ref role="3TtcxE" to="yv47:4ZbdskRDGMh" resolve="setters" />
                 </node>
               </node>
               <node concept="1v1jN8" id="4ZbdskRGtLL" role="2OqNvi" />
@@ -13005,7 +13005,7 @@
                 <node concept="2OqwBi" id="4ZbdskRJZAJ" role="2Oq$k0">
                   <node concept="30H73N" id="4ZbdskRJZAK" role="2Oq$k0" />
                   <node concept="3Tsc0h" id="4ZbdskRJZAL" role="2OqNvi">
-                    <ref role="3TtcxE" to="yv47:4ZbdskRDGMh" resolve="values" />
+                    <ref role="3TtcxE" to="yv47:4ZbdskRDGMh" resolve="setters" />
                   </node>
                 </node>
                 <node concept="1v1jN8" id="4ZbdskRJZAM" role="2OqNvi" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/generator/template/org.iets3.core.expr.genjava.toplevel@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/generator/template/org.iets3.core.expr.genjava.toplevel@generator.mps
@@ -2186,7 +2186,7 @@
                                     <ref role="37wK5l" to="nu60:4ZbdskSg3_i" resolve="getTupleDeclaration" />
                                   </node>
                                   <node concept="37vLTw" id="4ZbdskTgxSb" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="4ZbdskTgxS5" resolve="node" />
+                                    <ref role="3cqZAo" node="4ZbdskTgxS5" resolve="accessExpr" />
                                   </node>
                                 </node>
                                 <node concept="2qgKlT" id="4ZbdskRhv6C" role="2OqNvi">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/generator/template/org.iets3.core.expr.genjava.toplevel@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/generator/template/org.iets3.core.expr.genjava.toplevel@generator.mps
@@ -2114,22 +2114,6 @@
                 </node>
               </node>
             </node>
-            <node concept="3cpWs8" id="4ZbdskRj_TW" role="3cqZAp">
-              <node concept="3cpWsn" id="4ZbdskRj_TX" role="3cpWs9">
-                <property role="TrG5h" value="i" />
-                <node concept="3uibUv" id="4ZbdskRj_TY" role="1tU5fm">
-                  <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
-                </node>
-                <node concept="2ShNRf" id="4ZbdskRj_TZ" role="33vP2m">
-                  <node concept="1pGfFk" id="4ZbdskRj_U0" role="2ShVmc">
-                    <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
-                    <node concept="Xl_RD" id="4ZbdskRj_U1" role="37wK5m">
-                      <property role="Xl_RC" value="0" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="3cpWs6" id="4ZbdskRj_U2" role="3cqZAp">
               <node concept="2OqwBi" id="4ZbdskRj_U3" role="3cqZAk">
                 <node concept="37vLTw" id="4ZbdskRj_U4" role="2Oq$k0">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/generator/template/org.iets3.core.expr.genjava.toplevel@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.toplevel/generator/template/org.iets3.core.expr.genjava.toplevel@generator.mps
@@ -444,7 +444,9 @@
       <concept id="1140131837776" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithAnotherOperation" flags="nn" index="1P9Npp">
         <child id="1140131861877" name="replacementNode" index="1P9ThW" />
       </concept>
-      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -512,6 +514,7 @@
       </concept>
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
@@ -1224,6 +1227,10 @@
       <node concept="gft3U" id="lH$PuiWhx5" role="1lVwrX">
         <node concept="2kixu8" id="lH$PuiWhx6" role="gfFT$" />
       </node>
+    </node>
+    <node concept="3aamgX" id="4ZbdskR3Ly_" role="3acgRq">
+      <ref role="30HIoZ" to="yv47:4ZbdskR3pBE" resolve="NamedTupleDeclaration" />
+      <node concept="b5Tf3" id="4ZbdskR3OE1" role="1lVwrX" />
     </node>
     <node concept="2rT7sh" id="2qRo6DhZXuC" role="2rTMjI">
       <property role="TrG5h" value="Funktion" />
@@ -2057,6 +2064,153 @@
                 <node concept="chp4Y" id="5ymSrLXVReh" role="cj9EA">
                   <ref role="cht4Q" to="yv47:7cphKbLtLQW" resolve="InlineRecordMemberAccess" />
                 </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="4ZbdskTe3uG" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+      <node concept="30G5F_" id="4ZbdskTfafv" role="30HLyM">
+        <node concept="3clFbS" id="4ZbdskTfafw" role="2VODD2">
+          <node concept="3clFbF" id="4ZbdskTfajv" role="3cqZAp">
+            <node concept="2OqwBi" id="4ZbdskTfeLj" role="3clFbG">
+              <node concept="2OqwBi" id="4ZbdskTfaD7" role="2Oq$k0">
+                <node concept="30H73N" id="4ZbdskTfaju" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4ZbdskTfb6I" role="2OqNvi">
+                  <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                </node>
+              </node>
+              <node concept="1mIQ4w" id="4ZbdskTfibv" role="2OqNvi">
+                <node concept="chp4Y" id="4ZbdskTfipx" role="cj9EA">
+                  <ref role="cht4Q" to="yv47:4ZbdskRgKyK" resolve="TupleNamedAccessExpr" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1Koe21" id="4ZbdskRj_TM" role="1lVwrX">
+        <node concept="3clFb_" id="4ZbdskRj_TN" role="1Koe22">
+          <property role="DiZV1" value="false" />
+          <property role="od$2w" value="false" />
+          <property role="2aFKle" value="false" />
+          <property role="TrG5h" value="foo" />
+          <node concept="3Tm1VV" id="4ZbdskRj_TO" role="1B3o_S" />
+          <node concept="17QB3L" id="4ZbdskRj_TP" role="3clF45" />
+          <node concept="3clFbS" id="4ZbdskRj_TQ" role="3clF47">
+            <node concept="3cpWs8" id="4ZbdskRj_TR" role="3cqZAp">
+              <node concept="3cpWsn" id="4ZbdskRj_TS" role="3cpWs9">
+                <property role="TrG5h" value="tpv" />
+                <node concept="3uibUv" id="4ZbdskRj_TT" role="1tU5fm">
+                  <ref role="3uigEE" to="j10v:~TreePVector" resolve="TreePVector" />
+                  <node concept="17QB3L" id="4ZbdskRj_TU" role="11_B2D" />
+                </node>
+                <node concept="2YIFZM" id="4ZbdskRj_TV" role="33vP2m">
+                  <ref role="1Pybhc" to="j10v:~TreePVector" resolve="TreePVector" />
+                  <ref role="37wK5l" to="j10v:~TreePVector.empty()" resolve="empty" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="4ZbdskRj_TW" role="3cqZAp">
+              <node concept="3cpWsn" id="4ZbdskRj_TX" role="3cpWs9">
+                <property role="TrG5h" value="i" />
+                <node concept="3uibUv" id="4ZbdskRj_TY" role="1tU5fm">
+                  <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                </node>
+                <node concept="2ShNRf" id="4ZbdskRj_TZ" role="33vP2m">
+                  <node concept="1pGfFk" id="4ZbdskRj_U0" role="2ShVmc">
+                    <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
+                    <node concept="Xl_RD" id="4ZbdskRj_U1" role="37wK5m">
+                      <property role="Xl_RC" value="0" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="4ZbdskRj_U2" role="3cqZAp">
+              <node concept="2OqwBi" id="4ZbdskRj_U3" role="3cqZAk">
+                <node concept="37vLTw" id="4ZbdskRj_U4" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4ZbdskRj_TS" resolve="tpv" />
+                  <node concept="29HgVG" id="4ZbdskRj_U5" role="lGtFl">
+                    <node concept="3NFfHV" id="4ZbdskRj_U6" role="3NFExx">
+                      <node concept="3clFbS" id="4ZbdskRj_U7" role="2VODD2">
+                        <node concept="3clFbF" id="4ZbdskRj_U8" role="3cqZAp">
+                          <node concept="2OqwBi" id="4ZbdskRj_U9" role="3clFbG">
+                            <node concept="30H73N" id="4ZbdskRj_Ub" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="4ZbdskTfoqj" role="2OqNvi">
+                              <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="4ZbdskRj_Uc" role="2OqNvi">
+                  <ref role="37wK5l" to="j10v:~TreePVector.get(int)" resolve="get" />
+                  <node concept="3cmrfG" id="4ZbdskRj_Ud" role="37wK5m">
+                    <property role="3cmrfH" value="1" />
+                    <node concept="17Uvod" id="4ZbdskRj_Ue" role="lGtFl">
+                      <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580320020/1068580320021" />
+                      <property role="2qtEX9" value="value" />
+                      <node concept="3zFVjK" id="4ZbdskRj_Uf" role="3zH0cK">
+                        <node concept="3clFbS" id="4ZbdskRj_Ug" role="2VODD2">
+                          <node concept="3cpWs8" id="4ZbdskTgxS4" role="3cqZAp">
+                            <node concept="3cpWsn" id="4ZbdskTgxS5" role="3cpWs9">
+                              <property role="TrG5h" value="accessExpr" />
+                              <node concept="3Tqbb2" id="4ZbdskTgj7u" role="1tU5fm">
+                                <ref role="ehGHo" to="yv47:4ZbdskRgKyK" resolve="TupleNamedAccessExpr" />
+                              </node>
+                              <node concept="1PxgMI" id="4ZbdskTgxS6" role="33vP2m">
+                                <property role="1BlNFB" value="true" />
+                                <node concept="chp4Y" id="4ZbdskTgxS7" role="3oSUPX">
+                                  <ref role="cht4Q" to="yv47:4ZbdskRgKyK" resolve="TupleNamedAccessExpr" />
+                                </node>
+                                <node concept="2OqwBi" id="4ZbdskTgxS8" role="1m5AlR">
+                                  <node concept="30H73N" id="4ZbdskTgxS9" role="2Oq$k0" />
+                                  <node concept="3TrEf2" id="4ZbdskTgxSa" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="4ZbdskRj_Uh" role="3cqZAp">
+                            <node concept="2OqwBi" id="4ZbdskRhwQs" role="3clFbG">
+                              <node concept="2OqwBi" id="4ZbdskRhu5p" role="2Oq$k0">
+                                <node concept="2OqwBi" id="4ZbdskRhisL" role="2Oq$k0">
+                                  <node concept="2qgKlT" id="4ZbdskStZii" role="2OqNvi">
+                                    <ref role="37wK5l" to="nu60:4ZbdskSg3_i" resolve="getTupleDeclaration" />
+                                  </node>
+                                  <node concept="37vLTw" id="4ZbdskTgxSb" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="4ZbdskTgxS5" resolve="node" />
+                                  </node>
+                                </node>
+                                <node concept="2qgKlT" id="4ZbdskRhv6C" role="2OqNvi">
+                                  <ref role="37wK5l" to="nu60:4ZbdskRgmME" resolve="nonEmptyMembers" />
+                                </node>
+                              </node>
+                              <node concept="2WmjW8" id="4ZbdskRhx$r" role="2OqNvi">
+                                <node concept="2OqwBi" id="4ZbdskRhybB" role="25WWJ7">
+                                  <node concept="3TrEf2" id="4ZbdskRhyTO" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="yv47:4ZbdskRgN6H" resolve="member" />
+                                  </node>
+                                  <node concept="37vLTw" id="4ZbdskTgE0J" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="4ZbdskTgxS5" resolve="accessExpr" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="raruj" id="4ZbdskRj_Ul" role="lGtFl" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/typesystem.mps
@@ -1407,7 +1407,7 @@
               <node concept="2OqwBi" id="7HzLUeHnCpS" role="2Oq$k0">
                 <node concept="2OqwBi" id="7HzLUeHnBFf" role="2Oq$k0">
                   <node concept="37vLTw" id="7HzLUeHnBtM" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7HzLUeHnBt3" resolve="ctx" />
+                    <ref role="3cqZAo" node="7HzLUeHnBt3" resolve="context" />
                   </node>
                   <node concept="liA8E" id="7HzLUeHnC65" role="2OqNvi">
                     <ref role="37wK5l" to="2ahs:2X4$XGmeuKp" resolve="getEnvironment" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -9,6 +9,7 @@
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="-1" />
     <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
+    <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -186,6 +187,7 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
       <concept id="6626851894249711936" name="jetbrains.mps.lang.extension.structure.ExtensionPointExpression" flags="nn" index="2O5UvJ">
@@ -283,7 +285,12 @@
       <concept id="3562215692195599741" name="jetbrains.mps.lang.smodel.structure.SLinkImplicitSelect" flags="nn" index="13MTOL">
         <reference id="3562215692195600259" name="link" index="13MTZf" />
       </concept>
-      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
+      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz">
+        <reference id="6677504323281689839" name="conceptDeclaraton" index="3bZ5Sy" />
+      </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
@@ -311,7 +318,9 @@
       <concept id="1140131837776" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithAnotherOperation" flags="nn" index="1P9Npp">
         <child id="1140131861877" name="replacementNode" index="1P9ThW" />
       </concept>
-      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -396,6 +405,7 @@
       <concept id="4611582986551314327" name="jetbrains.mps.baseLanguage.collections.structure.OfTypeOperation" flags="nn" index="UnYns">
         <child id="4611582986551314344" name="requestedType" index="UnYnz" />
       </concept>
+      <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
       <concept id="1205753243362" name="jetbrains.mps.baseLanguage.collections.structure.ChunkOperation" flags="nn" index="2WvAvU">
         <child id="1205753261887" name="length" index="2WvESB" />
       </concept>
@@ -405,6 +415,9 @@
       <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
       <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
+        <child id="1240687658305" name="delimiter" index="3uJOhx" />
+      </concept>
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
         <child id="1225711182005" name="list" index="1y566C" />
@@ -9894,6 +9907,1148 @@
         </node>
       </node>
       <node concept="17QB3L" id="c36CPsAtHA" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4ZbdskR3pXJ">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="13h7C2" to="yv47:4ZbdskR3pBF" resolve="ITupleMember" />
+    <node concept="13hLZK" id="4ZbdskR3pXK" role="13h7CW">
+      <node concept="3clFbS" id="4ZbdskR3pXL" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4ZbdskR3pXU" role="13h7CS">
+      <property role="TrG5h" value="allowUmlaute" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" to="gdgh:5YygIlbih$m" resolve="allowUmlaute" />
+      <node concept="3Tm1VV" id="4ZbdskR3pXV" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskR3pY0" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskR3qgw" role="3cqZAp">
+          <node concept="3clFbT" id="4ZbdskR3qgv" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="4ZbdskR3pY1" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="4ZbdskR3qgO" role="13h7CS">
+      <property role="TrG5h" value="allowParagraph" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" to="gdgh:4ZH31cjGRan" resolve="allowParagraph" />
+      <node concept="3Tm1VV" id="4ZbdskR3qgP" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskR3qgU" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskR3qu2" role="3cqZAp">
+          <node concept="2YIFZM" id="4ZbdskR3qva" role="3clFbG">
+            <ref role="37wK5l" to="xfg9:3NUSEp5yd8T" resolve="allowParagraphsInIdentifiers" />
+            <ref role="1Pybhc" to="xfg9:6fmG8CYTWg1" resolve="IdentifierConfiguratorAccess" />
+            <node concept="1fM9EW" id="4ZbdskR3qw6" role="37wK5m" />
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="4ZbdskR3qgV" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="4ZbdskR3qAb" role="13h7CS">
+      <property role="TrG5h" value="getFqName" />
+      <ref role="13i0hy" to="tpcu:hEwIO9y" resolve="getFqName" />
+      <node concept="3Tm1VV" id="4ZbdskR3qAU" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskR3qAV" role="3clF47">
+        <node concept="Jncv_" id="4ZbdskR3qPM" role="3cqZAp">
+          <ref role="JncvD" to="tpck:h0TrEE$" resolve="INamedConcept" />
+          <node concept="2OqwBi" id="4ZbdskR3r6Q" role="JncvB">
+            <node concept="13iPFW" id="4ZbdskR3qQf" role="2Oq$k0" />
+            <node concept="1mfA1w" id="4ZbdskR3ryq" role="2OqNvi" />
+          </node>
+          <node concept="3clFbS" id="4ZbdskR3qPO" role="Jncv$">
+            <node concept="3cpWs6" id="4ZbdskR3r_9" role="3cqZAp">
+              <node concept="3cpWs3" id="4ZbdskR3sSE" role="3cqZAk">
+                <node concept="2OqwBi" id="4ZbdskR3tcB" role="3uHU7w">
+                  <node concept="13iPFW" id="4ZbdskR3sSU" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="4ZbdskR3tLO" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+                <node concept="3cpWs3" id="4ZbdskR3siT" role="3uHU7B">
+                  <node concept="2OqwBi" id="4ZbdskR3rJM" role="3uHU7B">
+                    <node concept="Jnkvi" id="4ZbdskR3rBD" role="2Oq$k0">
+                      <ref role="1M0zk5" node="4ZbdskR3qPP" resolve="nc" />
+                    </node>
+                    <node concept="2qgKlT" id="4ZbdskR3rVn" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIO9y" resolve="getFqName" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="4ZbdskR3siW" role="3uHU7w">
+                    <property role="Xl_RC" value="." />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="4ZbdskR3qPP" role="JncvA">
+            <property role="TrG5h" value="nc" />
+            <node concept="2jxLKc" id="4ZbdskR3qPQ" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="4ZbdskR3tZe" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskR3vnM" role="3cqZAk">
+            <node concept="13iAh5" id="4ZbdskR3uua" role="2Oq$k0">
+              <ref role="3eA5LN" to="4kwy:cJpacq5T0O" resolve="IValidNamedConcept" />
+            </node>
+            <node concept="2qgKlT" id="4ZbdskR3vN4" role="2OqNvi">
+              <ref role="37wK5l" to="tpcu:hEwIO9y" resolve="getFqName" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4ZbdskR3qAW" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4ZbdskR3Avr">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="13h7C2" to="yv47:4ZbdskR3$vC" resolve="TupleMember" />
+    <node concept="13hLZK" id="4ZbdskR3Avs" role="13h7CW">
+      <node concept="3clFbS" id="4ZbdskR3Avt" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4ZbdskR3AvA" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4ZbdskR3Aw1" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskR3BCh" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskR3BLx" role="3cqZAp">
+          <node concept="3cpWs3" id="4ZbdskR3D8C" role="3clFbG">
+            <node concept="2OqwBi" id="4ZbdskR3EYS" role="3uHU7w">
+              <node concept="2OqwBi" id="4ZbdskR3DBb" role="2Oq$k0">
+                <node concept="13iPFW" id="4ZbdskR3DhM" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4ZbdskR3Ec7" role="2OqNvi">
+                  <ref role="3Tt5mk" to="hm2y:7D7uZV2iYAD" resolve="type" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="4ZbdskR3Fp9" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="4ZbdskR3CU1" role="3uHU7B">
+              <node concept="2OqwBi" id="4ZbdskR3C2e" role="3uHU7B">
+                <node concept="13iPFW" id="4ZbdskR3BLs" role="2Oq$k0" />
+                <node concept="3TrcHB" id="4ZbdskR3CyP" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="4ZbdskR3CU4" role="3uHU7w">
+                <property role="Xl_RC" value=": " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4ZbdskR3BCi" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4ZbdskRgkAQ">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="13h7C2" to="yv47:4ZbdskRggS1" resolve="ITupleDeclaration" />
+    <node concept="13i0hz" id="4ZbdskRgmME" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="nonEmptyMembers" />
+      <node concept="3Tm1VV" id="4ZbdskRgmMF" role="1B3o_S" />
+      <node concept="A3Dl8" id="4ZbdskRgmMG" role="3clF45">
+        <node concept="3Tqbb2" id="4ZbdskRgmMH" role="A3Ik2">
+          <ref role="ehGHo" to="yv47:4ZbdskR3pBF" resolve="ITupleMember" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="4ZbdskRgmMI" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskRgmMJ" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskRgmMK" role="3clFbG">
+            <node concept="2OqwBi" id="4ZbdskRgmML" role="2Oq$k0">
+              <node concept="13iPFW" id="4ZbdskRgmMM" role="2Oq$k0" />
+              <node concept="2qgKlT" id="4ZbdskRgmMN" role="2OqNvi">
+                <ref role="37wK5l" node="4ZbdskRgmOY" />
+              </node>
+            </node>
+            <node concept="3zZkjj" id="4ZbdskRgmMO" role="2OqNvi">
+              <node concept="1bVj0M" id="4ZbdskRgmMP" role="23t8la">
+                <node concept="3clFbS" id="4ZbdskRgmMQ" role="1bW5cS">
+                  <node concept="3clFbF" id="4ZbdskRgmMR" role="3cqZAp">
+                    <node concept="3fqX7Q" id="4ZbdskRgmMS" role="3clFbG">
+                      <node concept="2OqwBi" id="4ZbdskRgmMT" role="3fr31v">
+                        <node concept="37vLTw" id="4ZbdskRgmMU" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4ZbdskRgmMX" resolve="it" />
+                        </node>
+                        <node concept="1mIQ4w" id="4ZbdskRgmMV" role="2OqNvi">
+                          <node concept="chp4Y" id="4ZbdskRgmMW" role="cj9EA">
+                            <ref role="cht4Q" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="4ZbdskRgmMX" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="4ZbdskRgmMY" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4ZbdskRgmN8" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="namedNodesForComment" />
+      <ref role="13i0hy" to="pbu6:5ElkanPUl6T" resolve="namedNodesForComment" />
+      <node concept="3Tm1VV" id="4ZbdskRgmN9" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskRgmNa" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskRgmNb" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskRgmNc" role="3clFbG">
+            <node concept="13iPFW" id="4ZbdskRgmNd" role="2Oq$k0" />
+            <node concept="3Tsc0h" id="4ZbdskRgmNe" role="2OqNvi">
+              <ref role="3TtcxE" to="yv47:4ZbdskRgjgF" resolve="members" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="4ZbdskRgmNf" role="3clF45">
+        <node concept="3Tqbb2" id="4ZbdskRgmNg" role="A3Ik2">
+          <ref role="ehGHo" to="4kwy:cJpacq5T0O" resolve="IValidNamedConcept" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4ZbdskRgmNh" role="13h7CS">
+      <property role="TrG5h" value="visibleContentsOfType" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
+      <node concept="3Tm1VV" id="4ZbdskRgmNi" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskRgmNj" role="3clF47">
+        <node concept="3clFbJ" id="4ZbdskRgmNk" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskRgmNl" role="3clFbw">
+            <node concept="37vLTw" id="4ZbdskRgmNm" role="2Oq$k0">
+              <ref role="3cqZAo" node="4ZbdskRgmNB" resolve="targetConcept" />
+            </node>
+            <node concept="3O6GUB" id="4ZbdskRgmNn" role="2OqNvi">
+              <node concept="chp4Y" id="4ZbdskRgrik" role="3QVz_e">
+                <ref role="cht4Q" to="yv47:4ZbdskR3pBF" resolve="ITupleMember" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="4ZbdskRgmNp" role="3clFbx">
+            <node concept="3cpWs6" id="4ZbdskRgmNq" role="3cqZAp">
+              <node concept="2OqwBi" id="4ZbdskRgmNr" role="3cqZAk">
+                <node concept="13iPFW" id="4ZbdskRgmNs" role="2Oq$k0" />
+                <node concept="2qgKlT" id="4ZbdskRgmNt" role="2OqNvi">
+                  <ref role="37wK5l" node="4ZbdskRgmOY" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="4ZbdskRgmNu" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskRgmNv" role="3cqZAk">
+            <node concept="2OqwBi" id="4ZbdskRgmNw" role="2Oq$k0">
+              <node concept="13iPFW" id="4ZbdskRgmNx" role="2Oq$k0" />
+              <node concept="2Xjw5R" id="4ZbdskRgmNy" role="2OqNvi">
+                <node concept="1xMEDy" id="4ZbdskRgmNz" role="1xVPHs">
+                  <node concept="chp4Y" id="4ZbdskRgmN$" role="ri$Ld">
+                    <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2qgKlT" id="4ZbdskRgmN_" role="2OqNvi">
+              <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
+              <node concept="37vLTw" id="4ZbdskRgmNA" role="37wK5m">
+                <ref role="3cqZAo" node="4ZbdskRgmNB" resolve="targetConcept" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4ZbdskRgmNB" role="3clF46">
+        <property role="TrG5h" value="targetConcept" />
+        <node concept="3THzug" id="4ZbdskRgmNC" role="1tU5fm" />
+      </node>
+      <node concept="A3Dl8" id="4ZbdskRgmND" role="3clF45">
+        <node concept="3Tqbb2" id="4ZbdskRgmNE" role="A3Ik2" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="4ZbdskRgmNF" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="getDependenciesRelevantForCycleDetection" />
+      <ref role="13i0hy" to="hwgx:59HbAIOYveX" resolve="getDependenciesRelevantForCycleDetection" />
+      <node concept="3Tm1VV" id="4ZbdskRgmNG" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskRgmNH" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskRgmNI" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskRgmNJ" role="3clFbG">
+            <node concept="2OqwBi" id="4ZbdskRgmNK" role="2Oq$k0">
+              <node concept="2OqwBi" id="4ZbdskRgmNL" role="2Oq$k0">
+                <node concept="13iPFW" id="4ZbdskRgmNM" role="2Oq$k0" />
+                <node concept="2qgKlT" id="4ZbdskRgmNN" role="2OqNvi">
+                  <ref role="37wK5l" node="4ZbdskRgmOY" />
+                </node>
+              </node>
+              <node concept="3zZkjj" id="4ZbdskRgmNO" role="2OqNvi">
+                <node concept="1bVj0M" id="4ZbdskRgmNP" role="23t8la">
+                  <node concept="3clFbS" id="4ZbdskRgmNQ" role="1bW5cS">
+                    <node concept="3clFbF" id="4ZbdskRgmNR" role="3cqZAp">
+                      <node concept="2OqwBi" id="4ZbdskRgmNS" role="3clFbG">
+                        <node concept="2OqwBi" id="4ZbdskRgmNT" role="2Oq$k0">
+                          <node concept="37vLTw" id="4ZbdskRgmNU" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4ZbdskRgmNY" resolve="it" />
+                          </node>
+                          <node concept="2qgKlT" id="4ZbdskRgmNV" role="2OqNvi">
+                            <ref role="37wK5l" to="pbu6:4WLweXm3SW5" resolve="type" />
+                          </node>
+                        </node>
+                        <node concept="1mIQ4w" id="4ZbdskRgmNW" role="2OqNvi">
+                          <node concept="chp4Y" id="4ZbdskRgmNX" role="cj9EA">
+                            <ref role="cht4Q" to="yv47:4ZbdskRgu$y" resolve="NamedTupleType" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="4ZbdskRgmNY" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="4ZbdskRgmNZ" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3$u5V9" id="4ZbdskRgmO0" role="2OqNvi">
+              <node concept="1bVj0M" id="4ZbdskRgmO1" role="23t8la">
+                <node concept="3clFbS" id="4ZbdskRgmO2" role="1bW5cS">
+                  <node concept="3clFbF" id="4ZbdskRgmO3" role="3cqZAp">
+                    <node concept="2OqwBi" id="4ZbdskRgmO4" role="3clFbG">
+                      <node concept="1PxgMI" id="4ZbdskRgmO5" role="2Oq$k0">
+                        <node concept="2OqwBi" id="4ZbdskRgmO7" role="1m5AlR">
+                          <node concept="37vLTw" id="4ZbdskRgmO8" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4ZbdskRgmOb" resolve="it" />
+                          </node>
+                          <node concept="2qgKlT" id="4ZbdskRgmO9" role="2OqNvi">
+                            <ref role="37wK5l" to="pbu6:4WLweXm3SW5" resolve="type" />
+                          </node>
+                        </node>
+                        <node concept="chp4Y" id="4ZbdskRgsHo" role="3oSUPX">
+                          <ref role="cht4Q" to="yv47:4ZbdskRgu$y" resolve="NamedTupleType" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="4ZbdskRgmOa" role="2OqNvi">
+                        <ref role="3Tt5mk" to="yv47:4ZbdskRgu_6" resolve="tuple" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="4ZbdskRgmOb" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="4ZbdskRgmOc" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="4ZbdskRgmOd" role="3clF45">
+        <node concept="3Tqbb2" id="4ZbdskRgmOe" role="A3Ik2">
+          <ref role="ehGHo" to="vs0r:59HbAIOYkEn" resolve="IDetectCycle" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4ZbdskRgmOf" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="traceBackElementInCycle" />
+      <ref role="13i0hy" to="hwgx:17fjvcLF7UR" resolve="traceBackElementInCycle" />
+      <node concept="3Tm1VV" id="4ZbdskRgmOg" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskRgmOh" role="3clF47">
+        <node concept="3cpWs8" id="4ZbdskRgmOi" role="3cqZAp">
+          <node concept="3cpWsn" id="4ZbdskRgmOj" role="3cpWs9">
+            <property role="TrG5h" value="res" />
+            <node concept="2hMVRd" id="4ZbdskRgmOk" role="1tU5fm">
+              <node concept="3Tqbb2" id="4ZbdskRgmOl" role="2hN53Y" />
+            </node>
+            <node concept="2ShNRf" id="4ZbdskRgmOm" role="33vP2m">
+              <node concept="2i4dXS" id="4ZbdskRgmOn" role="2ShVmc">
+                <node concept="3Tqbb2" id="4ZbdskRgmOo" role="HW$YZ" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4ZbdskRgmOp" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskRgmOq" role="3clFbG">
+            <node concept="37vLTw" id="4ZbdskRgmOr" role="2Oq$k0">
+              <ref role="3cqZAo" node="4ZbdskRgmOj" resolve="res" />
+            </node>
+            <node concept="TSZUe" id="4ZbdskRgmOs" role="2OqNvi">
+              <node concept="37vLTw" id="4ZbdskRgmOt" role="25WWJ7">
+                <ref role="3cqZAo" node="4ZbdskRgmOw" resolve="dependency" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="4ZbdskRgmOu" role="3cqZAp">
+          <node concept="37vLTw" id="4ZbdskRgmOv" role="3cqZAk">
+            <ref role="3cqZAo" node="4ZbdskRgmOj" resolve="res" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4ZbdskRgmOw" role="3clF46">
+        <property role="TrG5h" value="dependency" />
+        <node concept="3Tqbb2" id="4ZbdskRgmOx" role="1tU5fm">
+          <ref role="ehGHo" to="vs0r:59HbAIOYkEn" resolve="IDetectCycle" />
+        </node>
+      </node>
+      <node concept="2hMVRd" id="4ZbdskRgmOy" role="3clF45">
+        <node concept="3Tqbb2" id="4ZbdskRgmOz" role="2hN53Y" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="4ZbdskRgmOI" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="hasItsOwnType" />
+      <node concept="3Tm1VV" id="4ZbdskRgmOJ" role="1B3o_S" />
+      <node concept="10P_77" id="4ZbdskRgmOK" role="3clF45" />
+      <node concept="3clFbS" id="4ZbdskRgmOL" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskRgmOM" role="3cqZAp">
+          <node concept="3clFbT" id="4ZbdskRgmON" role="3clFbG">
+            <property role="3clFbU" value="false" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4ZbdskRgmOY" role="13h7CS">
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="effectiveMembers" />
+      <node concept="3Tm1VV" id="4ZbdskRgmOZ" role="1B3o_S" />
+      <node concept="A3Dl8" id="4ZbdskRgmP0" role="3clF45">
+        <node concept="3Tqbb2" id="4ZbdskRgmP1" role="A3Ik2">
+          <ref role="ehGHo" to="yv47:4ZbdskR3pBF" resolve="ITupleMember" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="4ZbdskRgmP2" role="3clF47">
+        <node concept="3cpWs8" id="4ZbdskRgmP3" role="3cqZAp">
+          <node concept="3cpWsn" id="4ZbdskRgmP4" role="3cpWs9">
+            <property role="TrG5h" value="r" />
+            <node concept="3Tqbb2" id="4ZbdskRgmP5" role="1tU5fm">
+              <ref role="ehGHo" to="yv47:olugnm5RHo" resolve="IDeclarationExtensionContext" />
+            </node>
+            <node concept="2OqwBi" id="4ZbdskRgmP6" role="33vP2m">
+              <node concept="13iPFW" id="4ZbdskRgmP7" role="2Oq$k0" />
+              <node concept="2Xjw5R" id="4ZbdskRgmP8" role="2OqNvi">
+                <node concept="1xMEDy" id="4ZbdskRgmP9" role="1xVPHs">
+                  <node concept="chp4Y" id="4ZbdskRgmPa" role="ri$Ld">
+                    <ref role="cht4Q" to="yv47:olugnm5RHo" resolve="IDeclarationExtensionContext" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4ZbdskRgmPb" role="3cqZAp">
+          <node concept="3clFbS" id="4ZbdskRgmPc" role="3clFbx">
+            <node concept="3cpWs6" id="4ZbdskRgmPd" role="3cqZAp">
+              <node concept="2OqwBi" id="4ZbdskRgmPe" role="3cqZAk">
+                <node concept="2OqwBi" id="4ZbdskRgmPf" role="2Oq$k0">
+                  <node concept="37vLTw" id="4ZbdskRgmPg" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4ZbdskRgmP4" resolve="r" />
+                  </node>
+                  <node concept="2qgKlT" id="4ZbdskRgmPh" role="2OqNvi">
+                    <ref role="37wK5l" node="olugnm5RHX" resolve="effectiveMembers" />
+                    <node concept="13iPFW" id="4ZbdskRgmPi" role="37wK5m" />
+                  </node>
+                </node>
+                <node concept="UnYns" id="4ZbdskRgmPj" role="2OqNvi">
+                  <node concept="3Tqbb2" id="4ZbdskRgmPk" role="UnYnz">
+                    <ref role="ehGHo" to="yv47:4ZbdskR3pBF" resolve="ITupleMember" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="4ZbdskRgmPl" role="3clFbw">
+            <node concept="10Nm6u" id="4ZbdskRgmPm" role="3uHU7w" />
+            <node concept="37vLTw" id="4ZbdskRgmPn" role="3uHU7B">
+              <ref role="3cqZAo" node="4ZbdskRgmP4" resolve="r" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4ZbdskRgmPo" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskRgmPp" role="3clFbG">
+            <node concept="13iPFW" id="4ZbdskRgmPq" role="2Oq$k0" />
+            <node concept="3Tsc0h" id="4ZbdskRgmPr" role="2OqNvi">
+              <ref role="3TtcxE" to="yv47:4ZbdskRgjgF" resolve="members" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4ZbdskRgmPs" role="13h7CS">
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="equals" />
+      <node concept="3Tm1VV" id="4ZbdskRgmPt" role="1B3o_S" />
+      <node concept="10P_77" id="4ZbdskRgmPu" role="3clF45" />
+      <node concept="3clFbS" id="4ZbdskRgmPv" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskRgmPw" role="3cqZAp">
+          <node concept="17R0WA" id="4ZbdskRgmPx" role="3clFbG">
+            <node concept="37vLTw" id="4ZbdskRgmPy" role="3uHU7w">
+              <ref role="3cqZAo" node="4ZbdskRgmP$" resolve="declaration" />
+            </node>
+            <node concept="13iPFW" id="4ZbdskRgmPz" role="3uHU7B" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4ZbdskRgmP$" role="3clF46">
+        <property role="TrG5h" value="declaration" />
+        <node concept="3Tqbb2" id="4ZbdskRgmP_" role="1tU5fm">
+          <ref role="ehGHo" to="yv47:xu7xcKinTJ" resolve="IRecordDeclaration" />
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="4ZbdskRgkAR" role="13h7CW">
+      <node concept="3clFbS" id="4ZbdskRgkAS" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4ZbdskRgDLc">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="13h7C2" to="yv47:4ZbdskR3pBE" resolve="NamedTupleDeclaration" />
+    <node concept="13i0hz" id="4ZbdskRgmOO" role="13h7CS">
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="createTypeNode" />
+      <node concept="3Tm1VV" id="4ZbdskRgmOP" role="1B3o_S" />
+      <node concept="3Tqbb2" id="4ZbdskRgmOQ" role="3clF45">
+        <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+      </node>
+      <node concept="3clFbS" id="4ZbdskRgmOR" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskRgmOS" role="3cqZAp">
+          <node concept="2pJPEk" id="4ZbdskRgmOT" role="3clFbG">
+            <node concept="2pJPED" id="4ZbdskRgmOU" role="2pJPEn">
+              <ref role="2pJxaS" to="yv47:4ZbdskRgu$y" resolve="NamedTupleType" />
+              <node concept="2pIpSj" id="4ZbdskRgmOV" role="2pJxcM">
+                <ref role="2pIpSl" to="yv47:4ZbdskRgu_6" resolve="tuple" />
+                <node concept="36biLy" id="4ZbdskRgmOW" role="28nt2d">
+                  <node concept="13iPFW" id="4ZbdskRgmOX" role="36biLW" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4ZbdskRgF36" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="getUniquelyNamedElements" />
+      <ref role="13i0hy" to="hwgx:4qSf1u1TRfj" resolve="getUniquelyNamedElements" />
+      <node concept="3Tm1VV" id="4ZbdskRgF37" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskRgF38" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskRgF39" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskRgF3a" role="3clFbG">
+            <node concept="13iPFW" id="4ZbdskRgF3b" role="2Oq$k0" />
+            <node concept="2qgKlT" id="4ZbdskRgF3c" role="2OqNvi">
+              <ref role="37wK5l" node="4ZbdskRgmOY" resolve="effectiveMembers" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="4ZbdskRgF3d" role="3clF45">
+        <node concept="3Tqbb2" id="4ZbdskRgF3e" role="A3Ik2">
+          <ref role="ehGHo" to="tpck:h0TrEE$" resolve="INamedConcept" />
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="4ZbdskRgDLd" role="13h7CW">
+      <node concept="3clFbS" id="4ZbdskRgDLe" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4ZbdskT1_R1">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="13h7C2" to="yv47:4ZbdskRgu$y" resolve="NamedTupleType" />
+    <node concept="13hLZK" id="4ZbdskT1_R2" role="13h7CW">
+      <node concept="3clFbS" id="4ZbdskT1_R3" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4ZbdskT1_Rc" role="13h7CS">
+      <property role="TrG5h" value="getElementTypes" />
+      <ref role="13i0hy" to="pbu6:4ZbdskT1yfk" resolve="getElementTypes" />
+      <node concept="3Tm1VV" id="4ZbdskT1_Rd" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskT1_Rh" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskT1_Ry" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskT1FPq" role="3clFbG">
+            <node concept="2OqwBi" id="4ZbdskT1DPN" role="2Oq$k0">
+              <node concept="2OqwBi" id="4ZbdskT1CDE" role="2Oq$k0">
+                <node concept="2OqwBi" id="4ZbdskT1A5m" role="2Oq$k0">
+                  <node concept="13iPFW" id="4ZbdskT1_Rx" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4ZbdskT1Aoo" role="2OqNvi">
+                    <ref role="3Tt5mk" to="yv47:4ZbdskRgu_6" resolve="tuple" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4ZbdskT1Drf" role="2OqNvi">
+                  <ref role="37wK5l" node="4ZbdskRgmME" resolve="nonEmptyMembers" />
+                </node>
+              </node>
+              <node concept="3$u5V9" id="4ZbdskT1EeK" role="2OqNvi">
+                <node concept="1bVj0M" id="4ZbdskT1EeM" role="23t8la">
+                  <node concept="3clFbS" id="4ZbdskT1EeN" role="1bW5cS">
+                    <node concept="3clFbF" id="4ZbdskT1EeW" role="3cqZAp">
+                      <node concept="2OqwBi" id="4ZbdskT1Eym" role="3clFbG">
+                        <node concept="37vLTw" id="4ZbdskT1EeV" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4ZbdskT1EeO" resolve="it" />
+                        </node>
+                        <node concept="2qgKlT" id="4ZbdskT1Few" role="2OqNvi">
+                          <ref role="37wK5l" to="pbu6:4WLweXm3SW5" resolve="type" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="4ZbdskT1EeO" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="4ZbdskT1EeP" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="ANE8D" id="4ZbdskT1GvX" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="4ZbdskT1_Ri" role="3clF45">
+        <node concept="3Tqbb2" id="4ZbdskT1_Rj" role="_ZDj9">
+          <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="4ZbdskRE2GU">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="13h7C2" to="yv47:4ZbdskRDH_N" resolve="TupleMemberSetter" />
+    <node concept="13i0hz" id="672JozWmCJh" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <node concept="3Tm1VV" id="672JozWmCJi" role="1B3o_S" />
+      <node concept="3clFbS" id="672JozWmCJj" role="3clF47">
+        <node concept="3clFbF" id="672JozWmCJk" role="3cqZAp">
+          <node concept="3cpWs3" id="672JozWmCJl" role="3clFbG">
+            <node concept="2OqwBi" id="672JozWmCJm" role="3uHU7w">
+              <node concept="2OqwBi" id="672JozWmCJn" role="2Oq$k0">
+                <node concept="13iPFW" id="672JozWmCJo" role="2Oq$k0" />
+                <node concept="3TrEf2" id="672JozWmCJp" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yv47:672JozWmCHZ" resolve="value" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="672JozWmCJq" role="2OqNvi">
+                <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="672JozWmCJr" role="3uHU7B">
+              <node concept="2OqwBi" id="672JozWmCJs" role="3uHU7B">
+                <node concept="2OqwBi" id="672JozWmCJt" role="2Oq$k0">
+                  <node concept="13iPFW" id="672JozWmCJu" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="672JozWmCJv" role="2OqNvi">
+                    <ref role="3Tt5mk" to="yv47:4ZbdskRDH_O" resolve="member" />
+                  </node>
+                </node>
+                <node concept="3TrcHB" id="672JozWmCJw" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="672JozWmCJx" role="3uHU7w">
+                <property role="Xl_RC" value="-&gt;" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="672JozWmCJy" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="4ZbdskRE2GV" role="13h7CW">
+      <node concept="3clFbS" id="4ZbdskRE2GW" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4ZbdskRgNZZ">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="13h7C2" to="yv47:4ZbdskRgKyK" resolve="TupleNamedAccessExpr" />
+    <node concept="13i0hz" id="4ZbdskSljH_" role="13h7CS">
+      <property role="TrG5h" value="getExpression" />
+      <node concept="3Tm1VV" id="4ZbdskSljHA" role="1B3o_S" />
+      <node concept="3Tqbb2" id="4ZbdskSljKM" role="3clF45">
+        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+      </node>
+      <node concept="3clFbS" id="4ZbdskSljHC" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskSljLd" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskSlk7Q" role="3clFbG">
+            <node concept="1PxgMI" id="4ZbdskSljLf" role="2Oq$k0">
+              <node concept="2OqwBi" id="4ZbdskSljLg" role="1m5AlR">
+                <node concept="13iPFW" id="4ZbdskSljLh" role="2Oq$k0" />
+                <node concept="1mfA1w" id="4ZbdskSljLi" role="2OqNvi" />
+              </node>
+              <node concept="chp4Y" id="4ZbdskSljLj" role="3oSUPX">
+                <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+              </node>
+            </node>
+            <node concept="3TrEf2" id="4ZbdskSlllM" role="2OqNvi">
+              <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4ZbdskSgauX" role="13h7CS">
+      <property role="TrG5h" value="getType" />
+      <node concept="3Tm1VV" id="4ZbdskSgauY" role="1B3o_S" />
+      <node concept="3Tqbb2" id="4ZbdskSgauZ" role="3clF45">
+        <ref role="ehGHo" to="yv47:4ZbdskRgu$y" resolve="NamedTupleType" />
+      </node>
+      <node concept="3clFbS" id="4ZbdskSgav0" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskSgav1" role="3cqZAp">
+          <node concept="1PxgMI" id="4ZbdskSgav3" role="3clFbG">
+            <property role="1BlNFB" value="true" />
+            <node concept="chp4Y" id="4ZbdskSgav4" role="3oSUPX">
+              <ref role="cht4Q" to="yv47:4ZbdskRgu$y" resolve="NamedTupleType" />
+            </node>
+            <node concept="2OqwBi" id="4ZbdskSgav5" role="1m5AlR">
+              <node concept="3JvlWi" id="4ZbdskSgavb" role="2OqNvi" />
+              <node concept="BsUDl" id="4ZbdskTjPht" role="2Oq$k0">
+                <ref role="37wK5l" node="4ZbdskSljH_" resolve="getExpression" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4ZbdskSg3_i" role="13h7CS">
+      <property role="TrG5h" value="getTupleDeclaration" />
+      <node concept="3Tm1VV" id="4ZbdskSg3_j" role="1B3o_S" />
+      <node concept="3Tqbb2" id="4ZbdskSg3Dz" role="3clF45">
+        <ref role="ehGHo" to="yv47:4ZbdskR3pBE" resolve="NamedTupleDeclaration" />
+      </node>
+      <node concept="3clFbS" id="4ZbdskSg3_l" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskSg48B" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskSg7yg" role="3clFbG">
+            <node concept="3TrEf2" id="4ZbdskSg7T6" role="2OqNvi">
+              <ref role="3Tt5mk" to="yv47:4ZbdskRgu_6" resolve="tuple" />
+            </node>
+            <node concept="BsUDl" id="4ZbdskTjOST" role="2Oq$k0">
+              <ref role="37wK5l" node="4ZbdskSgauX" resolve="getType" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4ZbdskSGpNG" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:6kR0qIbI2yi" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4ZbdskSGpNH" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskSGpNK" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskSGpNN" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskSGrdV" role="3clFbG">
+            <node concept="2OqwBi" id="4ZbdskSGq_9" role="2Oq$k0">
+              <node concept="13iPFW" id="4ZbdskSGqwn" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4ZbdskSGqYz" role="2OqNvi">
+                <ref role="3Tt5mk" to="yv47:4ZbdskRgN6H" resolve="member" />
+              </node>
+            </node>
+            <node concept="3TrcHB" id="4ZbdskSGrLs" role="2OqNvi">
+              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4ZbdskSGpNL" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="4ZbdskRgO0G" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="effectDescriptor" />
+      <ref role="13i0hy" to="pbu6:6GySMNjjWfO" resolve="effectDescriptor" />
+      <node concept="3Tm1VV" id="4ZbdskRgO0H" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskRgO0I" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskRgO0J" role="3cqZAp">
+          <node concept="BsUDl" id="4ZbdskRgO0K" role="3clFbG">
+            <ref role="37wK5l" to="pbu6:6KxoTHgL$U0" resolve="deriveFrom" />
+            <node concept="2OqwBi" id="4ZbdskRgO0L" role="37wK5m">
+              <node concept="13iPFW" id="4ZbdskRgO0M" role="2Oq$k0" />
+              <node concept="2qgKlT" id="4ZbdskSg9wR" role="2OqNvi">
+                <ref role="37wK5l" node="4ZbdskSg3_i" resolve="getTupleDeclaration" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="4ZbdskRgO0O" role="3clF45">
+        <ref role="3uigEE" to="oq0c:3ni3WieuV7z" resolve="EffectDescriptor" />
+      </node>
+    </node>
+    <node concept="13hLZK" id="4ZbdskRgO00" role="13h7CW">
+      <node concept="3clFbS" id="4ZbdskRgO01" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4ZbdskRDO$6">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="13h7C2" to="yv47:4ZbdskRDGLl" resolve="NamedTupleValue" />
+    <node concept="13i0hz" id="4ZbdskRN8Dn" role="13h7CS">
+      <property role="TrG5h" value="getIndexSortedSetters" />
+      <node concept="3Tm1VV" id="4ZbdskRN8Do" role="1B3o_S" />
+      <node concept="_YKpA" id="4ZbdskRNb_d" role="3clF45">
+        <node concept="3Tqbb2" id="4ZbdskRNbCB" role="_ZDj9">
+          <ref role="ehGHo" to="yv47:4ZbdskRDH_N" resolve="TupleMemberSetter" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="4ZbdskRN8Dq" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskRN96z" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskRNfiH" role="3clFbG">
+            <node concept="2OqwBi" id="4ZbdskRNaJz" role="2Oq$k0">
+              <node concept="2S7cBI" id="4ZbdskRNc$B" role="2OqNvi">
+                <node concept="1bVj0M" id="4ZbdskRNc$D" role="23t8la">
+                  <node concept="3clFbS" id="4ZbdskRNc$E" role="1bW5cS">
+                    <node concept="3clFbF" id="4ZbdskRNcFa" role="3cqZAp">
+                      <node concept="2OqwBi" id="4ZbdskRNdJF" role="3clFbG">
+                        <node concept="2OqwBi" id="4ZbdskRNdlU" role="2Oq$k0">
+                          <node concept="2OqwBi" id="4ZbdskRNcOP" role="2Oq$k0">
+                            <node concept="13iPFW" id="4ZbdskRNcF9" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="4ZbdskRNd11" role="2OqNvi">
+                              <ref role="3Tt5mk" to="yv47:4ZbdskRDJtl" resolve="tuple" />
+                            </node>
+                          </node>
+                          <node concept="2qgKlT" id="4ZbdskRNd_m" role="2OqNvi">
+                            <ref role="37wK5l" node="4ZbdskRgmME" resolve="nonEmptyMembers" />
+                          </node>
+                        </node>
+                        <node concept="2WmjW8" id="4ZbdskRNe94" role="2OqNvi">
+                          <node concept="2OqwBi" id="4ZbdskRNgom" role="25WWJ7">
+                            <node concept="37vLTw" id="4ZbdskRNeBh" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4ZbdskRNc$F" resolve="it" />
+                            </node>
+                            <node concept="3TrEf2" id="4ZbdskRNgT4" role="2OqNvi">
+                              <ref role="3Tt5mk" to="yv47:4ZbdskRDH_O" resolve="member" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="4ZbdskRNc$F" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="4ZbdskRNc$G" role="1tU5fm" />
+                  </node>
+                </node>
+                <node concept="1nlBCl" id="4ZbdskRNc$H" role="2S7zOq">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4ZbdskRN99t" role="2Oq$k0">
+                <node concept="13iPFW" id="4ZbdskRN96y" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="4ZbdskRN9GK" role="2OqNvi">
+                  <ref role="3TtcxE" to="yv47:4ZbdskRDGMh" resolve="setters" />
+                </node>
+              </node>
+            </node>
+            <node concept="ANE8D" id="4ZbdskRNfSh" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4ZbdskRO1Cc" role="13h7CS">
+      <property role="TrG5h" value="getIndexSortedValues" />
+      <node concept="3Tm1VV" id="4ZbdskRO1Cd" role="1B3o_S" />
+      <node concept="_YKpA" id="4ZbdskRO1Ce" role="3clF45">
+        <node concept="3Tqbb2" id="4ZbdskRO1Cf" role="_ZDj9">
+          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="4ZbdskRO1Cg" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskRO2KN" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskRS0uZ" role="3clFbG">
+            <node concept="2OqwBi" id="4ZbdskRO3UI" role="2Oq$k0">
+              <node concept="BsUDl" id="4ZbdskRO2KM" role="2Oq$k0">
+                <ref role="37wK5l" node="4ZbdskRN8Dn" resolve="getIndexSortedSetters" />
+              </node>
+              <node concept="3$u5V9" id="4ZbdskRO6ka" role="2OqNvi">
+                <node concept="1bVj0M" id="4ZbdskRO6kc" role="23t8la">
+                  <node concept="3clFbS" id="4ZbdskRO6kd" role="1bW5cS">
+                    <node concept="3clFbF" id="4ZbdskRO6q7" role="3cqZAp">
+                      <node concept="2OqwBi" id="4ZbdskRO6xS" role="3clFbG">
+                        <node concept="37vLTw" id="4ZbdskRO6q6" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4ZbdskRO6ke" resolve="it" />
+                        </node>
+                        <node concept="3TrEf2" id="4ZbdskRO6GX" role="2OqNvi">
+                          <ref role="3Tt5mk" to="yv47:672JozWmCHZ" resolve="value" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="4ZbdskRO6ke" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="4ZbdskRO6kf" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="ANE8D" id="4ZbdskRS0Vq" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4ZbdskSdFcj" role="13h7CS">
+      <property role="TrG5h" value="getUniquelyNamedElements" />
+      <ref role="13i0hy" to="hwgx:4qSf1u1TRfj" resolve="getUniquelyNamedElements" />
+      <node concept="3Tm1VV" id="4ZbdskSdFck" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskSdFco" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskSdFYZ" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskSdIoC" role="3clFbG">
+            <node concept="2OqwBi" id="4ZbdskSdGeN" role="2Oq$k0">
+              <node concept="13iPFW" id="4ZbdskSdFYY" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="4ZbdskSdGA3" role="2OqNvi">
+                <ref role="3TtcxE" to="yv47:4ZbdskRDGMh" resolve="setters" />
+              </node>
+            </node>
+            <node concept="3$u5V9" id="4ZbdskSdK8T" role="2OqNvi">
+              <node concept="1bVj0M" id="4ZbdskSdK8V" role="23t8la">
+                <node concept="3clFbS" id="4ZbdskSdK8W" role="1bW5cS">
+                  <node concept="3clFbF" id="4ZbdskSdK95" role="3cqZAp">
+                    <node concept="2OqwBi" id="4ZbdskSdKkO" role="3clFbG">
+                      <node concept="37vLTw" id="4ZbdskSdK94" role="2Oq$k0">
+                        <ref role="3cqZAo" node="4ZbdskSdK8X" resolve="it" />
+                      </node>
+                      <node concept="3TrEf2" id="4ZbdskSdKA_" role="2OqNvi">
+                        <ref role="3Tt5mk" to="yv47:4ZbdskRDH_O" resolve="member" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="4ZbdskSdK8X" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="4ZbdskSdK8Y" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="4ZbdskSdFcp" role="3clF45">
+        <node concept="3Tqbb2" id="4ZbdskSdFcq" role="A3Ik2">
+          <ref role="ehGHo" to="tpck:h0TrEE$" resolve="INamedConcept" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4ZbdskSW4$8" role="13h7CS">
+      <property role="TrG5h" value="getValues" />
+      <ref role="13i0hy" to="pbu6:4ZbdskSW3D7" resolve="getValues" />
+      <node concept="3Tm1VV" id="4ZbdskSW4$9" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskSW4$d" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskSW5sW" role="3cqZAp">
+          <node concept="BsUDl" id="4ZbdskSW5sV" role="3clFbG">
+            <ref role="37wK5l" node="4ZbdskRO1Cc" resolve="getIndexSortedValues" />
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="4ZbdskSW4$e" role="3clF45">
+        <node concept="3Tqbb2" id="4ZbdskSW4$f" role="_ZDj9">
+          <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4ZbdskSXYHM" role="13h7CS">
+      <property role="TrG5h" value="getConceptOfType" />
+      <ref role="13i0hy" to="pbu6:4ZbdskSXUP5" resolve="getConceptOfType" />
+      <node concept="3Tm1VV" id="4ZbdskSXYHN" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskSXYHO" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskSXYHP" role="3cqZAp">
+          <node concept="35c_gC" id="4ZbdskSXYHQ" role="3clFbG">
+            <ref role="35c_gD" to="yv47:4ZbdskRgu$y" resolve="NamedTupleType" />
+          </node>
+        </node>
+      </node>
+      <node concept="3bZ5Sz" id="4ZbdskSXYHS" role="3clF45">
+        <ref role="3bZ5Sy" to="hm2y:6sdnDbSlaok" resolve="Type" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="4ZbdskRDO$h" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4ZbdskRDO$i" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskRDO$j" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskRDO$k" role="3cqZAp">
+          <node concept="3cpWs3" id="4ZbdskRDO$l" role="3clFbG">
+            <node concept="Xl_RD" id="4ZbdskRDO$m" role="3uHU7w">
+              <property role="Xl_RC" value="]" />
+            </node>
+            <node concept="3cpWs3" id="4ZbdskRDO$n" role="3uHU7B">
+              <node concept="Xl_RD" id="4ZbdskRDO$o" role="3uHU7B">
+                <property role="Xl_RC" value="[" />
+              </node>
+              <node concept="2OqwBi" id="4ZbdskRE4yf" role="3uHU7w">
+                <node concept="2OqwBi" id="4ZbdskRE06R" role="2Oq$k0">
+                  <node concept="2OqwBi" id="4ZbdskRDXYv" role="2Oq$k0">
+                    <node concept="13iPFW" id="4ZbdskRDXIh" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="4ZbdskRDYiq" role="2OqNvi">
+                      <ref role="3TtcxE" to="yv47:4ZbdskRDGMh" resolve="setters" />
+                    </node>
+                  </node>
+                  <node concept="3$u5V9" id="4ZbdskRE1Lq" role="2OqNvi">
+                    <node concept="1bVj0M" id="4ZbdskRE1Ls" role="23t8la">
+                      <node concept="3clFbS" id="4ZbdskRE1Lt" role="1bW5cS">
+                        <node concept="3clFbF" id="4ZbdskRE1VM" role="3cqZAp">
+                          <node concept="2OqwBi" id="4ZbdskRE29D" role="3clFbG">
+                            <node concept="37vLTw" id="4ZbdskRE1VL" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4ZbdskRE1Lu" resolve="it" />
+                            </node>
+                            <node concept="2qgKlT" id="4ZbdskRE47s" role="2OqNvi">
+                              <ref role="37wK5l" node="672JozWmCJh" resolve="renderReadable" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="4ZbdskRE1Lu" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="4ZbdskRE1Lv" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3uJxvA" id="4ZbdskRE53C" role="2OqNvi">
+                  <node concept="Xl_RD" id="4ZbdskRE653" role="3uJOhx">
+                    <property role="Xl_RC" value="," />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4ZbdskRDO$t" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="4ZbdskRDO$u" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="effectDescriptor" />
+      <ref role="13i0hy" to="pbu6:6GySMNjjWfO" resolve="effectDescriptor" />
+      <node concept="3Tm1VV" id="4ZbdskRDO$v" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskRDO$w" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskRDO$x" role="3cqZAp">
+          <node concept="2YIFZM" id="4ZbdskRDO$y" role="3clFbG">
+            <ref role="1Pybhc" to="oq0c:3ni3WieuV7z" resolve="EffectDescriptor" />
+            <ref role="37wK5l" to="oq0c:6GySMNjCKBZ" resolve="forNodes" />
+            <node concept="2OqwBi" id="4ZbdskRDO$z" role="37wK5m">
+              <node concept="13iPFW" id="4ZbdskRDO$$" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="4ZbdskRE7il" role="2OqNvi">
+                <ref role="3TtcxE" to="yv47:4ZbdskRDGMh" resolve="setters" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="4ZbdskRDO$A" role="3clF45">
+        <ref role="3uigEE" to="oq0c:3ni3WieuV7z" resolve="EffectDescriptor" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="4ZbdskRDO$B" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="isLValue" />
+      <ref role="13i0hy" to="pbu6:aPhVmWYjn5" resolve="isLValue" />
+      <node concept="3Tm1VV" id="4ZbdskRDO$C" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskRDO$D" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskRDO$E" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskRDO$F" role="3clFbG">
+            <node concept="2OqwBi" id="4ZbdskRDO$G" role="2Oq$k0">
+              <node concept="13iPFW" id="4ZbdskRDO$H" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="4ZbdskRE7c5" role="2OqNvi">
+                <ref role="3TtcxE" to="yv47:4ZbdskRDGMh" resolve="setters" />
+              </node>
+            </node>
+            <node concept="2HxqBE" id="4ZbdskRDO$J" role="2OqNvi">
+              <node concept="1bVj0M" id="4ZbdskRDO$K" role="23t8la">
+                <node concept="3clFbS" id="4ZbdskRDO$L" role="1bW5cS">
+                  <node concept="3clFbF" id="4ZbdskRDO$M" role="3cqZAp">
+                    <node concept="1Wc70l" id="4ZbdskRDO$N" role="3clFbG">
+                      <node concept="2OqwBi" id="4ZbdskRDO$O" role="3uHU7w">
+                        <node concept="1PxgMI" id="4ZbdskRDO$P" role="2Oq$k0">
+                          <node concept="chp4Y" id="4ZbdskRDO$Q" role="3oSUPX">
+                            <ref role="cht4Q" to="hm2y:aPhVmWYjmk" resolve="ICanBeLValue" />
+                          </node>
+                          <node concept="37vLTw" id="4ZbdskRDO$R" role="1m5AlR">
+                            <ref role="3cqZAo" node="4ZbdskRDO$X" resolve="it" />
+                          </node>
+                        </node>
+                        <node concept="2qgKlT" id="4ZbdskRDO$S" role="2OqNvi">
+                          <ref role="37wK5l" to="pbu6:aPhVmWYjn5" resolve="isLValue" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="4ZbdskRDO$T" role="3uHU7B">
+                        <node concept="37vLTw" id="4ZbdskRDO$U" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4ZbdskRDO$X" resolve="it" />
+                        </node>
+                        <node concept="1mIQ4w" id="4ZbdskRDO$V" role="2OqNvi">
+                          <node concept="chp4Y" id="4ZbdskRDO$W" role="cj9EA">
+                            <ref role="cht4Q" to="hm2y:aPhVmWYjmk" resolve="ICanBeLValue" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="4ZbdskRDO$X" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="4ZbdskRDO$Y" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="4ZbdskRDO$Z" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="4ZbdskRDO_0" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="isUsedAsLValue" />
+      <ref role="13i0hy" to="pbu6:YMJl2BJIOO" resolve="isUsedAsLValue" />
+      <node concept="3Tm1VV" id="4ZbdskRDO_1" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskRDO_2" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskRDO_3" role="3cqZAp">
+          <node concept="2OqwBi" id="4ZbdskRDO_4" role="3clFbG">
+            <node concept="2OqwBi" id="4ZbdskRDO_5" role="2Oq$k0">
+              <node concept="13iPFW" id="4ZbdskRDO_6" role="2Oq$k0" />
+              <node concept="1mfA1w" id="4ZbdskRDO_7" role="2OqNvi" />
+            </node>
+            <node concept="1mIQ4w" id="4ZbdskRDO_8" role="2OqNvi">
+              <node concept="chp4Y" id="4ZbdskRDO_9" role="cj9EA">
+                <ref role="cht4Q" to="hm2y:aPhVmWYxIJ" resolve="AssignmentExpr" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="4ZbdskRDO_a" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="4ZbdskRDO_b" role="13h7CS">
+      <property role="13i0iv" value="false" />
+      <property role="13i0it" value="false" />
+      <property role="TrG5h" value="assignmentProducedEffect" />
+      <ref role="13i0hy" to="pbu6:1VmWkC0_H15" resolve="assignmentProducedEffect" />
+      <node concept="3Tm1VV" id="4ZbdskRDO_c" role="1B3o_S" />
+      <node concept="3clFbS" id="4ZbdskRDO_d" role="3clF47">
+        <node concept="3clFbF" id="4ZbdskRDO_e" role="3cqZAp">
+          <node concept="2YIFZM" id="4ZbdskRDO_f" role="3clFbG">
+            <ref role="37wK5l" to="oq0c:6GySMNjCKBZ" resolve="forNodes" />
+            <ref role="1Pybhc" to="oq0c:3ni3WieuV7z" resolve="EffectDescriptor" />
+            <node concept="2OqwBi" id="4ZbdskRDO_g" role="37wK5m">
+              <node concept="13iPFW" id="4ZbdskRDO_h" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="4ZbdskRE79Z" role="2OqNvi">
+                <ref role="3TtcxE" to="yv47:4ZbdskRDGMh" resolve="setters" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3uibUv" id="4ZbdskRDO_j" role="3clF45">
+        <ref role="3uigEE" to="oq0c:3ni3WieuV7z" resolve="EffectDescriptor" />
+      </node>
+    </node>
+    <node concept="13hLZK" id="4ZbdskRDO$7" role="13h7CW">
+      <node concept="3clFbS" id="4ZbdskRDO$8" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -10407,6 +10407,20 @@
     <node concept="13hLZK" id="4ZbdskRgkAR" role="13h7CW">
       <node concept="3clFbS" id="4ZbdskRgkAS" role="2VODD2" />
     </node>
+    <node concept="13i0hz" id="1pkymqLzE6W" role="13h7CS">
+      <property role="TrG5h" value="allowNonIdentifierNames" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" to="gdgh:4SwD0JT7m0l" resolve="allowNonIdentifierNames" />
+      <node concept="3Tm1VV" id="1pkymqLzE6X" role="1B3o_S" />
+      <node concept="3clFbS" id="1pkymqLzE76" role="3clF47">
+        <node concept="3clFbF" id="1pkymqLzFfc" role="3cqZAp">
+          <node concept="3clFbT" id="1pkymqLzFfb" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="1pkymqLzE77" role="3clF45" />
+    </node>
   </node>
   <node concept="13h7C7" id="4ZbdskRgDLc">
     <property role="3GE5qa" value="tuples" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -10060,7 +10060,7 @@
             <node concept="2OqwBi" id="4ZbdskRgmML" role="2Oq$k0">
               <node concept="13iPFW" id="4ZbdskRgmMM" role="2Oq$k0" />
               <node concept="2qgKlT" id="4ZbdskRgmMN" role="2OqNvi">
-                <ref role="37wK5l" node="4ZbdskRgmOY" />
+                <ref role="37wK5l" node="4ZbdskRgmOY" resolve="effectiveMembers" />
               </node>
             </node>
             <node concept="3zZkjj" id="4ZbdskRgmMO" role="2OqNvi">
@@ -10136,7 +10136,7 @@
               <node concept="2OqwBi" id="4ZbdskRgmNr" role="3cqZAk">
                 <node concept="13iPFW" id="4ZbdskRgmNs" role="2Oq$k0" />
                 <node concept="2qgKlT" id="4ZbdskRgmNt" role="2OqNvi">
-                  <ref role="37wK5l" node="4ZbdskRgmOY" />
+                  <ref role="37wK5l" node="4ZbdskRgmOY" resolve="effectiveMembers" />
                 </node>
               </node>
             </node>
@@ -10184,7 +10184,7 @@
               <node concept="2OqwBi" id="4ZbdskRgmNL" role="2Oq$k0">
                 <node concept="13iPFW" id="4ZbdskRgmNM" role="2Oq$k0" />
                 <node concept="2qgKlT" id="4ZbdskRgmNN" role="2OqNvi">
-                  <ref role="37wK5l" node="4ZbdskRgmOY" />
+                  <ref role="37wK5l" node="4ZbdskRgmOY" resolve="effectiveMembers" />
                 </node>
               </node>
               <node concept="3zZkjj" id="4ZbdskRgmNO" role="2OqNvi">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -10516,6 +10516,60 @@
         </node>
       </node>
     </node>
+    <node concept="13i0hz" id="7yOFqusn8Rg" role="13h7CS">
+      <property role="TrG5h" value="convertToTupleType" />
+      <node concept="3Tm1VV" id="7yOFqusn8Rh" role="1B3o_S" />
+      <node concept="3Tqbb2" id="7yOFqusn9dI" role="3clF45">
+        <ref role="ehGHo" to="hm2y:S$tO8ocniU" resolve="TupleType" />
+      </node>
+      <node concept="3clFbS" id="7yOFqusn8Rj" role="3clF47">
+        <node concept="3clFbF" id="7yOFqusn9gi" role="3cqZAp">
+          <node concept="2pJPEk" id="7yOFqusn9gg" role="3clFbG">
+            <node concept="2pJPED" id="7yOFqusn9gh" role="2pJPEn">
+              <ref role="2pJxaS" to="hm2y:S$tO8ocniU" resolve="TupleType" />
+              <node concept="2pIpSj" id="7yOFqusn9pd" role="2pJxcM">
+                <ref role="2pIpSl" to="hm2y:S$tO8ocniV" resolve="elementTypes" />
+                <node concept="36biLy" id="7yOFqusn9uB" role="28nt2d">
+                  <node concept="2OqwBi" id="7yOFqusnc6m" role="36biLW">
+                    <node concept="2OqwBi" id="7yOFqusnaG4" role="2Oq$k0">
+                      <node concept="2OqwBi" id="7yOFqusn9O_" role="2Oq$k0">
+                        <node concept="13iPFW" id="7yOFqusn9xD" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="7yOFqusnaeQ" role="2OqNvi">
+                          <ref role="3Tt5mk" to="yv47:4ZbdskRgu_6" resolve="tuple" />
+                        </node>
+                      </node>
+                      <node concept="2qgKlT" id="7yOFqusnbyr" role="2OqNvi">
+                        <ref role="37wK5l" node="4ZbdskRgmME" resolve="nonEmptyMembers" />
+                      </node>
+                    </node>
+                    <node concept="3$u5V9" id="7yOFqusnczQ" role="2OqNvi">
+                      <node concept="1bVj0M" id="7yOFqusnczS" role="23t8la">
+                        <node concept="3clFbS" id="7yOFqusnczT" role="1bW5cS">
+                          <node concept="3clFbF" id="7yOFqusncED" role="3cqZAp">
+                            <node concept="2OqwBi" id="7yOFqusncYQ" role="3clFbG">
+                              <node concept="37vLTw" id="7yOFqusncEC" role="2Oq$k0">
+                                <ref role="3cqZAo" node="7yOFqusnczU" resolve="it" />
+                              </node>
+                              <node concept="2qgKlT" id="7yOFqusndHi" role="2OqNvi">
+                                <ref role="37wK5l" to="pbu6:4WLweXm3SW5" resolve="type" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="7yOFqusnczU" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="7yOFqusnczV" role="1tU5fm" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="13h7C7" id="4ZbdskRE2GU">
     <property role="3GE5qa" value="tuples" />
@@ -10794,32 +10848,10 @@
       <node concept="3Tm1VV" id="4ZbdskSdFck" role="1B3o_S" />
       <node concept="3clFbS" id="4ZbdskSdFco" role="3clF47">
         <node concept="3clFbF" id="4ZbdskSdFYZ" role="3cqZAp">
-          <node concept="2OqwBi" id="4ZbdskSdIoC" role="3clFbG">
-            <node concept="2OqwBi" id="4ZbdskSdGeN" role="2Oq$k0">
-              <node concept="13iPFW" id="4ZbdskSdFYY" role="2Oq$k0" />
-              <node concept="3Tsc0h" id="4ZbdskSdGA3" role="2OqNvi">
-                <ref role="3TtcxE" to="yv47:4ZbdskRDGMh" resolve="setters" />
-              </node>
-            </node>
-            <node concept="3$u5V9" id="4ZbdskSdK8T" role="2OqNvi">
-              <node concept="1bVj0M" id="4ZbdskSdK8V" role="23t8la">
-                <node concept="3clFbS" id="4ZbdskSdK8W" role="1bW5cS">
-                  <node concept="3clFbF" id="4ZbdskSdK95" role="3cqZAp">
-                    <node concept="2OqwBi" id="4ZbdskSdKkO" role="3clFbG">
-                      <node concept="37vLTw" id="4ZbdskSdK94" role="2Oq$k0">
-                        <ref role="3cqZAo" node="4ZbdskSdK8X" resolve="it" />
-                      </node>
-                      <node concept="3TrEf2" id="4ZbdskSdKA_" role="2OqNvi">
-                        <ref role="3Tt5mk" to="yv47:4ZbdskRDH_O" resolve="member" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="Rh6nW" id="4ZbdskSdK8X" role="1bW2Oz">
-                  <property role="TrG5h" value="it" />
-                  <node concept="2jxLKc" id="4ZbdskSdK8Y" role="1tU5fm" />
-                </node>
-              </node>
+          <node concept="2OqwBi" id="4ZbdskSdGeN" role="3clFbG">
+            <node concept="13iPFW" id="4ZbdskSdFYY" role="2Oq$k0" />
+            <node concept="3Tsc0h" id="4ZbdskSdGA3" role="2OqNvi">
+              <ref role="3TtcxE" to="yv47:4ZbdskRDGMh" resolve="setters" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/constraints.mps
@@ -2242,6 +2242,26 @@
         </node>
       </node>
     </node>
+    <node concept="EnEH3" id="7yOFqurE_MJ" role="1MhHOB">
+      <ref role="EomxK" to="tpck:h0TrG11" resolve="name" />
+      <node concept="Eqf_E" id="7yOFqurE_Nj" role="EtsB7">
+        <node concept="3clFbS" id="7yOFqurE_Nk" role="2VODD2">
+          <node concept="3clFbF" id="7yOFqurEAxp" role="3cqZAp">
+            <node concept="2OqwBi" id="7yOFqurEBsG" role="3clFbG">
+              <node concept="2OqwBi" id="7yOFqurEAID" role="2Oq$k0">
+                <node concept="EsrRn" id="7yOFqurEAxo" role="2Oq$k0" />
+                <node concept="3TrEf2" id="7yOFqurEAXY" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yv47:4ZbdskRDH_O" resolve="member" />
+                </node>
+              </node>
+              <node concept="3TrcHB" id="7yOFqurEBY5" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="1M2fIO" id="4ZbdskSg1G7">
     <property role="3GE5qa" value="tuples" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/constraints.mps
@@ -5,6 +5,9 @@
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="6" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
+    <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
     <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
   </languages>
   <imports>
@@ -257,10 +260,23 @@
       <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
+        <child id="1153944400369" name="variable" index="2Gsz3X" />
+        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
+      </concept>
+      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
+        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
+      </concept>
+      <concept id="1227022210526" name="jetbrains.mps.baseLanguage.collections.structure.ClearAllElementsOperation" flags="nn" index="2Kehj3" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
@@ -2160,6 +2176,258 @@
                 <node concept="2qgKlT" id="4opGcINclsz" role="2OqNvi">
                   <ref role="37wK5l" to="nu60:1qrYg08iahZ" resolve="effectiveMembers" />
                 </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="4ZbdskR3yMO">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="1M2myG" to="yv47:4ZbdskR3wqq" resolve="EmptyTupleMember" />
+    <node concept="EnEH3" id="4ZbdskR3yMP" role="1MhHOB">
+      <ref role="EomxK" to="tpck:h0TrG11" resolve="name" />
+      <node concept="Eqf_E" id="4ZbdskR3yTm" role="EtsB7">
+        <node concept="3clFbS" id="4ZbdskR3yTn" role="2VODD2">
+          <node concept="3clFbF" id="4ZbdskR3yVF" role="3cqZAp">
+            <node concept="3cpWs3" id="4ZbdskR3zkv" role="3clFbG">
+              <node concept="2OqwBi" id="4ZbdskR3zKd" role="3uHU7w">
+                <node concept="EsrRn" id="4ZbdskR3zl3" role="2Oq$k0" />
+                <node concept="2bSWHS" id="4ZbdskR3$l_" role="2OqNvi" />
+              </node>
+              <node concept="Xl_RD" id="4ZbdskR3yVE" role="3uHU7B">
+                <property role="Xl_RC" value="___empty_" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="4ZbdskRDI3k">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="1M2myG" to="yv47:4ZbdskRDH_N" resolve="TupleMemberSetter" />
+    <node concept="1N5Pfh" id="4ZbdskRDI3l" role="1Mr941">
+      <ref role="1N5Vy1" to="yv47:4ZbdskRDH_O" resolve="member" />
+      <node concept="3dgokm" id="4ZbdskRDI5d" role="1N6uqs">
+        <node concept="3clFbS" id="4ZbdskRDI5e" role="2VODD2">
+          <node concept="3clFbF" id="4ZbdskRDI9w" role="3cqZAp">
+            <node concept="2YIFZM" id="4ZbdskRDIfa" role="3clFbG">
+              <ref role="37wK5l" to="o8zo:4IP40Bi3eAf" resolve="forNamedElements" />
+              <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+              <node concept="2OqwBi" id="4ZbdskRDKlA" role="37wK5m">
+                <node concept="2OqwBi" id="4ZbdskRDJ6a" role="2Oq$k0">
+                  <node concept="2OqwBi" id="4ZbdskRDIqU" role="2Oq$k0">
+                    <node concept="2rP1CM" id="4ZbdskRDIj$" role="2Oq$k0" />
+                    <node concept="2Xjw5R" id="4ZbdskRDIzW" role="2OqNvi">
+                      <node concept="1xMEDy" id="4ZbdskRDIzY" role="1xVPHs">
+                        <node concept="chp4Y" id="4ZbdskRDIF_" role="ri$Ld">
+                          <ref role="cht4Q" to="yv47:4ZbdskRDGLl" resolve="NamedTupleValue" />
+                        </node>
+                      </node>
+                      <node concept="1xIGOp" id="4ZbdskRDITe" role="1xVPHs" />
+                    </node>
+                  </node>
+                  <node concept="3TrEf2" id="4ZbdskRDJWI" role="2OqNvi">
+                    <ref role="3Tt5mk" to="yv47:4ZbdskRDJtl" resolve="tuple" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4ZbdskRDKAB" role="2OqNvi">
+                  <ref role="37wK5l" to="nu60:4ZbdskRgmME" resolve="nonEmptyMembers" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="4ZbdskSg1G7">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="1M2myG" to="yv47:4ZbdskRgKyK" resolve="TupleNamedAccessExpr" />
+    <node concept="9S07l" id="4ZbdskSg1G8" role="9Vyp8">
+      <node concept="3clFbS" id="4ZbdskSg1G9" role="2VODD2">
+        <node concept="3clFbF" id="6b_jefnKylm" role="3cqZAp">
+          <node concept="2OqwBi" id="6b_jefnKyln" role="3clFbG">
+            <node concept="1PxgMI" id="6b_jefnKylo" role="2Oq$k0">
+              <node concept="nLn13" id="6b_jefnKylp" role="1m5AlR" />
+              <node concept="chp4Y" id="6b_jefnKyoa" role="3oSUPX">
+                <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="6b_jefnKylq" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:5WNmJ7DokMG" resolve="expectType" />
+              <node concept="35c_gC" id="6b_jefnKylr" role="37wK5m">
+                <ref role="35c_gD" to="yv47:4ZbdskRgu$y" resolve="NamedTupleType" />
+              </node>
+              <node concept="3clFbT" id="6b_jefnKyls" role="37wK5m">
+                <property role="3clFbU" value="false" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1N5Pfh" id="672JozXQ06l" role="1Mr941">
+      <ref role="1N5Vy1" to="yv47:4ZbdskRgN6H" resolve="member" />
+      <node concept="3dgokm" id="672JozXQ0aj" role="1N6uqs">
+        <node concept="3clFbS" id="672JozXQ0al" role="2VODD2">
+          <node concept="3cpWs8" id="1F1F0IUZAom" role="3cqZAp">
+            <node concept="3cpWsn" id="1F1F0IUZAon" role="3cpWs9">
+              <property role="TrG5h" value="t" />
+              <node concept="3Tqbb2" id="1F1F0IUZAoo" role="1tU5fm" />
+              <node concept="2OqwBi" id="1F1F0IUZAop" role="33vP2m">
+                <node concept="2OqwBi" id="1F1F0IUZAoq" role="2Oq$k0">
+                  <node concept="1PxgMI" id="1F1F0IUZAor" role="2Oq$k0">
+                    <node concept="chp4Y" id="1F1F0IUZAos" role="3oSUPX">
+                      <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+                    </node>
+                    <node concept="1eOMI4" id="1F1F0IUZApJ" role="1m5AlR">
+                      <node concept="3K4zz7" id="1F1F0IUZApK" role="1eOMHV">
+                        <node concept="2rP1CM" id="1F1F0IUZApL" role="3K4E3e" />
+                        <node concept="2OqwBi" id="1F1F0IUZApM" role="3K4Cdx">
+                          <node concept="3kakTB" id="1F1F0IUZApN" role="2Oq$k0" />
+                          <node concept="3w_OXm" id="1F1F0IUZApO" role="2OqNvi" />
+                        </node>
+                        <node concept="2OqwBi" id="1F1F0IUZApP" role="3K4GZi">
+                          <node concept="3kakTB" id="1F1F0IUZApQ" role="2Oq$k0" />
+                          <node concept="1mfA1w" id="1F1F0IUZApR" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3TrEf2" id="1F1F0IUZAou" role="2OqNvi">
+                    <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                  </node>
+                </node>
+                <node concept="3JvlWi" id="1F1F0IUZAov" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="672JozXQ0eJ" role="3cqZAp">
+            <node concept="2YIFZM" id="672JozXQ0kp" role="3clFbG">
+              <ref role="37wK5l" to="o8zo:4IP40Bi3eAf" resolve="forNamedElements" />
+              <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+              <node concept="2OqwBi" id="672JozXQ1Af" role="37wK5m">
+                <node concept="2OqwBi" id="672JozXQ0EM" role="2Oq$k0">
+                  <node concept="1PxgMI" id="672JozXQAtN" role="2Oq$k0">
+                    <property role="1BlNFB" value="true" />
+                    <node concept="chp4Y" id="672JozXQAH6" role="3oSUPX">
+                      <ref role="cht4Q" to="yv47:4ZbdskRgu$y" resolve="NamedTupleType" />
+                    </node>
+                    <node concept="37vLTw" id="672JozXSsfV" role="1m5AlR">
+                      <ref role="3cqZAo" node="1F1F0IUZAon" resolve="t" />
+                    </node>
+                  </node>
+                  <node concept="3TrEf2" id="672JozXQBtf" role="2OqNvi">
+                    <ref role="3Tt5mk" to="yv47:4ZbdskRgu_6" resolve="tuple" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="672JozXQ2jS" role="2OqNvi">
+                  <ref role="37wK5l" to="nu60:4ZbdskRgmME" resolve="nonEmptyMembers" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="4ZbdskS2ULW">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="1M2myG" to="yv47:4ZbdskRDGLl" resolve="NamedTupleValue" />
+    <node concept="1N5Pfh" id="4ZbdskS2ULX" role="1Mr941">
+      <ref role="1N5Vy1" to="yv47:4ZbdskRDJtl" resolve="tuple" />
+      <node concept="3dgokm" id="4ZbdskS2UNP" role="1N6uqs">
+        <node concept="3clFbS" id="4ZbdskS2UNQ" role="2VODD2">
+          <node concept="3clFbF" id="672JozWmCPy" role="3cqZAp">
+            <node concept="2YIFZM" id="672JozWmCPz" role="3clFbG">
+              <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
+              <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+              <node concept="2OqwBi" id="672JozWmCP$" role="37wK5m">
+                <node concept="2OqwBi" id="672JozWmCP_" role="2Oq$k0">
+                  <node concept="2OqwBi" id="672JozWmCPA" role="2Oq$k0">
+                    <node concept="2rP1CM" id="672JozWmCPB" role="2Oq$k0" />
+                    <node concept="2Xjw5R" id="672JozWmCPC" role="2OqNvi">
+                      <node concept="1xMEDy" id="672JozWmCPD" role="1xVPHs">
+                        <node concept="chp4Y" id="672JozWmCPE" role="ri$Ld">
+                          <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="672JozWmCPF" role="2OqNvi">
+                    <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
+                    <node concept="3TUQnm" id="672JozWmCPG" role="37wK5m">
+                      <ref role="3TV0OU" to="yv47:4ZbdskR3pBE" resolve="NamedTupleDeclaration" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="v3k3i" id="672JozWmCPH" role="2OqNvi">
+                  <node concept="chp4Y" id="672JozWmCPI" role="v3oSu">
+                    <ref role="cht4Q" to="yv47:4ZbdskR3pBE" resolve="NamedTupleDeclaration" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3k9gUc" id="4ZbdskSd9U2" role="3kmjI7">
+        <node concept="3clFbS" id="4ZbdskSd9U3" role="2VODD2">
+          <node concept="3clFbF" id="4ZbdskSda3d" role="3cqZAp">
+            <node concept="2OqwBi" id="4ZbdskSdcdy" role="3clFbG">
+              <node concept="2OqwBi" id="4ZbdskSdafq" role="2Oq$k0">
+                <node concept="3kakTB" id="4ZbdskSda3c" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="4ZbdskSdaxY" role="2OqNvi">
+                  <ref role="3TtcxE" to="yv47:4ZbdskRDGMh" resolve="setters" />
+                </node>
+              </node>
+              <node concept="2Kehj3" id="4ZbdskSddAQ" role="2OqNvi" />
+            </node>
+          </node>
+          <node concept="2Gpval" id="4ZbdskSdnmo" role="3cqZAp">
+            <node concept="2GrKxI" id="4ZbdskSdnmq" role="2Gsz3X">
+              <property role="TrG5h" value="member" />
+            </node>
+            <node concept="3clFbS" id="4ZbdskSdnmu" role="2LFqv$">
+              <node concept="3clFbF" id="4ZbdskSdpOg" role="3cqZAp">
+                <node concept="2OqwBi" id="4ZbdskSds1N" role="3clFbG">
+                  <node concept="2OqwBi" id="4ZbdskSdq0w" role="2Oq$k0">
+                    <node concept="3kakTB" id="4ZbdskSdpOf" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="4ZbdskSdqj2" role="2OqNvi">
+                      <ref role="3TtcxE" to="yv47:4ZbdskRDGMh" resolve="setters" />
+                    </node>
+                  </node>
+                  <node concept="TSZUe" id="4ZbdskSdto2" role="2OqNvi">
+                    <node concept="2pJPEk" id="4ZbdskSdt$1" role="25WWJ7">
+                      <node concept="2pJPED" id="4ZbdskSdt$3" role="2pJPEn">
+                        <ref role="2pJxaS" to="yv47:4ZbdskRDH_N" resolve="TupleMemberSetter" />
+                        <node concept="2pIpSj" id="4ZbdskSdtY5" role="2pJxcM">
+                          <ref role="2pIpSl" to="yv47:4ZbdskRDH_O" resolve="member" />
+                          <node concept="36biLy" id="4ZbdskSdu54" role="28nt2d">
+                            <node concept="2GrUjf" id="4ZbdskSdu5n" role="36biLW">
+                              <ref role="2Gs0qQ" node="4ZbdskSdnmq" resolve="member" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2pIpSj" id="4ZbdskSdugT" role="2pJxcM">
+                          <ref role="2pIpSl" to="yv47:672JozWmCHZ" resolve="value" />
+                          <node concept="2pJPED" id="4ZbdskSdyw0" role="28nt2d">
+                            <ref role="2pJxaS" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4ZbdskSdkn6" role="2GsD0m">
+              <node concept="3khVwk" id="4ZbdskSd9WA" role="2Oq$k0" />
+              <node concept="2qgKlT" id="4ZbdskSdkq9" role="2OqNvi">
+                <ref role="37wK5l" to="nu60:4ZbdskRgmME" resolve="nonEmptyMembers" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -5165,6 +5165,21 @@
         </node>
       </node>
     </node>
+    <node concept="3EZMnI" id="7yOFqurLn4g" role="6VMZX">
+      <node concept="2iRfu4" id="7yOFqurLn4h" role="2iSdaV" />
+      <node concept="3F0ifn" id="7yOFqurLmOD" role="3EZMnx">
+        <property role="3F0ifm" value="tuple declaration:" />
+      </node>
+      <node concept="1iCGBv" id="7yOFqurLn6D" role="3EZMnx">
+        <ref role="1NtTu8" to="yv47:4ZbdskRgu_6" resolve="tuple" />
+        <node concept="1sVBvm" id="7yOFqurLn6F" role="1sWHZn">
+          <node concept="3F0A7n" id="7yOFqurLn6N" role="2wV5jI">
+            <property role="1Intyy" value="true" />
+            <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="24kQdi" id="4ZbdskRDH_Z">
     <property role="3GE5qa" value="tuples" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -37,8 +37,8 @@
     <import index="q4oi" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellActions(MPS.Editor/)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="hox0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.style(MPS.Editor/)" />
+    <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
     <import index="i6kd" ref="r:2261c766-d7b6-49d7-91bd-1207e471af0b(org.iets3.core.expr.lambda.editor)" implicit="true" />
-    <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
@@ -231,6 +231,9 @@
         <property id="1140017977771" name="readOnly" index="1Intyy" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
+      <concept id="7991336459489871999" name="jetbrains.mps.lang.editor.structure.IOutputConceptSubstituteMenuPart" flags="ng" index="3EoQpk">
+        <reference id="7991336459489872009" name="outputConcept" index="3EoQqy" />
+      </concept>
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
         <property id="1130859485024" name="attractsFocus" index="1cu_pB" />
         <reference id="1081339532145" name="keyMap" index="34QXea" />
@@ -295,6 +298,7 @@
       <concept id="1198256887712" name="jetbrains.mps.lang.editor.structure.CellModel_Indent" flags="ng" index="3XFhqQ" />
       <concept id="8428109087107030357" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_ReferenceScope" flags="ng" index="3XHNnq">
         <reference id="8428109087107339113" name="reference" index="3XGfJA" />
+        <child id="1154858122099170744" name="visibleMatchingTextFunction" index="3PHfNJ" />
         <child id="4307758654694904293" name="matchingTextFunction" index="1WZ6D9" />
       </concept>
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
@@ -538,10 +542,13 @@
       <concept id="6202678563380238499" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_GetElements" flags="ig" index="s8sZD" />
       <concept id="6202678563380233810" name="com.mbeddr.mpsutil.editor.querylist.structure.CellModel_QueryList" flags="ng" index="s8t4o">
         <property id="730823979356023502" name="duplicatesSafe" index="28Zw97" />
+        <property id="1140524450557" name="separatorText" index="2czwfP" />
         <reference id="730823979350682502" name="elementsConcept" index="28F8cf" />
         <child id="1140524464360" name="cellLayout" index="2czzBy" />
         <child id="6202678563380433923" name="query" index="sbcd9" />
+        <child id="7238779735251877228" name="editorComponent" index="1yzFaX" />
       </concept>
+      <concept id="7238779735251712681" name="com.mbeddr.mpsutil.editor.querylist.structure.QueryListInlineEditorComponent" flags="ig" index="1yz3lS" />
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
       <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
@@ -4891,6 +4898,364 @@
         <node concept="3F0A7n" id="3sWKo0E1oBl" role="2wV5jI">
           <property role="1Intyy" value="true" />
           <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="4ZbdskR3yCh">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="1XX52x" to="yv47:4ZbdskR3wqq" resolve="EmptyTupleMember" />
+    <node concept="3F0ifn" id="4ZbdskR3yCj" role="2wV5jI">
+      <property role="3F0ifm" value="" />
+      <node concept="VPxyj" id="4ZbdskR3yCk" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
+    </node>
+  </node>
+  <node concept="22mcaB" id="4ZbdskR3yCL">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="aqKnT" to="yv47:4ZbdskR3wqq" resolve="EmptyTupleMember" />
+    <node concept="22hDWj" id="4ZbdskR3yCM" role="22hAXT" />
+  </node>
+  <node concept="24kQdi" id="4ZbdskR3$YD">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="1XX52x" to="yv47:4ZbdskR3$vC" resolve="TupleMember" />
+    <node concept="3EZMnI" id="4ZbdskR3$YF" role="2wV5jI">
+      <node concept="2iRfu4" id="4ZbdskR3$YG" role="2iSdaV" />
+      <node concept="1kIj98" id="4ZbdskR3$YH" role="3EZMnx">
+        <node concept="3F0A7n" id="4ZbdskR3$YI" role="1kIj9b">
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+          <node concept="OXEIz" id="4ZbdskR3$YJ" role="P5bDN">
+            <node concept="PvTIS" id="4ZbdskR3$YK" role="OY2wv">
+              <node concept="MLZmj" id="4ZbdskR3$YL" role="PvTIR">
+                <node concept="3clFbS" id="4ZbdskR3$YM" role="2VODD2">
+                  <node concept="3clFbF" id="4ZbdskR3$YN" role="3cqZAp">
+                    <node concept="2YIFZM" id="4ZbdskR3$YO" role="3clFbG">
+                      <ref role="1Pybhc" to="oq0c:UwUtc1nzGQ" resolve="NC" />
+                      <ref role="37wK5l" to="oq0c:UwUtc1okvZ" resolve="proposals" />
+                      <node concept="3GMtW1" id="4ZbdskR3$YP" role="37wK5m" />
+                      <node concept="2OqwBi" id="4ZbdskR3$YQ" role="37wK5m">
+                        <node concept="3GMtW1" id="4ZbdskR3$YR" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="4ZbdskR3$YS" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="4ZbdskR3$YT" role="3EZMnx">
+        <property role="3F0ifm" value=":" />
+      </node>
+      <node concept="3F1sOY" id="4ZbdskR3$YU" role="3EZMnx">
+        <ref role="1NtTu8" to="hm2y:7D7uZV2iYAD" resolve="type" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="4ZbdskRgeiZ">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="1XX52x" to="yv47:4ZbdskR3pBE" resolve="NamedTupleDeclaration" />
+    <node concept="3EZMnI" id="4ZbdskRgej1" role="2wV5jI">
+      <property role="S$Qs1" value="true" />
+      <node concept="2iRkQZ" id="4ZbdskRgej2" role="2iSdaV" />
+      <node concept="3EZMnI" id="4ZbdskRgej3" role="3EZMnx">
+        <node concept="3F0ifn" id="4ZbdskRgeja" role="3EZMnx">
+          <property role="3F0ifm" value="named tuple" />
+          <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
+        </node>
+        <node concept="3F0A7n" id="4ZbdskRgejb" role="3EZMnx">
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+          <node concept="OXEIz" id="4ZbdskRgejc" role="P5bDN">
+            <node concept="PvTIS" id="4ZbdskRgejd" role="OY2wv">
+              <node concept="MLZmj" id="4ZbdskRgeje" role="PvTIR">
+                <node concept="3clFbS" id="4ZbdskRgejf" role="2VODD2">
+                  <node concept="3clFbF" id="4ZbdskRgejg" role="3cqZAp">
+                    <node concept="2YIFZM" id="4ZbdskRgejh" role="3clFbG">
+                      <ref role="37wK5l" to="oq0c:UwUtc1okvZ" resolve="proposals" />
+                      <ref role="1Pybhc" to="oq0c:UwUtc1nzGQ" resolve="NC" />
+                      <node concept="3GMtW1" id="4ZbdskRgeji" role="37wK5m" />
+                      <node concept="2OqwBi" id="4ZbdskRgejj" role="37wK5m">
+                        <node concept="3GMtW1" id="4ZbdskRgejk" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="4ZbdskRgejl" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3F0ifn" id="4ZbdskRgejm" role="3EZMnx">
+          <property role="3F0ifm" value="{" />
+        </node>
+        <node concept="2iRfu4" id="4ZbdskRgejn" role="2iSdaV" />
+      </node>
+      <node concept="3EZMnI" id="4ZbdskRgejo" role="3EZMnx">
+        <node concept="VPM3Z" id="4ZbdskRgejp" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+        <node concept="3XFhqQ" id="4ZbdskRgejq" role="3EZMnx" />
+        <node concept="3F2HdR" id="4ZbdskRgejr" role="3EZMnx">
+          <ref role="1NtTu8" to="yv47:4ZbdskRgjgF" resolve="members" />
+          <node concept="2EHx9g" id="4ZbdskRgejs" role="2czzBx" />
+          <node concept="3F0ifn" id="4ZbdskRgejt" role="2czzBI">
+            <property role="3F0ifm" value="" />
+            <node concept="VPxyj" id="4ZbdskRgeju" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2iRfu4" id="4ZbdskRgejv" role="2iSdaV" />
+      </node>
+      <node concept="3EZMnI" id="4ZbdskRgejw" role="3EZMnx">
+        <node concept="VPM3Z" id="4ZbdskRgejx" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+        <node concept="3F0ifn" id="4ZbdskRgejy" role="3EZMnx">
+          <property role="3F0ifm" value="}" />
+          <node concept="pVoyu" id="4ZbdskRgejz" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+            <node concept="3nzxsE" id="4ZbdskRgej$" role="3n$kyP">
+              <node concept="3clFbS" id="4ZbdskRgej_" role="2VODD2">
+                <node concept="3clFbF" id="4ZbdskRgejA" role="3cqZAp">
+                  <node concept="3eOSWO" id="4ZbdskRgejB" role="3clFbG">
+                    <node concept="3cmrfG" id="4ZbdskRgejC" role="3uHU7w">
+                      <property role="3cmrfH" value="1" />
+                    </node>
+                    <node concept="2OqwBi" id="4ZbdskRgejD" role="3uHU7B">
+                      <node concept="2OqwBi" id="4ZbdskRgejE" role="2Oq$k0">
+                        <node concept="pncrf" id="4ZbdskRgejF" role="2Oq$k0" />
+                        <node concept="3Tsc0h" id="4ZbdskRgejG" role="2OqNvi">
+                          <ref role="3TtcxE" to="yv47:4ZbdskRgjgF" resolve="members" />
+                        </node>
+                      </node>
+                      <node concept="34oBXx" id="4ZbdskRgejH" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2iRfu4" id="4ZbdskRgek5" role="2iSdaV" />
+      </node>
+      <node concept="3EZMnI" id="4ZbdskRgek6" role="AHCbl">
+        <node concept="3F0ifn" id="4ZbdskRgekd" role="3EZMnx">
+          <property role="3F0ifm" value="named tuple" />
+          <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
+        </node>
+        <node concept="3F0A7n" id="4ZbdskRgeke" role="3EZMnx">
+          <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+          <node concept="OXEIz" id="4ZbdskRgekf" role="P5bDN">
+            <node concept="PvTIS" id="4ZbdskRgekg" role="OY2wv">
+              <node concept="MLZmj" id="4ZbdskRgekh" role="PvTIR">
+                <node concept="3clFbS" id="4ZbdskRgeki" role="2VODD2">
+                  <node concept="3clFbF" id="4ZbdskRgekj" role="3cqZAp">
+                    <node concept="2YIFZM" id="4ZbdskRgekk" role="3clFbG">
+                      <ref role="37wK5l" to="oq0c:UwUtc1okvZ" resolve="proposals" />
+                      <ref role="1Pybhc" to="oq0c:UwUtc1nzGQ" resolve="NC" />
+                      <node concept="3GMtW1" id="4ZbdskRgekl" role="37wK5m" />
+                      <node concept="2OqwBi" id="4ZbdskRgekm" role="37wK5m">
+                        <node concept="3GMtW1" id="4ZbdskRgekn" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="4ZbdskRgeko" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3F0ifn" id="4ZbdskRgekp" role="3EZMnx">
+          <property role="3F0ifm" value="{..}" />
+        </node>
+        <node concept="2iRfu4" id="4ZbdskRgekq" role="2iSdaV" />
+        <node concept="VPM3Z" id="4ZbdskRgekr" role="3F10Kt">
+          <property role="VOm3f" value="false" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="4ZbdskRgu$E">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="1XX52x" to="yv47:4ZbdskRgu$y" resolve="NamedTupleType" />
+    <node concept="3EZMnI" id="4ZbdskS_75W" role="2wV5jI">
+      <node concept="2iRfu4" id="4ZbdskS_75X" role="2iSdaV" />
+      <node concept="3F0ifn" id="4ZbdskS_75Y" role="3EZMnx">
+        <property role="3F0ifm" value="[" />
+        <node concept="11LMrY" id="4ZbdskS_75Z" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="OXEIz" id="4ZbdskS_760" role="P5bDN">
+          <node concept="UkePV" id="4ZbdskS_761" role="OY2wv">
+            <ref role="Ul1FP" to="hm2y:6sdnDbSlaok" resolve="Type" />
+          </node>
+        </node>
+      </node>
+      <node concept="s8t4o" id="4ZbdskS_76y" role="3EZMnx">
+        <property role="28Zw97" value="true" />
+        <property role="2czwfP" value="," />
+        <ref role="28F8cf" to="yv47:4ZbdskR3pBF" resolve="ITupleMember" />
+        <node concept="xShMh" id="4ZbdskS_76$" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="s8sZD" id="4ZbdskS_76_" role="sbcd9">
+          <node concept="3clFbS" id="4ZbdskS_76A" role="2VODD2">
+            <node concept="3clFbF" id="4ZbdskS_78U" role="3cqZAp">
+              <node concept="2OqwBi" id="4ZbdskS_8oP" role="3clFbG">
+                <node concept="2OqwBi" id="4ZbdskS_7nx" role="2Oq$k0">
+                  <node concept="pncrf" id="4ZbdskS_78T" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4ZbdskS_7DJ" role="2OqNvi">
+                    <ref role="3Tt5mk" to="yv47:4ZbdskRgu_6" resolve="tuple" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4ZbdskS_8yF" role="2OqNvi">
+                  <ref role="37wK5l" to="nu60:4ZbdskRgmME" resolve="nonEmptyMembers" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1yz3lS" id="4ZbdskS_8RO" role="1yzFaX">
+          <node concept="3EZMnI" id="4ZbdskS_9c9" role="2wV5jI">
+            <node concept="2iRfu4" id="4ZbdskS_9ca" role="2iSdaV" />
+            <node concept="3F0A7n" id="4ZbdskS_970" role="3EZMnx">
+              <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+            </node>
+            <node concept="3F0ifn" id="4ZbdskS_9ci" role="3EZMnx">
+              <property role="3F0ifm" value=":" />
+            </node>
+            <node concept="1HlG4h" id="4ZbdskS_9cq" role="3EZMnx">
+              <ref role="1k5W1q" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
+              <node concept="1HfYo3" id="4ZbdskS_9cs" role="1HlULh">
+                <node concept="3TQlhw" id="4ZbdskS_9cu" role="1Hhtcw">
+                  <node concept="3clFbS" id="4ZbdskS_9cw" role="2VODD2">
+                    <node concept="3clFbF" id="4ZbdskS_9hf" role="3cqZAp">
+                      <node concept="2OqwBi" id="4ZbdskS_aoM" role="3clFbG">
+                        <node concept="2OqwBi" id="4ZbdskS_9$p" role="2Oq$k0">
+                          <node concept="pncrf" id="4ZbdskS_9he" role="2Oq$k0" />
+                          <node concept="2qgKlT" id="4ZbdskS_a5_" role="2OqNvi">
+                            <ref role="37wK5l" to="pbu6:4WLweXm3SW5" resolve="type" />
+                          </node>
+                        </node>
+                        <node concept="2qgKlT" id="4ZbdskS_aSp" role="2OqNvi">
+                          <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="4ZbdskS_766" role="3EZMnx">
+        <property role="3F0ifm" value="]" />
+        <node concept="11L4FC" id="4ZbdskS_767" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="4ZbdskRDH_Z">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="1XX52x" to="yv47:4ZbdskRDH_N" resolve="TupleMemberSetter" />
+    <node concept="3EZMnI" id="672JozWmCKX" role="2wV5jI">
+      <node concept="1iCGBv" id="672JozWmCKY" role="3EZMnx">
+        <ref role="1NtTu8" to="yv47:4ZbdskRDH_O" resolve="member" />
+        <node concept="1sVBvm" id="672JozWmCKZ" role="1sWHZn">
+          <node concept="3F0A7n" id="672JozWmCL0" role="2wV5jI">
+            <property role="1Intyy" value="true" />
+            <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="4ZbdskSaz9J" role="3EZMnx">
+        <property role="3F0ifm" value="-&gt;" />
+      </node>
+      <node concept="3F1sOY" id="672JozWmCL1" role="3EZMnx">
+        <ref role="1NtTu8" to="yv47:672JozWmCHZ" resolve="value" />
+      </node>
+      <node concept="2iRfu4" id="672JozWmCL2" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="4ZbdskRgN6R">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="1XX52x" to="yv47:4ZbdskRgKyK" resolve="TupleNamedAccessExpr" />
+    <node concept="3EZMnI" id="4ZbdskSg3Td" role="2wV5jI">
+      <node concept="2iRfu4" id="4ZbdskSg3Te" role="2iSdaV" />
+      <node concept="1iCGBv" id="4ZbdskRgN_n" role="3EZMnx">
+        <ref role="1NtTu8" to="yv47:4ZbdskRgN6H" resolve="member" />
+        <node concept="1sVBvm" id="4ZbdskRgN_p" role="1sWHZn">
+          <node concept="3F0A7n" id="4ZbdskRgNIO" role="2wV5jI">
+            <property role="1Intyy" value="true" />
+            <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="22mcaB" id="4ZbdskS30xj">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="aqKnT" to="yv47:4ZbdskRDGLl" resolve="NamedTupleValue" />
+    <node concept="22hDWj" id="4ZbdskS30xk" role="22hAXT" />
+    <node concept="3XHNnq" id="4ZbdskS30xm" role="3ft7WO">
+      <ref role="3XGfJA" to="yv47:4ZbdskRDJtl" resolve="tuple" />
+      <ref role="3EoQqy" to="yv47:4ZbdskRDGLl" resolve="NamedTupleValue" />
+      <node concept="1WAQ3h" id="4ZbdskS30xq" role="3PHfNJ">
+        <node concept="3clFbS" id="4ZbdskS30xs" role="2VODD2">
+          <node concept="3clFbF" id="4ZbdskS30A7" role="3cqZAp">
+            <node concept="3cpWs3" id="4ZbdskS32pD" role="3clFbG">
+              <node concept="Xl_RD" id="4ZbdskS32qp" role="3uHU7w">
+                <property role="Xl_RC" value=" [" />
+              </node>
+              <node concept="2OqwBi" id="4ZbdskS314l" role="3uHU7B">
+                <node concept="1WAUZh" id="4ZbdskS30A6" role="2Oq$k0" />
+                <node concept="3TrcHB" id="4ZbdskS31Vn" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="4ZbdskS83Bf">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="1XX52x" to="yv47:4ZbdskRDGLl" resolve="NamedTupleValue" />
+    <node concept="3EZMnI" id="4ZbdskS83Bh" role="2wV5jI">
+      <node concept="2iRfu4" id="4ZbdskS83Bi" role="2iSdaV" />
+      <node concept="3F0ifn" id="4ZbdskS83Bj" role="3EZMnx">
+        <property role="3F0ifm" value="[" />
+        <node concept="11LMrY" id="4ZbdskS83Bk" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F2HdR" id="4ZbdskS83Bl" role="3EZMnx">
+        <property role="2czwfO" value="," />
+        <ref role="1NtTu8" to="yv47:4ZbdskRDGMh" resolve="setters" />
+        <node concept="2iRfu4" id="4ZbdskS83Bm" role="2czzBx" />
+        <node concept="3F0ifn" id="4ZbdskS83Bn" role="2czzBI">
+          <property role="3F0ifm" value="" />
+          <node concept="VPxyj" id="4ZbdskS83Bo" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="4ZbdskS83Bp" role="3EZMnx">
+        <property role="3F0ifm" value="]" />
+        <node concept="11L4FC" id="4ZbdskS83Bq" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/structure.mps
@@ -1267,5 +1267,188 @@
       <ref role="20lvS9" node="xu7xcKdQCB" resolve="IRecordMember" />
     </node>
   </node>
+  <node concept="1TIwiD" id="4ZbdskR3pBE">
+    <property role="EcuMT" value="5749748470417037802" />
+    <property role="TrG5h" value="NamedTupleDeclaration" />
+    <property role="3GE5qa" value="tuples" />
+    <property role="34LRSv" value="named tuple" />
+    <ref role="1TJDcQ" node="7zXSNv$jGoK" resolve="AbstractTypeDeclaration" />
+    <node concept="PrWs8" id="4ZbdskRgjgH" role="PzmwI">
+      <ref role="PrY4T" node="4ZbdskRggS1" resolve="ITupleDeclaration" />
+    </node>
+  </node>
+  <node concept="PlHQZ" id="4ZbdskR3pBF">
+    <property role="EcuMT" value="5749748470417037803" />
+    <property role="3GE5qa" value="tuples" />
+    <property role="TrG5h" value="ITupleMember" />
+    <node concept="PrWs8" id="4ZbdskR3pBG" role="PrDN$">
+      <ref role="PrY4T" to="lmd:6LLGpXJ1KSq" resolve="IMember" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskR3pBI" role="PrDN$">
+      <ref role="PrY4T" to="4kwy:cJpacq5T0O" resolve="IValidNamedConcept" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskR3pBL" role="PrDN$">
+      <ref role="PrY4T" to="hm2y:4WLweXm3SVw" resolve="ITypeable" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskR3pBP" role="PrDN$">
+      <ref role="PrY4T" to="vs0r:65XyadYMMYC" resolve="ICommentable" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskR3pBU" role="PrDN$">
+      <ref role="PrY4T" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskR3pC0" role="PrDN$">
+      <ref role="PrY4T" to="hm2y:4AahbtUNHrQ" resolve="IProgramLocationProvider" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="4ZbdskR3wqq">
+    <property role="EcuMT" value="5749748470417065626" />
+    <property role="3GE5qa" value="tuples" />
+    <property role="TrG5h" value="EmptyTupleMember" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="PrWs8" id="4ZbdskR3wqr" role="PzmwI">
+      <ref role="PrY4T" node="4ZbdskR3pBF" resolve="ITupleMember" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskR3wqt" role="PzmwI">
+      <ref role="PrY4T" to="tpck:2WmWrdnSpX3" resolve="ISuppressErrors" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskR3wqw" role="PzmwI">
+      <ref role="PrY4T" to="vs0r:Ug1QzfhXN3" resolve="IEmpty" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="4ZbdskR3$vC">
+    <property role="EcuMT" value="5749748470417082344" />
+    <property role="3GE5qa" value="tuples" />
+    <property role="TrG5h" value="TupleMember" />
+    <property role="R4oN_" value="a new member in this tuple" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="PrWs8" id="4ZbdskR3$zZ" role="PzmwI">
+      <ref role="PrY4T" node="4ZbdskR3pBF" resolve="ITupleMember" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskR3$$1" role="PzmwI">
+      <ref role="PrY4T" to="hm2y:68xoVn7qAL8" resolve="ITyped" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskR3$$4" role="PzmwI">
+      <ref role="PrY4T" to="vs0r:3m8H$lmFM60" resolve="IDocumentable" />
+    </node>
+  </node>
+  <node concept="PlHQZ" id="4ZbdskRggS1">
+    <property role="EcuMT" value="5749748470420409857" />
+    <property role="3GE5qa" value="tuples" />
+    <property role="TrG5h" value="ITupleDeclaration" />
+    <node concept="1TJgyj" id="4ZbdskRgjgF" role="1TKVEi">
+      <property role="IQ2ns" value="5749748470420419627" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="members" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="4ZbdskR3pBF" resolve="ITupleMember" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskRggS2" role="PrDN$">
+      <ref role="PrY4T" node="2uR5X5ayM7T" resolve="IToplevelExprContent" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskRggS4" role="PrDN$">
+      <ref role="PrY4T" to="vs0r:4qSf1u1TQeO" resolve="IContainerOfUniqueNames" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskRggSV" role="PrDN$">
+      <ref role="PrY4T" to="hm2y:5ElkanPUl6g" resolve="IDocumentableWordProvider" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskRgi5q" role="PrDN$">
+      <ref role="PrY4T" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskRgjgs" role="PrDN$">
+      <ref role="PrY4T" to="vs0r:59HbAIOYkEn" resolve="IDetectCycle" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskRgjgz" role="PrDN$">
+      <ref role="PrY4T" to="hm2y:5ElkanPUl6g" resolve="IDocumentableWordProvider" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskRggSZ" role="PrDN$">
+      <ref role="PrY4T" to="hm2y:4AahbtUNHrQ" resolve="IProgramLocationProvider" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="4ZbdskRgu$y">
+    <property role="EcuMT" value="5749748470420465954" />
+    <property role="3GE5qa" value="tuples" />
+    <property role="TrG5h" value="NamedTupleType" />
+    <property role="R4oN_" value="a n-nary named tuple type" />
+    <ref role="1TJDcQ" to="hm2y:6sdnDbSlaok" resolve="Type" />
+    <node concept="1TJgyj" id="4ZbdskRgu_6" role="1TKVEi">
+      <property role="IQ2ns" value="5749748470420465990" />
+      <property role="20kJfa" value="tuple" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="4ZbdskR3pBE" resolve="NamedTupleDeclaration" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskT0qly" role="PzmwI">
+      <ref role="PrY4T" to="hm2y:4ZbdskT0qlt" resolve="ITupleType" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="4ZbdskRDH_N">
+    <property role="EcuMT" value="5749748470427081075" />
+    <property role="3GE5qa" value="tuples" />
+    <property role="TrG5h" value="TupleMemberSetter" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="672JozWmCHZ" role="1TKVEi">
+      <property role="IQ2ns" value="5070313213710413816" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="value" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="hm2y:6sdnDbSla17" resolve="Expression" />
+    </node>
+    <node concept="1TJgyj" id="4ZbdskRDH_O" role="1TKVEi">
+      <property role="IQ2ns" value="5749748470427081076" />
+      <property role="20kJfa" value="member" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="4ZbdskR3pBF" resolve="ITupleMember" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="4ZbdskRgKyK">
+    <property role="EcuMT" value="5749748470420539568" />
+    <property role="3GE5qa" value="tuples" />
+    <property role="TrG5h" value="TupleNamedAccessExpr" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="4ZbdskRgN6H" role="1TKVEi">
+      <property role="IQ2ns" value="5749748470420550061" />
+      <property role="20kJfa" value="member" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="4ZbdskR3pBF" resolve="ITupleMember" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskSGpxN" role="PzmwI">
+      <ref role="PrY4T" to="hm2y:7NJy08a3O9a" resolve="IDotTarget" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskRgL2i" role="PzmwI">
+      <ref role="PrY4T" to="hm2y:6KxoTHgLv_I" resolve="IMayHaveEffect" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="4ZbdskRDGLl">
+    <property role="EcuMT" value="5749748470427077717" />
+    <property role="3GE5qa" value="tuples" />
+    <property role="TrG5h" value="NamedTupleValue" />
+    <property role="34LRSv" value="[" />
+    <property role="R4oN_" value="a n-ary named tuple value" />
+    <ref role="1TJDcQ" to="hm2y:6sdnDbSla17" resolve="Expression" />
+    <node concept="1TJgyj" id="4ZbdskRDJtl" role="1TKVEi">
+      <property role="IQ2ns" value="5749748470427088725" />
+      <property role="20kJfa" value="tuple" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="4ZbdskR3pBE" resolve="NamedTupleDeclaration" />
+    </node>
+    <node concept="1TJgyj" id="4ZbdskRDGMh" role="1TKVEi">
+      <property role="IQ2ns" value="5749748470427077777" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="setters" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="4ZbdskRDH_N" resolve="TupleMemberSetter" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskSW3CT" role="PzmwI">
+      <ref role="PrY4T" to="hm2y:4ZbdskSW2Ng" resolve="ITupleValue" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskRDGLm" role="PzmwI">
+      <ref role="PrY4T" to="hm2y:6KxoTHgLv_I" resolve="IMayHaveEffect" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskSdEpv" role="PzmwI">
+      <ref role="PrY4T" to="vs0r:4qSf1u1TQeO" resolve="IContainerOfUniqueNames" />
+    </node>
+    <node concept="PrWs8" id="4ZbdskRDGLo" role="PzmwI">
+      <ref role="PrY4T" to="hm2y:aPhVmWYjmk" resolve="ICanBeLValue" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/structure.mps
@@ -1272,6 +1272,7 @@
     <property role="TrG5h" value="NamedTupleDeclaration" />
     <property role="3GE5qa" value="tuples" />
     <property role="34LRSv" value="named tuple" />
+    <property role="R4oN_" value="a tuple declaration with named members" />
     <ref role="1TJDcQ" node="7zXSNv$jGoK" resolve="AbstractTypeDeclaration" />
     <node concept="PrWs8" id="4ZbdskRgjgH" role="PzmwI">
       <ref role="PrY4T" node="4ZbdskRggS1" resolve="ITupleDeclaration" />
@@ -1397,6 +1398,9 @@
       <property role="20kJfa" value="member" />
       <property role="20lbJX" value="fLJekj4/_1" />
       <ref role="20lvS9" node="4ZbdskR3pBF" resolve="ITupleMember" />
+    </node>
+    <node concept="PrWs8" id="7yOFqurE$VZ" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
     </node>
   </node>
   <node concept="1TIwiD" id="4ZbdskRgKyK">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/structure.mps
@@ -1305,7 +1305,7 @@
     <property role="EcuMT" value="5749748470417065626" />
     <property role="3GE5qa" value="tuples" />
     <property role="TrG5h" value="EmptyTupleMember" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="PrWs8" id="4ZbdskR3wqr" role="PzmwI">
       <ref role="PrY4T" node="4ZbdskR3pBF" resolve="ITupleMember" />
     </node>
@@ -1321,7 +1321,7 @@
     <property role="3GE5qa" value="tuples" />
     <property role="TrG5h" value="TupleMember" />
     <property role="R4oN_" value="a new member in this tuple" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="PrWs8" id="4ZbdskR3$zZ" role="PzmwI">
       <ref role="PrY4T" node="4ZbdskR3pBF" resolve="ITupleMember" />
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/typesystem.mps
@@ -4534,7 +4534,7 @@
                                 </node>
                                 <node concept="2OqwBi" id="7yOFqurG75p" role="3uHU7B">
                                   <node concept="37vLTw" id="7yOFqurG75q" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="7yOFqurG75s" resolve="it" />
+                                    <ref role="3cqZAo" node="7yOFqurG75s" resolve="setter" />
                                   </node>
                                   <node concept="3TrEf2" id="7yOFqurG75r" role="2OqNvi">
                                     <ref role="3Tt5mk" to="yv47:4ZbdskRDH_O" resolve="member" />
@@ -4765,7 +4765,7 @@
             <node concept="2OqwBi" id="7yOFqurKW3m" role="3uHU7w">
               <node concept="2OqwBi" id="7yOFqurKW3n" role="2Oq$k0">
                 <node concept="1YBJjd" id="7yOFqurKW3o" role="2Oq$k0">
-                  <ref role="1YBMHb" node="7yOFqurKW2U" resolve="tupleType" />
+                  <ref role="1YBMHb" node="7yOFqurKW2U" resolve="namedTupleType2" />
                 </node>
                 <node concept="2qgKlT" id="7yOFqurKXv2" role="2OqNvi">
                   <ref role="37wK5l" to="pbu6:4ZbdskT1yfk" resolve="getElementTypes" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/typesystem.mps
@@ -74,6 +74,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -362,6 +363,9 @@
       </concept>
       <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
       <concept id="5699792037748043353" name="jetbrains.mps.baseLanguage.collections.structure.TestAddElementOperation" flags="nn" index="2oyXjL" />
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
       <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
       <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
         <child id="1153944400369" name="variable" index="2Gsz3X" />
@@ -4485,6 +4489,324 @@
     <node concept="1YaCAy" id="4ZbdskSftn$" role="1YuTPh">
       <property role="TrG5h" value="ntv" />
       <ref role="1YaFvo" to="yv47:4ZbdskRDGLl" resolve="NamedTupleValue" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="7yOFqurFX6u">
+    <property role="TrG5h" value="check_NamedTupleValue" />
+    <property role="3GE5qa" value="tuples" />
+    <node concept="3clFbS" id="7yOFqurFX6v" role="18ibNy">
+      <node concept="3clFbF" id="7yOFqurFX6A" role="3cqZAp">
+        <node concept="2OqwBi" id="7yOFqurFZe1" role="3clFbG">
+          <node concept="2OqwBi" id="7yOFqurFY74" role="2Oq$k0">
+            <node concept="2OqwBi" id="7yOFqurFXkp" role="2Oq$k0">
+              <node concept="1YBJjd" id="7yOFqurFX6_" role="2Oq$k0">
+                <ref role="1YBMHb" node="7yOFqurFX6x" resolve="namedTupleValue" />
+              </node>
+              <node concept="3TrEf2" id="7yOFqurFXHH" role="2OqNvi">
+                <ref role="3Tt5mk" to="yv47:4ZbdskRDJtl" resolve="tuple" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="7yOFqurFYTd" role="2OqNvi">
+              <ref role="37wK5l" to="nu60:4ZbdskRgmME" resolve="nonEmptyMembers" />
+            </node>
+          </node>
+          <node concept="2es0OD" id="7yOFqurFZqE" role="2OqNvi">
+            <node concept="1bVj0M" id="7yOFqurFZqG" role="23t8la">
+              <node concept="3clFbS" id="7yOFqurFZqH" role="1bW5cS">
+                <node concept="3clFbJ" id="7yOFqurFZB0" role="3cqZAp">
+                  <node concept="3fqX7Q" id="7yOFqurG75d" role="3clFbw">
+                    <node concept="2OqwBi" id="7yOFqurG75f" role="3fr31v">
+                      <node concept="2OqwBi" id="7yOFqurG75g" role="2Oq$k0">
+                        <node concept="1YBJjd" id="7yOFqurG75h" role="2Oq$k0">
+                          <ref role="1YBMHb" node="7yOFqurFX6x" resolve="namedTupleValue" />
+                        </node>
+                        <node concept="3Tsc0h" id="7yOFqurG75i" role="2OqNvi">
+                          <ref role="3TtcxE" to="yv47:4ZbdskRDGMh" resolve="setters" />
+                        </node>
+                      </node>
+                      <node concept="2HwmR7" id="7yOFqurG75j" role="2OqNvi">
+                        <node concept="1bVj0M" id="7yOFqurG75k" role="23t8la">
+                          <node concept="3clFbS" id="7yOFqurG75l" role="1bW5cS">
+                            <node concept="3clFbF" id="7yOFqurG75m" role="3cqZAp">
+                              <node concept="17R0WA" id="7yOFqurG75n" role="3clFbG">
+                                <node concept="37vLTw" id="7yOFqurG75o" role="3uHU7w">
+                                  <ref role="3cqZAo" node="7yOFqurFZqI" resolve="it" />
+                                </node>
+                                <node concept="2OqwBi" id="7yOFqurG75p" role="3uHU7B">
+                                  <node concept="37vLTw" id="7yOFqurG75q" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="7yOFqurG75s" resolve="it" />
+                                  </node>
+                                  <node concept="3TrEf2" id="7yOFqurG75r" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="yv47:4ZbdskRDH_O" resolve="member" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="7yOFqurG75s" role="1bW2Oz">
+                            <property role="TrG5h" value="setter" />
+                            <node concept="2jxLKc" id="7yOFqurG75t" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="7yOFqurFZB2" role="3clFbx">
+                    <node concept="2MkqsV" id="7yOFqurG7p4" role="3cqZAp">
+                      <node concept="3cpWs3" id="7yOFqurG8km" role="2MkJ7o">
+                        <node concept="2OqwBi" id="7yOFqurG8Do" role="3uHU7w">
+                          <node concept="37vLTw" id="7yOFqurG8kt" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7yOFqurFZqI" resolve="it" />
+                          </node>
+                          <node concept="3TrcHB" id="7yOFqurG9ib" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                        <node concept="Xl_RD" id="7yOFqurG7rh" role="3uHU7B">
+                          <property role="Xl_RC" value="No value for member " />
+                        </node>
+                      </node>
+                      <node concept="1YBJjd" id="7yOFqurG9sG" role="1urrMF">
+                        <ref role="1YBMHb" node="7yOFqurFX6x" resolve="namedTupleValue" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="Rh6nW" id="7yOFqurFZqI" role="1bW2Oz">
+                <property role="TrG5h" value="it" />
+                <node concept="2jxLKc" id="7yOFqurFZqJ" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="7yOFqurFX6x" role="1YuTPh">
+      <property role="TrG5h" value="namedTupleValue" />
+      <ref role="1YaFvo" to="yv47:4ZbdskRDGLl" resolve="NamedTupleValue" />
+    </node>
+  </node>
+  <node concept="35pCF_" id="7yOFqurKiAl">
+    <property role="3GE5qa" value="tuples" />
+    <property role="TrG5h" value="NamedTupleComparableToTupleType" />
+    <node concept="1YaCAy" id="7yOFqurKiBZ" role="35pZ6h">
+      <property role="TrG5h" value="tupleType" />
+      <ref role="1YaFvo" to="hm2y:S$tO8ocniU" resolve="TupleType" />
+    </node>
+    <node concept="3clFbS" id="7yOFqurKiAn" role="2sgrp5">
+      <node concept="3cpWs8" id="7yOFqurKzjS" role="3cqZAp">
+        <node concept="3cpWsn" id="7yOFqurKzjV" role="3cpWs9">
+          <property role="TrG5h" value="index" />
+          <node concept="10Oyi0" id="7yOFqurKzjQ" role="1tU5fm" />
+          <node concept="3cmrfG" id="7yOFqurKzy5" role="33vP2m">
+            <property role="3cmrfH" value="0" />
+          </node>
+        </node>
+      </node>
+      <node concept="2Gpval" id="1ufrWYcM9SV" role="3cqZAp">
+        <node concept="2GrKxI" id="1ufrWYcM9SW" role="2Gsz3X">
+          <property role="TrG5h" value="e" />
+        </node>
+        <node concept="3clFbS" id="1ufrWYcM9SY" role="2LFqv$">
+          <node concept="1ZobV4" id="1ufrWYcMap8" role="3cqZAp">
+            <node concept="mw_s8" id="1ufrWYcMapB" role="1ZfhKB">
+              <node concept="2OqwBi" id="1ufrWYcMcvm" role="mwGJk">
+                <node concept="2OqwBi" id="1ufrWYcMawX" role="2Oq$k0">
+                  <node concept="1YBJjd" id="1ufrWYcMap_" role="2Oq$k0">
+                    <ref role="1YBMHb" node="7yOFqurKiBZ" resolve="tupleType" />
+                  </node>
+                  <node concept="3Tsc0h" id="1ufrWYcMaQn" role="2OqNvi">
+                    <ref role="3TtcxE" to="hm2y:S$tO8ocniV" resolve="elementTypes" />
+                  </node>
+                </node>
+                <node concept="34jXtK" id="1ufrWYcMfkM" role="2OqNvi">
+                  <node concept="3uNrnE" id="7yOFqurK$zR" role="25WWJ7">
+                    <node concept="37vLTw" id="7yOFqurK$zT" role="2$L3a6">
+                      <ref role="3cqZAo" node="7yOFqurKzjV" resolve="index" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="mw_s8" id="1ufrWYcMapb" role="1ZfhK$">
+              <node concept="2GrUjf" id="1ufrWYcMao_" role="mwGJk">
+                <ref role="2Gs0qQ" node="1ufrWYcM9SW" resolve="e" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2OqwBi" id="7yOFqurKuN4" role="2GsD0m">
+          <node concept="1YBJjd" id="7yOFqurKuz3" role="2Oq$k0">
+            <ref role="1YBMHb" node="7yOFqurKiAp" resolve="namedTupleType" />
+          </node>
+          <node concept="2qgKlT" id="7yOFqurKz3r" role="2OqNvi">
+            <ref role="37wK5l" to="pbu6:4ZbdskT1yfk" resolve="getElementTypes" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="7yOFqurKiAp" role="1YuTPh">
+      <property role="TrG5h" value="namedTupleType" />
+      <ref role="1YaFvo" to="yv47:4ZbdskRgu$y" resolve="NamedTupleType" />
+    </node>
+    <node concept="1xSnZT" id="7yOFqurKiCo" role="1xSnZW">
+      <node concept="3clFbS" id="7yOFqurKiCp" role="2VODD2">
+        <node concept="3clFbF" id="7yOFqurKiGw" role="3cqZAp">
+          <node concept="3clFbC" id="7yOFqurKmJ8" role="3clFbG">
+            <node concept="2OqwBi" id="7yOFqurKrqO" role="3uHU7w">
+              <node concept="2OqwBi" id="7yOFqurKnF2" role="2Oq$k0">
+                <node concept="1YBJjd" id="7yOFqurKnfB" role="2Oq$k0">
+                  <ref role="1YBMHb" node="7yOFqurKiBZ" resolve="tupleType" />
+                </node>
+                <node concept="3Tsc0h" id="7yOFqurKoHl" role="2OqNvi">
+                  <ref role="3TtcxE" to="hm2y:S$tO8ocniV" resolve="elementTypes" />
+                </node>
+              </node>
+              <node concept="34oBXx" id="7yOFqurKujS" role="2OqNvi" />
+            </node>
+            <node concept="2OqwBi" id="7yOFqurKlmS" role="3uHU7B">
+              <node concept="2OqwBi" id="7yOFqurKiYp" role="2Oq$k0">
+                <node concept="1YBJjd" id="7yOFqurKiGv" role="2Oq$k0">
+                  <ref role="1YBMHb" node="7yOFqurKiAp" resolve="namedTupleType" />
+                </node>
+                <node concept="2qgKlT" id="7yOFqurKxuz" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:4ZbdskT1yfk" resolve="getElementTypes" />
+                </node>
+              </node>
+              <node concept="34oBXx" id="7yOFqurKlNb" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="35pCF_" id="7yOFqurKW2T">
+    <property role="3GE5qa" value="tuples" />
+    <property role="TrG5h" value="NamedTupleComparableToNamedType" />
+    <node concept="1YaCAy" id="7yOFqurKW2U" role="35pZ6h">
+      <property role="TrG5h" value="namedTupleType2" />
+      <ref role="1YaFvo" to="yv47:4ZbdskRgu$y" resolve="NamedTupleType" />
+    </node>
+    <node concept="3clFbS" id="7yOFqurKW2V" role="2sgrp5">
+      <node concept="3cpWs8" id="7yOFqurKW2W" role="3cqZAp">
+        <node concept="3cpWsn" id="7yOFqurKW2X" role="3cpWs9">
+          <property role="TrG5h" value="index" />
+          <node concept="10Oyi0" id="7yOFqurKW2Y" role="1tU5fm" />
+          <node concept="3cmrfG" id="7yOFqurKW2Z" role="33vP2m">
+            <property role="3cmrfH" value="0" />
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="7yOFqurKZjz" role="3cqZAp">
+        <node concept="3cpWsn" id="7yOFqurKZj$" role="3cpWs9">
+          <property role="TrG5h" value="elementTypesOther" />
+          <node concept="_YKpA" id="7yOFqurKZi6" role="1tU5fm">
+            <node concept="3Tqbb2" id="7yOFqurKZi9" role="_ZDj9">
+              <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7yOFqurKZj_" role="33vP2m">
+            <node concept="1YBJjd" id="7yOFqurKZjA" role="2Oq$k0">
+              <ref role="1YBMHb" node="7yOFqurKW2U" resolve="namedTupleType2" />
+            </node>
+            <node concept="2qgKlT" id="7yOFqurKZjB" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:4ZbdskT1yfk" resolve="getElementTypes" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="7yOFqurL04x" role="3cqZAp" />
+      <node concept="2Gpval" id="7yOFqurKW30" role="3cqZAp">
+        <node concept="2GrKxI" id="7yOFqurKW31" role="2Gsz3X">
+          <property role="TrG5h" value="e" />
+        </node>
+        <node concept="3clFbS" id="7yOFqurKW32" role="2LFqv$">
+          <node concept="1ZobV4" id="7yOFqurKW33" role="3cqZAp">
+            <node concept="mw_s8" id="7yOFqurKW34" role="1ZfhKB">
+              <node concept="2OqwBi" id="7yOFqurKW35" role="mwGJk">
+                <node concept="37vLTw" id="7yOFqurKZjC" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7yOFqurKZj$" resolve="elementTypesOther" />
+                </node>
+                <node concept="34jXtK" id="7yOFqurKW39" role="2OqNvi">
+                  <node concept="3uNrnE" id="7yOFqurKW3a" role="25WWJ7">
+                    <node concept="37vLTw" id="7yOFqurKW3b" role="2$L3a6">
+                      <ref role="3cqZAo" node="7yOFqurKW2X" resolve="index" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="mw_s8" id="7yOFqurKW3c" role="1ZfhK$">
+              <node concept="2GrUjf" id="7yOFqurKW3d" role="mwGJk">
+                <ref role="2Gs0qQ" node="7yOFqurKW31" resolve="e" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2OqwBi" id="7yOFqurKZbk" role="2GsD0m">
+          <node concept="1YBJjd" id="7yOFqurKZbl" role="2Oq$k0">
+            <ref role="1YBMHb" node="7yOFqurKW3h" resolve="namedTupleType" />
+          </node>
+          <node concept="2qgKlT" id="7yOFqurKZbm" role="2OqNvi">
+            <ref role="37wK5l" to="pbu6:4ZbdskT1yfk" resolve="getElementTypes" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="7yOFqurKW3h" role="1YuTPh">
+      <property role="TrG5h" value="namedTupleType" />
+      <ref role="1YaFvo" to="yv47:4ZbdskRgu$y" resolve="NamedTupleType" />
+    </node>
+    <node concept="1xSnZT" id="7yOFqurKW3i" role="1xSnZW">
+      <node concept="3clFbS" id="7yOFqurKW3j" role="2VODD2">
+        <node concept="3clFbF" id="7yOFqurKW3k" role="3cqZAp">
+          <node concept="3clFbC" id="7yOFqurKW3l" role="3clFbG">
+            <node concept="2OqwBi" id="7yOFqurKW3m" role="3uHU7w">
+              <node concept="2OqwBi" id="7yOFqurKW3n" role="2Oq$k0">
+                <node concept="1YBJjd" id="7yOFqurKW3o" role="2Oq$k0">
+                  <ref role="1YBMHb" node="7yOFqurKW2U" resolve="tupleType" />
+                </node>
+                <node concept="2qgKlT" id="7yOFqurKXv2" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:4ZbdskT1yfk" resolve="getElementTypes" />
+                </node>
+              </node>
+              <node concept="34oBXx" id="7yOFqurKW3q" role="2OqNvi" />
+            </node>
+            <node concept="2OqwBi" id="7yOFqurKW3r" role="3uHU7B">
+              <node concept="2OqwBi" id="7yOFqurKW3s" role="2Oq$k0">
+                <node concept="1YBJjd" id="7yOFqurKW3t" role="2Oq$k0">
+                  <ref role="1YBMHb" node="7yOFqurKW3h" resolve="namedTupleType" />
+                </node>
+                <node concept="2qgKlT" id="7yOFqurKW3u" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:4ZbdskT1yfk" resolve="getElementTypes" />
+                </node>
+              </node>
+              <node concept="34oBXx" id="7yOFqurKW3v" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2sgARr" id="7yOFqusn81o">
+    <property role="3GE5qa" value="tuples" />
+    <property role="TrG5h" value="NamedTupleSubTypeOfTupleType" />
+    <node concept="3clFbS" id="7yOFqusn81p" role="2sgrp5">
+      <node concept="3clFbF" id="7yOFqusne3_" role="3cqZAp">
+        <node concept="2OqwBi" id="7yOFqusneeQ" role="3clFbG">
+          <node concept="1YBJjd" id="7yOFqusne3$" role="2Oq$k0">
+            <ref role="1YBMHb" node="7yOFqusn82j" resolve="namedTupleType" />
+          </node>
+          <node concept="2qgKlT" id="7yOFqusneyB" role="2OqNvi">
+            <ref role="37wK5l" to="nu60:7yOFqusn8Rg" resolve="convertToTupleType" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="7yOFqusn82j" role="1YuTPh">
+      <property role="TrG5h" value="namedTupleType" />
+      <ref role="1YaFvo" to="yv47:4ZbdskRgu$y" resolve="NamedTupleType" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/typesystem.mps
@@ -4,6 +4,9 @@
   <languages>
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
     <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
   </languages>
   <imports>
@@ -4319,6 +4322,169 @@
     <node concept="1YaCAy" id="bAwKVX3rBm" role="1YuTPh">
       <property role="TrG5h" value="enumDeclaration" />
       <ref role="1YaFvo" to="yv47:67Y8mp$DMUI" resolve="EnumDeclaration" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="4ZbdskRDMLZ">
+    <property role="TrG5h" value="typeof_TupleMemberSetter" />
+    <property role="3GE5qa" value="tuples" />
+    <node concept="3clFbS" id="4ZbdskRDMM0" role="18ibNy">
+      <node concept="nvevp" id="672JozWmCKm" role="3cqZAp">
+        <node concept="3clFbS" id="672JozWmCKn" role="nvhr_">
+          <node concept="1Z5TYs" id="672JozWmCKo" role="3cqZAp">
+            <node concept="mw_s8" id="672JozWmCKp" role="1ZfhKB">
+              <node concept="2X3wrD" id="672JozWmCKq" role="mwGJk">
+                <ref role="2X3Bk0" node="672JozWmCKN" resolve="orgFieldType" />
+              </node>
+            </node>
+            <node concept="mw_s8" id="672JozWmCKr" role="1ZfhK$">
+              <node concept="1Z2H0r" id="672JozWmCKs" role="mwGJk">
+                <node concept="1YBJjd" id="672JozWmCKt" role="1Z2MuG">
+                  <ref role="1YBMHb" node="4ZbdskRDMM2" resolve="tms" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1ZxtTE" id="672JozWmCKu" role="3cqZAp">
+            <property role="TrG5h" value="realFieldType" />
+          </node>
+          <node concept="1Z5TYs" id="672JozWmCKv" role="3cqZAp">
+            <node concept="mw_s8" id="672JozWmCKw" role="1ZfhKB">
+              <node concept="2YIFZM" id="672JozWmCKx" role="mwGJk">
+                <ref role="37wK5l" to="oq0c:4$QBvTqTZCM" resolve="override" />
+                <ref role="1Pybhc" to="oq0c:4$QBvTqTPch" resolve="TOF" />
+                <node concept="1YBJjd" id="672JozWmCKy" role="37wK5m">
+                  <ref role="1YBMHb" node="4ZbdskRDMM2" resolve="tms" />
+                </node>
+                <node concept="1PxgMI" id="672JozWmCKz" role="37wK5m">
+                  <node concept="chp4Y" id="672JozWmCK$" role="3oSUPX">
+                    <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                  </node>
+                  <node concept="2X3wrD" id="672JozWmCK_" role="1m5AlR">
+                    <ref role="2X3Bk0" node="672JozWmCKN" resolve="orgFieldType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="mw_s8" id="672JozWmCKA" role="1ZfhK$">
+              <node concept="1Z$b5t" id="672JozWmCKB" role="mwGJk">
+                <ref role="1Z$eMM" node="672JozWmCKu" resolve="realFieldType" />
+              </node>
+            </node>
+          </node>
+          <node concept="1ZobV4" id="672JozWmCKC" role="3cqZAp">
+            <node concept="mw_s8" id="672JozWmCKD" role="1ZfhKB">
+              <node concept="1Z$b5t" id="672JozWmCKE" role="mwGJk">
+                <ref role="1Z$eMM" node="672JozWmCKu" resolve="realFieldType" />
+              </node>
+            </node>
+            <node concept="mw_s8" id="672JozWmCKF" role="1ZfhK$">
+              <node concept="1Z2H0r" id="672JozWmCKG" role="mwGJk">
+                <node concept="2OqwBi" id="672JozWmCKH" role="1Z2MuG">
+                  <node concept="3TrEf2" id="672JozWmCKI" role="2OqNvi">
+                    <ref role="3Tt5mk" to="yv47:672JozWmCHZ" resolve="value" />
+                  </node>
+                  <node concept="1YBJjd" id="4ZbdskRDNHK" role="2Oq$k0">
+                    <ref role="1YBMHb" node="4ZbdskRDMM2" resolve="tms" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1Z2H0r" id="672JozWmCKJ" role="nvjzm">
+          <node concept="2OqwBi" id="672JozWmCKK" role="1Z2MuG">
+            <node concept="1YBJjd" id="672JozWmCKL" role="2Oq$k0">
+              <ref role="1YBMHb" node="4ZbdskRDMM2" resolve="tms" />
+            </node>
+            <node concept="3TrEf2" id="672JozWmCKM" role="2OqNvi">
+              <ref role="3Tt5mk" to="yv47:4ZbdskRDH_O" resolve="member" />
+            </node>
+          </node>
+        </node>
+        <node concept="2X1qdy" id="672JozWmCKN" role="2X0Ygz">
+          <property role="TrG5h" value="orgFieldType" />
+          <node concept="2jxLKc" id="672JozWmCKO" role="1tU5fm" />
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="4ZbdskRDMM2" role="1YuTPh">
+      <property role="TrG5h" value="tms" />
+      <ref role="1YaFvo" to="yv47:4ZbdskRDH_N" resolve="TupleMemberSetter" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="4ZbdskRgRLv">
+    <property role="TrG5h" value="typeof_TupleNamedAccessExpr" />
+    <property role="3GE5qa" value="tuples" />
+    <node concept="3clFbS" id="4ZbdskRgRLw" role="18ibNy">
+      <node concept="1Z5TYs" id="4ZbdskRgTgH" role="3cqZAp">
+        <node concept="mw_s8" id="4ZbdskRgTgK" role="1ZfhK$">
+          <node concept="1Z2H0r" id="4ZbdskRgT6n" role="mwGJk">
+            <node concept="1YBJjd" id="4ZbdskRgT8h" role="1Z2MuG">
+              <ref role="1YBMHb" node="4ZbdskRgRLy" resolve="tnae" />
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="4ZbdskRgUlC" role="1ZfhKB">
+          <node concept="1Z2H0r" id="4ZbdskRgUlA" role="mwGJk">
+            <node concept="2OqwBi" id="672JozXPpNl" role="1Z2MuG">
+              <node concept="2OqwBi" id="4ZbdskRgUy1" role="2Oq$k0">
+                <node concept="1YBJjd" id="4ZbdskRgUlT" role="2Oq$k0">
+                  <ref role="1YBMHb" node="4ZbdskRgRLy" resolve="tnae" />
+                </node>
+                <node concept="3TrEf2" id="672JozXPqAp" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yv47:4ZbdskRgN6H" resolve="member" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="672JozXPsls" role="2OqNvi">
+                <ref role="37wK5l" to="pbu6:4WLweXm3SW5" resolve="type" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="4ZbdskRgRLy" role="1YuTPh">
+      <property role="TrG5h" value="tnae" />
+      <ref role="1YaFvo" to="yv47:4ZbdskRgKyK" resolve="TupleNamedAccessExpr" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="4ZbdskSftnx">
+    <property role="TrG5h" value="typeof_NamedTupleValue" />
+    <property role="3GE5qa" value="tuples" />
+    <node concept="3clFbS" id="4ZbdskSftny" role="18ibNy">
+      <node concept="1Z5TYs" id="4ZbdskSfyD_" role="3cqZAp">
+        <node concept="mw_s8" id="4ZbdskSfyDT" role="1ZfhKB">
+          <node concept="2pJPEk" id="4ZbdskSfyDP" role="mwGJk">
+            <node concept="2pJPED" id="4ZbdskSfyDR" role="2pJPEn">
+              <ref role="2pJxaS" to="yv47:4ZbdskRgu$y" resolve="NamedTupleType" />
+              <node concept="2pIpSj" id="4ZbdskSfyFi" role="2pJxcM">
+                <ref role="2pIpSl" to="yv47:4ZbdskRgu_6" resolve="tuple" />
+                <node concept="36biLy" id="4ZbdskSfyFv" role="28nt2d">
+                  <node concept="2OqwBi" id="4ZbdskSfyUR" role="36biLW">
+                    <node concept="1YBJjd" id="4ZbdskSfyFE" role="2Oq$k0">
+                      <ref role="1YBMHb" node="4ZbdskSftn$" resolve="ntv" />
+                    </node>
+                    <node concept="3TrEf2" id="4ZbdskSfzh5" role="2OqNvi">
+                      <ref role="3Tt5mk" to="yv47:4ZbdskRDJtl" resolve="tuple" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="4ZbdskSfyDC" role="1ZfhK$">
+          <node concept="1Z2H0r" id="4ZbdskSfyid" role="mwGJk">
+            <node concept="1YBJjd" id="4ZbdskSfyk7" role="1Z2MuG">
+              <ref role="1YBMHb" node="4ZbdskSftn$" resolve="ntv" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="4ZbdskSftn$" role="1YuTPh">
+      <property role="TrG5h" value="ntv" />
+      <ref role="1YaFvo" to="yv47:4ZbdskRDGLl" resolve="NamedTupleValue" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/behavior.mps
@@ -33,6 +33,8 @@
     <import index="u78q" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.typesystem.inference(MPS.Core/)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="gdgh" ref="r:e4d9478b-ae0e-416e-be60-73d136571015(org.iets3.core.base.behavior)" />
+    <import index="yv47" ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" implicit="true" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
     <import index="zzzn" ref="r:af0af2e7-f7e1-4536-83b5-6bf010d4afd2(org.iets3.core.expr.lambda.structure)" implicit="true" />
   </imports>
@@ -221,12 +223,19 @@
         <reference id="5455284157994012188" name="link" index="2pIpSl" />
         <child id="1595412875168045827" name="initValue" index="28nt2d" />
       </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
       <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
         <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
       </concept>
       <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
         <reference id="5455284157993910961" name="concept" index="2pJxaS" />
         <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
       </concept>
       <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
         <child id="8182547171709752112" name="expression" index="36biLW" />
@@ -275,6 +284,9 @@
       </concept>
       <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
       <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
+      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
+        <child id="1145404616321" name="leftExpression" index="2JrQYb" />
+      </concept>
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
       <concept id="1145567426890" name="jetbrains.mps.lang.smodel.structure.SNodeListCreator" flags="nn" index="2T8Vx0">
         <child id="1145567471833" name="createdType" index="2T96Bj" />
@@ -349,6 +361,7 @@
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
       <concept id="1176923520476" name="jetbrains.mps.baseLanguage.collections.structure.ExcludeOperation" flags="nn" index="66VNe" />
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
       <concept id="1224414427926" name="jetbrains.mps.baseLanguage.collections.structure.SequenceCreator" flags="nn" index="kMnCb">
         <child id="1224414456414" name="elementType" index="kMuH3" />
       </concept>
@@ -4780,6 +4793,127 @@
       <node concept="37vLTG" id="7vcJOhhEpat" role="3clF46">
         <property role="TrG5h" value="currentNode" />
         <node concept="3Tqbb2" id="7vcJOhhEpau" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="1pkymqKYkyS" role="13h7CS">
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="updateResultType" />
+      <node concept="3Tm1VV" id="1pkymqKYkyT" role="1B3o_S" />
+      <node concept="3cqZAl" id="1pkymqKYmWJ" role="3clF45" />
+      <node concept="3clFbS" id="1pkymqKYkyV" role="3clF47">
+        <node concept="3clFbF" id="1pkymqKYmXj" role="3cqZAp">
+          <node concept="37vLTI" id="1pkymqKYscG" role="3clFbG">
+            <node concept="2pJPEk" id="1pkymqKYsjY" role="37vLTx">
+              <node concept="2pJPED" id="1pkymqKYsk0" role="2pJPEn">
+                <ref role="2pJxaS" to="yv47:4ZbdskR3pBE" resolve="NamedTupleDeclaration" />
+                <node concept="2pJxcG" id="1pkymqKYuJt" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="WxPPo" id="1pkymqKYuQS" role="28ntcv">
+                    <node concept="3cpWs3" id="1pkymqKYwCr" role="WxPPp">
+                      <node concept="Xl_RD" id="1pkymqKYwCu" role="3uHU7w">
+                        <property role="Xl_RC" value="_ResultTuple" />
+                      </node>
+                      <node concept="2OqwBi" id="1pkymqKYwdN" role="3uHU7B">
+                        <node concept="2OqwBi" id="1pkymqKYvOW" role="2Oq$k0">
+                          <node concept="2JrnkZ" id="1pkymqKYvyL" role="2Oq$k0">
+                            <node concept="13iPFW" id="1pkymqKYuQQ" role="2JrQYb" />
+                          </node>
+                          <node concept="liA8E" id="1pkymqKYw3m" role="2OqNvi">
+                            <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="1pkymqKYwlz" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1pkymqKYn6N" role="37vLTJ">
+              <node concept="13iPFW" id="1pkymqKYmXi" role="2Oq$k0" />
+              <node concept="3TrEf2" id="1pkymqKYnjf" role="2OqNvi">
+                <ref role="3Tt5mk" to="kfo3:1pkymqKXZmh" resolve="resultTupleDeclaration" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1pkymqKYxcL" role="3cqZAp">
+          <node concept="2OqwBi" id="1pkymqKYySn" role="3clFbG">
+            <node concept="2OqwBi" id="1pkymqKYy3W" role="2Oq$k0">
+              <node concept="2OqwBi" id="1pkymqKYxsI" role="2Oq$k0">
+                <node concept="13iPFW" id="1pkymqKYxcJ" role="2Oq$k0" />
+                <node concept="2qgKlT" id="1pkymqKYxLP" role="2OqNvi">
+                  <ref role="37wK5l" node="7FuUjk_57S0" resolve="resultColDefs" />
+                </node>
+              </node>
+              <node concept="v3k3i" id="1pkymqKYyk7" role="2OqNvi">
+                <node concept="chp4Y" id="1pkymqKYyw4" role="v3oSu">
+                  <ref role="cht4Q" to="kfo3:8XWEtdX_Yl" resolve="ResultColDef" />
+                </node>
+              </node>
+            </node>
+            <node concept="2es0OD" id="1pkymqKYzeI" role="2OqNvi">
+              <node concept="1bVj0M" id="1pkymqKYzeK" role="23t8la">
+                <node concept="3clFbS" id="1pkymqKYzeL" role="1bW5cS">
+                  <node concept="3clFbF" id="1pkymqKYzu$" role="3cqZAp">
+                    <node concept="2OqwBi" id="1pkymqKYDEG" role="3clFbG">
+                      <node concept="2OqwBi" id="1pkymqKY$Sk" role="2Oq$k0">
+                        <node concept="2OqwBi" id="1pkymqKYzL$" role="2Oq$k0">
+                          <node concept="13iPFW" id="1pkymqKYzuz" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="1pkymqKY$c6" role="2OqNvi">
+                            <ref role="3Tt5mk" to="kfo3:1pkymqKXZmh" resolve="resultTupleDeclaration" />
+                          </node>
+                        </node>
+                        <node concept="3Tsc0h" id="1pkymqKY_KW" role="2OqNvi">
+                          <ref role="3TtcxE" to="yv47:4ZbdskRgjgF" resolve="members" />
+                        </node>
+                      </node>
+                      <node concept="TSZUe" id="1pkymqKYGFV" role="2OqNvi">
+                        <node concept="2pJPEk" id="1pkymqKYH0O" role="25WWJ7">
+                          <node concept="2pJPED" id="1pkymqKYH0Q" role="2pJPEn">
+                            <ref role="2pJxaS" to="yv47:4ZbdskR3$vC" resolve="TupleMember" />
+                            <node concept="2pJxcG" id="1pkymqKYIaB" role="2pJxcM">
+                              <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                              <node concept="WxPPo" id="1pkymqKYIM1" role="28ntcv">
+                                <node concept="2OqwBi" id="1pkymqKYJlH" role="WxPPp">
+                                  <node concept="37vLTw" id="1pkymqKYILZ" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="1pkymqKYzeM" resolve="it" />
+                                  </node>
+                                  <node concept="3TrcHB" id="1pkymqKYKkd" role="2OqNvi">
+                                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="2pIpSj" id="1pkymqKYLwn" role="2pJxcM">
+                              <ref role="2pIpSl" to="hm2y:7D7uZV2iYAD" resolve="type" />
+                              <node concept="36biLy" id="1pkymqKYMb3" role="28nt2d">
+                                <node concept="2OqwBi" id="1pkymqKYNlY" role="36biLW">
+                                  <node concept="37vLTw" id="1pkymqKYMJy" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="1pkymqKYzeM" resolve="it" />
+                                  </node>
+                                  <node concept="3TrEf2" id="1pkymqKYOhX" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="kfo3:8XWEtdX_Yo" resolve="type" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="Rh6nW" id="1pkymqKYzeM" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="1pkymqKYzeN" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/intentions.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/intentions.mps
@@ -8,6 +8,7 @@
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="f47b95d4-5e73-4c04-9204-18076950153b" name="com.mbeddr.mpsutil.compare" version="0" />
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -23,8 +24,12 @@
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" implicit="true" />
     <import index="b1h1" ref="r:ac5f749f-6179-4d4f-ad24-ad9edbd8077b(org.iets3.core.expr.simpleTypes.behavior)" implicit="true" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" implicit="true" />
   </imports>
   <registry>
+    <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
+      <concept id="1194033889146" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1XNTG" />
+    </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
@@ -4416,6 +4421,45 @@
     </node>
     <node concept="1SWQZ3" id="7RxIimvtPhP" role="lGtFl">
       <property role="1SWRpm" value="TREE" />
+    </node>
+  </node>
+  <node concept="2S6QgY" id="7yOFqus7Z5V">
+    <property role="3GE5qa" value="multidectab.expr" />
+    <property role="TrG5h" value="DeclareReturnType" />
+    <property role="2ZfUl0" value="true" />
+    <ref role="2ZfgGC" to="kfo3:8XWEtdX_Xs" resolve="MultiDecTab" />
+    <node concept="2S6ZIM" id="7yOFqus7Z5W" role="2ZfVej">
+      <node concept="3clFbS" id="7yOFqus7Z5X" role="2VODD2">
+        <node concept="3clFbF" id="7yOFqus7Z5Y" role="3cqZAp">
+          <node concept="Xl_RD" id="7yOFqus7Z5Z" role="3clFbG">
+            <property role="Xl_RC" value="Declare The Return Type" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="7yOFqus7Z60" role="2ZfgGD">
+      <node concept="3clFbS" id="7yOFqus7Z61" role="2VODD2">
+        <node concept="3clFbF" id="7yOFqus8mC6" role="3cqZAp">
+          <node concept="2OqwBi" id="7yOFqus8mI3" role="3clFbG">
+            <node concept="1XNTG" id="7yOFqus8mC5" role="2Oq$k0" />
+            <node concept="liA8E" id="7yOFqus8mK5" role="2OqNvi">
+              <ref role="37wK5l" to="cj4x:~EditorContext.select(org.jetbrains.mps.openapi.model.SNode)" resolve="select" />
+              <node concept="2Sf5sV" id="7yOFqus8mMg" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7yOFqus822R" role="3cqZAp">
+          <node concept="2OqwBi" id="7yOFqus82eB" role="3clFbG">
+            <node concept="1XNTG" id="7yOFqus822Q" role="2Oq$k0" />
+            <node concept="liA8E" id="7yOFqus82s9" role="2OqNvi">
+              <ref role="37wK5l" to="cj4x:~EditorContext.openInspector()" resolve="openInspector" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1SWQZ3" id="7yOFqus7Z6g" role="lGtFl">
+      <property role="1SWRpm" value="TABLE" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/migration.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/migration.mps
@@ -4,20 +4,119 @@
   <languages>
     <use id="90746344-04fd-4286-97d5-b46ae6a81709" name="jetbrains.mps.lang.migration" version="2" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="5" />
+    <use id="d4615e3b-d671-4ba9-af01-2b78369b0ba7" name="jetbrains.mps.lang.pattern" version="2" />
   </languages>
-  <imports />
+  <imports>
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="slm6" ref="90746344-04fd-4286-97d5-b46ae6a81709/r:52a3d974-bd4f-4651-ba6e-a2de5e336d95(jetbrains.mps.lang.migration/jetbrains.mps.lang.migration.methods)" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="kfo3" ref="r:6bb59b1e-6116-48ad-b11d-2641d4f6b6a1(org.iets3.core.expr.util.structure)" implicit="true" />
+    <import index="wthy" ref="r:a4614e23-a6b5-4dbe-9bc5-9ff1ecfd0a3a(org.iets3.core.expr.util.behavior)" implicit="true" />
+  </imports>
   <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl">
+      <concept id="8880393040217246788" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MethodParameterInstance" flags="ig" index="ffn8J">
+        <reference id="8880393040217294897" name="decl" index="ffrpq" />
+      </concept>
+      <concept id="3751132065236767083" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.DependentTypeInstance" flags="ig" index="q3mfm">
+        <reference id="3751132065236767084" name="decl" index="q3mfh" />
+        <reference id="9097849371505568270" name="point" index="1QQUv3" />
+      </concept>
+      <concept id="3751132065236767060" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MethodInstance" flags="ig" index="q3mfD">
+        <reference id="19209059688387895" name="decl" index="2VtyIY" />
+      </concept>
+      <concept id="6478870542308708689" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.PropertyInstance" flags="ig" index="3tT0cZ">
+        <reference id="8585153554445465961" name="decl" index="25KYV2" />
+      </concept>
+      <concept id="6478870542308703666" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MemberPlaceholder" flags="ng" index="3tTeZs">
+        <property id="6478870542308703667" name="caption" index="3tTeZt" />
+        <reference id="6478870542308703669" name="decl" index="3tTeZr" />
+      </concept>
+      <concept id="6478870542308871875" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.BooleanPropertyInstance" flags="ig" index="3tYpMH">
+        <property id="6478870542308871876" name="value" index="3tYpME" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="6911370362349121511" name="jetbrains.mps.lang.smodel.structure.ConceptId" flags="nn" index="2x4n5u">
         <property id="6911370362349122519" name="conceptName" index="2x4mPI" />
         <property id="6911370362349121516" name="conceptId" index="2x4n5l" />
         <property id="6911370362349133804" name="isInterface" index="2x4o5l" />
         <child id="6911370362349121514" name="languageIdentity" index="2x4n5j" />
       </concept>
+      <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="8415841354032330471" name="jetbrains.mps.lang.smodel.structure.ContainmentLinkId" flags="ng" index="HUanS">
         <property id="8415841354032330474" name="linkName" index="HUanP" />
         <property id="8415841354032330473" name="linkId" index="HUanQ" />
         <child id="8415841354032330472" name="conceptIdentity" index="HUanR" />
+      </concept>
+      <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7">
+        <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
       </concept>
       <concept id="3542851458883438784" name="jetbrains.mps.lang.smodel.structure.LanguageId" flags="nn" index="2V$Bhx">
         <property id="3542851458883439831" name="namespace" index="2V$B1Q" />
@@ -68,6 +167,24 @@
         <property id="3597905718825595716" name="optionId" index="1w76tO" />
         <property id="3597905718825650036" name="description" index="1w7ld4" />
       </concept>
+      <concept id="8352104482584315555" name="jetbrains.mps.lang.migration.structure.MigrationScript" flags="ig" index="3SyAh_">
+        <property id="5820409521797704727" name="fromVersion" index="qMTe8" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
+        <child id="1153944400369" name="variable" index="2Gsz3X" />
+        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
+      </concept>
+      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
+        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
+      </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
     </language>
   </registry>
   <node concept="Z5qvL" id="7FuUjk_57Cx">
@@ -236,6 +353,114 @@
         <property role="2pBcow" value="r:6bb59b1e-6116-48ad-b11d-2641d4f6b6a1(org.iets3.core.expr.util.structure)" />
         <property role="2pBc3U" value="rows" />
       </node>
+    </node>
+  </node>
+  <node concept="3SyAh_" id="1pkymqL3eLY">
+    <property role="qMTe8" value="2" />
+    <property role="TrG5h" value="AddResultTypeToIMultiDecTab" />
+    <node concept="3Tm1VV" id="1pkymqL3eLZ" role="1B3o_S" />
+    <node concept="3tTeZs" id="1pkymqL3eM0" role="jymVt">
+      <property role="3tTeZt" value="&lt;no execute after&gt;" />
+      <ref role="3tTeZr" to="slm6:7ay_HjIMt1a" resolve="execute after" />
+    </node>
+    <node concept="3tTeZs" id="1pkymqL3eM1" role="jymVt">
+      <property role="3tTeZt" value="&lt;no required data&gt;" />
+      <ref role="3tTeZr" to="slm6:5TUCQr2FPTh" resolve="requires annotation data" />
+    </node>
+    <node concept="3tTeZs" id="1pkymqL3eM2" role="jymVt">
+      <property role="3tTeZt" value="&lt;no produced data&gt;" />
+      <ref role="3tTeZr" to="slm6:5TUCQr2C271" resolve="produces annotation data" />
+    </node>
+    <node concept="2tJIrI" id="1pkymqL3eM3" role="jymVt" />
+    <node concept="3tYpMH" id="1pkymqL3eM4" role="jymVt">
+      <property role="TrG5h" value="isRerunnable" />
+      <property role="3tYpME" value="true" />
+      <ref role="25KYV2" to="slm6:1JWcQ2VeWIs" resolve="isRerunnable" />
+      <node concept="3Tm1VV" id="1pkymqL3eM5" role="1B3o_S" />
+      <node concept="10P_77" id="1pkymqL3eM6" role="1tU5fm" />
+    </node>
+    <node concept="3tTeZs" id="1pkymqL3eM7" role="jymVt">
+      <property role="3tTeZt" value="&lt;description&gt;" />
+      <ref role="3tTeZr" to="slm6:1_lSsE3RFpE" resolve="description" />
+    </node>
+    <node concept="q3mfD" id="1pkymqL3eM8" role="jymVt">
+      <property role="TrG5h" value="execute" />
+      <ref role="2VtyIY" to="slm6:4ubqdNOF9cA" resolve="execute" />
+      <node concept="3Tm1VV" id="1pkymqL3eMa" role="1B3o_S" />
+      <node concept="3clFbS" id="1pkymqL3eMc" role="3clF47">
+        <node concept="2Gpval" id="1pkymqL3g9i" role="3cqZAp">
+          <node concept="2GrKxI" id="1pkymqL3g9j" role="2Gsz3X">
+            <property role="TrG5h" value="model" />
+          </node>
+          <node concept="3clFbS" id="1pkymqL3g9l" role="2LFqv$">
+            <node concept="3clFbF" id="1pkymqL3gkS" role="3cqZAp">
+              <node concept="2OqwBi" id="1pkymqL3lEH" role="3clFbG">
+                <node concept="2OqwBi" id="1pkymqL3jXF" role="2Oq$k0">
+                  <node concept="1eOMI4" id="1pkymqL3gkQ" role="2Oq$k0">
+                    <node concept="10QFUN" id="1pkymqL3gkN" role="1eOMHV">
+                      <node concept="H_c77" id="1pkymqL3jJ0" role="10QFUM" />
+                      <node concept="2GrUjf" id="1pkymqL3jNC" role="10QFUP">
+                        <ref role="2Gs0qQ" node="1pkymqL3g9j" resolve="model" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2SmgA7" id="1pkymqL3k9X" role="2OqNvi">
+                    <node concept="chp4Y" id="1pkymqL3kjj" role="1dBWTz">
+                      <ref role="cht4Q" to="kfo3:7FuUjk_57Bw" resolve="IMultiDecTab" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="2es0OD" id="1pkymqL3nS8" role="2OqNvi">
+                  <node concept="1bVj0M" id="1pkymqL3nSa" role="23t8la">
+                    <node concept="3clFbS" id="1pkymqL3nSb" role="1bW5cS">
+                      <node concept="3clFbF" id="1pkymqL3o8n" role="3cqZAp">
+                        <node concept="2OqwBi" id="1pkymqL3okt" role="3clFbG">
+                          <node concept="37vLTw" id="1pkymqL3o8m" role="2Oq$k0">
+                            <ref role="3cqZAo" node="1pkymqL3nSc" resolve="it" />
+                          </node>
+                          <node concept="2qgKlT" id="1pkymqL3oNU" role="2OqNvi">
+                            <ref role="37wK5l" to="wthy:1pkymqKYkyS" resolve="updateResultType" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="1pkymqL3nSc" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="1pkymqL3nSd" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="1pkymqL3fag" role="2GsD0m">
+            <node concept="37vLTw" id="1pkymqL3f5P" role="2Oq$k0">
+              <ref role="3cqZAo" node="1pkymqL3eMe" resolve="m" />
+            </node>
+            <node concept="liA8E" id="1pkymqL3g46" role="2OqNvi">
+              <ref role="37wK5l" to="lui2:~SModule.getModels()" resolve="getModels" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="ffn8J" id="1pkymqL3eMe" role="3clF46">
+        <property role="TrG5h" value="m" />
+        <ref role="ffrpq" to="slm6:7fCCGqboj9J" resolve="m" />
+        <node concept="3uibUv" id="1pkymqL3eMd" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+        </node>
+      </node>
+      <node concept="q3mfm" id="1pkymqL3eMf" role="3clF45">
+        <ref role="q3mfh" to="slm6:4F5w8gPXEEe" />
+        <ref role="1QQUv3" node="1pkymqL3eM8" resolve="execute" />
+      </node>
+    </node>
+    <node concept="3tTeZs" id="1pkymqL3eMg" role="jymVt">
+      <property role="3tTeZt" value="&lt;no result checking&gt;" />
+      <ref role="3tTeZr" to="slm6:1JWcQ2VeXpD" resolve="check" />
+    </node>
+    <node concept="3uibUv" id="1pkymqL3eMh" role="1zkMxy">
+      <ref role="3uigEE" to="slm6:5TUCQr2ybBO" resolve="HasMigrationScriptReference" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/org.iets3.core.expr.util.listeners.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/org.iets3.core.expr.util.listeners.mps
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:ffa27aa1-4bbf-456c-82f8-8174ae6a9559(org.iets3.core.expr.util.listeners)">
+  <persistence version="9" />
+  <languages>
+    <use id="309e0004-4976-4416-b947-ec02ae4ecef2" name="com.mbeddr.mpsutil.modellisteners" version="0" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="kfo3" ref="r:6bb59b1e-6116-48ad-b11d-2641d4f6b6a1(org.iets3.core.expr.util.structure)" implicit="true" />
+    <import index="wthy" ref="r:a4614e23-a6b5-4dbe-9bc5-9ff1ecfd0a3a(org.iets3.core.expr.util.behavior)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
+    </language>
+    <language id="309e0004-4976-4416-b947-ec02ae4ecef2" name="com.mbeddr.mpsutil.modellisteners">
+      <concept id="5818559022137765390" name="com.mbeddr.mpsutil.modellisteners.structure.Parameter_child" flags="ng" index="j_sak" />
+      <concept id="5818559022137760597" name="com.mbeddr.mpsutil.modellisteners.structure.Parameter_instance" flags="ng" index="j_vvf" />
+      <concept id="5818559022137644042" name="com.mbeddr.mpsutil.modellisteners.structure.ChildAddedListener" flags="ig" index="j_Nyg" />
+      <concept id="5818559022137644848" name="com.mbeddr.mpsutil.modellisteners.structure.ChildRemovedListener" flags="ig" index="j_NIE" />
+      <concept id="5818559022137597839" name="com.mbeddr.mpsutil.modellisteners.structure.ConceptModelListeners" flags="ng" index="jA7cl">
+        <reference id="1213093996982" name="concept" index="1M2myG" />
+        <child id="5818559022137986141" name="listeners" index="j$A37" />
+      </concept>
+      <concept id="6105788070830360713" name="com.mbeddr.mpsutil.modellisteners.structure.AbstractRoleListener" flags="ig" index="3v5llJ">
+        <reference id="5818559022137756708" name="role" index="j_u2Y" />
+      </concept>
+      <concept id="6105788070833315443" name="com.mbeddr.mpsutil.modellisteners.structure.PropertyListener" flags="ig" index="3vq$el">
+        <reference id="6105788070833315720" name="property" index="3vq$9I" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="jA7cl" id="1pkymqKYhNu">
+    <ref role="1M2myG" to="kfo3:7FuUjk_57Bw" resolve="IMultiDecTab" />
+    <node concept="j_Nyg" id="1pkymqKYOWR" role="j$A37">
+      <ref role="j_u2Y" to="kfo3:7FuUjk_57Cw" resolve="colDefs" />
+      <node concept="3clFbS" id="1pkymqKYOWS" role="2VODD2">
+        <node concept="3clFbJ" id="1pkymqLm$HN" role="3cqZAp">
+          <node concept="3clFbS" id="1pkymqLm$HP" role="3clFbx">
+            <node concept="3clFbF" id="1pkymqKYOXc" role="3cqZAp">
+              <node concept="2OqwBi" id="1pkymqKYP6E" role="3clFbG">
+                <node concept="j_vvf" id="1pkymqKYOXb" role="2Oq$k0" />
+                <node concept="2qgKlT" id="1pkymqKYPja" role="2OqNvi">
+                  <ref role="37wK5l" to="wthy:1pkymqKYkyS" resolve="updateResultType" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="1pkymqLm$Xb" role="3clFbw">
+            <node concept="j_sak" id="1pkymqLm$Is" role="2Oq$k0" />
+            <node concept="1mIQ4w" id="1pkymqLm_6e" role="2OqNvi">
+              <node concept="chp4Y" id="1pkymqLm_8U" role="cj9EA">
+                <ref role="cht4Q" to="kfo3:8XWEtdX_Yl" resolve="ResultColDef" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="j_NIE" id="1pkymqKYPt1" role="j$A37">
+      <ref role="j_u2Y" to="kfo3:7FuUjk_57Cw" resolve="colDefs" />
+      <node concept="3clFbS" id="1pkymqKYPt3" role="2VODD2">
+        <node concept="3clFbJ" id="1pkymqLmB0N" role="3cqZAp">
+          <node concept="3clFbS" id="1pkymqLmB0O" role="3clFbx">
+            <node concept="3clFbF" id="1pkymqLmB0P" role="3cqZAp">
+              <node concept="2OqwBi" id="1pkymqLmB0Q" role="3clFbG">
+                <node concept="j_vvf" id="1pkymqLmB0R" role="2Oq$k0" />
+                <node concept="2qgKlT" id="1pkymqLmB0S" role="2OqNvi">
+                  <ref role="37wK5l" to="wthy:1pkymqKYkyS" resolve="updateResultType" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="1pkymqLmB0T" role="3clFbw">
+            <node concept="j_sak" id="1pkymqLmB0U" role="2Oq$k0" />
+            <node concept="1mIQ4w" id="1pkymqLmB0V" role="2OqNvi">
+              <node concept="chp4Y" id="1pkymqLmB0W" role="cj9EA">
+                <ref role="cht4Q" to="kfo3:8XWEtdX_Yl" resolve="ResultColDef" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="jA7cl" id="1pkymqKYQ0v">
+    <ref role="1M2myG" to="kfo3:8XWEtdX_Yl" resolve="ResultColDef" />
+    <node concept="3vq$el" id="1pkymqKYQ0w" role="j$A37">
+      <ref role="3vq$9I" to="tpck:h0TrG11" resolve="name" />
+      <node concept="3clFbS" id="1pkymqKYQ0x" role="2VODD2">
+        <node concept="3clFbF" id="1pkymqKYQ0P" role="3cqZAp">
+          <node concept="2OqwBi" id="1pkymqKYRuI" role="3clFbG">
+            <node concept="2OqwBi" id="1pkymqKYQcV" role="2Oq$k0">
+              <node concept="j_vvf" id="1pkymqKYQ0O" role="2Oq$k0" />
+              <node concept="2Xjw5R" id="1pkymqKYQvz" role="2OqNvi">
+                <node concept="1xMEDy" id="1pkymqKYQv_" role="1xVPHs">
+                  <node concept="chp4Y" id="1pkymqKYRjG" role="ri$Ld">
+                    <ref role="cht4Q" to="kfo3:7FuUjk_57Bw" resolve="IMultiDecTab" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2qgKlT" id="1pkymqKYRH1" role="2OqNvi">
+              <ref role="37wK5l" to="wthy:1pkymqKYkyS" resolve="updateResultType" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/structure.mps
@@ -582,6 +582,11 @@
     <property role="EcuMT" value="8853770331921611232" />
     <property role="3GE5qa" value="multidectab.expr" />
     <property role="TrG5h" value="IMultiDecTab" />
+    <node concept="1TJgyj" id="7yOFqus30SM" role="1TKVEi">
+      <property role="IQ2ns" value="8697767715748449842" />
+      <property role="20kJfa" value="resultTuple" />
+      <ref role="20lvS9" to="yv47:4ZbdskR3pBE" resolve="NamedTupleDeclaration" />
+    </node>
     <node concept="1TJgyj" id="7FuUjk_57Cw" role="1TKVEi">
       <property role="IQ2ns" value="8853770331921611296" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/structure.mps
@@ -582,11 +582,6 @@
     <property role="EcuMT" value="8853770331921611232" />
     <property role="3GE5qa" value="multidectab.expr" />
     <property role="TrG5h" value="IMultiDecTab" />
-    <node concept="1TJgyj" id="7yOFqus30SM" role="1TKVEi">
-      <property role="IQ2ns" value="8697767715748449842" />
-      <property role="20kJfa" value="resultTuple" />
-      <ref role="20lvS9" to="yv47:4ZbdskR3pBE" resolve="NamedTupleDeclaration" />
-    </node>
     <node concept="1TJgyj" id="7FuUjk_57Cw" role="1TKVEi">
       <property role="IQ2ns" value="8853770331921611296" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -600,6 +595,13 @@
       <property role="20kJfa" value="rows" />
       <property role="20lbJX" value="fLJekj5/_0__n" />
       <ref role="20lvS9" node="8XWEtdYbNZ" resolve="DataRow" />
+    </node>
+    <node concept="1TJgyj" id="1pkymqKXZmh" role="1TKVEi">
+      <property role="IQ2ns" value="1609062041026819473" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="resultTupleDeclaration" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="yv47:4ZbdskR3pBE" resolve="NamedTupleDeclaration" />
     </node>
     <node concept="PrWs8" id="2U$lnbPqLp1" role="PrDN$">
       <ref role="PrY4T" to="3673:5IKJrJHNBNb" resolve="ICanHaveTestCoverage" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/typesystem.mps
@@ -15,6 +15,7 @@
     <import index="t4jv" ref="r:80cf2246-750c-4158-9056-a619ebcf894c(org.iets3.core.expr.base.typesystem)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
+    <import index="yv47" ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -238,7 +239,6 @@
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
-      <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
@@ -1583,66 +1583,31 @@
         </node>
         <node concept="9aQIb" id="8XWEte6$I5" role="9aQIa">
           <node concept="3clFbS" id="8XWEte6$I6" role="9aQI4">
-            <node concept="3cpWs8" id="8XWEte6_8p" role="3cqZAp">
-              <node concept="3cpWsn" id="8XWEte6_8s" role="3cpWs9">
-                <property role="TrG5h" value="tt" />
-                <node concept="3Tqbb2" id="8XWEte6_8o" role="1tU5fm">
-                  <ref role="ehGHo" to="hm2y:S$tO8ocniU" resolve="TupleType" />
-                </node>
-                <node concept="2ShNRf" id="8XWEte6_8S" role="33vP2m">
-                  <node concept="3zrR0B" id="8XWEte6_8I" role="2ShVmc">
-                    <node concept="3Tqbb2" id="8XWEte6_8J" role="3zrR0E">
-                      <ref role="ehGHo" to="hm2y:S$tO8ocniU" resolve="TupleType" />
-                    </node>
+            <node concept="1Z5TYs" id="7yOFqus349z" role="3cqZAp">
+              <node concept="mw_s8" id="7yOFqus349A" role="1ZfhK$">
+                <node concept="1Z2H0r" id="7yOFqus349B" role="mwGJk">
+                  <node concept="1YBJjd" id="7yOFqus349C" role="1Z2MuG">
+                    <ref role="1YBMHb" node="8XWEte6nsv" resolve="iMultiDecTab" />
                   </node>
                 </node>
               </node>
-            </node>
-            <node concept="2Gpval" id="8XWEte6BhG" role="3cqZAp">
-              <node concept="2GrKxI" id="8XWEte6BhI" role="2Gsz3X">
-                <property role="TrG5h" value="rcd" />
-              </node>
-              <node concept="37vLTw" id="8XWEte6Big" role="2GsD0m">
-                <ref role="3cqZAo" node="8XWEte6zuP" resolve="rcds" />
-              </node>
-              <node concept="3clFbS" id="8XWEte6BhM" role="2LFqv$">
-                <node concept="3clFbF" id="8XWEte6BiO" role="3cqZAp">
-                  <node concept="2OqwBi" id="8XWEte6Dcv" role="3clFbG">
-                    <node concept="2OqwBi" id="8XWEte6Br3" role="2Oq$k0">
-                      <node concept="37vLTw" id="8XWEte6BiN" role="2Oq$k0">
-                        <ref role="3cqZAo" node="8XWEte6_8s" resolve="tt" />
-                      </node>
-                      <node concept="3Tsc0h" id="8XWEte6Bz$" role="2OqNvi">
-                        <ref role="3TtcxE" to="hm2y:S$tO8ocniV" resolve="elementTypes" />
-                      </node>
-                    </node>
-                    <node concept="TSZUe" id="8XWEte6Exx" role="2OqNvi">
-                      <node concept="2OqwBi" id="8XWEte6FJD" role="25WWJ7">
-                        <node concept="2OqwBi" id="8XWEte6EYQ" role="2Oq$k0">
-                          <node concept="2GrUjf" id="8XWEte6EF3" role="2Oq$k0">
-                            <ref role="2Gs0qQ" node="8XWEte6BhI" resolve="rcd" />
+              <node concept="mw_s8" id="1pkymqKYo_o" role="1ZfhKB">
+                <node concept="2pJPEk" id="1pkymqKYo_m" role="mwGJk">
+                  <node concept="2pJPED" id="1pkymqKYo_n" role="2pJPEn">
+                    <ref role="2pJxaS" to="yv47:4ZbdskRgu$y" resolve="NamedTupleType" />
+                    <node concept="2pIpSj" id="1pkymqKYoB0" role="2pJxcM">
+                      <ref role="2pIpSl" to="yv47:4ZbdskRgu_6" resolve="tuple" />
+                      <node concept="36biLy" id="1pkymqKYoBd" role="28nt2d">
+                        <node concept="2OqwBi" id="1pkymqKYoN0" role="36biLW">
+                          <node concept="1YBJjd" id="1pkymqKYoBo" role="2Oq$k0">
+                            <ref role="1YBMHb" node="8XWEte6nsv" resolve="iMultiDecTab" />
                           </node>
-                          <node concept="3TrEf2" id="8XWEte6FhE" role="2OqNvi">
-                            <ref role="3Tt5mk" to="kfo3:8XWEtdX_Yo" resolve="type" />
+                          <node concept="3TrEf2" id="1pkymqKYpA_" role="2OqNvi">
+                            <ref role="3Tt5mk" to="kfo3:1pkymqKXZmh" resolve="resultTupleDeclaration" />
                           </node>
                         </node>
-                        <node concept="1$rogu" id="8XWEte6G86" role="2OqNvi" />
                       </node>
                     </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1Z5TYs" id="8XWEte6_Yb" role="3cqZAp">
-              <node concept="mw_s8" id="8XWEte6Bgt" role="1ZfhKB">
-                <node concept="37vLTw" id="8XWEte6Bgr" role="mwGJk">
-                  <ref role="3cqZAo" node="8XWEte6_8s" resolve="tt" />
-                </node>
-              </node>
-              <node concept="mw_s8" id="8XWEte6_Yj" role="1ZfhK$">
-                <node concept="1Z2H0r" id="8XWEte6_Yk" role="mwGJk">
-                  <node concept="1YBJjd" id="8XWEte6_Yl" role="1Z2MuG">
-                    <ref role="1YBMHb" node="8XWEte6nsv" resolve="iMultiDecTab" />
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/org.iets3.core.expr.util.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/org.iets3.core.expr.util.mpl
@@ -77,6 +77,7 @@
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
     <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
     <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
+    <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/org.iets3.core.expr.util.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/org.iets3.core.expr.util.mpl
@@ -41,6 +41,7 @@
     <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="2" />
     <language slang="l:b4f35ed8-45af-4efa-abe4-00ac26956e69:com.mbeddr.mpsutil.grammarcells.runtimelang" version="0" />
     <language slang="l:b92f861d-0184-446d-b88b-6dcf0e070241:com.mbeddr.mpsutil.intentions" version="0" />
+    <language slang="l:309e0004-4976-4416-b947-ec02ae4ecef2:com.mbeddr.mpsutil.modellisteners" version="0" />
     <language slang="l:c73b17af-16a1-4490-8072-8a84937c5206:com.mbeddr.mpsutil.treenotation" version="0" />
     <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
     <language slang="l:52733268-be24-4f5f-ab84-a73b7c0c03b0:de.slisson.mps.richtext.customcell" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/org.iets3.core.expr.util.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/org.iets3.core.expr.util.mpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<language namespace="org.iets3.core.expr.util" uuid="8bb1251e-eae5-47ab-9843-33adfae8edaa" languageVersion="2" moduleVersion="2">
+<language namespace="org.iets3.core.expr.util" uuid="8bb1251e-eae5-47ab-9843-33adfae8edaa" languageVersion="3" moduleVersion="2">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.interpreter/models/plugin.mps
@@ -10,6 +10,7 @@
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="-1" />
     <use id="817e4e70-961e-4a95-98a1-15e9f32231f1" name="jetbrains.mps.ide.httpsupport" version="-1" />
     <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="-1" />
+    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
   </languages>
   <imports>
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
@@ -23,6 +24,8 @@
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="j10v" ref="b76a0f63-5959-456b-993a-c796cc0d0c13/java:org.pcollections(org.iets3.core.expr.base.collections.stubs/)" />
     <import index="ppzb" ref="r:5db517a0-f62d-4841-a421-11bb7269799d(org.iets3.core.expr.base.shared.runtime)" />
+    <import index="yv47" ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" />
+    <import index="nu60" ref="r:cfd59c48-ecc8-4b0c-8ae8-6d876c46ebbb(org.iets3.core.expr.toplevel.behavior)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -307,6 +310,7 @@
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
@@ -3112,59 +3116,59 @@
         </node>
       </node>
     </node>
-    <node concept="qq9P1" id="49WTic8lPAJ" role="qq9xR">
+    <node concept="qq9P1" id="672JozYfTR0" role="qq9xR">
       <property role="2TnfIJ" value="true" />
-      <ref role="qq9wM" to="hm2y:S$tO8ocnpq" resolve="TupleValue" />
-      <node concept="3dA_Gj" id="49WTic8lPLX" role="3vQZUl">
-        <node concept="9aQIb" id="49WTic8lPLZ" role="3vcmbn">
-          <node concept="3clFbS" id="49WTic8lPM1" role="9aQI4">
-            <node concept="3cpWs8" id="49WTic8m0uf" role="3cqZAp">
-              <node concept="3cpWsn" id="49WTic8m0ug" role="3cpWs9">
+      <ref role="qq9wM" to="hm2y:4ZbdskSW2Ng" resolve="ITupleValue" />
+      <node concept="3dA_Gj" id="672JozYfXwu" role="3vQZUl">
+        <node concept="9aQIb" id="672JozYfXww" role="3vcmbn">
+          <node concept="3clFbS" id="672JozYfXwy" role="9aQI4">
+            <node concept="3cpWs8" id="672JozYfXwJ" role="3cqZAp">
+              <node concept="3cpWsn" id="672JozYfXwK" role="3cpWs9">
                 <property role="TrG5h" value="list" />
-                <node concept="_YKpA" id="49WTic8m0ud" role="1tU5fm">
-                  <node concept="3uibUv" id="49WTic8m0$v" role="_ZDj9">
+                <node concept="_YKpA" id="672JozYfXwL" role="1tU5fm">
+                  <node concept="3uibUv" id="672JozYfXwM" role="_ZDj9">
                     <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
                   </node>
                 </node>
-                <node concept="2ShNRf" id="49WTic8m0uh" role="33vP2m">
-                  <node concept="Tc6Ow" id="49WTic8m0ui" role="2ShVmc">
-                    <node concept="3uibUv" id="49WTic8m1jb" role="HW$YZ">
+                <node concept="2ShNRf" id="672JozYfXwN" role="33vP2m">
+                  <node concept="Tc6Ow" id="672JozYfXwO" role="2ShVmc">
+                    <node concept="3uibUv" id="672JozYfXwP" role="HW$YZ">
                       <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
                     </node>
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="2Gpval" id="49WTic8m23A" role="3cqZAp">
-              <node concept="2GrKxI" id="49WTic8m23C" role="2Gsz3X">
+            <node concept="2Gpval" id="672JozYfXwQ" role="3cqZAp">
+              <node concept="2GrKxI" id="672JozYfXwR" role="2Gsz3X">
                 <property role="TrG5h" value="e" />
               </node>
-              <node concept="3clFbS" id="49WTic8m23E" role="2LFqv$">
-                <node concept="3clFbF" id="49WTic8m2i5" role="3cqZAp">
-                  <node concept="2OqwBi" id="49WTic8m2pP" role="3clFbG">
-                    <node concept="37vLTw" id="49WTic8m2i3" role="2Oq$k0">
-                      <ref role="3cqZAo" node="49WTic8m0ug" resolve="list" />
+              <node concept="3clFbS" id="672JozYfXwS" role="2LFqv$">
+                <node concept="3clFbF" id="672JozYfXwT" role="3cqZAp">
+                  <node concept="2OqwBi" id="672JozYfXwU" role="3clFbG">
+                    <node concept="37vLTw" id="672JozYfXwV" role="2Oq$k0">
+                      <ref role="3cqZAo" node="672JozYfXwK" resolve="list" />
                     </node>
-                    <node concept="TSZUe" id="49WTic8m2JZ" role="2OqNvi">
-                      <node concept="qpA2v" id="49WTic8m2P1" role="25WWJ7">
-                        <node concept="2GrUjf" id="49WTic8m2PZ" role="3SLO0q">
-                          <ref role="2Gs0qQ" node="49WTic8m23C" resolve="e" />
+                    <node concept="TSZUe" id="672JozYfXwW" role="2OqNvi">
+                      <node concept="qpA2v" id="672JozYfXwX" role="25WWJ7">
+                        <node concept="2GrUjf" id="672JozYfXwY" role="3SLO0q">
+                          <ref role="2Gs0qQ" node="672JozYfXwR" resolve="e" />
                         </node>
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="2OqwBi" id="49WTic8m29o" role="2GsD0m">
-                <node concept="oxGPV" id="49WTic8m27f" role="2Oq$k0" />
-                <node concept="3Tsc0h" id="49WTic8m2e9" role="2OqNvi">
-                  <ref role="3TtcxE" to="hm2y:S$tO8ocnpr" resolve="values" />
+              <node concept="2OqwBi" id="672JozYfXwZ" role="2GsD0m">
+                <node concept="oxGPV" id="672JozYfXx0" role="2Oq$k0" />
+                <node concept="2qgKlT" id="672JozYfY1w" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:4ZbdskSW3D7" resolve="getValues" />
                 </node>
               </node>
             </node>
-            <node concept="3cpWs6" id="49WTic8m1Ps" role="3cqZAp">
-              <node concept="37vLTw" id="49WTic8m1Pu" role="3cqZAk">
-                <ref role="3cqZAo" node="49WTic8m0ug" resolve="list" />
+            <node concept="3cpWs6" id="672JozYfXx2" role="3cqZAp">
+              <node concept="37vLTw" id="672JozYfXx3" role="3cqZAk">
+                <ref role="3cqZAo" node="672JozYfXwK" resolve="list" />
               </node>
             </node>
           </node>
@@ -3264,6 +3268,117 @@
             </node>
           </node>
           <node concept="liA8E" id="58wi_gLyLSH" role="2OqNvi">
+            <ref role="37wK5l" to="xfg9:26cjRABQZG3" resolve="run" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="qq9P1" id="4ZbdskRheX5" role="qq9xR">
+      <property role="2TnfIJ" value="true" />
+      <ref role="qq9wM" to="yv47:4ZbdskRgKyK" resolve="TupleNamedAccessExpr" />
+      <node concept="3vetai" id="4ZbdskRhisb" role="3vQZUl">
+        <node concept="2OqwBi" id="4ZbdskRhisp" role="3vdyny">
+          <node concept="2ShNRf" id="4ZbdskRhisq" role="2Oq$k0">
+            <node concept="1pGfFk" id="4ZbdskRhisr" role="2ShVmc">
+              <ref role="37wK5l" to="xfg9:3nVyItrYOln" resolve="NixSupport" />
+              <node concept="2OqwBi" id="4ZbdskSliLB" role="37wK5m">
+                <node concept="oxGPV" id="4ZbdskSlioR" role="2Oq$k0" />
+                <node concept="2qgKlT" id="4ZbdskSllE9" role="2OqNvi">
+                  <ref role="37wK5l" to="nu60:4ZbdskSljH_" resolve="getExpression" />
+                </node>
+              </node>
+              <node concept="oxGPV" id="4ZbdskRhist" role="37wK5m" />
+              <node concept="1bVj0M" id="4ZbdskRhisu" role="37wK5m">
+                <node concept="37vLTG" id="4ZbdskRhisv" role="1bW2Oz">
+                  <property role="TrG5h" value="ns" />
+                  <node concept="3uibUv" id="4ZbdskRhisw" role="1tU5fm">
+                    <ref role="3uigEE" to="xfg9:3nVyItrYOkv" resolve="NixSupport" />
+                  </node>
+                </node>
+                <node concept="3clFbS" id="4ZbdskRhisx" role="1bW5cS">
+                  <node concept="3cpWs8" id="4ZbdskRhisy" role="3cqZAp">
+                    <node concept="3cpWsn" id="4ZbdskRhisz" role="3cpWs9">
+                      <property role="TrG5h" value="list" />
+                      <node concept="_YKpA" id="4ZbdskRhis$" role="1tU5fm">
+                        <node concept="3uibUv" id="4ZbdskRhis_" role="_ZDj9">
+                          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                        </node>
+                      </node>
+                      <node concept="10QFUN" id="672JozYhgKj" role="33vP2m">
+                        <node concept="_YKpA" id="672JozYhhcV" role="10QFUM">
+                          <node concept="3uibUv" id="672JozYhhRV" role="_ZDj9">
+                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                          </node>
+                        </node>
+                        <node concept="qpA2v" id="672JozYhgdR" role="10QFUP">
+                          <node concept="2OqwBi" id="672JozYheNO" role="3SLO0q">
+                            <node concept="oxGPV" id="672JozYheNP" role="2Oq$k0" />
+                            <node concept="2qgKlT" id="672JozYheNQ" role="2OqNvi">
+                              <ref role="37wK5l" to="pbu6:6zmBjqUivyF" resolve="contextExpression" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="4ZbdskRhisI" role="3cqZAp">
+                    <node concept="3cpWsn" id="4ZbdskRhisJ" role="3cpWs9">
+                      <property role="TrG5h" value="index" />
+                      <node concept="10Oyi0" id="4ZbdskRhisK" role="1tU5fm" />
+                      <node concept="2OqwBi" id="4ZbdskRhwQs" role="33vP2m">
+                        <node concept="2OqwBi" id="4ZbdskRhu5p" role="2Oq$k0">
+                          <node concept="2OqwBi" id="4ZbdskRhisL" role="2Oq$k0">
+                            <node concept="oxGPV" id="4ZbdskRhisM" role="2Oq$k0" />
+                            <node concept="2qgKlT" id="4ZbdskSlmZT" role="2OqNvi">
+                              <ref role="37wK5l" to="nu60:4ZbdskSg3_i" resolve="getTupleDeclaration" />
+                            </node>
+                          </node>
+                          <node concept="2qgKlT" id="4ZbdskRhv6C" role="2OqNvi">
+                            <ref role="37wK5l" to="nu60:4ZbdskRgmME" resolve="nonEmptyMembers" />
+                          </node>
+                        </node>
+                        <node concept="2WmjW8" id="4ZbdskRhx$r" role="2OqNvi">
+                          <node concept="2OqwBi" id="4ZbdskRhybB" role="25WWJ7">
+                            <node concept="oxGPV" id="4ZbdskRhxE4" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="4ZbdskRhyTO" role="2OqNvi">
+                              <ref role="3Tt5mk" to="yv47:4ZbdskRgN6H" resolve="member" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs6" id="4ZbdskRhisO" role="3cqZAp">
+                    <node concept="3K4zz7" id="4ZbdskRhisP" role="3cqZAk">
+                      <node concept="10Nm6u" id="4ZbdskRhisQ" role="3K4GZi" />
+                      <node concept="1eOMI4" id="4ZbdskRhisR" role="3K4Cdx">
+                        <node concept="3eOVzh" id="4ZbdskRhisS" role="1eOMHV">
+                          <node concept="2OqwBi" id="4ZbdskRhisT" role="3uHU7w">
+                            <node concept="37vLTw" id="4ZbdskRhisU" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4ZbdskRhisz" resolve="list" />
+                            </node>
+                            <node concept="34oBXx" id="4ZbdskRhisV" role="2OqNvi" />
+                          </node>
+                          <node concept="37vLTw" id="4ZbdskRhisW" role="3uHU7B">
+                            <ref role="3cqZAo" node="4ZbdskRhisJ" resolve="index" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="1y4W85" id="4ZbdskRhisX" role="3K4E3e">
+                        <node concept="37vLTw" id="4ZbdskRhisY" role="1y566C">
+                          <ref role="3cqZAo" node="4ZbdskRhisz" resolve="list" />
+                        </node>
+                        <node concept="37vLTw" id="4ZbdskRhisZ" role="1y58nS">
+                          <ref role="3cqZAo" node="4ZbdskRhisJ" resolve="index" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="liA8E" id="4ZbdskRhit0" role="2OqNvi">
             <ref role="37wK5l" to="xfg9:26cjRABQZG3" resolve="run" />
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.interpreter/org.iets3.core.expr.base.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.interpreter/org.iets3.core.expr.base.interpreter.msd
@@ -19,12 +19,14 @@
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
     <dependency reexport="false">b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)</dependency>
     <dependency reexport="false">00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)</dependency>
+    <dependency reexport="false">71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:47f075a6-558e-4640-a606-7ce0236c8023:com.mbeddr.mpsutil.interpreter" version="1" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:817e4e70-961e-4a95-98a1-15e9f32231f1:jetbrains.mps.ide.httpsupport" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
@@ -50,6 +52,7 @@
     <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />
     <module reference="b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)" version="0" />
     <module reference="726886d1-ef90-4249-a08f-1e3ec23a7113(com.mbeddr.mpsutil.traceExplorer)" version="0" />
+    <module reference="3819ba36-98f4-49ac-b779-34f3a458c09b(com.mbeddr.mpsutil.varscope)" version="0" />
     <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
     <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
     <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
@@ -73,6 +76,10 @@
     <module reference="cf90f965-8554-4a16-aa0b-6387f27474ab(org.iets3.core.expr.base.interpreter)" version="0" />
     <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
     <module reference="00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)" version="0" />
+    <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="5" />
+    <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="0" />
+    <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="2" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.lambda.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.lambda.interpreter/models/plugin.mps
@@ -20,6 +20,8 @@
     <import index="5s8v" ref="r:06389a24-a77a-450d-bc88-bccec0aae7d8(org.iets3.core.expr.lambda.behavior)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="pu3r" ref="r:9e94dd0f-9221-4302-af65-0a889986fe22(com.mbeddr.mpsutil.traceExplorer.plugin)" />
+    <import index="yv47" ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" />
+    <import index="nu60" ref="r:cfd59c48-ecc8-4b0c-8ae8-6d876c46ebbb(org.iets3.core.expr.toplevel.behavior)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -32,6 +34,9 @@
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+        <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -56,6 +61,7 @@
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
@@ -86,6 +92,9 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
@@ -112,6 +121,7 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
@@ -467,6 +477,138 @@
                 </node>
               </node>
             </node>
+            <node concept="3clFbJ" id="4ZbdskROymg" role="3cqZAp">
+              <node concept="3clFbS" id="4ZbdskROymh" role="3clFbx">
+                <node concept="3clFbJ" id="4ZbdskROymi" role="3cqZAp">
+                  <node concept="3clFbS" id="4ZbdskROymj" role="3clFbx">
+                    <node concept="3cpWs8" id="4ZbdskROymk" role="3cqZAp">
+                      <node concept="3cpWsn" id="4ZbdskROyml" role="3cpWs9">
+                        <property role="TrG5h" value="tv" />
+                        <node concept="3Tqbb2" id="4ZbdskROymm" role="1tU5fm">
+                          <ref role="ehGHo" to="yv47:4ZbdskRDGLl" resolve="NamedTupleValue" />
+                        </node>
+                        <node concept="1PxgMI" id="4ZbdskROymn" role="33vP2m">
+                          <node concept="chp4Y" id="4ZbdskROymo" role="3oSUPX">
+                            <ref role="cht4Q" to="yv47:4ZbdskRDGLl" resolve="NamedTupleValue" />
+                          </node>
+                          <node concept="2OqwBi" id="4ZbdskROymp" role="1m5AlR">
+                            <node concept="oxGPV" id="4ZbdskROymq" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="4ZbdskROymr" role="2OqNvi">
+                              <ref role="3Tt5mk" to="hm2y:4rZeNQ6MpKm" resolve="left" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="4ZbdskRO$LJ" role="3cqZAp">
+                      <node concept="3cpWsn" id="4ZbdskRO$LM" role="3cpWs9">
+                        <property role="TrG5h" value="index" />
+                        <node concept="10Oyi0" id="4ZbdskRO$LH" role="1tU5fm" />
+                        <node concept="3cmrfG" id="4ZbdskRO_dk" role="33vP2m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2Gpval" id="4ZbdskROyms" role="3cqZAp">
+                      <node concept="2GrKxI" id="4ZbdskROymt" role="2Gsz3X">
+                        <property role="TrG5h" value="element" />
+                      </node>
+                      <node concept="2OqwBi" id="4ZbdskROymu" role="2GsD0m">
+                        <node concept="37vLTw" id="4ZbdskROymv" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4ZbdskROyml" resolve="tv" />
+                        </node>
+                        <node concept="2qgKlT" id="4ZbdskRO$hL" role="2OqNvi">
+                          <ref role="37wK5l" to="nu60:4ZbdskRO1Cc" resolve="getIndexSortedValues" />
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="4ZbdskROymx" role="2LFqv$">
+                        <node concept="3clFbJ" id="4ZbdskROymy" role="3cqZAp">
+                          <node concept="3clFbS" id="4ZbdskROymz" role="3clFbx">
+                            <node concept="3clFbF" id="4ZbdskROym$" role="3cqZAp">
+                              <node concept="37vLTI" id="4ZbdskROym_" role="3clFbG">
+                                <node concept="2OqwBi" id="4ZbdskROymA" role="37vLTx">
+                                  <node concept="1eOMI4" id="4ZbdskROymB" role="2Oq$k0">
+                                    <node concept="10QFUN" id="4ZbdskROymC" role="1eOMHV">
+                                      <node concept="37vLTw" id="4ZbdskROymD" role="10QFUP">
+                                        <ref role="3cqZAo" node="1VmWkC0CMUv" resolve="value" />
+                                      </node>
+                                      <node concept="3uibUv" id="4ZbdskROymE" role="10QFUM">
+                                        <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="liA8E" id="4ZbdskROymF" role="2OqNvi">
+                                    <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
+                                    <node concept="3uNrnE" id="4ZbdskROAbW" role="37wK5m">
+                                      <node concept="37vLTw" id="4ZbdskROAbY" role="2$L3a6">
+                                        <ref role="3cqZAo" node="4ZbdskRO$LM" resolve="index" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="3EllGN" id="4ZbdskROymJ" role="37vLTJ">
+                                  <node concept="2OqwBi" id="4ZbdskROymK" role="3ElVtu">
+                                    <node concept="1PxgMI" id="4ZbdskROymL" role="2Oq$k0">
+                                      <node concept="chp4Y" id="4ZbdskROymM" role="3oSUPX">
+                                        <ref role="cht4Q" to="zzzn:1VmWkC0$wKA" resolve="LocalVarRef" />
+                                      </node>
+                                      <node concept="2GrUjf" id="4ZbdskROymN" role="1m5AlR">
+                                        <ref role="2Gs0qQ" node="4ZbdskROymt" resolve="element" />
+                                      </node>
+                                    </node>
+                                    <node concept="3TrEf2" id="4ZbdskROymO" role="2OqNvi">
+                                      <ref role="3Tt5mk" to="zzzn:1VmWkC0$wL2" resolve="var" />
+                                    </node>
+                                  </node>
+                                  <node concept="TvHiN" id="4ZbdskROymP" role="3ElQJh" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="4ZbdskROymQ" role="3clFbw">
+                            <node concept="2GrUjf" id="4ZbdskROymR" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="4ZbdskROymt" resolve="element" />
+                            </node>
+                            <node concept="1mIQ4w" id="4ZbdskROymS" role="2OqNvi">
+                              <node concept="chp4Y" id="4ZbdskROymT" role="cj9EA">
+                                <ref role="cht4Q" to="zzzn:1VmWkC0$wKA" resolve="LocalVarRef" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs6" id="4ZbdskROymU" role="3cqZAp">
+                      <node concept="37vLTw" id="4ZbdskROymV" role="3cqZAk">
+                        <ref role="3cqZAo" node="1VmWkC0CMUv" resolve="value" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2ZW3vV" id="4ZbdskROymW" role="3clFbw">
+                    <node concept="3uibUv" id="4ZbdskROymX" role="2ZW6by">
+                      <ref role="3uigEE" to="33ny:~List" resolve="List" />
+                    </node>
+                    <node concept="37vLTw" id="4ZbdskROymY" role="2ZW6bz">
+                      <ref role="3cqZAo" node="1VmWkC0CMUv" resolve="value" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4ZbdskROymZ" role="3clFbw">
+                <node concept="2OqwBi" id="4ZbdskROyn0" role="2Oq$k0">
+                  <node concept="oxGPV" id="4ZbdskROyn1" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4ZbdskROyn2" role="2OqNvi">
+                    <ref role="3Tt5mk" to="hm2y:4rZeNQ6MpKm" resolve="left" />
+                  </node>
+                </node>
+                <node concept="1mIQ4w" id="4ZbdskROyn3" role="2OqNvi">
+                  <node concept="chp4Y" id="4ZbdskROyn4" role="cj9EA">
+                    <ref role="cht4Q" to="yv47:4ZbdskRDGLl" resolve="NamedTupleValue" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="4ZbdskROxUs" role="3cqZAp" />
             <node concept="3cpWs6" id="1VmWkC0CMLr" role="3cqZAp">
               <node concept="2gcYsJ" id="1VmWkC0CMLz" role="3cqZAk" />
             </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.lambda.interpreter/org.iets3.core.expr.lambda.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.lambda.interpreter/org.iets3.core.expr.lambda.interpreter.msd
@@ -18,6 +18,7 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">735f86bc-17fb-4d1c-a664-82c2b8e8a34e(com.mbeddr.mpsutil.interpreter.rt)</dependency>
     <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
+    <dependency reexport="false">71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:47f075a6-558e-4640-a606-7ce0236c8023:com.mbeddr.mpsutil.interpreter" version="1" />
@@ -66,8 +67,11 @@
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
     <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="3" />
     <module reference="cf90f965-8554-4a16-aa0b-6387f27474ab(org.iets3.core.expr.base.interpreter)" version="0" />
+    <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="5" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="0" />
     <module reference="8ba65567-1c8a-4983-beb8-0482324d7e44(org.iets3.core.expr.lambda.interpreter)" version="0" />
+    <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
+    <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="2" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.plugin/models/plugin.mps
@@ -8338,19 +8338,19 @@
               <ref role="3cqZAo" node="kZqQ800dDB" resolve="options" />
             </node>
             <node concept="liA8E" id="4SH1Ldj_FpZ" role="2OqNvi">
-              <ref role="37wK5l" to="pu3r:4SH1LdjmhBl" resolve="hideToolButton" />
+              <ref role="37wK5l" to="pu3r:4SH1LdjmhBl" resolve="hideToolButtons" />
               <node concept="2ShNRf" id="4SH1LdjEAJK" role="37wK5m">
                 <node concept="3g6Rrh" id="4SH1LdjELyd" role="2ShVmc">
                   <node concept="3uibUv" id="4SH1LdjEKhj" role="3g7fb8">
-                    <ref role="3uigEE" to="pu3r:4SH1LdjhYoh" resolve="ToolButtonEnum" />
+                    <ref role="3uigEE" to="pu3r:4SH1LdjhYoh" resolve="TraceTabOptions.ToolButtonEnum" />
                   </node>
                   <node concept="Rm8GO" id="4SH1LdjER7k" role="3g7hyw">
                     <ref role="Rm8GQ" to="pu3r:4SH1Ldjinkn" resolve="NextTrace" />
-                    <ref role="1Px2BO" to="pu3r:4SH1LdjhYoh" resolve="ToolButtonEnum" />
+                    <ref role="1Px2BO" to="pu3r:4SH1LdjhYoh" resolve="TraceTabOptions.ToolButtonEnum" />
                   </node>
                   <node concept="Rm8GO" id="4SH1LdjETU0" role="3g7hyw">
                     <ref role="Rm8GQ" to="pu3r:4SH1Ldjintc" resolve="Rerun" />
-                    <ref role="1Px2BO" to="pu3r:4SH1LdjhYoh" resolve="ToolButtonEnum" />
+                    <ref role="1Px2BO" to="pu3r:4SH1LdjhYoh" resolve="TraceTabOptions.ToolButtonEnum" />
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -2975,6 +2975,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="672JozYGBDj" role="3bR37C">
+          <node concept="3bR9La" id="672JozYGBDk" role="1SiIV1">
+            <ref role="3bR37D" node="2uR5X5azttH" resolve="org.iets3.core.expr.toplevel" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="5Nr2ndjUDzy" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -3687,6 +3692,11 @@
             <node concept="3qWCbU" id="1RMC8GHEwDr" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="672JozWqXVb" role="3bR37C">
+          <node concept="3bR9La" id="672JozWqXVc" role="1SiIV1">
+            <ref role="3bR37D" node="2uR5X5azttH" resolve="org.iets3.core.expr.toplevel" />
           </node>
         </node>
       </node>
@@ -7379,6 +7389,11 @@
         <node concept="1SiIV0" id="3qKzW8QxKUj" role="3bR37C">
           <node concept="3bR9La" id="3qKzW8QxKUk" role="1SiIV1">
             <ref role="3bR37D" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4ZbdskSSPlG" role="3bR37C">
+          <node concept="3bR9La" id="4ZbdskSSPlH" role="1SiIV1">
+            <ref role="3bR37D" node="2uR5X5azttH" resolve="org.iets3.core.expr.toplevel" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/solutions/test.ex.core.expr.genjava/models/messages@tests.mps
+++ b/code/languages/org.iets3.opensource/solutions/test.ex.core.expr.genjava/models/messages@tests.mps
@@ -7,7 +7,7 @@
     <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="4" />
     <use id="553a35c5-ccd6-40ba-9923-5e3b354d0c76" name="org.iets3.core.expr.messages" version="0" />
     <use id="d441fba0-f46b-43cd-b723-dad7b65da615" name="org.iets3.core.expr.tests" version="1" />
-    <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="2" />
+    <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="3" />
     <devkit ref="ffc660b2-672c-4f91-9291-8426ed4e58de(org.iets3.core.expr.genjava.advanced.devkit)" />
   </languages>
   <imports />

--- a/code/languages/org.iets3.opensource/solutions/test.ex.core.expr.genjava/test.ex.core.expr.genjava.msd
+++ b/code/languages/org.iets3.opensource/solutions/test.ex.core.expr.genjava/test.ex.core.expr.genjava.msd
@@ -50,7 +50,7 @@
     <language slang="l:6b277d9a-d52d-416f-a209-1919bd737f50:org.iets3.core.expr.simpleTypes" version="1" />
     <language slang="l:d441fba0-f46b-43cd-b723-dad7b65da615:org.iets3.core.expr.tests" version="1" />
     <language slang="l:71934284-d7d1-45ee-a054-8c072591085f:org.iets3.core.expr.toplevel" version="4" />
-    <language slang="l:8bb1251e-eae5-47ab-9843-33adfae8edaa:org.iets3.core.expr.util" version="2" />
+    <language slang="l:8bb1251e-eae5-47ab-9843-33adfae8edaa:org.iets3.core.expr.util" version="3" />
   </languageVersions>
   <dependencyVersions>
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/operatorgroup@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/operatorgroup@tests.mps
@@ -5,7 +5,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base" version="0" />
-    <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="2" />
+    <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="3" />
     <devkit ref="c4e521ab-b605-4ef9-a7c3-68075da058f0(org.iets3.core.expr.core.devkit)" />
   </languages>
   <imports />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.datatable@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.datatable@tests.mps
@@ -5,7 +5,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base" version="0" />
-    <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="2" />
+    <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="3" />
     <use id="b25b8ad1-4d3d-4e45-8c78-72091b39fdda" name="org.iets3.core.expr.data" version="1" />
     <devkit ref="c4e521ab-b605-4ef9-a7c3-68075da058f0(org.iets3.core.expr.core.devkit)" />
   </languages>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.dectabs@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.dectabs@tests.mps
@@ -72,9 +72,6 @@
       </concept>
     </language>
     <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
-      <concept id="1019070541450015930" name="org.iets3.core.expr.base.structure.TupleType" flags="ng" index="m5gfS">
-        <child id="1019070541450015931" name="elementTypes" index="m5gfT" />
-      </concept>
       <concept id="7089558164905593724" name="org.iets3.core.expr.base.structure.IOptionallyTyped" flags="ng" index="2zM23E">
         <child id="7089558164905593725" name="type" index="2zM23F" />
       </concept>
@@ -152,6 +149,9 @@
       <concept id="4790956042240148643" name="org.iets3.core.expr.toplevel.structure.Function" flags="ng" index="1aga60" />
       <concept id="5749748470420409857" name="org.iets3.core.expr.toplevel.structure.ITupleDeclaration" flags="ng" index="1SyzJ4">
         <child id="5749748470420419627" name="members" index="1Syw7I" />
+      </concept>
+      <concept id="5749748470420465954" name="org.iets3.core.expr.toplevel.structure.NamedTupleType" flags="ng" index="1SyHNB">
+        <reference id="5749748470420465990" name="tuple" index="1SyHM3" />
       </concept>
       <concept id="5749748470417082344" name="org.iets3.core.expr.toplevel.structure.TupleMember" flags="ng" index="1SLn8H" />
       <concept id="5749748470417037802" name="org.iets3.core.expr.toplevel.structure.NamedTupleDeclaration" flags="ng" index="1SLEKJ" />
@@ -909,6 +909,22 @@
       </node>
     </node>
     <node concept="_ixoA" id="6OunYCfqiYO" role="_iOnB" />
+    <node concept="1SLEKJ" id="1pkymqL_Qs3" role="_iOnB">
+      <property role="TrG5h" value="FareAndDiscount" />
+      <node concept="1SLn8H" id="1pkymqL_QTV" role="1Syw7I">
+        <property role="TrG5h" value="currency" />
+        <node concept="1WbbFT" id="1pkymqL_QTY" role="2S399n">
+          <ref role="1WbbFS" node="6OunYCfqD$8" resolve="Currency" />
+        </node>
+      </node>
+      <node concept="1SLn8H" id="1pkymqL_QUq" role="1Syw7I">
+        <property role="TrG5h" value="percentage" />
+        <node concept="1WbbFT" id="1pkymqL_QUv" role="2S399n">
+          <ref role="1WbbFS" node="6OunYCfqBWH" resolve="Percentage" />
+        </node>
+      </node>
+    </node>
+    <node concept="_ixoA" id="1pkymqL_PYo" role="_iOnB" />
     <node concept="1aga60" id="6OunYCfqwc5" role="_iOnB">
       <property role="TrG5h" value="calculateFare" />
       <node concept="1fMURV" id="6OunYCfqx56" role="1ahQXP">
@@ -1167,13 +1183,8 @@
         <property role="TrG5h" value="club" />
         <node concept="2vmvy5" id="6OunYCfq$1p" role="3ix9CU" />
       </node>
-      <node concept="m5gfS" id="6OunYCfqHUN" role="2zM23F">
-        <node concept="1WbbFT" id="6OunYCfqHUO" role="m5gfT">
-          <ref role="1WbbFS" node="6OunYCfqD$8" resolve="Currency" />
-        </node>
-        <node concept="1WbbFT" id="6OunYCfqHUP" role="m5gfT">
-          <ref role="1WbbFS" node="6OunYCfqBWH" resolve="Percentage" />
-        </node>
+      <node concept="1SyHNB" id="1pkymqL_RvP" role="2zM23F">
+        <ref role="1SyHM3" node="1pkymqL_Qs3" resolve="FareAndDiscount" />
       </node>
     </node>
     <node concept="_ixoA" id="6OunYCfqJny" role="_iOnB" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.dectabs@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.dectabs@tests.mps
@@ -4,7 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="2" />
+    <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="3" />
     <devkit ref="33eb240b-05aa-417a-b719-386d26df80b8(org.iets3.core.expr.genall.advanced.devkit)" />
     <devkit ref="c4e521ab-b605-4ef9-a7c3-68075da058f0(org.iets3.core.expr.core.devkit)" />
   </languages>
@@ -58,6 +58,7 @@
       </concept>
       <concept id="161551962036658012" name="org.iets3.core.expr.util.structure.MultiDecTab" flags="ng" index="1fMURV" />
       <concept id="8853770331921611232" name="org.iets3.core.expr.util.structure.IMultiDecTab" flags="ng" index="1vMD3l">
+        <child id="1609062041026819473" name="resultTupleDeclaration" index="2ACRNR" />
         <child id="8853770331921611296" name="colDefs" index="1vMDcl" />
         <child id="8853770331921611812" name="rows" index="1vMDkh" />
       </concept>
@@ -76,6 +77,9 @@
       </concept>
       <concept id="7089558164905593724" name="org.iets3.core.expr.base.structure.IOptionallyTyped" flags="ng" index="2zM23E">
         <child id="7089558164905593725" name="type" index="2zM23F" />
+      </concept>
+      <concept id="7071042522334260296" name="org.iets3.core.expr.base.structure.ITyped" flags="ng" index="2_iKZX">
+        <child id="8811147530085329321" name="type" index="2S399n" />
       </concept>
       <concept id="5115872837156802409" name="org.iets3.core.expr.base.structure.UnaryExpression" flags="ng" index="30czhk">
         <child id="5115872837156802411" name="expr" index="30czhm" />
@@ -146,6 +150,11 @@
       <concept id="543569365052765011" name="org.iets3.core.expr.toplevel.structure.EmptyToplevelContent" flags="ng" index="_ixoA" />
       <concept id="4790956042240570348" name="org.iets3.core.expr.toplevel.structure.FunctionCall" flags="ng" index="1af_rf" />
       <concept id="4790956042240148643" name="org.iets3.core.expr.toplevel.structure.Function" flags="ng" index="1aga60" />
+      <concept id="5749748470420409857" name="org.iets3.core.expr.toplevel.structure.ITupleDeclaration" flags="ng" index="1SyzJ4">
+        <child id="5749748470420419627" name="members" index="1Syw7I" />
+      </concept>
+      <concept id="5749748470417082344" name="org.iets3.core.expr.toplevel.structure.TupleMember" flags="ng" index="1SLn8H" />
+      <concept id="5749748470417037802" name="org.iets3.core.expr.toplevel.structure.NamedTupleDeclaration" flags="ng" index="1SLEKJ" />
       <concept id="7740953487936183912" name="org.iets3.core.expr.toplevel.structure.Typedef" flags="ng" index="1WbbD7">
         <child id="7740953487936183915" name="originalType" index="1WbbD4" />
       </concept>
@@ -483,6 +492,13 @@
             <property role="TrG5h" value="r" />
             <node concept="mLuIC" id="6OunYCfi$nV" role="1fMUOZ" />
           </node>
+          <node concept="1SLEKJ" id="1pkymqLocJx" role="2ACRNR">
+            <property role="TrG5h" value="7862827458318976204_ResultTuple" />
+            <node concept="1SLn8H" id="1pkymqLocJy" role="1Syw7I">
+              <property role="TrG5h" value="r" />
+              <node concept="mLuIC" id="1pkymqLocJz" role="2S399n" />
+            </node>
+          </node>
         </node>
       </node>
       <node concept="1ahQXy" id="6OunYCfi$jO" role="1ahQWs">
@@ -584,6 +600,17 @@
             <node concept="mLuIC" id="7vcJOhhDxoI" role="1fMUOZ">
               <node concept="2gteS_" id="7vcJOhhDBU1" role="2gteVg">
                 <property role="2gteVv" value="1" />
+              </node>
+            </node>
+          </node>
+          <node concept="1SLEKJ" id="1pkymqLocJ$" role="2ACRNR">
+            <property role="TrG5h" value="8632484885910918669_ResultTuple" />
+            <node concept="1SLn8H" id="1pkymqLocJ_" role="1Syw7I">
+              <property role="TrG5h" value="r" />
+              <node concept="mLuIC" id="1pkymqLocJA" role="2S399n">
+                <node concept="2gteS_" id="1pkymqLocJB" role="2gteVg">
+                  <property role="2gteVv" value="1" />
+                </node>
               </node>
             </node>
           </node>
@@ -961,6 +988,17 @@
             </node>
           </node>
         </node>
+        <node concept="1SLEKJ" id="1pkymqLocJC" role="2ACRNR">
+          <property role="TrG5h" value="7862827458321060166_ResultTuple" />
+          <node concept="1SLn8H" id="1pkymqLocJD" role="1Syw7I">
+            <property role="TrG5h" value="base" />
+            <node concept="mLuIC" id="1pkymqLocJE" role="2S399n">
+              <node concept="2gteS_" id="1pkymqLocJF" role="2gteVg">
+                <property role="2gteVv" value="2" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="1ahQXy" id="6OunYCfqwBU" role="1ahQWs">
         <property role="TrG5h" value="state" />
@@ -1101,6 +1139,21 @@
           <property role="TrG5h" value="volDiscount" />
           <node concept="1WbbFT" id="6OunYCfqDxB" role="1fMUOZ">
             <ref role="1WbbFS" node="6OunYCfqBWH" resolve="Percentage" />
+          </node>
+        </node>
+        <node concept="1SLEKJ" id="1pkymqLocJG" role="2ACRNR">
+          <property role="TrG5h" value="7862827458321072184_ResultTuple" />
+          <node concept="1SLn8H" id="1pkymqLocJH" role="1Syw7I">
+            <property role="TrG5h" value="base" />
+            <node concept="1WbbFT" id="1pkymqLocJI" role="2S399n">
+              <ref role="1WbbFS" node="6OunYCfqD$8" resolve="Currency" />
+            </node>
+          </node>
+          <node concept="1SLn8H" id="1pkymqLocJJ" role="1Syw7I">
+            <property role="TrG5h" value="volDiscount" />
+            <node concept="1WbbFT" id="1pkymqLocJK" role="2S399n">
+              <ref role="1WbbFS" node="6OunYCfqBWH" resolve="Percentage" />
+            </node>
           </node>
         </node>
       </node>
@@ -1257,6 +1310,21 @@
           <property role="TrG5h" value="volDiscount" />
           <node concept="1WbbFT" id="6OunYCfqIGN" role="1fMUOZ">
             <ref role="1WbbFS" node="6OunYCfqBWH" resolve="Percentage" />
+          </node>
+        </node>
+        <node concept="1SLEKJ" id="1pkymqLocJL" role="2ACRNR">
+          <property role="TrG5h" value="7862827458321115908_ResultTuple" />
+          <node concept="1SLn8H" id="1pkymqLocJM" role="1Syw7I">
+            <property role="TrG5h" value="base" />
+            <node concept="1WbbFT" id="1pkymqLocJN" role="2S399n">
+              <ref role="1WbbFS" node="6OunYCfqD$8" resolve="Currency" />
+            </node>
+          </node>
+          <node concept="1SLn8H" id="1pkymqLocJO" role="1Syw7I">
+            <property role="TrG5h" value="volDiscount" />
+            <node concept="1WbbFT" id="1pkymqLocJP" role="2S399n">
+              <ref role="1WbbFS" node="6OunYCfqBWH" resolve="Percentage" />
+            </node>
           </node>
         </node>
       </node>
@@ -1483,6 +1551,21 @@
           <property role="TrG5h" value="volDiscount" />
           <node concept="1WbbFT" id="6OunYCfqNYO" role="1fMUOZ">
             <ref role="1WbbFS" node="6OunYCfqBWH" resolve="Percentage" />
+          </node>
+        </node>
+        <node concept="1SLEKJ" id="1pkymqLocJQ" role="2ACRNR">
+          <property role="TrG5h" value="7862827458321137539_ResultTuple" />
+          <node concept="1SLn8H" id="1pkymqLocJR" role="1Syw7I">
+            <property role="TrG5h" value="base" />
+            <node concept="1WbbFT" id="1pkymqLocJS" role="2S399n">
+              <ref role="1WbbFS" node="6OunYCfqD$8" resolve="Currency" />
+            </node>
+          </node>
+          <node concept="1SLn8H" id="1pkymqLocJT" role="1Syw7I">
+            <property role="TrG5h" value="volDiscount" />
+            <node concept="1WbbFT" id="1pkymqLocJU" role="2S399n">
+              <ref role="1WbbFS" node="6OunYCfqBWH" resolve="Percentage" />
+            </node>
           </node>
         </node>
       </node>
@@ -1715,6 +1798,21 @@
           <property role="TrG5h" value="volDiscount" />
           <node concept="1WbbFT" id="7vcJOhhDCqH" role="1fMUOZ">
             <ref role="1WbbFS" node="6OunYCfqBWH" resolve="Percentage" />
+          </node>
+        </node>
+        <node concept="1SLEKJ" id="1pkymqLocJV" role="2ACRNR">
+          <property role="TrG5h" value="8632484885910947423_ResultTuple" />
+          <node concept="1SLn8H" id="1pkymqLocJW" role="1Syw7I">
+            <property role="TrG5h" value="base" />
+            <node concept="1WbbFT" id="1pkymqLocJX" role="2S399n">
+              <ref role="1WbbFS" node="6OunYCfqD$8" resolve="Currency" />
+            </node>
+          </node>
+          <node concept="1SLn8H" id="1pkymqLocJY" role="1Syw7I">
+            <property role="TrG5h" value="volDiscount" />
+            <node concept="1WbbFT" id="1pkymqLocJZ" role="2S399n">
+              <ref role="1WbbFS" node="6OunYCfqBWH" resolve="Percentage" />
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.nix@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.nix@tests.mps
@@ -5,7 +5,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base" version="0" />
-    <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="2" />
+    <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="3" />
     <use id="289fb12b-7f53-4ef7-bc2e-1ed2c6a7c998" name="org.iets3.core.expr.datetime" version="0" />
     <devkit ref="c4e521ab-b605-4ef9-a7c3-68075da058f0(org.iets3.core.expr.core.devkit)" />
   </languages>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.query@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.query@tests.mps
@@ -5,7 +5,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base" version="0" />
-    <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="2" />
+    <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="3" />
     <use id="10e056b2-49fd-40ca-8b64-de69c81163ac" name="org.iets3.core.expr.query" version="0" />
     <devkit ref="c4e521ab-b605-4ef9-a7c3-68075da058f0(org.iets3.core.expr.core.devkit)" />
   </languages>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tuples@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tuples@tests.mps
@@ -278,6 +278,10 @@
         <node concept="30bXR$" id="4ZbdskSIb6y" role="2S399n" />
       </node>
     </node>
+    <node concept="_ixoA" id="7yOFqurGGEA" role="_iOnB" />
+    <node concept="1SLEKJ" id="7yOFqurGGMV" role="_iOnB">
+      <property role="TrG5h" value="Empty" />
+    </node>
     <node concept="_ixoA" id="4ZbdskRDGHp" role="_iOnB" />
     <node concept="2zPypq" id="4ZbdskRDGJG" role="_iOnB">
       <property role="TrG5h" value="p1" />
@@ -340,6 +344,12 @@
             <property role="30bXRw" value="12" />
           </node>
         </node>
+      </node>
+    </node>
+    <node concept="2zPypq" id="7yOFqurGH1i" role="_iOnB">
+      <property role="TrG5h" value="empty" />
+      <node concept="1SrvAg" id="7yOFqurGH7$" role="2zPyp_">
+        <ref role="1Srsag" node="7yOFqurGGMV" resolve="Empty" />
       </node>
     </node>
     <node concept="_ixoA" id="672JozXPITP" role="_iOnB" />
@@ -429,6 +439,16 @@
         </node>
         <node concept="30bXRB" id="672JozXSF1T" role="_fkuS">
           <property role="30bXRw" value="12" />
+        </node>
+      </node>
+      <node concept="3dYjL0" id="7yOFqurGGSW" role="_fkp5" />
+      <node concept="_fkuZ" id="7yOFqurGGUf" role="_fkp5">
+        <node concept="_fku$" id="7yOFqurGGUg" role="_fkur" />
+        <node concept="_emDc" id="7yOFqurISuB" role="_fkuS">
+          <ref role="_emDf" node="7yOFqurGH1i" resolve="empty" />
+        </node>
+        <node concept="_emDc" id="7yOFqurGH7W" role="_fkuY">
+          <ref role="_emDf" node="7yOFqurGH1i" resolve="empty" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tuples@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tuples@tests.mps
@@ -4,6 +4,7 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel" version="4" />
     <devkit ref="ec967770-4707-442f-baaf-a8b7bb554717(org.iets3.core.expr.genall.core.devkit)" />
     <devkit ref="c4e521ab-b605-4ef9-a7c3-68075da058f0(org.iets3.core.expr.core.devkit)" />
   </languages>
@@ -32,9 +33,18 @@
       <concept id="7089558164905593724" name="org.iets3.core.expr.base.structure.IOptionallyTyped" flags="ng" index="2zM23E">
         <child id="7089558164905593725" name="type" index="2zM23F" />
       </concept>
+      <concept id="7071042522334260296" name="org.iets3.core.expr.base.structure.ITyped" flags="ng" index="2_iKZX">
+        <child id="8811147530085329321" name="type" index="2S399n" />
+      </concept>
+      <concept id="5115872837156802409" name="org.iets3.core.expr.base.structure.UnaryExpression" flags="ng" index="30czhk">
+        <child id="5115872837156802411" name="expr" index="30czhm" />
+      </concept>
       <concept id="2527679671886479690" name="org.iets3.core.expr.base.structure.TupleAccessExpr" flags="ng" index="3nOhSe">
         <property id="2527679671886575030" name="index" index="3nOAFM" />
         <child id="2527679671886479717" name="tuple" index="3nOhSx" />
+      </concept>
+      <concept id="9002563722476995145" name="org.iets3.core.expr.base.structure.DotExpression" flags="ng" index="1QScDb">
+        <child id="9002563722476995147" name="target" index="1QScD9" />
       </concept>
     </language>
     <language id="d441fba0-f46b-43cd-b723-dad7b65da615" name="org.iets3.core.expr.tests">
@@ -75,6 +85,25 @@
         <reference id="543569365051789114" name="constant" index="_emDf" />
       </concept>
       <concept id="543569365052765011" name="org.iets3.core.expr.toplevel.structure.EmptyToplevelContent" flags="ng" index="_ixoA" />
+      <concept id="5749748470427081075" name="org.iets3.core.expr.toplevel.structure.TupleMemberSetter" flags="ng" index="1SruMQ">
+        <reference id="5749748470427081076" name="member" index="1SruML" />
+        <child id="5070313213710413816" name="value" index="1lsf3T" />
+      </concept>
+      <concept id="5749748470427077717" name="org.iets3.core.expr.toplevel.structure.NamedTupleValue" flags="ng" index="1SrvAg">
+        <reference id="5749748470427088725" name="tuple" index="1Srsag" />
+        <child id="5749748470427077777" name="setters" index="1Srv_k" />
+      </concept>
+      <concept id="5749748470420539568" name="org.iets3.core.expr.toplevel.structure.TupleNamedAccessExpr" flags="ng" index="1Sy3PP">
+        <reference id="5749748470420550061" name="member" index="1Sy0hC" />
+      </concept>
+      <concept id="5749748470420409857" name="org.iets3.core.expr.toplevel.structure.ITupleDeclaration" flags="ng" index="1SyzJ4">
+        <child id="5749748470420419627" name="members" index="1Syw7I" />
+      </concept>
+      <concept id="5749748470420465954" name="org.iets3.core.expr.toplevel.structure.NamedTupleType" flags="ng" index="1SyHNB">
+        <reference id="5749748470420465990" name="tuple" index="1SyHM3" />
+      </concept>
+      <concept id="5749748470417082344" name="org.iets3.core.expr.toplevel.structure.TupleMember" flags="ng" index="1SLn8H" />
+      <concept id="5749748470417037802" name="org.iets3.core.expr.toplevel.structure.NamedTupleDeclaration" flags="ng" index="1SLEKJ" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -102,7 +131,6 @@
       </node>
     </node>
     <node concept="_ixoA" id="6HHp2WmY4cE" role="_iOnB" />
-    <node concept="_ixoA" id="6HHp2WmY4cB" role="_iOnB" />
     <node concept="_fkuM" id="6HHp2WmY4bj" role="_iOnB">
       <property role="TrG5h" value="utils_tuples" />
       <node concept="_fkuZ" id="1IomA9w$4TS" role="_fkp5">
@@ -224,6 +252,184 @@
           </node>
         </node>
         <node concept="2vmpnb" id="3aItn4K2ftb" role="_fkuS" />
+      </node>
+    </node>
+    <node concept="_ixoA" id="4ZbdskRCalz" role="_iOnB" />
+    <node concept="1SLEKJ" id="4ZbdskRgdBl" role="_iOnB">
+      <property role="TrG5h" value="Point" />
+      <node concept="1SLn8H" id="4ZbdskRDGGU" role="1Syw7I">
+        <property role="TrG5h" value="x" />
+        <node concept="30bXR$" id="4ZbdskRDGGX" role="2S399n" />
+      </node>
+      <node concept="1SLn8H" id="4ZbdskRDGHd" role="1Syw7I">
+        <property role="TrG5h" value="y" />
+        <node concept="30bXR$" id="4ZbdskRDGHi" role="2S399n" />
+      </node>
+    </node>
+    <node concept="_ixoA" id="4ZbdskSIb9W" role="_iOnB" />
+    <node concept="1SLEKJ" id="4ZbdskSIb6w" role="_iOnB">
+      <property role="TrG5h" value="Point2" />
+      <node concept="1SLn8H" id="4ZbdskSIb6z" role="1Syw7I">
+        <property role="TrG5h" value="y" />
+        <node concept="30bXR$" id="4ZbdskSIb6$" role="2S399n" />
+      </node>
+      <node concept="1SLn8H" id="4ZbdskSIb6x" role="1Syw7I">
+        <property role="TrG5h" value="x" />
+        <node concept="30bXR$" id="4ZbdskSIb6y" role="2S399n" />
+      </node>
+    </node>
+    <node concept="_ixoA" id="4ZbdskRDGHp" role="_iOnB" />
+    <node concept="2zPypq" id="4ZbdskRDGJG" role="_iOnB">
+      <property role="TrG5h" value="p1" />
+      <node concept="1SyHNB" id="4ZbdskRDGL9" role="2zM23F">
+        <ref role="1SyHM3" node="4ZbdskRgdBl" resolve="Point" />
+      </node>
+      <node concept="1SrvAg" id="4ZbdskSdEoi" role="2zPyp_">
+        <ref role="1Srsag" node="4ZbdskRgdBl" resolve="Point" />
+        <node concept="1SruMQ" id="4ZbdskSdEok" role="1Srv_k">
+          <ref role="1SruML" node="4ZbdskRDGGU" resolve="x" />
+          <node concept="30bXRB" id="4ZbdskSfrnT" role="1lsf3T">
+            <property role="30bXRw" value="10" />
+          </node>
+        </node>
+        <node concept="1SruMQ" id="4ZbdskSdEom" role="1Srv_k">
+          <ref role="1SruML" node="4ZbdskRDGHd" resolve="y" />
+          <node concept="30bXRB" id="4ZbdskSfroL" role="1lsf3T">
+            <property role="30bXRw" value="12" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2zPypq" id="4ZbdskSIb0Z" role="_iOnB">
+      <property role="TrG5h" value="p2" />
+      <node concept="1SyHNB" id="4ZbdskSIb10" role="2zM23F">
+        <ref role="1SyHM3" node="4ZbdskSIb6w" resolve="Point2" />
+      </node>
+      <node concept="1SrvAg" id="672JozXPHVq" role="2zPyp_">
+        <ref role="1Srsag" node="4ZbdskSIb6w" resolve="Point2" />
+        <node concept="1SruMQ" id="672JozXPHVs" role="1Srv_k">
+          <ref role="1SruML" node="4ZbdskSIb6z" resolve="y" />
+          <node concept="30bXRB" id="672JozXPHXQ" role="1lsf3T">
+            <property role="30bXRw" value="12" />
+          </node>
+        </node>
+        <node concept="1SruMQ" id="672JozXPHVu" role="1Srv_k">
+          <ref role="1SruML" node="4ZbdskSIb6x" resolve="x" />
+          <node concept="30bXRB" id="672JozXPHYw" role="1lsf3T">
+            <property role="30bXRw" value="10" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2zPypq" id="672JozXSEJs" role="_iOnB">
+      <property role="TrG5h" value="p3" />
+      <node concept="1SyHNB" id="672JozXSEJt" role="2zM23F">
+        <ref role="1SyHM3" node="4ZbdskSIb6w" resolve="Point2" />
+      </node>
+      <node concept="1SrvAg" id="672JozXSEJu" role="2zPyp_">
+        <ref role="1Srsag" node="4ZbdskSIb6w" resolve="Point2" />
+        <node concept="1SruMQ" id="672JozXSEJv" role="1Srv_k">
+          <ref role="1SruML" node="4ZbdskSIb6x" resolve="x" />
+          <node concept="30bXRB" id="672JozXSEJw" role="1lsf3T">
+            <property role="30bXRw" value="10" />
+          </node>
+        </node>
+        <node concept="1SruMQ" id="672JozXSEJx" role="1Srv_k">
+          <ref role="1SruML" node="4ZbdskSIb6z" resolve="y" />
+          <node concept="30bXRB" id="672JozXSEYy" role="1lsf3T">
+            <property role="30bXRw" value="12" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="_ixoA" id="672JozXPITP" role="_iOnB" />
+    <node concept="_fkuM" id="4ZbdskRCanE" role="_iOnB">
+      <property role="TrG5h" value="namedTupleAccess" />
+      <node concept="_fkuZ" id="4ZbdskSg1iu" role="_fkp5">
+        <node concept="_fku$" id="4ZbdskSg1iv" role="_fkur" />
+        <node concept="1QScDb" id="4ZbdskSg1mi" role="_fkuY">
+          <node concept="_emDc" id="4ZbdskSg1iF" role="30czhm">
+            <ref role="_emDf" node="4ZbdskRDGJG" resolve="p1" />
+          </node>
+          <node concept="1Sy3PP" id="672JozXSAzT" role="1QScD9">
+            <ref role="1Sy0hC" node="4ZbdskRDGGU" resolve="x" />
+          </node>
+        </node>
+        <node concept="30bXRB" id="4ZbdskSIaWF" role="_fkuS">
+          <property role="30bXRw" value="10" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="4ZbdskSIaX4" role="_fkp5">
+        <node concept="_fku$" id="4ZbdskSIaX5" role="_fkur" />
+        <node concept="1QScDb" id="4ZbdskSIaX$" role="_fkuY">
+          <node concept="_emDc" id="4ZbdskSIaXq" role="30czhm">
+            <ref role="_emDf" node="4ZbdskRDGJG" resolve="p1" />
+          </node>
+          <node concept="1Sy3PP" id="672JozXSAAL" role="1QScD9">
+            <ref role="1Sy0hC" node="4ZbdskRDGHd" resolve="y" />
+          </node>
+        </node>
+        <node concept="30bXRB" id="4ZbdskSIb0$" role="_fkuS">
+          <property role="30bXRw" value="12" />
+        </node>
+      </node>
+      <node concept="3dYjL0" id="4ZbdskSId2A" role="_fkp5" />
+      <node concept="_fkuZ" id="4ZbdskSId35" role="_fkp5">
+        <node concept="_fku$" id="4ZbdskSId36" role="_fkur" />
+        <node concept="1QScDb" id="4ZbdskSId37" role="_fkuY">
+          <node concept="_emDc" id="4ZbdskSId39" role="30czhm">
+            <ref role="_emDf" node="4ZbdskSIb0Z" resolve="p2" />
+          </node>
+          <node concept="1Sy3PP" id="672JozXSAD$" role="1QScD9">
+            <ref role="1Sy0hC" node="4ZbdskSIb6x" resolve="x" />
+          </node>
+        </node>
+        <node concept="30bXRB" id="4ZbdskSId3a" role="_fkuS">
+          <property role="30bXRw" value="10" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="4ZbdskSId3b" role="_fkp5">
+        <node concept="_fku$" id="4ZbdskSId3c" role="_fkur" />
+        <node concept="1QScDb" id="4ZbdskSId3d" role="_fkuY">
+          <node concept="1Sy3PP" id="4ZbdskSId3e" role="1QScD9">
+            <ref role="1Sy0hC" node="4ZbdskSIb6z" resolve="y" />
+          </node>
+          <node concept="_emDc" id="4ZbdskSId3f" role="30czhm">
+            <ref role="_emDf" node="4ZbdskSIb0Z" resolve="p2" />
+          </node>
+        </node>
+        <node concept="30bXRB" id="4ZbdskSId3g" role="_fkuS">
+          <property role="30bXRw" value="12" />
+        </node>
+      </node>
+      <node concept="3dYjL0" id="672JozXSF0P" role="_fkp5" />
+      <node concept="_fkuZ" id="672JozXSF1I" role="_fkp5">
+        <node concept="_fku$" id="672JozXSF1J" role="_fkur" />
+        <node concept="1QScDb" id="672JozXSF1K" role="_fkuY">
+          <node concept="_emDc" id="672JozXSF1L" role="30czhm">
+            <ref role="_emDf" node="672JozXSEJs" resolve="p3" />
+          </node>
+          <node concept="1Sy3PP" id="672JozXSF1M" role="1QScD9">
+            <ref role="1Sy0hC" node="4ZbdskSIb6x" resolve="x" />
+          </node>
+        </node>
+        <node concept="30bXRB" id="672JozXSF1N" role="_fkuS">
+          <property role="30bXRw" value="10" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="672JozXSF1O" role="_fkp5">
+        <node concept="_fku$" id="672JozXSF1P" role="_fkur" />
+        <node concept="1QScDb" id="672JozXSF1Q" role="_fkuY">
+          <node concept="1Sy3PP" id="672JozXSF1R" role="1QScD9">
+            <ref role="1Sy0hC" node="4ZbdskSIb6z" resolve="y" />
+          </node>
+          <node concept="_emDc" id="672JozXSF1S" role="30czhm">
+            <ref role="_emDf" node="672JozXSEJs" resolve="p3" />
+          </node>
+        </node>
+        <node concept="30bXRB" id="672JozXSF1T" role="_fkuS">
+          <property role="30bXRw" value="12" />
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/todo@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/todo@tests.mps
@@ -14,7 +14,7 @@
     <use id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base" version="-1" />
     <use id="d441fba0-f46b-43cd-b723-dad7b65da615" name="org.iets3.core.expr.tests" version="-1" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="-1" />
-    <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="2" />
+    <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="3" />
   </languages>
   <imports />
   <registry>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/utils@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/utils@tests.mps
@@ -5,7 +5,7 @@
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="-1" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="-1" />
     <use id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base" version="-1" />
-    <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="-1" />
+    <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="3" />
     <devkit ref="c4e521ab-b605-4ef9-a7c3-68075da058f0(org.iets3.core.expr.core.devkit)" />
   </languages>
   <imports />
@@ -74,6 +74,7 @@
         <child id="8853770331926305952" name="values" index="1vwJml" />
       </concept>
       <concept id="8853770331921611232" name="org.iets3.core.expr.util.structure.IMultiDecTab" flags="ng" index="1vMD3l">
+        <child id="1609062041026819473" name="resultTupleDeclaration" index="2ACRNR" />
         <child id="8853770331921611296" name="colDefs" index="1vMDcl" />
         <child id="8853770331921611812" name="rows" index="1vMDkh" />
       </concept>
@@ -210,6 +211,11 @@
       <concept id="543569365052765011" name="org.iets3.core.expr.toplevel.structure.EmptyToplevelContent" flags="ng" index="_ixoA" />
       <concept id="4790956042240570348" name="org.iets3.core.expr.toplevel.structure.FunctionCall" flags="ng" index="1af_rf" />
       <concept id="4790956042240148643" name="org.iets3.core.expr.toplevel.structure.Function" flags="ng" index="1aga60" />
+      <concept id="5749748470420409857" name="org.iets3.core.expr.toplevel.structure.ITupleDeclaration" flags="ng" index="1SyzJ4">
+        <child id="5749748470420419627" name="members" index="1Syw7I" />
+      </concept>
+      <concept id="5749748470417082344" name="org.iets3.core.expr.toplevel.structure.TupleMember" flags="ng" index="1SLn8H" />
+      <concept id="5749748470417037802" name="org.iets3.core.expr.toplevel.structure.NamedTupleDeclaration" flags="ng" index="1SLEKJ" />
       <concept id="7740953487936183912" name="org.iets3.core.expr.toplevel.structure.Typedef" flags="ng" index="1WbbD7">
         <child id="7740953487936183915" name="originalType" index="1WbbD4" />
       </concept>
@@ -549,6 +555,17 @@
             </node>
           </node>
         </node>
+        <node concept="1SLEKJ" id="1pkymqLocK0" role="2ACRNR">
+          <property role="TrG5h" value="161551962045608507_ResultTuple" />
+          <node concept="1SLn8H" id="1pkymqLocK1" role="1Syw7I">
+            <property role="TrG5h" value="a" />
+            <node concept="30bXR$" id="1pkymqLocK2" role="2S399n" />
+          </node>
+          <node concept="1SLn8H" id="1pkymqLocK3" role="1Syw7I">
+            <property role="TrG5h" value="b" />
+            <node concept="30bXR$" id="1pkymqLocK4" role="2S399n" />
+          </node>
+        </node>
       </node>
       <node concept="1ahQXy" id="8XWEtevIVV" role="1ahQWs">
         <property role="TrG5h" value="n" />
@@ -777,6 +794,17 @@
           <node concept="30bXRB" id="7FuUjk_k0zD" role="1fLbpZ">
             <property role="30bXRw" value="6" />
           </node>
+        </node>
+      </node>
+      <node concept="1SLEKJ" id="1pkymqLocKF" role="2ACRNR">
+        <property role="TrG5h" value="8853770331923330120_ResultTuple" />
+        <node concept="1SLn8H" id="1pkymqLocKG" role="1Syw7I">
+          <property role="TrG5h" value="a" />
+          <node concept="30bXR$" id="1pkymqLocKH" role="2S399n" />
+        </node>
+        <node concept="1SLn8H" id="1pkymqLocKI" role="1Syw7I">
+          <property role="TrG5h" value="b" />
+          <node concept="30bXR$" id="1pkymqLocKJ" role="2S399n" />
         </node>
       </node>
     </node>
@@ -1043,6 +1071,9 @@
             <node concept="uhfPG" id="6OunYCf7k2M" role="1zTEop">
               <ref role="uhfO8" node="6OunYCeYb65" resolve="t1" />
             </node>
+          </node>
+          <node concept="1SLEKJ" id="1pkymqLocK5" role="2ACRNR">
+            <property role="TrG5h" value="7862827458315014845_ResultTuple" />
           </node>
         </node>
         <node concept="uhfPG" id="6OunYCf2GN4" role="1aduh9">
@@ -1515,6 +1546,13 @@
             <ref role="1fLbst" node="38udS81r6ra" />
           </node>
         </node>
+        <node concept="1SLEKJ" id="1pkymqLocK6" role="2ACRNR">
+          <property role="TrG5h" value="3611384982706874057_ResultTuple" />
+          <node concept="1SLn8H" id="1pkymqLocK7" role="1Syw7I">
+            <property role="TrG5h" value="res" />
+            <node concept="30bXR$" id="1pkymqLocK8" role="2S399n" />
+          </node>
+        </node>
       </node>
       <node concept="1ahQXy" id="38udS81r6AV" role="1ahQWs">
         <property role="TrG5h" value="v1" />
@@ -1671,6 +1709,13 @@
           <node concept="1fMUOM" id="6OunYCfi$n6" role="1vMDcl">
             <property role="TrG5h" value="r" />
             <node concept="mLuIC" id="6OunYCfi$nV" role="1fMUOZ" />
+          </node>
+          <node concept="1SLEKJ" id="1pkymqLocK9" role="2ACRNR">
+            <property role="TrG5h" value="7862827458318976204_ResultTuple" />
+            <node concept="1SLn8H" id="1pkymqLocKa" role="1Syw7I">
+              <property role="TrG5h" value="r" />
+              <node concept="mLuIC" id="1pkymqLocKb" role="2S399n" />
+            </node>
           </node>
         </node>
       </node>
@@ -1918,6 +1963,17 @@
             </node>
           </node>
         </node>
+        <node concept="1SLEKJ" id="1pkymqLocKc" role="2ACRNR">
+          <property role="TrG5h" value="7862827458321060166_ResultTuple" />
+          <node concept="1SLn8H" id="1pkymqLocKd" role="1Syw7I">
+            <property role="TrG5h" value="base" />
+            <node concept="mLuIC" id="1pkymqLocKe" role="2S399n">
+              <node concept="2gteS_" id="1pkymqLocKf" role="2gteVg">
+                <property role="2gteVv" value="2" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
       <node concept="1ahQXy" id="6OunYCfqwBU" role="1ahQWs">
         <property role="TrG5h" value="state" />
@@ -2058,6 +2114,21 @@
           <property role="TrG5h" value="volDiscount" />
           <node concept="1WbbFT" id="6OunYCfqDxB" role="1fMUOZ">
             <ref role="1WbbFS" node="6OunYCfqBWH" resolve="Percentage" />
+          </node>
+        </node>
+        <node concept="1SLEKJ" id="1pkymqLocKg" role="2ACRNR">
+          <property role="TrG5h" value="7862827458321072184_ResultTuple" />
+          <node concept="1SLn8H" id="1pkymqLocKh" role="1Syw7I">
+            <property role="TrG5h" value="base" />
+            <node concept="1WbbFT" id="1pkymqLocKi" role="2S399n">
+              <ref role="1WbbFS" node="6OunYCfqD$8" resolve="Currency" />
+            </node>
+          </node>
+          <node concept="1SLn8H" id="1pkymqLocKj" role="1Syw7I">
+            <property role="TrG5h" value="volDiscount" />
+            <node concept="1WbbFT" id="1pkymqLocKk" role="2S399n">
+              <ref role="1WbbFS" node="6OunYCfqBWH" resolve="Percentage" />
+            </node>
           </node>
         </node>
       </node>
@@ -2214,6 +2285,21 @@
           <property role="TrG5h" value="volDiscount" />
           <node concept="1WbbFT" id="6OunYCfqIGN" role="1fMUOZ">
             <ref role="1WbbFS" node="6OunYCfqBWH" resolve="Percentage" />
+          </node>
+        </node>
+        <node concept="1SLEKJ" id="1pkymqLocKl" role="2ACRNR">
+          <property role="TrG5h" value="7862827458321115908_ResultTuple" />
+          <node concept="1SLn8H" id="1pkymqLocKm" role="1Syw7I">
+            <property role="TrG5h" value="base" />
+            <node concept="1WbbFT" id="1pkymqLocKn" role="2S399n">
+              <ref role="1WbbFS" node="6OunYCfqD$8" resolve="Currency" />
+            </node>
+          </node>
+          <node concept="1SLn8H" id="1pkymqLocKo" role="1Syw7I">
+            <property role="TrG5h" value="volDiscount" />
+            <node concept="1WbbFT" id="1pkymqLocKp" role="2S399n">
+              <ref role="1WbbFS" node="6OunYCfqBWH" resolve="Percentage" />
+            </node>
           </node>
         </node>
       </node>
@@ -2440,6 +2526,21 @@
           <property role="TrG5h" value="volDiscount" />
           <node concept="1WbbFT" id="6OunYCfqNYO" role="1fMUOZ">
             <ref role="1WbbFS" node="6OunYCfqBWH" resolve="Percentage" />
+          </node>
+        </node>
+        <node concept="1SLEKJ" id="1pkymqLocKq" role="2ACRNR">
+          <property role="TrG5h" value="7862827458321137539_ResultTuple" />
+          <node concept="1SLn8H" id="1pkymqLocKr" role="1Syw7I">
+            <property role="TrG5h" value="base" />
+            <node concept="1WbbFT" id="1pkymqLocKs" role="2S399n">
+              <ref role="1WbbFS" node="6OunYCfqD$8" resolve="Currency" />
+            </node>
+          </node>
+          <node concept="1SLn8H" id="1pkymqLocKt" role="1Syw7I">
+            <property role="TrG5h" value="volDiscount" />
+            <node concept="1WbbFT" id="1pkymqLocKu" role="2S399n">
+              <ref role="1WbbFS" node="6OunYCfqBWH" resolve="Percentage" />
+            </node>
           </node>
         </node>
       </node>
@@ -2692,6 +2793,21 @@
           <ref role="1WbbFS" node="6OunYCfqBWH" resolve="Percentage" />
         </node>
       </node>
+      <node concept="1SLEKJ" id="1pkymqLocKK" role="2ACRNR">
+        <property role="TrG5h" value="5872516655158242989_ResultTuple" />
+        <node concept="1SLn8H" id="1pkymqLocKL" role="1Syw7I">
+          <property role="TrG5h" value="base" />
+          <node concept="1WbbFT" id="1pkymqLocKM" role="2S399n">
+            <ref role="1WbbFS" node="6OunYCfqD$8" resolve="Currency" />
+          </node>
+        </node>
+        <node concept="1SLn8H" id="1pkymqLocKN" role="1Syw7I">
+          <property role="TrG5h" value="volDiscount" />
+          <node concept="1WbbFT" id="1pkymqLocKO" role="2S399n">
+            <ref role="1WbbFS" node="6OunYCfqBWH" resolve="Percentage" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="_ixoA" id="6OunYCfqyZo" role="_iOnB" />
     <node concept="_ixoA" id="6OunYCfqyU4" role="_iOnB" />
@@ -2772,6 +2888,17 @@
           <ref role="1fLbst" node="6OunYCfqn8d" resolve="base" />
           <node concept="30bXRB" id="6OunYCfqspP" role="1fLbpZ">
             <property role="30bXRw" value="1.20" />
+          </node>
+        </node>
+      </node>
+      <node concept="1SLEKJ" id="1pkymqLocKP" role="2ACRNR">
+        <property role="TrG5h" value="7862827458320992049_ResultTuple" />
+        <node concept="1SLn8H" id="1pkymqLocKQ" role="1Syw7I">
+          <property role="TrG5h" value="base" />
+          <node concept="mLuIC" id="1pkymqLocKR" role="2S399n">
+            <node concept="2gteS_" id="1pkymqLocKS" role="2gteVg">
+              <property role="2gteVv" value="2" />
+            </node>
           </node>
         </node>
       </node>
@@ -3428,6 +3555,9 @@
               <ref role="uhfO8" node="6hYPZtwvBuy" resolve="x" />
             </node>
           </node>
+          <node concept="1SLEKJ" id="1pkymqLocKv" role="2ACRNR">
+            <property role="TrG5h" value="7241462708334131240_ResultTuple" />
+          </node>
         </node>
         <node concept="uhfPG" id="6hYPZtwvBHL" role="1aduh9">
           <ref role="uhfO8" node="6hYPZtwvBuy" resolve="x" />
@@ -3551,6 +3681,13 @@
           <node concept="1fMUOM" id="pogkgseXc9" role="1vMDcl">
             <property role="TrG5h" value="x" />
             <node concept="mLuIC" id="pogkgseXcu" role="1fMUOZ" />
+          </node>
+          <node concept="1SLEKJ" id="1pkymqLocKw" role="2ACRNR">
+            <property role="TrG5h" value="457187122965369198_ResultTuple" />
+            <node concept="1SLn8H" id="1pkymqLocKx" role="1Syw7I">
+              <property role="TrG5h" value="x" />
+              <node concept="mLuIC" id="1pkymqLocKy" role="2S399n" />
+            </node>
           </node>
         </node>
         <node concept="30bXRB" id="pogkgseXnb" role="_fkuS">
@@ -3688,6 +3825,17 @@
           <node concept="1fMUOM" id="pogkgseXEz" role="1vMDcl">
             <property role="TrG5h" value="y" />
             <node concept="mLuIC" id="pogkgseXG2" role="1fMUOZ" />
+          </node>
+          <node concept="1SLEKJ" id="1pkymqLocKz" role="2ACRNR">
+            <property role="TrG5h" value="457187122965371425_ResultTuple" />
+            <node concept="1SLn8H" id="1pkymqLocK$" role="1Syw7I">
+              <property role="TrG5h" value="x" />
+              <node concept="mLuIC" id="1pkymqLocK_" role="2S399n" />
+            </node>
+            <node concept="1SLn8H" id="1pkymqLocKA" role="1Syw7I">
+              <property role="TrG5h" value="y" />
+              <node concept="mLuIC" id="1pkymqLocKB" role="2S399n" />
+            </node>
           </node>
         </node>
       </node>
@@ -3872,6 +4020,13 @@
         <node concept="1fMUOM" id="Nuz63eB9on" role="1vMDcl">
           <property role="TrG5h" value="d" />
           <node concept="30bXR$" id="Nuz63eB9oD" role="1fMUOZ" />
+        </node>
+        <node concept="1SLEKJ" id="1pkymqLocKC" role="2ACRNR">
+          <property role="TrG5h" value="927332920696015616_ResultTuple" />
+          <node concept="1SLn8H" id="1pkymqLocKD" role="1Syw7I">
+            <property role="TrG5h" value="d" />
+            <node concept="30bXR$" id="1pkymqLocKE" role="2S399n" />
+          </node>
         </node>
       </node>
       <node concept="1ahQXy" id="Nuz63eB8Fo" role="1ahQWs">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/utils@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/utils@tests.mps
@@ -144,6 +144,10 @@
         <child id="2245119349904068815" name="max" index="1eiLjC" />
         <child id="2245119349904068814" name="min" index="1eiLjD" />
       </concept>
+      <concept id="2527679671886479690" name="org.iets3.core.expr.base.structure.TupleAccessExpr" flags="ng" index="3nOhSe">
+        <property id="2527679671886575030" name="index" index="3nOAFM" />
+        <child id="2527679671886479717" name="tuple" index="3nOhSx" />
+      </concept>
       <concept id="9002563722476995145" name="org.iets3.core.expr.base.structure.DotExpression" flags="ng" index="1QScDb">
         <child id="9002563722476995147" name="target" index="1QScD9" />
       </concept>
@@ -211,6 +215,9 @@
       <concept id="543569365052765011" name="org.iets3.core.expr.toplevel.structure.EmptyToplevelContent" flags="ng" index="_ixoA" />
       <concept id="4790956042240570348" name="org.iets3.core.expr.toplevel.structure.FunctionCall" flags="ng" index="1af_rf" />
       <concept id="4790956042240148643" name="org.iets3.core.expr.toplevel.structure.Function" flags="ng" index="1aga60" />
+      <concept id="5749748470420539568" name="org.iets3.core.expr.toplevel.structure.TupleNamedAccessExpr" flags="ng" index="1Sy3PP">
+        <reference id="5749748470420550061" name="member" index="1Sy0hC" />
+      </concept>
       <concept id="5749748470420409857" name="org.iets3.core.expr.toplevel.structure.ITupleDeclaration" flags="ng" index="1SyzJ4">
         <child id="5749748470420419627" name="members" index="1Syw7I" />
       </concept>
@@ -3622,6 +3629,154 @@
       </node>
     </node>
     <node concept="_ixoA" id="6hYPZtwvARp" role="_iOnB" />
+    <node concept="2zPypq" id="1pkymqL_g3x" role="_iOnB">
+      <property role="TrG5h" value="tableResult" />
+      <node concept="1fMURV" id="pogkgseXCx" role="2zPyp_">
+        <property role="0Rz4W" value="1850566804" />
+        <node concept="1fLkTo" id="pogkgseXGq" role="1vMDkh">
+          <node concept="1fLbrf" id="pogkgseXGM" role="1fLbpX">
+            <ref role="1fLbst" node="pogkgseXCy" />
+            <node concept="30bXRB" id="pogkgseXGL" role="1fLbpZ">
+              <property role="30bXRw" value="10" />
+            </node>
+            <node concept="30bXRB" id="pogkgseXJO" role="1fLbpZ">
+              <property role="30bXRw" value="5" />
+            </node>
+          </node>
+          <node concept="1fLbrf" id="pogkgseXMG" role="1fLbpX">
+            <ref role="1fLbst" node="pogkgseXDy" resolve="x" />
+            <node concept="30bXRB" id="pogkgseXMF" role="1fLbpZ">
+              <property role="30bXRw" value="0" />
+            </node>
+          </node>
+          <node concept="1fLbrf" id="pogkgseXNg" role="1fLbpX">
+            <ref role="1fLbst" node="pogkgseXEz" resolve="y" />
+            <node concept="30bXRB" id="pogkgseXNf" role="1fLbpZ">
+              <property role="30bXRw" value="0" />
+            </node>
+          </node>
+          <node concept="1fLbrf" id="pogkgseYt7" role="1fLbpX">
+            <ref role="1fLbst" node="pogkgseXCz" />
+            <node concept="30bXRB" id="pogkgseYCP" role="1fLbpZ">
+              <property role="30bXRw" value="4" />
+            </node>
+            <node concept="30bXRB" id="pogkgseYKM" role="1fLbpZ">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+        </node>
+        <node concept="1fLkTo" id="pogkgseXNN" role="1vMDkh">
+          <node concept="1fLbrf" id="pogkgseXOz" role="1fLbpX">
+            <ref role="1fLbst" node="pogkgseXCz" />
+            <node concept="30bXRB" id="pogkgseY2X" role="1fLbpZ">
+              <property role="30bXRw" value="4" />
+            </node>
+            <node concept="30bXRB" id="pogkgseY3b" role="1fLbpZ">
+              <property role="30bXRw" value="5" />
+            </node>
+            <node concept="30bXRB" id="pogkgseY6n" role="1fLbpZ">
+              <property role="30bXRw" value="6" />
+            </node>
+          </node>
+          <node concept="1fLbrf" id="pogkgseXRh" role="1fLbpX">
+            <ref role="1fLbst" node="pogkgseXCy" />
+            <node concept="30bXRB" id="pogkgseXRg" role="1fLbpZ">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="pogkgseXRQ" role="1fLbpZ">
+              <property role="30bXRw" value="2" />
+            </node>
+            <node concept="30bXRB" id="pogkgseXZ3" role="1fLbpZ">
+              <property role="30bXRw" value="3" />
+            </node>
+          </node>
+          <node concept="1fLbrf" id="pogkgseYaM" role="1fLbpX">
+            <ref role="1fLbst" node="pogkgseXDy" resolve="x" />
+            <node concept="30bXRB" id="pogkgseYaL" role="1fLbpZ">
+              <property role="30bXRw" value="1" />
+            </node>
+          </node>
+          <node concept="1fLbrf" id="pogkgseYbw" role="1fLbpX">
+            <ref role="1fLbst" node="pogkgseXEz" resolve="y" />
+            <node concept="30bXRB" id="pogkgseYbv" role="1fLbpZ">
+              <property role="30bXRw" value="1" />
+            </node>
+          </node>
+        </node>
+        <node concept="1fLkTo" id="pogkgseYcd" role="1vMDkh">
+          <node concept="1fLbrf" id="pogkgseYdv" role="1fLbpX">
+            <ref role="1fLbst" node="pogkgseXCy" />
+            <node concept="30bXRB" id="pogkgseYdu" role="1fLbpZ">
+              <property role="30bXRw" value="5" />
+            </node>
+            <node concept="30bXRB" id="pogkgseYdJ" role="1fLbpZ">
+              <property role="30bXRw" value="10" />
+            </node>
+          </node>
+          <node concept="1fLbrf" id="pogkgseYew" role="1fLbpX">
+            <ref role="1fLbst" node="pogkgseXCz" />
+            <node concept="30bXRB" id="pogkgseYev" role="1fLbpZ">
+              <property role="30bXRw" value="10" />
+            </node>
+            <node concept="30bXRB" id="pogkgseYeQ" role="1fLbpZ">
+              <property role="30bXRw" value="20" />
+            </node>
+          </node>
+          <node concept="1fLbrf" id="pogkgseYfB" role="1fLbpX">
+            <ref role="1fLbst" node="pogkgseXDy" resolve="x" />
+            <node concept="30bXRB" id="pogkgseYfA" role="1fLbpZ">
+              <property role="30bXRw" value="100" />
+            </node>
+          </node>
+          <node concept="1fLbrf" id="pogkgseYgh" role="1fLbpX">
+            <ref role="1fLbst" node="pogkgseXEz" resolve="y" />
+            <node concept="30bXRB" id="1pkymqL_jA$" role="1fLbpZ">
+              <property role="30bXRw" value="200" />
+            </node>
+          </node>
+        </node>
+        <node concept="1fMUR7" id="pogkgseXCy" role="1vMDcl">
+          <node concept="_emDc" id="pogkgseXCU" role="1fMUOQ">
+            <ref role="_emDf" node="pogkgseX6Z" resolve="ten" />
+          </node>
+        </node>
+        <node concept="1fMUR7" id="pogkgseXCz" role="1vMDcl">
+          <node concept="_emDc" id="pogkgseXDh" role="1fMUOQ">
+            <ref role="_emDf" node="pogkgseX9x" resolve="twenty" />
+          </node>
+        </node>
+        <node concept="1fMUOM" id="pogkgseXDy" role="1vMDcl">
+          <property role="TrG5h" value="x" />
+          <node concept="mLuIC" id="pogkgseXDR" role="1fMUOZ" />
+        </node>
+        <node concept="1fMUOM" id="pogkgseXEz" role="1vMDcl">
+          <property role="TrG5h" value="y" />
+          <node concept="mLuIC" id="pogkgseXG2" role="1fMUOZ" />
+        </node>
+        <node concept="1SLEKJ" id="1pkymqLocKz" role="2ACRNR">
+          <property role="TrG5h" value="457187122965371425_ResultTuple" />
+          <node concept="1SLn8H" id="1pkymqLocK$" role="1Syw7I">
+            <property role="TrG5h" value="x" />
+            <node concept="mLuIC" id="1pkymqLocK_" role="2S399n" />
+          </node>
+          <node concept="1SLn8H" id="1pkymqLocKA" role="1Syw7I">
+            <property role="TrG5h" value="y" />
+            <node concept="mLuIC" id="1pkymqLocKB" role="2S399n" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2zPypq" id="1pkymqLAIEZ" role="_iOnB">
+      <property role="TrG5h" value="tableResult2" />
+      <node concept="_emDc" id="1pkymqLAILr" role="2zPyp_">
+        <ref role="_emDf" node="1pkymqL_g3x" resolve="tableResult" />
+      </node>
+      <node concept="m5gfS" id="1pkymqLAIJG" role="2zM23F">
+        <node concept="mLuIC" id="1pkymqLAIK1" role="m5gfT" />
+        <node concept="mLuIC" id="1pkymqLAIKF" role="m5gfT" />
+      </node>
+    </node>
+    <node concept="_ixoA" id="1pkymqL_fZz" role="_iOnB" />
     <node concept="_fkuM" id="pogkgseX5t" role="_iOnB">
       <property role="TrG5h" value="multidectab" />
       <node concept="_fkuZ" id="pogkgseX5v" role="_fkp5">
@@ -3701,142 +3856,63 @@
             <property role="30bXRw" value="100" />
           </node>
           <node concept="30bXRB" id="pogkgseYhU" role="m5g4p">
-            <property role="30bXRw" value="100" />
+            <property role="30bXRw" value="200" />
           </node>
         </node>
-        <node concept="1fMURV" id="pogkgseXCx" role="_fkuY">
-          <property role="0Rz4W" value="1850566804" />
-          <node concept="1fLkTo" id="pogkgseXGq" role="1vMDkh">
-            <node concept="1fLbrf" id="pogkgseXGM" role="1fLbpX">
-              <ref role="1fLbst" node="pogkgseXCy" />
-              <node concept="30bXRB" id="pogkgseXGL" role="1fLbpZ">
-                <property role="30bXRw" value="10" />
-              </node>
-              <node concept="30bXRB" id="pogkgseXJO" role="1fLbpZ">
-                <property role="30bXRw" value="5" />
-              </node>
-            </node>
-            <node concept="1fLbrf" id="pogkgseXMG" role="1fLbpX">
-              <ref role="1fLbst" node="pogkgseXDy" resolve="x" />
-              <node concept="30bXRB" id="pogkgseXMF" role="1fLbpZ">
-                <property role="30bXRw" value="0" />
-              </node>
-            </node>
-            <node concept="1fLbrf" id="pogkgseXNg" role="1fLbpX">
-              <ref role="1fLbst" node="pogkgseXEz" resolve="y" />
-              <node concept="30bXRB" id="pogkgseXNf" role="1fLbpZ">
-                <property role="30bXRw" value="0" />
-              </node>
-            </node>
-            <node concept="1fLbrf" id="pogkgseYt7" role="1fLbpX">
-              <ref role="1fLbst" node="pogkgseXCz" />
-              <node concept="30bXRB" id="pogkgseYCP" role="1fLbpZ">
-                <property role="30bXRw" value="4" />
-              </node>
-              <node concept="30bXRB" id="pogkgseYKM" role="1fLbpZ">
-                <property role="30bXRw" value="4" />
-              </node>
-            </node>
+        <node concept="_emDc" id="1pkymqL_gjC" role="_fkuY">
+          <ref role="_emDf" node="1pkymqL_g3x" resolve="tableResult" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="1pkymqL_jdG" role="_fkp5">
+        <node concept="_fku$" id="1pkymqL_jdH" role="_fkur" />
+        <node concept="1QScDb" id="1pkymqL_jeD" role="_fkuY">
+          <node concept="1Sy3PP" id="1pkymqL_jmF" role="1QScD9">
+            <ref role="1Sy0hC" node="1pkymqLocK$" resolve="x" />
           </node>
-          <node concept="1fLkTo" id="pogkgseXNN" role="1vMDkh">
-            <node concept="1fLbrf" id="pogkgseXOz" role="1fLbpX">
-              <ref role="1fLbst" node="pogkgseXCz" />
-              <node concept="30bXRB" id="pogkgseY2X" role="1fLbpZ">
-                <property role="30bXRw" value="4" />
-              </node>
-              <node concept="30bXRB" id="pogkgseY3b" role="1fLbpZ">
-                <property role="30bXRw" value="5" />
-              </node>
-              <node concept="30bXRB" id="pogkgseY6n" role="1fLbpZ">
-                <property role="30bXRw" value="6" />
-              </node>
-            </node>
-            <node concept="1fLbrf" id="pogkgseXRh" role="1fLbpX">
-              <ref role="1fLbst" node="pogkgseXCy" />
-              <node concept="30bXRB" id="pogkgseXRg" role="1fLbpZ">
-                <property role="30bXRw" value="1" />
-              </node>
-              <node concept="30bXRB" id="pogkgseXRQ" role="1fLbpZ">
-                <property role="30bXRw" value="2" />
-              </node>
-              <node concept="30bXRB" id="pogkgseXZ3" role="1fLbpZ">
-                <property role="30bXRw" value="3" />
-              </node>
-            </node>
-            <node concept="1fLbrf" id="pogkgseYaM" role="1fLbpX">
-              <ref role="1fLbst" node="pogkgseXDy" resolve="x" />
-              <node concept="30bXRB" id="pogkgseYaL" role="1fLbpZ">
-                <property role="30bXRw" value="1" />
-              </node>
-            </node>
-            <node concept="1fLbrf" id="pogkgseYbw" role="1fLbpX">
-              <ref role="1fLbst" node="pogkgseXEz" resolve="y" />
-              <node concept="30bXRB" id="pogkgseYbv" role="1fLbpZ">
-                <property role="30bXRw" value="1" />
-              </node>
-            </node>
+          <node concept="_emDc" id="1pkymqL_jew" role="30czhm">
+            <ref role="_emDf" node="1pkymqL_g3x" resolve="tableResult" />
           </node>
-          <node concept="1fLkTo" id="pogkgseYcd" role="1vMDkh">
-            <node concept="1fLbrf" id="pogkgseYdv" role="1fLbpX">
-              <ref role="1fLbst" node="pogkgseXCy" />
-              <node concept="30bXRB" id="pogkgseYdu" role="1fLbpZ">
-                <property role="30bXRw" value="5" />
-              </node>
-              <node concept="30bXRB" id="pogkgseYdJ" role="1fLbpZ">
-                <property role="30bXRw" value="10" />
-              </node>
-            </node>
-            <node concept="1fLbrf" id="pogkgseYew" role="1fLbpX">
-              <ref role="1fLbst" node="pogkgseXCz" />
-              <node concept="30bXRB" id="pogkgseYev" role="1fLbpZ">
-                <property role="30bXRw" value="10" />
-              </node>
-              <node concept="30bXRB" id="pogkgseYeQ" role="1fLbpZ">
-                <property role="30bXRw" value="20" />
-              </node>
-            </node>
-            <node concept="1fLbrf" id="pogkgseYfB" role="1fLbpX">
-              <ref role="1fLbst" node="pogkgseXDy" resolve="x" />
-              <node concept="30bXRB" id="pogkgseYfA" role="1fLbpZ">
-                <property role="30bXRw" value="100" />
-              </node>
-            </node>
-            <node concept="1fLbrf" id="pogkgseYgh" role="1fLbpX">
-              <ref role="1fLbst" node="pogkgseXEz" resolve="y" />
-              <node concept="30bXRB" id="pogkgseYgg" role="1fLbpZ">
-                <property role="30bXRw" value="100" />
-              </node>
-            </node>
+        </node>
+        <node concept="30bXRB" id="1pkymqL_jnv" role="_fkuS">
+          <property role="30bXRw" value="100" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="1pkymqL_jor" role="_fkp5">
+        <node concept="_fku$" id="1pkymqL_jos" role="_fkur" />
+        <node concept="1QScDb" id="1pkymqL_jpw" role="_fkuY">
+          <node concept="1Sy3PP" id="1pkymqL_jxJ" role="1QScD9">
+            <ref role="1Sy0hC" node="1pkymqLocKA" resolve="y" />
           </node>
-          <node concept="1fMUR7" id="pogkgseXCy" role="1vMDcl">
-            <node concept="_emDc" id="pogkgseXCU" role="1fMUOQ">
-              <ref role="_emDf" node="pogkgseX6Z" resolve="ten" />
-            </node>
+          <node concept="_emDc" id="1pkymqL_jpn" role="30czhm">
+            <ref role="_emDf" node="1pkymqL_g3x" resolve="tableResult" />
           </node>
-          <node concept="1fMUR7" id="pogkgseXCz" role="1vMDcl">
-            <node concept="_emDc" id="pogkgseXDh" role="1fMUOQ">
-              <ref role="_emDf" node="pogkgseX9x" resolve="twenty" />
-            </node>
+        </node>
+        <node concept="30bXRB" id="1pkymqL_jEa" role="_fkuS">
+          <property role="30bXRw" value="200" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="1pkymqLAIyq" role="_fkp5">
+        <node concept="_fku$" id="1pkymqLAIyr" role="_fkur" />
+        <node concept="3nOhSe" id="1pkymqLAINn" role="_fkuY">
+          <property role="3nOAFM" value="0" />
+          <node concept="_emDc" id="1pkymqLAIyu" role="3nOhSx">
+            <ref role="_emDf" node="1pkymqLAIEZ" resolve="tableResult2" />
           </node>
-          <node concept="1fMUOM" id="pogkgseXDy" role="1vMDcl">
-            <property role="TrG5h" value="x" />
-            <node concept="mLuIC" id="pogkgseXDR" role="1fMUOZ" />
+        </node>
+        <node concept="30bXRB" id="1pkymqLAIyv" role="_fkuS">
+          <property role="30bXRw" value="100" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="1pkymqLAIyw" role="_fkp5">
+        <node concept="_fku$" id="1pkymqLAIyx" role="_fkur" />
+        <node concept="3nOhSe" id="1pkymqLAIUA" role="_fkuY">
+          <property role="3nOAFM" value="1" />
+          <node concept="_emDc" id="1pkymqLAIy$" role="3nOhSx">
+            <ref role="_emDf" node="1pkymqLAIEZ" resolve="tableResult2" />
           </node>
-          <node concept="1fMUOM" id="pogkgseXEz" role="1vMDcl">
-            <property role="TrG5h" value="y" />
-            <node concept="mLuIC" id="pogkgseXG2" role="1fMUOZ" />
-          </node>
-          <node concept="1SLEKJ" id="1pkymqLocKz" role="2ACRNR">
-            <property role="TrG5h" value="457187122965371425_ResultTuple" />
-            <node concept="1SLn8H" id="1pkymqLocK$" role="1Syw7I">
-              <property role="TrG5h" value="x" />
-              <node concept="mLuIC" id="1pkymqLocK_" role="2S399n" />
-            </node>
-            <node concept="1SLn8H" id="1pkymqLocKA" role="1Syw7I">
-              <property role="TrG5h" value="y" />
-              <node concept="mLuIC" id="1pkymqLocKB" role="2S399n" />
-            </node>
-          </node>
+        </node>
+        <node concept="30bXRB" id="1pkymqLAIy_" role="_fkuS">
+          <property role="30bXRw" value="200" />
         </node>
       </node>
       <node concept="_fkuZ" id="6hYPZtwvCJD" role="_fkp5">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/test.in.expr.os.msd
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/test.in.expr.os.msd
@@ -90,7 +90,7 @@
     <language slang="l:2c8e8304-72f7-4e6a-853a-ac0616a47569:org.iets3.core.expr.typetags.lib" version="0" />
     <language slang="l:cb91a38e-738a-4811-a96d-448d08f526fa:org.iets3.core.expr.typetags.units" version="1" />
     <language slang="l:be679007-4312-4db1-9ac0-ab7dfbe66a74:org.iets3.core.expr.typetags.units.quantity" version="0" />
-    <language slang="l:8bb1251e-eae5-47ab-9843-33adfae8edaa:org.iets3.core.expr.util" version="2" />
+    <language slang="l:8bb1251e-eae5-47ab-9843-33adfae8edaa:org.iets3.core.expr.util" version="3" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.tuples@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.tuples@tests.mps
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:558ff07a-881d-4d69-8441-7a69df2cf738(test.ts.expr.os.tuples@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <devkit ref="c4e521ab-b605-4ef9-a7c3-68075da058f0(org.iets3.core.expr.core.devkit)" />
+  </languages>
+  <imports>
+    <import index="9zoj" ref="r:1b0f275e-bd62-4f6e-8c4b-51b05d651a63(com.mbeddr.core.base.typesystem)" />
+    <import index="yjde" ref="r:8023e40c-26d4-4543-bd46-2ec2c03f861f(org.iets3.core.expr.toplevel.typesystem)" />
+    <import index="t4jv" ref="r:80cf2246-750c-4158-9056-a619ebcf894c(org.iets3.core.expr.base.typesystem)" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1215507671101" name="jetbrains.mps.lang.test.structure.NodeErrorCheckOperation" flags="ng" index="1TM$A">
+        <child id="8489045168660938517" name="errorRef" index="3lydEf" />
+      </concept>
+      <concept id="1215603922101" name="jetbrains.mps.lang.test.structure.NodeOperationsContainer" flags="ng" index="7CXmI">
+        <child id="1215604436604" name="nodeOperations" index="7EUXB" />
+      </concept>
+      <concept id="1215607067978" name="jetbrains.mps.lang.test.structure.CheckNodeForErrorMessagesOperation" flags="ng" index="7OXhh">
+        <property id="3743352646565420194" name="includeSelf" index="GvXf4" />
+      </concept>
+      <concept id="7691029917083872157" name="jetbrains.mps.lang.test.structure.IRuleReference" flags="ng" index="2u4UPC">
+        <reference id="8333855927540250453" name="declaration" index="39XzEq" />
+      </concept>
+      <concept id="428590876651279930" name="jetbrains.mps.lang.test.structure.NodeTypeSystemErrorCheckOperation" flags="ng" index="2DdRWr">
+        <child id="4649457259824818099" name="equationRef" index="MJxsd" />
+      </concept>
+      <concept id="4649457259824807647" name="jetbrains.mps.lang.test.structure.TypesystemEquationReference" flags="ng" index="MGsTx" />
+      <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
+      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
+        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
+      </concept>
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
+      <concept id="1019070541450015930" name="org.iets3.core.expr.base.structure.TupleType" flags="ng" index="m5gfS">
+        <child id="1019070541450015931" name="elementTypes" index="m5gfT" />
+      </concept>
+      <concept id="7089558164905593724" name="org.iets3.core.expr.base.structure.IOptionallyTyped" flags="ng" index="2zM23E">
+        <child id="7089558164905593725" name="type" index="2zM23F" />
+      </concept>
+      <concept id="7071042522334260296" name="org.iets3.core.expr.base.structure.ITyped" flags="ng" index="2_iKZX">
+        <child id="8811147530085329321" name="type" index="2S399n" />
+      </concept>
+    </language>
+    <language id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes">
+      <concept id="5115872837157252551" name="org.iets3.core.expr.simpleTypes.structure.StringType" flags="ng" index="30bdrU" />
+      <concept id="5115872837157054169" name="org.iets3.core.expr.simpleTypes.structure.IntegerType" flags="ng" index="30bXR$" />
+      <concept id="5115872837157054170" name="org.iets3.core.expr.simpleTypes.structure.NumberLiteral" flags="ng" index="30bXRB">
+        <property id="5115872837157054173" name="value" index="30bXRw" />
+      </concept>
+    </language>
+    <language id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel">
+      <concept id="7089558164906249676" name="org.iets3.core.expr.toplevel.structure.Constant" flags="ng" index="2zPypq">
+        <child id="7089558164906249715" name="value" index="2zPyp_" />
+      </concept>
+      <concept id="543569365052765011" name="org.iets3.core.expr.toplevel.structure.EmptyToplevelContent" flags="ng" index="_ixoA" />
+      <concept id="543569365052711055" name="org.iets3.core.expr.toplevel.structure.Library" flags="ng" index="_iOnU">
+        <child id="543569365052711058" name="contents" index="_iOnB" />
+      </concept>
+      <concept id="5749748470427081075" name="org.iets3.core.expr.toplevel.structure.TupleMemberSetter" flags="ng" index="1SruMQ">
+        <reference id="5749748470427081076" name="member" index="1SruML" />
+        <child id="5070313213710413816" name="value" index="1lsf3T" />
+      </concept>
+      <concept id="5749748470427077717" name="org.iets3.core.expr.toplevel.structure.NamedTupleValue" flags="ng" index="1SrvAg">
+        <reference id="5749748470427088725" name="tuple" index="1Srsag" />
+        <child id="5749748470427077777" name="setters" index="1Srv_k" />
+      </concept>
+      <concept id="5749748470420409857" name="org.iets3.core.expr.toplevel.structure.ITupleDeclaration" flags="ng" index="1SyzJ4">
+        <child id="5749748470420419627" name="members" index="1Syw7I" />
+      </concept>
+      <concept id="5749748470420465954" name="org.iets3.core.expr.toplevel.structure.NamedTupleType" flags="ng" index="1SyHNB">
+        <reference id="5749748470420465990" name="tuple" index="1SyHM3" />
+      </concept>
+      <concept id="5749748470417082344" name="org.iets3.core.expr.toplevel.structure.TupleMember" flags="ng" index="1SLn8H" />
+      <concept id="5749748470417037802" name="org.iets3.core.expr.toplevel.structure.NamedTupleDeclaration" flags="ng" index="1SLEKJ" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="2XOHcx" id="6OMpQn6WPOR">
+    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
+  </node>
+  <node concept="1lH9Xt" id="6OMpQn6WPO4">
+    <property role="TrG5h" value="NamedTuples" />
+    <node concept="1qefOq" id="7yOFqurExdr" role="1SKRRt">
+      <node concept="_iOnU" id="7yOFqurExes" role="1qenE9">
+        <property role="TrG5h" value="TestLibrary" />
+        <node concept="1SLEKJ" id="4ZbdskRgdBl" role="_iOnB">
+          <property role="TrG5h" value="PointDoubleX" />
+          <node concept="1SLn8H" id="4ZbdskRDGGU" role="1Syw7I">
+            <property role="TrG5h" value="x" />
+            <node concept="30bXR$" id="4ZbdskRDGGX" role="2S399n" />
+          </node>
+          <node concept="1SLn8H" id="4ZbdskRDGHd" role="1Syw7I">
+            <property role="TrG5h" value="x" />
+            <node concept="30bXR$" id="4ZbdskRDGHi" role="2S399n" />
+            <node concept="7CXmI" id="7yOFqurExcZ" role="lGtFl">
+              <node concept="1TM$A" id="7yOFqurExdg" role="7EUXB">
+                <node concept="2PYRI3" id="7yOFqurExdh" role="3lydEf">
+                  <ref role="39XzEq" to="9zoj:4qSf1u1TRgo" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="7yOFqurExeM" role="_iOnB" />
+        <node concept="1SLEKJ" id="7yOFqurExf9" role="_iOnB">
+          <property role="TrG5h" value="Point" />
+          <node concept="1SLn8H" id="7yOFqurExfq" role="1Syw7I">
+            <property role="TrG5h" value="x" />
+            <node concept="30bXR$" id="7yOFqurExft" role="2S399n" />
+          </node>
+          <node concept="1SLn8H" id="7yOFqurExfH" role="1Syw7I">
+            <property role="TrG5h" value="y" />
+            <node concept="30bXR$" id="7yOFqurExfM" role="2S399n" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="7yOFqurKRCE" role="_iOnB" />
+        <node concept="1SLEKJ" id="7yOFqurKVKK" role="_iOnB">
+          <property role="TrG5h" value="Point2" />
+          <node concept="1SLn8H" id="7yOFqurKVPS" role="1Syw7I">
+            <property role="TrG5h" value="x" />
+            <node concept="30bXR$" id="7yOFqurKVPV" role="2S399n" />
+          </node>
+          <node concept="1SLn8H" id="7yOFqurKVQb" role="1Syw7I">
+            <property role="TrG5h" value="y" />
+            <node concept="30bXR$" id="7yOFqurKVQg" role="2S399n" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="7yOFqurGGhs" role="_iOnB" />
+        <node concept="1SLEKJ" id="7yOFqurGGlc" role="_iOnB">
+          <property role="TrG5h" value="Empty" />
+        </node>
+        <node concept="_ixoA" id="7yOFqurExfT" role="_iOnB" />
+        <node concept="2zPypq" id="7yOFqurExgs" role="_iOnB">
+          <property role="TrG5h" value="duplicateMember" />
+          <node concept="1SrvAg" id="7yOFqurExgQ" role="2zPyp_">
+            <ref role="1Srsag" node="7yOFqurExf9" resolve="Point" />
+            <node concept="1SruMQ" id="7yOFqurExgS" role="1Srv_k">
+              <ref role="1SruML" node="7yOFqurExfq" resolve="x" />
+              <node concept="30bXRB" id="7yOFqurExi3" role="1lsf3T">
+                <property role="30bXRw" value="0" />
+              </node>
+            </node>
+            <node concept="1SruMQ" id="7yOFqurExgU" role="1Srv_k">
+              <ref role="1SruML" node="7yOFqurExfq" resolve="x" />
+              <node concept="30bXRB" id="7yOFqurExiT" role="1lsf3T">
+                <property role="30bXRw" value="0" />
+              </node>
+              <node concept="7CXmI" id="7yOFqurFV_8" role="lGtFl">
+                <node concept="1TM$A" id="7yOFqurFVBv" role="7EUXB">
+                  <node concept="2PYRI3" id="7yOFqurFVBw" role="3lydEf">
+                    <ref role="39XzEq" to="9zoj:4qSf1u1TRgo" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="7CXmI" id="7yOFqurGG7N" role="lGtFl">
+              <node concept="1TM$A" id="7yOFqurGGb6" role="7EUXB">
+                <node concept="2PYRI3" id="7yOFqurGGb7" role="3lydEf">
+                  <ref role="39XzEq" to="yjde:7yOFqurG7p4" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7yOFqurFVY1" role="_iOnB">
+          <property role="TrG5h" value="missingMember" />
+          <node concept="1SrvAg" id="7yOFqurFVZx" role="2zPyp_">
+            <ref role="1Srsag" node="7yOFqurExf9" resolve="Point" />
+            <node concept="1SruMQ" id="7yOFqurFVZz" role="1Srv_k">
+              <ref role="1SruML" node="7yOFqurExfH" resolve="y" />
+              <node concept="30bXRB" id="7yOFqurFW0b" role="1lsf3T">
+                <property role="30bXRw" value="0" />
+              </node>
+            </node>
+            <node concept="7CXmI" id="7yOFqurGGcF" role="lGtFl">
+              <node concept="1TM$A" id="7yOFqurGGfY" role="7EUXB">
+                <node concept="2PYRI3" id="7yOFqurGGfZ" role="3lydEf">
+                  <ref role="39XzEq" to="yjde:7yOFqurG7p4" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7yOFqurGGoZ" role="_iOnB">
+          <property role="TrG5h" value="empty" />
+          <node concept="1SrvAg" id="7yOFqurIH8w" role="2zPyp_">
+            <ref role="1Srsag" node="7yOFqurGGlc" resolve="Empty" />
+            <node concept="7CXmI" id="7yOFqurIH8G" role="lGtFl">
+              <node concept="7OXhh" id="7yOFqurIH8P" role="7EUXB">
+                <property role="GvXf4" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="7yOFqurKQx0" role="_iOnB" />
+        <node concept="2zPypq" id="7yOFqurKQ$W" role="_iOnB">
+          <property role="TrG5h" value="tupleCorrect" />
+          <node concept="1SrvAg" id="7yOFqurKQCl" role="2zPyp_">
+            <ref role="1Srsag" node="7yOFqurExf9" resolve="Point" />
+            <node concept="1SruMQ" id="7yOFqurKQCn" role="1Srv_k">
+              <ref role="1SruML" node="7yOFqurExfq" resolve="x" />
+              <node concept="30bXRB" id="7yOFqurKQDp" role="1lsf3T">
+                <property role="30bXRw" value="10" />
+              </node>
+            </node>
+            <node concept="1SruMQ" id="7yOFqurKQCp" role="1Srv_k">
+              <ref role="1SruML" node="7yOFqurExfH" resolve="y" />
+              <node concept="30bXRB" id="7yOFqurKQNT" role="1lsf3T">
+                <property role="30bXRw" value="12" />
+              </node>
+            </node>
+          </node>
+          <node concept="m5gfS" id="7yOFqurKQBf" role="2zM23F">
+            <node concept="30bXR$" id="7yOFqurKQB$" role="m5gfT" />
+            <node concept="30bXR$" id="7yOFqurKQBU" role="m5gfT" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="7yOFqurKQWB" role="_iOnB">
+          <property role="TrG5h" value="tuppleIncorrect" />
+          <node concept="1SrvAg" id="7yOFqurKReJ" role="2zPyp_">
+            <ref role="1Srsag" node="7yOFqurExf9" resolve="Point" />
+            <node concept="1SruMQ" id="7yOFqurKReL" role="1Srv_k">
+              <ref role="1SruML" node="7yOFqurExfq" resolve="x" />
+              <node concept="30bXRB" id="7yOFqurKRfO" role="1lsf3T">
+                <property role="30bXRw" value="10" />
+              </node>
+            </node>
+            <node concept="1SruMQ" id="7yOFqurKReN" role="1Srv_k">
+              <ref role="1SruML" node="7yOFqurExfH" resolve="y" />
+              <node concept="30bXRB" id="7yOFqurKRn$" role="1lsf3T">
+                <property role="30bXRw" value="10" />
+              </node>
+            </node>
+            <node concept="7CXmI" id="7yOFqurKRrr" role="lGtFl">
+              <node concept="2DdRWr" id="7yOFqurKR$w" role="7EUXB">
+                <node concept="MGsTx" id="7yOFqurKR$x" role="MJxsd">
+                  <ref role="39XzEq" to="yjde:1ufrWYcMap8" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="m5gfS" id="7yOFqurKRdn" role="2zM23F">
+            <node concept="30bXR$" id="7yOFqurKRdG" role="m5gfT" />
+            <node concept="30bdrU" id="7yOFqurKRem" role="m5gfT" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="7yOFqurKVVt" role="_iOnB">
+          <property role="TrG5h" value="pointCorrect" />
+          <node concept="1SrvAg" id="7yOFqurKW12" role="2zPyp_">
+            <ref role="1Srsag" node="7yOFqurKVKK" resolve="Point2" />
+            <node concept="1SruMQ" id="7yOFqurKW14" role="1Srv_k">
+              <ref role="1SruML" node="7yOFqurKVPS" resolve="x" />
+              <node concept="30bXRB" id="7yOFqurKW1K" role="1lsf3T">
+                <property role="30bXRw" value="0" />
+              </node>
+            </node>
+            <node concept="1SruMQ" id="7yOFqurKW16" role="1Srv_k">
+              <ref role="1SruML" node="7yOFqurKVQb" resolve="y" />
+              <node concept="30bXRB" id="7yOFqurKW2o" role="1lsf3T">
+                <property role="30bXRw" value="0" />
+              </node>
+            </node>
+          </node>
+          <node concept="1SyHNB" id="7yOFqurKW0S" role="2zM23F">
+            <ref role="1SyHM3" node="7yOFqurExf9" resolve="Point" />
+          </node>
+          <node concept="7CXmI" id="7yOFqurLlKz" role="lGtFl">
+            <node concept="7OXhh" id="7yOFqurLlLL" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7yOFqurLlTa" role="_iOnB">
+          <property role="TrG5h" value="pointIncorrect" />
+          <node concept="1SrvAg" id="7yOFqurLm1f" role="2zPyp_">
+            <ref role="1Srsag" node="7yOFqurGGlc" resolve="Empty" />
+            <node concept="7CXmI" id="7yOFqurLm1x" role="lGtFl">
+              <node concept="2DdRWr" id="7yOFqurLmd6" role="7EUXB">
+                <node concept="MGsTx" id="7yOFqurLmd7" role="MJxsd">
+                  <ref role="39XzEq" to="t4jv:5aHkq2w4P8w" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1SyHNB" id="7yOFqurLm15" role="2zM23F">
+            <ref role="1SyHM3" node="7yOFqurExf9" resolve="Point" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -12,7 +12,7 @@
     <use id="64e79176-30a1-4836-821c-bf62ff6c6091" name="org.iets3.core.expr.natlang" version="-1" />
     <use id="5fe6cb13-2fbd-4e21-9842-785bdd6fc5b1" name="org.iets3.core.expr.adt" version="-1" />
     <use id="289fb12b-7f53-4ef7-bc2e-1ed2c6a7c998" name="org.iets3.core.expr.datetime" version="-1" />
-    <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="2" />
+    <use id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util" version="3" />
     <use id="b25b8ad1-4d3d-4e45-8c78-72091b39fdda" name="org.iets3.core.expr.data" version="1" />
     <devkit ref="c4e521ab-b605-4ef9-a7c3-68075da058f0(org.iets3.core.expr.core.devkit)" />
   </languages>
@@ -98,6 +98,7 @@
       <concept id="161551962036658012" name="org.iets3.core.expr.util.structure.MultiDecTab" flags="ng" index="1fMURV" />
       <concept id="8853770331921611232" name="org.iets3.core.expr.util.structure.IMultiDecTab" flags="ng" index="1vMD3l">
         <reference id="8697767715748449842" name="resultTuple" index="3$Iael" />
+        <child id="1609062041026819473" name="resultTupleDeclaration" index="2ACRNR" />
         <child id="8853770331921611296" name="colDefs" index="1vMDcl" />
         <child id="8853770331921611812" name="rows" index="1vMDkh" />
       </concept>
@@ -16036,6 +16037,9 @@
                   </node>
                 </node>
               </node>
+              <node concept="1SLEKJ" id="1pkymqLocNk" role="2ACRNR">
+                <property role="TrG5h" value="7241462708334131240_ResultTuple" />
+              </node>
             </node>
             <node concept="uhfPG" id="6hYPZtwvBHL" role="1aduh9">
               <ref role="uhfO8" node="6hYPZtwvBuy" resolve="x" />
@@ -16152,6 +16156,21 @@
                     <node concept="1TM$A" id="3eQTdYHnapC" role="7EUXB">
                       <node concept="2PYRI3" id="6GvFh7h3wkB" role="3lydEf">
                         <ref role="39XzEq" to="523r:8XWEtek2IL" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1SLEKJ" id="1pkymqLocNl" role="2ACRNR">
+                  <property role="TrG5h" value="3726417391033032681_ResultTuple" />
+                  <node concept="1SLn8H" id="1pkymqLocNm" role="1Syw7I">
+                    <property role="TrG5h" value="res1" />
+                    <node concept="mLuIC" id="1pkymqLocNn" role="2S399n" />
+                  </node>
+                  <node concept="1SLn8H" id="1pkymqLocNo" role="1Syw7I">
+                    <property role="TrG5h" value="res2" />
+                    <node concept="mLuIC" id="1pkymqLocNp" role="2S399n">
+                      <node concept="2gteS_" id="1pkymqLocNq" role="2gteVg">
+                        <property role="2gteVv" value="1" />
                       </node>
                     </node>
                   </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -97,6 +97,7 @@
       </concept>
       <concept id="161551962036658012" name="org.iets3.core.expr.util.structure.MultiDecTab" flags="ng" index="1fMURV" />
       <concept id="8853770331921611232" name="org.iets3.core.expr.util.structure.IMultiDecTab" flags="ng" index="1vMD3l">
+        <reference id="8697767715748449842" name="resultTuple" index="3$Iael" />
         <child id="8853770331921611296" name="colDefs" index="1vMDcl" />
         <child id="8853770331921611812" name="rows" index="1vMDkh" />
       </concept>
@@ -511,6 +512,11 @@
         <reference id="2861782275883762408" name="extFun" index="1He9kT" />
         <child id="2861782275883807063" name="args" index="1H9Mq6" />
       </concept>
+      <concept id="5749748470420409857" name="org.iets3.core.expr.toplevel.structure.ITupleDeclaration" flags="ng" index="1SyzJ4">
+        <child id="5749748470420419627" name="members" index="1Syw7I" />
+      </concept>
+      <concept id="5749748470417082344" name="org.iets3.core.expr.toplevel.structure.TupleMember" flags="ng" index="1SLn8H" />
+      <concept id="5749748470417037802" name="org.iets3.core.expr.toplevel.structure.NamedTupleDeclaration" flags="ng" index="1SLEKJ" />
       <concept id="7740953487936183912" name="org.iets3.core.expr.toplevel.structure.Typedef" flags="ng" index="1WbbD7">
         <child id="7740953487936183915" name="originalType" index="1WbbD4" />
       </concept>
@@ -15943,6 +15949,22 @@
     <node concept="1qefOq" id="5aYM8itcbxT" role="1SKRRt">
       <node concept="_iOnV" id="5aYM8itcbxW" role="1qenE9">
         <property role="TrG5h" value="lib" />
+        <node concept="1SLEKJ" id="7yOFqusmHRB" role="_iOnC">
+          <property role="TrG5h" value="ResultType" />
+          <node concept="1SLn8H" id="7yOFqusn6$q" role="1Syw7I">
+            <property role="TrG5h" value="res1" />
+            <node concept="mLuIC" id="7yOFqusn6Av" role="2S399n" />
+          </node>
+          <node concept="1SLn8H" id="7yOFqusn6D5" role="1Syw7I">
+            <property role="TrG5h" value="res2" />
+            <node concept="mLuIC" id="7yOFqusn6Fc" role="2S399n">
+              <node concept="2gteS_" id="7yOFqusn6Fl" role="2gteVg">
+                <property role="2gteVv" value="1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="7yOFqusmHQl" role="_iOnC" />
         <node concept="1aga60" id="6hYPZtwvBlr" role="_iOnC">
           <property role="TrG5h" value="usesVar" />
           <property role="0Rz4W" value="1467106227" />
@@ -16035,100 +16057,109 @@
             <property role="TrG5h" value="c" />
             <node concept="mLuIC" id="7Z_pmaBQiJ2" role="3ix9CU" />
           </node>
-          <node concept="1fMURV" id="3eQTdYHn9ZD" role="1ahQXP">
-            <node concept="1fMUR7" id="3eQTdYHn9ZE" role="1vMDcl">
-              <node concept="1afdae" id="3eQTdYHn9ZF" role="1fMUOQ">
-                <ref role="1afue_" node="3eQTdYHn9Zz" resolve="a" />
-              </node>
-            </node>
-            <node concept="1fMUR7" id="3eQTdYHn9ZG" role="1vMDcl">
-              <node concept="1afdae" id="3eQTdYHn9ZH" role="1fMUOQ">
-                <ref role="1afue_" node="3eQTdYHn9Z_" resolve="b" />
-              </node>
-            </node>
-            <node concept="1fMUR7" id="3eQTdYHn9ZI" role="1vMDcl">
-              <node concept="1afdae" id="3eQTdYHn9ZJ" role="1fMUOQ">
-                <ref role="1afue_" node="3eQTdYHn9ZB" resolve="c" />
-              </node>
-            </node>
-            <node concept="1fMUOM" id="3eQTdYHn9ZK" role="1vMDcl">
-              <property role="TrG5h" value="res1" />
-              <node concept="mLuIC" id="7Z_pmaBQiJ3" role="1fMUOZ" />
-            </node>
-            <node concept="1fMUOM" id="3eQTdYHn9ZM" role="1vMDcl">
-              <property role="TrG5h" value="res2" />
-              <node concept="mLuIC" id="3eQTdYHn9ZN" role="1fMUOZ">
-                <node concept="2gteS_" id="3eQTdYHn9ZO" role="2gteVg">
-                  <property role="2gteVv" value="1" />
-                </node>
-              </node>
-            </node>
-            <node concept="1fLkTo" id="3eQTdYHn9ZP" role="1vMDkh">
-              <property role="2b1Mha" value="easy" />
-              <node concept="1fLbrf" id="3eQTdYHn9ZQ" role="1fLbpX">
-                <ref role="1fLbst" node="3eQTdYHn9ZE" />
-                <node concept="30bXRB" id="4LQ7f3jHPcc" role="1fLbpZ">
-                  <property role="30bXRw" value="1" />
-                </node>
-              </node>
-              <node concept="1fLbrf" id="3eQTdYHn9ZS" role="1fLbpX">
-                <ref role="1fLbst" node="3eQTdYHn9ZG" />
-                <node concept="30bXRB" id="4LQ7f3jHPeb" role="1fLbpZ">
-                  <property role="30bXRw" value="2" />
-                </node>
-              </node>
-              <node concept="1fLbrf" id="3eQTdYHn9ZU" role="1fLbpX">
-                <ref role="1fLbst" node="3eQTdYHn9ZK" resolve="res1" />
-                <node concept="30bXRB" id="4LQ7f3jHPi9" role="1fLbpZ">
-                  <property role="30bXRw" value="3" />
-                </node>
-              </node>
-              <node concept="1fLbrf" id="3eQTdYHn9ZW" role="1fLbpX">
-                <ref role="1fLbst" node="3eQTdYHn9ZI" />
-                <node concept="30bXRB" id="4LQ7f3jHPga" role="1fLbpZ">
-                  <property role="30bXRw" value="3" />
-                </node>
-              </node>
-              <node concept="1fLbrf" id="3eQTdYHn9ZY" role="1fLbpX">
-                <ref role="1fLbst" node="3eQTdYHn9ZM" resolve="res2" />
-                <node concept="30bXRB" id="4LQ7f3jHPk6" role="1fLbpZ">
-                  <property role="30bXRw" value="2.0" />
-                </node>
-                <node concept="30bXRB" id="4LQ7f3jKgc1" role="1fLbpZ">
-                  <property role="30bXRw" value="3.0" />
-                </node>
-                <node concept="7CXmI" id="6GvFh7h3u8x" role="lGtFl">
-                  <node concept="1TM$A" id="6GvFh7h3une" role="7EUXB">
-                    <node concept="2PYRI3" id="6GvFh7h3unf" role="3lydEf">
-                      <ref role="39XzEq" to="523r:4LQ7f3j$Orz" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1fLkTo" id="3eQTdYHna00" role="1vMDkh">
-              <property role="2b1Mha" value="complicated" />
-              <node concept="1fLbrf" id="3eQTdYHna01" role="1fLbpX">
-                <ref role="1fLbst" node="3eQTdYHn9ZK" resolve="res1" />
-                <node concept="30bXRB" id="4LQ7f3jHPlY" role="1fLbpZ">
-                  <property role="30bXRw" value="1" />
-                </node>
-              </node>
-              <node concept="7CXmI" id="3eQTdYHnapB" role="lGtFl">
-                <node concept="1TM$A" id="3eQTdYHnapC" role="7EUXB">
-                  <node concept="2PYRI3" id="6GvFh7h3wkB" role="3lydEf">
-                    <ref role="39XzEq" to="523r:8XWEtek2IL" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
           <node concept="m5gfS" id="3eQTdYHna05" role="2zM23F">
             <node concept="mLuIC" id="7Z_pmaBQiJ4" role="m5gfT" />
             <node concept="mLuIC" id="3eQTdYHna07" role="m5gfT">
               <node concept="2gteS_" id="3eQTdYHna08" role="2gteVg">
                 <property role="2gteVv" value="1" />
               </node>
+            </node>
+          </node>
+          <node concept="1aduha" id="7yOFqurYkhf" role="1ahQXP">
+            <node concept="1adJid" id="7yOFqurYkin" role="1aduh9">
+              <property role="TrG5h" value="result" />
+              <node concept="1fMURV" id="3eQTdYHn9ZD" role="1adJij">
+                <ref role="3$Iael" node="7yOFqusmHRB" resolve="ResultType" />
+                <node concept="1fMUR7" id="3eQTdYHn9ZE" role="1vMDcl">
+                  <node concept="1afdae" id="3eQTdYHn9ZF" role="1fMUOQ">
+                    <ref role="1afue_" node="3eQTdYHn9Zz" resolve="a" />
+                  </node>
+                </node>
+                <node concept="1fMUR7" id="3eQTdYHn9ZG" role="1vMDcl">
+                  <node concept="1afdae" id="3eQTdYHn9ZH" role="1fMUOQ">
+                    <ref role="1afue_" node="3eQTdYHn9Z_" resolve="b" />
+                  </node>
+                </node>
+                <node concept="1fMUR7" id="3eQTdYHn9ZI" role="1vMDcl">
+                  <node concept="1afdae" id="3eQTdYHn9ZJ" role="1fMUOQ">
+                    <ref role="1afue_" node="3eQTdYHn9ZB" resolve="c" />
+                  </node>
+                </node>
+                <node concept="1fMUOM" id="3eQTdYHn9ZK" role="1vMDcl">
+                  <property role="TrG5h" value="res1" />
+                  <node concept="mLuIC" id="7Z_pmaBQiJ3" role="1fMUOZ" />
+                </node>
+                <node concept="1fMUOM" id="3eQTdYHn9ZM" role="1vMDcl">
+                  <property role="TrG5h" value="res2" />
+                  <node concept="mLuIC" id="3eQTdYHn9ZN" role="1fMUOZ">
+                    <node concept="2gteS_" id="3eQTdYHn9ZO" role="2gteVg">
+                      <property role="2gteVv" value="1" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="1fLkTo" id="3eQTdYHn9ZP" role="1vMDkh">
+                  <property role="2b1Mha" value="easy" />
+                  <node concept="1fLbrf" id="3eQTdYHn9ZQ" role="1fLbpX">
+                    <ref role="1fLbst" node="3eQTdYHn9ZE" />
+                    <node concept="30bXRB" id="4LQ7f3jHPcc" role="1fLbpZ">
+                      <property role="30bXRw" value="1" />
+                    </node>
+                  </node>
+                  <node concept="1fLbrf" id="3eQTdYHn9ZS" role="1fLbpX">
+                    <ref role="1fLbst" node="3eQTdYHn9ZG" />
+                    <node concept="30bXRB" id="4LQ7f3jHPeb" role="1fLbpZ">
+                      <property role="30bXRw" value="2" />
+                    </node>
+                  </node>
+                  <node concept="1fLbrf" id="3eQTdYHn9ZU" role="1fLbpX">
+                    <ref role="1fLbst" node="3eQTdYHn9ZK" resolve="res1" />
+                    <node concept="30bXRB" id="4LQ7f3jHPi9" role="1fLbpZ">
+                      <property role="30bXRw" value="3" />
+                    </node>
+                  </node>
+                  <node concept="1fLbrf" id="3eQTdYHn9ZW" role="1fLbpX">
+                    <ref role="1fLbst" node="3eQTdYHn9ZI" />
+                    <node concept="30bXRB" id="4LQ7f3jHPga" role="1fLbpZ">
+                      <property role="30bXRw" value="3" />
+                    </node>
+                  </node>
+                  <node concept="1fLbrf" id="3eQTdYHn9ZY" role="1fLbpX">
+                    <ref role="1fLbst" node="3eQTdYHn9ZM" resolve="res2" />
+                    <node concept="30bXRB" id="4LQ7f3jHPk6" role="1fLbpZ">
+                      <property role="30bXRw" value="2.0" />
+                    </node>
+                    <node concept="30bXRB" id="4LQ7f3jKgc1" role="1fLbpZ">
+                      <property role="30bXRw" value="3.0" />
+                    </node>
+                    <node concept="7CXmI" id="6GvFh7h3u8x" role="lGtFl">
+                      <node concept="1TM$A" id="6GvFh7h3une" role="7EUXB">
+                        <node concept="2PYRI3" id="6GvFh7h3unf" role="3lydEf">
+                          <ref role="39XzEq" to="523r:4LQ7f3j$Orz" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1fLkTo" id="3eQTdYHna00" role="1vMDkh">
+                  <property role="2b1Mha" value="complicated" />
+                  <node concept="1fLbrf" id="3eQTdYHna01" role="1fLbpX">
+                    <ref role="1fLbst" node="3eQTdYHn9ZK" resolve="res1" />
+                    <node concept="30bXRB" id="4LQ7f3jHPlY" role="1fLbpZ">
+                      <property role="30bXRw" value="1" />
+                    </node>
+                  </node>
+                  <node concept="7CXmI" id="3eQTdYHnapB" role="lGtFl">
+                    <node concept="1TM$A" id="3eQTdYHnapC" role="7EUXB">
+                      <node concept="2PYRI3" id="6GvFh7h3wkB" role="3lydEf">
+                        <ref role="39XzEq" to="523r:8XWEtek2IL" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1adzI2" id="7yOFqus30Kd" role="1aduh9">
+              <ref role="1adwt6" node="7yOFqurYkin" resolve="result" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
@@ -80,7 +80,7 @@
     <language slang="l:2c8e8304-72f7-4e6a-853a-ac0616a47569:org.iets3.core.expr.typetags.lib" version="0" />
     <language slang="l:cb91a38e-738a-4811-a96d-448d08f526fa:org.iets3.core.expr.typetags.units" version="1" />
     <language slang="l:be679007-4312-4db1-9ac0-ab7dfbe66a74:org.iets3.core.expr.typetags.units.quantity" version="0" />
-    <language slang="l:8bb1251e-eae5-47ab-9843-33adfae8edaa:org.iets3.core.expr.util" version="2" />
+    <language slang="l:8bb1251e-eae5-47ab-9843-33adfae8edaa:org.iets3.core.expr.util" version="3" />
     <language slang="l:a2242e6f-d308-41e6-ac06-28b0a2a4ad79:test.ts.expr.os.validNameConcept" version="0" />
   </languageVersions>
   <dependencyVersions>


### PR DESCRIPTION
The main motivation was to have multi-decision tables return a named tuple so that you can reference the result columns per name instead of per index. The named tuples are compatible with each other and normal tuples if they structurally match.

Known/found issues:
- When a result column in a dectab is renamed the references to this field break.
- The dot expression implementation of tuple types in the [generator](http://127.0.0.1:63320/node?ref=r%3A4243557f-1c7a-4d6b-953a-807576e4bee7%28org.iets3.core.expr.genjava.base%40generator%29%2F3863896640935437510) looks very broken to me. I've disabled two general operations on tuples as a result.


<img width="1032" alt="Screenshot 2023-12-20 at 12 07 19" src="https://github.com/IETS3/iets3.opensource/assets/88385944/6e1fca3d-54ad-4988-9b33-8750457b879c">