### PR TITLE
build.gradle: added build fail on test failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 ### Added
 
+- updated gradle build. Build will now fail in case tests were failing.
 - Enumerations can have an order by declaration, by literal or by value ascociated with the literal 
 
 ## January 2024

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 import de.itemis.mps.gradle.*
-
+import groovy.xml.XmlSlurper
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
@@ -212,6 +212,16 @@ task buildAndRunTests(type: TestLanguages, dependsOn: buildLanguages) {
             report(format: 'frames', todir: "$buildDir/junitreport")
         }
         ant.echo("JUnit report placed into $buildDir/junitreport/index.html")
+
+        // evaluate junit result and fail on error
+        def junitResult = new XmlSlurper().parse(file('TESTS-TestSuites.xml'))
+        def failures = junitResult.'**'.findAll { it.name() == 'failure' }
+        def errors = junitResult.'**'.findAll { it.name() == 'errors' }
+
+        if (failures || errors) {
+            def amount = failures.size() + errors.size()
+            throw new GradleException(amount + " JUnit tests failed. Check the test report for details.")
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -212,8 +212,13 @@ task buildAndRunTests(type: TestLanguages, dependsOn: buildLanguages) {
             report(format: 'frames', todir: "$buildDir/junitreport")
         }
         ant.echo("JUnit report placed into $buildDir/junitreport/index.html")
+    }
+}
 
-        // evaluate junit result and fail on error
+task failOnTestError() {
+    description 'evaluate junit result and fail on error'
+    doLast {
+        
         def junitResult = new XmlSlurper().parse(file('TESTS-TestSuites.xml'))
         def failures = junitResult.'**'.findAll { it.name() == 'failure' }
         def errors = junitResult.'**'.findAll { it.name() == 'errors' }
@@ -223,8 +228,9 @@ task buildAndRunTests(type: TestLanguages, dependsOn: buildLanguages) {
             throw new GradleException(amount + " JUnit tests failed. Check the test report for details.")
         }
     }
-}
 
+}
+buildAndRunTests.configure { finalizedBy failOnTestError }
 check.dependsOn buildAndRunTests
 
 task packageLanguages(type: Zip, dependsOn: buildLanguages) {

--- a/build.gradle
+++ b/build.gradle
@@ -219,16 +219,18 @@ task failOnTestError() {
     description 'evaluate junit result and fail on error'
     doLast {
         
-        def junitResult = new XmlSlurper().parse(file('TESTS-TestSuites.xml'))
-        def failures = junitResult.'**'.findAll { it.name() == 'failure' }
-        def errors = junitResult.'**'.findAll { it.name() == 'errors' }
+        def juniXml = file('TESTS-TestSuites.xml')
+        if(juniXml.exists()){
+            def junitResult = new XmlSlurper().parse(juniXml)
+            def failures = junitResult.'**'.findAll { it.name() == 'failure' }
+            def errors = junitResult.'**'.findAll { it.name() == 'errors' }
 
-        if (failures || errors) {
-            def amount = failures.size() + errors.size()
-            throw new GradleException(amount + " JUnit tests failed. Check the test report for details.")
+            if (failures || errors) {
+                def amount = failures.size() + errors.size()
+                throw new GradleException(amount + " JUnit tests failed. Check the test report for details.")
+            }
         }
     }
-
 }
 buildAndRunTests.configure { finalizedBy failOnTestError }
 check.dependsOn buildAndRunTests

--- a/build.gradle
+++ b/build.gradle
@@ -223,7 +223,7 @@ task failOnTestError() {
         if(juniXml.exists()){
             def junitResult = new XmlSlurper().parse(juniXml)
             def failures = junitResult.'**'.findAll { it.name() == 'failure' }
-            def errors = junitResult.'**'.findAll { it.name() == 'errors' }
+            def errors = junitResult.'**'.findAll { it.name() == 'error' }
 
             if (failures || errors) {
                 def amount = failures.size() + errors.size()


### PR DESCRIPTION
At the moment our TC configuration allows the execution of the `publish` task despite of failing tests. This PR adds additional functionality to fail our build in case we have failing tests. 

We want to still execute all tests and collect their results as part of the junit result xml file. However in addition we want the build to fail in case tests are failing.  Therefore the `buildAndRunTests()` task was updated to parse the result xml file and throw an exception in case of test failures.