### PR TITLE
Update PCollections to 4.0.1 and Gradle 8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). 
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## January 2024
+
+### Changed
+
+- The PCollections library was updated to version 4.0.1.
+
 ## December 2023
 
 ### Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,7 @@ dependencies {
     mps "com.jetbrains:mps:$mpsVersion"
     languageLibs "com.mbeddr:platform:$mbeddrVersionSelector"
     junitAnt 'org.apache.ant:ant-junit:1.10.6'
-    pcollections 'org.pcollections:pcollections:3.1.4'
+    pcollections 'org.pcollections:pcollections:4.0.1'
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ ext.incrementalBuild = !project.hasProperty("disableIncrementalBuild")
 
 
 wrapper {
-    gradleVersion '5.5.1'
+    gradleVersion '8.5'
     distributionType Wrapper.DistributionType.ALL
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+# https://docs.gradle.org/current/userguide/upgrading_version_8.html#xml_parsing_now_requires_recent_parsers
+
+systemProp.javax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl
+systemProp.javax.xml.transform.TransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl
+systemProp.javax.xml.parsers.DocumentBuilderFactory=com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Version 4.0.1 of PCollections is backwards compatible with 4.0.1.
- I've upgraded Gradle to 8.5 to fix an issue where the JBR couldn't be extracted: `org.gradle.api.GradleException: Unable to expand TAR`