### PR TITLE
adapt iets3.os to use snapshot repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,10 +82,10 @@ if (project.hasProperty('iets3OpenSourceVersion')) {
         currentBranch = GitBasedVersioning.gitBranch
 
         def buildNumber = System.env.BUILD_NUMBER.toInteger()
-        if (currentBranch.startsWith("maintenance") || currentBranch.startsWith("mps")) {
+        if (currentBranch.startsWith("maintenance") || currentBranch.startsWith("mps") || currentBranch == "master" || currentBranch.contains("datev") ) {
             version = "$major.$minor.$buildNumber.${GitBasedVersioning.gitShortCommitHash}"
         } else {
-            version = GitBasedVersioning.getVersionWithCount(major, minor, buildNumber)
+            version = GitBasedVersioning.getVersionWithCount(major, minor, buildNumber) + "-SNAPSHOT"
         }
         println "##teamcity[buildNumber '${version}']"
     } else {
@@ -108,6 +108,7 @@ if (!project.hasProperty("mbeddrVersion")) {
 ext.releaseRepository = 'https://artifacts.itemis.cloud/repository/maven-mps-releases/'
 ext.snapshotRepository = 'https://artifacts.itemis.cloud/repository/maven-mps-snapshots'
 ext.publishingRepository = version.toString().endsWith("-SNAPSHOT") ? snapshotRepository : releaseRepository
+
 
 
 // 'artifacts' is used in the generated ant scripts as build output directory

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ if (project.hasProperty('iets3OpenSourceVersion')) {
         currentBranch = GitBasedVersioning.gitBranch
 
         def buildNumber = System.env.BUILD_NUMBER.toInteger()
-        if (currentBranch.startsWith("maintenance") || currentBranch.startsWith("mps") || currentBranch == "master" || currentBranch.contains("datev") ) {
+        if (currentBranch.startsWith("maintenance/") || currentBranch.startsWith("datev/")) {
             version = "$major.$minor.$buildNumber.${GitBasedVersioning.gitShortCommitHash}"
         } else {
             version = GitBasedVersioning.getVersionWithCount(major, minor, buildNumber) + "-SNAPSHOT"

--- a/build.gradle
+++ b/build.gradle
@@ -275,7 +275,7 @@ publishing {
                 }
             }
         }
-        if (currentBranch == "master" || currentBranch.startsWith("maintenance") || currentBranch.startsWith("mps")) {
+        if (currentBranch == "master" || currentBranch.startsWith("maintenance") ) {
             maven {
                 name = "GitHubPackages"
                 url = uri("https://maven.pkg.github.com/IETS3/iets3.opensource")


### PR DESCRIPTION
All branches except main, maintenance and customer branches should go to the -SNAPSHOT branch. 

fix #823 
