### PR TITLE
core.expr.genjava.base: added type cast for TupleAccessExpr

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
@@ -12989,55 +12989,79 @@
                 </node>
               </node>
             </node>
-            <node concept="3cpWs8" id="2ICvjplTaRG" role="3cqZAp">
-              <node concept="3cpWsn" id="2ICvjplTaRH" role="3cpWs9">
-                <property role="TrG5h" value="i" />
-                <node concept="3uibUv" id="2ICvjplTaRI" role="1tU5fm">
-                  <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
-                </node>
-                <node concept="2ShNRf" id="2ICvjplTaRJ" role="33vP2m">
-                  <node concept="1pGfFk" id="2ICvjplTaRK" role="2ShVmc">
-                    <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
-                    <node concept="Xl_RD" id="2ICvjplTaRL" role="37wK5m">
-                      <property role="Xl_RC" value="0" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="3cpWs6" id="2ICvjplTaRM" role="3cqZAp">
-              <node concept="2OqwBi" id="2ICvjplTaRN" role="3cqZAk">
-                <node concept="37vLTw" id="2ICvjplTaRO" role="2Oq$k0">
-                  <ref role="3cqZAo" node="2ICvjplTaRC" resolve="tpv" />
-                  <node concept="29HgVG" id="2ICvjplTaRP" role="lGtFl">
-                    <node concept="3NFfHV" id="2ICvjplTaRQ" role="3NFExx">
-                      <node concept="3clFbS" id="2ICvjplTaRR" role="2VODD2">
-                        <node concept="3clFbF" id="2ICvjplTaRS" role="3cqZAp">
-                          <node concept="2OqwBi" id="2ICvjplTaRT" role="3clFbG">
-                            <node concept="3TrEf2" id="2ICvjplTYqZ" role="2OqNvi">
-                              <ref role="3Tt5mk" to="hm2y:2ck7OjOLg5_" resolve="tuple" />
+              <node concept="1eOMI4" id="1fSpSxRozbj" role="3cqZAk">
+                <node concept="10QFUN" id="1fSpSxRozbg" role="1eOMHV">
+                  <node concept="3uibUv" id="1fSpSxSovG8" role="10QFUM">
+                    <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+                    <node concept="29HgVG" id="1fSpSxSoGVd" role="lGtFl">
+                      <node concept="3NFfHV" id="1fSpSxSoGVe" role="3NFExx">
+                        <node concept="3clFbS" id="1fSpSxSoGVf" role="2VODD2">
+                          <node concept="3clFbJ" id="1fSpSxRTk3J" role="3cqZAp">
+                            <node concept="2OqwBi" id="1fSpSxRTl8Y" role="3clFbw">
+                              <node concept="2OqwBi" id="1fSpSxRTkrV" role="2Oq$k0">
+                                <node concept="30H73N" id="1fSpSxRTk3Q" role="2Oq$k0" />
+                                <node concept="3JvlWi" id="1fSpSxRTkP5" role="2OqNvi" />
+                              </node>
+                              <node concept="3w_OXm" id="1fSpSxRTlYp" role="2OqNvi" />
                             </node>
-                            <node concept="30H73N" id="2ICvjplTaRV" role="2Oq$k0" />
+                            <node concept="3clFbS" id="1fSpSxRTk3L" role="3clFbx">
+                              <node concept="3clFbF" id="1fSpSxRTmGx" role="3cqZAp">
+                                <node concept="2OqwBi" id="1fSpSxRTnj9" role="3clFbG">
+                                  <node concept="1iwH7S" id="1fSpSxRTmGw" role="2Oq$k0" />
+                                  <node concept="2k5nB$" id="1fSpSxRTo9f" role="2OqNvi">
+                                    <node concept="Xl_RD" id="1fSpSxRToU0" role="2k5Stb">
+                                      <property role="Xl_RC" value="No typesystem type detected for " />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3cpWs6" id="1fSpSxRTumn" role="3cqZAp">
+                            <node concept="2OqwBi" id="1fSpSxRTump" role="3cqZAk">
+                              <node concept="30H73N" id="1fSpSxRTumq" role="2Oq$k0" />
+                              <node concept="3JvlWi" id="1fSpSxRTumr" role="2OqNvi" />
+                            </node>
                           </node>
                         </node>
                       </node>
                     </node>
                   </node>
-                </node>
-                <node concept="liA8E" id="2ICvjplTaRW" role="2OqNvi">
-                  <ref role="37wK5l" to="j10v:~TreePVector.get(int)" resolve="get" />
-                  <node concept="3cmrfG" id="2ICvjplU1vN" role="37wK5m">
-                    <property role="3cmrfH" value="1" />
-                    <node concept="17Uvod" id="2ICvjplU2sX" role="lGtFl">
-                      <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580320020/1068580320021" />
-                      <property role="2qtEX9" value="value" />
-                      <node concept="3zFVjK" id="2ICvjplU2sY" role="3zH0cK">
-                        <node concept="3clFbS" id="2ICvjplU2sZ" role="2VODD2">
-                          <node concept="3clFbF" id="2ICvjplU2Wf" role="3cqZAp">
-                            <node concept="2OqwBi" id="2ICvjplU3hj" role="3clFbG">
-                              <node concept="30H73N" id="2ICvjplU2We" role="2Oq$k0" />
-                              <node concept="3TrcHB" id="2ICvjplU3MT" role="2OqNvi">
-                                <ref role="3TsBF5" to="hm2y:2ck7OjOLBmQ" resolve="index" />
+                  <node concept="2OqwBi" id="2ICvjplTaRN" role="10QFUP">
+                    <node concept="liA8E" id="2ICvjplTaRW" role="2OqNvi">
+                      <ref role="37wK5l" to="j10v:~TreePVector.get(int)" resolve="get" />
+                      <node concept="3cmrfG" id="2ICvjplU1vN" role="37wK5m">
+                        <property role="3cmrfH" value="1" />
+                        <node concept="17Uvod" id="2ICvjplU2sX" role="lGtFl">
+                          <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580320020/1068580320021" />
+                          <property role="2qtEX9" value="value" />
+                          <node concept="3zFVjK" id="2ICvjplU2sY" role="3zH0cK">
+                            <node concept="3clFbS" id="2ICvjplU2sZ" role="2VODD2">
+                              <node concept="3clFbF" id="2ICvjplU2Wf" role="3cqZAp">
+                                <node concept="2OqwBi" id="2ICvjplU3hj" role="3clFbG">
+                                  <node concept="30H73N" id="2ICvjplU2We" role="2Oq$k0" />
+                                  <node concept="3TrcHB" id="2ICvjplU3MT" role="2OqNvi">
+                                    <ref role="3TsBF5" to="hm2y:2ck7OjOLBmQ" resolve="index" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="2ICvjplTaRO" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2ICvjplTaRC" resolve="tpv" />
+                      <node concept="29HgVG" id="2ICvjplTaRP" role="lGtFl">
+                        <node concept="3NFfHV" id="2ICvjplTaRQ" role="3NFExx">
+                          <node concept="3clFbS" id="2ICvjplTaRR" role="2VODD2">
+                            <node concept="3clFbF" id="2ICvjplTaRS" role="3cqZAp">
+                              <node concept="2OqwBi" id="2ICvjplTaRT" role="3clFbG">
+                                <node concept="3TrEf2" id="2ICvjplTYqZ" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="hm2y:2ck7OjOLg5_" resolve="tuple" />
+                                </node>
+                                <node concept="30H73N" id="2ICvjplTaRV" role="2Oq$k0" />
                               </node>
                             </node>
                           </node>
@@ -13046,7 +13070,7 @@
                     </node>
                   </node>
                 </node>
-                <node concept="raruj" id="2ICvjplTaS7" role="lGtFl" />
+                <node concept="raruj" id="1fSpSxRoziY" role="lGtFl" />
               </node>
             </node>
           </node>


### PR DESCRIPTION
This PR  updates the reduction rule for TupleAccessExpr and adds an additional type cast in case a typesystem type is present. 
Those change prevents issue #774 from happening and avoid a compilation error.