### PR TITLE
Use BUILD_COUNTER instead of BUILD_NUMBER

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ if (project.hasProperty('iets3OpenSourceVersion')) {
     if (ciBuild) {
         currentBranch = GitBasedVersioning.gitBranch
 
-        def buildNumber = System.env.BUILD_NUMBER.toInteger()
+        def buildNumber = System.env.BUILD_COUNTER.toInteger()
         if (currentBranch.startsWith("maintenance-")) {
             version = "$major.$minor.$buildNumber.${GitBasedVersioning.gitShortCommitHash}"
         } else {


### PR DESCRIPTION
BUILD_NUMBER is redefined by this build file on CI so we cannot run more than one Gradle step. BUILD_COUNTER is defined on TeamCity to be %build.counter% and is not touched by the build.