### PR TITLE
Bugfix/type system improvement

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.base/org.iets3.core.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.base/org.iets3.core.base.mpl
@@ -20,7 +20,7 @@
     <dependency reexport="false">f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
+    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
     <language slang="l:b92f861d-0184-446d-b88b-6dcf0e070241:com.mbeddr.mpsutil.intentions" version="0" />
     <language slang="l:62a3babb-5d40-4920-897f-d4144dc99c9d:com.mbeddr.mpsutil.userstyles" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
@@ -72,10 +72,10 @@
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
     <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />
     <module reference="b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)" version="0" />
-    <module reference="5454dbfd-2075-4de0-b85e-fa645eb6957e(com.mbeddr.mpsutil.serializer.xml)" version="0" />
     <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
     <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
     <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
+    <module reference="5454dbfd-2075-4de0-b85e-fa645eb6957e(de.itemis.mps.utils.serializer.xml)" version="0" />
     <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.base/org.iets3.core.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.base/org.iets3.core.base.mpl
@@ -16,11 +16,11 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
     <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
-    <dependency reexport="false">5454dbfd-2075-4de0-b85e-fa645eb6957e(com.mbeddr.mpsutil.serializer.xml)</dependency>
+    <dependency reexport="false">5454dbfd-2075-4de0-b85e-fa645eb6957e(de.itemis.mps.utils.serializer.xml)</dependency>
     <dependency reexport="false">f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
+    <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="1" />
     <language slang="l:b92f861d-0184-446d-b88b-6dcf0e070241:com.mbeddr.mpsutil.intentions" version="0" />
     <language slang="l:62a3babb-5d40-4920-897f-d4144dc99c9d:com.mbeddr.mpsutil.userstyles" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -22903,6 +22903,84 @@
       </node>
       <node concept="17QB3L" id="7VuYlCR4z4M" role="3clF45" />
     </node>
+    <node concept="13i0hz" id="H8GgRpqbgk" role="13h7CS">
+      <property role="TrG5h" value="sortTypes" />
+      <node concept="3Tm1VV" id="H8GgRpqbgl" role="1B3o_S" />
+      <node concept="3cqZAl" id="H8GgRpqtdX" role="3clF45" />
+      <node concept="3clFbS" id="H8GgRpqbgn" role="3clF47">
+        <node concept="3cpWs8" id="H8GgRpq_ig" role="3cqZAp">
+          <node concept="3cpWsn" id="H8GgRpq_ij" role="3cpWs9">
+            <property role="TrG5h" value="sortedTypes" />
+            <node concept="2I9FWS" id="H8GgRpq_ie" role="1tU5fm">
+              <ref role="2I9WkF" to="hm2y:6sdnDbSlaok" resolve="Type" />
+            </node>
+            <node concept="2OqwBi" id="H8GgRpqPv3" role="33vP2m">
+              <node concept="2OqwBi" id="H8GgRpqBU5" role="2Oq$k0">
+                <node concept="2OqwBi" id="H8GgRpqtp5" role="2Oq$k0">
+                  <node concept="13iPFW" id="H8GgRpqtew" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="H8GgRpqtFR" role="2OqNvi">
+                    <ref role="3TtcxE" to="hm2y:7VuYlCQZ3lm" resolve="types" />
+                  </node>
+                </node>
+                <node concept="2S7cBI" id="H8GgRpqMKU" role="2OqNvi">
+                  <node concept="1bVj0M" id="H8GgRpqMKW" role="23t8la">
+                    <node concept="3clFbS" id="H8GgRpqMKX" role="1bW5cS">
+                      <node concept="3clFbF" id="H8GgRpqMQm" role="3cqZAp">
+                        <node concept="2OqwBi" id="H8GgRpqO9H" role="3clFbG">
+                          <node concept="2OqwBi" id="H8GgRpqN5i" role="2Oq$k0">
+                            <node concept="37vLTw" id="H8GgRpqMQl" role="2Oq$k0">
+                              <ref role="3cqZAo" node="H8GgRpqMKY" resolve="it" />
+                            </node>
+                            <node concept="2yIwOk" id="H8GgRpqNHd" role="2OqNvi" />
+                          </node>
+                          <node concept="liA8E" id="H8GgRpqOBY" role="2OqNvi">
+                            <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="H8GgRpqMKY" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="H8GgRpqMKZ" role="1tU5fm" />
+                    </node>
+                  </node>
+                  <node concept="1nlBCl" id="H8GgRpqML0" role="2S7zOq">
+                    <property role="3clFbU" value="true" />
+                  </node>
+                </node>
+              </node>
+              <node concept="ANE8D" id="H8GgRpqQu3" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="H8GgRpqQBG" role="3cqZAp">
+          <node concept="2OqwBi" id="H8GgRpqTBH" role="3clFbG">
+            <node concept="2OqwBi" id="H8GgRpqQUt" role="2Oq$k0">
+              <node concept="13iPFW" id="H8GgRpqQBE" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="H8GgRpqRuE" role="2OqNvi">
+                <ref role="3TtcxE" to="hm2y:7VuYlCQZ3lm" resolve="types" />
+              </node>
+            </node>
+            <node concept="2Kehj3" id="H8GgRpqYAB" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="H8GgRpr4Hu" role="3cqZAp">
+          <node concept="2OqwBi" id="H8GgRprgMy" role="3clFbG">
+            <node concept="2OqwBi" id="H8GgRpr84a" role="2Oq$k0">
+              <node concept="13iPFW" id="H8GgRpr4Hs" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="H8GgRprbCF" role="2OqNvi">
+                <ref role="3TtcxE" to="hm2y:7VuYlCQZ3lm" resolve="types" />
+              </node>
+            </node>
+            <node concept="X8dFx" id="H8GgRprm0$" role="2OqNvi">
+              <node concept="37vLTw" id="H8GgRprqSp" role="25WWJ7">
+                <ref role="3cqZAo" node="H8GgRpq_ij" resolve="sortedTypes" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="13h7C7" id="XblfskIwwQ">
     <ref role="13h7C2" to="hm2y:XblfskIwr9" resolve="IMultiTraceRoot" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/plugin.mps
@@ -24,6 +24,7 @@
     <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" />
     <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
+    <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -1941,7 +1942,16 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="7JCDpchR3PS" role="3cqZAp" />
+        <node concept="3clFbF" id="738HPfgQhkT" role="3cqZAp">
+          <node concept="2OqwBi" id="738HPfgQtDZ" role="3clFbG">
+            <node concept="37vLTw" id="738HPfgQhkR" role="2Oq$k0">
+              <ref role="3cqZAo" node="1cX0cm8Zurw" resolve="jt" />
+            </node>
+            <node concept="2qgKlT" id="738HPfgQB1O" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:H8GgRpqbgk" resolve="sortTypes" />
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="7JCDpchDZwS" role="3cqZAp">
           <node concept="2OqwBi" id="7JCDpchEFHq" role="3clFbG">
             <node concept="2OqwBi" id="7JCDpchEaLn" role="2Oq$k0">
@@ -2695,6 +2705,16 @@
               <node concept="37vLTw" id="1G7Ce6wlPOp" role="25WWJ7">
                 <ref role="3cqZAo" node="1G7Ce6wsKy$" resolve="resultTypes" />
               </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="738HPfgQXcL" role="3cqZAp">
+          <node concept="2OqwBi" id="738HPfgR54b" role="3clFbG">
+            <node concept="37vLTw" id="738HPfgQXcJ" role="2Oq$k0">
+              <ref role="3cqZAo" node="1G7Ce6wlPOc" resolve="jt" />
+            </node>
+            <node concept="2qgKlT" id="738HPfgRkXU" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:H8GgRpqbgk" resolve="sortTypes" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/plugin.mps
@@ -22,6 +22,7 @@
     <import index="btm1" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3(org.apache.commons/)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" />
+    <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
@@ -99,6 +100,9 @@
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -195,6 +199,7 @@
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+        <child id="1201186121363" name="typeParameter" index="2Ghqu4" />
       </concept>
     </language>
     <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
@@ -359,6 +364,7 @@
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
         <child id="1225711182005" name="list" index="1y566C" />
         <child id="1225711191269" name="index" index="1y58nS" />
@@ -1935,6 +1941,90 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="7JCDpchR3PS" role="3cqZAp" />
+        <node concept="3clFbF" id="7JCDpchDZwS" role="3cqZAp">
+          <node concept="2OqwBi" id="7JCDpchEFHq" role="3clFbG">
+            <node concept="2OqwBi" id="7JCDpchEaLn" role="2Oq$k0">
+              <node concept="37vLTw" id="7JCDpchDZwR" role="2Oq$k0">
+                <ref role="3cqZAo" node="1cX0cm8Zurw" resolve="jt" />
+              </node>
+              <node concept="3Tsc0h" id="7JCDpchEouj" role="2OqNvi">
+                <ref role="3TtcxE" to="hm2y:7VuYlCQZ3lm" resolve="types" />
+              </node>
+            </node>
+            <node concept="liA8E" id="7JCDpchF17F" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Collection.removeIf(java.util.function.Predicate)" resolve="removeIf" />
+              <node concept="2ShNRf" id="7JCDpchLjN2" role="37wK5m">
+                <node concept="YeOm9" id="7JCDpchL_eb" role="2ShVmc">
+                  <node concept="1Y3b0j" id="7JCDpchL_ee" role="YeSDq">
+                    <property role="2bfB8j" value="true" />
+                    <property role="373rjd" value="true" />
+                    <ref role="1Y3XeK" to="82uw:~Predicate" resolve="Predicate" />
+                    <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                    <node concept="3Tm1VV" id="7JCDpchL_ef" role="1B3o_S" />
+                    <node concept="3clFb_" id="7JCDpchL_et" role="jymVt">
+                      <property role="TrG5h" value="test" />
+                      <node concept="3Tm1VV" id="7JCDpchL_eu" role="1B3o_S" />
+                      <node concept="10P_77" id="7JCDpchL_ew" role="3clF45" />
+                      <node concept="37vLTG" id="7JCDpchL_ex" role="3clF46">
+                        <property role="TrG5h" value="p1" />
+                        <node concept="3uibUv" id="7JCDpchL_i0" role="1tU5fm">
+                          <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="7JCDpchL_ez" role="3clF47">
+                        <node concept="3clFbF" id="7JCDpchLOGR" role="3cqZAp">
+                          <node concept="2OqwBi" id="7JCDpchLYU4" role="3clFbG">
+                            <node concept="37vLTw" id="7JCDpchLOGQ" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7JCDpchL_ex" resolve="p1" />
+                            </node>
+                            <node concept="liA8E" id="7JCDpchMax_" role="2OqNvi">
+                              <ref role="37wK5l" to="mhbf:~SNode.isInstanceOfConcept(org.jetbrains.mps.openapi.language.SAbstractConcept)" resolve="isInstanceOfConcept" />
+                              <node concept="35c_gC" id="7JCDpchMp6y" role="37wK5m">
+                                <ref role="35c_gD" to="hm2y:3tcv7J0pmjC" resolve="EmptyType" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2AHcQZ" id="7JCDpchL_e_" role="2AJF6D">
+                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                      </node>
+                    </node>
+                    <node concept="3uibUv" id="7JCDpchL_hZ" role="2Ghqu4">
+                      <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="7JCDpch_jK9" role="3cqZAp">
+          <node concept="3clFbS" id="7JCDpch_jKb" role="3clFbx">
+            <node concept="3cpWs6" id="7JCDpchOmSQ" role="3cqZAp">
+              <node concept="2ShNRf" id="7JCDpchOI_u" role="3cqZAk">
+                <node concept="3zrR0B" id="7JCDpchOIyJ" role="2ShVmc">
+                  <node concept="3Tqbb2" id="7JCDpchOIyK" role="3zrR0E">
+                    <ref role="ehGHo" to="hm2y:3tcv7J0pmjC" resolve="EmptyType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="7JCDpch$tFj" role="3clFbw">
+            <node concept="2OqwBi" id="7JCDpch$3ie" role="2Oq$k0">
+              <node concept="37vLTw" id="7JCDpchzQLK" role="2Oq$k0">
+                <ref role="3cqZAo" node="1cX0cm8Zurw" resolve="jt" />
+              </node>
+              <node concept="3Tsc0h" id="7JCDpch$eRZ" role="2OqNvi">
+                <ref role="3TtcxE" to="hm2y:7VuYlCQZ3lm" resolve="types" />
+              </node>
+            </node>
+            <node concept="1v1jN8" id="7JCDpchNXIY" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="7JCDpchRjjZ" role="3cqZAp" />
         <node concept="3clFbJ" id="6irnVZTrlW7" role="3cqZAp">
           <node concept="3clFbS" id="6irnVZTrlW9" role="3clFbx">
             <node concept="3cpWs6" id="6irnVZTtp2C" role="3cqZAp">
@@ -2671,7 +2761,7 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="5Am5nOKXK3Z" role="3cqZAp" />
+        <node concept="3clFbH" id="7JCDpchWuq7" role="3cqZAp" />
         <node concept="3cpWs8" id="1G7Ce6wQ1ls" role="3cqZAp">
           <node concept="3cpWsn" id="1G7Ce6wQ1lv" role="3cpWs9">
             <property role="TrG5h" value="idxA" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.LeastCommonSuperType@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.LeastCommonSuperType@tests.mps
@@ -59,6 +59,9 @@
         <child id="606861080870797310" name="expr" index="pf3We" />
       </concept>
       <concept id="7089558164908491660" name="org.iets3.core.expr.base.structure.EmptyExpression" flags="ng" index="2zH6wq" />
+      <concept id="7089558164905593724" name="org.iets3.core.expr.base.structure.IOptionallyTyped" flags="ng" index="2zM23E">
+        <child id="7089558164905593725" name="type" index="2zM23F" />
+      </concept>
       <concept id="7071042522334260296" name="org.iets3.core.expr.base.structure.ITyped" flags="ng" index="2_iKZX">
         <child id="8811147530085329321" name="type" index="2S399n" />
       </concept>
@@ -80,6 +83,7 @@
         <child id="7849560302565679723" name="condition" index="39w5ZE" />
         <child id="7849560302565679725" name="thenPart" index="39w5ZG" />
       </concept>
+      <concept id="3889855429450038473" name="org.iets3.core.expr.base.structure.EmptyValue" flags="ng" index="1I1voI" />
     </language>
     <language id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes">
       <concept id="7971844778467001950" name="org.iets3.core.expr.simpleTypes.structure.OtherwiseLiteral" flags="ng" index="2fHqz8" />
@@ -95,6 +99,7 @@
         <child id="1330041117646892937" name="prec" index="2gteVg" />
       </concept>
       <concept id="7425695345928358745" name="org.iets3.core.expr.simpleTypes.structure.TrueLiteral" flags="ng" index="2vmpnb" />
+      <concept id="7425695345928358774" name="org.iets3.core.expr.simpleTypes.structure.FalseLiteral" flags="ng" index="2vmpn$" />
       <concept id="7425695345928349207" name="org.iets3.core.expr.simpleTypes.structure.BooleanType" flags="ng" index="2vmvy5" />
       <concept id="5115872837157252552" name="org.iets3.core.expr.simpleTypes.structure.StringLiteral" flags="ng" index="30bdrP">
         <property id="5115872837157252555" name="value" index="30bdrQ" />
@@ -106,6 +111,12 @@
       </concept>
     </language>
     <language id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel">
+      <concept id="7089558164906249676" name="org.iets3.core.expr.toplevel.structure.Constant" flags="ng" index="2zPypq">
+        <child id="7089558164906249715" name="value" index="2zPyp_" />
+      </concept>
+      <concept id="543569365051789113" name="org.iets3.core.expr.toplevel.structure.ConstantRef" flags="ng" index="_emDc">
+        <reference id="543569365051789114" name="constant" index="_emDf" />
+      </concept>
       <concept id="543569365052765011" name="org.iets3.core.expr.toplevel.structure.EmptyToplevelContent" flags="ng" index="_ixoA" />
       <concept id="543569365052711055" name="org.iets3.core.expr.toplevel.structure.Library" flags="ng" index="_iOnU">
         <child id="543569365052711058" name="contents" index="_iOnB" />
@@ -197,6 +208,121 @@
           <node concept="2Ss9d7" id="3yVmeSjL7lC" role="S5Trm">
             <property role="TrG5h" value="name" />
             <node concept="30bdrU" id="3yVmeSjL7lD" role="2S399n" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="7JCDpchUsGh" role="_iOnB" />
+        <node concept="2zPypq" id="7JCDpcho27J" role="_iOnB">
+          <property role="TrG5h" value="a" />
+          <node concept="30bXRB" id="7JCDpcho29c" role="2zPyp_">
+            <property role="30bXRw" value="0" />
+          </node>
+          <node concept="30bXR$" id="7JCDpcho28Y" role="2zM23F" />
+        </node>
+        <node concept="_ixoA" id="7JCDpchU$zZ" role="_iOnB" />
+        <node concept="2zPypq" id="7JCDpcho2xc" role="_iOnB">
+          <property role="TrG5h" value="n2" />
+          <node concept="2fGnzi" id="7JCDpcho2DC" role="2zPyp_">
+            <node concept="2fGnzd" id="7JCDpcho2DD" role="2fGnxs">
+              <node concept="30cPrO" id="7JCDpcho2Ez" role="2fGnzS">
+                <node concept="30bXRB" id="7JCDpcho2IB" role="30dEs_">
+                  <property role="30bXRw" value="0" />
+                </node>
+                <node concept="_emDc" id="7JCDpcho2E7" role="30dEsF">
+                  <ref role="_emDf" node="7JCDpcho27J" resolve="a" />
+                </node>
+              </node>
+              <node concept="1I1voI" id="7JCDpcho2Mr" role="2fGnzA" />
+            </node>
+            <node concept="2fGnzd" id="7JCDpcho2DE" role="2fGnxs">
+              <node concept="30cPrO" id="7JCDpcho2Vw" role="2fGnzS">
+                <node concept="30bXRB" id="7JCDpcho2Zz" role="30dEs_">
+                  <property role="30bXRw" value="1" />
+                </node>
+                <node concept="_emDc" id="7JCDpcho2QW" role="30dEsF">
+                  <ref role="_emDf" node="7JCDpcho27J" resolve="a" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="7JCDpcho33X" role="2fGnzA">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="7CXmI" id="7JCDpchUzPE" role="lGtFl">
+              <node concept="30Omv" id="7JCDpchU$0s" role="7EUXB">
+                <node concept="mLuIC" id="7JCDpchUDWs" role="31d$z">
+                  <node concept="2gteSW" id="7JCDpchUDWy" role="2gteSx">
+                    <property role="2gteSQ" value="1" />
+                    <property role="2gteSD" value="1" />
+                  </node>
+                  <node concept="2gteS_" id="7JCDpchUDWx" role="2gteVg">
+                    <property role="2gteVv" value="0" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="30bXR$" id="7JCDpcho2Dm" role="2zM23F" />
+        </node>
+        <node concept="_ixoA" id="7JCDpchU_5H" role="_iOnB" />
+        <node concept="2zPypq" id="7JCDpcho3l9" role="_iOnB">
+          <property role="TrG5h" value="v1" />
+          <node concept="2fGnzi" id="7JCDpcho3nd" role="2zPyp_">
+            <node concept="2fGnzd" id="7JCDpcho6jw" role="2fGnxs">
+              <node concept="30cPrO" id="7JCDpcho6xr" role="2fGnzS">
+                <node concept="30bXRB" id="7JCDpcho6xC" role="30dEs_">
+                  <property role="30bXRw" value="0" />
+                </node>
+                <node concept="_emDc" id="7JCDpcho6q7" role="30dEsF">
+                  <ref role="_emDf" node="7JCDpcho27J" resolve="a" />
+                </node>
+              </node>
+              <node concept="1I1voI" id="7JCDpchzxip" role="2fGnzA" />
+            </node>
+            <node concept="2fGnzd" id="7JCDpcho3nf" role="2fGnxs">
+              <node concept="30cPrO" id="7JCDpcho3RZ" role="2fGnzS">
+                <node concept="30bXRB" id="7JCDpcho3YJ" role="30dEs_">
+                  <property role="30bXRw" value="1" />
+                </node>
+                <node concept="_emDc" id="7JCDpcho3Le" role="30dEsF">
+                  <ref role="_emDf" node="7JCDpcho27J" resolve="a" />
+                </node>
+              </node>
+              <node concept="m5g4o" id="7JCDpcho6Rs" role="2fGnzA">
+                <node concept="30bXRB" id="7JCDpcho6YI" role="m5g4p">
+                  <property role="30bXRw" value="1" />
+                </node>
+                <node concept="30bXRB" id="7JCDpcho75M" role="m5g4p">
+                  <property role="30bXRw" value="12" />
+                </node>
+              </node>
+            </node>
+            <node concept="7CXmI" id="7JCDpchU$dJ" role="lGtFl">
+              <node concept="30Omv" id="7JCDpchU$ox" role="7EUXB">
+                <node concept="m5gfS" id="7JCDpchUDJ9" role="31d$z">
+                  <node concept="mLuIC" id="7JCDpchUDJx" role="m5gfT">
+                    <node concept="2gteSW" id="7JCDpchUDJy" role="2gteSx">
+                      <property role="2gteSQ" value="1" />
+                      <property role="2gteSD" value="1" />
+                    </node>
+                    <node concept="2gteS_" id="7JCDpchUDJz" role="2gteVg">
+                      <property role="2gteVv" value="0" />
+                    </node>
+                  </node>
+                  <node concept="mLuIC" id="7JCDpchUDJu" role="m5gfT">
+                    <node concept="2gteSW" id="7JCDpchUDJv" role="2gteSx">
+                      <property role="2gteSQ" value="12" />
+                      <property role="2gteSD" value="12" />
+                    </node>
+                    <node concept="2gteS_" id="7JCDpchUDJw" role="2gteVg">
+                      <property role="2gteVv" value="0" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="m5gfS" id="7JCDpcho5Rr" role="2zM23F">
+            <node concept="30bXR$" id="7JCDpcho5Yg" role="m5gfT" />
+            <node concept="30bXR$" id="7JCDpcho6c$" role="m5gfT" />
           </node>
         </node>
         <node concept="_ixoA" id="7OpkuU_yBkZ" role="_iOnB" />
@@ -2474,6 +2600,114 @@
                 </node>
               </node>
             </node>
+          </node>
+        </node>
+        <node concept="1aga60" id="7JCDpchV4er" role="_iOnB">
+          <property role="TrG5h" value="f1" />
+          <node concept="1aduha" id="7JCDpchV4Lb" role="1ahQXP">
+            <node concept="2fGnzi" id="7JCDpchV4Lt" role="1aduh9">
+              <node concept="2fGnzd" id="7JCDpchV4Lu" role="2fGnxs">
+                <node concept="30cPrO" id="7JCDpchV4Mw" role="2fGnzS">
+                  <node concept="30bXRB" id="7JCDpchV4MJ" role="30dEs_">
+                    <property role="30bXRw" value="1" />
+                  </node>
+                  <node concept="1afdae" id="7JCDpchV4LU" role="30dEsF">
+                    <ref role="1afue_" node="7JCDpchV4KC" resolve="i" />
+                  </node>
+                </node>
+                <node concept="30bdrP" id="7JCDpchV4Se" role="2fGnzA">
+                  <property role="30bdrQ" value="xsc" />
+                </node>
+              </node>
+              <node concept="2fGnzd" id="7JCDpchV4Lv" role="2fGnxs">
+                <node concept="30cPrO" id="7JCDpchV4PH" role="2fGnzS">
+                  <node concept="30bXRB" id="7JCDpchV4PU" role="30dEs_">
+                    <property role="30bXRw" value="2" />
+                  </node>
+                  <node concept="1afdae" id="7JCDpchV4Oj" role="30dEsF">
+                    <ref role="1afue_" node="7JCDpchV4KC" resolve="i" />
+                  </node>
+                </node>
+                <node concept="30bXRB" id="7JCDpchV4WE" role="2fGnzA">
+                  <property role="30bXRw" value="123" />
+                </node>
+              </node>
+              <node concept="2fGnzd" id="7JCDpchV546" role="2fGnxs">
+                <node concept="30cPrO" id="7JCDpchV5a3" role="2fGnzS">
+                  <node concept="30bXRB" id="7JCDpchV5aa" role="30dEs_">
+                    <property role="30bXRw" value="3" />
+                  </node>
+                  <node concept="1afdae" id="7JCDpchV570" role="30dEsF">
+                    <ref role="1afue_" node="7JCDpchV4KC" resolve="i" />
+                  </node>
+                </node>
+                <node concept="2vmpnb" id="7JCDpchV5dX" role="2fGnzA" />
+              </node>
+            </node>
+          </node>
+          <node concept="1ahQXy" id="7JCDpchV4KC" role="1ahQWs">
+            <property role="TrG5h" value="i" />
+            <node concept="mLuIC" id="7JCDpchV4KY" role="3ix9CU" />
+          </node>
+          <node concept="7CXmI" id="7JCDpchV8eg" role="lGtFl" />
+          <node concept="188GKf" id="7JCDpchZ4wn" role="2zM23F">
+            <node concept="2vmvy5" id="7JCDpchZ4FL" role="188GKc" />
+            <node concept="mLuIC" id="7JCDpchZ5Dq" role="188GKc" />
+            <node concept="30bdrU" id="7JCDpchZ62P" role="188GKc" />
+          </node>
+        </node>
+        <node concept="1aga60" id="7JCDpchV5OU" role="_iOnB">
+          <property role="TrG5h" value="f2" />
+          <node concept="1aduha" id="7JCDpchV6o4" role="1ahQXP">
+            <node concept="2fGnzi" id="7JCDpchV6of" role="1aduh9">
+              <node concept="2fGnzd" id="7JCDpchV6oq" role="2fGnxs">
+                <node concept="30cPrO" id="7JCDpchV6or" role="2fGnzS">
+                  <node concept="30bXRB" id="7JCDpchV6os" role="30dEs_">
+                    <property role="30bXRw" value="3" />
+                  </node>
+                  <node concept="1afdae" id="7JCDpchV6ot" role="30dEsF">
+                    <ref role="1afue_" node="7JCDpchV6np" resolve="i" />
+                  </node>
+                </node>
+                <node concept="2vmpn$" id="7JCDpchV6GD" role="2fGnzA" />
+              </node>
+              <node concept="2fGnzd" id="7JCDpchV6og" role="2fGnxs">
+                <node concept="30cPrO" id="7JCDpchV6oh" role="2fGnzS">
+                  <node concept="30bXRB" id="7JCDpchV6oi" role="30dEs_">
+                    <property role="30bXRw" value="1" />
+                  </node>
+                  <node concept="1afdae" id="7JCDpchV6oj" role="30dEsF">
+                    <ref role="1afue_" node="7JCDpchV6np" resolve="i" />
+                  </node>
+                </node>
+                <node concept="30bdrP" id="7JCDpchV6ok" role="2fGnzA">
+                  <property role="30bdrQ" value="xsc" />
+                </node>
+              </node>
+              <node concept="2fGnzd" id="7JCDpchV6ol" role="2fGnxs">
+                <node concept="30cPrO" id="7JCDpchV6om" role="2fGnzS">
+                  <node concept="30bXRB" id="7JCDpchV6on" role="30dEs_">
+                    <property role="30bXRw" value="2" />
+                  </node>
+                  <node concept="1afdae" id="7JCDpchV6oo" role="30dEsF">
+                    <ref role="1afue_" node="7JCDpchV6np" resolve="i" />
+                  </node>
+                </node>
+                <node concept="30bXRB" id="7JCDpchV6op" role="2fGnzA">
+                  <property role="30bXRw" value="123" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1ahQXy" id="7JCDpchV6np" role="1ahQWs">
+            <property role="TrG5h" value="i" />
+            <node concept="mLuIC" id="7JCDpchV6nR" role="3ix9CU" />
+          </node>
+          <node concept="7CXmI" id="7JCDpchV9Rr" role="lGtFl" />
+          <node concept="188GKf" id="7JCDpchZ5fE" role="2zM23F">
+            <node concept="2vmvy5" id="7JCDpchZ5fF" role="188GKc" />
+            <node concept="30bdrU" id="7JCDpchZ5fG" role="188GKc" />
+            <node concept="mLuIC" id="7JCDpchZ5fH" role="188GKc" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.LeastCommonSuperType@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.LeastCommonSuperType@tests.mps
@@ -23,6 +23,9 @@
       <concept id="1215603922101" name="jetbrains.mps.lang.test.structure.NodeOperationsContainer" flags="ng" index="7CXmI">
         <child id="1215604436604" name="nodeOperations" index="7EUXB" />
       </concept>
+      <concept id="1215607067978" name="jetbrains.mps.lang.test.structure.CheckNodeForErrorMessagesOperation" flags="ng" index="7OXhh">
+        <property id="3743352646565420194" name="includeSelf" index="GvXf4" />
+      </concept>
       <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
       </concept>
@@ -179,6 +182,7 @@
       </concept>
       <concept id="4790956042240522396" name="org.iets3.core.expr.lambda.structure.IFunctionCall" flags="ng" index="1afhQZ">
         <reference id="4790956042240522408" name="function" index="1afhQb" />
+        <child id="4790956042240522406" name="args" index="1afhQ5" />
       </concept>
       <concept id="4790956042240100911" name="org.iets3.core.expr.lambda.structure.IFunctionLike" flags="ng" index="1ahQWc">
         <child id="4790956042240100927" name="args" index="1ahQWs" />
@@ -1588,7 +1592,6 @@
           <node concept="7CXmI" id="2Ml_6NDT9E9" role="lGtFl">
             <node concept="30Omv" id="2Ml_6NDT9Ea" role="7EUXB">
               <node concept="188GKf" id="2Ml_6NDTaEc" role="31d$z">
-                <node concept="30bdrU" id="2Ml_6NDTaEk" role="188GKc" />
                 <node concept="mLuIC" id="2Ml_6NDT9Eb" role="188GKc">
                   <node concept="2gteSW" id="2Ml_6NDT9Ec" role="2gteSx">
                     <property role="2gteSQ" value="-5" />
@@ -1598,6 +1601,7 @@
                     <property role="2gteVv" value="1" />
                   </node>
                 </node>
+                <node concept="30bdrU" id="738HPfh5jFB" role="188GKc" />
               </node>
             </node>
           </node>
@@ -1692,10 +1696,6 @@
           <node concept="7CXmI" id="2Ml_6NDTkZE" role="lGtFl">
             <node concept="30Omv" id="2Ml_6NDTkZF" role="7EUXB">
               <node concept="188GKf" id="2Ml_6NDTkZG" role="31d$z">
-                <node concept="30bdrU" id="2Ml_6NDTkZH" role="188GKc" />
-                <node concept="2Ss9cW" id="2Ml_6NDTrHy" role="188GKc">
-                  <ref role="2Ss9cX" node="3yVmeSjL7l_" resolve="City" />
-                </node>
                 <node concept="mLuIC" id="2Ml_6NDTkZI" role="188GKc">
                   <node concept="2gteSW" id="2Ml_6NDTkZJ" role="2gteSx">
                     <property role="2gteSQ" value="-5" />
@@ -1705,6 +1705,10 @@
                     <property role="2gteVv" value="0" />
                   </node>
                 </node>
+                <node concept="2Ss9cW" id="738HPfh5jH$" role="188GKc">
+                  <ref role="2Ss9cX" node="3yVmeSjL7l_" resolve="City" />
+                </node>
+                <node concept="30bdrU" id="2Ml_6NDTkZH" role="188GKc" />
               </node>
             </node>
           </node>
@@ -1819,10 +1823,6 @@
             <node concept="30Omv" id="2Ml_6NDTrKC" role="7EUXB">
               <node concept="Uns6S" id="2Ml_6NDTURM" role="31d$z">
                 <node concept="188GKf" id="2Ml_6NDTURN" role="Uns6T">
-                  <node concept="30bdrU" id="2Ml_6NDTURO" role="188GKc" />
-                  <node concept="2Ss9cW" id="2Ml_6NDTURP" role="188GKc">
-                    <ref role="2Ss9cX" node="3yVmeSjL7l_" resolve="City" />
-                  </node>
                   <node concept="mLuIC" id="2Ml_6NDTURQ" role="188GKc">
                     <node concept="2gteSW" id="2Ml_6NDTURR" role="2gteSx">
                       <property role="2gteSQ" value="-5" />
@@ -1832,6 +1832,10 @@
                       <property role="2gteVv" value="0" />
                     </node>
                   </node>
+                  <node concept="2Ss9cW" id="2Ml_6NDTURP" role="188GKc">
+                    <ref role="2Ss9cX" node="3yVmeSjL7l_" resolve="City" />
+                  </node>
+                  <node concept="30bdrU" id="738HPfh5jSn" role="188GKc" />
                 </node>
               </node>
             </node>
@@ -2016,7 +2020,6 @@
             <node concept="30Omv" id="3A7Uik3ozve" role="7EUXB">
               <node concept="188GKf" id="3A7Uik3ozvf" role="31d$z">
                 <node concept="2vmvy5" id="3A7Uik3ozvg" role="188GKc" />
-                <node concept="30bdrU" id="3A7Uik3ozvh" role="188GKc" />
                 <node concept="mLuIC" id="3A7Uik3ozvi" role="188GKc">
                   <node concept="2gteSW" id="3A7Uik3ozvj" role="2gteSx">
                     <property role="2gteSQ" value="1" />
@@ -2026,6 +2029,7 @@
                     <property role="2gteVv" value="1" />
                   </node>
                 </node>
+                <node concept="30bdrU" id="738HPfh5jPH" role="188GKc" />
               </node>
             </node>
           </node>
@@ -2208,7 +2212,6 @@
               <node concept="Uns6S" id="3A7Uik3oNHT" role="31d$z">
                 <node concept="188GKf" id="3A7Uik3oNHU" role="Uns6T">
                   <node concept="2vmvy5" id="3A7Uik3oNHV" role="188GKc" />
-                  <node concept="30bdrU" id="3A7Uik3oNHW" role="188GKc" />
                   <node concept="mLuIC" id="3A7Uik3oNHX" role="188GKc">
                     <node concept="2gteSW" id="3A7Uik3oNHY" role="2gteSx">
                       <property role="2gteSQ" value="1" />
@@ -2218,6 +2221,7 @@
                       <property role="2gteVv" value="0" />
                     </node>
                   </node>
+                  <node concept="30bdrU" id="738HPfh5jOe" role="188GKc" />
                 </node>
               </node>
             </node>
@@ -2407,7 +2411,6 @@
               <node concept="Uns6S" id="3A7Uik3oPIR" role="31d$z">
                 <node concept="188GKf" id="3A7Uik3oPIS" role="Uns6T">
                   <node concept="2vmvy5" id="3A7Uik3oPIT" role="188GKc" />
-                  <node concept="30bdrU" id="3A7Uik3oPIU" role="188GKc" />
                   <node concept="mLuIC" id="3A7Uik3oPIV" role="188GKc">
                     <node concept="2gteSW" id="3A7Uik3oPIW" role="2gteSx">
                       <property role="2gteSQ" value="1" />
@@ -2417,6 +2420,7 @@
                       <property role="2gteVv" value="1" />
                     </node>
                   </node>
+                  <node concept="30bdrU" id="738HPfh5jLp" role="188GKc" />
                 </node>
               </node>
             </node>
@@ -2587,7 +2591,6 @@
               <node concept="Uns6S" id="3A7Uik3oH8m" role="31d$z">
                 <node concept="188GKf" id="3A7Uik3oH8n" role="Uns6T">
                   <node concept="2vmvy5" id="3A7Uik3oH8o" role="188GKc" />
-                  <node concept="30bdrU" id="3A7Uik3oH8p" role="188GKc" />
                   <node concept="mLuIC" id="3A7Uik3oH8q" role="188GKc">
                     <node concept="2gteSW" id="3A7Uik3oH8r" role="2gteSx">
                       <property role="2gteSQ" value="1" />
@@ -2597,13 +2600,15 @@
                       <property role="2gteVv" value="1" />
                     </node>
                   </node>
+                  <node concept="30bdrU" id="738HPfh5jJt" role="188GKc" />
                 </node>
               </node>
             </node>
           </node>
         </node>
+        <node concept="_ixoA" id="H8GgRpwta0" role="_iOnB" />
         <node concept="1aga60" id="7JCDpchV4er" role="_iOnB">
-          <property role="TrG5h" value="f1" />
+          <property role="TrG5h" value="fa" />
           <node concept="1aduha" id="7JCDpchV4Lb" role="1ahQXP">
             <node concept="2fGnzi" id="7JCDpchV4Lt" role="1aduh9">
               <node concept="2fGnzd" id="7JCDpchV4Lu" role="2fGnxs">
@@ -2649,67 +2654,204 @@
             <property role="TrG5h" value="i" />
             <node concept="mLuIC" id="7JCDpchV4KY" role="3ix9CU" />
           </node>
-          <node concept="7CXmI" id="7JCDpchV8eg" role="lGtFl" />
-          <node concept="188GKf" id="7JCDpchZ4wn" role="2zM23F">
-            <node concept="2vmvy5" id="7JCDpchZ4FL" role="188GKc" />
-            <node concept="mLuIC" id="7JCDpchZ5Dq" role="188GKc" />
-            <node concept="30bdrU" id="7JCDpchZ62P" role="188GKc" />
+          <node concept="7CXmI" id="7JCDpchV8eg" role="lGtFl">
+            <node concept="30Omv" id="3sm5hNvpbzZ" role="7EUXB">
+              <node concept="188GKf" id="3sm5hNvpfhk" role="31d$z">
+                <node concept="2vmvy5" id="H8GgRp$kzb" role="188GKc" />
+                <node concept="mLuIC" id="H8GgRpw_Nj" role="188GKc">
+                  <node concept="2gteSW" id="H8GgRp_5w8" role="2gteSx">
+                    <property role="2gteSQ" value="123" />
+                    <property role="2gteSD" value="123" />
+                  </node>
+                  <node concept="2gteS_" id="H8GgRp_5xH" role="2gteVg">
+                    <property role="2gteVv" value="0" />
+                  </node>
+                </node>
+                <node concept="30bdrU" id="738HPfgRv98" role="188GKc" />
+              </node>
+            </node>
           </node>
         </node>
-        <node concept="1aga60" id="7JCDpchV5OU" role="_iOnB">
-          <property role="TrG5h" value="f2" />
-          <node concept="1aduha" id="7JCDpchV6o4" role="1ahQXP">
-            <node concept="2fGnzi" id="7JCDpchV6of" role="1aduh9">
-              <node concept="2fGnzd" id="7JCDpchV6oq" role="2fGnxs">
-                <node concept="30cPrO" id="7JCDpchV6or" role="2fGnzS">
-                  <node concept="30bXRB" id="7JCDpchV6os" role="30dEs_">
-                    <property role="30bXRw" value="3" />
-                  </node>
-                  <node concept="1afdae" id="7JCDpchV6ot" role="30dEsF">
-                    <ref role="1afue_" node="7JCDpchV6np" resolve="i" />
-                  </node>
-                </node>
-                <node concept="2vmpn$" id="7JCDpchV6GD" role="2fGnzA" />
-              </node>
-              <node concept="2fGnzd" id="7JCDpchV6og" role="2fGnxs">
-                <node concept="30cPrO" id="7JCDpchV6oh" role="2fGnzS">
-                  <node concept="30bXRB" id="7JCDpchV6oi" role="30dEs_">
+        <node concept="1aga60" id="738HPfh5HJL" role="_iOnB">
+          <property role="TrG5h" value="fb" />
+          <node concept="1aduha" id="738HPfh5HJM" role="1ahQXP">
+            <node concept="2fGnzi" id="738HPfh5HJN" role="1aduh9">
+              <node concept="2fGnzd" id="738HPfh5HJY" role="2fGnxs">
+                <node concept="30cPrO" id="738HPfh5HJZ" role="2fGnzS">
+                  <node concept="30bXRB" id="738HPfh5HK0" role="30dEs_">
                     <property role="30bXRw" value="1" />
                   </node>
-                  <node concept="1afdae" id="7JCDpchV6oj" role="30dEsF">
-                    <ref role="1afue_" node="7JCDpchV6np" resolve="i" />
+                  <node concept="1afdae" id="738HPfh5HK1" role="30dEsF">
+                    <ref role="1afue_" node="738HPfh5HK3" resolve="i" />
                   </node>
                 </node>
-                <node concept="30bdrP" id="7JCDpchV6ok" role="2fGnzA">
-                  <property role="30bdrQ" value="xsc" />
-                </node>
+                <node concept="2vmpn$" id="738HPfh5L5Z" role="2fGnzA" />
               </node>
-              <node concept="2fGnzd" id="7JCDpchV6ol" role="2fGnxs">
-                <node concept="30cPrO" id="7JCDpchV6om" role="2fGnzS">
-                  <node concept="30bXRB" id="7JCDpchV6on" role="30dEs_">
+              <node concept="2fGnzd" id="738HPfh5HJT" role="2fGnxs">
+                <node concept="30cPrO" id="738HPfh5HJU" role="2fGnzS">
+                  <node concept="1afdae" id="738HPfh5HJW" role="30dEsF">
+                    <ref role="1afue_" node="738HPfh5HK3" resolve="i" />
+                  </node>
+                  <node concept="30bXRB" id="738HPfh5LF2" role="30dEs_">
                     <property role="30bXRw" value="2" />
                   </node>
-                  <node concept="1afdae" id="7JCDpchV6oo" role="30dEsF">
-                    <ref role="1afue_" node="7JCDpchV6np" resolve="i" />
+                </node>
+                <node concept="30bXRB" id="738HPfh5HJX" role="2fGnzA">
+                  <property role="30bXRw" value="123" />
+                </node>
+              </node>
+              <node concept="2fGnzd" id="738HPfh5HJO" role="2fGnxs">
+                <node concept="30cPrO" id="738HPfh5HJP" role="2fGnzS">
+                  <node concept="1afdae" id="738HPfh5HJR" role="30dEsF">
+                    <ref role="1afue_" node="738HPfh5HK3" resolve="i" />
+                  </node>
+                  <node concept="30bXRB" id="738HPfh5LYb" role="30dEs_">
+                    <property role="30bXRw" value="3" />
                   </node>
                 </node>
-                <node concept="30bXRB" id="7JCDpchV6op" role="2fGnzA">
-                  <property role="30bXRw" value="123" />
+                <node concept="30bdrP" id="738HPfh5HJS" role="2fGnzA">
+                  <property role="30bdrQ" value="xsc" />
                 </node>
               </node>
             </node>
           </node>
-          <node concept="1ahQXy" id="7JCDpchV6np" role="1ahQWs">
+          <node concept="1ahQXy" id="738HPfh5HK3" role="1ahQWs">
             <property role="TrG5h" value="i" />
-            <node concept="mLuIC" id="7JCDpchV6nR" role="3ix9CU" />
+            <node concept="mLuIC" id="738HPfh5HK4" role="3ix9CU" />
           </node>
-          <node concept="7CXmI" id="7JCDpchV9Rr" role="lGtFl" />
-          <node concept="188GKf" id="7JCDpchZ5fE" role="2zM23F">
-            <node concept="2vmvy5" id="7JCDpchZ5fF" role="188GKc" />
-            <node concept="30bdrU" id="7JCDpchZ5fG" role="188GKc" />
-            <node concept="mLuIC" id="7JCDpchZ5fH" role="188GKc" />
+          <node concept="7CXmI" id="738HPfh5HK5" role="lGtFl">
+            <node concept="30Omv" id="738HPfh5HK6" role="7EUXB">
+              <node concept="188GKf" id="738HPfh5HK7" role="31d$z">
+                <node concept="2vmvy5" id="738HPfh5HK8" role="188GKc" />
+                <node concept="mLuIC" id="738HPfh5HK9" role="188GKc">
+                  <node concept="2gteSW" id="738HPfh5HKa" role="2gteSx">
+                    <property role="2gteSQ" value="123" />
+                    <property role="2gteSD" value="123" />
+                  </node>
+                  <node concept="2gteS_" id="738HPfh5HKb" role="2gteVg">
+                    <property role="2gteVv" value="0" />
+                  </node>
+                </node>
+                <node concept="30bdrU" id="738HPfh5HKc" role="188GKc" />
+              </node>
+            </node>
           </node>
         </node>
+        <node concept="2zPypq" id="H8GgRpw7N8" role="_iOnB">
+          <property role="TrG5h" value="x1" />
+          <node concept="1af_rf" id="H8GgRpw8mJ" role="2zPyp_">
+            <ref role="1afhQb" node="7JCDpchV4er" resolve="f1a" />
+            <node concept="30bXRB" id="H8GgRpw8Ve" role="1afhQ5">
+              <property role="30bXRw" value="1" />
+            </node>
+          </node>
+          <node concept="188GKf" id="H8GgRpw9sq" role="2zM23F">
+            <node concept="30bdrU" id="H8GgRpw9R6" role="188GKc" />
+            <node concept="2vmvy5" id="H8GgRpw9sr" role="188GKc" />
+            <node concept="mLuIC" id="H8GgRpwiTu" role="188GKc" />
+          </node>
+          <node concept="7CXmI" id="H8GgRpy2jV" role="lGtFl">
+            <node concept="7OXhh" id="H8GgRpy2_q" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="H8GgRpwaCX" role="_iOnB">
+          <property role="TrG5h" value="x2" />
+          <node concept="188GKf" id="H8GgRpwaD0" role="2zM23F">
+            <node concept="2vmvy5" id="H8GgRpweOZ" role="188GKc" />
+            <node concept="30bdrU" id="H8GgRpwf0C" role="188GKc" />
+            <node concept="mLuIC" id="H8GgRpwjn0" role="188GKc" />
+          </node>
+          <node concept="1af_rf" id="H8GgRpwcaE" role="2zPyp_">
+            <ref role="1afhQb" node="7JCDpchV4er" resolve="f1a" />
+            <node concept="30bXRB" id="H8GgRpweDF" role="1afhQ5">
+              <property role="30bXRw" value="1" />
+            </node>
+          </node>
+          <node concept="7CXmI" id="H8GgRpy2Py" role="lGtFl">
+            <node concept="7OXhh" id="H8GgRpy371" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="H8GgRpwbfk" role="_iOnB">
+          <property role="TrG5h" value="x3" />
+          <node concept="1af_rf" id="H8GgRpwbfl" role="2zPyp_">
+            <ref role="1afhQb" node="7JCDpchV4er" resolve="fa" />
+            <node concept="30bXRB" id="H8GgRpwbfm" role="1afhQ5">
+              <property role="30bXRw" value="1" />
+            </node>
+          </node>
+          <node concept="188GKf" id="H8GgRpwbfn" role="2zM23F">
+            <node concept="2vmvy5" id="H8GgRpwfb6" role="188GKc" />
+            <node concept="mLuIC" id="H8GgRpwjMs" role="188GKc" />
+            <node concept="30bdrU" id="H8GgRpwfx0" role="188GKc" />
+          </node>
+          <node concept="7CXmI" id="738HPfh5NUq" role="lGtFl">
+            <node concept="7OXhh" id="738HPfh5Odr" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="H8GgRpwfGy" role="_iOnB">
+          <property role="TrG5h" value="x4" />
+          <node concept="1af_rf" id="H8GgRpwfGz" role="2zPyp_">
+            <ref role="1afhQb" node="7JCDpchV4er" resolve="fa" />
+            <node concept="30bXRB" id="H8GgRpwfG$" role="1afhQ5">
+              <property role="30bXRw" value="1" />
+            </node>
+          </node>
+          <node concept="188GKf" id="H8GgRpwfG_" role="2zM23F">
+            <node concept="mLuIC" id="H8GgRpwfGB" role="188GKc" />
+            <node concept="2vmvy5" id="H8GgRpwgS7" role="188GKc" />
+            <node concept="30bdrU" id="H8GgRpwfGE" role="188GKc" />
+          </node>
+          <node concept="7CXmI" id="738HPfh5Ovi" role="lGtFl">
+            <node concept="7OXhh" id="738HPfh5OMj" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="H8GgRpwh4N" role="_iOnB">
+          <property role="TrG5h" value="x5" />
+          <node concept="1af_rf" id="H8GgRpwh4O" role="2zPyp_">
+            <ref role="1afhQb" node="7JCDpchV4er" resolve="fa" />
+            <node concept="30bXRB" id="H8GgRpwh4P" role="1afhQ5">
+              <property role="30bXRw" value="1" />
+            </node>
+          </node>
+          <node concept="188GKf" id="H8GgRpwh4Q" role="2zM23F">
+            <node concept="mLuIC" id="H8GgRpwh4R" role="188GKc" />
+            <node concept="30bdrU" id="H8GgRpwh4V" role="188GKc" />
+            <node concept="2vmvy5" id="H8GgRpwioQ" role="188GKc" />
+          </node>
+          <node concept="7CXmI" id="738HPfh5P4a" role="lGtFl">
+            <node concept="7OXhh" id="738HPfh5Pm1" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="H8GgRpwmjt" role="_iOnB">
+          <property role="TrG5h" value="x6" />
+          <node concept="1af_rf" id="H8GgRpwmju" role="2zPyp_">
+            <ref role="1afhQb" node="7JCDpchV4er" resolve="fa" />
+            <node concept="30bXRB" id="H8GgRpwmjv" role="1afhQ5">
+              <property role="30bXRw" value="1" />
+            </node>
+          </node>
+          <node concept="188GKf" id="H8GgRpwmjw" role="2zM23F">
+            <node concept="30bdrU" id="H8GgRpwmjy" role="188GKc" />
+            <node concept="mLuIC" id="H8GgRpwn_7" role="188GKc" />
+            <node concept="2vmvy5" id="H8GgRpwmjz" role="188GKc" />
+          </node>
+          <node concept="7CXmI" id="738HPfh5PD2" role="lGtFl">
+            <node concept="7OXhh" id="738HPfh5PUT" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="H8GgRpw8nM" role="_iOnB" />
       </node>
     </node>
   </node>


### PR DESCRIPTION
Issues: #505 and #848

EmptyType is deleted from the list of types of a JoinType, if there is at least one other type (in the another case the least common supertype is simply the EmptyType and not a JoinType at all).
The list of types of a JoinType is now sorted lexical. So there is no difference in the order of given of types within a  JoinType.
