### PR TITLE
Merge changes from master into maintenance/mps20222

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ def major = "2022"
 def minor = "2"
 
 // Dependency versions
-ext.mpsVersion = '2022.2.1'
+ext.mpsVersion = '2022.2.2'
 
 def mbeddrVersion = "2022.2+"
 


### PR DESCRIPTION
Before closing #741, we need to make sure the `maintenance/mps20222` branch is up-to-date with the changes applied to this version.