### PR TITLE
Improve DateLiteral constraints for months and days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 - The PCollections library was updated to version 4.0.1.
 
+### Fixed
+
+- The DateLiteral constraints for months and days were improved.
+
 ## December 2023
 
 ### Fixed

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.datetime/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.datetime/models/constraints.mps
@@ -184,8 +184,8 @@
               <node concept="1Wqviy" id="8iseid1uGE" role="2Oq$k0" />
               <node concept="liA8E" id="8iseid1uGF" role="2OqNvi">
                 <ref role="37wK5l" to="wyt6:~String.matches(java.lang.String)" resolve="matches" />
-                <node concept="Xl_RD" id="8iseid1uGG" role="37wK5m">
-                  <property role="Xl_RC" value="\\d\\d" />
+                <node concept="Xl_RD" id="knfvDjEZj0" role="37wK5m">
+                  <property role="Xl_RC" value="(0[1-9]|[12]\\d|3[01])" />
                 </node>
               </node>
             </node>
@@ -202,8 +202,8 @@
               <node concept="1Wqviy" id="3C_9jV3oYu" role="2Oq$k0" />
               <node concept="liA8E" id="3C_9jV3oYv" role="2OqNvi">
                 <ref role="37wK5l" to="wyt6:~String.matches(java.lang.String)" resolve="matches" />
-                <node concept="Xl_RD" id="3C_9jV3oYw" role="37wK5m">
-                  <property role="Xl_RC" value="\\d\\d" />
+                <node concept="Xl_RD" id="8iseid1uGG" role="37wK5m">
+                  <property role="Xl_RC" value="(0[1-9]|1[0-2])" />
                 </node>
               </node>
             </node>


### PR DESCRIPTION
The problem is `DateLiteral#toDate` which throws a `DateTimeException` because of possible invalid parsed years or days (default value: 0). We can't fix the issue but rather prevent the user from entering invalid values.