### PR TITLE
Migrate or remove deprecated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## April 2024
+
+### Changed
+
+- `ComponentKind#canbeContent(conceptNode<>)` was deprecated in favour of `ComponentKind#canbeContent(concept<>)` 
+- `Component#canBeInComponentContent(conceptNode<>)` was deprecated in favour of `Component#canBeInComponentContent(concept<>)`
+
 ## March 2024
 
 ### Added

--- a/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/plugin.mps
@@ -24,7 +24,7 @@
     <import index="juu2" ref="r:197c9a7f-bef3-4d38-a48a-51524151fecf(org.iets3.core.base.plugin)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
-    <import index="9sez" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:org.apache.commons.collections4(de.q60.mps.libs/)" />
+    <import index="9sez" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:org.apache.commons.collections4(de.q60.mps.collections.libs/)" />
     <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
     <import index="gdgh" ref="r:e4d9478b-ae0e-416e-be60-73d136571015(org.iets3.core.base.behavior)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
@@ -33,7 +33,7 @@
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
     <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" />
-    <import index="gyfg" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.base(de.q60.mps.libs/)" />
+    <import index="gyfg" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.base(de.q60.mps.collections.libs/)" />
     <import index="d6hs" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.errors.item(MPS.Core/)" />
     <import index="2gg1" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.errors(MPS.Core/)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
@@ -57,7 +57,7 @@
     <import index="9w4s" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util(MPS.IDEA/)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="dzyv" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time.temporal(JDK/)" />
-    <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.libs/)" />
+    <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.collections.libs/)" />
     <import index="3a50" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide(MPS.Platform/)" />
     <import index="gspm" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.ui.popup(MPS.IDEA/)" />
     <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/plugin.mps
@@ -8775,7 +8775,7 @@
                     <ref role="3cqZAo" node="2S0X1v6N1c0" resolve="widgetText" />
                   </node>
                   <node concept="liA8E" id="5HzZDakJctS" role="2OqNvi">
-                    <ref role="37wK5l" to="jkny:~StatusBarWidget$TextPresentation.getMaxPossibleText()" resolve="getMaxPossibleText" />
+                    <ref role="37wK5l" to="jkny:~StatusBarWidget$TextPresentation.getText()" resolve="getText" />
                   </node>
                 </node>
                 <node concept="10M0yZ" id="$0lM0JKFLd" role="37wK5m">
@@ -9219,9 +9219,12 @@
               <ref role="3cqZAo" node="5do60t9v3W2" resolve="myStatusBar" />
             </node>
             <node concept="liA8E" id="2S0X1v6Mkqk" role="2OqNvi">
-              <ref role="37wK5l" to="jkny:~StatusBar.addWidget(com.intellij.openapi.wm.StatusBarWidget)" resolve="addWidget" />
+              <ref role="37wK5l" to="jkny:~StatusBar.addWidget(com.intellij.openapi.wm.StatusBarWidget,com.intellij.openapi.Disposable)" resolve="addWidget" />
               <node concept="37vLTw" id="2S0X1v6Mkw8" role="37wK5m">
                 <ref role="3cqZAo" node="2S0X1v6M02G" resolve="widget" />
+              </node>
+              <node concept="37vLTw" id="3Q$zA1C$r1L" role="37wK5m">
+                <ref role="3cqZAo" node="5do60t9v3W2" resolve="myStatusBar" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
@@ -2495,7 +2495,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="GJLa3qj1J_" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" />
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="13i0hz" id="GJLa3qj27l" role="13h7CS">
@@ -2804,7 +2804,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="GJLa3qiYW1" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Deprecated" />
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
     </node>
     <node concept="13i0hz" id="GJLa3qj070" role="13h7CS">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/behavior.mps
@@ -300,6 +300,9 @@
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
         <child id="8970989240999019149" name="part" index="1dT_Ay" />
       </concept>
+      <concept id="8465538089690331492" name="jetbrains.mps.baseLanguage.javadoc.structure.DeprecatedBlockDocTag" flags="ng" index="TZ5HI">
+        <child id="2667874559098216723" name="text" index="3HnX3l" />
+      </concept>
       <concept id="2217234381367190443" name="jetbrains.mps.baseLanguage.javadoc.structure.SeeBlockDocTag" flags="ng" index="VUp57">
         <child id="2217234381367190458" name="reference" index="VUp5m" />
       </concept>
@@ -354,6 +357,7 @@
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
+      <concept id="8866923313515890008" name="jetbrains.mps.lang.smodel.structure.AsNodeOperation" flags="nn" index="FGMqu" />
       <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
@@ -396,6 +400,7 @@
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
+      <concept id="334628810661441841" name="jetbrains.mps.lang.smodel.structure.AsSConcept" flags="nn" index="1rGIog" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
@@ -2465,9 +2470,12 @@
               </node>
             </node>
             <node concept="2qgKlT" id="4PGMP7y0uIp" role="2OqNvi">
-              <ref role="37wK5l" node="33B7rHqxSMr" resolve="canBeInContent" />
-              <node concept="37vLTw" id="4PGMP7y0uIq" role="37wK5m">
-                <ref role="3cqZAo" node="4PGMP7y0u6d" resolve="concept" />
+              <ref role="37wK5l" node="GJLa3qj070" resolve="canBeInContent" />
+              <node concept="2OqwBi" id="GJLa3qjajS" role="37wK5m">
+                <node concept="37vLTw" id="4PGMP7y0uIq" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4PGMP7y0u6d" resolve="concept" />
+                </node>
+                <node concept="1rGIog" id="GJLa3qjaxp" role="2OqNvi" />
               </node>
             </node>
           </node>
@@ -2476,6 +2484,45 @@
       <node concept="37vLTG" id="4PGMP7y0u6d" role="3clF46">
         <property role="TrG5h" value="concept" />
         <node concept="3THzug" id="4PGMP7y0vJU" role="1tU5fm" />
+      </node>
+      <node concept="P$JXv" id="GJLa3qj1Jy" role="lGtFl">
+        <node concept="TZ5HI" id="GJLa3qj1Jz" role="3nqlJM">
+          <node concept="TZ5HA" id="GJLa3qj1J$" role="3HnX3l">
+            <node concept="1dT_AC" id="GJLa3qj1V7" role="1dT_Ay">
+              <property role="1dT_AB" value="use canBeInComponentContent(concept) instead" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="GJLa3qj1J_" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="GJLa3qj27l" role="13h7CS">
+      <property role="TrG5h" value="canBeInComponentContent" />
+      <node concept="3Tm1VV" id="GJLa3qj27m" role="1B3o_S" />
+      <node concept="10P_77" id="GJLa3qj9Mk" role="3clF45" />
+      <node concept="3clFbS" id="GJLa3qj27o" role="3clF47">
+        <node concept="3cpWs6" id="GJLa3qjaJw" role="3cqZAp">
+          <node concept="2OqwBi" id="GJLa3qjaJx" role="3cqZAk">
+            <node concept="2OqwBi" id="GJLa3qjaJy" role="2Oq$k0">
+              <node concept="13iPFW" id="GJLa3qjaJz" role="2Oq$k0" />
+              <node concept="3TrEf2" id="GJLa3qjaJ$" role="2OqNvi">
+                <ref role="3Tt5mk" to="w9y2:6LfBX8Yj9rR" resolve="kind" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="GJLa3qjaJ_" role="2OqNvi">
+              <ref role="37wK5l" node="GJLa3qj070" resolve="canBeInContent" />
+              <node concept="37vLTw" id="GJLa3qjaJB" role="37wK5m">
+                <ref role="3cqZAo" node="GJLa3qjaAh" resolve="concept" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="GJLa3qjaAh" role="3clF46">
+        <property role="TrG5h" value="concept" />
+        <node concept="3bZ5Sz" id="GJLa3qjaAg" role="1tU5fm" />
       </node>
     </node>
     <node concept="13i0hz" id="spmH6cGckY" role="13h7CS">
@@ -2746,6 +2793,41 @@
       <node concept="37vLTG" id="4PGMP7y0qFd" role="3clF46">
         <property role="TrG5h" value="concept" />
         <node concept="3THzug" id="4PGMP7y0vZO" role="1tU5fm" />
+      </node>
+      <node concept="P$JXv" id="GJLa3qiYVY" role="lGtFl">
+        <node concept="TZ5HI" id="GJLa3qiYVZ" role="3nqlJM">
+          <node concept="TZ5HA" id="GJLa3qiYW0" role="3HnX3l">
+            <node concept="1dT_AC" id="GJLa3qiYY4" role="1dT_Ay">
+              <property role="1dT_AB" value="use the canBeInContent(concept) instead" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="GJLa3qiYW1" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="GJLa3qj070" role="13h7CS">
+      <property role="TrG5h" value="canBeInContent" />
+      <property role="13i0it" value="true" />
+      <node concept="3Tm1VV" id="GJLa3qj071" role="1B3o_S" />
+      <node concept="10P_77" id="GJLa3qj0gt" role="3clF45" />
+      <node concept="3clFbS" id="GJLa3qj073" role="3clF47">
+        <node concept="3clFbF" id="GJLa3su7rX" role="3cqZAp">
+          <node concept="BsUDl" id="GJLa3su7rW" role="3clFbG">
+            <ref role="37wK5l" node="33B7rHqxSMr" resolve="canBeInContent" />
+            <node concept="2OqwBi" id="GJLa3su7Z_" role="37wK5m">
+              <node concept="37vLTw" id="GJLa3su7ut" role="2Oq$k0">
+                <ref role="3cqZAo" node="GJLa3qj0qt" resolve="concept" />
+              </node>
+              <node concept="FGMqu" id="GJLa3su84u" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="GJLa3qj0qt" role="3clF46">
+        <property role="TrG5h" value="concept" />
+        <node concept="3bZ5Sz" id="GJLa3qj0qs" role="1tU5fm" />
       </node>
     </node>
     <node concept="13i0hz" id="6$fTUGAuTlR" role="13h7CS">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/constraints.mps
@@ -4,6 +4,7 @@
   <languages>
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="6" />
     <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
   </languages>
   <imports>
@@ -175,7 +176,6 @@
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
       <concept id="1761385620274348152" name="jetbrains.mps.lang.smodel.structure.SConceptTypeCastExpression" flags="nn" index="2CBFar" />
-      <concept id="8866923313515890008" name="jetbrains.mps.lang.smodel.structure.AsNodeOperation" flags="nn" index="FGMqu" />
       <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
         <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
         <child id="1883223317721008709" name="body" index="Jncv$" />
@@ -223,9 +223,6 @@
       </concept>
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
-      </concept>
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -290,7 +287,7 @@
               <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
               <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
               <node concept="2OqwBi" id="1F1F0IUZ_cX" role="37wK5m">
-                <node concept="2OqwBi" id="1F1F0IUZ_cY" role="2Oq$k0">
+                <node concept="2OqwBi" id="3Q$zA1CDXOZ" role="2Oq$k0">
                   <node concept="2OqwBi" id="1F1F0IUZ_cZ" role="2Oq$k0">
                     <node concept="2OqwBi" id="1F1F0IUZ_d0" role="2Oq$k0">
                       <node concept="2rP1CM" id="1F1F0IUZ_d1" role="2Oq$k0" />
@@ -303,14 +300,14 @@
                       </node>
                     </node>
                     <node concept="2qgKlT" id="1F1F0IUZ_d5" role="2OqNvi">
-                      <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                      <node concept="3TUQnm" id="1F1F0IUZ_d6" role="37wK5m">
-                        <ref role="3TV0OU" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+                      <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                      <node concept="35c_gC" id="3Q$zA1C_cDu" role="37wK5m">
+                        <ref role="35c_gD" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
                       </node>
                     </node>
                   </node>
-                  <node concept="v3k3i" id="1F1F0IUZ_d7" role="2OqNvi">
-                    <node concept="chp4Y" id="1F1F0IUZ_d8" role="v3oSu">
+                  <node concept="v3k3i" id="3Q$zA1CDY6h" role="2OqNvi">
+                    <node concept="chp4Y" id="3Q$zA1CDYef" role="v3oSu">
                       <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
                     </node>
                   </node>
@@ -682,11 +679,8 @@
               </node>
             </node>
             <node concept="2qgKlT" id="6b_jefnKwks" role="2OqNvi">
-              <ref role="37wK5l" to="3eba:33B7rHqzGFf" resolve="canBeInComponentContent" />
-              <node concept="2OqwBi" id="6b_jefnKwkv" role="37wK5m">
-                <node concept="FGMqu" id="6b_jefnKwkw" role="2OqNvi" />
-                <node concept="2DD5aU" id="6b_jefnKwku" role="2Oq$k0" />
-              </node>
+              <ref role="37wK5l" to="3eba:GJLa3qj27l" resolve="canBeInComponentContent" />
+              <node concept="2DD5aU" id="6b_jefnKwku" role="37wK5m" />
             </node>
           </node>
         </node>
@@ -889,11 +883,8 @@
               </node>
             </node>
             <node concept="2qgKlT" id="6b_jefnKwl2" role="2OqNvi">
-              <ref role="37wK5l" to="3eba:33B7rHqzGFf" resolve="canBeInComponentContent" />
-              <node concept="2OqwBi" id="6b_jefnKwl5" role="37wK5m">
-                <node concept="FGMqu" id="6b_jefnKwl6" role="2OqNvi" />
-                <node concept="2DD5aU" id="6b_jefnKwl4" role="2Oq$k0" />
-              </node>
+              <ref role="37wK5l" to="3eba:GJLa3qj27l" resolve="canBeInComponentContent" />
+              <node concept="2DD5aU" id="GJLa3qjd$H" role="37wK5m" />
             </node>
           </node>
         </node>
@@ -1731,7 +1722,7 @@
             <node concept="2YIFZM" id="1F1F0IUZ_h5" role="3clFbG">
               <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
               <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
-              <node concept="2OqwBi" id="1F1F0IUZ_h6" role="37wK5m">
+              <node concept="2OqwBi" id="3Q$zA1CDZ5H" role="37wK5m">
                 <node concept="2OqwBi" id="1F1F0IUZ_h7" role="2Oq$k0">
                   <node concept="2OqwBi" id="1F1F0IUZ_h8" role="2Oq$k0">
                     <node concept="2rP1CM" id="1F1F0IUZ_h9" role="2Oq$k0" />
@@ -1745,14 +1736,14 @@
                     </node>
                   </node>
                   <node concept="2qgKlT" id="1F1F0IUZ_he" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                    <node concept="3TUQnm" id="1F1F0IUZ_hf" role="37wK5m">
-                      <ref role="3TV0OU" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
+                    <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                    <node concept="35c_gC" id="3Q$zA1C$Kig" role="37wK5m">
+                      <ref role="35c_gD" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
                     </node>
                   </node>
                 </node>
-                <node concept="v3k3i" id="1F1F0IUZ_hg" role="2OqNvi">
-                  <node concept="chp4Y" id="1F1F0IUZ_hh" role="v3oSu">
+                <node concept="v3k3i" id="3Q$zA1CDZn3" role="2OqNvi">
+                  <node concept="chp4Y" id="3Q$zA1CDZtN" role="v3oSu">
                     <ref role="cht4Q" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
                   </node>
                 </node>
@@ -2129,11 +2120,8 @@
               </node>
             </node>
             <node concept="2qgKlT" id="6b_jefnKwhE" role="2OqNvi">
-              <ref role="37wK5l" to="3eba:33B7rHqzGFf" resolve="canBeInComponentContent" />
-              <node concept="2OqwBi" id="6b_jefnKwhH" role="37wK5m">
-                <node concept="FGMqu" id="6b_jefnKwhI" role="2OqNvi" />
-                <node concept="2DD5aU" id="6b_jefnKwhG" role="2Oq$k0" />
-              </node>
+              <ref role="37wK5l" to="3eba:GJLa3qj27l" resolve="canBeInComponentContent" />
+              <node concept="2DD5aU" id="GJLa3qjbs6" role="37wK5m" />
             </node>
           </node>
         </node>
@@ -2159,11 +2147,8 @@
               </node>
             </node>
             <node concept="2qgKlT" id="6b_jefnKwij" role="2OqNvi">
-              <ref role="37wK5l" to="3eba:33B7rHqzGFf" resolve="canBeInComponentContent" />
-              <node concept="2OqwBi" id="6b_jefnKwim" role="37wK5m">
-                <node concept="FGMqu" id="6b_jefnKwin" role="2OqNvi" />
-                <node concept="2DD5aU" id="6b_jefnKwil" role="2Oq$k0" />
-              </node>
+              <ref role="37wK5l" to="3eba:GJLa3qj27l" resolve="canBeInComponentContent" />
+              <node concept="2DD5aU" id="6b_jefnKwil" role="37wK5m" />
             </node>
           </node>
         </node>
@@ -2189,11 +2174,8 @@
               </node>
             </node>
             <node concept="2qgKlT" id="6b_jefnKwi$" role="2OqNvi">
-              <ref role="37wK5l" to="3eba:33B7rHqzGFf" resolve="canBeInComponentContent" />
-              <node concept="2OqwBi" id="6b_jefnKwiB" role="37wK5m">
-                <node concept="FGMqu" id="6b_jefnKwiC" role="2OqNvi" />
-                <node concept="2DD5aU" id="6b_jefnKwiA" role="2Oq$k0" />
-              </node>
+              <ref role="37wK5l" to="3eba:GJLa3qj27l" resolve="canBeInComponentContent" />
+              <node concept="2DD5aU" id="6b_jefnKwiA" role="37wK5m" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
@@ -395,6 +395,7 @@
       <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
         <property id="8355037393041754995" name="isNative" index="2aFKle" />
       </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
@@ -419,7 +420,6 @@
         <child id="1163668922816" name="ifTrue" index="3K4E3e" />
         <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
-      <concept id="3066917033203108594" name="jetbrains.mps.baseLanguage.structure.LocalInstanceMethodCall" flags="nn" index="3P9mCS" />
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
@@ -9750,7 +9750,7 @@
                         <node concept="3cpWsn" id="5$bT90ZdOVt" role="3cpWs9">
                           <property role="TrG5h" value="y" />
                           <node concept="10Oyi0" id="5$bT90ZdOVu" role="1tU5fm" />
-                          <node concept="3P9mCS" id="5$bT90ZdPbq" role="33vP2m">
+                          <node concept="1rXfSq" id="3Q$zA1C_mwd" role="33vP2m">
                             <ref role="37wK5l" to="g51k:~EditorCell_Basic.getY()" resolve="getY" />
                           </node>
                         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.req/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.req/models/behavior.mps
@@ -69,6 +69,7 @@
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="334628810661441841" name="jetbrains.mps.lang.smodel.structure.AsSConcept" flags="nn" index="1rGIog" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
@@ -111,9 +112,12 @@
               </node>
             </node>
             <node concept="2qgKlT" id="cJpacq5XyM" role="2OqNvi">
-              <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-              <node concept="37vLTw" id="cJpacq5X$7" role="37wK5m">
-                <ref role="3cqZAo" node="cJpacq5XaR" resolve="targetConcept" />
+              <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+              <node concept="2OqwBi" id="3Q$zA1C_rwB" role="37wK5m">
+                <node concept="37vLTw" id="cJpacq5X$7" role="2Oq$k0">
+                  <ref role="3cqZAo" node="cJpacq5XaR" resolve="targetConcept" />
+                </node>
+                <node concept="1rGIog" id="3Q$zA1C_rHw" role="2OqNvi" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.attributes/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.attributes/models/behavior.mps
@@ -77,7 +77,6 @@
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
       <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
-        <property id="1181808852946" name="isFinal" index="DiZV1" />
         <child id="1068580123133" name="returnType" index="3clF45" />
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
@@ -715,7 +714,6 @@
       <property role="13i0iv" value="false" />
       <property role="13i0it" value="false" />
       <property role="TrG5h" value="getAllAttributes" />
-      <property role="DiZV1" value="true" />
       <node concept="3Tm1VV" id="spmH6cG2lB" role="1B3o_S" />
       <node concept="3clFbS" id="spmH6cG2lD" role="3clF47">
         <node concept="3clFbF" id="spmH6cG4N4" role="3cqZAp">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.base/org.iets3.core.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.base/org.iets3.core.base.mpl
@@ -16,7 +16,7 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
     <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
-    <dependency reexport="false">5454dbfd-2075-4de0-b85e-fa645eb6957e(com.mbeddr.mpsutil.serializer.xml)</dependency>
+    <dependency reexport="false">5454dbfd-2075-4de0-b85e-fa645eb6957e(de.itemis.mps.utils.serializer.xml)</dependency>
     <dependency reexport="false">f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)</dependency>
   </dependencies>
   <languageVersions>
@@ -69,10 +69,10 @@
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
     <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />
     <module reference="b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)" version="0" />
-    <module reference="5454dbfd-2075-4de0-b85e-fa645eb6957e(com.mbeddr.mpsutil.serializer.xml)" version="0" />
     <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
     <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
     <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
+    <module reference="5454dbfd-2075-4de0-b85e-fa645eb6957e(de.itemis.mps.utils.serializer.xml)" version="0" />
     <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/models/constraints.mps
@@ -159,9 +159,6 @@
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
-      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -203,9 +200,9 @@
                     </node>
                   </node>
                   <node concept="2qgKlT" id="5a_u3OzPSQZ" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                    <node concept="3TUQnm" id="5a_u3OzPSR0" role="37wK5m">
-                      <ref role="3TV0OU" to="v0r8:5a_u3OyMtco" resolve="AlgebraicDeclaration" />
+                    <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                    <node concept="35c_gC" id="3Q$zA1C_wYF" role="37wK5m">
+                      <ref role="35c_gD" to="v0r8:5a_u3OyMtco" resolve="AlgebraicDeclaration" />
                     </node>
                   </node>
                 </node>
@@ -267,9 +264,9 @@
                             </node>
                           </node>
                           <node concept="2qgKlT" id="5a_u3OzPYSQ" role="2OqNvi">
-                            <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                            <node concept="3TUQnm" id="5a_u3OzPYSR" role="37wK5m">
-                              <ref role="3TV0OU" to="v0r8:5a_u3OyMtco" resolve="AlgebraicDeclaration" />
+                            <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                            <node concept="35c_gC" id="3Q$zA1C_t7V" role="37wK5m">
+                              <ref role="35c_gD" to="v0r8:5a_u3OyMtco" resolve="AlgebraicDeclaration" />
                             </node>
                           </node>
                         </node>
@@ -332,9 +329,9 @@
                               </node>
                             </node>
                             <node concept="2qgKlT" id="5a_u3OzPVj3" role="2OqNvi">
-                              <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                              <node concept="3TUQnm" id="5a_u3OzPVj4" role="37wK5m">
-                                <ref role="3TV0OU" to="v0r8:5a_u3OyMtco" resolve="AlgebraicDeclaration" />
+                              <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                              <node concept="35c_gC" id="3Q$zA1C_twQ" role="37wK5m">
+                                <ref role="35c_gD" to="v0r8:5a_u3OyMtco" resolve="AlgebraicDeclaration" />
                               </node>
                             </node>
                           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/constraints.mps
@@ -841,9 +841,6 @@
       </node>
     </node>
   </node>
-  <node concept="1M2fIO" id="6BCTLIjCrHS">
-    <ref role="1M2myG" to="hm2y:6BCTLIjCra2" resolve="IControlAdvancedFeatures_old" />
-  </node>
   <node concept="1M2fIO" id="4fgA7QrKSvs">
     <ref role="1M2myG" to="hm2y:4fgA7QrKSsR" resolve="ThisExpression" />
     <node concept="9S07l" id="4fgA7QrKSvz" role="9Vyp8">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.constraints.mps
@@ -104,9 +104,6 @@
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
-      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -124,7 +121,7 @@
             <node concept="2YIFZM" id="1F1F0IUZB12" role="3clFbG">
               <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
               <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
-              <node concept="2OqwBi" id="1F1F0IUZB13" role="37wK5m">
+              <node concept="2OqwBi" id="3Q$zA1CE1oZ" role="37wK5m">
                 <node concept="2OqwBi" id="1F1F0IUZB14" role="2Oq$k0">
                   <node concept="2OqwBi" id="1F1F0IUZB15" role="2Oq$k0">
                     <node concept="2rP1CM" id="1F1F0IUZB16" role="2Oq$k0" />
@@ -138,14 +135,14 @@
                     </node>
                   </node>
                   <node concept="2qgKlT" id="1F1F0IUZB1a" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                    <node concept="3TUQnm" id="1F1F0IUZB1b" role="37wK5m">
-                      <ref role="3TV0OU" to="e9k1:cPLa7Fp8FI" resolve="DataTable" />
+                    <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                    <node concept="35c_gC" id="3Q$zA1C_Tzg" role="37wK5m">
+                      <ref role="35c_gD" to="e9k1:cPLa7Fp8FI" resolve="DataTable" />
                     </node>
                   </node>
                 </node>
-                <node concept="v3k3i" id="1F1F0IUZB1c" role="2OqNvi">
-                  <node concept="chp4Y" id="cPLa7Fs40P" role="v3oSu">
+                <node concept="v3k3i" id="3Q$zA1CE1_o" role="2OqNvi">
+                  <node concept="chp4Y" id="3Q$zA1CE1JM" role="v3oSu">
                     <ref role="cht4Q" to="e9k1:cPLa7Fp8FI" resolve="DataTable" />
                   </node>
                 </node>
@@ -166,7 +163,7 @@
             <node concept="2YIFZM" id="cPLa7Fswqk" role="3clFbG">
               <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
               <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
-              <node concept="2OqwBi" id="cPLa7Fswql" role="37wK5m">
+              <node concept="2OqwBi" id="3Q$zA1CDZZU" role="37wK5m">
                 <node concept="2OqwBi" id="cPLa7Fswqm" role="2Oq$k0">
                   <node concept="2OqwBi" id="cPLa7Fswqn" role="2Oq$k0">
                     <node concept="2rP1CM" id="cPLa7Fswqo" role="2Oq$k0" />
@@ -180,14 +177,14 @@
                     </node>
                   </node>
                   <node concept="2qgKlT" id="cPLa7Fswqt" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                    <node concept="3TUQnm" id="cPLa7Fswqu" role="37wK5m">
-                      <ref role="3TV0OU" to="e9k1:cPLa7Fp8FI" resolve="DataTable" />
+                    <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                    <node concept="35c_gC" id="3Q$zA1C_ST3" role="37wK5m">
+                      <ref role="35c_gD" to="e9k1:cPLa7Fp8FI" resolve="DataTable" />
                     </node>
                   </node>
                 </node>
-                <node concept="v3k3i" id="cPLa7Fswqv" role="2OqNvi">
-                  <node concept="chp4Y" id="cPLa7Fswqw" role="v3oSu">
+                <node concept="v3k3i" id="3Q$zA1CE0fl" role="2OqNvi">
+                  <node concept="chp4Y" id="3Q$zA1CE0m5" role="v3oSu">
                     <ref role="cht4Q" to="e9k1:cPLa7Fp8FI" resolve="DataTable" />
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/constraints.mps
@@ -148,9 +148,6 @@
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
-      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -216,9 +213,9 @@
                     </node>
                   </node>
                   <node concept="2qgKlT" id="VFjlN5$L_K" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                    <node concept="3TUQnm" id="VFjlN5$Ue6" role="37wK5m">
-                      <ref role="3TV0OU" to="kelk:3vxfdxbcs9j" resolve="IMessageNamespace" />
+                    <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                    <node concept="35c_gC" id="3Q$zA1CACvl" role="37wK5m">
+                      <ref role="35c_gD" to="kelk:3vxfdxbcs9j" resolve="IMessageNamespace" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
@@ -177,7 +177,6 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
@@ -211,17 +210,10 @@
       <concept id="848437706375087728" name="com.mbeddr.mpsutil.grammarcells.structure.ICanHaveDescriptionText" flags="ng" index="1djCvD">
         <child id="848437706375087729" name="descriptionText" index="1djCvC" />
       </concept>
-      <concept id="484443907672824414" name="com.mbeddr.mpsutil.grammarcells.structure.FlagCell_SubstituteCondition" flags="ig" index="3gMsPO" />
-      <concept id="7363578995839203705" name="com.mbeddr.mpsutil.grammarcells.structure.FlagCell" flags="sg" stub="1984422498400729024" index="1kHk_G">
-        <property id="7617962380315063287" name="flagText" index="ZjSer" />
-        <child id="484443907672828832" name="substituteCondition" index="3gMvMa" />
-        <child id="621193272061064649" name="sideTransformCondition" index="1m$hSO" />
-      </concept>
       <concept id="7363578995839435357" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell" flags="ng" index="1kIj98">
         <property id="484443907677193054" name="focusWrapped" index="3g2DhO" />
         <child id="7363578995839435358" name="wrapped" index="1kIj9b" />
       </concept>
-      <concept id="621193272061064420" name="com.mbeddr.mpsutil.grammarcells.structure.FlagCell_SideTransformationCondition" flags="ig" index="1m$hWp" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
@@ -728,40 +720,6 @@
               <property role="1Intyy" value="true" />
               <ref role="1k5W1q" node="3vxfdxbhnuU" resolve="message" />
               <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="1kHk_G" id="4AahbtV9GlW" role="3EZMnx">
-        <property role="ZjSer" value="!" />
-        <ref role="1k5W1q" node="3vxfdxbhnuU" resolve="message" />
-        <ref role="1NtTu8" to="kelk:4AahbtV9FsC" resolve="messageValue_DEPRECATED" />
-        <node concept="11L4FC" id="4AahbtVaxPr" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-        <node concept="VechU" id="7OtDX6qkaOM" role="3F10Kt">
-          <property role="Vb096" value="fLwANPn/red" />
-        </node>
-        <node concept="uPpia" id="1ZlHRbg48H7" role="1djCvC">
-          <node concept="3clFbS" id="1ZlHRbg48H8" role="2VODD2">
-            <node concept="3clFbF" id="1ZlHRbg48Hd" role="3cqZAp">
-              <node concept="Xl_RD" id="1ZlHRbg48Hc" role="3clFbG">
-                <property role="Xl_RC" value="deprecated" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3gMsPO" id="1ZlHRbg7DGg" role="3gMvMa">
-          <node concept="3clFbS" id="1ZlHRbg7DGh" role="2VODD2">
-            <node concept="3clFbF" id="1ZlHRbg7DGC" role="3cqZAp">
-              <node concept="3clFbT" id="1ZlHRbg7DGB" role="3clFbG" />
-            </node>
-          </node>
-        </node>
-        <node concept="1m$hWp" id="1ZlHRbg7DHc" role="1m$hSO">
-          <node concept="3clFbS" id="1ZlHRbg7DHd" role="2VODD2">
-            <node concept="3clFbF" id="1ZlHRbg7DHi" role="3cqZAp">
-              <node concept="3clFbT" id="1ZlHRbg7DHh" role="3clFbG" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.mutable/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.mutable/models/plugin.mps
@@ -219,7 +219,9 @@
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="1173122760281" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorsOperation" flags="nn" index="z$bX8" />
+      <concept id="8866923313515890008" name="jetbrains.mps.lang.smodel.structure.AsNodeOperation" flags="nn" index="FGMqu" />
       <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
@@ -236,7 +238,6 @@
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
-      <concept id="1172323065820" name="jetbrains.mps.lang.smodel.structure.Node_GetConceptOperation" flags="nn" index="3NT_Vc" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
@@ -3965,16 +3966,19 @@
                       <ref role="3cqZAo" node="4IV0h47OJdp" resolve="evaled" />
                     </node>
                     <node concept="3EllGN" id="4IV0h47OLeI" role="37vLTJ">
-                      <node concept="2OqwBi" id="4IV0h47OLMM" role="3ElVtu">
-                        <node concept="2OqwBi" id="4IV0h47OLnA" role="2Oq$k0">
-                          <node concept="37vLTw" id="4IV0h47OLg0" role="2Oq$k0">
-                            <ref role="3cqZAo" node="4IV0h47OJdp" resolve="evaled" />
+                      <node concept="2OqwBi" id="3Q$zA1CEiNF" role="3ElVtu">
+                        <node concept="2OqwBi" id="4IV0h47OLMM" role="2Oq$k0">
+                          <node concept="2OqwBi" id="4IV0h47OLnA" role="2Oq$k0">
+                            <node concept="37vLTw" id="4IV0h47OLg0" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4IV0h47OJdp" resolve="evaled" />
+                            </node>
+                            <node concept="2OwXpG" id="4IV0h47OLxA" role="2OqNvi">
+                              <ref role="2Oxat5" node="4IV0h47l1DZ" resolve="arg" />
+                            </node>
                           </node>
-                          <node concept="2OwXpG" id="4IV0h47OLxA" role="2OqNvi">
-                            <ref role="2Oxat5" node="4IV0h47l1DZ" resolve="arg" />
-                          </node>
+                          <node concept="2yIwOk" id="3Q$zA1CEgSm" role="2OqNvi" />
                         </node>
-                        <node concept="3NT_Vc" id="4IV0h47OM1l" role="2OqNvi" />
+                        <node concept="FGMqu" id="3Q$zA1CEjt0" role="2OqNvi" />
                       </node>
                       <node concept="37vLTw" id="4IV0h47OJLj" role="3ElQJh">
                         <ref role="3cqZAo" node="4IV0h47OBcu" resolve="res" />
@@ -4095,16 +4099,19 @@
                   <ref role="2Gs0qQ" node="4IV0h47OVGz" resolve="cv" />
                 </node>
                 <node concept="3EllGN" id="4IV0h47OWxV" role="37vLTJ">
-                  <node concept="2OqwBi" id="4IV0h47OWxW" role="3ElVtu">
-                    <node concept="2OqwBi" id="4IV0h47OWxX" role="2Oq$k0">
-                      <node concept="2GrUjf" id="4IV0h47OWCd" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="4IV0h47OVGz" resolve="cv" />
+                  <node concept="2OqwBi" id="3Q$zA1CEk2F" role="3ElVtu">
+                    <node concept="2OqwBi" id="4IV0h47OWxW" role="2Oq$k0">
+                      <node concept="2OqwBi" id="4IV0h47OWxX" role="2Oq$k0">
+                        <node concept="2GrUjf" id="4IV0h47OWCd" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="4IV0h47OVGz" resolve="cv" />
+                        </node>
+                        <node concept="2OwXpG" id="4IV0h47OWxZ" role="2OqNvi">
+                          <ref role="2Oxat5" node="4IV0h47l1DZ" resolve="arg" />
+                        </node>
                       </node>
-                      <node concept="2OwXpG" id="4IV0h47OWxZ" role="2OqNvi">
-                        <ref role="2Oxat5" node="4IV0h47l1DZ" resolve="arg" />
-                      </node>
+                      <node concept="2yIwOk" id="3Q$zA1CEjS1" role="2OqNvi" />
                     </node>
-                    <node concept="3NT_Vc" id="4IV0h47OWy0" role="2OqNvi" />
+                    <node concept="FGMqu" id="3Q$zA1CEke3" role="2OqNvi" />
                   </node>
                   <node concept="37vLTw" id="4IV0h47OWy1" role="3ElQJh">
                     <ref role="3cqZAo" node="4IV0h47OBcu" resolve="res" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.natlang/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.natlang/models/constraints.mps
@@ -117,14 +117,14 @@
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
-      </concept>
-      <concept id="1219352745532" name="jetbrains.mps.lang.smodel.structure.NodeRefExpression" flags="nn" index="3B5_sB">
-        <reference id="1219352800908" name="referentNode" index="3B5MYn" />
       </concept>
       <concept id="6407023681583036853" name="jetbrains.mps.lang.smodel.structure.NodeAttributeQualifier" flags="ng" index="3CFYIy">
         <reference id="6407023681583036854" name="attributeConcept" index="3CFYIx" />
@@ -280,9 +280,9 @@
                       </node>
                     </node>
                     <node concept="2qgKlT" id="1F1F0IV2N8X" role="2OqNvi">
-                      <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                      <node concept="3B5_sB" id="1F1F0IV2N8Y" role="37wK5m">
-                        <ref role="3B5MYn" to="zzzn:49WTic8eSCJ" resolve="IFunctionLike" />
+                      <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                      <node concept="35c_gC" id="3Q$zA1CAIL5" role="37wK5m">
+                        <ref role="35c_gD" to="zzzn:49WTic8eSCJ" resolve="IFunctionLike" />
                       </node>
                     </node>
                   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.process/models/org.iets3.core.expr.process.constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.process/models/org.iets3.core.expr.process.constraints.mps
@@ -112,9 +112,6 @@
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
-      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -149,9 +146,9 @@
                     </node>
                   </node>
                   <node concept="2qgKlT" id="1F1F0IUZAOZ" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                    <node concept="3TUQnm" id="1F1F0IUZAP0" role="37wK5m">
-                      <ref role="3TV0OU" to="7y2b:7WFhXJlQowD" resolve="Process" />
+                    <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                    <node concept="35c_gC" id="3Q$zA1CAKjc" role="37wK5m">
+                      <ref role="35c_gD" to="7y2b:7WFhXJlQowD" resolve="Process" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/behavior.mps
@@ -27,6 +27,7 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="xk6s" ref="r:7961970e-5737-42e2-b144-9bef3ad8d077(org.iets3.core.expr.tests.behavior)" />
+    <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -310,10 +311,12 @@
       <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
         <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
+      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
+      <concept id="334628810661441841" name="jetbrains.mps.lang.smodel.structure.AsSConcept" flags="nn" index="1rGIog" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
@@ -1542,6 +1545,34 @@
       <ref role="13i0hy" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
       <node concept="3Tm1VV" id="7bd8pkl6B1n" role="1B3o_S" />
       <node concept="3clFbS" id="7bd8pkl6B2E" role="3clF47">
+        <node concept="3clFbF" id="3Q$zA1CEqZs" role="3cqZAp">
+          <node concept="2OqwBi" id="3Q$zA1CErpb" role="3clFbG">
+            <node concept="13iPFW" id="3Q$zA1CEqZq" role="2Oq$k0" />
+            <node concept="2qgKlT" id="3Q$zA1CEsbw" role="2OqNvi">
+              <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+              <node concept="2OqwBi" id="3Q$zA1CEsBC" role="37wK5m">
+                <node concept="37vLTw" id="3Q$zA1CEsi5" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7bd8pkl6B2F" resolve="targetConcept" />
+                </node>
+                <node concept="1rGIog" id="3Q$zA1CEsXO" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7bd8pkl6B2F" role="3clF46">
+        <property role="TrG5h" value="targetConcept" />
+        <node concept="3THzug" id="7bd8pkl6B2G" role="1tU5fm" />
+      </node>
+      <node concept="A3Dl8" id="7bd8pkl6B2H" role="3clF45">
+        <node concept="3Tqbb2" id="7bd8pkl6B2I" role="A3Ik2" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="3Q$zA1CEpWs" role="13h7CS">
+      <property role="TrG5h" value="visibleContentsOfType" />
+      <ref role="13i0hy" to="hwgx:79$zShlSHxZ" resolve="visibleContentsOfType" />
+      <node concept="3Tm1VV" id="3Q$zA1CEpWv" role="1B3o_S" />
+      <node concept="3clFbS" id="3Q$zA1CEpX3" role="3clF47">
         <node concept="3cpWs8" id="7bd8pkl6B_y" role="3cqZAp">
           <node concept="3cpWsn" id="7bd8pkl6B_z" role="3cpWs9">
             <property role="TrG5h" value="supers" />
@@ -1551,9 +1582,9 @@
             <node concept="2OqwBi" id="7bd8pkl6B_$" role="33vP2m">
               <node concept="13iAh5" id="7bd8pkl6B__" role="2Oq$k0" />
               <node concept="2qgKlT" id="7bd8pkl6B_A" role="2OqNvi">
-                <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
+                <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
                 <node concept="37vLTw" id="7bd8pkl6B_B" role="37wK5m">
-                  <ref role="3cqZAo" node="7bd8pkl6B2F" resolve="targetConcept" />
+                  <ref role="3cqZAo" node="3Q$zA1CEpX4" resolve="targetConcept" />
                 </node>
               </node>
             </node>
@@ -1562,22 +1593,26 @@
         <node concept="3clFbJ" id="7bd8pkl6CL1" role="3cqZAp">
           <node concept="3clFbS" id="7bd8pkl6CL3" role="3clFbx">
             <node concept="3cpWs6" id="7bd8pkl6F7l" role="3cqZAp">
-              <node concept="2OqwBi" id="7bd8pkl6FkM" role="3cqZAk">
-                <node concept="37vLTw" id="7bd8pkl6F7Q" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7bd8pkl6B_z" resolve="supers" />
-                </node>
-                <node concept="4Tj9Z" id="7bd8pkl6FEO" role="2OqNvi">
-                  <node concept="2OqwBi" id="7bd8pkl6IKT" role="576Qk">
-                    <node concept="2OqwBi" id="7bd8pkl6Ga2" role="2Oq$k0">
-                      <node concept="13iPFW" id="7bd8pkl6FQ3" role="2Oq$k0" />
-                      <node concept="3TrEf2" id="7bd8pkl6I1K" role="2OqNvi">
-                        <ref role="3Tt5mk" to="wtll:7bd8pkl401w" resolve="sourceScope" />
+              <node concept="2YIFZM" id="3Q$zA1CGq6i" role="3cqZAk">
+                <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
+                <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+                <node concept="2OqwBi" id="3Q$zA1CGq6j" role="37wK5m">
+                  <node concept="37vLTw" id="3Q$zA1CGq6k" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7bd8pkl6B_z" resolve="supers" />
+                  </node>
+                  <node concept="4Tj9Z" id="3Q$zA1CGq6l" role="2OqNvi">
+                    <node concept="2OqwBi" id="3Q$zA1CGq6m" role="576Qk">
+                      <node concept="2OqwBi" id="3Q$zA1CGq6n" role="2Oq$k0">
+                        <node concept="13iPFW" id="3Q$zA1CGq6o" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="3Q$zA1CGq6p" role="2OqNvi">
+                          <ref role="3Tt5mk" to="wtll:7bd8pkl401w" resolve="sourceScope" />
+                        </node>
                       </node>
-                    </node>
-                    <node concept="2qgKlT" id="7bd8pkl6J93" role="2OqNvi">
-                      <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                      <node concept="37vLTw" id="7bd8pkl6Jpx" role="37wK5m">
-                        <ref role="3cqZAo" node="7bd8pkl6B2F" resolve="targetConcept" />
+                      <node concept="2qgKlT" id="3Q$zA1CGq6q" role="2OqNvi">
+                        <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                        <node concept="37vLTw" id="3Q$zA1CGq6r" role="37wK5m">
+                          <ref role="3cqZAo" node="3Q$zA1CEpX4" resolve="targetConcept" />
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -1595,18 +1630,22 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="7bd8pkl6JGJ" role="3cqZAp">
-          <node concept="37vLTw" id="7bd8pkl6JGD" role="3clFbG">
-            <ref role="3cqZAo" node="7bd8pkl6B_z" resolve="supers" />
+        <node concept="3clFbF" id="3Q$zA1CEyn2" role="3cqZAp">
+          <node concept="2YIFZM" id="3Q$zA1CGrBX" role="3clFbG">
+            <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
+            <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+            <node concept="37vLTw" id="3Q$zA1CGrBY" role="37wK5m">
+              <ref role="3cqZAo" node="7bd8pkl6B_z" resolve="supers" />
+            </node>
           </node>
         </node>
       </node>
-      <node concept="37vLTG" id="7bd8pkl6B2F" role="3clF46">
+      <node concept="37vLTG" id="3Q$zA1CEpX4" role="3clF46">
         <property role="TrG5h" value="targetConcept" />
-        <node concept="3THzug" id="7bd8pkl6B2G" role="1tU5fm" />
+        <node concept="3bZ5Sz" id="3Q$zA1CEpX5" role="1tU5fm" />
       </node>
-      <node concept="A3Dl8" id="7bd8pkl6B2H" role="3clF45">
-        <node concept="3Tqbb2" id="7bd8pkl6B2I" role="A3Ik2" />
+      <node concept="3uibUv" id="3Q$zA1CEpX6" role="3clF45">
+        <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
       </node>
     </node>
     <node concept="13i0hz" id="7bd8pklbX6n" role="13h7CS">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/constraints.mps
@@ -141,6 +141,9 @@
       </concept>
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
@@ -157,9 +160,6 @@
       </concept>
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
-      </concept>
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -824,9 +824,9 @@
                       </node>
                     </node>
                     <node concept="2qgKlT" id="1F1F0IUZBhv" role="2OqNvi">
-                      <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                      <node concept="3TUQnm" id="1F1F0IUZBhw" role="37wK5m">
-                        <ref role="3TV0OU" to="wtll:3_Nra3E2xlO" resolve="TopLevelSheet" />
+                      <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                      <node concept="35c_gC" id="3Q$zA1CB5PP" role="37wK5m">
+                        <ref role="35c_gD" to="wtll:3_Nra3E2xlO" resolve="TopLevelSheet" />
                       </node>
                     </node>
                   </node>
@@ -912,9 +912,9 @@
                       </node>
                     </node>
                     <node concept="2qgKlT" id="3pIANU_3npn" role="2OqNvi">
-                      <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                      <node concept="3TUQnm" id="3pIANU_3npo" role="37wK5m">
-                        <ref role="3TV0OU" to="wtll:3_Nra3E2xlO" resolve="TopLevelSheet" />
+                      <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                      <node concept="35c_gC" id="3Q$zA1CB5o9" role="37wK5m">
+                        <ref role="35c_gD" to="wtll:3_Nra3E2xlO" resolve="TopLevelSheet" />
                       </node>
                     </node>
                   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/plugin.mps
@@ -156,10 +156,11 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
+      <concept id="8866923313515890008" name="jetbrains.mps.lang.smodel.structure.AsNodeOperation" flags="nn" index="FGMqu" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
@@ -646,8 +647,11 @@
                       </node>
                       <node concept="liA8E" id="3rApyZ4FgbJ" role="2OqNvi">
                         <ref role="37wK5l" to="33ny:~Map.get(java.lang.Object)" resolve="get" />
-                        <node concept="3TUQnm" id="3rApyZ4FgbK" role="37wK5m">
-                          <ref role="3TV0OU" to="l462:3rApyZ4E9Wd" resolve="DefaultSliceValueExpr" />
+                        <node concept="2OqwBi" id="3Q$zA1CBvH8" role="37wK5m">
+                          <node concept="35c_gC" id="3Q$zA1CBqHr" role="2Oq$k0">
+                            <ref role="35c_gD" to="l462:3rApyZ4E9Wd" resolve="DefaultSliceValueExpr" />
+                          </node>
+                          <node concept="FGMqu" id="3Q$zA1CBxEL" role="2OqNvi" />
                         </node>
                       </node>
                     </node>
@@ -734,8 +738,11 @@
                       </node>
                       <node concept="liA8E" id="3rApyZ4FkrM" role="2OqNvi">
                         <ref role="37wK5l" to="33ny:~Map.get(java.lang.Object)" resolve="get" />
-                        <node concept="3TUQnm" id="3rApyZ4FkrN" role="37wK5m">
-                          <ref role="3TV0OU" to="l462:3rApyZ4E9Wd" resolve="DefaultSliceValueExpr" />
+                        <node concept="2OqwBi" id="3Q$zA1CBzUY" role="37wK5m">
+                          <node concept="35c_gC" id="3Q$zA1CBzUZ" role="2Oq$k0">
+                            <ref role="35c_gD" to="l462:3rApyZ4E9Wd" resolve="DefaultSliceValueExpr" />
+                          </node>
+                          <node concept="FGMqu" id="3Q$zA1CBzV0" role="2OqNvi" />
                         </node>
                       </node>
                     </node>
@@ -1021,8 +1028,11 @@
                       </node>
                       <node concept="liA8E" id="3rApyZ4FwG8" role="2OqNvi">
                         <ref role="37wK5l" to="33ny:~Map.get(java.lang.Object)" resolve="get" />
-                        <node concept="3TUQnm" id="3rApyZ4FwG9" role="37wK5m">
-                          <ref role="3TV0OU" to="l462:3rApyZ4E9Wd" resolve="DefaultSliceValueExpr" />
+                        <node concept="2OqwBi" id="3Q$zA1CB_rk" role="37wK5m">
+                          <node concept="35c_gC" id="3Q$zA1CB_rl" role="2Oq$k0">
+                            <ref role="35c_gD" to="l462:3rApyZ4E9Wd" resolve="DefaultSliceValueExpr" />
+                          </node>
+                          <node concept="FGMqu" id="3Q$zA1CB_rm" role="2OqNvi" />
                         </node>
                       </node>
                     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/typesystem.mps
@@ -2306,7 +2306,7 @@
                           <ref role="2Gs0qQ" node="5kIYKlpqDvV" resolve="part" />
                         </node>
                         <node concept="liA8E" id="5kIYKlpqLkl" role="2OqNvi">
-                          <ref role="37wK5l" to="c17a:~SContainmentLink.getRoleName()" resolve="getRoleName" />
+                          <ref role="37wK5l" to="c17a:~SNamedElement.getName()" resolve="getName" />
                         </node>
                       </node>
                     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -10,6 +10,7 @@
     <use id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi" version="-1" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -61,6 +62,8 @@
     <import index="wcxw" ref="r:b9f36c08-4a75-4513-9277-a390d3426e0f(jetbrains.mps.editor.runtime.impl.cellActions)" />
     <import index="jpm3" ref="r:e3e5593b-dfcd-4a2e-b10f-f1ed4a43f093(org.iets3.core.expr.plugin.plugin)" />
     <import index="dj6k" ref="r:59d52af6-663b-49dc-8980-30d79b8dffa1(org.iets3.core.expr.simpleTypes.runtime)" />
+    <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -316,6 +319,9 @@
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
       </concept>
     </language>
+    <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
+      <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
+    </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
@@ -346,7 +352,6 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="1960721196051541146" name="jetbrains.mps.lang.smodel.structure.Node_GetContainingRoleOperation" flags="nn" index="13GOg" />
       <concept id="4705942098322609812" name="jetbrains.mps.lang.smodel.structure.EnumMember_IsOperation" flags="ng" index="21noJN">
         <child id="4705942098322609813" name="member" index="21noJM" />
       </concept>
@@ -1981,6 +1986,31 @@
       <ref role="13i0hy" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
       <node concept="3Tm1VV" id="5$JCxfbTgvL" role="1B3o_S" />
       <node concept="3clFbS" id="5$JCxfbTgvP" role="3clF47">
+        <node concept="3clFbF" id="3Q$zA1CFJW2" role="3cqZAp">
+          <node concept="BsUDl" id="3Q$zA1CFJW0" role="3clFbG">
+            <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+            <node concept="2OqwBi" id="3Q$zA1CFNtl" role="37wK5m">
+              <node concept="37vLTw" id="3Q$zA1CFLtp" role="2Oq$k0">
+                <ref role="3cqZAo" node="5$JCxfbTgvQ" resolve="targetConcept" />
+              </node>
+              <node concept="1rGIog" id="3Q$zA1CFP6u" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5$JCxfbTgvQ" role="3clF46">
+        <property role="TrG5h" value="targetConcept" />
+        <node concept="3THzug" id="5$JCxfbTgvR" role="1tU5fm" />
+      </node>
+      <node concept="A3Dl8" id="5$JCxfbTgvS" role="3clF45">
+        <node concept="3Tqbb2" id="5$JCxfbTgvT" role="A3Ik2" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="3Q$zA1CFDRD" role="13h7CS">
+      <property role="TrG5h" value="visibleContentsOfType" />
+      <ref role="13i0hy" to="hwgx:79$zShlSHxZ" resolve="visibleContentsOfType" />
+      <node concept="3Tm1VV" id="3Q$zA1CFDRG" role="1B3o_S" />
+      <node concept="3clFbS" id="3Q$zA1CFDSg" role="3clF47">
         <node concept="3cpWs8" id="1KPsfaLJpkx" role="3cqZAp">
           <node concept="3cpWsn" id="1KPsfaLJpk$" role="3cpWs9">
             <property role="TrG5h" value="res" />
@@ -2021,7 +2051,7 @@
                       <node concept="25Kdxt" id="230lIJUhGN" role="v3oSu">
                         <node concept="2OqwBi" id="230lIJUlC6" role="25KhWn">
                           <node concept="37vLTw" id="230lIJUjQS" role="2Oq$k0">
-                            <ref role="3cqZAo" node="5$JCxfbTgvQ" resolve="targetConcept" />
+                            <ref role="3cqZAo" node="3Q$zA1CFDSh" resolve="targetConcept" />
                           </node>
                           <node concept="1rGIog" id="230lIJUo4M" role="2OqNvi" />
                         </node>
@@ -2050,7 +2080,7 @@
                         <node concept="25Kdxt" id="230lIJTXRs" role="3MHPCF">
                           <node concept="2OqwBi" id="230lIJU1LH" role="25KhWn">
                             <node concept="37vLTw" id="230lIJTZd6" role="2Oq$k0">
-                              <ref role="3cqZAo" node="5$JCxfbTgvQ" resolve="targetConcept" />
+                              <ref role="3cqZAo" node="3Q$zA1CFDSh" resolve="targetConcept" />
                             </node>
                             <node concept="1rGIog" id="230lIJU2UF" role="2OqNvi" />
                           </node>
@@ -2080,9 +2110,9 @@
                       </node>
                     </node>
                     <node concept="2qgKlT" id="XZevpFoLIa" role="2OqNvi">
-                      <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
+                      <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
                       <node concept="37vLTw" id="XZevpFoLIb" role="37wK5m">
-                        <ref role="3cqZAo" node="5$JCxfbTgvQ" resolve="targetConcept" />
+                        <ref role="3cqZAo" node="3Q$zA1CFDSh" resolve="targetConcept" />
                       </node>
                     </node>
                   </node>
@@ -2100,41 +2130,45 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="1KPsfaLJH5h" role="3cqZAp">
-          <node concept="2OqwBi" id="230lIJTLgN" role="3clFbG">
-            <node concept="37vLTw" id="1KPsfaLJH5f" role="2Oq$k0">
-              <ref role="3cqZAo" node="1KPsfaLJpk$" resolve="res" />
-            </node>
-            <node concept="3zZkjj" id="230lIJTFuU" role="2OqNvi">
-              <node concept="1bVj0M" id="230lIJTFuW" role="23t8la">
-                <node concept="3clFbS" id="230lIJTFuX" role="1bW5cS">
-                  <node concept="3clFbF" id="230lIJTF$c" role="3cqZAp">
-                    <node concept="3fqX7Q" id="230lIJTGhW" role="3clFbG">
-                      <node concept="2YIFZM" id="230lIJTGhY" role="3fr31v">
-                        <ref role="37wK5l" to="wcxw:7YnpPzFReKN" resolve="isCommentedOut" />
-                        <ref role="1Pybhc" to="wcxw:5FzO4t9gN3W" resolve="CommentUtil" />
-                        <node concept="37vLTw" id="230lIJTGhZ" role="37wK5m">
-                          <ref role="3cqZAo" node="230lIJTFuY" resolve="it" />
+        <node concept="3clFbF" id="3Q$zA1CG2xV" role="3cqZAp">
+          <node concept="2YIFZM" id="3Q$zA1CGv$_" role="3clFbG">
+            <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
+            <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+            <node concept="2OqwBi" id="3Q$zA1CGv$A" role="37wK5m">
+              <node concept="37vLTw" id="3Q$zA1CGv$B" role="2Oq$k0">
+                <ref role="3cqZAo" node="1KPsfaLJpk$" resolve="res" />
+              </node>
+              <node concept="3zZkjj" id="3Q$zA1CGv$C" role="2OqNvi">
+                <node concept="1bVj0M" id="3Q$zA1CGv$D" role="23t8la">
+                  <node concept="3clFbS" id="3Q$zA1CGv$E" role="1bW5cS">
+                    <node concept="3clFbF" id="3Q$zA1CGv$F" role="3cqZAp">
+                      <node concept="3fqX7Q" id="3Q$zA1CGv$G" role="3clFbG">
+                        <node concept="2YIFZM" id="3Q$zA1CGv$H" role="3fr31v">
+                          <ref role="37wK5l" to="wcxw:7YnpPzFReKN" resolve="isCommentedOut" />
+                          <ref role="1Pybhc" to="wcxw:5FzO4t9gN3W" resolve="CommentUtil" />
+                          <node concept="37vLTw" id="3Q$zA1CGv$I" role="37wK5m">
+                            <ref role="3cqZAo" node="3Q$zA1CGv$J" resolve="it" />
+                          </node>
                         </node>
                       </node>
                     </node>
                   </node>
-                </node>
-                <node concept="Rh6nW" id="230lIJTFuY" role="1bW2Oz">
-                  <property role="TrG5h" value="it" />
-                  <node concept="2jxLKc" id="230lIJTFuZ" role="1tU5fm" />
+                  <node concept="Rh6nW" id="3Q$zA1CGv$J" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="3Q$zA1CGv$K" role="1tU5fm" />
+                  </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
       </node>
-      <node concept="37vLTG" id="5$JCxfbTgvQ" role="3clF46">
+      <node concept="37vLTG" id="3Q$zA1CFDSh" role="3clF46">
         <property role="TrG5h" value="targetConcept" />
-        <node concept="3THzug" id="5$JCxfbTgvR" role="1tU5fm" />
+        <node concept="3bZ5Sz" id="3Q$zA1CFDSi" role="1tU5fm" />
       </node>
-      <node concept="A3Dl8" id="5$JCxfbTgvS" role="3clF45">
-        <node concept="3Tqbb2" id="5$JCxfbTgvT" role="A3Ik2" />
+      <node concept="3uibUv" id="3Q$zA1CFDSj" role="3clF45">
+        <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
       </node>
     </node>
     <node concept="13i0hz" id="ORfz$E8km0" role="13h7CS">
@@ -5251,17 +5285,33 @@
                           </node>
                         </node>
                         <node concept="1PxgMI" id="18$bUx5_ErL" role="37vLTx">
-                          <node concept="2OqwBi" id="18$bUx5_ErM" role="1m5AlR">
-                            <node concept="2OqwBi" id="18$bUx5_ErN" role="2Oq$k0">
-                              <node concept="37vLTw" id="18$bUx5_J3X" role="2Oq$k0">
-                                <ref role="3cqZAo" node="18$bUx5_EmA" resolve="it" />
+                          <node concept="2OqwBi" id="3Q$zA1CFalY" role="1m5AlR">
+                            <node concept="2OqwBi" id="18$bUx5_ErM" role="2Oq$k0">
+                              <node concept="2OqwBi" id="18$bUx5_ErN" role="2Oq$k0">
+                                <node concept="37vLTw" id="18$bUx5_J3X" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="18$bUx5_EmA" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="18$bUx5_ErP" role="2OqNvi">
+                                  <ref role="37wK5l" to="pbu6:3_DFadMHbO3" resolve="concept" />
+                                </node>
                               </node>
-                              <node concept="liA8E" id="18$bUx5_ErP" role="2OqNvi">
-                                <ref role="37wK5l" to="pbu6:3_DFadMHbO3" resolve="concept" />
+                              <node concept="liA8E" id="18$bUx5_ErQ" role="2OqNvi">
+                                <ref role="37wK5l" to="c17a:~SAbstractConcept.getSourceNode()" resolve="getSourceNode" />
                               </node>
                             </node>
-                            <node concept="liA8E" id="18$bUx5_ErQ" role="2OqNvi">
-                              <ref role="37wK5l" to="c17a:~SAbstractConcept.getDeclarationNode()" resolve="getDeclarationNode" />
+                            <node concept="liA8E" id="3Q$zA1CFaWu" role="2OqNvi">
+                              <ref role="37wK5l" to="mhbf:~SNodeReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                              <node concept="2OqwBi" id="3Q$zA1CFf3P" role="37wK5m">
+                                <node concept="2JrnkZ" id="3Q$zA1CFeLZ" role="2Oq$k0">
+                                  <node concept="2OqwBi" id="3Q$zA1CFbMz" role="2JrQYb">
+                                    <node concept="13iPFW" id="3Q$zA1CFbo9" role="2Oq$k0" />
+                                    <node concept="I4A8Y" id="3Q$zA1CFcjP" role="2OqNvi" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="3Q$zA1CFfwU" role="2OqNvi">
+                                  <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+                                </node>
+                              </node>
                             </node>
                           </node>
                           <node concept="chp4Y" id="6b_jefnKzbD" role="3oSUPX">
@@ -5819,6 +5869,25 @@
       <ref role="13i0hy" to="hwgx:7hIyKqbFNeu" resolve="runQuery" />
       <node concept="3Tm1VV" id="4XlPKepaajx" role="1B3o_S" />
       <node concept="3clFbS" id="4XlPKepaaj$" role="3clF47">
+        <node concept="3cpWs8" id="GJLa3pNsvQ" role="3cqZAp">
+          <node concept="3cpWsn" id="GJLa3pNsvR" role="3cpWs9">
+            <property role="TrG5h" value="repository" />
+            <node concept="3uibUv" id="GJLa3pNr4w" role="1tU5fm">
+              <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+            </node>
+            <node concept="2OqwBi" id="GJLa3pNsvS" role="33vP2m">
+              <node concept="2JrnkZ" id="GJLa3pNsvT" role="2Oq$k0">
+                <node concept="2OqwBi" id="GJLa3pNsvU" role="2JrQYb">
+                  <node concept="13iPFW" id="GJLa3pNsvV" role="2Oq$k0" />
+                  <node concept="I4A8Y" id="GJLa3pNsvW" role="2OqNvi" />
+                </node>
+              </node>
+              <node concept="liA8E" id="GJLa3pNsvX" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModel.getRepository()" resolve="getRepository" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="4XlPKepbSJT" role="3cqZAp">
           <node concept="3cpWsn" id="4XlPKepbSJU" role="3cpWs9">
             <property role="TrG5h" value="sca" />
@@ -6115,15 +6184,23 @@
                           <node concept="chp4Y" id="4llm6dEryIt" role="3oSUPX">
                             <ref role="cht4Q" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
                           </node>
-                          <node concept="2OqwBi" id="4llm6dErxNG" role="1m5AlR">
-                            <node concept="2OqwBi" id="ucawTXJKao" role="2Oq$k0">
-                              <node concept="2GrUjf" id="ucawTXJKap" role="2Oq$k0">
-                                <ref role="2Gs0qQ" node="ucawTXJKa1" resolve="n" />
+                          <node concept="2EnYce" id="3Q$zA1CFt8l" role="1m5AlR">
+                            <node concept="liA8E" id="3Q$zA1CFpNQ" role="2OqNvi">
+                              <ref role="37wK5l" to="mhbf:~SNodeReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                              <node concept="37vLTw" id="GJLa3pNsvY" role="37wK5m">
+                                <ref role="3cqZAo" node="GJLa3pNsvR" resolve="repository" />
                               </node>
-                              <node concept="2NL2c5" id="4llm6dErxDh" role="2OqNvi" />
                             </node>
-                            <node concept="liA8E" id="4llm6dErygO" role="2OqNvi">
-                              <ref role="37wK5l" to="c17a:~SContainmentLink.getDeclarationNode()" resolve="getDeclarationNode" />
+                            <node concept="2OqwBi" id="4llm6dErxNG" role="2Oq$k0">
+                              <node concept="2OqwBi" id="ucawTXJKao" role="2Oq$k0">
+                                <node concept="2GrUjf" id="ucawTXJKap" role="2Oq$k0">
+                                  <ref role="2Gs0qQ" node="ucawTXJKa1" resolve="n" />
+                                </node>
+                                <node concept="2NL2c5" id="4llm6dErxDh" role="2OqNvi" />
+                              </node>
+                              <node concept="liA8E" id="4llm6dErygO" role="2OqNvi">
+                                <ref role="37wK5l" to="c17a:~SElement.getSourceNode()" resolve="getSourceNode" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -6200,17 +6277,25 @@
                                 <ref role="ehGHo" to="tpce:f_TJgxE" resolve="LinkDeclaration" />
                               </node>
                               <node concept="1PxgMI" id="1yEri41iIyR" role="33vP2m">
-                                <node concept="2OqwBi" id="1yEri41iIyS" role="1m5AlR">
-                                  <node concept="2OqwBi" id="1yEri41iIyT" role="2Oq$k0">
-                                    <node concept="37vLTw" id="1yEri41iIyU" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="CrzyxmC2fv" resolve="it" />
+                                <node concept="2EnYce" id="3Q$zA1CFwIR" role="1m5AlR">
+                                  <node concept="2OqwBi" id="1yEri41iIyS" role="2Oq$k0">
+                                    <node concept="2OqwBi" id="1yEri41iIyT" role="2Oq$k0">
+                                      <node concept="37vLTw" id="1yEri41iIyU" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="CrzyxmC2fv" resolve="it" />
+                                      </node>
+                                      <node concept="liA8E" id="1yEri41iIyV" role="2OqNvi">
+                                        <ref role="37wK5l" to="mhbf:~SReference.getLink()" resolve="getLink" />
+                                      </node>
                                     </node>
-                                    <node concept="liA8E" id="1yEri41iIyV" role="2OqNvi">
-                                      <ref role="37wK5l" to="mhbf:~SReference.getLink()" resolve="getLink" />
+                                    <node concept="liA8E" id="1yEri41iIyW" role="2OqNvi">
+                                      <ref role="37wK5l" to="c17a:~SElement.getSourceNode()" resolve="getSourceNode" />
                                     </node>
                                   </node>
-                                  <node concept="liA8E" id="1yEri41iIyW" role="2OqNvi">
-                                    <ref role="37wK5l" to="c17a:~SReferenceLink.getDeclarationNode()" resolve="getDeclarationNode" />
+                                  <node concept="liA8E" id="3Q$zA1CFxLH" role="2OqNvi">
+                                    <ref role="37wK5l" to="mhbf:~SNodeReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                                    <node concept="37vLTw" id="GJLa3pNsvZ" role="37wK5m">
+                                      <ref role="3cqZAo" node="GJLa3pNsvR" resolve="repository" />
+                                    </node>
                                   </node>
                                 </node>
                                 <node concept="chp4Y" id="1yEri41iIyX" role="3oSUPX">
@@ -6362,12 +6447,20 @@
                                     <node concept="chp4Y" id="5s_NuasXEvn" role="3oSUPX">
                                       <ref role="cht4Q" to="tpce:f_TJgxF" resolve="PropertyDeclaration" />
                                     </node>
-                                    <node concept="2OqwBi" id="5s_NuasXDYU" role="1m5AlR">
-                                      <node concept="37vLTw" id="5s_NuasXDGe" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="5s_NuasXDtV" resolve="it" />
+                                    <node concept="2EnYce" id="3Q$zA1CF$VR" role="1m5AlR">
+                                      <node concept="2OqwBi" id="5s_NuasXDYU" role="2Oq$k0">
+                                        <node concept="37vLTw" id="5s_NuasXDGe" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="5s_NuasXDtV" resolve="it" />
+                                        </node>
+                                        <node concept="liA8E" id="5s_NuasXEev" role="2OqNvi">
+                                          <ref role="37wK5l" to="c17a:~SElement.getSourceNode()" resolve="getSourceNode" />
+                                        </node>
                                       </node>
-                                      <node concept="liA8E" id="5s_NuasXEev" role="2OqNvi">
-                                        <ref role="37wK5l" to="c17a:~SProperty.getDeclarationNode()" resolve="getDeclarationNode" />
+                                      <node concept="liA8E" id="3Q$zA1CF_HH" role="2OqNvi">
+                                        <ref role="37wK5l" to="mhbf:~SNodeReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                                        <node concept="37vLTw" id="GJLa3pNsw0" role="37wK5m">
+                                          <ref role="3cqZAo" node="GJLa3pNsvR" resolve="repository" />
+                                        </node>
                                       </node>
                                     </node>
                                   </node>
@@ -12259,12 +12352,12 @@
                       <ref role="3cqZAo" node="1qjbRynmRjY" resolve="bf" />
                     </node>
                     <node concept="liA8E" id="1qjbRynn1vR" role="2OqNvi">
-                      <ref role="37wK5l" to="wyt6:~StringBuffer.append(java.lang.String)" resolve="append" />
+                      <ref role="37wK5l" to="wyt6:~StringBuffer.append(java.lang.Object)" resolve="append" />
                       <node concept="2OqwBi" id="1qjbRynn1I0" role="37wK5m">
                         <node concept="2GrUjf" id="1qjbRynn1xo" role="2Oq$k0">
                           <ref role="2Gs0qQ" node="1qjbRynmRVQ" resolve="a" />
                         </node>
-                        <node concept="13GOg" id="1qjbRynnda$" role="2OqNvi" />
+                        <node concept="2NL2c5" id="3Q$zA1CFjNn" role="2OqNvi" />
                       </node>
                     </node>
                   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -5859,10 +5859,38 @@
       <ref role="13i0hy" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
       <node concept="3Tm1VV" id="28GlH0_EVlx" role="1B3o_S" />
       <node concept="3clFbS" id="28GlH0_EVl_" role="3clF47">
+        <node concept="3clFbF" id="3Q$zA1CGESD" role="3cqZAp">
+          <node concept="BsUDl" id="3Q$zA1CGESC" role="3clFbG">
+            <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+            <node concept="2OqwBi" id="3Q$zA1CGFcs" role="37wK5m">
+              <node concept="37vLTw" id="3Q$zA1CGEW0" role="2Oq$k0">
+                <ref role="3cqZAo" node="28GlH0_EVlA" resolve="targetConcept" />
+              </node>
+              <node concept="1rGIog" id="3Q$zA1CGFx2" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="28GlH0_EVlA" role="3clF46">
+        <property role="TrG5h" value="targetConcept" />
+        <node concept="3THzug" id="28GlH0_EVlB" role="1tU5fm" />
+      </node>
+      <node concept="A3Dl8" id="28GlH0_EVlC" role="3clF45">
+        <node concept="3Tqbb2" id="28GlH0_EVlD" role="A3Ik2" />
+      </node>
+    </node>
+    <node concept="13hLZK" id="2S3ZC$oz3DV" role="13h7CW">
+      <node concept="3clFbS" id="2S3ZC$oz3DW" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="3Q$zA1CGD_q" role="13h7CS">
+      <property role="TrG5h" value="visibleContentsOfType" />
+      <ref role="13i0hy" to="hwgx:79$zShlSHxZ" resolve="visibleContentsOfType" />
+      <node concept="3Tm1VV" id="3Q$zA1CGD_t" role="1B3o_S" />
+      <node concept="3clFbS" id="3Q$zA1CGDA1" role="3clF47">
         <node concept="3clFbJ" id="28GlH0_EWaG" role="3cqZAp">
           <node concept="2OqwBi" id="28GlH0_EWmg" role="3clFbw">
             <node concept="37vLTw" id="28GlH0_EWb0" role="2Oq$k0">
-              <ref role="3cqZAo" node="28GlH0_EVlA" resolve="targetConcept" />
+              <ref role="3cqZAo" node="3Q$zA1CGDA2" resolve="targetConcept" />
             </node>
             <node concept="3O6GUB" id="28GlH0_EWDV" role="2OqNvi">
               <node concept="chp4Y" id="28GlH0_EWG_" role="3QVz_e">
@@ -5887,27 +5915,31 @@
               </node>
               <node concept="3clFbS" id="28GlH0_EWJy" role="3clFbx">
                 <node concept="3cpWs6" id="28GlH0_EWJz" role="3cqZAp">
-                  <node concept="2OqwBi" id="28GlH0_EWJ$" role="3cqZAk">
-                    <node concept="2OqwBi" id="28GlH0_EWJ_" role="2Oq$k0">
-                      <node concept="1PxgMI" id="28GlH0_EWJA" role="2Oq$k0">
-                        <node concept="chp4Y" id="6b_jefnKzkG" role="3oSUPX">
-                          <ref role="cht4Q" to="yv47:7D7uZV2dYz2" resolve="RecordType" />
-                        </node>
-                        <node concept="2OqwBi" id="28GlH0_EWJB" role="1m5AlR">
-                          <node concept="13iPFW" id="28GlH0_EWJC" role="2Oq$k0" />
-                          <node concept="3TrEf2" id="28GlH0_EWJD" role="2OqNvi">
-                            <ref role="3Tt5mk" to="yv47:6HHp2WngtTF" resolve="originalType" />
+                  <node concept="2YIFZM" id="3Q$zA1CGFQl" role="3cqZAk">
+                    <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
+                    <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+                    <node concept="2OqwBi" id="28GlH0_EWJ$" role="37wK5m">
+                      <node concept="2OqwBi" id="28GlH0_EWJ_" role="2Oq$k0">
+                        <node concept="1PxgMI" id="28GlH0_EWJA" role="2Oq$k0">
+                          <node concept="chp4Y" id="6b_jefnKzkG" role="3oSUPX">
+                            <ref role="cht4Q" to="yv47:7D7uZV2dYz2" resolve="RecordType" />
+                          </node>
+                          <node concept="2OqwBi" id="28GlH0_EWJB" role="1m5AlR">
+                            <node concept="13iPFW" id="28GlH0_EWJC" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="28GlH0_EWJD" role="2OqNvi">
+                              <ref role="3Tt5mk" to="yv47:6HHp2WngtTF" resolve="originalType" />
+                            </node>
                           </node>
                         </node>
+                        <node concept="3TrEf2" id="28GlH0_EWJE" role="2OqNvi">
+                          <ref role="3Tt5mk" to="yv47:7D7uZV2dYz3" resolve="record" />
+                        </node>
                       </node>
-                      <node concept="3TrEf2" id="28GlH0_EWJE" role="2OqNvi">
-                        <ref role="3Tt5mk" to="yv47:7D7uZV2dYz3" resolve="record" />
-                      </node>
-                    </node>
-                    <node concept="2qgKlT" id="28GlH0_GSCp" role="2OqNvi">
-                      <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                      <node concept="37vLTw" id="28GlH0_GSXP" role="37wK5m">
-                        <ref role="3cqZAo" node="28GlH0_EVlA" resolve="targetConcept" />
+                      <node concept="2qgKlT" id="28GlH0_GSCp" role="2OqNvi">
+                        <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                        <node concept="37vLTw" id="28GlH0_GSXP" role="37wK5m">
+                          <ref role="3cqZAo" node="3Q$zA1CGDA2" resolve="targetConcept" />
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -5924,36 +5956,37 @@
           </node>
         </node>
         <node concept="3cpWs6" id="28GlH0_EXkk" role="3cqZAp">
-          <node concept="2OqwBi" id="28GlH0_EZnI" role="3cqZAk">
-            <node concept="2OqwBi" id="28GlH0_EYfM" role="2Oq$k0">
-              <node concept="13iPFW" id="28GlH0_EXSM" role="2Oq$k0" />
-              <node concept="2Xjw5R" id="28GlH0_EYEo" role="2OqNvi">
-                <node concept="1xMEDy" id="28GlH0_EYEq" role="1xVPHs">
-                  <node concept="chp4Y" id="28GlH0_EYWF" role="ri$Ld">
-                    <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
+          <node concept="2YIFZM" id="3Q$zA1CGHgZ" role="3cqZAk">
+            <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
+            <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+            <node concept="2OqwBi" id="28GlH0_EZnI" role="37wK5m">
+              <node concept="2OqwBi" id="28GlH0_EYfM" role="2Oq$k0">
+                <node concept="13iPFW" id="28GlH0_EXSM" role="2Oq$k0" />
+                <node concept="2Xjw5R" id="28GlH0_EYEo" role="2OqNvi">
+                  <node concept="1xMEDy" id="28GlH0_EYEq" role="1xVPHs">
+                    <node concept="chp4Y" id="28GlH0_EYWF" role="ri$Ld">
+                      <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
+                    </node>
                   </node>
                 </node>
               </node>
-            </node>
-            <node concept="2qgKlT" id="28GlH0_EZJS" role="2OqNvi">
-              <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-              <node concept="37vLTw" id="28GlH0_GR2e" role="37wK5m">
-                <ref role="3cqZAo" node="28GlH0_EVlA" resolve="targetConcept" />
+              <node concept="2qgKlT" id="28GlH0_EZJS" role="2OqNvi">
+                <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                <node concept="37vLTw" id="28GlH0_GR2e" role="37wK5m">
+                  <ref role="3cqZAo" node="3Q$zA1CGDA2" resolve="targetConcept" />
+                </node>
               </node>
             </node>
           </node>
         </node>
       </node>
-      <node concept="37vLTG" id="28GlH0_EVlA" role="3clF46">
+      <node concept="37vLTG" id="3Q$zA1CGDA2" role="3clF46">
         <property role="TrG5h" value="targetConcept" />
-        <node concept="3THzug" id="28GlH0_EVlB" role="1tU5fm" />
+        <node concept="3bZ5Sz" id="3Q$zA1CGDA3" role="1tU5fm" />
       </node>
-      <node concept="A3Dl8" id="28GlH0_EVlC" role="3clF45">
-        <node concept="3Tqbb2" id="28GlH0_EVlD" role="A3Ik2" />
+      <node concept="3uibUv" id="3Q$zA1CGDA4" role="3clF45">
+        <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
       </node>
-    </node>
-    <node concept="13hLZK" id="2S3ZC$oz3DV" role="13h7CW">
-      <node concept="3clFbS" id="2S3ZC$oz3DW" role="2VODD2" />
     </node>
     <node concept="13i0hz" id="3aPPYyxz0xp" role="13h7CS">
       <property role="13i0iv" value="false" />
@@ -6998,45 +7031,14 @@
       <ref role="13i0hy" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
       <node concept="3Tm1VV" id="28GlH0_ES3p" role="1B3o_S" />
       <node concept="3clFbS" id="28GlH0_ES3t" role="3clF47">
-        <node concept="3clFbJ" id="28GlH0_ESaa" role="3cqZAp">
-          <node concept="2OqwBi" id="28GlH0_ESlI" role="3clFbw">
-            <node concept="37vLTw" id="28GlH0_ESau" role="2Oq$k0">
-              <ref role="3cqZAo" node="28GlH0_ES3u" resolve="targetConcept" />
-            </node>
-            <node concept="3O6GUB" id="28GlH0_ESsN" role="2OqNvi">
-              <node concept="chp4Y" id="28GlH0_ESvr" role="3QVz_e">
-                <ref role="cht4Q" to="yv47:xu7xcKdQCB" resolve="IRecordMember" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbS" id="28GlH0_ESac" role="3clFbx">
-            <node concept="3cpWs6" id="5$JCxfbP2_3" role="3cqZAp">
-              <node concept="2OqwBi" id="5$JCxfbP2_5" role="3cqZAk">
-                <node concept="13iPFW" id="5$JCxfbP2_6" role="2Oq$k0" />
-                <node concept="2qgKlT" id="1qrYg08iS7d" role="2OqNvi">
-                  <ref role="37wK5l" node="1qrYg08iahZ" resolve="effectiveMembers" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs6" id="28GlH0_ETbO" role="3cqZAp">
-          <node concept="2OqwBi" id="28GlH0_EU8A" role="3cqZAk">
-            <node concept="2OqwBi" id="28GlH0_ETx5" role="2Oq$k0">
-              <node concept="13iPFW" id="28GlH0_ETfz" role="2Oq$k0" />
-              <node concept="2Xjw5R" id="28GlH0_ETSD" role="2OqNvi">
-                <node concept="1xMEDy" id="28GlH0_ETSF" role="1xVPHs">
-                  <node concept="chp4Y" id="28GlH0_ETWs" role="ri$Ld">
-                    <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="2qgKlT" id="28GlH0_EUig" role="2OqNvi">
-              <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-              <node concept="37vLTw" id="28GlH0_EUpy" role="37wK5m">
+        <node concept="3clFbF" id="3Q$zA1CG_PH" role="3cqZAp">
+          <node concept="BsUDl" id="3Q$zA1CG_PG" role="3clFbG">
+            <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+            <node concept="2OqwBi" id="3Q$zA1CGA9U" role="37wK5m">
+              <node concept="37vLTw" id="3Q$zA1CG_Tu" role="2Oq$k0">
                 <ref role="3cqZAo" node="28GlH0_ES3u" resolve="targetConcept" />
               </node>
+              <node concept="1rGIog" id="3Q$zA1CGAq2" role="2OqNvi" />
             </node>
           </node>
         </node>
@@ -7047,6 +7049,70 @@
       </node>
       <node concept="A3Dl8" id="28GlH0_ES3w" role="3clF45">
         <node concept="3Tqbb2" id="28GlH0_ES3x" role="A3Ik2" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="3Q$zA1CG$YC" role="13h7CS">
+      <property role="TrG5h" value="visibleContentsOfType" />
+      <ref role="13i0hy" to="hwgx:79$zShlSHxZ" resolve="visibleContentsOfType" />
+      <node concept="3Tm1VV" id="3Q$zA1CG$YF" role="1B3o_S" />
+      <node concept="3clFbS" id="3Q$zA1CG$Zf" role="3clF47">
+        <node concept="3clFbJ" id="28GlH0_ESaa" role="3cqZAp">
+          <node concept="2OqwBi" id="28GlH0_ESlI" role="3clFbw">
+            <node concept="37vLTw" id="28GlH0_ESau" role="2Oq$k0">
+              <ref role="3cqZAo" node="3Q$zA1CG$Zg" resolve="targetConcept" />
+            </node>
+            <node concept="3O6GUB" id="28GlH0_ESsN" role="2OqNvi">
+              <node concept="chp4Y" id="28GlH0_ESvr" role="3QVz_e">
+                <ref role="cht4Q" to="yv47:xu7xcKdQCB" resolve="IRecordMember" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="28GlH0_ESac" role="3clFbx">
+            <node concept="3cpWs6" id="5$JCxfbP2_3" role="3cqZAp">
+              <node concept="2YIFZM" id="3Q$zA1CGAMt" role="3cqZAk">
+                <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
+                <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+                <node concept="2OqwBi" id="5$JCxfbP2_5" role="37wK5m">
+                  <node concept="13iPFW" id="5$JCxfbP2_6" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="1qrYg08iS7d" role="2OqNvi">
+                    <ref role="37wK5l" node="1qrYg08iahZ" resolve="effectiveMembers" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="28GlH0_ETbO" role="3cqZAp">
+          <node concept="2YIFZM" id="3Q$zA1CGBHX" role="3cqZAk">
+            <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
+            <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+            <node concept="2OqwBi" id="28GlH0_EU8A" role="37wK5m">
+              <node concept="2OqwBi" id="28GlH0_ETx5" role="2Oq$k0">
+                <node concept="13iPFW" id="28GlH0_ETfz" role="2Oq$k0" />
+                <node concept="2Xjw5R" id="28GlH0_ETSD" role="2OqNvi">
+                  <node concept="1xMEDy" id="28GlH0_ETSF" role="1xVPHs">
+                    <node concept="chp4Y" id="28GlH0_ETWs" role="ri$Ld">
+                      <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2qgKlT" id="28GlH0_EUig" role="2OqNvi">
+                <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                <node concept="37vLTw" id="28GlH0_EUpy" role="37wK5m">
+                  <ref role="3cqZAo" node="3Q$zA1CG$Zg" resolve="targetConcept" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3Q$zA1CG$Zg" role="3clF46">
+        <property role="TrG5h" value="targetConcept" />
+        <node concept="3bZ5Sz" id="3Q$zA1CG$Zh" role="1tU5fm" />
+      </node>
+      <node concept="3uibUv" id="3Q$zA1CG$Zi" role="3clF45">
+        <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
       </node>
     </node>
     <node concept="13i0hz" id="6JZACDWGX$r" role="13h7CS">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/constraints.mps
@@ -60,6 +60,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -237,9 +238,6 @@
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
-      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -295,9 +293,9 @@
                     </node>
                   </node>
                   <node concept="2qgKlT" id="1F1F0IUZBhv" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                    <node concept="3TUQnm" id="1F1F0IUZBhw" role="37wK5m">
-                      <ref role="3TV0OU" to="zzzn:49WTic8eSCJ" resolve="IFunctionLike" />
+                    <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                    <node concept="35c_gC" id="3Q$zA1CCgjn" role="37wK5m">
+                      <ref role="35c_gD" to="zzzn:49WTic8eSCJ" resolve="IFunctionLike" />
                     </node>
                   </node>
                 </node>
@@ -337,9 +335,9 @@
                     </node>
                   </node>
                   <node concept="2qgKlT" id="1F1F0IUZBps" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                    <node concept="3TUQnm" id="1F1F0IUZBpt" role="37wK5m">
-                      <ref role="3TV0OU" to="zzzn:49WTic8eSCJ" resolve="IFunctionLike" />
+                    <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                    <node concept="35c_gC" id="3Q$zA1CCfRo" role="37wK5m">
+                      <ref role="35c_gD" to="zzzn:49WTic8eSCJ" resolve="IFunctionLike" />
                     </node>
                   </node>
                 </node>
@@ -384,9 +382,9 @@
                       </node>
                     </node>
                     <node concept="2qgKlT" id="1F1F0IUZBpI" role="2OqNvi">
-                      <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                      <node concept="3TUQnm" id="1F1F0IUZBpJ" role="37wK5m">
-                        <ref role="3TV0OU" to="zzzn:49WTic8eSCJ" resolve="IFunctionLike" />
+                      <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                      <node concept="35c_gC" id="3Q$zA1CCewI" role="37wK5m">
+                        <ref role="35c_gD" to="zzzn:49WTic8eSCJ" resolve="IFunctionLike" />
                       </node>
                     </node>
                   </node>
@@ -463,34 +461,34 @@
                   <node concept="1bVj0M" id="1F1F0IUZB$I" role="23t8la">
                     <node concept="3clFbS" id="1F1F0IUZB$J" role="1bW5cS">
                       <node concept="3clFbF" id="1F1F0IUZB$K" role="3cqZAp">
-                        <node concept="3clFbC" id="1F1F0IUZB$L" role="3clFbG">
-                          <node concept="2OqwBi" id="1F1F0IUZB$M" role="3uHU7B">
-                            <node concept="2OqwBi" id="1F1F0IUZB$N" role="2Oq$k0">
-                              <node concept="2OqwBi" id="1F1F0IUZB$O" role="2Oq$k0">
-                                <node concept="2OqwBi" id="1F1F0IUZB$P" role="2Oq$k0">
-                                  <node concept="2OqwBi" id="1F1F0IUZB$Q" role="2Oq$k0">
-                                    <node concept="37vLTw" id="1F1F0IUZB$R" role="2Oq$k0">
+                        <node concept="17R0WA" id="3Q$zA1CCeTC" role="3clFbG">
+                          <node concept="2OqwBi" id="3Q$zA1CCeTD" role="3uHU7B">
+                            <node concept="2OqwBi" id="3Q$zA1CCeTE" role="2Oq$k0">
+                              <node concept="2OqwBi" id="3Q$zA1CCeTF" role="2Oq$k0">
+                                <node concept="2OqwBi" id="3Q$zA1CCeTG" role="2Oq$k0">
+                                  <node concept="2OqwBi" id="3Q$zA1CCeTH" role="2Oq$k0">
+                                    <node concept="37vLTw" id="3Q$zA1CCeTI" role="2Oq$k0">
                                       <ref role="3cqZAo" node="1F1F0IUZB_0" resolve="it" />
                                     </node>
-                                    <node concept="3Tsc0h" id="1F1F0IUZB$S" role="2OqNvi">
+                                    <node concept="3Tsc0h" id="3Q$zA1CCeTJ" role="2OqNvi">
                                       <ref role="3TtcxE" to="zzzn:49WTic8eSCZ" resolve="args" />
                                     </node>
                                   </node>
-                                  <node concept="1uHKPH" id="1F1F0IUZB$T" role="2OqNvi" />
+                                  <node concept="1uHKPH" id="3Q$zA1CCeTK" role="2OqNvi" />
                                 </node>
-                                <node concept="3TrEf2" id="1F1F0IUZB$U" role="2OqNvi">
+                                <node concept="3TrEf2" id="3Q$zA1CCeTL" role="2OqNvi">
                                   <ref role="3Tt5mk" to="zzzn:6zmBjqUkwsc" resolve="type" />
                                 </node>
                               </node>
-                              <node concept="3JvlWi" id="1F1F0IUZB$V" role="2OqNvi" />
+                              <node concept="3JvlWi" id="3Q$zA1CCeTM" role="2OqNvi" />
                             </node>
-                            <node concept="2yIwOk" id="1F1F0IUZB$W" role="2OqNvi" />
+                            <node concept="2yIwOk" id="3Q$zA1CCeTN" role="2OqNvi" />
                           </node>
-                          <node concept="2OqwBi" id="1F1F0IUZB$X" role="3uHU7w">
-                            <node concept="37vLTw" id="1F1F0IUZB$Y" role="2Oq$k0">
+                          <node concept="2OqwBi" id="3Q$zA1CCeTO" role="3uHU7w">
+                            <node concept="37vLTw" id="3Q$zA1CCeTP" role="2Oq$k0">
                               <ref role="3cqZAo" node="1F1F0IUZBpW" resolve="t" />
                             </node>
-                            <node concept="2yIwOk" id="1F1F0IUZB$Z" role="2OqNvi" />
+                            <node concept="2yIwOk" id="3Q$zA1CCeTQ" role="2OqNvi" />
                           </node>
                         </node>
                       </node>
@@ -532,9 +530,9 @@
                     </node>
                   </node>
                   <node concept="2qgKlT" id="1F1F0IUZAOZ" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                    <node concept="3TUQnm" id="1F1F0IUZAP0" role="37wK5m">
-                      <ref role="3TV0OU" to="yv47:69zaTr1HgRc" resolve="Constant" />
+                    <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                    <node concept="35c_gC" id="3Q$zA1CCbUZ" role="37wK5m">
+                      <ref role="35c_gD" to="yv47:69zaTr1HgRc" resolve="Constant" />
                     </node>
                   </node>
                 </node>
@@ -773,9 +771,9 @@
                     </node>
                   </node>
                   <node concept="2qgKlT" id="1F1F0IUZB1r" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                    <node concept="3TUQnm" id="1F1F0IUZB1s" role="37wK5m">
-                      <ref role="3TV0OU" to="yv47:6HHp2WngtTC" resolve="Typedef" />
+                    <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                    <node concept="35c_gC" id="3Q$zA1CCjkW" role="37wK5m">
+                      <ref role="35c_gD" to="yv47:6HHp2WngtTC" resolve="Typedef" />
                     </node>
                   </node>
                 </node>
@@ -866,9 +864,9 @@
                     </node>
                   </node>
                   <node concept="2qgKlT" id="1F1F0IUZAWz" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                    <node concept="3TUQnm" id="1F1F0IUZAW$" role="37wK5m">
-                      <ref role="3TV0OU" to="yv47:xu7xcKdQCB" resolve="IRecordMember" />
+                    <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                    <node concept="35c_gC" id="3Q$zA1CChQ8" role="37wK5m">
+                      <ref role="35c_gD" to="yv47:xu7xcKdQCB" resolve="IRecordMember" />
                     </node>
                   </node>
                 </node>
@@ -1023,9 +1021,9 @@
                       </node>
                     </node>
                     <node concept="2qgKlT" id="1F1F0IUZB1a" role="2OqNvi">
-                      <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                      <node concept="3TUQnm" id="1F1F0IUZB1b" role="37wK5m">
-                        <ref role="3TV0OU" to="yv47:xu7xcKinTJ" resolve="IRecordDeclaration" />
+                      <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                      <node concept="35c_gC" id="3Q$zA1CCiwT" role="37wK5m">
+                        <ref role="35c_gD" to="yv47:xu7xcKinTJ" resolve="IRecordDeclaration" />
                       </node>
                     </node>
                   </node>
@@ -1295,9 +1293,9 @@
                     </node>
                   </node>
                   <node concept="2qgKlT" id="1F1F0IUZASB" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                    <node concept="3TUQnm" id="1F1F0IUZASC" role="37wK5m">
-                      <ref role="3TV0OU" to="yv47:67Y8mp$DMUI" resolve="EnumDeclaration" />
+                    <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                    <node concept="35c_gC" id="3Q$zA1CCdz9" role="37wK5m">
+                      <ref role="35c_gD" to="yv47:67Y8mp$DMUI" resolve="EnumDeclaration" />
                     </node>
                   </node>
                 </node>
@@ -1341,9 +1339,9 @@
                     </node>
                   </node>
                   <node concept="2qgKlT" id="4zsmO3KsMJX" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                    <node concept="3TUQnm" id="4zsmO3KsMJY" role="37wK5m">
-                      <ref role="3TV0OU" to="yv47:67Y8mp$DMUI" resolve="EnumDeclaration" />
+                    <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                    <node concept="35c_gC" id="3Q$zA1CCcUU" role="37wK5m">
+                      <ref role="35c_gD" to="yv47:67Y8mp$DMUI" resolve="EnumDeclaration" />
                     </node>
                   </node>
                 </node>
@@ -1841,10 +1839,6 @@
     <property role="3GE5qa" value="record.builder" />
     <ref role="1M2myG" to="yv47:4ptnK4jbr8C" resolve="BuilderAdapter" />
   </node>
-  <node concept="1M2fIO" id="mQGcCvA5Jk">
-    <property role="3GE5qa" value="adapter" />
-    <ref role="1M2myG" to="yv47:mQGcCvDeqQ" resolve="AbstractFunctionAdapter" />
-  </node>
   <node concept="1M2fIO" id="3ijD2AhNIas">
     <property role="3GE5qa" value="adapter" />
     <ref role="1M2myG" to="yv47:3ijD2AhNGn8" resolve="AbstractToplevelExprAdapter" />
@@ -2016,9 +2010,9 @@
                     </node>
                   </node>
                   <node concept="2qgKlT" id="4zsmO3Kw5Ao" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                    <node concept="3TUQnm" id="4zsmO3Kw5Ap" role="37wK5m">
-                      <ref role="3TV0OU" to="yv47:67Y8mp$DMUI" resolve="EnumDeclaration" />
+                    <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                    <node concept="35c_gC" id="3Q$zA1CCh2d" role="37wK5m">
+                      <ref role="35c_gD" to="yv47:67Y8mp$DMUI" resolve="EnumDeclaration" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
@@ -38,6 +38,7 @@
     <import index="i3ya" ref="r:4f64e2f0-6a4e-4db3-b3bf-7977f44949b6(org.iets3.core.expr.typetags.physunits.structure)" />
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="oq0c" ref="r:6c6155f0-4bbe-4af5-8c26-244d570e21e4(org.iets3.core.expr.base.plugin)" />
+    <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
     <import index="b1h1" ref="r:ac5f749f-6179-4d4f-ad24-ad9edbd8077b(org.iets3.core.expr.simpleTypes.behavior)" implicit="true" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
     <import index="yv47" ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" implicit="true" />
@@ -517,6 +518,7 @@
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
+      <concept id="334628810661441841" name="jetbrains.mps.lang.smodel.structure.AsSConcept" flags="nn" index="1rGIog" />
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
@@ -546,9 +548,6 @@
         <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
       <concept id="1172420572800" name="jetbrains.mps.lang.smodel.structure.ConceptNodeType" flags="in" index="3THzug" />
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
-      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -11634,9 +11633,9 @@
                         </node>
                       </node>
                       <node concept="2qgKlT" id="2JXkwhJgnmI" role="2OqNvi">
-                        <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                        <node concept="3TUQnm" id="2JXkwhJgnmJ" role="37wK5m">
-                          <ref role="3TV0OU" to="i3ya:VmEWGR2Mzb" resolve="ConversionRule" />
+                        <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                        <node concept="35c_gC" id="3Q$zA1CCTLv" role="37wK5m">
+                          <ref role="35c_gD" to="i3ya:VmEWGR2Mzb" resolve="ConversionRule" />
                         </node>
                       </node>
                     </node>
@@ -12509,6 +12508,31 @@
         <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
       </node>
       <node concept="3clFbS" id="73cP8Dpyo7n" role="3clF47">
+        <node concept="3clFbF" id="3Q$zA1CGLMv" role="3cqZAp">
+          <node concept="BsUDl" id="3Q$zA1CGLMu" role="3clFbG">
+            <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+            <node concept="2OqwBi" id="3Q$zA1CGMaz" role="37wK5m">
+              <node concept="37vLTw" id="3Q$zA1CGLQU" role="2Oq$k0">
+                <ref role="3cqZAo" node="73cP8Dpyo7o" resolve="targetConcept" />
+              </node>
+              <node concept="1rGIog" id="3Q$zA1CGMFl" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="73cP8Dpyo7o" role="3clF46">
+        <property role="TrG5h" value="targetConcept" />
+        <node concept="3THzug" id="73cP8Dpyo7p" role="1tU5fm" />
+      </node>
+      <node concept="A3Dl8" id="73cP8Dpyo7q" role="3clF45">
+        <node concept="3Tqbb2" id="73cP8Dpyo7r" role="A3Ik2" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="3Q$zA1CGJUi" role="13h7CS">
+      <property role="TrG5h" value="visibleContentsOfType" />
+      <ref role="13i0hy" to="hwgx:79$zShlSHxZ" resolve="visibleContentsOfType" />
+      <node concept="3Tm1VV" id="3Q$zA1CGJUl" role="1B3o_S" />
+      <node concept="3clFbS" id="3Q$zA1CGJUT" role="3clF47">
         <node concept="3cpWs8" id="73cP8DpyqJ1" role="3cqZAp">
           <node concept="3cpWsn" id="73cP8DpyqJ4" role="3cpWs9">
             <property role="TrG5h" value="quantities" />
@@ -12528,9 +12552,9 @@
                   </node>
                 </node>
                 <node concept="2qgKlT" id="73cP8DpyoU2" role="2OqNvi">
-                  <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                  <node concept="3TUQnm" id="73cP8DpyoU3" role="37wK5m">
-                    <ref role="3TV0OU" to="i3ya:1KUmgSFpwWn" resolve="Quantity" />
+                  <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                  <node concept="35c_gC" id="GJLa3qkM2v" role="37wK5m">
+                    <ref role="35c_gD" to="i3ya:1KUmgSFpwWn" resolve="Quantity" />
                   </node>
                 </node>
               </node>
@@ -12561,18 +12585,22 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="73cP8Dpyv_U" role="3cqZAp">
-          <node concept="37vLTw" id="73cP8Dpyv_S" role="3clFbG">
-            <ref role="3cqZAo" node="73cP8DpyqJ4" resolve="quantities" />
+        <node concept="3clFbF" id="3Q$zA1CGN_R" role="3cqZAp">
+          <node concept="2YIFZM" id="3Q$zA1CGNLx" role="3clFbG">
+            <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
+            <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+            <node concept="37vLTw" id="3Q$zA1CGO7w" role="37wK5m">
+              <ref role="3cqZAo" node="73cP8DpyqJ4" resolve="quantities" />
+            </node>
           </node>
         </node>
       </node>
-      <node concept="37vLTG" id="73cP8Dpyo7o" role="3clF46">
+      <node concept="37vLTG" id="3Q$zA1CGJUU" role="3clF46">
         <property role="TrG5h" value="targetConcept" />
-        <node concept="3THzug" id="73cP8Dpyo7p" role="1tU5fm" />
+        <node concept="3bZ5Sz" id="3Q$zA1CGJUV" role="1tU5fm" />
       </node>
-      <node concept="A3Dl8" id="73cP8Dpyo7q" role="3clF45">
-        <node concept="3Tqbb2" id="73cP8Dpyo7r" role="A3Ik2" />
+      <node concept="3uibUv" id="3Q$zA1CGJUW" role="3clF45">
+        <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
       </node>
     </node>
     <node concept="13i0hz" id="u36xDg44He" role="13h7CS">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.constraints.mps
@@ -14,7 +14,7 @@
     <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
     <import index="i3ya" ref="r:4f64e2f0-6a4e-4db3-b3bf-7977f44949b6(org.iets3.core.expr.typetags.physunits.structure)" />
-    <import index="rppw" ref="r:720d563d-1633-46b3-a98e-08d2fde4c4a8(org.iets3.core.expr.typetags.quantities.behavior)" />
+    <import index="rppw" ref="r:720d563d-1633-46b3-a98e-08d2fde4c4a8(org.iets3.core.expr.typetags.physunits.behavior)" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" implicit="true" />
     <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" implicit="true" />
     <import index="qlm2" ref="r:c0482758-b46b-48c3-8482-fa4a3115b53b(org.iets3.core.expr.typetags.behavior)" implicit="true" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.constraints.mps
@@ -165,9 +165,6 @@
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
-      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -616,9 +613,9 @@
                   </node>
                 </node>
                 <node concept="2qgKlT" id="1F1F0IUZAOZ" role="2OqNvi">
-                  <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                  <node concept="3TUQnm" id="1F1F0IUZAP0" role="37wK5m">
-                    <ref role="3TV0OU" to="i3ya:1KUmgSFpwWn" resolve="Quantity" />
+                  <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                  <node concept="35c_gC" id="3Q$zA1CCWRN" role="37wK5m">
+                    <ref role="35c_gD" to="i3ya:1KUmgSFpwWn" resolve="Quantity" />
                   </node>
                 </node>
               </node>
@@ -709,9 +706,9 @@
                   </node>
                 </node>
                 <node concept="2qgKlT" id="42$mjgfqkdg" role="2OqNvi">
-                  <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                  <node concept="3TUQnm" id="42$mjgfqkdh" role="37wK5m">
-                    <ref role="3TV0OU" to="i3ya:1KUmgSFpwWn" resolve="Quantity" />
+                  <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                  <node concept="35c_gC" id="3Q$zA1CCWzK" role="37wK5m">
+                    <ref role="35c_gD" to="i3ya:1KUmgSFpwWn" resolve="Quantity" />
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.editor.mps
@@ -576,6 +576,9 @@
       <concept id="1240170042401" name="jetbrains.mps.lang.smodel.structure.SEnumerationMemberType" flags="in" index="2ZThk1">
         <reference id="1240170836027" name="enum" index="2ZWj4r" />
       </concept>
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
@@ -606,9 +609,6 @@
       </concept>
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
-      </concept>
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
       </concept>
       <concept id="5779574625830813396" name="jetbrains.mps.lang.smodel.structure.EnumerationIdRefExpression" flags="ng" index="1XH99k">
         <reference id="5779574625830813397" name="enumDeclaration" index="1XH99l" />
@@ -4001,9 +4001,9 @@
                   <node concept="1yR$tW" id="9M53mI1lVy" role="2Oq$k0" />
                 </node>
                 <node concept="2qgKlT" id="1F1F0IUZAOZ" role="2OqNvi">
-                  <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                  <node concept="3TUQnm" id="1F1F0IUZAP0" role="37wK5m">
-                    <ref role="3TV0OU" to="i3ya:1KUmgSFpwWn" resolve="Quantity" />
+                  <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                  <node concept="35c_gC" id="3Q$zA1CCXzJ" role="37wK5m">
+                    <ref role="35c_gD" to="i3ya:1KUmgSFpwWn" resolve="Quantity" />
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/behavior.mps
@@ -398,9 +398,6 @@
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
-      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -9828,9 +9825,9 @@
                         </node>
                       </node>
                       <node concept="2qgKlT" id="2JXkwhJgnmI" role="2OqNvi">
-                        <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                        <node concept="3TUQnm" id="2JXkwhJgnmJ" role="37wK5m">
-                          <ref role="3TV0OU" to="b0gq:VmEWGR2Mzb" resolve="ConversionRule" />
+                        <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                        <node concept="35c_gC" id="3Q$zA1CCZFi" role="37wK5m">
+                          <ref role="35c_gD" to="b0gq:VmEWGR2Mzb" resolve="ConversionRule" />
                         </node>
                       </node>
                     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/editor.mps
@@ -478,6 +478,7 @@
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
+      <concept id="8866923313515890008" name="jetbrains.mps.lang.smodel.structure.AsNodeOperation" flags="nn" index="FGMqu" />
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
@@ -486,6 +487,9 @@
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1143511969223" name="jetbrains.mps.lang.smodel.structure.Node_GetPrevSiblingOperation" flags="nn" index="YBYNd" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
@@ -515,9 +519,6 @@
       </concept>
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
-      </concept>
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
       </concept>
       <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
     </language>
@@ -1775,11 +1776,14 @@
                       <ref role="37wK5l" to="vj5k:3IFXLmiudY7" resolve="setProperty" />
                       <node concept="2OqwBi" id="3IFXLmixSmq" role="37wK5m">
                         <node concept="2OqwBi" id="3IFXLmixQQW" role="2Oq$k0">
-                          <node concept="3TUQnm" id="3IFXLmixQKj" role="2Oq$k0">
-                            <ref role="3TV0OU" to="kfo3:1mPSRGtN8X5" resolve="TreeGroup" />
-                          </node>
                           <node concept="3Tsc0h" id="3IFXLmixR0w" role="2OqNvi">
                             <ref role="3TtcxE" to="tpce:f_TKVDG" resolve="propertyDeclaration" />
+                          </node>
+                          <node concept="2OqwBi" id="GJLa3ql_Ts" role="2Oq$k0">
+                            <node concept="35c_gC" id="GJLa3ql_Tt" role="2Oq$k0">
+                              <ref role="35c_gD" to="kfo3:1mPSRGtN8X5" resolve="TreeGroup" />
+                            </node>
+                            <node concept="FGMqu" id="GJLa3ql_Tu" role="2OqNvi" />
                           </node>
                         </node>
                         <node concept="1z4cxt" id="3IFXLmixUbx" role="2OqNvi">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.plugin/models/org/iets3/core/plugin/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.plugin/models/org/iets3/core/plugin/plugin.mps
@@ -435,7 +435,7 @@
                       <ref role="3cqZAo" node="6LfBX8Yg$YB" resolve="project" />
                     </node>
                     <node concept="liA8E" id="6LfBX8Yg$Y4" role="2OqNvi">
-                      <ref role="37wK5l" to="z1c3:~Project.getModules()" resolve="getModules" />
+                      <ref role="37wK5l" to="z1c3:~IProject.getProjectModules()" resolve="getProjectModules" />
                     </node>
                   </node>
                   <node concept="A3Dl8" id="6LfBX8Yg$Y5" role="10QFUM">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.trace.sandbox/models/org/iets3/core/trace/test/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.trace.sandbox/models/org/iets3/core/trace/test/behavior.mps
@@ -66,14 +66,14 @@
         <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
-      </concept>
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -113,9 +113,9 @@
                 </node>
               </node>
               <node concept="2qgKlT" id="1HLccB8wR7r" role="2OqNvi">
-                <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                <node concept="3TUQnm" id="1HLccB8wRdf" role="37wK5m">
-                  <ref role="3TV0OU" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                <node concept="35c_gC" id="3Q$zA1CDJcq" role="37wK5m">
+                  <ref role="35c_gD" to="tpck:h0TrEE$" resolve="INamedConcept" />
                 </node>
               </node>
             </node>
@@ -160,9 +160,9 @@
                 </node>
               </node>
               <node concept="2qgKlT" id="1HLccB8wS9W" role="2OqNvi">
-                <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                <node concept="3TUQnm" id="1HLccB8wS9X" role="37wK5m">
-                  <ref role="3TV0OU" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                <node concept="35c_gC" id="3Q$zA1CDJCP" role="37wK5m">
+                  <ref role="35c_gD" to="tpck:h0TrEE$" resolve="INamedConcept" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.trace/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.trace/models/plugin.mps
@@ -1031,7 +1031,7 @@
                           <ref role="3cqZAo" node="6_Ift$_DjDD" resolve="results" />
                         </node>
                         <node concept="liA8E" id="6_Ift$_DjDM" role="2OqNvi">
-                          <ref role="37wK5l" to="g4jo:J2bOg02Hc_" resolve="getSearchResults" />
+                          <ref role="37wK5l" to="g4jo:4mN_90IMjqo" resolve="getSearchResults2" />
                         </node>
                       </node>
                       <node concept="liA8E" id="6_Ift$_DjDN" role="2OqNvi">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/behavior.mps
@@ -127,9 +127,6 @@
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
-      <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
-        <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
-      </concept>
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC">
         <reference id="1139880128956" name="concept" index="1A9B2P" />
@@ -154,7 +151,9 @@
         <reference id="1139877738879" name="concept" index="1A0vxQ" />
       </concept>
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
-      <concept id="1182511038748" name="jetbrains.mps.lang.smodel.structure.Model_NodesIncludingImportedOperation" flags="nn" index="1j9C0f" />
+      <concept id="1182511038748" name="jetbrains.mps.lang.smodel.structure.Model_NodesIncludingImportedOperation" flags="nn" index="1j9C0f">
+        <child id="6750920497477143623" name="conceptArgument" index="3MHPCF" />
+      </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
@@ -303,16 +302,13 @@
           <node concept="2YIFZM" id="GJLa3qlEoR" role="3clFbG">
             <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
             <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
-            <node concept="2OqwBi" id="7Dcax7A9XSO" role="37wK5m">
-              <node concept="2OqwBi" id="7Dcax7A9UIN" role="2Oq$k0">
-                <node concept="2OqwBi" id="7Dcax7A9Ujb" role="2Oq$k0">
-                  <node concept="13iPFW" id="7Dcax7A9UcA" role="2Oq$k0" />
-                  <node concept="I4A8Y" id="7Dcax7A9UwK" role="2OqNvi" />
-                </node>
-                <node concept="1j9C0f" id="7Dcax7A9XCo" role="2OqNvi" />
+            <node concept="2OqwBi" id="7Dcax7A9UIN" role="37wK5m">
+              <node concept="2OqwBi" id="7Dcax7A9Ujb" role="2Oq$k0">
+                <node concept="13iPFW" id="7Dcax7A9UcA" role="2Oq$k0" />
+                <node concept="I4A8Y" id="7Dcax7A9UwK" role="2OqNvi" />
               </node>
-              <node concept="v3k3i" id="7Dcax7A9YPV" role="2OqNvi">
-                <node concept="25Kdxt" id="7XSydr1Gei" role="v3oSu">
+              <node concept="1j9C0f" id="7Dcax7A9XCo" role="2OqNvi">
+                <node concept="25Kdxt" id="46ME_lOVRpW" role="3MHPCF">
                   <node concept="2OqwBi" id="XlcHWd_qx4" role="25KhWn">
                     <node concept="37vLTw" id="7Dcax7A9Z3t" role="2Oq$k0">
                       <ref role="3cqZAo" node="GJLa3qlDPk" resolve="targetConcept" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/behavior.mps
@@ -11,6 +11,7 @@
     <import index="plfp" ref="r:82415404-e5c7-47c8-ae5b-951fc882e316(org.iets3.req.core.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="2c95" ref="r:5f7188a9-e7b4-4a2e-bef9-38d2cf379fdc(com.mbeddr.doc.structure)" />
+    <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="4gky" ref="r:e1dfab1d-c7a7-43e7-9f26-028afd483e82(com.mbeddr.doc.behavior)" implicit="true" />
   </imports>
@@ -51,6 +52,9 @@
       </concept>
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
@@ -102,6 +106,9 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
@@ -146,6 +153,7 @@
       <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
         <reference id="1139877738879" name="concept" index="1A0vxQ" />
       </concept>
+      <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
       <concept id="1182511038748" name="jetbrains.mps.lang.smodel.structure.Model_NodesIncludingImportedOperation" flags="nn" index="1j9C0f" />
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
@@ -267,23 +275,13 @@
       <node concept="3Tm1VV" id="7Dcax7A9U1N" role="1B3o_S" />
       <node concept="3clFbS" id="7Dcax7A9U36" role="3clF47">
         <node concept="3clFbF" id="7Dcax7A9UcG" role="3cqZAp">
-          <node concept="2OqwBi" id="7Dcax7A9XSO" role="3clFbG">
-            <node concept="2OqwBi" id="7Dcax7A9UIN" role="2Oq$k0">
-              <node concept="2OqwBi" id="7Dcax7A9Ujb" role="2Oq$k0">
-                <node concept="13iPFW" id="7Dcax7A9UcA" role="2Oq$k0" />
-                <node concept="I4A8Y" id="7Dcax7A9UwK" role="2OqNvi" />
+          <node concept="BsUDl" id="GJLa3qlEIe" role="3clFbG">
+            <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+            <node concept="2OqwBi" id="GJLa3qlF1J" role="37wK5m">
+              <node concept="37vLTw" id="GJLa3qlELz" role="2Oq$k0">
+                <ref role="3cqZAo" node="7Dcax7A9U37" resolve="targetConcept" />
               </node>
-              <node concept="1j9C0f" id="7Dcax7A9XCo" role="2OqNvi" />
-            </node>
-            <node concept="v3k3i" id="7Dcax7A9YPV" role="2OqNvi">
-              <node concept="25Kdxt" id="7XSydr1Gei" role="v3oSu">
-                <node concept="2OqwBi" id="XlcHWd_qx4" role="25KhWn">
-                  <node concept="37vLTw" id="7Dcax7A9Z3t" role="2Oq$k0">
-                    <ref role="3cqZAo" node="7Dcax7A9U37" resolve="targetConcept" />
-                  </node>
-                  <node concept="1rGIog" id="XlcHWd_qJH" role="2OqNvi" />
-                </node>
-              </node>
+              <node concept="1rGIog" id="GJLa3qlFiQ" role="2OqNvi" />
             </node>
           </node>
         </node>
@@ -294,6 +292,45 @@
       </node>
       <node concept="A3Dl8" id="7Dcax7A9U39" role="3clF45">
         <node concept="3Tqbb2" id="7Dcax7A9U3a" role="A3Ik2" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="GJLa3qlDOG" role="13h7CS">
+      <property role="TrG5h" value="visibleContentsOfType" />
+      <ref role="13i0hy" to="hwgx:79$zShlSHxZ" resolve="visibleContentsOfType" />
+      <node concept="3Tm1VV" id="GJLa3qlDOJ" role="1B3o_S" />
+      <node concept="3clFbS" id="GJLa3qlDPj" role="3clF47">
+        <node concept="3clFbF" id="GJLa3qlEiE" role="3cqZAp">
+          <node concept="2YIFZM" id="GJLa3qlEoR" role="3clFbG">
+            <ref role="37wK5l" to="o8zo:3jEbQoczdCs" resolve="forResolvableElements" />
+            <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+            <node concept="2OqwBi" id="7Dcax7A9XSO" role="37wK5m">
+              <node concept="2OqwBi" id="7Dcax7A9UIN" role="2Oq$k0">
+                <node concept="2OqwBi" id="7Dcax7A9Ujb" role="2Oq$k0">
+                  <node concept="13iPFW" id="7Dcax7A9UcA" role="2Oq$k0" />
+                  <node concept="I4A8Y" id="7Dcax7A9UwK" role="2OqNvi" />
+                </node>
+                <node concept="1j9C0f" id="7Dcax7A9XCo" role="2OqNvi" />
+              </node>
+              <node concept="v3k3i" id="7Dcax7A9YPV" role="2OqNvi">
+                <node concept="25Kdxt" id="7XSydr1Gei" role="v3oSu">
+                  <node concept="2OqwBi" id="XlcHWd_qx4" role="25KhWn">
+                    <node concept="37vLTw" id="7Dcax7A9Z3t" role="2Oq$k0">
+                      <ref role="3cqZAo" node="GJLa3qlDPk" resolve="targetConcept" />
+                    </node>
+                    <node concept="1rGIog" id="XlcHWd_qJH" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="GJLa3qlDPk" role="3clF46">
+        <property role="TrG5h" value="targetConcept" />
+        <node concept="3bZ5Sz" id="GJLa3qlDPl" role="1tU5fm" />
+      </node>
+      <node concept="3uibUv" id="GJLa3qlDPm" role="3clF45">
+        <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
       </node>
     </node>
     <node concept="13i0hz" id="7Dcax7AauE5" role="13h7CS">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/constraints.mps
@@ -95,6 +95,9 @@
       <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
         <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
       </concept>
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
@@ -102,9 +105,6 @@
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
-      </concept>
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -350,9 +350,9 @@
                     </node>
                   </node>
                   <node concept="2qgKlT" id="1F1F0IUZBZv" role="2OqNvi">
-                    <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                    <node concept="3TUQnm" id="1F1F0IUZBZw" role="37wK5m">
-                      <ref role="3TV0OU" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+                    <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                    <node concept="35c_gC" id="3Q$zA1CDLcm" role="37wK5m">
+                      <ref role="35c_gD" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/editor.mps
@@ -470,9 +470,6 @@
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
-      </concept>
       <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -2669,9 +2666,9 @@
                         </node>
                       </node>
                       <node concept="2qgKlT" id="3wHxcnxBRil" role="2OqNvi">
-                        <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                        <node concept="3TUQnm" id="3wHxcnxBRkh" role="37wK5m">
-                          <ref role="3TV0OU" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+                        <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                        <node concept="35c_gC" id="3Q$zA1CDNwI" role="37wK5m">
+                          <ref role="35c_gD" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
                         </node>
                       </node>
                     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.plugin/models/org/iets3/req/plugin/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.plugin/models/org/iets3/req/plugin/plugin.mps
@@ -286,9 +286,6 @@
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
-      </concept>
       <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -496,9 +493,9 @@
                 </node>
               </node>
               <node concept="2qgKlT" id="3wHxcnxBRil" role="2OqNvi">
-                <ref role="37wK5l" to="hwgx:6clJcrJXo2_" resolve="visibleContentsOfType" />
-                <node concept="3TUQnm" id="3wHxcnxBRkh" role="37wK5m">
-                  <ref role="3TV0OU" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+                <ref role="37wK5l" to="hwgx:3g6LnlWuSo8" resolve="visibleContentsOfTypeAsSequence" />
+                <node concept="35c_gC" id="3Q$zA1CDOoW" role="37wK5m">
+                  <ref role="35c_gD" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.doc.plugin/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.doc.plugin/models/plugin.mps
@@ -15,6 +15,7 @@
     <import index="34lm" ref="r:04cb519f-2059-4c60-9414-918c7823fd79(org.iets3.core.expr.doc.structure)" />
     <import index="srqo" ref="r:5957d4c9-cc37-4d16-870b-eb83bcfdff2c(org.iets3.core.expr.doc.behavior)" />
     <import index="upz5" ref="r:33366a6f-09e8-45e7-ae7f-cb8cf0c7ed05(jetbrains.mps.baseLanguage.tuples.runtime)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -106,7 +107,6 @@
       </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
-        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
@@ -404,49 +404,57 @@
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="2m0pXWN7Go" role="3cqZAp">
-          <node concept="3cpWsn" id="2m0pXWN7Gp" role="3cpWs9">
-            <property role="TrG5h" value="projectModels" />
-            <node concept="3uibUv" id="2m0pXWN7Gk" role="1tU5fm">
-              <ref role="3uigEE" to="wyt6:~Iterable" resolve="Iterable" />
-              <node concept="H_c77" id="2m0pXWNjUK" role="11_B2D" />
-            </node>
-            <node concept="2OqwBi" id="2m0pXWN7Gq" role="33vP2m">
-              <node concept="37vLTw" id="2m0pXWNbNf" role="2Oq$k0">
-                <ref role="3cqZAo" node="2m0pXWN9O5" resolve="project" />
+        <node concept="2Gpval" id="3Q$zA1CA23K" role="3cqZAp">
+          <node concept="2GrKxI" id="3Q$zA1CA23M" role="2Gsz3X">
+            <property role="TrG5h" value="module" />
+          </node>
+          <node concept="3clFbS" id="3Q$zA1CA23Q" role="2LFqv$">
+            <node concept="2Gpval" id="3Q$zA1CAaxI" role="3cqZAp">
+              <node concept="2GrKxI" id="3Q$zA1CAaxJ" role="2Gsz3X">
+                <property role="TrG5h" value="model" />
               </node>
-              <node concept="liA8E" id="2m0pXWN7Gs" role="2OqNvi">
-                <ref role="37wK5l" to="z1c3:~Project.getProjectModels()" resolve="getProjectModels" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2Gpval" id="2m0pXWNdlT" role="3cqZAp">
-          <node concept="2GrKxI" id="2m0pXWNdlV" role="2Gsz3X">
-            <property role="TrG5h" value="m" />
-          </node>
-          <node concept="37vLTw" id="2m0pXWNdOK" role="2GsD0m">
-            <ref role="3cqZAo" node="2m0pXWN7Gp" resolve="projectModels" />
-          </node>
-          <node concept="3clFbS" id="2m0pXWNdlZ" role="2LFqv$">
-            <node concept="3clFbF" id="2m0pXWNdXT" role="3cqZAp">
-              <node concept="2OqwBi" id="2m0pXWNePg" role="3clFbG">
-                <node concept="37vLTw" id="2m0pXWNdXS" role="2Oq$k0">
-                  <ref role="3cqZAo" node="2m0pXWNdwy" resolve="bookmarks" />
+              <node concept="2OqwBi" id="3Q$zA1CAi7A" role="2GsD0m">
+                <node concept="2GrUjf" id="3Q$zA1CAgS$" role="2Oq$k0">
+                  <ref role="2Gs0qQ" node="3Q$zA1CA23M" resolve="module" />
                 </node>
-                <node concept="X8dFx" id="2m0pXWNgb8" role="2OqNvi">
-                  <node concept="2OqwBi" id="2m0pXWNiLq" role="25WWJ7">
-                    <node concept="2GrUjf" id="2m0pXWNhjw" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="2m0pXWNdlV" resolve="m" />
+                <node concept="liA8E" id="3Q$zA1CAjhk" role="2OqNvi">
+                  <ref role="37wK5l" to="lui2:~SModule.getModels()" resolve="getModels" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="3Q$zA1CAaxL" role="2LFqv$">
+                <node concept="3clFbF" id="2m0pXWNdXT" role="3cqZAp">
+                  <node concept="2OqwBi" id="2m0pXWNePg" role="3clFbG">
+                    <node concept="37vLTw" id="2m0pXWNdXS" role="2Oq$k0">
+                      <ref role="3cqZAo" node="2m0pXWNdwy" resolve="bookmarks" />
                     </node>
-                    <node concept="2SmgA7" id="2m0pXWNm6S" role="2OqNvi">
-                      <node concept="chp4Y" id="2m0pXWNmrK" role="1dBWTz">
-                        <ref role="cht4Q" to="34lm:2m0pXWMyXx" resolve="IBookmark" />
+                    <node concept="X8dFx" id="2m0pXWNgb8" role="2OqNvi">
+                      <node concept="2OqwBi" id="2m0pXWNiLq" role="25WWJ7">
+                        <node concept="2SmgA7" id="2m0pXWNm6S" role="2OqNvi">
+                          <node concept="chp4Y" id="2m0pXWNmrK" role="1dBWTz">
+                            <ref role="cht4Q" to="34lm:2m0pXWMyXx" resolve="IBookmark" />
+                          </node>
+                        </node>
+                        <node concept="1eOMI4" id="3Q$zA1CAw$e" role="2Oq$k0">
+                          <node concept="10QFUN" id="3Q$zA1CAw$b" role="1eOMHV">
+                            <node concept="H_c77" id="3Q$zA1CAyFj" role="10QFUM" />
+                            <node concept="2GrUjf" id="3Q$zA1CAzs0" role="10QFUP">
+                              <ref role="2Gs0qQ" node="3Q$zA1CAaxJ" resolve="model" />
+                            </node>
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="2m0pXWN7Gq" role="2GsD0m">
+            <node concept="37vLTw" id="2m0pXWNbNf" role="2Oq$k0">
+              <ref role="3cqZAo" node="2m0pXWN9O5" resolve="project" />
+            </node>
+            <node concept="liA8E" id="2m0pXWN7Gs" role="2OqNvi">
+              <ref role="37wK5l" to="z1c3:~IProject.getProjectModules()" resolve="getProjectModules" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.mutable.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.mutable.interpreter/models/plugin.mps
@@ -182,16 +182,17 @@
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
+      <concept id="8866923313515890008" name="jetbrains.mps.lang.smodel.structure.AsNodeOperation" flags="nn" index="FGMqu" />
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
-      <concept id="1172323065820" name="jetbrains.mps.lang.smodel.structure.Node_GetConceptOperation" flags="nn" index="3NT_Vc" />
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
@@ -247,14 +248,17 @@
       <ref role="qq9wM" to="8lgj:4IV0h47Gcws" resolve="ContextArgExpr" />
       <node concept="3vetai" id="4IV0h47Nufk" role="3vQZUl">
         <node concept="3EllGN" id="4IV0h47NuDP" role="3vdyny">
-          <node concept="2OqwBi" id="4IV0h47OfhL" role="3ElVtu">
-            <node concept="2OqwBi" id="4IV0h47NuQb" role="2Oq$k0">
-              <node concept="oxGPV" id="4IV0h47NuF7" role="2Oq$k0" />
-              <node concept="3TrEf2" id="4IV0h47Nv7C" role="2OqNvi">
-                <ref role="3Tt5mk" to="8lgj:4IV0h47Gcwt" resolve="arg" />
+          <node concept="2OqwBi" id="GJLa3qki2w" role="3ElVtu">
+            <node concept="2OqwBi" id="4IV0h47OfhL" role="2Oq$k0">
+              <node concept="2OqwBi" id="4IV0h47NuQb" role="2Oq$k0">
+                <node concept="oxGPV" id="4IV0h47NuF7" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4IV0h47Nv7C" role="2OqNvi">
+                  <ref role="3Tt5mk" to="8lgj:4IV0h47Gcwt" resolve="arg" />
+                </node>
               </node>
+              <node concept="2yIwOk" id="GJLa3qkhMe" role="2OqNvi" />
             </node>
-            <node concept="3NT_Vc" id="4IV0h47OfOB" role="2OqNvi" />
+            <node concept="FGMqu" id="GJLa3qkik2" role="2OqNvi" />
           </node>
           <node concept="TvHiN" id="4IV0h47Nufq" role="3ElQJh" />
         </node>
@@ -780,16 +784,19 @@
                         </node>
                         <node concept="3EllGN" id="4IV0h47Pd7O" role="37vLTJ">
                           <node concept="TvHiN" id="4IV0h47Pd7P" role="3ElQJh" />
-                          <node concept="2OqwBi" id="4IV0h47Pd7Q" role="3ElVtu">
-                            <node concept="2OqwBi" id="4IV0h47Pd7R" role="2Oq$k0">
-                              <node concept="2GrUjf" id="4IV0h47Pd7S" role="2Oq$k0">
-                                <ref role="2Gs0qQ" node="4IV0h47Pd7H" resolve="cv" />
+                          <node concept="2OqwBi" id="3Q$zA1CEnvo" role="3ElVtu">
+                            <node concept="2OqwBi" id="4IV0h47Pd7Q" role="2Oq$k0">
+                              <node concept="2OqwBi" id="4IV0h47Pd7R" role="2Oq$k0">
+                                <node concept="2GrUjf" id="4IV0h47Pd7S" role="2Oq$k0">
+                                  <ref role="2Gs0qQ" node="4IV0h47Pd7H" resolve="cv" />
+                                </node>
+                                <node concept="2OwXpG" id="4IV0h47Pd7T" role="2OqNvi">
+                                  <ref role="2Oxat5" to="n9sl:4IV0h47l1DZ" resolve="arg" />
+                                </node>
                               </node>
-                              <node concept="2OwXpG" id="4IV0h47Pd7T" role="2OqNvi">
-                                <ref role="2Oxat5" to="n9sl:4IV0h47l1DZ" resolve="arg" />
-                              </node>
+                              <node concept="2yIwOk" id="3Q$zA1CEnpu" role="2OqNvi" />
                             </node>
-                            <node concept="3NT_Vc" id="4IV0h47Pd7U" role="2OqNvi" />
+                            <node concept="FGMqu" id="3Q$zA1CEnBX" role="2OqNvi" />
                           </node>
                         </node>
                       </node>
@@ -996,16 +1003,19 @@
                         </node>
                         <node concept="3EllGN" id="4IV0h47NxVD" role="37vLTJ">
                           <node concept="TvHiN" id="4IV0h47Nxv0" role="3ElQJh" />
-                          <node concept="2OqwBi" id="4IV0h47OgWH" role="3ElVtu">
-                            <node concept="2OqwBi" id="4IV0h47OgWI" role="2Oq$k0">
-                              <node concept="2GrUjf" id="4IV0h47OgWJ" role="2Oq$k0">
-                                <ref role="2Gs0qQ" node="4IV0h47NwY$" resolve="cv" />
+                          <node concept="2OqwBi" id="3Q$zA1CEnQd" role="3ElVtu">
+                            <node concept="2OqwBi" id="4IV0h47OgWH" role="2Oq$k0">
+                              <node concept="2OqwBi" id="4IV0h47OgWI" role="2Oq$k0">
+                                <node concept="2GrUjf" id="4IV0h47OgWJ" role="2Oq$k0">
+                                  <ref role="2Gs0qQ" node="4IV0h47NwY$" resolve="cv" />
+                                </node>
+                                <node concept="2OwXpG" id="4IV0h47OgWK" role="2OqNvi">
+                                  <ref role="2Oxat5" to="n9sl:4IV0h47l1DZ" resolve="arg" />
+                                </node>
                               </node>
-                              <node concept="2OwXpG" id="4IV0h47OgWK" role="2OqNvi">
-                                <ref role="2Oxat5" to="n9sl:4IV0h47l1DZ" resolve="arg" />
-                              </node>
+                              <node concept="2yIwOk" id="3Q$zA1CEnJd" role="2OqNvi" />
                             </node>
-                            <node concept="3NT_Vc" id="4IV0h47OgWL" role="2OqNvi" />
+                            <node concept="FGMqu" id="3Q$zA1CEnYL" role="2OqNvi" />
                           </node>
                         </node>
                       </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.temporal.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.temporal.interpreter/models/plugin.mps
@@ -231,7 +231,11 @@
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="8866923313515890008" name="jetbrains.mps.lang.smodel.structure.AsNodeOperation" flags="nn" index="FGMqu" />
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
@@ -248,9 +252,6 @@
       </concept>
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
-      </concept>
-      <concept id="1172424058054" name="jetbrains.mps.lang.smodel.structure.ConceptRefExpression" flags="nn" index="3TUQnm">
-        <reference id="1172424100906" name="conceptDeclaration" index="3TV0OU" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -442,8 +443,11 @@
                   <ref role="rqRob" to="l462:3rApyZ4E9We" resolve="value" />
                 </node>
                 <node concept="3EllGN" id="3rApyZ4ES0a" role="37vLTJ">
-                  <node concept="3TUQnm" id="3rApyZ4ETmY" role="3ElVtu">
-                    <ref role="3TV0OU" to="l462:3rApyZ4E9Wd" resolve="DefaultSliceValueExpr" />
+                  <node concept="2OqwBi" id="3Q$zA1CBJyh" role="3ElVtu">
+                    <node concept="35c_gC" id="3Q$zA1CBJiZ" role="2Oq$k0">
+                      <ref role="35c_gD" to="l462:3rApyZ4E9Wd" resolve="DefaultSliceValueExpr" />
+                    </node>
+                    <node concept="FGMqu" id="3Q$zA1CBJIW" role="2OqNvi" />
                   </node>
                   <node concept="TvHiN" id="3rApyZ4ERGf" role="3ElQJh" />
                 </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/models/org.iets3.core.expr.tracing.plugin.plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/models/org.iets3.core.expr.tracing.plugin.plugin.mps
@@ -5082,13 +5082,14 @@
                               <ref role="37wK5l" to="tqvn:~TemporaryModels.getInstance()" resolve="getInstance" />
                             </node>
                             <node concept="liA8E" id="6DRSV4dGwGL" role="2OqNvi">
-                              <ref role="37wK5l" to="tqvn:~TemporaryModels.create(boolean,boolean,jetbrains.mps.smodel.tempmodel.TempModuleOptions)" resolve="create" />
+                              <ref role="37wK5l" to="tqvn:~TemporaryModels.create(boolean,boolean,java.lang.String,jetbrains.mps.smodel.tempmodel.TempModuleOptions)" resolve="create" />
                               <node concept="3clFbT" id="6DRSV4dGwGM" role="37wK5m">
                                 <property role="3clFbU" value="true" />
                               </node>
                               <node concept="3clFbT" id="6DRSV4dGwGN" role="37wK5m">
                                 <property role="3clFbU" value="false" />
                               </node>
+                              <node concept="10Nm6u" id="3Q$zA1CCHH0" role="37wK5m" />
                               <node concept="2YIFZM" id="6DRSV4dGwGO" role="37wK5m">
                                 <ref role="37wK5l" to="tqvn:~TempModuleOptions.forDefaultModule()" resolve="forDefaultModule" />
                                 <ref role="1Pybhc" to="tqvn:~TempModuleOptions" resolve="TempModuleOptions" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -7127,7 +7127,7 @@
         </node>
         <node concept="1SiIV0" id="6LJ5wQxCDvl" role="3bR37C">
           <node concept="3bR9La" id="6LJ5wQxCDvm" role="1SiIV1">
-            <ref role="3bR37D" to="90a9:6860Y5A00Lp" resolve="com.mbeddr.mpsutil.serializer.xml" />
+            <ref role="3bR37D" to="90a9:6860Y5A00Lp" resolve="de.itemis.mps.utils.serializer.xml" />
           </node>
         </node>
         <node concept="1BupzO" id="1RMC8GHEwND" role="3bR31x">
@@ -14107,7 +14107,7 @@
       </node>
       <node concept="1SiIV0" id="1YwzPHwBxrS" role="3bR37C">
         <node concept="3bR9La" id="1YwzPHwBxrT" role="1SiIV1">
-          <ref role="3bR37D" to="90a9:6860Y5A00Lp" resolve="com.mbeddr.mpsutil.serializer.xml" />
+          <ref role="3bR37D" to="90a9:6860Y5A00Lp" resolve="de.itemis.mps.utils.serializer.xml" />
         </node>
       </node>
       <node concept="1BupzO" id="1YwzPHwBxrU" role="3bR31x">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -13940,8 +13940,8 @@
     <property role="TrG5h" value="iets3.os.prebuild" />
     <property role="turDy" value="prebuild.xml" />
     <node concept="2igEWh" id="sIFyDYHT4z" role="1hWBAP">
-      <property role="3UIfUI" value="10000" />
       <property role="1YnnvL" value="1024" />
+      <property role="3UIfUI" value="10000" />
     </node>
     <node concept="1E1JtD" id="1YwzPHwBxpc" role="3989C9">
       <property role="BnDLt" value="true" />

--- a/code/languages/org.iets3.opensource/solutions/test.ex.core.expr.genjava/models/messages@tests.mps
+++ b/code/languages/org.iets3.opensource/solutions/test.ex.core.expr.genjava/models/messages@tests.mps
@@ -90,7 +90,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <reference id="2032654994493517823" name="scoper" index="2HwdWd" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
@@ -177,7 +176,6 @@
         <child id="4026566441518474145" name="args" index="1WPDXT" />
       </concept>
       <concept id="4026566441518284472" name="org.iets3.core.expr.messages.structure.MessageTarget" flags="ng" index="1WPo9w">
-        <property id="5299123466390648616" name="messageValue_DEPRECATED" index="MFfev" />
         <reference id="4026566441518284476" name="message" index="1WPo9$" />
         <child id="4026566441519855930" name="args" index="1WFony" />
       </concept>
@@ -225,7 +223,6 @@
   </registry>
   <node concept="_iOnU" id="3vxfdxbrcas">
     <property role="TrG5h" value="messages" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <ref role="2HwdWd" node="1CNpG_h50DB" resolve="Data" />
     <node concept="1aga60" id="4AahbtV2zVo" role="_iOnB">
@@ -234,7 +231,6 @@
       <node concept="1aduha" id="4AahbtV2zZB" role="1ahQXP">
         <node concept="1QScDb" id="4AahbtV2$0Y" role="1aduh9">
           <node concept="1WPo9w" id="4AahbtV2$be" role="1QScD9">
-            <property role="MFfev" value="false" />
             <ref role="1WPo9$" node="3vxfdxbrKAj" resolve="m1" />
           </node>
           <node concept="1WPpZc" id="4AahbtV2$0v" role="30czhm">
@@ -271,7 +267,6 @@
               <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
             </node>
             <node concept="1WPo9w" id="4AahbtV2$bB" role="1QScD9">
-              <property role="MFfev" value="false" />
               <ref role="1WPo9$" node="3vxfdxbrKAj" resolve="m1" />
             </node>
           </node>
@@ -287,7 +282,6 @@
           <node concept="NjiR8" id="7OtDX6qlgNi" role="1QScD9" />
           <node concept="1QScDb" id="3vxfdxbs7eB" role="30czhm">
             <node concept="1WPo9w" id="3vxfdxbs7iJ" role="1QScD9">
-              <property role="MFfev" value="false" />
               <ref role="1WPo9$" node="3vxfdxbrKAQ" resolve="m2" />
             </node>
             <node concept="1WPpZc" id="3vxfdxbs7eD" role="30czhm">
@@ -306,7 +300,6 @@
           <node concept="NjiR8" id="7OtDX6qlh5K" role="1QScD9" />
           <node concept="1QScDb" id="3vxfdxbs7f6" role="30czhm">
             <node concept="1WPo9w" id="3vxfdxbs7jj" role="1QScD9">
-              <property role="MFfev" value="false" />
               <ref role="1WPo9$" node="3vxfdxbrKCL" resolve="m3" />
             </node>
             <node concept="1WPpZc" id="3vxfdxbs7f8" role="30czhm">
@@ -403,7 +396,6 @@
           <node concept="NjiR8" id="4AahbtUNAHD" role="1QScD9" />
           <node concept="1QScDb" id="3vxfdxbtTgw" role="30czhm">
             <node concept="1WPo9w" id="3vxfdxbtTgx" role="1QScD9">
-              <property role="MFfev" value="false" />
               <ref role="1WPo9$" node="3vxfdxbthSE" resolve="m5" />
               <node concept="30bXRB" id="3vxfdxbtTqq" role="1WFony">
                 <property role="30bXRw" value="33" />
@@ -651,7 +643,6 @@
         <node concept="InuEK" id="4AahbtVbbGs" role="I61D1">
           <node concept="1QScDb" id="4AahbtVRMRz" role="2izrR8">
             <node concept="1WPo9w" id="4AahbtVRNhJ" role="1QScD9">
-              <property role="MFfev" value="false" />
               <ref role="1WPo9$" node="4AahbtVRLW6" resolve="xeey" />
               <node concept="XrbUJ" id="4AahbtVRNmn" role="1WFony">
                 <ref role="XrbUP" node="4AahbtVbbGn" resolve="x" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/algebraic@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/algebraic@tests.mps
@@ -150,7 +150,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -349,7 +348,6 @@
   <node concept="_iOnU" id="5a_u3OyP53I">
     <property role="TrG5h" value="algebraic" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="1KraG_" id="5a_u3OyMFHu" role="_iOnB">
       <property role="TrG5h" value="Exp" />
       <node concept="1KraX1" id="5a_u3OyMFHz" role="1KraX0">
@@ -1268,7 +1266,6 @@
   <node concept="_iOnU" id="28$LOSAPZOM">
     <property role="TrG5h" value="algebraicQuoting" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="1KraG_" id="28$LOSAPZON" role="_iOnB">
       <property role="TrG5h" value="Exp" />
       <node concept="1KraX1" id="28$LOSAPZOO" role="1KraX0">
@@ -1469,7 +1466,6 @@
   <node concept="_iOnU" id="28$LOSAdrbI">
     <property role="TrG5h" value="algebraicTrafo" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="1KraG_" id="28$LOSAdrbJ" role="_iOnB">
       <property role="TrG5h" value="Exp" />
       <node concept="1KraX1" id="28$LOSAdrbK" role="1KraX0">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/dataflow@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/dataflow@tests.mps
@@ -64,7 +64,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
     </language>
@@ -201,7 +200,6 @@
   </registry>
   <node concept="_iOnU" id="5I_8B5ugs0i">
     <property role="TrG5h" value="Examples" />
-    <property role="2SXJ1i" value="true" />
     <node concept="_ixoA" id="2nByCcxCZHA" role="_iOnB" />
     <node concept="_ixoA" id="2nByCcxD6kM" role="_iOnB" />
     <node concept="1aga60" id="2nByCcxCWbO" role="_iOnB">
@@ -4752,7 +4750,6 @@
   </node>
   <node concept="_iOnU" id="4qjJWfVq$ZE">
     <property role="TrG5h" value="BasicBlocks" />
-    <property role="2SXJ1i" value="true" />
     <node concept="1KScRn" id="4YhD5cZsw6X" role="_iOnB">
       <property role="TrG5h" value="plus" />
       <property role="1k_erx" value="+" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/datetime@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/datetime@tests.mps
@@ -96,7 +96,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -326,7 +325,6 @@
   <node concept="_iOnU" id="26CArgU5oFZ">
     <property role="1XBH2A" value="true" />
     <property role="TrG5h" value="date" />
-    <property role="2SXJ1i" value="true" />
     <node concept="2zPypq" id="26CArgU3lPZ" role="_iOnB">
       <property role="TrG5h" value="feb_1_2017" />
       <property role="0Rz4W" value="579282025" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/math@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/math@tests.mps
@@ -91,7 +91,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -235,7 +234,6 @@
   </node>
   <node concept="_iOnU" id="1yW0h04Clb1">
     <property role="TrG5h" value="math" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="2zPypq" id="1ghGxCiS9JQ" role="_iOnB">
       <property role="TrG5h" value="rat" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/messages@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/messages@tests.mps
@@ -189,7 +189,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <reference id="2032654994493517823" name="scoper" index="2HwdWd" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
@@ -284,7 +283,6 @@
         <child id="4026566441518474145" name="args" index="1WPDXT" />
       </concept>
       <concept id="4026566441518284472" name="org.iets3.core.expr.messages.structure.MessageTarget" flags="ng" index="1WPo9w">
-        <property id="5299123466390648616" name="messageValue_DEPRECATED" index="MFfev" />
         <reference id="4026566441518284476" name="message" index="1WPo9$" />
         <child id="4026566441519855930" name="args" index="1WFony" />
       </concept>
@@ -353,7 +351,6 @@
   </registry>
   <node concept="_iOnU" id="3vxfdxbrcas">
     <property role="TrG5h" value="messages" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <ref role="2HwdWd" node="1CNpG_h50DB" resolve="Data" />
     <node concept="1aga60" id="4AahbtV2zVo" role="_iOnB">
@@ -362,7 +359,6 @@
       <node concept="1aduha" id="4AahbtV2zZB" role="1ahQXP">
         <node concept="1QScDb" id="4AahbtV2$0Y" role="1aduh9">
           <node concept="1WPo9w" id="4AahbtV2$be" role="1QScD9">
-            <property role="MFfev" value="false" />
             <ref role="1WPo9$" node="3vxfdxbrKAj" resolve="m1" />
           </node>
           <node concept="1WPpZc" id="4AahbtV2$0v" role="30czhm">
@@ -423,7 +419,6 @@
               <ref role="1WPpZZ" node="3vxfdxbret3" resolve="Messages" />
             </node>
             <node concept="1WPo9w" id="4AahbtV2$bB" role="1QScD9">
-              <property role="MFfev" value="false" />
               <ref role="1WPo9$" node="3vxfdxbrKAj" resolve="m1" />
             </node>
           </node>
@@ -447,7 +442,6 @@
               <node concept="NlJPO" id="4AahbtURxg3" role="1QScD9" />
               <node concept="1QScDb" id="4AahbtURx4f" role="30czhm">
                 <node concept="1WPo9w" id="4AahbtURx4g" role="1QScD9">
-                  <property role="MFfev" value="false" />
                   <ref role="1WPo9$" node="3vxfdxbrKAj" resolve="m1" />
                 </node>
                 <node concept="1WPpZc" id="4AahbtURx4h" role="30czhm">
@@ -466,7 +460,6 @@
           <node concept="NjiR8" id="7OtDX6qlCJ2" role="1QScD9" />
           <node concept="1QScDb" id="3vxfdxbs7eB" role="30czhm">
             <node concept="1WPo9w" id="3vxfdxbs7iJ" role="1QScD9">
-              <property role="MFfev" value="false" />
               <ref role="1WPo9$" node="3vxfdxbrKAQ" resolve="m2" />
             </node>
             <node concept="1WPpZc" id="3vxfdxbs7eD" role="30czhm">
@@ -485,7 +478,6 @@
           <node concept="NjiR8" id="7OtDX6qlD1i" role="1QScD9" />
           <node concept="1QScDb" id="3vxfdxbs7f6" role="30czhm">
             <node concept="1WPo9w" id="3vxfdxbs7jj" role="1QScD9">
-              <property role="MFfev" value="false" />
               <ref role="1WPo9$" node="3vxfdxbrKCL" resolve="m3" />
             </node>
             <node concept="1WPpZc" id="3vxfdxbs7f8" role="30czhm">
@@ -582,7 +574,6 @@
           <node concept="MxAYs" id="4AahbtV3fgs" role="1QScD9" />
           <node concept="1QScDb" id="4AahbtV3f1_" role="30czhm">
             <node concept="1WPo9w" id="4AahbtV3f1A" role="1QScD9">
-              <property role="MFfev" value="false" />
               <ref role="1WPo9$" node="3vxfdxbthSx" resolve="m4" />
               <node concept="30bXRB" id="4AahbtV3f1B" role="1WFony">
                 <property role="30bXRw" value="42" />
@@ -620,7 +611,6 @@
             <node concept="MxAYs" id="4AahbtV85bD" role="1QScD9" />
             <node concept="1QScDb" id="4AahbtV85bE" role="30czhm">
               <node concept="1WPo9w" id="4AahbtV85bF" role="1QScD9">
-                <property role="MFfev" value="false" />
                 <ref role="1WPo9$" node="3vxfdxbthSx" resolve="m4" />
                 <node concept="30bXRB" id="4AahbtV85bG" role="1WFony">
                   <property role="30bXRw" value="42" />
@@ -648,7 +638,6 @@
           <node concept="NjiR8" id="4AahbtUNAHD" role="1QScD9" />
           <node concept="1QScDb" id="3vxfdxbtTgw" role="30czhm">
             <node concept="1WPo9w" id="3vxfdxbtTgx" role="1QScD9">
-              <property role="MFfev" value="false" />
               <ref role="1WPo9$" node="3vxfdxbthSE" resolve="m5" />
               <node concept="30bXRB" id="3vxfdxbtTqq" role="1WFony">
                 <property role="30bXRw" value="33" />
@@ -896,7 +885,6 @@
         <node concept="InuEK" id="4AahbtVbbGs" role="I61D1">
           <node concept="1QScDb" id="4AahbtVRMRz" role="2izrR8">
             <node concept="1WPo9w" id="4AahbtVRNhJ" role="1QScD9">
-              <property role="MFfev" value="false" />
               <ref role="1WPo9$" node="4AahbtVRLW6" resolve="xeey" />
               <node concept="XrbUJ" id="4AahbtVRNmn" role="1WFony">
                 <ref role="XrbUP" node="4AahbtVbbGn" resolve="x" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/mutable@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/mutable@tests.mps
@@ -360,7 +360,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -673,7 +672,6 @@
   </registry>
   <node concept="_iOnU" id="79jc6Yz$UXd">
     <property role="TrG5h" value="mutable_tx2" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <property role="3GE5qa" value="tx" />
     <node concept="2zPypq" id="79jc6Yz$UXm" role="_iOnB">
@@ -873,7 +871,6 @@
   </node>
   <node concept="_iOnU" id="3GdqffC8MiJ">
     <property role="TrG5h" value="mutable_tx" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <property role="3GE5qa" value="tx" />
     <node concept="1WbbD7" id="35BERW$gp9l" role="_iOnB">
@@ -1492,7 +1489,6 @@
   </node>
   <node concept="_iOnU" id="7$TgoCYai8P">
     <property role="TrG5h" value="B_statemachinesAuto" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <property role="3GE5qa" value="sm" />
     <node concept="174hOD" id="7Z_fDCwiQCg" role="_iOnB">
@@ -1873,7 +1869,6 @@
   </node>
   <node concept="_iOnU" id="3GdqffBKPkQ">
     <property role="TrG5h" value="mutable_boxes" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <property role="3GE5qa" value="mutable" />
     <node concept="2zPypq" id="3GdqffBKPpQ" role="_iOnB">
@@ -2444,7 +2439,6 @@
   </node>
   <node concept="_iOnU" id="35BERWyOOpU">
     <property role="TrG5h" value="mutable_globals" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <property role="3GE5qa" value="mutable" />
     <node concept="2zPypq" id="35BERWyOOpV" role="_iOnB">
@@ -2593,7 +2587,6 @@
   </node>
   <node concept="_iOnU" id="79jc6YzLq4C">
     <property role="TrG5h" value="mutable_Demo" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <property role="3GE5qa" value="mutable" />
     <node concept="2zPypq" id="79jc6YzLq4D" role="_iOnB">
@@ -3260,7 +3253,6 @@
   </node>
   <node concept="_iOnU" id="1RzljfOgq38">
     <property role="TrG5h" value="mutable_tx3" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <property role="3GE5qa" value="tx" />
     <node concept="2zPypq" id="1RzljfOgq39" role="_iOnB">
@@ -11074,7 +11066,6 @@
   </node>
   <node concept="_iOnU" id="7Z_fDCwiPc0">
     <property role="TrG5h" value="A_statemachinesBasic" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <property role="3GE5qa" value="sm" />
     <node concept="1WbbD7" id="7Z_fDCwiPc1" role="_iOnB">
@@ -12280,7 +12271,6 @@
     <property role="1XBH2A" value="true" />
     <property role="TrG5h" value="REPLDemo" />
     <property role="3GE5qa" value="repl" />
-    <property role="2SXJ1i" value="true" />
     <node concept="2zPypq" id="7bd8pklaJq6" role="_iOnB">
       <property role="TrG5h" value="aNumber" />
       <node concept="30bXRB" id="7bd8pklaJql" role="2zPyp_">
@@ -15231,7 +15221,6 @@
   </node>
   <node concept="_iOnU" id="31BLocd6QAm">
     <property role="TrG5h" value="updateCheck" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <property role="3GE5qa" value="mutable" />
     <node concept="1Ws0TD" id="31BLocd6YX5" role="_iOnB">
@@ -16930,7 +16919,6 @@
   </node>
   <node concept="_iOnU" id="2zpAVpBZYrk">
     <property role="TrG5h" value="boxes" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <property role="3GE5qa" value="boxes" />
     <node concept="2zPypq" id="2zpAVpBZYrl" role="_iOnB">
@@ -17588,8 +17576,6 @@
           <node concept="15qgo_" id="3sNJH551L8Y" role="30czhm">
             <node concept="3sNe5_" id="3sNJH551L9b" role="15qgo$">
               <node concept="1DGDPD" id="3sNJH551L9w" role="3sNe5$">
-                <node concept="30bdrU" id="3sNJH551Lan" role="1bPNon" />
-                <node concept="30bXR$" id="3sNJH551Lb4" role="1bPNsv" />
                 <node concept="30bdrU" id="3JZRUPdr4HE" role="1DGDPC" />
                 <node concept="30bXR$" id="3JZRUPdr4Kx" role="1DGDPA" />
               </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/operatorgroup@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/operatorgroup@tests.mps
@@ -49,7 +49,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -82,7 +81,6 @@
   </node>
   <node concept="_iOnU" id="6WstIz8wNvD">
     <property role="TrG5h" value="logicalgroups" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="2zPypq" id="6WstIz8Gbtx" role="_iOnB">
       <property role="TrG5h" value="one" />
@@ -342,7 +340,6 @@
   </node>
   <node concept="_iOnU" id="7rdMSLlrdN6">
     <property role="TrG5h" value="arithgroups" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="2zPypq" id="7rdMSLlrdN7" role="_iOnB">
       <property role="TrG5h" value="one" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.alt@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.alt@tests.mps
@@ -85,7 +85,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -159,7 +158,6 @@
   </registry>
   <node concept="_iOnU" id="3PrmTp69tvG">
     <property role="TrG5h" value="alt" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="_ixoA" id="ucawTYfJSb" role="_iOnB" />
     <node concept="1aga60" id="3PrmTp69tvH" role="_iOnB">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.applicationExamples@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.applicationExamples@tests.mps
@@ -88,7 +88,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -212,7 +211,6 @@
   <node concept="_iOnU" id="5ElkanPNlMT">
     <property role="TrG5h" value="temperature" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="1Ws0TD" id="5ElkanPNlMU" role="_iOnB">
       <property role="1WsWdv" value="Stuff used only in the UI-related code" />
     </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.base@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.base@tests.mps
@@ -126,7 +126,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -865,7 +864,6 @@
   </node>
   <node concept="_iOnU" id="5jYrMSmCNyr">
     <property role="TrG5h" value="base2" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="1Ws0TD" id="3PrmTp6egdk" role="_iOnB">
       <property role="1WsWdv" value="expr.base tests which are not supported by c++ interpreter" />
@@ -1118,7 +1116,6 @@
   <node concept="_iOnU" id="3MHhZL0BptG">
     <property role="TrG5h" value="binary" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="_fkuM" id="1MPB7epHrgD" role="_iOnB">
       <property role="TrG5h" value="logic" />
       <node concept="_fkuZ" id="1MPB7epMJ17" role="_fkp5">
@@ -2139,7 +2136,6 @@
   </node>
   <node concept="_iOnU" id="6HHp2WmT$Y1">
     <property role="TrG5h" value="logic" />
-    <property role="2SXJ1i" value="true" />
     <node concept="_fkuM" id="6HHp2WmT$Y2" role="_iOnB">
       <property role="TrG5h" value="logic" />
       <node concept="_fkuZ" id="6HHp2WmUY1S" role="_fkp5">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.collections@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.collections@tests.mps
@@ -157,9 +157,7 @@
       <concept id="606861080870797309" name="org.iets3.core.expr.base.structure.IfElseSection" flags="ng" index="pf3Wd">
         <child id="606861080870797310" name="expr" index="pf3We" />
       </concept>
-      <concept id="2390066428848651932" name="org.iets3.core.expr.base.structure.BangOp" flags="ng" index="wdKpt">
-        <child id="2390066428848651933" name="optionValue" index="wdKps" />
-      </concept>
+      <concept id="2390066428848651932" name="org.iets3.core.expr.base.structure.BangOp" flags="ng" index="wdKpt" />
       <concept id="7089558164905593724" name="org.iets3.core.expr.base.structure.IOptionallyTyped" flags="ng" index="2zM23E">
         <child id="7089558164905593725" name="type" index="2zM23F" />
       </concept>
@@ -248,7 +246,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="8477405154719741309" name="showTypes" index="35xRTJ" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
@@ -397,7 +394,6 @@
   <node concept="_iOnU" id="6HHp2WmUZLJ">
     <property role="TrG5h" value="collections" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <property role="35xRTJ" value="true" />
     <node concept="_ixoA" id="G5D_q$Ks2d" role="_iOnB" />
     <node concept="_ixoA" id="3tudP_B0u4K" role="_iOnB" />
@@ -8955,46 +8951,6 @@
         <node concept="_fku$" id="7RvhnOBCsWI" role="_fkur" />
         <node concept="1QScDb" id="7RvhnOBCsWJ" role="_fkuY">
           <node concept="wdKpt" id="24oBF3$qrMM" role="30czhm">
-            <node concept="1QScDb" id="7RvhnOBCsWL" role="wdKps">
-              <node concept="3iB7TU" id="7RvhnOBCsWM" role="1QScD9" />
-              <node concept="1QScDb" id="7RvhnOBCsWN" role="30czhm">
-                <node concept="22cOCA" id="7RvhnOBCsWO" role="1QScD9">
-                  <node concept="22cOCE" id="7RvhnOBCsWP" role="22cODC">
-                    <property role="TrG5h" value="num" />
-                    <node concept="1QScDb" id="7RvhnOBCsWQ" role="22cOCG">
-                      <node concept="3o_JK" id="7RvhnOBCsWR" role="1QScD9">
-                        <ref role="3o_JH" node="7RvhnOBCsNT" resolve="n" />
-                      </node>
-                      <node concept="22msUl" id="7RvhnOBCsWS" role="30czhm" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3iBYfx" id="7RvhnOBCsWT" role="30czhm">
-                  <node concept="2S399m" id="7RvhnOBCsWU" role="3iBYfI">
-                    <node concept="2Ss9cW" id="7RvhnOBCsWV" role="2S399n">
-                      <ref role="2Ss9cX" node="7RvhnOBCsNS" resolve="item" />
-                    </node>
-                    <node concept="30bXRB" id="7RvhnOBCsWW" role="2S399l">
-                      <property role="30bXRw" value="1" />
-                    </node>
-                    <node concept="30bdrP" id="7RvhnOBCsWX" role="2S399l">
-                      <property role="30bdrQ" value="1" />
-                    </node>
-                  </node>
-                  <node concept="2S399m" id="7RvhnOBCsWY" role="3iBYfI">
-                    <node concept="2Ss9cW" id="7RvhnOBCsWZ" role="2S399n">
-                      <ref role="2Ss9cX" node="7RvhnOBCsNS" resolve="item" />
-                    </node>
-                    <node concept="30bXRB" id="7RvhnOBCsX0" role="2S399l">
-                      <property role="30bXRw" value="2" />
-                    </node>
-                    <node concept="30bdrP" id="7RvhnOBCsX1" role="2S399l">
-                      <property role="30bdrQ" value="2" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="1QScDb" id="7B4QWue4psu" role="30czhm">
               <node concept="3iB7TU" id="7B4QWue57dc" role="1QScD9" />
               <node concept="1QScDb" id="7B4QWue1F$B" role="30czhm">
@@ -12876,25 +12832,6 @@
         <node concept="_fku$" id="7RvhnOBM9Lw" role="_fkur" />
         <node concept="1QScDb" id="7RvhnOBM9Lx" role="_fkuY">
           <node concept="wdKpt" id="24oBF3_ezNc" role="30czhm">
-            <node concept="1QScDb" id="7RvhnOBM9Lz" role="wdKps">
-              <node concept="3iB7TU" id="7Pk458FYWEt" role="1QScD9" />
-              <node concept="1QScDb" id="7RvhnOBM9L_" role="30czhm">
-                <node concept="22cOCA" id="7RvhnOBM9LA" role="1QScD9">
-                  <node concept="22cOCE" id="7RvhnOBM9LB" role="22cODC">
-                    <property role="TrG5h" value="num" />
-                    <node concept="1QScDb" id="7RvhnOBM9LC" role="22cOCG">
-                      <node concept="3o_JK" id="7RvhnOBM9LD" role="1QScD9">
-                        <ref role="3o_JH" node="7RvhnOBCsNT" resolve="n" />
-                      </node>
-                      <node concept="22msUl" id="7RvhnOBM9LE" role="30czhm" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="_emDc" id="7RvhnOBO2js" role="30czhm">
-                  <ref role="_emDf" node="7RvhnOBNWT$" resolve="l4" />
-                </node>
-              </node>
-            </node>
             <node concept="1QScDb" id="7B4QWue9KRS" role="30czhm">
               <node concept="3iB7TU" id="7B4QWueavlm" role="1QScD9" />
               <node concept="1QScDb" id="7B4QWue6pL6" role="30czhm">
@@ -16275,25 +16212,6 @@
           </node>
           <node concept="1QScDb" id="7bfEHZ_ILN1" role="1aduh9">
             <node concept="wdKpt" id="24oBF3_5t82" role="30czhm">
-              <node concept="1QScDb" id="7bfEHZ_ILN3" role="wdKps">
-                <node concept="3iB7TU" id="7bfEHZ_ILN4" role="1QScD9" />
-                <node concept="1QScDb" id="7bfEHZ_ILN5" role="30czhm">
-                  <node concept="22cOCA" id="7bfEHZ_ILN6" role="1QScD9">
-                    <node concept="22cOCE" id="7bfEHZ_ILN7" role="22cODC">
-                      <property role="TrG5h" value="num" />
-                      <node concept="1QScDb" id="7bfEHZ_ILN8" role="22cOCG">
-                        <node concept="3o_JK" id="7bfEHZ_ILN9" role="1QScD9">
-                          <ref role="3o_JH" node="7RvhnOBCsNT" resolve="n" />
-                        </node>
-                        <node concept="22msUl" id="7bfEHZ_ILNa" role="30czhm" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="1adzI2" id="1Voj9wmHZjc" role="30czhm">
-                    <ref role="1adwt6" node="1Voj9wmH8Y8" resolve="v4" />
-                  </node>
-                </node>
-              </node>
               <node concept="1QScDb" id="7B4QWuecG2j" role="30czhm">
                 <node concept="3iB7TU" id="7B4QWuedqMB" role="1QScD9" />
                 <node concept="1QScDb" id="7B4QWueazbq" role="30czhm">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.contracts@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.contracts@tests.mps
@@ -134,7 +134,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -283,7 +282,6 @@
   </registry>
   <node concept="_iOnU" id="KaZMgy69hp">
     <property role="TrG5h" value="contracts" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="1WbbD7" id="1EIbarK3KGI" role="_iOnB">
       <property role="TrG5h" value="BiggerThanTen" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.datatablegen@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.datatablegen@tests.mps
@@ -36,7 +36,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -108,7 +107,6 @@
   <node concept="_iOnU" id="28$LOSAPZOM">
     <property role="TrG5h" value="TestsForDataTableGenerator" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="_ixoA" id="6wzrxL2Tkns" role="_iOnB" />
     <node concept="3CkkTf" id="6wzrxL2VwCV" role="_iOnB">
       <property role="TrG5h" value="Table" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.dectabs@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.dectabs@tests.mps
@@ -112,7 +112,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -210,7 +209,6 @@
   </registry>
   <node concept="_iOnU" id="6OunYCfiz1J">
     <property role="TrG5h" value="utils_dectab_ranges" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="1aga60" id="5crSXLqhzU" role="_iOnB">
       <property role="TrG5h" value="decideRanges" />
@@ -406,7 +404,6 @@
   </node>
   <node concept="_iOnU" id="5crSXMhjI0">
     <property role="TrG5h" value="utils_dectab_ranges_1" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="1aga60" id="6OunYCfi$iC" role="_iOnB">
       <property role="TrG5h" value="testInt" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.enums@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.enums@tests.mps
@@ -91,7 +91,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -235,7 +234,6 @@
   <node concept="_iOnU" id="67Y8mp$FfMg">
     <property role="TrG5h" value="enums" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="1Ws0TD" id="3PrmTp7ow7A" role="_iOnB">
       <property role="1WsWdv" value="Copied from test.tx.expr.os.m1" />
     </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.error@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.error@tests.mps
@@ -99,7 +99,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -173,7 +172,6 @@
   </registry>
   <node concept="_iOnU" id="7ZoBx3xgVRK">
     <property role="TrG5h" value="error" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="1WbbD7" id="4H6xI_iSglJ" role="_iOnB">
       <property role="TrG5h" value="attemptType" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.functions@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.functions@tests.mps
@@ -102,7 +102,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -180,7 +179,6 @@
   </registry>
   <node concept="_iOnU" id="6HHp2WmVmw8">
     <property role="TrG5h" value="functions" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="2zPypq" id="1EIbarJ$BYs" role="_iOnB">
       <property role="TrG5h" value="constantNumber" />
@@ -980,7 +978,6 @@
   </node>
   <node concept="_iOnU" id="1VmWkC0GQng">
     <property role="TrG5h" value="vars" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="_ixoA" id="1VmWkC1vOrt" role="_iOnB" />
     <node concept="1aga60" id="1VmWkC0GQOr" role="_iOnB">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.ignoredTests@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.ignoredTests@tests.mps
@@ -30,7 +30,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -52,7 +51,6 @@
   <node concept="_iOnU" id="48NC6VzWjct">
     <property role="TrG5h" value="ignoredTests" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="_fkuM" id="48NC6VzWo04" role="_iOnB">
       <property role="TrG5h" value="Testing" />
       <node concept="_fkuZ" id="48NC6VzWo8J" role="_fkp5">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.lambda@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.lambda@tests.mps
@@ -92,7 +92,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -194,7 +193,6 @@
   <node concept="_iOnU" id="7cphKbKN3Se">
     <property role="TrG5h" value="doubleLambda" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="2Ss9d8" id="7cphKbKN6I3" role="_iOnB">
       <property role="TrG5h" value="Order" />
       <node concept="2Ss9d7" id="7cphKbKN78D" role="S5Trm">
@@ -616,7 +614,6 @@
   </node>
   <node concept="_iOnU" id="6HHp2WmWc6N">
     <property role="TrG5h" value="lambda" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="2zPypq" id="6HHp2WmWcom" role="_iOnB">
       <property role="TrG5h" value="l1" />
@@ -1383,7 +1380,6 @@
   </node>
   <node concept="_iOnU" id="6HHp2WmWx5q">
     <property role="TrG5h" value="recursionWithLambda" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="2zPypq" id="6HHp2WmWx9C" role="_iOnB">
       <property role="TrG5h" value="plus" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.nix@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.nix@tests.mps
@@ -79,7 +79,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -154,7 +153,6 @@
   </node>
   <node concept="_iOnU" id="3nVyIts6iiI">
     <property role="TrG5h" value="nix" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="2zPypq" id="3nVyIts6jOS" role="_iOnB">
       <property role="TrG5h" value="a1" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.numbers@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.numbers@tests.mps
@@ -83,7 +83,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -182,7 +181,6 @@
   </registry>
   <node concept="_iOnU" id="1RwPUjzhA8h">
     <property role="TrG5h" value="minMax" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="2zPypq" id="1RwPUjznwy$" role="_iOnB">
       <property role="TrG5h" value="m" />
@@ -440,7 +438,6 @@
   <node concept="_iOnU" id="6rdp$3y_pap">
     <property role="TrG5h" value="numbers" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="2zPypq" id="7Wa2sv44gWb" role="_iOnB">
       <property role="TrG5h" value="a1" />
       <node concept="30dDZf" id="7Wa2sv44tPt" role="2zPyp_">
@@ -1656,7 +1653,6 @@
   <node concept="_iOnU" id="2M9Ik4CVVAB">
     <property role="TrG5h" value="precision" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="1WbbD7" id="1IomA9waU6k" role="_iOnB">
       <property role="TrG5h" value="BP0" />
       <node concept="mLuIC" id="1IomA9wb$tP" role="1WbbD4" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.options@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.options@tests.mps
@@ -157,7 +157,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -300,7 +299,6 @@
   </registry>
   <node concept="_iOnU" id="7u9eNXf5ZVJ">
     <property role="TrG5h" value="option_strings" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="2zPypq" id="7u9eNXf5ZVL" role="_iOnB">
       <property role="TrG5h" value="s" />
@@ -1006,7 +1004,6 @@
   <node concept="_iOnU" id="7u9eNXgpmuL">
     <property role="TrG5h" value="option_records" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="2zPypq" id="7u9eNXgpmuN" role="_iOnB">
       <property role="TrG5h" value="p1" />
       <node concept="2S399m" id="7u9eNXgpmuO" role="2zPyp_">
@@ -1464,7 +1461,6 @@
   </node>
   <node concept="_iOnU" id="7u9eNXj2Iya">
     <property role="TrG5h" value="option_logic" />
-    <property role="2SXJ1i" value="true" />
     <node concept="_fkuM" id="7u9eNXj2Iyc" role="_iOnB">
       <property role="TrG5h" value="logic" />
       <node concept="_fkuZ" id="7u9eNXj2Iyd" role="_fkp5">
@@ -1650,7 +1646,6 @@
   </node>
   <node concept="_iOnU" id="7u9eNXjmWrF">
     <property role="TrG5h" value="option_defaultValues" />
-    <property role="2SXJ1i" value="true" />
     <node concept="1Ws0TD" id="7u9eNXjmWrG" role="_iOnB">
       <property role="1WsWdv" value="complete, compiles, all tests ok" />
     </node>
@@ -1801,7 +1796,6 @@
   </node>
   <node concept="_iOnU" id="40vJDLnkwjz">
     <property role="TrG5h" value="option_binary_arith" />
-    <property role="2SXJ1i" value="true" />
     <node concept="_ixoA" id="40vJDLneDP6" role="_iOnB" />
     <node concept="2zPypq" id="40vJDLneEZE" role="_iOnB">
       <property role="TrG5h" value="n" />
@@ -3038,7 +3032,6 @@
   </node>
   <node concept="_iOnU" id="7u9eNXkkQGv">
     <property role="TrG5h" value="option_base2" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="1Ws0TD" id="7u9eNXkkQGx" role="_iOnB">
       <property role="1WsWdv" value="expr.base tests which are not supported by c++ interpreter" />
@@ -3334,7 +3327,6 @@
   <node concept="_iOnU" id="7u9eNXjF6xJ">
     <property role="TrG5h" value="option_base" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="2zPypq" id="7u9eNXjF6y8" role="_iOnB">
       <property role="TrG5h" value="constant5" />
       <node concept="30bXRB" id="7u9eNXjF6ya" role="2zPyp_">
@@ -3468,7 +3460,6 @@
   <node concept="_iOnU" id="6HHp2WmWPOB">
     <property role="TrG5h" value="option" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="2zPypq" id="5yJrCoWjtoQ" role="_iOnB">
       <property role="TrG5h" value="noneNone" />
       <node concept="UmHTt" id="5yJrCoWj_rb" role="2zPyp_" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.records@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.records@tests.mps
@@ -69,9 +69,7 @@
     <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
       <concept id="7782108600712067692" name="org.iets3.core.expr.base.structure.DeRefTarget" flags="ng" index="n2Y3A" />
       <concept id="7782108600709141067" name="org.iets3.core.expr.base.structure.MakeRefTarget" flags="ng" index="ne4z1" />
-      <concept id="2390066428848651932" name="org.iets3.core.expr.base.structure.BangOp" flags="ng" index="wdKpt">
-        <child id="2390066428848651933" name="optionValue" index="wdKps" />
-      </concept>
+      <concept id="2390066428848651932" name="org.iets3.core.expr.base.structure.BangOp" flags="ng" index="wdKpt" />
       <concept id="7089558164905593724" name="org.iets3.core.expr.base.structure.IOptionallyTyped" flags="ng" index="2zM23E">
         <child id="7089558164905593725" name="type" index="2zM23F" />
       </concept>
@@ -129,7 +127,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -316,7 +313,6 @@
   </registry>
   <node concept="_iOnU" id="6JZACDWVYZm">
     <property role="TrG5h" value="references" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="2Ss9d8" id="6JZACDWVZt$" role="_iOnB">
       <property role="TrG5h" value="Person" />
@@ -430,7 +426,6 @@
   <node concept="_iOnU" id="6HHp2WmXx3n">
     <property role="TrG5h" value="records" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="2zPypq" id="6HHp2WmXy1j" role="_iOnB">
       <property role="TrG5h" value="p1" />
       <node concept="2S399m" id="6HHp2WmXy1k" role="2zPyp_">
@@ -1842,7 +1837,6 @@
   <node concept="_iOnU" id="7cphKbLeYOb">
     <property role="TrG5h" value="projection" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="2Ss9d8" id="7cphKbLeYOe" role="_iOnB">
       <property role="TrG5h" value="Item" />
       <node concept="2Ss9d7" id="7cphKbLeYOf" role="S5Trm">
@@ -2549,12 +2543,6 @@
         <node concept="_fku$" id="5dXjecSI3mA" role="_fkur" />
         <node concept="1QScDb" id="5dXjecSI4_X" role="_fkuY">
           <node concept="wdKpt" id="24oBF3$bfOM" role="30czhm">
-            <node concept="1QScDb" id="5dXjecSI3nP" role="wdKps">
-              <node concept="3iB7TU" id="5dXjecSI3Wn" role="1QScD9" />
-              <node concept="_emDc" id="5dXjecSI3nh" role="30czhm">
-                <ref role="_emDf" node="5dXjecSHGXM" resolve="c1" />
-              </node>
-            </node>
             <node concept="1QScDb" id="7B4QWueeaUm" role="30czhm">
               <node concept="3iB7TU" id="7B4QWueei$8" role="1QScD9" />
               <node concept="1QScDb" id="7B4QWuedJq0" role="30czhm">
@@ -2606,12 +2594,6 @@
         <node concept="_fku$" id="5dXjecSIBlT" role="_fkur" />
         <node concept="1QScDb" id="5dXjecSIDgK" role="_fkuY">
           <node concept="wdKpt" id="24oBF3$bKR1" role="30czhm">
-            <node concept="1QScDb" id="5dXjecSIBnJ" role="wdKps">
-              <node concept="3iB7TU" id="5dXjecSICAH" role="1QScD9" />
-              <node concept="1af_rf" id="5dXjecSIBnc" role="30czhm">
-                <ref role="1afhQb" node="5dXjecSIysV" resolve="f2" />
-              </node>
-            </node>
             <node concept="1QScDb" id="7B4QWueft4q" role="30czhm">
               <node concept="1af_rf" id="7B4QWuefqtN" role="30czhm">
                 <ref role="1afhQb" node="5dXjecSIysV" resolve="f2" />
@@ -2634,34 +2616,6 @@
         </node>
         <node concept="1QScDb" id="5dXjecSIkR3" role="_fkuY">
           <node concept="wdKpt" id="24oBF3$c0zg" role="30czhm">
-            <node concept="1QScDb" id="5dXjecSIa_l" role="wdKps">
-              <node concept="3iB7TU" id="5dXjecSIbw3" role="1QScD9" />
-              <node concept="1QScDb" id="5dXjecSIa13" role="30czhm">
-                <node concept="22cOCA" id="5dXjecSIa14" role="1QScD9">
-                  <node concept="22cOCE" id="5dXjecSIa15" role="22cODC">
-                    <property role="TrG5h" value="num" />
-                    <node concept="1QScDb" id="5dXjecSIa16" role="22cOCG">
-                      <node concept="3o_JK" id="5dXjecSIa17" role="1QScD9">
-                        <ref role="3o_JH" node="5dXjecSHGYF" resolve="n" />
-                      </node>
-                      <node concept="22msUl" id="5dXjecSIa18" role="30czhm" />
-                    </node>
-                  </node>
-                  <node concept="22cOCE" id="5dXjecSIa19" role="22cODC">
-                    <property role="TrG5h" value="str" />
-                    <node concept="1QScDb" id="5dXjecSIa1a" role="22cOCG">
-                      <node concept="3o_JK" id="5dXjecSIa1b" role="1QScD9">
-                        <ref role="3o_JH" node="5dXjecSHGZr" resolve="s" />
-                      </node>
-                      <node concept="22msUl" id="5dXjecSIa1c" role="30czhm" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="_emDc" id="5dXjecSIa1d" role="30czhm">
-                  <ref role="_emDf" node="5dXjecSHH0D" resolve="data1" />
-                </node>
-              </node>
-            </node>
             <node concept="1QScDb" id="7B4QWuegBye" role="30czhm">
               <node concept="3iB7TU" id="7B4QWuegQXI" role="1QScD9" />
               <node concept="_emDc" id="7B4QWueg$Pe" role="30czhm">
@@ -2707,12 +2661,6 @@
           </node>
           <node concept="1QScDb" id="5dXjecSJ0wk" role="1aduh9">
             <node concept="wdKpt" id="24oBF3$cgD0" role="30czhm">
-              <node concept="1QScDb" id="5dXjecSIY$_" role="wdKps">
-                <node concept="3iB7TU" id="5dXjecSIZCu" role="1QScD9" />
-                <node concept="1adzI2" id="5dXjecSIY$B" role="30czhm">
-                  <ref role="1adwt6" node="5dXjecSIY$p" resolve="v1" />
-                </node>
-              </node>
               <node concept="1QScDb" id="7B4QWueh27T" role="30czhm">
                 <node concept="3iB7TU" id="7B4QWuehhJj" role="1QScD9" />
                 <node concept="1adzI2" id="7B4QWueh25z" role="30czhm">
@@ -2883,15 +2831,6 @@
         <node concept="_fku$" id="5dXjecSNSJC" role="_fkur" />
         <node concept="1QScDb" id="5dXjecSOEmd" role="_fkuY">
           <node concept="wdKpt" id="24oBF3$cEJi" role="30czhm">
-            <node concept="1QScDb" id="5dXjecSOxsB" role="wdKps">
-              <node concept="3iB7TU" id="5dXjecSOCQp" role="1QScD9" />
-              <node concept="1QScDb" id="5dXjecSNSLw" role="30czhm">
-                <node concept="_emDc" id="5dXjecSNSKW" role="30czhm">
-                  <ref role="_emDf" node="5dXjecSHGXM" resolve="c1" />
-                </node>
-                <node concept="2Tjeny" id="5dXjecSOux5" role="1QScD9" />
-              </node>
-            </node>
             <node concept="1QScDb" id="7B4QWuehWSS" role="30czhm">
               <node concept="3iB7TU" id="7B4QWueihtQ" role="1QScD9" />
               <node concept="1QScDb" id="7B4QWuehxwE" role="30czhm">
@@ -3139,7 +3078,6 @@
   <node concept="_iOnU" id="6HHp2WmWQjh">
     <property role="TrG5h" value="path" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="2zPypq" id="6HHp2WmWQzH" role="_iOnB">
       <property role="TrG5h" value="person" />
       <node concept="2S399m" id="6HHp2WmWQzI" role="2zPyp_">
@@ -3903,7 +3841,6 @@
   <node concept="_iOnU" id="7cphKbKqVBQ">
     <property role="TrG5h" value="grouping" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="2Ss9d8" id="7cphKbKqWTD" role="_iOnB">
       <property role="TrG5h" value="Item" />
       <node concept="2Ss9d7" id="7cphKbKqWUl" role="S5Trm">
@@ -4125,12 +4062,6 @@
           <node concept="3iB7TU" id="7B4QWuedDH_" role="1QScD9" />
           <node concept="1QScDb" id="4psmta9IKWk" role="30czhm">
             <node concept="wdKpt" id="24oBF3$eD15" role="30czhm">
-              <node concept="1QScDb" id="4psmta9IKWm" role="wdKps">
-                <node concept="3iB7TU" id="4psmta9IKWn" role="1QScD9" />
-                <node concept="_emDc" id="4psmta9IKWo" role="30czhm">
-                  <ref role="_emDf" node="7cphKbKuAzQ" resolve="groups" />
-                </node>
-              </node>
               <node concept="1QScDb" id="7B4QWuedsNT" role="30czhm">
                 <node concept="3iB7TU" id="7B4QWuedB8u" role="1QScD9" />
                 <node concept="_emDc" id="7B4QWuedsMD" role="30czhm">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.strings@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.strings@tests.mps
@@ -80,7 +80,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -137,7 +136,6 @@
   </registry>
   <node concept="_iOnU" id="1EIbarKa15w">
     <property role="TrG5h" value="strings" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="2zPypq" id="ucawTYEC8j" role="_iOnB">
       <property role="TrG5h" value="s" />
@@ -1089,7 +1087,6 @@
   </node>
   <node concept="_iOnU" id="60Qa1k_r0P5">
     <property role="TrG5h" value="stringsDefaultValues" />
-    <property role="2SXJ1i" value="true" />
     <node concept="_ixoA" id="60Qa1k_Hz8D" role="_iOnB" />
     <node concept="_fkuM" id="60Qa1k_r2ku" role="_iOnB">
       <property role="TrG5h" value="TestDefaultValues" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.stringvalidation@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.stringvalidation@tests.mps
@@ -80,7 +80,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -228,7 +227,6 @@
   </registry>
   <node concept="_iOnU" id="1EIbarKa15w">
     <property role="TrG5h" value="acceptance_tests" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="2zPypq" id="6KviS2JbEGx" role="_iOnB">
       <property role="TrG5h" value="ok" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tests@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tests@tests.mps
@@ -60,7 +60,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -115,7 +114,6 @@
   <node concept="_iOnU" id="7ZoBx3wxvdq">
     <property role="TrG5h" value="tests" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="1Ws0TD" id="7ZoBx3xn6jt" role="_iOnB">
       <property role="1WsWdv" value="TODO negative assert equals test" />
     </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tuples@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tuples@tests.mps
@@ -48,7 +48,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -84,7 +83,6 @@
   </registry>
   <node concept="_iOnU" id="6HHp2WmY4bi">
     <property role="TrG5h" value="tuples" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="2zPypq" id="6HHp2WmY4cI" role="_iOnB">
       <property role="TrG5h" value="t1" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.typedefs@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.typedefs@tests.mps
@@ -111,7 +111,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -198,7 +197,6 @@
   <node concept="_iOnU" id="2S3ZC$oC8Qh">
     <property role="TrG5h" value="typedefs" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="1Ws0TD" id="$9KWJqJk6l" role="_iOnB">
       <property role="1WsWdv" value="complete, compiles, all tests ok" />
     </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/todo@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/todo@tests.mps
@@ -56,7 +56,6 @@
       <concept id="5849458724932670346" name="org.iets3.core.expr.collections.structure.BracketOp" flags="ng" index="2yLE0X">
         <child id="5849458724932670347" name="index" index="2yLE0W" />
       </concept>
-      <concept id="8872269265511400449" name="org.iets3.core.expr.collections.structure.DistinctOp" flags="ng" index="2Tjeny" />
       <concept id="8872269265513219132" name="org.iets3.core.expr.collections.structure.AsImmutableListOp" flags="ng" index="2TEanv" />
       <concept id="8872269265520080263" name="org.iets3.core.expr.collections.structure.SetType" flags="ng" index="2TO1h$" />
       <concept id="8872269265520081293" name="org.iets3.core.expr.collections.structure.SetLiteral" flags="ng" index="2TO1xI">
@@ -127,9 +126,7 @@
       <concept id="606861080870797309" name="org.iets3.core.expr.base.structure.IfElseSection" flags="ng" index="pf3Wd">
         <child id="606861080870797310" name="expr" index="pf3We" />
       </concept>
-      <concept id="2390066428848651932" name="org.iets3.core.expr.base.structure.BangOp" flags="ng" index="wdKpt">
-        <child id="2390066428848651933" name="optionValue" index="wdKps" />
-      </concept>
+      <concept id="2390066428848651932" name="org.iets3.core.expr.base.structure.BangOp" flags="ng" index="wdKpt" />
       <concept id="7089558164909884363" name="org.iets3.core.expr.base.structure.TryErrorClause" flags="ng" index="2zzUxt">
         <child id="7089558164909884398" name="expr" index="2zzUxS" />
         <child id="7089558164910923907" name="errorLiteral" index="2zBOGl" />
@@ -233,7 +230,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <reference id="2032654994493517823" name="scoper" index="2HwdWd" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
@@ -451,7 +447,6 @@
   </registry>
   <node concept="_iOnU" id="KaZMgy69hp">
     <property role="TrG5h" value="contracts" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="1WbbD7" id="1EIbarK3KGI" role="_iOnB">
       <property role="TrG5h" value="BiggerThanTen" />
@@ -1085,19 +1080,6 @@
         <node concept="_fku$" id="7hc$_$DbasB" role="_fkur" />
         <node concept="1QScDb" id="7hc$_$Dbo3x" role="_fkuY">
           <node concept="wdKpt" id="24oBF3$hmmA" role="30czhm">
-            <node concept="1QScDb" id="7hc$_$DbkgA" role="wdKps">
-              <node concept="3iB7bo" id="7hc$_$Dbm8l" role="1QScD9" />
-              <node concept="1QScDb" id="7hc$_$Dbch$" role="30czhm">
-                <node concept="2TEanv" id="7hc$_$Dbgdy" role="1QScD9" />
-                <node concept="1af_rf" id="7hc$_$Dbaug" role="30czhm">
-                  <property role="0Rz4W" value="1021772686" />
-                  <ref role="1afhQb" node="5ipapt3EfHe" resolve="brotherAges4" />
-                  <node concept="_emDc" id="7hc$_$DbauZ" role="1afhQ5">
-                    <ref role="_emDf" node="5ipapt3Ejin" resolve="p1" />
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="1QScDb" id="6H5IFDiYQmj" role="30czhm">
               <node concept="3iB7bo" id="6H5IFDj1keB" role="1QScD9" />
               <node concept="1QScDb" id="6H5IFDiX_Pm" role="30czhm">
@@ -1244,22 +1226,6 @@
         <node concept="_fku$" id="2siuZwWkyu0" role="_fkur" />
         <node concept="1QScDb" id="2siuZwWlrPC" role="_fkuY">
           <node concept="wdKpt" id="24oBF3$iBhI" role="30czhm">
-            <node concept="1QScDb" id="2siuZwWl9S6" role="wdKps">
-              <node concept="3iB7TU" id="2siuZwWliNN" role="1QScD9" />
-              <node concept="1QScDb" id="2siuZwWkS9q" role="30czhm">
-                <node concept="2Tjeny" id="2siuZwWl0Xd" role="1QScD9" />
-                <node concept="1QScDb" id="2siuZwWkAGA" role="30czhm">
-                  <node concept="2TEanv" id="2siuZwWkJo1" role="1QScD9" />
-                  <node concept="1af_rf" id="2siuZwWkyyX" role="30czhm">
-                    <property role="0Rz4W" value="832062604" />
-                    <ref role="1afhQb" node="5ipapt3EfHe" resolve="brotherAges4" />
-                    <node concept="_emDc" id="2siuZwWkyzG" role="1afhQ5">
-                      <ref role="_emDf" node="5ipapt3Ejin" resolve="p1" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="1QScDb" id="6H5IFDj2XDD" role="30czhm">
               <node concept="1QScDb" id="6H5IFDj1G$h" role="30czhm">
                 <node concept="2TEanv" id="6H5IFDj2nwl" role="1QScD9" />
@@ -1324,15 +1290,6 @@
         <node concept="_fku$" id="2siuZwWLLNS" role="_fkur" />
         <node concept="1QScDb" id="2siuZwWMpc6" role="_fkuY">
           <node concept="wdKpt" id="24oBF3$jsa$" role="30czhm">
-            <node concept="1QScDb" id="2siuZwWM5pb" role="wdKps">
-              <node concept="3iB7TU" id="2siuZwWMff_" role="1QScD9" />
-              <node concept="1QScDb" id="2siuZwWLLP2" role="30czhm">
-                <node concept="2TEanv" id="2siuZwWLVz$" role="1QScD9" />
-                <node concept="_emDc" id="2siuZwWLLOn" role="30czhm">
-                  <ref role="_emDf" node="2siuZwWJFE5" resolve="c" />
-                </node>
-              </node>
-            </node>
             <node concept="1QScDb" id="6H5IFDj6RYD" role="30czhm">
               <node concept="3iB7TU" id="6H5IFDj7syo" role="1QScD9" />
               <node concept="1QScDb" id="6H5IFDj5gTQ" role="30czhm">
@@ -1355,15 +1312,6 @@
         <node concept="_fku$" id="2siuZwWNqOE" role="_fkur" />
         <node concept="1QScDb" id="2siuZwWNNwk" role="_fkuY">
           <node concept="wdKpt" id="24oBF3$kghq" role="30czhm">
-            <node concept="1QScDb" id="2siuZwWNDGw" role="wdKps">
-              <node concept="3iB7bo" id="2siuZwWNI$J" role="1QScD9" />
-              <node concept="1QScDb" id="2siuZwWNqQ8" role="30czhm">
-                <node concept="2TEanv" id="2siuZwWN$Q3" role="1QScD9" />
-                <node concept="_emDc" id="2siuZwWNqPt" role="30czhm">
-                  <ref role="_emDf" node="2siuZwWJFE5" resolve="c" />
-                </node>
-              </node>
-            </node>
             <node concept="1QScDb" id="6H5IFDj8_mh" role="30czhm">
               <node concept="3iB7bo" id="6H5IFDj9ain" role="1QScD9" />
               <node concept="1QScDb" id="6H5IFDj7G7V" role="30czhm">
@@ -1533,15 +1481,6 @@
           </node>
           <node concept="1QScDb" id="7aUGNm6RHnk" role="1aduh9">
             <node concept="wdKpt" id="24oBF3$m28r" role="30czhm">
-              <node concept="1QScDb" id="7aUGNm6RizN" role="wdKps">
-                <node concept="3iB7TU" id="7aUGNm6R$zD" role="1QScD9" />
-                <node concept="1QScDb" id="7aUGNm6QNQF" role="30czhm">
-                  <node concept="2TEanv" id="7aUGNm6R0$V" role="1QScD9" />
-                  <node concept="1adzI2" id="7aUGNm6QNQH" role="30czhm">
-                    <ref role="1adwt6" node="7aUGNm6QNQt" resolve="v" />
-                  </node>
-                </node>
-              </node>
               <node concept="1QScDb" id="6H5IFDjaIXK" role="30czhm">
                 <node concept="3iB7TU" id="6H5IFDjbjRi" role="1QScD9" />
                 <node concept="1QScDb" id="6H5IFDj9PMS" role="30czhm">
@@ -1600,15 +1539,6 @@
           </node>
           <node concept="1QScDb" id="7aUGNm6Tgqn" role="1aduh9">
             <node concept="wdKpt" id="24oBF3$mQmb" role="30czhm">
-              <node concept="1QScDb" id="7aUGNm6SPiV" role="wdKps">
-                <node concept="3iB7bo" id="7aUGNm6T7v7" role="1QScD9" />
-                <node concept="1QScDb" id="7aUGNm6QOr5" role="30czhm">
-                  <node concept="1adzI2" id="7aUGNm6QOr7" role="30czhm">
-                    <ref role="1adwt6" node="7aUGNm6QOqR" resolve="v" />
-                  </node>
-                  <node concept="2TEanv" id="7aUGNm6Sz79" role="1QScD9" />
-                </node>
-              </node>
               <node concept="1QScDb" id="6H5IFDjcohr" role="30czhm">
                 <node concept="3iB7bo" id="6H5IFDjcXyL" role="1QScD9" />
                 <node concept="1QScDb" id="6H5IFDjbuyw" role="30czhm">
@@ -1854,7 +1784,6 @@
   <node concept="_iOnU" id="6HHp2WmXx3n">
     <property role="TrG5h" value="records" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="2zPypq" id="6HHp2WmXy1j" role="_iOnB">
       <property role="TrG5h" value="p1" />
       <node concept="2S399m" id="6HHp2WmXy1k" role="2zPyp_">
@@ -2506,7 +2435,6 @@
   </node>
   <node concept="_iOnU" id="1VmWkC0GQng">
     <property role="TrG5h" value="vars" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <ref role="2HwdWd" node="1VmWkC0I5UE" resolve="varLib" />
     <node concept="_ixoA" id="4C_Rnzf$Std" role="_iOnB" />
@@ -3841,7 +3769,6 @@
   </node>
   <node concept="_iOnU" id="1URbfFFNt7E">
     <property role="TrG5h" value="dectre" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <ref role="2HwdWd" node="1VmWkC0I5UE" resolve="varLib" />
     <node concept="_ixoA" id="1URbfFFNt7F" role="_iOnB" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/utils@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/utils@tests.mps
@@ -161,7 +161,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -251,7 +250,6 @@
   </registry>
   <node concept="_iOnU" id="6HHp2WmYcwz">
     <property role="TrG5h" value="utils_dectab" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="2zPypq" id="6HHp2WmYcwQ" role="_iOnB">
       <property role="TrG5h" value="a" />
@@ -1582,7 +1580,6 @@
   </node>
   <node concept="_iOnU" id="6OunYCfiz1J">
     <property role="TrG5h" value="utils_dectab_ranges" />
-    <property role="2SXJ1i" value="true" />
     <property role="1XBH2A" value="true" />
     <node concept="1aga60" id="6OunYCfi$iC" role="_iOnB">
       <property role="TrG5h" value="test" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.phyunits@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.phyunits@tests.mps
@@ -9521,7 +9521,6 @@
                   <ref role="39XzEq" to="x0pf:yGiRIEWkAm" />
                 </node>
               </node>
-              <node concept="o5Tdl" id="7F14or$g9br" role="7EUXB" />
               <node concept="1TM$A" id="7F14or$g9bs" role="7EUXB">
                 <node concept="2PYRI3" id="7F14or$g9bt" role="3lydEf">
                   <ref role="39XzEq" to="x0pf:6RONOaUn1yk" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -429,7 +429,6 @@
         <child id="543569365052056267" name="actual" index="_fkuY" />
       </concept>
       <concept id="543569365052711055" name="org.iets3.core.expr.tests.structure.TestSuite" flags="ng" index="_iOnU">
-        <property id="8811147530091989932" name="executeAutomatically" index="2SXJ1i" />
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
@@ -16167,7 +16166,6 @@
   <node concept="_iOnU" id="2S3ZC$oC8Qh">
     <property role="TrG5h" value="typedefs" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="1WbbD7" id="252QIDyjnZm" role="_iOnB">
       <property role="TrG5h" value="posint" />
       <property role="0Rz4W" value="11119707" />
@@ -16556,7 +16554,6 @@
   <node concept="_iOnU" id="3kzwyUOu7db">
     <property role="TrG5h" value="typedefs2" />
     <property role="1XBH2A" value="true" />
-    <property role="2SXJ1i" value="true" />
     <node concept="1aga60" id="3kzwyUOuHi6" role="_iOnB">
       <property role="TrG5h" value="testSymbol" />
       <node concept="39w5ZF" id="3kzwyUOuNke" role="1ahQXP">
@@ -20422,7 +20419,6 @@
     <node concept="1qefOq" id="5gz1ElMSDBM" role="1SKRRt">
       <node concept="_iOnU" id="6HHp2WmY4bi" role="1qenE9">
         <property role="TrG5h" value="tuples" />
-        <property role="2SXJ1i" value="true" />
         <property role="1XBH2A" value="true" />
         <node concept="1aga60" id="1c6hIxyYixT" role="_iOnB">
           <property role="TrG5h" value="simpleMulteResults" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
@@ -95,12 +95,21 @@
       <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
         <child id="1239714902950" name="expression" index="2$L3a6" />
       </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
@@ -124,6 +133,9 @@
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -7512,11 +7524,23 @@
             <node concept="3uibUv" id="31Bxel01iNS" role="1tU5fm">
               <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
             </node>
-            <node concept="2YIFZM" id="31Bxel01qHE" role="33vP2m">
-              <ref role="37wK5l" to="pbu6:3xDNhgd54rl" resolve="evaluate" />
-              <ref role="1Pybhc" to="pbu6:3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
-              <node concept="3xONca" id="31Bxel01qHF" role="37wK5m">
-                <ref role="3xOPvv" node="31BxekZX$Xj" resolve="test1" />
+            <node concept="2OqwBi" id="GJLa3qqYFv" role="33vP2m">
+              <node concept="2OqwBi" id="GJLa3qqYgU" role="2Oq$k0">
+                <node concept="2ShNRf" id="GJLa3qqWWU" role="2Oq$k0">
+                  <node concept="HV5vD" id="GJLa3qqY96" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="HV5vE" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="GJLa3qqYte" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:2nydsCfz7eH" resolve="evaluate" />
+                  <node concept="3xONca" id="GJLa3qqYw0" role="37wK5m">
+                    <ref role="3xOPvv" node="31BxekZX$Xj" resolve="test1" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OwXpG" id="GJLa3qqYTz" role="2OqNvi">
+                <ref role="2Oxat5" to="pbu6:7lHetQyBz3x" resolve="value" />
               </node>
             </node>
           </node>
@@ -7562,11 +7586,23 @@
             <node concept="3uibUv" id="31BxekZYSWr" role="1tU5fm">
               <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
             </node>
-            <node concept="2YIFZM" id="31BxekZYVPP" role="33vP2m">
-              <ref role="37wK5l" to="pbu6:3xDNhgd54rl" resolve="evaluate" />
-              <ref role="1Pybhc" to="pbu6:3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
-              <node concept="3xONca" id="31BxekZYVPQ" role="37wK5m">
-                <ref role="3xOPvv" node="31BxekZXQ0w" resolve="test2" />
+            <node concept="2OqwBi" id="GJLa3qr0f6" role="33vP2m">
+              <node concept="2OqwBi" id="GJLa3qr0f7" role="2Oq$k0">
+                <node concept="2ShNRf" id="GJLa3qr0f8" role="2Oq$k0">
+                  <node concept="HV5vD" id="GJLa3qr0f9" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="HV5vE" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="GJLa3qr0fa" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:2nydsCfz7eH" resolve="evaluate" />
+                  <node concept="3xONca" id="GJLa3qr0fb" role="37wK5m">
+                    <ref role="3xOPvv" node="31BxekZXQ0w" resolve="test2" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OwXpG" id="GJLa3qr0fc" role="2OqNvi">
+                <ref role="2Oxat5" to="pbu6:7lHetQyBz3x" resolve="value" />
               </node>
             </node>
           </node>
@@ -7612,11 +7648,23 @@
             <node concept="3uibUv" id="31Bxel01rk7" role="1tU5fm">
               <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
             </node>
-            <node concept="2YIFZM" id="31Bxel01rk8" role="33vP2m">
-              <ref role="37wK5l" to="pbu6:3xDNhgd54rl" resolve="evaluate" />
-              <ref role="1Pybhc" to="pbu6:3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
-              <node concept="3xONca" id="31Bxel01rk9" role="37wK5m">
-                <ref role="3xOPvv" node="31BxekZXR26" resolve="test3" />
+            <node concept="2OqwBi" id="GJLa3qr0BX" role="33vP2m">
+              <node concept="2OqwBi" id="GJLa3qr0BY" role="2Oq$k0">
+                <node concept="2ShNRf" id="GJLa3qr0BZ" role="2Oq$k0">
+                  <node concept="HV5vD" id="GJLa3qr0C0" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="HV5vE" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="GJLa3qr0C1" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:2nydsCfz7eH" resolve="evaluate" />
+                  <node concept="3xONca" id="GJLa3qr0C2" role="37wK5m">
+                    <ref role="3xOPvv" node="31BxekZXR26" resolve="test3" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OwXpG" id="GJLa3qr0C3" role="2OqNvi">
+                <ref role="2Oxat5" to="pbu6:7lHetQyBz3x" resolve="value" />
               </node>
             </node>
           </node>
@@ -7662,11 +7710,23 @@
             <node concept="3uibUv" id="31Bxel01rGZ" role="1tU5fm">
               <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
             </node>
-            <node concept="2YIFZM" id="31Bxel01rH0" role="33vP2m">
-              <ref role="37wK5l" to="pbu6:3xDNhgd54rl" resolve="evaluate" />
-              <ref role="1Pybhc" to="pbu6:3xDNhgd53E_" resolve="IETS3ExprEvalHelper" />
-              <node concept="3xONca" id="31Bxel01rH1" role="37wK5m">
-                <ref role="3xOPvv" node="31BxekZXS46" resolve="test4" />
+            <node concept="2OqwBi" id="GJLa3qr0JN" role="33vP2m">
+              <node concept="2OqwBi" id="GJLa3qr0JO" role="2Oq$k0">
+                <node concept="2ShNRf" id="GJLa3qr0JP" role="2Oq$k0">
+                  <node concept="HV5vD" id="GJLa3qr0JQ" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="HV5vE" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="GJLa3qr0JR" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:2nydsCfz7eH" resolve="evaluate" />
+                  <node concept="3xONca" id="GJLa3qr0JS" role="37wK5m">
+                    <ref role="3xOPvv" node="31BxekZXS46" resolve="test4" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OwXpG" id="GJLa3qr0JT" role="2OqNvi">
+                <ref role="2Oxat5" to="pbu6:7lHetQyBz3x" resolve="value" />
               </node>
             </node>
           </node>


### PR DESCRIPTION
- The target branch is 2022.2 because I did the original cleanup in https://github.com/IETS3/iets3.opensource/pull/681 also on this branch.
- The deprecation warnings went down from about 353 to 145. For most of the remaining warnings, we would have to remove the deprecated concepts.