### PR TITLE
expr.temporal: improved exception handling in check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 - The PCollections library was updated to version 4.0.1.
 
+### Fixed
+- Uncatched `DateTimeException` during check DateLiteral
+
 ## December 2023
 
 ### Fixed

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
@@ -154,16 +154,12 @@
         <child id="8276990574895933173" name="catchBody" index="1zc67A" />
         <child id="8276990574895933172" name="throwable" index="1zc67B" />
       </concept>
-      <concept id="8276990574909231788" name="jetbrains.mps.baseLanguage.structure.FinallyClause" flags="ng" index="1wplmZ">
-        <child id="8276990574909234106" name="finallyBody" index="1wplMD" />
-      </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
         <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
-        <child id="8276990574886367509" name="finallyClause" index="1zxBo6" />
         <child id="8276990574886367508" name="body" index="1zxBo7" />
       </concept>
       <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
@@ -1022,27 +1018,23 @@
                                           </node>
                                         </node>
                                       </node>
-                                    </node>
-                                  </node>
-                                  <node concept="3clFbS" id="4vJmyITi0OE" role="1zxBo7">
-                                    <node concept="3clFbF" id="1MJboh4O5Hy" role="3cqZAp">
-                                      <node concept="2OqwBi" id="1MJboh4O6xy" role="3clFbG">
-                                        <node concept="37vLTw" id="1MJboh4O5Hx" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="1MJboh4O57C" resolve="it" />
-                                        </node>
-                                        <node concept="2qgKlT" id="1MJboh4O9p7" role="2OqNvi">
-                                          <ref role="37wK5l" to="pbu6:7GwCuf2r4g6" resolve="isSameAs" />
-                                          <node concept="37vLTw" id="1MJboh4Oacz" role="37wK5m">
-                                            <ref role="3cqZAo" node="5oaaToWY2tT" resolve="date" />
-                                          </node>
-                                        </node>
+                                      <node concept="3cpWs6" id="JblrdgIUTz" role="3cqZAp">
+                                        <node concept="3clFbT" id="JblrdgIUTX" role="3cqZAk" />
                                       </node>
                                     </node>
                                   </node>
-                                  <node concept="1wplmZ" id="4vJmyITiBiS" role="1zxBo6">
-                                    <node concept="3clFbS" id="4vJmyITiBiT" role="1wplMD">
-                                      <node concept="3cpWs6" id="4vJmyITiMGT" role="3cqZAp">
-                                        <node concept="3clFbT" id="4vJmyITiMHc" role="3cqZAk" />
+                                  <node concept="3clFbS" id="4vJmyITi0OE" role="1zxBo7">
+                                    <node concept="3cpWs6" id="JblrdgIKOg" role="3cqZAp">
+                                      <node concept="2OqwBi" id="JblrdgIKOi" role="3cqZAk">
+                                        <node concept="37vLTw" id="JblrdgIKOj" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="1MJboh4O57C" resolve="it" />
+                                        </node>
+                                        <node concept="2qgKlT" id="JblrdgIKOk" role="2OqNvi">
+                                          <ref role="37wK5l" to="pbu6:7GwCuf2r4g6" resolve="isSameAs" />
+                                          <node concept="37vLTw" id="JblrdgIKOl" role="37wK5m">
+                                            <ref role="3cqZAo" node="5oaaToWY2tT" resolve="date" />
+                                          </node>
+                                        </node>
                                       </node>
                                     </node>
                                   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
@@ -42,6 +42,9 @@
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
+        <child id="8118189177080264854" name="alternative" index="nSUat" />
+      </concept>
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
         <child id="1076505808688" name="condition" index="2$JKZa" />
@@ -68,6 +71,7 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
@@ -146,9 +150,21 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
+        <child id="8276990574895933173" name="catchBody" index="1zc67A" />
+        <child id="8276990574895933172" name="throwable" index="1zc67B" />
+      </concept>
+      <concept id="8276990574909231788" name="jetbrains.mps.baseLanguage.structure.FinallyClause" flags="ng" index="1wplmZ">
+        <child id="8276990574909234106" name="finallyBody" index="1wplMD" />
+      </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+        <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
+        <child id="8276990574886367509" name="finallyClause" index="1zxBo6" />
+        <child id="8276990574886367508" name="body" index="1zxBo7" />
       </concept>
       <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
         <child id="1163668914799" name="condition" index="3K4Cdx" />
@@ -284,6 +300,12 @@
       <concept id="1174663118805" name="jetbrains.mps.lang.typesystem.structure.CreateLessThanInequationStatement" flags="nn" index="1ZobV4" />
       <concept id="1174663239020" name="jetbrains.mps.lang.typesystem.structure.CreateGreaterThanInequationStatement" flags="nn" index="1ZoDhX" />
     </language>
+    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
+      <concept id="2034914114981261497" name="jetbrains.mps.baseLanguage.logging.structure.LogLowLevelStatement" flags="ng" index="RRSsy">
+        <property id="2034914114981261751" name="severity" index="RRSoG" />
+        <child id="2034914114981261753" name="message" index="RRSoy" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
@@ -398,6 +420,7 @@
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
+      <concept id="31378964227347002" name="jetbrains.mps.baseLanguage.collections.structure.SelectNotNullOperation" flags="ng" index="1KnU$U" />
     </language>
   </registry>
   <node concept="2sgARr" id="50smQ1V8pHj">
@@ -963,21 +986,63 @@
                           </node>
                         </node>
                         <node concept="2OqwBi" id="1MJboh4NXrW" role="3clFbw">
-                          <node concept="37vLTw" id="1MJboh4NW0c" role="2Oq$k0">
-                            <ref role="3cqZAo" node="1MJboh4Ntv7" resolve="dates" />
+                          <node concept="2OqwBi" id="4vJmyIT5Pn5" role="2Oq$k0">
+                            <node concept="37vLTw" id="1MJboh4NW0c" role="2Oq$k0">
+                              <ref role="3cqZAo" node="1MJboh4Ntv7" resolve="dates" />
+                            </node>
+                            <node concept="1KnU$U" id="4vJmyIThUq$" role="2OqNvi" />
                           </node>
                           <node concept="2HwmR7" id="1MJboh4O57$" role="2OqNvi">
                             <node concept="1bVj0M" id="1MJboh4O57A" role="23t8la">
                               <node concept="3clFbS" id="1MJboh4O57B" role="1bW5cS">
-                                <node concept="3clFbF" id="1MJboh4O5Hy" role="3cqZAp">
-                                  <node concept="2OqwBi" id="1MJboh4O6xy" role="3clFbG">
-                                    <node concept="37vLTw" id="1MJboh4O5Hx" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="1MJboh4O57C" resolve="it" />
+                                <node concept="3J1_TO" id="4vJmyITi0OC" role="3cqZAp">
+                                  <node concept="3uVAMA" id="4vJmyITi11d" role="1zxBo5">
+                                    <node concept="XOnhg" id="4vJmyITi11e" role="1zc67B">
+                                      <property role="TrG5h" value="ex" />
+                                      <node concept="nSUau" id="4vJmyITi11f" role="1tU5fm">
+                                        <node concept="3uibUv" id="4vJmyITi2nS" role="nSUat">
+                                          <ref role="3uigEE" to="wyt6:~RuntimeException" resolve="RuntimeException" />
+                                        </node>
+                                      </node>
                                     </node>
-                                    <node concept="2qgKlT" id="1MJboh4O9p7" role="2OqNvi">
-                                      <ref role="37wK5l" to="pbu6:7GwCuf2r4g6" resolve="isSameAs" />
-                                      <node concept="37vLTw" id="1MJboh4Oacz" role="37wK5m">
-                                        <ref role="3cqZAo" node="5oaaToWY2tT" resolve="date" />
+                                    <node concept="3clFbS" id="4vJmyITi11g" role="1zc67A">
+                                      <node concept="RRSsy" id="4vJmyITi5ZX" role="3cqZAp">
+                                        <property role="RRSoG" value="gZ5fh_4/error" />
+                                        <node concept="3cpWs3" id="4vJmyITiW3E" role="RRSoy">
+                                          <node concept="Xl_RD" id="4vJmyITiWrz" role="3uHU7B">
+                                            <property role="Xl_RC" value="Failed to compare date literals. " />
+                                          </node>
+                                          <node concept="2OqwBi" id="4vJmyITibzb" role="3uHU7w">
+                                            <node concept="37vLTw" id="4vJmyITiaBE" role="2Oq$k0">
+                                              <ref role="3cqZAo" node="4vJmyITi11e" resolve="ex" />
+                                            </node>
+                                            <node concept="liA8E" id="4vJmyITibWH" role="2OqNvi">
+                                              <ref role="37wK5l" to="wyt6:~Throwable.getMessage()" resolve="getMessage" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3clFbS" id="4vJmyITi0OE" role="1zxBo7">
+                                    <node concept="3clFbF" id="1MJboh4O5Hy" role="3cqZAp">
+                                      <node concept="2OqwBi" id="1MJboh4O6xy" role="3clFbG">
+                                        <node concept="37vLTw" id="1MJboh4O5Hx" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="1MJboh4O57C" resolve="it" />
+                                        </node>
+                                        <node concept="2qgKlT" id="1MJboh4O9p7" role="2OqNvi">
+                                          <ref role="37wK5l" to="pbu6:7GwCuf2r4g6" resolve="isSameAs" />
+                                          <node concept="37vLTw" id="1MJboh4Oacz" role="37wK5m">
+                                            <ref role="3cqZAo" node="5oaaToWY2tT" resolve="date" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="1wplmZ" id="4vJmyITiBiS" role="1zxBo6">
+                                    <node concept="3clFbS" id="4vJmyITiBiT" role="1wplMD">
+                                      <node concept="3cpWs6" id="4vJmyITiMGT" role="3cqZAp">
+                                        <node concept="3clFbT" id="4vJmyITiMHc" role="3cqZAk" />
                                       </node>
                                     </node>
                                   </node>


### PR DESCRIPTION
The initial creation of a [DateLiteral](http://127.0.0.1:63320/node?ref=r%3A9ec53fca-e669-4a18-ba8b-6c9f4f1cb361%28org.iets3.core.expr.datetime.structure%29%2F3885635233757569297) lead to a `DateTimeException`.


**Thrown exception**
```
DateTimeException: Invalid value for MonthOfYear (valid values 1 - 12): 0
	at java.base/java.time.temporal.ValueRange.checkValidValue(ValueRange.java:311)
	at java.base/java.time.temporal.ChronoField.checkValidValue(ChronoField.java:717)
	at java.base/java.time.LocalDate.of(LocalDate.java:269)
	at org.iets3.core.expr.datetime.behavior.DateLiteral__BehaviorDescriptor.toDate_id26CArgU4p85(DateLiteral__BehaviorDescriptor.java:61)
	at org.iets3.core.expr.datetime.behavior.DateLiteral__BehaviorDescriptor.invokeSpecial0(DateLiteral__BehaviorDescriptor.java:115)
	at jetbrains.mps.core.aspects.behaviour.BaseBHDescriptor.invokeSpecial(BaseBHDescriptor.java:347)
	at jetbrains.mps.core.aspects.behaviour.BaseBHDescriptor.invokeNonVirtualCommon(BaseBHDescriptor.java:295)
	at jetbrains.mps.core.aspects.behaviour.BaseBHDescriptor.invokeNonVirtual(BaseBHDescriptor.java:271)
	at jetbrains.mps.core.aspects.behaviour.BaseBHDescriptor.invoke(BaseBHDescriptor.java:232)
	at jetbrains.mps.core.aspects.behaviour.SMethodImpl.invoke0(SMethodImpl.java:153)
	at jetbrains.mps.core.aspects.behaviour.SMethodImpl.invoke(SMethodImpl.java:128)
	at org.iets3.core.expr.datetime.behavior.DateLiteral__BehaviorDescriptor.isSameAs_id7GwCuf2r4g6(DateLiteral__BehaviorDescriptor.java:94)
	at org.iets3.core.expr.datetime.behavior.DateLiteral__BehaviorDescriptor.invokeSpecial0(DateLiteral__BehaviorDescriptor.java:125)
	at jetbrains.mps.core.aspects.behaviour.BaseBHDescriptor.invokeSpecial(BaseBHDescriptor.java:347)
	at jetbrains.mps.core.aspects.behaviour.BaseBHDescriptor.invokeVirtual(BaseBHDescriptor.java:306)
	at jetbrains.mps.core.aspects.behaviour.BaseBHDescriptor.invoke(BaseBHDescriptor.java:230)
	at jetbrains.mps.core.aspects.behaviour.SMethodImpl.invoke0(SMethodImpl.java:153)
	at jetbrains.mps.core.aspects.behaviour.SMethodImpl.invoke(SMethodImpl.java:128)
	at org.iets3.core.expr.temporal.typesystem.check_TemporalLiteral_NonTypesystemRule$1$1.accept(check_TemporalLiteral_NonTypesystemRule.java:56)
	at org.iets3.core.expr.temporal.typesystem.check_TemporalLiteral_NonTypesystemRule$1$1.accept(check_TemporalLiteral_NonTypesystemRule.java:54)
```
**Proposed fixes**

- Added better exception handling in [check_TemporalLiteral](http://127.0.0.1:63320/node?ref=r%3A782cab7d-c30f-4797-991c-cb17d0274086%28org.iets3.core.expr.temporal.typesystem%29%2F5183460839965330728) and only perform the check on valid content
