### PR TITLE
If there is only a single CC menu entry, select it for concepts that act as empty placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 - The unnecessary super types of the tuple type were removed and are not necessary anymore.
 
+### Fixed
+
+- Empty-like nodes now automatically select the first code completion entry if there is only one entry.
+
 ## March 2024
 
 ### Added

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
@@ -52,6 +52,7 @@
     <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="bd8o" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.application(MPS.IDEA/)" />
+    <import index="buwp" ref="r:8405f486-53b5-4fe6-af3e-7f68358bd631(org.iets3.core.expr.base.editor)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="itrz" ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)" implicit="true" />
@@ -60,6 +61,9 @@
     <import index="138" ref="r:2c1007f3-e814-47ba-b729-c3ea0297f627(org.iets3.core.attributes.structure)" implicit="true" />
   </imports>
   <registry>
+    <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
+      <concept id="1194033889146" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1XNTG" />
+    </language>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="1402906326895675325" name="jetbrains.mps.lang.editor.structure.CellActionMap_FunctionParm_selectedNode" flags="nn" index="0IXxy" />
       <concept id="5991739802479784073" name="jetbrains.mps.lang.editor.structure.MenuTypeDefault" flags="ng" index="22hDWj" />
@@ -467,6 +471,15 @@
         <child id="8945098465480008160" name="transformationText" index="ZWbT9" />
       </concept>
       <concept id="8945098465480383073" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell_TransformationText" flags="ig" index="ZYGn8" />
+      <concept id="6856661361479784527" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem" flags="ng" index="130t_x">
+        <property id="1139535298778" name="actionId" index="1hAc7k" />
+        <child id="6856661361479798753" name="execute" index="130oVf" />
+      </concept>
+      <concept id="6856661361479784534" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem_ExecuteFunction" flags="ig" index="130t_S" />
+      <concept id="6856661361479732075" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapCell" flags="ng" index="130CD5">
+        <child id="6856661361479798957" name="actions" index="130p63" />
+        <child id="6856661361479732085" name="cell" index="130CDr" />
+      </concept>
       <concept id="848437706375087728" name="com.mbeddr.mpsutil.grammarcells.structure.ICanHaveDescriptionText" flags="ng" index="1djCvD">
         <child id="848437706375087729" name="descriptionText" index="1djCvC" />
       </concept>
@@ -1160,10 +1173,26 @@
   <node concept="24kQdi" id="6LfBX8Yi4uM">
     <property role="3GE5qa" value="components" />
     <ref role="1XX52x" to="w9y2:6LfBX8Yi4ug" resolve="EmptyComponentContent" />
-    <node concept="3F0ifn" id="6LfBX8Yi4uO" role="2wV5jI">
-      <property role="3F0ifm" value="" />
-      <node concept="VPxyj" id="6LfBX8Yi4vF" role="3F10Kt">
-        <property role="VOm3f" value="true" />
+    <node concept="130CD5" id="5KNBYKZ3AgY" role="2wV5jI">
+      <node concept="3F0ifn" id="5KNBYKZ3AgZ" role="130CDr">
+        <property role="3F0ifm" value="" />
+        <node concept="VPxyj" id="5KNBYKZ3Ah0" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="130t_x" id="5KNBYKZ3Ah1" role="130p63">
+        <property role="1hAc7k" value="7P1WhNABBiJ/complete_action_id" />
+        <node concept="130t_S" id="5KNBYKZ3Ah2" role="130oVf">
+          <node concept="3clFbS" id="5KNBYKZ3Ah3" role="2VODD2">
+            <node concept="3clFbF" id="5KNBYKZ3Ah4" role="3cqZAp">
+              <node concept="2YIFZM" id="5KNBYKZ3Ah5" role="3clFbG">
+                <ref role="37wK5l" to="buwp:Ss0aue3QB0" resolve="selectIfApplicable" />
+                <ref role="1Pybhc" to="buwp:Ss0aue3Qrs" resolve="SingleEntrySelector" />
+                <node concept="1XNTG" id="5KNBYKZ3Ah6" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>
@@ -1379,10 +1408,26 @@
   <node concept="24kQdi" id="6LfBX8Yivyg">
     <property role="3GE5qa" value="chunk" />
     <ref role="1XX52x" to="w9y2:6LfBX8YivxI" resolve="EmptyComponentsChunkContent" />
-    <node concept="3F0ifn" id="6LfBX8Yivyi" role="2wV5jI">
-      <property role="3F0ifm" value="" />
-      <node concept="VPxyj" id="6LfBX8Yivz9" role="3F10Kt">
-        <property role="VOm3f" value="true" />
+    <node concept="130CD5" id="Ss0aue60P6" role="2wV5jI">
+      <node concept="3F0ifn" id="Ss0aue60P7" role="130CDr">
+        <property role="3F0ifm" value="" />
+        <node concept="VPxyj" id="Ss0aue60P8" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="130t_x" id="Ss0aue60P9" role="130p63">
+        <property role="1hAc7k" value="7P1WhNABBiJ/complete_action_id" />
+        <node concept="130t_S" id="Ss0aue60Pa" role="130oVf">
+          <node concept="3clFbS" id="Ss0aue60Pb" role="2VODD2">
+            <node concept="3clFbF" id="Ss0aue60Pc" role="3cqZAp">
+              <node concept="2YIFZM" id="Ss0aue60Pd" role="3clFbG">
+                <ref role="1Pybhc" to="buwp:Ss0aue3Qrs" resolve="SingleEntrySelector" />
+                <ref role="37wK5l" to="buwp:Ss0aue3QB0" resolve="selectIfApplicable" />
+                <node concept="1XNTG" id="Ss0aue60Pe" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>
@@ -1887,10 +1932,26 @@
   <node concept="24kQdi" id="siw10FjaPT">
     <property role="3GE5qa" value="components.substructure" />
     <ref role="1XX52x" to="w9y2:siw10FjaPn" resolve="EmptySubstructureContent" />
-    <node concept="3F0ifn" id="siw10FjaPV" role="2wV5jI">
-      <property role="3F0ifm" value="" />
-      <node concept="VPxyj" id="siw10FjaRC" role="3F10Kt">
-        <property role="VOm3f" value="true" />
+    <node concept="130CD5" id="Ss0aue60PL" role="2wV5jI">
+      <node concept="3F0ifn" id="Ss0aue60PM" role="130CDr">
+        <property role="3F0ifm" value="" />
+        <node concept="VPxyj" id="Ss0aue60PN" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="130t_x" id="Ss0aue60PO" role="130p63">
+        <property role="1hAc7k" value="7P1WhNABBiJ/complete_action_id" />
+        <node concept="130t_S" id="Ss0aue60PP" role="130oVf">
+          <node concept="3clFbS" id="Ss0aue60PQ" role="2VODD2">
+            <node concept="3clFbF" id="Ss0aue60PR" role="3cqZAp">
+              <node concept="2YIFZM" id="Ss0aue60PS" role="3clFbG">
+                <ref role="1Pybhc" to="buwp:Ss0aue3Qrs" resolve="SingleEntrySelector" />
+                <ref role="37wK5l" to="buwp:Ss0aue3QB0" resolve="selectIfApplicable" />
+                <node concept="1XNTG" id="Ss0aue60PT" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>
@@ -12000,10 +12061,26 @@
   <node concept="24kQdi" id="x8tpS_Roxp">
     <property role="3GE5qa" value="components.iface.ports" />
     <ref role="1XX52x" to="w9y2:x8tpS_RowE" resolve="EmptyComponentInterfaceContent" />
-    <node concept="3F0ifn" id="x8tpS_Roxr" role="2wV5jI">
-      <property role="3F0ifm" value="" />
-      <node concept="VPxyj" id="x8tpS_RoA4" role="3F10Kt">
-        <property role="VOm3f" value="true" />
+    <node concept="130CD5" id="Ss0aue5Xux" role="2wV5jI">
+      <node concept="3F0ifn" id="Ss0aue5XuD" role="130CDr">
+        <property role="3F0ifm" value="" />
+        <node concept="VPxyj" id="x8tpS_RoA4" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="130t_x" id="Ss0aue5XuH" role="130p63">
+        <property role="1hAc7k" value="7P1WhNABBiJ/complete_action_id" />
+        <node concept="130t_S" id="Ss0aue5XuI" role="130oVf">
+          <node concept="3clFbS" id="Ss0aue5XuJ" role="2VODD2">
+            <node concept="3clFbF" id="Ss0aue60mu" role="3cqZAp">
+              <node concept="2YIFZM" id="Ss0aue60mR" role="3clFbG">
+                <ref role="37wK5l" to="buwp:Ss0aue3QB0" resolve="selectIfApplicable" />
+                <ref role="1Pybhc" to="buwp:Ss0aue3Qrs" resolve="SingleEntrySelector" />
+                <node concept="1XNTG" id="Ss0aue60LR" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.attributes/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.attributes/models/editor.mps
@@ -22,11 +22,15 @@
     <import index="i51s" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.lang.smodel.generator.smodelAdapter(MPS.Core/)" />
     <import index="zce0" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.smodel.action(MPS.Editor/)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
+    <import index="buwp" ref="r:8405f486-53b5-4fe6-af3e-7f68358bd631(org.iets3.core.expr.base.editor)" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
+    <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
+      <concept id="1194033889146" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1XNTG" />
+    </language>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="5991739802479784073" name="jetbrains.mps.lang.editor.structure.MenuTypeDefault" flags="ng" index="22hDWj" />
       <concept id="2000375450116423800" name="jetbrains.mps.lang.editor.structure.SubstituteMenu" flags="ng" index="22mcaB" />
@@ -160,6 +164,9 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
@@ -202,6 +209,15 @@
     </language>
     <language id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells">
       <concept id="7408935449007503509" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell_SubstituteCondition" flags="ig" index="7duGs" />
+      <concept id="6856661361479784527" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem" flags="ng" index="130t_x">
+        <property id="1139535298778" name="actionId" index="1hAc7j" />
+        <child id="6856661361479798753" name="execute" index="130oVf" />
+      </concept>
+      <concept id="6856661361479784534" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem_ExecuteFunction" flags="ig" index="130t_S" />
+      <concept id="6856661361479732075" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapCell" flags="ng" index="130CD5">
+        <child id="6856661361479798957" name="actions" index="130p63" />
+        <child id="6856661361479732085" name="cell" index="130CDr" />
+      </concept>
       <concept id="7363578995839435357" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell" flags="ng" index="1kIj98">
         <child id="7408935449007570592" name="substituteCondition" index="7deOD" />
         <child id="7363578995839435358" name="wrapped" index="1kIj9b" />
@@ -932,10 +948,26 @@
   <node concept="24kQdi" id="4fgA7QrG5MD">
     <property role="3GE5qa" value="attributes" />
     <ref role="1XX52x" to="138:4fgA7QrG5LS" resolve="EmptyAttribute" />
-    <node concept="3F0ifn" id="4fgA7QrG5MO" role="2wV5jI">
-      <property role="3F0ifm" value="" />
-      <node concept="VPxyj" id="4fgA7QrG5MS" role="3F10Kt">
-        <property role="VOm3f" value="true" />
+    <node concept="130CD5" id="Ss0aue5Xux" role="2wV5jI">
+      <node concept="3F0ifn" id="Ss0aue5XuD" role="130CDr">
+        <property role="3F0ifm" value="" />
+        <node concept="VPxyj" id="x8tpS_RoA4" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="130t_x" id="Ss0aue5XuH" role="130p63">
+        <property role="1hAc7j" value="7P1WhNABBiJ/complete_action_id" />
+        <node concept="130t_S" id="Ss0aue5XuI" role="130oVf">
+          <node concept="3clFbS" id="Ss0aue5XuJ" role="2VODD2">
+            <node concept="3clFbF" id="Ss0aue60mu" role="3cqZAp">
+              <node concept="2YIFZM" id="Ss0aue60mR" role="3clFbG">
+                <ref role="1Pybhc" to="buwp:Ss0aue3Qrs" resolve="SingleEntrySelector" />
+                <ref role="37wK5l" to="buwp:Ss0aue3QB0" resolve="selectIfApplicable" />
+                <node concept="1XNTG" id="Ss0aue60LR" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.attributes/org.iets3.core.attributes.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.attributes/org.iets3.core.attributes.mpl
@@ -20,6 +20,7 @@
     <dependency reexport="false">583939be-ded0-4735-a055-a74f8477fc34(org.iets3.core.attributes)</dependency>
     <dependency reexport="false">f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)</dependency>
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+    <dependency reexport="false">cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:120e1c9d-4e27-4478-b2af-b2c3bd3850b0:com.mbeddr.mpsutil.editor.querylist" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
@@ -12,6 +12,8 @@
     <use id="b8bb702e-43ed-4090-a902-d180d3e5f292" name="de.slisson.mps.conditionalEditor" version="0" />
     <use id="52733268-be24-4f5f-ab84-a73b7c0c03b0" name="de.slisson.mps.richtext.customcell" version="0" />
     <use id="b1ab8c10-c118-4755-bf2a-cebab35cf533" name="jetbrains.mps.lang.editor.tooltips" version="0" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -53,6 +55,9 @@
         <property id="8436908933892732653" name="uniqueName" index="3NULOk" />
         <child id="2877762237607015161" name="condition" index="RtEXV" />
       </concept>
+    </language>
+    <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
+      <concept id="1194033889146" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1XNTG" />
     </language>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="1402906326895675325" name="jetbrains.mps.lang.editor.structure.CellActionMap_FunctionParm_selectedNode" flags="nn" index="0IXxy" />
@@ -529,6 +534,15 @@
       </concept>
       <concept id="8207263695491691232" name="com.mbeddr.mpsutil.grammarcells.structure.SubconceptExpression" flags="ng" index="2EmZKS" />
       <concept id="8945098465480383073" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell_TransformationText" flags="ig" index="ZYGn8" />
+      <concept id="6856661361479784527" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem" flags="ng" index="130t_x">
+        <property id="1139535298778" name="actionId" index="1hAc7k" />
+        <child id="6856661361479798753" name="execute" index="130oVf" />
+      </concept>
+      <concept id="6856661361479784534" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem_ExecuteFunction" flags="ig" index="130t_S" />
+      <concept id="6856661361479732075" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapCell" flags="ng" index="130CD5">
+        <child id="6856661361479798957" name="actions" index="130p63" />
+        <child id="6856661361479732085" name="cell" index="130CDr" />
+      </concept>
       <concept id="848437706375087728" name="com.mbeddr.mpsutil.grammarcells.structure.ICanHaveDescriptionText" flags="ng" index="1djCvD">
         <child id="848437706375087729" name="descriptionText" index="1djCvC" />
       </concept>
@@ -712,6 +726,7 @@
       <concept id="5232196642625574978" name="jetbrains.mps.baseLanguage.collections.structure.HeadListOperation" flags="nn" index="1eb2ty">
         <child id="5232196642625574980" name="upToIndex" index="1eb2t$" />
       </concept>
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
         <child id="1240687658305" name="delimiter" index="3uJOhx" />
       </concept>
@@ -2551,10 +2566,26 @@
   </node>
   <node concept="24kQdi" id="69zaTr1POf9">
     <ref role="1XX52x" to="hm2y:69zaTr1POec" resolve="EmptyExpression" />
-    <node concept="3F0ifn" id="69zaTr1POfb" role="2wV5jI">
-      <property role="3F0ifm" value="" />
-      <node concept="VPxyj" id="69zaTr1POgj" role="3F10Kt">
-        <property role="VOm3f" value="true" />
+    <node concept="130CD5" id="Ss0aue5God" role="2wV5jI">
+      <node concept="3F0ifn" id="Ss0aue5Gol" role="130CDr">
+        <property role="3F0ifm" value="" />
+        <node concept="VPxyj" id="Ss0aue5Goo" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="130t_x" id="Ss0aue5Goq" role="130p63">
+        <property role="1hAc7k" value="7P1WhNABBiJ/complete_action_id" />
+        <node concept="130t_S" id="Ss0aue5Gor" role="130oVf">
+          <node concept="3clFbS" id="Ss0aue5Gos" role="2VODD2">
+            <node concept="3clFbF" id="Ss0aue5H8D" role="3cqZAp">
+              <node concept="2YIFZM" id="Ss0aue5H92" role="3clFbG">
+                <ref role="37wK5l" node="Ss0aue3QB0" resolve="selectIfApplicable" />
+                <ref role="1Pybhc" node="Ss0aue3Qrs" resolve="SingleEntrySelector" />
+                <node concept="1XNTG" id="Ss0aue5H9l" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>
@@ -7511,6 +7542,159 @@
         </node>
       </node>
     </node>
+  </node>
+  <node concept="312cEu" id="Ss0aue3Qrs">
+    <property role="TrG5h" value="SingleEntrySelector" />
+    <node concept="2YIFZL" id="Ss0aue3QB0" role="jymVt">
+      <property role="TrG5h" value="selectIfApplicable" />
+      <node concept="3clFbS" id="Ss0aue3QB3" role="3clF47">
+        <node concept="3cpWs8" id="Ss0audTREN" role="3cqZAp">
+          <node concept="3cpWsn" id="Ss0audTREO" role="3cpWs9">
+            <property role="TrG5h" value="substituteInfo" />
+            <node concept="3uibUv" id="Ss0audTREP" role="1tU5fm">
+              <ref role="3uigEE" to="f4zo:~SubstituteInfo" resolve="SubstituteInfo" />
+            </node>
+            <node concept="2OqwBi" id="Ss0audTREQ" role="33vP2m">
+              <node concept="2OqwBi" id="Ss0audTRER" role="2Oq$k0">
+                <node concept="37vLTw" id="Ss0aue3Sxs" role="2Oq$k0">
+                  <ref role="3cqZAo" node="Ss0aue3RRb" resolve="editorContext" />
+                </node>
+                <node concept="liA8E" id="Ss0audTRET" role="2OqNvi">
+                  <ref role="37wK5l" to="cj4x:~EditorContext.getSelectedCell()" resolve="getSelectedCell" />
+                </node>
+              </node>
+              <node concept="liA8E" id="Ss0audTREU" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~EditorCell.getSubstituteInfo()" resolve="getSubstituteInfo" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="Ss0audTREV" role="3cqZAp">
+          <node concept="3cpWsn" id="Ss0audTREW" role="3cpWs9">
+            <property role="TrG5h" value="actions" />
+            <node concept="_YKpA" id="Ss0audTREX" role="1tU5fm">
+              <node concept="3uibUv" id="Ss0audTREY" role="_ZDj9">
+                <ref role="3uigEE" to="f4zo:~SubstituteAction" resolve="SubstituteAction" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="Ss0audTREZ" role="33vP2m">
+              <node concept="37vLTw" id="Ss0audTRF0" role="2Oq$k0">
+                <ref role="3cqZAo" node="Ss0audTREO" resolve="substituteInfo" />
+              </node>
+              <node concept="liA8E" id="Ss0audTRF1" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~SubstituteInfo.getMatchingActions(java.lang.String,boolean)" resolve="getMatchingActions" />
+                <node concept="Xl_RD" id="Ss0audTRF2" role="37wK5m">
+                  <property role="Xl_RC" value="" />
+                </node>
+                <node concept="3clFbT" id="Ss0audTRF3" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="Ss0audTRF4" role="3cqZAp">
+          <node concept="3cpWsn" id="Ss0audTRF5" role="3cpWs9">
+            <property role="TrG5h" value="firstAction" />
+            <node concept="3uibUv" id="Ss0audTRF6" role="1tU5fm">
+              <ref role="3uigEE" to="f4zo:~SubstituteAction" resolve="SubstituteAction" />
+            </node>
+            <node concept="2OqwBi" id="Ss0audTRF7" role="33vP2m">
+              <node concept="37vLTw" id="Ss0audTRF8" role="2Oq$k0">
+                <ref role="3cqZAo" node="Ss0audTREW" resolve="actions" />
+              </node>
+              <node concept="1uHKPH" id="Ss0audTRF9" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="Ss0audTRFa" role="3cqZAp">
+          <node concept="3cpWsn" id="Ss0audTRFb" role="3cpWs9">
+            <property role="TrG5h" value="text" />
+            <node concept="17QB3L" id="Ss0audTRFc" role="1tU5fm" />
+            <node concept="2OqwBi" id="Ss0audTRFd" role="33vP2m">
+              <node concept="37vLTw" id="Ss0audTRFe" role="2Oq$k0">
+                <ref role="3cqZAo" node="Ss0audTREO" resolve="substituteInfo" />
+              </node>
+              <node concept="liA8E" id="Ss0audTRFf" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~SubstituteInfo.getOriginalText()" resolve="getOriginalText" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="Ss0audTRFg" role="3cqZAp">
+          <node concept="3clFbS" id="Ss0audTRFh" role="3clFbx">
+            <node concept="3clFbF" id="Ss0audTRFi" role="3cqZAp">
+              <node concept="2OqwBi" id="Ss0audTRFj" role="3clFbG">
+                <node concept="37vLTw" id="Ss0audTRFk" role="2Oq$k0">
+                  <ref role="3cqZAo" node="Ss0audTRF5" resolve="firstAction" />
+                </node>
+                <node concept="liA8E" id="Ss0audTRFl" role="2OqNvi">
+                  <ref role="37wK5l" to="f4zo:~SubstituteAction.substitute(jetbrains.mps.openapi.editor.EditorContext,java.lang.String)" resolve="substitute" />
+                  <node concept="37vLTw" id="Ss0aue3T9T" role="37wK5m">
+                    <ref role="3cqZAo" node="Ss0aue3RRb" resolve="editorContext" />
+                  </node>
+                  <node concept="37vLTw" id="Ss0audTRFn" role="37wK5m">
+                    <ref role="3cqZAo" node="Ss0audTRFb" resolve="text" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1Wc70l" id="Ss0audTRFo" role="3clFbw">
+            <node concept="2OqwBi" id="Ss0audTRFp" role="3uHU7w">
+              <node concept="37vLTw" id="Ss0audTRFq" role="2Oq$k0">
+                <ref role="3cqZAo" node="Ss0audTRF5" resolve="firstAction" />
+              </node>
+              <node concept="liA8E" id="Ss0audTRFr" role="2OqNvi">
+                <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstitute(java.lang.String)" resolve="canSubstitute" />
+                <node concept="37vLTw" id="Ss0audTRFs" role="37wK5m">
+                  <ref role="3cqZAo" node="Ss0audTRFb" resolve="text" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbC" id="Ss0audTRFt" role="3uHU7B">
+              <node concept="2OqwBi" id="Ss0audTRFu" role="3uHU7B">
+                <node concept="37vLTw" id="Ss0audTRFv" role="2Oq$k0">
+                  <ref role="3cqZAo" node="Ss0audTREW" resolve="actions" />
+                </node>
+                <node concept="34oBXx" id="Ss0audTRFw" role="2OqNvi" />
+              </node>
+              <node concept="3cmrfG" id="Ss0audTRFx" role="3uHU7w">
+                <property role="3cmrfH" value="1" />
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="Ss0audTRFy" role="9aQIa">
+            <node concept="3clFbS" id="Ss0audTRFz" role="9aQI4">
+              <node concept="3clFbF" id="Ss0audTRF$" role="3cqZAp">
+                <node concept="2OqwBi" id="Ss0audTRF_" role="3clFbG">
+                  <node concept="2ShNRf" id="Ss0audTRFA" role="2Oq$k0">
+                    <node concept="1pGfFk" id="Ss0audTRFB" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" to="exr9:~NodeEditorActions$Complete.&lt;init&gt;(boolean)" resolve="Complete" />
+                      <node concept="3clFbT" id="Ss0audTRFC" role="37wK5m" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="Ss0audTRFD" role="2OqNvi">
+                    <ref role="37wK5l" to="exr9:~NodeEditorActions$Complete.execute(jetbrains.mps.openapi.editor.EditorContext)" resolve="execute" />
+                    <node concept="37vLTw" id="Ss0aue3TnB" role="37wK5m">
+                      <ref role="3cqZAo" node="Ss0aue3RRb" resolve="editorContext" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="Ss0aue3Qx6" role="1B3o_S" />
+      <node concept="3cqZAl" id="Ss0aue3QAP" role="3clF45" />
+      <node concept="37vLTG" id="Ss0aue3RRb" role="3clF46">
+        <property role="TrG5h" value="editorContext" />
+        <node concept="3uibUv" id="Ss0aue3RRa" role="1tU5fm">
+          <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="Ss0aue3Qrt" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
@@ -7669,7 +7669,7 @@
                   <node concept="2ShNRf" id="Ss0audTRFA" role="2Oq$k0">
                     <node concept="1pGfFk" id="Ss0audTRFB" role="2ShVmc">
                       <property role="373rjd" value="true" />
-                      <ref role="37wK5l" to="exr9:~NodeEditorActions$Complete.&lt;init&gt;(boolean)" resolve="Complete" />
+                      <ref role="37wK5l" to="exr9:~NodeEditorActions$Complete.&lt;init&gt;(boolean)" resolve="NodeEditorActions.Complete" />
                       <node concept="3clFbT" id="Ss0audTRFC" role="37wK5m" />
                     </node>
                   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
@@ -5,6 +5,7 @@
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells" version="2" />
     <use id="b1ab8c10-c118-4755-bf2a-cebab35cf533" name="jetbrains.mps.lang.editor.tooltips" version="0" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -16,12 +17,16 @@
     <import index="kelk" ref="r:1a11ce0d-cf54-4682-9b8a-ab4ee15fc129(org.iets3.core.expr.messages.structure)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
+    <import index="buwp" ref="r:8405f486-53b5-4fe6-af3e-7f68358bd631(org.iets3.core.expr.base.editor)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
   </imports>
   <registry>
+    <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
+      <concept id="1194033889146" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1XNTG" />
+    </language>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="5991739802479784073" name="jetbrains.mps.lang.editor.structure.MenuTypeDefault" flags="ng" index="22hDWj" />
       <concept id="2000375450116423800" name="jetbrains.mps.lang.editor.structure.SubstituteMenu" flags="ng" index="22mcaB" />
@@ -208,6 +213,15 @@
       <concept id="9041925471455857605" name="com.mbeddr.mpsutil.grammarcells.structure.Cell_DescriptionText" flags="ig" index="uPpia" />
       <concept id="5083944728298846680" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell" flags="ng" index="_tjkj">
         <child id="5083944728298846681" name="option" index="_tjki" />
+      </concept>
+      <concept id="6856661361479784527" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem" flags="ng" index="130t_x">
+        <property id="1139535298778" name="actionId" index="1hAc7j" />
+        <child id="6856661361479798753" name="execute" index="130oVf" />
+      </concept>
+      <concept id="6856661361479784534" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem_ExecuteFunction" flags="ig" index="130t_S" />
+      <concept id="6856661361479732075" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapCell" flags="ng" index="130CD5">
+        <child id="6856661361479798957" name="actions" index="130p63" />
+        <child id="6856661361479732085" name="cell" index="130CDr" />
       </concept>
       <concept id="848437706375087728" name="com.mbeddr.mpsutil.grammarcells.structure.ICanHaveDescriptionText" flags="ng" index="1djCvD">
         <child id="848437706375087729" name="descriptionText" index="1djCvC" />
@@ -653,10 +667,26 @@
   </node>
   <node concept="24kQdi" id="3vxfdxbcSAl">
     <ref role="1XX52x" to="kelk:3vxfdxbcS_H" resolve="EmptyMessageContent" />
-    <node concept="3F0ifn" id="3vxfdxbcSAn" role="2wV5jI">
-      <property role="3F0ifm" value="" />
-      <node concept="VPxyj" id="3vxfdxbcSAr" role="3F10Kt">
-        <property role="VOm3f" value="true" />
+    <node concept="130CD5" id="Ss0aue5Xux" role="2wV5jI">
+      <node concept="3F0ifn" id="Ss0aue5XuD" role="130CDr">
+        <property role="3F0ifm" value="" />
+        <node concept="VPxyj" id="x8tpS_RoA4" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="130t_x" id="Ss0aue5XuH" role="130p63">
+        <property role="1hAc7j" value="7P1WhNABBiJ/complete_action_id" />
+        <node concept="130t_S" id="Ss0aue5XuI" role="130oVf">
+          <node concept="3clFbS" id="Ss0aue5XuJ" role="2VODD2">
+            <node concept="3clFbF" id="Ss0aue60mu" role="3cqZAp">
+              <node concept="2YIFZM" id="Ss0aue60mR" role="3clFbG">
+                <ref role="1Pybhc" to="buwp:Ss0aue3Qrs" resolve="SingleEntrySelector" />
+                <ref role="37wK5l" to="buwp:Ss0aue3QB0" resolve="selectIfApplicable" />
+                <node concept="1XNTG" id="Ss0aue60LR" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/org.iets3.core.expr.messages.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/org.iets3.core.expr.messages.mpl
@@ -23,6 +23,7 @@
     <dependency reexport="false">71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)</dependency>
     <dependency reexport="false">2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)</dependency>
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
+    <dependency reexport="false">cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="2" />
@@ -58,6 +59,7 @@
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
     <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
     <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
+    <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:1a8554c4-eb84-43ba-8c34-6f0d90c6e75a:jetbrains.mps.lang.smodel.query" version="3" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.statemachines/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.statemachines/models/editor.mps
@@ -12,6 +12,7 @@
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" />
     <import index="w10o" ref="r:686388e3-73e9-45fe-97d6-89d89b0cf1ed(org.iets3.core.expr.statemachines.behavior)" />
+    <import index="buwp" ref="r:8405f486-53b5-4fe6-af3e-7f68358bd631(org.iets3.core.expr.base.editor)" />
     <import index="itrz" ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="fym6" ref="r:7b6888d5-e93c-46df-85f2-56bc59c85348(org.iets3.core.expr.mutable.editor)" implicit="true" />
@@ -20,6 +21,9 @@
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
   </imports>
   <registry>
+    <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
+      <concept id="1194033889146" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1XNTG" />
+    </language>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="5991739802479784073" name="jetbrains.mps.lang.editor.structure.MenuTypeDefault" flags="ng" index="22hDWj" />
       <concept id="2000375450116423800" name="jetbrains.mps.lang.editor.structure.SubstituteMenu" flags="ng" index="22mcaB" />
@@ -158,6 +162,9 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
@@ -249,6 +256,15 @@
         <child id="8945098465480008160" name="transformationText" index="ZWbT9" />
       </concept>
       <concept id="8945098465480383073" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell_TransformationText" flags="ig" index="ZYGn8" />
+      <concept id="6856661361479784527" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem" flags="ng" index="130t_x">
+        <property id="1139535298778" name="actionId" index="1hAc7j" />
+        <child id="6856661361479798753" name="execute" index="130oVf" />
+      </concept>
+      <concept id="6856661361479784534" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem_ExecuteFunction" flags="ig" index="130t_S" />
+      <concept id="6856661361479732075" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapCell" flags="ng" index="130CD5">
+        <child id="6856661361479798957" name="actions" index="130p63" />
+        <child id="6856661361479732085" name="cell" index="130CDr" />
+      </concept>
       <concept id="848437706375087728" name="com.mbeddr.mpsutil.grammarcells.structure.ICanHaveDescriptionText" flags="ng" index="1djCvD">
         <child id="848437706375087729" name="descriptionText" index="1djCvC" />
       </concept>
@@ -1347,10 +1363,26 @@
   <node concept="24kQdi" id="7$TgoCYkO5i">
     <property role="3GE5qa" value="machine" />
     <ref role="1XX52x" to="19m5:7$TgoCYkO4D" resolve="EmptySMC" />
-    <node concept="3F0ifn" id="7$TgoCYkO5q" role="2wV5jI">
-      <property role="3F0ifm" value="" />
-      <node concept="VPxyj" id="7$TgoCYkO5t" role="3F10Kt">
-        <property role="VOm3f" value="true" />
+    <node concept="130CD5" id="Ss0aue5Xux" role="2wV5jI">
+      <node concept="3F0ifn" id="Ss0aue5XuD" role="130CDr">
+        <property role="3F0ifm" value="" />
+        <node concept="VPxyj" id="x8tpS_RoA4" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="130t_x" id="Ss0aue5XuH" role="130p63">
+        <property role="1hAc7j" value="7P1WhNABBiJ/complete_action_id" />
+        <node concept="130t_S" id="Ss0aue5XuI" role="130oVf">
+          <node concept="3clFbS" id="Ss0aue5XuJ" role="2VODD2">
+            <node concept="3clFbF" id="Ss0aue60mu" role="3cqZAp">
+              <node concept="2YIFZM" id="Ss0aue60mR" role="3clFbG">
+                <ref role="1Pybhc" to="buwp:Ss0aue3Qrs" resolve="SingleEntrySelector" />
+                <ref role="37wK5l" to="buwp:Ss0aue3QB0" resolve="selectIfApplicable" />
+                <node concept="1XNTG" id="Ss0aue60LR" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>
@@ -1757,10 +1789,26 @@
   <node concept="24kQdi" id="mQGcCvv0NX">
     <property role="3GE5qa" value="machine" />
     <ref role="1XX52x" to="19m5:mQGcCvv0Nq" resolve="EmptyStateContent" />
-    <node concept="3F0ifn" id="mQGcCvv0NZ" role="2wV5jI">
-      <property role="3F0ifm" value="" />
-      <node concept="VPxyj" id="mQGcCvv0O2" role="3F10Kt">
-        <property role="VOm3f" value="true" />
+    <node concept="130CD5" id="Ss0aue61ns" role="2wV5jI">
+      <node concept="3F0ifn" id="Ss0aue61nt" role="130CDr">
+        <property role="3F0ifm" value="" />
+        <node concept="VPxyj" id="Ss0aue61nu" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="130t_x" id="Ss0aue61nv" role="130p63">
+        <property role="1hAc7j" value="7P1WhNABBiJ/complete_action_id" />
+        <node concept="130t_S" id="Ss0aue61nw" role="130oVf">
+          <node concept="3clFbS" id="Ss0aue61nx" role="2VODD2">
+            <node concept="3clFbF" id="Ss0aue61ny" role="3cqZAp">
+              <node concept="2YIFZM" id="Ss0aue61nz" role="3clFbG">
+                <ref role="1Pybhc" to="buwp:Ss0aue3Qrs" resolve="SingleEntrySelector" />
+                <ref role="37wK5l" to="buwp:Ss0aue3QB0" resolve="selectIfApplicable" />
+                <node concept="1XNTG" id="Ss0aue61n$" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
@@ -42,6 +42,7 @@
     <import index="oq0c" ref="r:6c6155f0-4bbe-4af5-8c26-244d570e21e4(org.iets3.core.expr.base.plugin)" />
     <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
+    <import index="buwp" ref="r:8405f486-53b5-4fe6-af3e-7f68358bd631(org.iets3.core.expr.base.editor)" />
     <import index="yv47" ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" implicit="true" />
     <import index="2ahs" ref="r:ea6cf71d-29d2-478d-8027-a9f4a4de53c4(com.mbeddr.mpsutil.interpreter.rt)" implicit="true" />
   </imports>
@@ -56,6 +57,7 @@
       </concept>
     </language>
     <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
+      <concept id="1194033889146" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1XNTG" />
       <concept id="1161622665029" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_model" flags="nn" index="1Q6Npb" />
     </language>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -397,6 +399,15 @@
         <child id="8945098465480008160" name="transformationText" index="ZWbT9" />
       </concept>
       <concept id="8945098465480383073" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell_TransformationText" flags="ig" index="ZYGn8" />
+      <concept id="6856661361479784527" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem" flags="ng" index="130t_x">
+        <property id="1139535298778" name="actionId" index="1hAc7k" />
+        <child id="6856661361479798753" name="execute" index="130oVf" />
+      </concept>
+      <concept id="6856661361479784534" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem_ExecuteFunction" flags="ig" index="130t_S" />
+      <concept id="6856661361479732075" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapCell" flags="ng" index="130CD5">
+        <child id="6856661361479798957" name="actions" index="130p63" />
+        <child id="6856661361479732085" name="cell" index="130CDr" />
+      </concept>
       <concept id="848437706375087728" name="com.mbeddr.mpsutil.grammarcells.structure.ICanHaveDescriptionText" flags="ng" index="1djCvD">
         <child id="848437706375087729" name="descriptionText" index="1djCvC" />
       </concept>
@@ -1889,10 +1900,26 @@
   </node>
   <node concept="24kQdi" id="4_qY3E4CWiZ">
     <ref role="1XX52x" to="av4b:4_qY3E4CWhU" resolve="EmptyTestItem" />
-    <node concept="3F0ifn" id="4_qY3E4CWjd" role="2wV5jI">
-      <property role="3F0ifm" value="" />
-      <node concept="VPxyj" id="4_qY3E4CWlo" role="3F10Kt">
-        <property role="VOm3f" value="true" />
+    <node concept="130CD5" id="Ss0aue5Xux" role="2wV5jI">
+      <node concept="3F0ifn" id="Ss0aue5XuD" role="130CDr">
+        <property role="3F0ifm" value="" />
+        <node concept="VPxyj" id="x8tpS_RoA4" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="130t_x" id="Ss0aue5XuH" role="130p63">
+        <property role="1hAc7k" value="7P1WhNABBiJ/complete_action_id" />
+        <node concept="130t_S" id="Ss0aue5XuI" role="130oVf">
+          <node concept="3clFbS" id="Ss0aue5XuJ" role="2VODD2">
+            <node concept="3clFbF" id="Ss0aue60mu" role="3cqZAp">
+              <node concept="2YIFZM" id="Ss0aue60mR" role="3clFbG">
+                <ref role="1Pybhc" to="buwp:Ss0aue3Qrs" resolve="SingleEntrySelector" />
+                <ref role="37wK5l" to="buwp:Ss0aue3QB0" resolve="selectIfApplicable" />
+                <node concept="1XNTG" id="Ss0aue60LR" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -276,6 +276,9 @@
       <concept id="1145567426890" name="jetbrains.mps.lang.smodel.structure.SNodeListCreator" flags="nn" index="2T8Vx0">
         <child id="1145567471833" name="createdType" index="2T96Bj" />
       </concept>
+      <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
+        <reference id="1139877738879" name="concept" index="1A0vxQ" />
+      </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
         <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
@@ -3580,7 +3583,21 @@
     <property role="3GE5qa" value="record" />
     <ref role="13h7C2" to="yv47:7D7uZV2dYyQ" resolve="RecordDeclaration" />
     <node concept="13hLZK" id="7D7uZV2fCZr" role="13h7CW">
-      <node concept="3clFbS" id="7D7uZV2fCZs" role="2VODD2" />
+      <node concept="3clFbS" id="7D7uZV2fCZs" role="2VODD2">
+        <node concept="3clFbF" id="Ss0audYmur" role="3cqZAp">
+          <node concept="2OqwBi" id="Ss0audYr$r" role="3clFbG">
+            <node concept="2OqwBi" id="Ss0audYmPf" role="2Oq$k0">
+              <node concept="13iPFW" id="Ss0audYmuq" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="Ss0audYnG4" role="2OqNvi">
+                <ref role="3TtcxE" to="yv47:xu7xcKioz5" resolve="members" />
+              </node>
+            </node>
+            <node concept="WFELt" id="Ss0audYvcJ" role="2OqNvi">
+              <ref role="1A0vxQ" to="yv47:58eyHuUiMwN" resolve="EmptyMember" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="13i0hz" id="7D7uZV2ybqD" role="13h7CS">
       <property role="13i0iv" value="false" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -11,6 +11,7 @@
     <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="-1" />
     <use id="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" name="com.mbeddr.mpsutil.editor.querylist" version="0" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -47,6 +48,9 @@
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
   </imports>
   <registry>
+    <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
+      <concept id="1194033889146" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1XNTG" />
+    </language>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="1402906326896143883" name="jetbrains.mps.lang.editor.structure.CellKeyMap_FunctionParm_selectedNode" flags="nn" index="0GJ7k" />
       <concept id="1402906326895675325" name="jetbrains.mps.lang.editor.structure.CellActionMap_FunctionParm_selectedNode" flags="nn" index="0IXxy" />
@@ -500,6 +504,15 @@
         <child id="8945098465480008160" name="transformationText" index="ZWbT9" />
       </concept>
       <concept id="8945098465480383073" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell_TransformationText" flags="ig" index="ZYGn8" />
+      <concept id="6856661361479784527" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem" flags="ng" index="130t_x">
+        <property id="1139535298778" name="actionId" index="1hAc7k" />
+        <child id="6856661361479798753" name="execute" index="130oVf" />
+      </concept>
+      <concept id="6856661361479784534" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapItem_ExecuteFunction" flags="ig" index="130t_S" />
+      <concept id="6856661361479732075" name="com.mbeddr.mpsutil.grammarcells.structure.InlineActionMapCell" flags="ng" index="130CD5">
+        <child id="6856661361479798957" name="actions" index="130p63" />
+        <child id="6856661361479732085" name="cell" index="130CDr" />
+      </concept>
       <concept id="848437706375087728" name="com.mbeddr.mpsutil.grammarcells.structure.ICanHaveDescriptionText" flags="ng" index="1djCvD">
         <child id="848437706375087729" name="descriptionText" index="1djCvC" />
       </concept>
@@ -1222,10 +1235,26 @@
   </node>
   <node concept="24kQdi" id="ub9nkyKjdP">
     <ref role="1XX52x" to="yv47:ub9nkyKjdj" resolve="EmptyToplevelContent" />
-    <node concept="3F0ifn" id="ub9nkyKjdR" role="2wV5jI">
-      <property role="3F0ifm" value="" />
-      <node concept="VPxyj" id="ub9nkyKjeI" role="3F10Kt">
-        <property role="VOm3f" value="true" />
+    <node concept="130CD5" id="Ss0audS5nT" role="2wV5jI">
+      <node concept="3F0ifn" id="Ss0audS5nU" role="130CDr">
+        <property role="3F0ifm" value="" />
+        <node concept="VPxyj" id="Ss0audS5nV" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="130t_x" id="Ss0audS5nW" role="130p63">
+        <property role="1hAc7k" value="7P1WhNABBiJ/complete_action_id" />
+        <node concept="130t_S" id="Ss0audS5nX" role="130oVf">
+          <node concept="3clFbS" id="Ss0audS5nY" role="2VODD2">
+            <node concept="3clFbF" id="Ss0aue3U6N" role="3cqZAp">
+              <node concept="2YIFZM" id="Ss0aue5H8k" role="3clFbG">
+                <ref role="37wK5l" to="buwp:Ss0aue3QB0" resolve="selectIfApplicable" />
+                <ref role="1Pybhc" to="buwp:Ss0aue3Qrs" resolve="SingleEntrySelector" />
+                <node concept="1XNTG" id="Ss0aue3U7x" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>
@@ -1330,10 +1359,39 @@
         <node concept="3F2HdR" id="11foXHHR041" role="3EZMnx">
           <ref role="1NtTu8" to="yv47:xu7xcKioz5" resolve="members" />
           <node concept="2EHx9g" id="11foXHHR04a" role="2czzBx" />
-          <node concept="3F0ifn" id="11foXHHR04e" role="2czzBI">
-            <property role="3F0ifm" value="" />
-            <node concept="VPxyj" id="11foXHHR04h" role="3F10Kt">
-              <property role="VOm3f" value="true" />
+          <node concept="130CD5" id="Ss0aue3U3C" role="2czzBI">
+            <node concept="3F0ifn" id="Ss0aue3U3I" role="130CDr">
+              <property role="3F0ifm" value="" />
+              <node concept="VPxyj" id="Ss0aue3U3L" role="3F10Kt">
+                <property role="VOm3f" value="true" />
+              </node>
+            </node>
+            <node concept="130t_x" id="Ss0aue3U3N" role="130p63">
+              <property role="1hAc7k" value="7P1WhNABBiJ/complete_action_id" />
+              <node concept="130t_S" id="Ss0aue3U3O" role="130oVf">
+                <node concept="3clFbS" id="Ss0aue3U3P" role="2VODD2">
+                  <node concept="3clFbF" id="Ss0aue3U44" role="3cqZAp">
+                    <node concept="2YIFZM" id="Ss0aue5H8l" role="3clFbG">
+                      <ref role="37wK5l" to="buwp:Ss0aue3QB0" resolve="selectIfApplicable" />
+                      <ref role="1Pybhc" to="buwp:Ss0aue3Qrs" resolve="SingleEntrySelector" />
+                      <node concept="1XNTG" id="Ss0aue3U4M" role="37wK5m" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="4$FPG" id="Ss0audFsX_" role="4_6I_">
+            <node concept="3clFbS" id="Ss0audFsXA" role="2VODD2">
+              <node concept="3clFbF" id="Ss0audFHWF" role="3cqZAp">
+                <node concept="2ShNRf" id="Ss0audFHWD" role="3clFbG">
+                  <node concept="3zrR0B" id="Ss0audG$x2" role="2ShVmc">
+                    <node concept="3Tqbb2" id="Ss0audG$x4" role="3zrR0E">
+                      <ref role="ehGHo" to="yv47:58eyHuUiMwN" resolve="EmptyMember" />
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -3733,10 +3791,26 @@
   <node concept="24kQdi" id="58eyHuUiMxr">
     <property role="3GE5qa" value="record" />
     <ref role="1XX52x" to="yv47:58eyHuUiMwN" resolve="EmptyMember" />
-    <node concept="3F0ifn" id="58eyHuUiMxt" role="2wV5jI">
-      <property role="3F0ifm" value="" />
-      <node concept="VPxyj" id="58eyHuUiSGI" role="3F10Kt">
-        <property role="VOm3f" value="true" />
+    <node concept="130CD5" id="Ss0audQhWW" role="2wV5jI">
+      <node concept="3F0ifn" id="Ss0audQhX4" role="130CDr">
+        <property role="3F0ifm" value="" />
+        <node concept="VPxyj" id="Ss0audQhX7" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="130t_x" id="Ss0audQhX9" role="130p63">
+        <property role="1hAc7k" value="7P1WhNABBiJ/complete_action_id" />
+        <node concept="130t_S" id="Ss0audQhXa" role="130oVf">
+          <node concept="3clFbS" id="Ss0audQhXb" role="2VODD2">
+            <node concept="3clFbF" id="Ss0aue3UQT" role="3cqZAp">
+              <node concept="2YIFZM" id="Ss0aue5H8m" role="3clFbG">
+                <ref role="37wK5l" to="buwp:Ss0aue3QB0" resolve="selectIfApplicable" />
+                <ref role="1Pybhc" to="buwp:Ss0aue3Qrs" resolve="SingleEntrySelector" />
+                <node concept="1XNTG" id="Ss0aue3URB" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -4890,6 +4890,11 @@
             <ref role="1Busuk" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
           </node>
         </node>
+        <node concept="1SiIV0" id="Ss0aue6178" role="3bR37C">
+          <node concept="3bR9La" id="Ss0aue6179" role="1SiIV1">
+            <ref role="3bR37D" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="ub9nkyRnyj" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -7804,6 +7809,11 @@
             <node concept="3qWCbU" id="1RMC8GHEwQd" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="Ss0aue61co" role="3bR37C">
+          <node concept="3bR9La" id="Ss0aue61cp" role="1SiIV1">
+            <ref role="3bR37D" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/solutions/test.org.iets3.core.comments/models/tests@tests.mps
+++ b/code/languages/org.iets3.opensource/solutions/test.org.iets3.core.comments/models/tests@tests.mps
@@ -98,12 +98,12 @@
       <node concept="1i1ALs" id="5kwEgmAh22m" role="1qenE9">
         <property role="TrG5h" value="TestChunk" />
         <node concept="1i1AuW" id="5kwEgmAh22K" role="1i1AA4">
-          <node concept="LIFWc" id="5kwEgmAi6Gs" role="lGtFl">
+          <node concept="LIFWc" id="2jufBumzkgZ" role="lGtFl">
             <property role="ZRATv" value="true" />
             <property role="OXtK3" value="true" />
             <property role="p6zMq" value="0" />
             <property role="p6zMs" value="0" />
-            <property role="LIFWd" value="Constant_wio9cu_a" />
+            <property role="LIFWd" value="Constant_wio9cu_a0" />
           </node>
         </node>
         <node concept="1i1XBj" id="5kwEgmAi6Gh" role="1i1AA4">
@@ -153,12 +153,12 @@
           </node>
           <node concept="GnABt" id="5kwEgmAh7qZ" role="1i1XAe">
             <node concept="GnyP7" id="5kwEgmAh7rP" role="GnABu">
-              <node concept="LIFWc" id="5kwEgmAh7sa" role="lGtFl">
+              <node concept="LIFWc" id="2jufBumzks0" role="lGtFl">
                 <property role="ZRATv" value="true" />
                 <property role="OXtK3" value="true" />
                 <property role="p6zMq" value="0" />
                 <property role="p6zMs" value="0" />
-                <property role="LIFWd" value="Constant_e3eoih_a" />
+                <property role="LIFWd" value="Constant_e3eoih_a0" />
               </node>
             </node>
             <node concept="1i6xzV" id="5kwEgmAh7r6" role="GnABu">
@@ -236,12 +236,12 @@
             <node concept="H_vQO" id="59rcyU3GDn2" role="H_jLS" />
           </node>
           <node concept="1i1Xx2" id="5kwEgmAi6LP" role="1i1XAe">
-            <node concept="LIFWc" id="5kwEgmAi6M6" role="lGtFl">
+            <node concept="LIFWc" id="2jufBumzkr_" role="lGtFl">
               <property role="ZRATv" value="true" />
               <property role="OXtK3" value="true" />
               <property role="p6zMq" value="0" />
               <property role="p6zMs" value="0" />
-              <property role="LIFWd" value="Constant_96uam9_a" />
+              <property role="LIFWd" value="Constant_96uam9_a0" />
             </node>
           </node>
           <node concept="GnABt" id="5kwEgmAi6LZ" role="1i1XAe" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
@@ -37,6 +37,7 @@
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
     <language slang="l:f47b95d4-5e73-4c04-9204-18076950153b:com.mbeddr.mpsutil.compare" version="0" />
     <language slang="l:d3a0fd26-445a-466c-900e-10444ddfed52:com.mbeddr.mpsutil.filepicker" version="0" />
+    <language slang="l:e776175c-3bf6-498e-ad36-e4c7dfa5fbe9:com.mbeddr.mpsutil.httpsupport" version="0" />
     <language slang="l:47f075a6-558e-4640-a606-7ce0236c8023:com.mbeddr.mpsutil.interpreter" version="1" />
     <language slang="l:d09a16fb-1d68-4a92-a5a4-20b4b2f86a62:com.mbeddr.mpsutil.jung" version="0" />
     <language slang="l:b4d28e19-7d2d-47e9-943e-3a41f97a0e52:com.mbeddr.mpsutil.plantuml.node" version="0" />
@@ -49,6 +50,7 @@
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:817e4e70-961e-4a95-98a1-15e9f32231f1:jetbrains.mps.ide.httpsupport" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />


### PR DESCRIPTION
These old steps to create a new member:
- create a record
- then you create an empty line
- then you need to create a record member if you don't know that you can just start typing (1)
    - <img width="713" alt="Screenshot 2024-04-22 at 10 32 19" src="https://github.com/IETS3/iets3.opensource/assets/88385944/c01a46ae-4bdb-45af-bb7c-5a75211f2691">
    - then you can set its name and data type
    
There is no information about (1), so people use the code completion menu to select the only applicable entry: a new member. With this PR, the only CC menu entry is automatically selected. The empty line is also inserted automatically when you create a new declaration.

The request was initially only for record declarations but I also added this feature to other concepts that represent empty placeholders like empty lines or other empty contents. It can still be relevant if those other concepts are filtered and only one subconcept is allowed at the end.

