### PR TITLE
Fix type calculation of field setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 ## March 2024
 
+### Added
+
 - *MessageDefiniton* uses *extensionPoint/IdentifierConfigurator/* that allows the user to decide to use german umlauts and paragraphs in it.
 - This extensionPoint got a new method to select which implementation will be chosen. 
 
+### Fixed
+
+- The type calculation of field setters now works.
 
 ## February 2024
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -8658,8 +8658,13 @@
       <node concept="3Tqbb2" id="7SszixhZWjX" role="3clF45" />
       <node concept="3clFbS" id="7SszixhZVRs" role="3clF47">
         <node concept="3clFbF" id="7SszixhZWys" role="3cqZAp">
-          <node concept="37vLTw" id="7SszixhZWyr" role="3clFbG">
-            <ref role="3cqZAo" node="7SszixhZWr_" resolve="setter" />
+          <node concept="2OqwBi" id="62KthWc7WCS" role="3clFbG">
+            <node concept="37vLTw" id="7SszixhZWyr" role="2Oq$k0">
+              <ref role="3cqZAo" node="7SszixhZWr_" resolve="setter" />
+            </node>
+            <node concept="3TrEf2" id="62KthWc7WPz" role="2OqNvi">
+              <ref role="3Tt5mk" to="yv47:4ptnK4jbqZQ" resolve="field" />
+            </node>
           </node>
         </node>
       </node>


### PR DESCRIPTION
Example node where it didn't work: http://127.0.0.1:63320/node?ref=r%3Aa2594bdc-f128-474d-863a-401664a7ab8e%28test.in.expr.os.todo%40tests%29%2F5070313213711196305
There was a warning that the type never gets concrete.