### PR TITLE
Add interpreter for makeTime

### DIFF
--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.datetime.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.datetime.interpreter/models/plugin.mps
@@ -3313,6 +3313,94 @@
         </node>
       </node>
     </node>
+    <node concept="qq9P1" id="2upbyyo12sC" role="qq9xR">
+      <property role="2TnfIJ" value="true" />
+      <ref role="qq9wM" to="mi3w:3HiHZey9lU5" resolve="MakeTime" />
+      <node concept="3dA_Gj" id="2upbyyo1eAZ" role="3vQZUl">
+        <node concept="9aQIb" id="2upbyyo1eB1" role="3vcmbn">
+          <node concept="3clFbS" id="2upbyyo1eB3" role="9aQI4">
+            <node concept="3cpWs8" id="2upbyyo1wC3" role="3cqZAp">
+              <node concept="3cpWsn" id="2upbyyo1wC4" role="3cpWs9">
+                <property role="TrG5h" value="h" />
+                <node concept="3uibUv" id="2upbyyo1uA8" role="1tU5fm">
+                  <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                </node>
+                <node concept="10QFUN" id="2upbyyo1NfX" role="33vP2m">
+                  <node concept="3uibUv" id="2upbyyo1NfZ" role="10QFUM">
+                    <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                  </node>
+                  <node concept="rqRoa" id="2upbyyo1Wuz" role="10QFUP">
+                    <ref role="rqRob" to="mi3w:3HiHZey9lU6" resolve="hourExpr" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="2upbyyo1CYU" role="3cqZAp">
+              <node concept="3cpWsn" id="2upbyyo1CYV" role="3cpWs9">
+                <property role="TrG5h" value="m" />
+                <node concept="3uibUv" id="2upbyyo1CYW" role="1tU5fm">
+                  <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                </node>
+                <node concept="10QFUN" id="2upbyyo1QkA" role="33vP2m">
+                  <node concept="rqRoa" id="2upbyyo1WHP" role="10QFUP">
+                    <ref role="rqRob" to="mi3w:3HiHZey9lU7" resolve="minutesExpr" />
+                  </node>
+                  <node concept="3uibUv" id="2upbyyo1QkC" role="10QFUM">
+                    <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="2upbyyo1JlU" role="3cqZAp">
+              <node concept="3cpWsn" id="2upbyyo1JlV" role="3cpWs9">
+                <property role="TrG5h" value="s" />
+                <node concept="3uibUv" id="2upbyyo1JlW" role="1tU5fm">
+                  <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                </node>
+                <node concept="10QFUN" id="2upbyyo1ToS" role="33vP2m">
+                  <node concept="rqRoa" id="2upbyyo1WWp" role="10QFUP">
+                    <ref role="rqRob" to="mi3w:3HiHZeybRMz" resolve="secondsExpr" />
+                  </node>
+                  <node concept="3uibUv" id="2upbyyo1ToU" role="10QFUM">
+                    <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="2upbyyo1u$X" role="3cqZAp">
+              <node concept="2YIFZM" id="2upbyyo1rye" role="3cqZAk">
+                <ref role="1Pybhc" to="28m1:~LocalTime" resolve="LocalTime" />
+                <ref role="37wK5l" to="28m1:~LocalTime.of(int,int,int)" resolve="of" />
+                <node concept="2OqwBi" id="2upbyyo1XrZ" role="37wK5m">
+                  <node concept="37vLTw" id="2upbyyo1wC6" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2upbyyo1wC4" resolve="h" />
+                  </node>
+                  <node concept="liA8E" id="2upbyyo1Yeu" role="2OqNvi">
+                    <ref role="37wK5l" to="xlxw:~BigInteger.intValue()" resolve="intValue" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="2upbyyo21$T" role="37wK5m">
+                  <node concept="37vLTw" id="2upbyyo21jn" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2upbyyo1CYV" resolve="m" />
+                  </node>
+                  <node concept="liA8E" id="2upbyyo22nM" role="2OqNvi">
+                    <ref role="37wK5l" to="xlxw:~BigInteger.intValue()" resolve="intValue" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="2upbyyo25MO" role="37wK5m">
+                  <node concept="37vLTw" id="2upbyyo25x0" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2upbyyo1JlV" resolve="s" />
+                  </node>
+                  <node concept="liA8E" id="2upbyyo2662" role="2OqNvi">
+                    <ref role="37wK5l" to="xlxw:~BigInteger.intValue()" resolve="intValue" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="qq9P1" id="64dkh69UXvQ" role="qq9xR">
       <property role="2TnfIJ" value="true" />
       <ref role="qq9wM" to="mi3w:1RwPUjzgIEp" resolve="EarliestExpression" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/datetime@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/datetime@tests.mps
@@ -8048,6 +8048,120 @@
         </node>
       </node>
     </node>
+    <node concept="2zPypq" id="3XIe3ZPnQvf" role="_iOnB">
+      <property role="TrG5h" value="madeTime2" />
+      <property role="0Rz4W" value="-1376704304" />
+      <node concept="2ptY_Q" id="3XIe3ZPnQvg" role="2zPyp_">
+        <node concept="30bXRB" id="3XIe3ZPnQvh" role="2ptY_P">
+          <property role="30bXRw" value="23" />
+        </node>
+        <node concept="30bXRB" id="3XIe3ZPnQvi" role="2ptY_O">
+          <property role="30bXRw" value="00" />
+        </node>
+        <node concept="30bXRB" id="3XIe3ZPnQvj" role="2pvsHg">
+          <property role="30bXRw" value="30" />
+        </node>
+      </node>
+    </node>
+    <node concept="_fkuM" id="3XIe3ZPk7t_" role="_iOnB">
+      <property role="TrG5h" value="makeTime" />
+      <node concept="_fkuZ" id="3XIe3ZPlZeV" role="_fkp5">
+        <node concept="_fku$" id="3XIe3ZPlZeW" role="_fkur" />
+        <node concept="30cPrO" id="3XIe3ZPlZfK" role="_fkuY">
+          <node concept="_emDc" id="3XIe3ZPlZjn" role="30dEs_">
+            <ref role="_emDf" node="3HiHZeyaf1r" resolve="typed" />
+          </node>
+          <node concept="_emDc" id="3XIe3ZPlZfv" role="30dEsF">
+            <ref role="_emDf" node="3HiHZeyanun" resolve="madeTime" />
+          </node>
+        </node>
+        <node concept="2vmpnb" id="3XIe3ZPlZn1" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="3XIe3ZPnQQk" role="_fkp5">
+        <node concept="_fku$" id="3XIe3ZPnQQl" role="_fkur" />
+        <node concept="30cPrR" id="3XIe3ZPnQW3" role="_fkuY">
+          <node concept="_emDc" id="3XIe3ZPnQQo" role="30dEsF">
+            <ref role="_emDf" node="3HiHZeyanun" resolve="madeTime" />
+          </node>
+          <node concept="_emDc" id="3XIe3ZPnQQn" role="30dEs_">
+            <ref role="_emDf" node="3XIe3ZPnQvf" resolve="madeTime2" />
+          </node>
+        </node>
+        <node concept="2vmpnb" id="3XIe3ZPnQQp" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="3XIe3ZPrLRi" role="_fkp5">
+        <node concept="_fku$" id="3XIe3ZPrLRj" role="_fkur" />
+        <node concept="30cPrO" id="3XIe3ZPrLSo" role="_fkuY">
+          <node concept="_emDc" id="3XIe3ZPrLRl" role="30dEsF">
+            <ref role="_emDf" node="3HiHZeyanun" resolve="madeTime" />
+          </node>
+          <node concept="_emDc" id="3XIe3ZPrLRm" role="30dEs_">
+            <ref role="_emDf" node="3XIe3ZPnQvf" resolve="madeTime2" />
+          </node>
+        </node>
+        <node concept="2vmpn$" id="3XIe3ZPrLY$" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="3XIe3ZPpIqN" role="_fkp5">
+        <node concept="_fku$" id="3XIe3ZPpIqO" role="_fkur" />
+        <node concept="30d6GJ" id="3XIe3ZPpIrJ" role="_fkuY">
+          <node concept="_emDc" id="3XIe3ZPpIwQ" role="30dEs_">
+            <ref role="_emDf" node="3XIe3ZPnQvf" resolve="madeTime2" />
+          </node>
+          <node concept="_emDc" id="3XIe3ZPpIrx" role="30dEsF">
+            <ref role="_emDf" node="3HiHZeyanun" resolve="madeTime" />
+          </node>
+        </node>
+        <node concept="2vmpnb" id="3XIe3ZPpI_Y" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="3XIe3ZPk7R_" role="_fkp5">
+        <node concept="_fku$" id="3XIe3ZPk7RA" role="_fkur" />
+        <node concept="1QScDb" id="3XIe3ZPk7S7" role="_fkuY">
+          <node concept="2poLz3" id="3XIe3ZPk7Tt" role="1QScD9" />
+          <node concept="_emDc" id="3XIe3ZPk7RS" role="30czhm">
+            <ref role="_emDf" node="3HiHZeyanun" resolve="madeTime" />
+          </node>
+        </node>
+        <node concept="30bXRB" id="3XIe3ZPk7VA" role="_fkuS">
+          <property role="30bXRw" value="23" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="3XIe3ZPk7VX" role="_fkp5">
+        <node concept="_fku$" id="3XIe3ZPk7VY" role="_fkur" />
+        <node concept="1QScDb" id="3XIe3ZPk7Wy" role="_fkuY">
+          <node concept="2poMIs" id="3XIe3ZPk7YR" role="1QScD9" />
+          <node concept="_emDc" id="3XIe3ZPk7Wj" role="30czhm">
+            <ref role="_emDf" node="3HiHZeyanun" resolve="madeTime" />
+          </node>
+        </node>
+        <node concept="30bXRB" id="3XIe3ZPk81N" role="_fkuS">
+          <property role="30bXRw" value="00" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="3XIe3ZPk82g" role="_fkp5">
+        <node concept="_fku$" id="3XIe3ZPk82h" role="_fkur" />
+        <node concept="1QScDb" id="3XIe3ZPk82V" role="_fkuY">
+          <node concept="2poLxH" id="3XIe3ZPk863" role="1QScD9" />
+          <node concept="_emDc" id="3XIe3ZPk82G" role="30czhm">
+            <ref role="_emDf" node="3HiHZeyanun" resolve="madeTime" />
+          </node>
+        </node>
+        <node concept="30bXRB" id="3XIe3ZPk89y" role="_fkuS">
+          <property role="30bXRw" value="00" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="3XIe3ZPrLNu" role="_fkp5">
+        <node concept="_fku$" id="3XIe3ZPrLNv" role="_fkur" />
+        <node concept="1QScDb" id="3XIe3ZPrLNw" role="_fkuY">
+          <node concept="2poLxH" id="3XIe3ZPrLNx" role="1QScD9" />
+          <node concept="_emDc" id="3XIe3ZPrLNy" role="30czhm">
+            <ref role="_emDf" node="3XIe3ZPnQvf" resolve="madeTime2" />
+          </node>
+        </node>
+        <node concept="30bXRB" id="3XIe3ZPrLNz" role="_fkuS">
+          <property role="30bXRw" value="30" />
+        </node>
+      </node>
+    </node>
     <node concept="_fkuM" id="3HiHZey9Yyz" role="_iOnB">
       <property role="TrG5h" value="valuOps" />
       <node concept="_fkuZ" id="3HiHZeycr_X" role="_fkp5">


### PR DESCRIPTION
This change adds an intepreter for [MakeTime](http://127.0.0.1:63320/node?ref=r%3A9ec53fca-e669-4a18-ba8b-6c9f4f1cb361%28org.iets3.core.expr.datetime.structure%29%2F4274681253353315973) into the [ExprDatetimeTypesInterpreter](http://127.0.0.1:63320/node?ref=r%3A9931730f-a933-4ee8-8dad-53a254a9519e%28org.iets3.core.expr.datetime.interpreter.plugin%29%2F553080662195419964). 

fixes #702 