### PR TITLE
temporal.runtime: TemporalOps.joinSlices can now handle null values of slices

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.base/org.iets3.core.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.base/org.iets3.core.base.mpl
@@ -16,7 +16,7 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
     <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
-    <dependency reexport="false">5454dbfd-2075-4de0-b85e-fa645eb6957e(com.mbeddr.mpsutil.serializer.xml)</dependency>
+    <dependency reexport="false">5454dbfd-2075-4de0-b85e-fa645eb6957e(de.itemis.mps.utils.serializer.xml)</dependency>
     <dependency reexport="false">f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)</dependency>
   </dependencies>
   <languageVersions>
@@ -72,10 +72,10 @@
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
     <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />
     <module reference="b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)" version="0" />
-    <module reference="5454dbfd-2075-4de0-b85e-fa645eb6957e(com.mbeddr.mpsutil.serializer.xml)" version="0" />
     <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
     <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
     <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
+    <module reference="5454dbfd-2075-4de0-b85e-fa645eb6957e(de.itemis.mps.utils.serializer.xml)" version="0" />
     <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.temporal/generator/template/org.iets3.core.expr.genjava.temporal@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.temporal/generator/template/org.iets3.core.expr.genjava.temporal@generator.mps
@@ -3870,8 +3870,9 @@
                       <ref role="37wK5l" to="8rdi:4voqclTDifZ" resolve="slices" />
                     </node>
                   </node>
-                  <node concept="TSZUe" id="2T4w_AkFNuJ" role="2OqNvi">
-                    <node concept="2ShNRf" id="2T4w_AkFNxb" role="25WWJ7">
+                  <node concept="liA8E" id="475Xz0y11E0" role="2OqNvi">
+                    <ref role="37wK5l" to="8rdi:475Xz0wPGET" resolve="add" />
+                    <node concept="2ShNRf" id="2T4w_AkFNxb" role="37wK5m">
                       <node concept="1pGfFk" id="2T4w_AkFNFY" role="2ShVmc">
                         <ref role="37wK5l" to="8rdi:50smQ1VbaTB" resolve="SliceValue" />
                         <node concept="37vLTw" id="2T4w_AkFNIu" role="37wK5m">
@@ -5399,7 +5400,7 @@
                         </node>
                       </node>
                       <node concept="liA8E" id="2Wqs7Xm9jBR" role="2OqNvi">
-                        <ref role="37wK5l" to="33ny:~List.isEmpty()" resolve="isEmpty" />
+                        <ref role="37wK5l" to="33ny:~ArrayList.isEmpty()" resolve="isEmpty" />
                       </node>
                     </node>
                   </node>
@@ -5832,7 +5833,7 @@
                         </node>
                       </node>
                       <node concept="liA8E" id="2Wqs7XmaqtK" role="2OqNvi">
-                        <ref role="37wK5l" to="33ny:~List.isEmpty()" resolve="isEmpty" />
+                        <ref role="37wK5l" to="33ny:~ArrayList.isEmpty()" resolve="isEmpty" />
                       </node>
                     </node>
                   </node>
@@ -6264,7 +6265,7 @@
                         </node>
                       </node>
                       <node concept="liA8E" id="2Wqs7XmarJ1" role="2OqNvi">
-                        <ref role="37wK5l" to="33ny:~List.isEmpty()" resolve="isEmpty" />
+                        <ref role="37wK5l" to="33ny:~ArrayList.isEmpty()" resolve="isEmpty" />
                       </node>
                     </node>
                   </node>
@@ -6838,7 +6839,7 @@
                         </node>
                       </node>
                       <node concept="liA8E" id="2Wqs7XmasQq" role="2OqNvi">
-                        <ref role="37wK5l" to="33ny:~List.isEmpty()" resolve="isEmpty" />
+                        <ref role="37wK5l" to="33ny:~ArrayList.isEmpty()" resolve="isEmpty" />
                       </node>
                     </node>
                   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.temporal/org.iets3.core.expr.genjava.temporal.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.temporal/org.iets3.core.expr.genjava.temporal.mpl
@@ -23,7 +23,9 @@
           <classes generated="true" path="${module}/generator/classes_gen" />
         </facet>
       </facets>
-      <external-templates />
+      <external-templates>
+        <generator generatorUID="4517af98-2eaa-4f19-a962-92df60010094(org.iets3.core.expr.genjava.base#8286534136181746510)" />
+      </external-templates>
       <dependencies>
         <dependency reexport="false">4621d3e3-b8a3-4bbe-b7ac-234b6e2d1d68(org.iets3.core.expr.temporal)</dependency>
         <dependency reexport="false">4517af98-2eaa-4f19-a962-92df60010094(org.iets3.core.expr.genjava.base#8286534136181746510)</dependency>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.temporal.runtime/models/org.iets3.core.expr.temporal.runtime.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.temporal.runtime/models/org.iets3.core.expr.temporal.runtime.mps
@@ -14,6 +14,7 @@
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
     <import index="dj6k" ref="r:59d52af6-663b-49dc-8980-30d79b8dffa1(org.iets3.core.expr.simpleTypes.runtime)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -230,6 +231,9 @@
       <node concept="3uibUv" id="50smQ1Vbb7T" role="1tU5fm">
         <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
       </node>
+      <node concept="2AHcQZ" id="3BA76Yi63_P" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
     </node>
     <node concept="312cEg" id="50smQ1Vbb8P" role="jymVt">
       <property role="TrG5h" value="myTime" />
@@ -304,11 +308,12 @@
         <node concept="3uibUv" id="50smQ1Vbb6v" role="1tU5fm">
           <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
         </node>
+        <node concept="2AHcQZ" id="3BA76YhV4GU" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
       </node>
     </node>
     <node concept="2tJIrI" id="50smQ1VbqzS" role="jymVt" />
-    <node concept="2tJIrI" id="6GCJsuCKADE" role="jymVt" />
-    <node concept="2tJIrI" id="3nGzaxUy$bQ" role="jymVt" />
     <node concept="3clFb_" id="3nGzaxUy$Sl" role="jymVt">
       <property role="TrG5h" value="copy" />
       <node concept="3uibUv" id="3nGzaxUyA2k" role="3clF45">
@@ -652,6 +657,9 @@
             </node>
           </node>
         </node>
+      </node>
+      <node concept="2AHcQZ" id="3BA76YhV97i" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
       </node>
     </node>
     <node concept="2tJIrI" id="50smQ1Vc4DL" role="jymVt" />
@@ -2165,30 +2173,29 @@
                           </node>
                         </node>
                       </node>
-                      <node concept="3fqX7Q" id="3KgQFIkaiW8" role="3clFbw">
-                        <node concept="2OqwBi" id="3KgQFIkaiW9" role="3fr31v">
-                          <node concept="2OqwBi" id="3KgQFIkaiWa" role="2Oq$k0">
-                            <node concept="2OqwBi" id="3KgQFIkaiWb" role="2Oq$k0">
-                              <node concept="37vLTw" id="3KgQFIkaiWc" role="2Oq$k0">
+                      <node concept="3fqX7Q" id="3BA76YhVaDA" role="3clFbw">
+                        <node concept="2YIFZM" id="3BA76YhVaDC" role="3fr31v">
+                          <ref role="37wK5l" to="33ny:~Objects.equals(java.lang.Object,java.lang.Object)" resolve="equals" />
+                          <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
+                          <node concept="2OqwBi" id="3BA76YhVaRN" role="37wK5m">
+                            <node concept="2OqwBi" id="3BA76YhVaRO" role="2Oq$k0">
+                              <node concept="37vLTw" id="3BA76YhVaRP" role="2Oq$k0">
                                 <ref role="3cqZAo" node="3KgQFIkaiVq" resolve="res" />
                               </node>
-                              <node concept="liA8E" id="3KgQFIkaiWd" role="2OqNvi">
+                              <node concept="liA8E" id="3BA76YhVaRQ" role="2OqNvi">
                                 <ref role="37wK5l" node="1Mp62pP171D" resolve="lastSlice" />
                               </node>
                             </node>
-                            <node concept="liA8E" id="3KgQFIkaiWe" role="2OqNvi">
+                            <node concept="liA8E" id="3BA76YhVaRR" role="2OqNvi">
                               <ref role="37wK5l" node="50smQ1VbR0B" resolve="value" />
                             </node>
                           </node>
-                          <node concept="liA8E" id="3KgQFIkaiWf" role="2OqNvi">
-                            <ref role="37wK5l" to="wyt6:~Object.equals(java.lang.Object)" resolve="equals" />
-                            <node concept="2OqwBi" id="3KgQFIkaiWg" role="37wK5m">
-                              <node concept="37vLTw" id="3KgQFIkaiWh" role="2Oq$k0">
-                                <ref role="3cqZAo" node="3KgQFIkaiVO" resolve="ithSlice" />
-                              </node>
-                              <node concept="liA8E" id="3KgQFIkaiWi" role="2OqNvi">
-                                <ref role="37wK5l" node="50smQ1VbR0B" resolve="value" />
-                              </node>
+                          <node concept="2OqwBi" id="3BA76YhVbvO" role="37wK5m">
+                            <node concept="37vLTw" id="3BA76YhVbvP" role="2Oq$k0">
+                              <ref role="3cqZAo" node="3KgQFIkaiVO" resolve="ithSlice" />
+                            </node>
+                            <node concept="liA8E" id="3BA76YhVbvQ" role="2OqNvi">
+                              <ref role="37wK5l" node="50smQ1VbR0B" resolve="value" />
                             </node>
                           </node>
                         </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.temporal.runtime/models/org.iets3.core.expr.temporal.runtime.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.temporal.runtime/models/org.iets3.core.expr.temporal.runtime.mps
@@ -40,6 +40,9 @@
       <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -92,10 +95,14 @@
       </concept>
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <child id="1095933932569" name="implementedInterface" index="EKbjA" />
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -164,12 +171,16 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1073063089578" name="jetbrains.mps.baseLanguage.structure.SuperMethodCall" flags="nn" index="3nyPlj" />
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk">
         <child id="1212687122400" name="typeParameter" index="1pMfVU" />
       </concept>
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1171903916106" name="jetbrains.mps.baseLanguage.structure.UpperBoundType" flags="in" index="3qUE_q">
+        <child id="1171903916107" name="bound" index="3qUE_r" />
       </concept>
       <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
         <property id="8355037393041754995" name="isNative" index="2aFKle" />
@@ -2104,7 +2115,7 @@
                   </node>
                 </node>
                 <node concept="liA8E" id="4OwGieAEATl" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                  <ref role="37wK5l" node="475Xz0wPGET" resolve="add" />
                   <node concept="2OqwBi" id="3KgQFIkaiVG" role="37wK5m">
                     <node concept="37vLTw" id="3KgQFIkaiVH" role="2Oq$k0">
                       <ref role="3cqZAo" node="3KgQFIkaiWz" resolve="tv" />
@@ -2136,7 +2147,7 @@
                             </node>
                           </node>
                           <node concept="liA8E" id="4OwGieAED1V" role="2OqNvi">
-                            <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
+                            <ref role="37wK5l" to="33ny:~ArrayList.get(int)" resolve="get" />
                             <node concept="37vLTw" id="4OwGieAEDq$" role="37wK5m">
                               <ref role="3cqZAo" node="3KgQFIkaiWj" resolve="i" />
                             </node>
@@ -2157,7 +2168,7 @@
                               </node>
                             </node>
                             <node concept="liA8E" id="4OwGieAEETs" role="2OqNvi">
-                              <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                              <ref role="37wK5l" node="475Xz0wPGET" resolve="add" />
                               <node concept="2OqwBi" id="3KgQFIkaiW4" role="37wK5m">
                                 <node concept="37vLTw" id="3KgQFIkaiW5" role="2Oq$k0">
                                   <ref role="3cqZAo" node="3KgQFIkaiVO" resolve="ithSlice" />
@@ -3349,17 +3360,336 @@
       <property role="TrG5h" value="slices" />
       <node concept="3Tm6S6" id="50smQ1V9OxF" role="1B3o_S" />
       <node concept="3uibUv" id="4OwGieAxPi2" role="1tU5fm">
-        <ref role="3uigEE" to="33ny:~List" resolve="List" />
-        <node concept="3uibUv" id="4OwGieAxWNE" role="11_B2D">
+        <ref role="3uigEE" node="475Xz0wPy4m" resolve="SliceArray" />
+      </node>
+      <node concept="2ShNRf" id="50smQ1V9OT5" role="33vP2m">
+        <node concept="HV5vD" id="475Xz0wTjG$" role="2ShVmc">
+          <ref role="HV5vE" node="475Xz0wPy4m" resolve="SliceArray" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="475Xz0wPdVj" role="jymVt" />
+    <node concept="312cEu" id="475Xz0wPy4m" role="jymVt">
+      <property role="2bfB8j" value="true" />
+      <property role="TrG5h" value="SliceArray" />
+      <node concept="3Tm1VV" id="475Xz0wWN2U" role="1B3o_S" />
+      <node concept="3uibUv" id="475Xz0wPFfC" role="1zkMxy">
+        <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
+        <node concept="3uibUv" id="475Xz0wPFCS" role="11_B2D">
           <ref role="3uigEE" node="50smQ1VbaN9" resolve="SliceValue" />
         </node>
       </node>
-      <node concept="2ShNRf" id="50smQ1V9OT5" role="33vP2m">
-        <node concept="1pGfFk" id="4OwGieAy73G" role="2ShVmc">
-          <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;()" resolve="ArrayList" />
-          <node concept="3uibUv" id="4OwGieAyeJh" role="1pMfVU">
+      <node concept="3clFb_" id="475Xz0wPGET" role="jymVt">
+        <property role="TrG5h" value="add" />
+        <node concept="3Tm1VV" id="475Xz0wPGEU" role="1B3o_S" />
+        <node concept="10P_77" id="475Xz0wPGEW" role="3clF45" />
+        <node concept="37vLTG" id="475Xz0wPGEX" role="3clF46">
+          <property role="TrG5h" value="e" />
+          <node concept="3uibUv" id="475Xz0wPGEZ" role="1tU5fm">
             <ref role="3uigEE" node="50smQ1VbaN9" resolve="SliceValue" />
           </node>
+        </node>
+        <node concept="3clFbS" id="475Xz0wPGF0" role="3clF47">
+          <node concept="3clFbJ" id="475Xz0wPTV4" role="3cqZAp">
+            <node concept="3clFbS" id="475Xz0wPTV6" role="3clFbx">
+              <node concept="3cpWs6" id="475Xz0wQ4tH" role="3cqZAp">
+                <node concept="3clFbT" id="475Xz0wQ7il" role="3cqZAk" />
+              </node>
+            </node>
+            <node concept="3clFbC" id="475Xz0wQ2jY" role="3clFbw">
+              <node concept="37vLTw" id="475Xz0wPVB4" role="3uHU7B">
+                <ref role="3cqZAo" node="475Xz0wPGEX" resolve="e" />
+              </node>
+              <node concept="10Nm6u" id="475Xz0wPXvn" role="3uHU7w" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="475Xz0wPGF4" role="3cqZAp">
+            <node concept="3nyPlj" id="475Xz0wPGF3" role="3clFbG">
+              <ref role="37wK5l" to="33ny:~ArrayList.add(java.lang.Object)" resolve="add" />
+              <node concept="37vLTw" id="475Xz0wPGF2" role="37wK5m">
+                <ref role="3cqZAo" node="475Xz0wPGEX" resolve="e" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="475Xz0wPGF1" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="475Xz0wPGF5" role="jymVt">
+        <property role="TrG5h" value="add" />
+        <node concept="3Tm1VV" id="475Xz0wPGF6" role="1B3o_S" />
+        <node concept="3cqZAl" id="475Xz0wPGF8" role="3clF45" />
+        <node concept="37vLTG" id="475Xz0wPGF9" role="3clF46">
+          <property role="TrG5h" value="index" />
+          <property role="3TUv4t" value="true" />
+          <node concept="10Oyi0" id="475Xz0wPGFa" role="1tU5fm" />
+        </node>
+        <node concept="37vLTG" id="475Xz0wPGFb" role="3clF46">
+          <property role="TrG5h" value="element" />
+          <property role="3TUv4t" value="true" />
+          <node concept="3uibUv" id="475Xz0wPGFd" role="1tU5fm">
+            <ref role="3uigEE" node="50smQ1VbaN9" resolve="SliceValue" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="475Xz0wPGFe" role="3clF47">
+          <node concept="3clFbJ" id="475Xz0wQa6l" role="3cqZAp">
+            <node concept="3clFbS" id="475Xz0wQa6n" role="3clFbx">
+              <node concept="3cpWs6" id="475Xz0wQjIn" role="3cqZAp" />
+            </node>
+            <node concept="3clFbC" id="475Xz0wQglZ" role="3clFbw">
+              <node concept="10Nm6u" id="475Xz0wQigd" role="3uHU7w" />
+              <node concept="37vLTw" id="475Xz0wQckD" role="3uHU7B">
+                <ref role="3cqZAo" node="475Xz0wPGFb" resolve="element" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="475Xz0wPGFj" role="3cqZAp">
+            <node concept="3nyPlj" id="475Xz0wPGFi" role="3clFbG">
+              <ref role="37wK5l" to="33ny:~ArrayList.add(int,java.lang.Object)" resolve="add" />
+              <node concept="37vLTw" id="475Xz0wPGFg" role="37wK5m">
+                <ref role="3cqZAo" node="475Xz0wPGF9" resolve="index" />
+              </node>
+              <node concept="37vLTw" id="475Xz0wPGFh" role="37wK5m">
+                <ref role="3cqZAo" node="475Xz0wPGFb" resolve="element" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="475Xz0wPGFf" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="475Xz0wPGFk" role="jymVt">
+        <property role="TrG5h" value="addAll" />
+        <node concept="3Tm1VV" id="475Xz0wPGFl" role="1B3o_S" />
+        <node concept="10P_77" id="475Xz0wPGFn" role="3clF45" />
+        <node concept="37vLTG" id="475Xz0wPGFo" role="3clF46">
+          <property role="TrG5h" value="c" />
+          <node concept="3uibUv" id="475Xz0wPGFp" role="1tU5fm">
+            <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+            <node concept="3qUE_q" id="475Xz0wPGFq" role="11_B2D">
+              <node concept="3uibUv" id="475Xz0wPGFs" role="3qUE_r">
+                <ref role="3uigEE" node="50smQ1VbaN9" resolve="SliceValue" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbS" id="475Xz0wPGFt" role="3clF47">
+          <node concept="3cpWs8" id="475Xz0wRvz9" role="3cqZAp">
+            <node concept="3cpWsn" id="475Xz0wRvzc" role="3cpWs9">
+              <property role="TrG5h" value="oldsize" />
+              <node concept="10Oyi0" id="475Xz0wRvz7" role="1tU5fm" />
+              <node concept="1rXfSq" id="475Xz0wR_WW" role="33vP2m">
+                <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="475Xz0wQJlY" role="3cqZAp">
+            <node concept="3cpWsn" id="475Xz0wQJlZ" role="3cpWs9">
+              <property role="TrG5h" value="cons" />
+              <node concept="3uibUv" id="475Xz0wQJlW" role="1tU5fm">
+                <ref role="3uigEE" to="82uw:~Consumer" resolve="Consumer" />
+                <node concept="3uibUv" id="475Xz0wQL_1" role="11_B2D">
+                  <ref role="3uigEE" node="50smQ1VbaN9" resolve="SliceValue" />
+                </node>
+              </node>
+              <node concept="2ShNRf" id="475Xz0wQXa$" role="33vP2m">
+                <node concept="YeOm9" id="475Xz0wQZRy" role="2ShVmc">
+                  <node concept="1Y3b0j" id="475Xz0wQZR_" role="YeSDq">
+                    <property role="2bfB8j" value="true" />
+                    <property role="373rjd" value="true" />
+                    <ref role="1Y3XeK" to="82uw:~Consumer" resolve="Consumer" />
+                    <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" />
+                    <node concept="3Tm1VV" id="475Xz0wQZRA" role="1B3o_S" />
+                    <node concept="3clFb_" id="475Xz0wQZRO" role="jymVt">
+                      <property role="TrG5h" value="accept" />
+                      <node concept="3Tm1VV" id="475Xz0wQZRP" role="1B3o_S" />
+                      <node concept="3cqZAl" id="475Xz0wQZRR" role="3clF45" />
+                      <node concept="37vLTG" id="475Xz0wQZRS" role="3clF46">
+                        <property role="TrG5h" value="p1" />
+                        <node concept="3uibUv" id="475Xz0wQZS0" role="1tU5fm">
+                          <ref role="3uigEE" node="50smQ1VbaN9" resolve="SliceValue" />
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="475Xz0wQZRU" role="3clF47">
+                        <node concept="3clFbF" id="475Xz0wR2TQ" role="3cqZAp">
+                          <node concept="1rXfSq" id="475Xz0wRacf" role="3clFbG">
+                            <ref role="37wK5l" node="475Xz0wPGET" resolve="add" />
+                            <node concept="37vLTw" id="475Xz0wRbJZ" role="37wK5m">
+                              <ref role="3cqZAo" node="475Xz0wQZRS" resolve="p1" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2AHcQZ" id="475Xz0wQZRW" role="2AJF6D">
+                        <ref role="2AI5Lk" to="wyt6:~Override" />
+                      </node>
+                    </node>
+                    <node concept="3uibUv" id="475Xz0wQZRZ" role="2Ghqu4">
+                      <ref role="3uigEE" node="50smQ1VbaN9" resolve="SliceValue" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="475Xz0wQ$fr" role="3cqZAp">
+            <node concept="2OqwBi" id="475Xz0wQ$zz" role="3clFbG">
+              <node concept="37vLTw" id="475Xz0wQ$fq" role="2Oq$k0">
+                <ref role="3cqZAo" node="475Xz0wPGFo" resolve="c" />
+              </node>
+              <node concept="liA8E" id="475Xz0wQ_Pb" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~Iterable.forEach(java.util.function.Consumer)" resolve="forEach" />
+                <node concept="37vLTw" id="475Xz0wRe0v" role="37wK5m">
+                  <ref role="3cqZAo" node="475Xz0wQJlZ" resolve="cons" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="475Xz0wRDz0" role="3cqZAp">
+            <node concept="3clFbC" id="475Xz0wRR8C" role="3cqZAk">
+              <node concept="3cpWs3" id="475Xz0wS3ib" role="3uHU7w">
+                <node concept="2OqwBi" id="475Xz0wS5F6" role="3uHU7w">
+                  <node concept="37vLTw" id="475Xz0wS3qK" role="2Oq$k0">
+                    <ref role="3cqZAo" node="475Xz0wPGFo" resolve="c" />
+                  </node>
+                  <node concept="liA8E" id="475Xz0wS7um" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Collection.size()" resolve="size" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="475Xz0wS19G" role="3uHU7B">
+                  <ref role="3cqZAo" node="475Xz0wRvzc" resolve="oldsize" />
+                </node>
+              </node>
+              <node concept="1rXfSq" id="475Xz0wRYOf" role="3uHU7B">
+                <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="475Xz0wPGFu" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" />
+        </node>
+      </node>
+      <node concept="3clFb_" id="475Xz0wPGFy" role="jymVt">
+        <property role="TrG5h" value="addAll" />
+        <node concept="3Tm1VV" id="475Xz0wPGFz" role="1B3o_S" />
+        <node concept="10P_77" id="475Xz0wPGF_" role="3clF45" />
+        <node concept="37vLTG" id="475Xz0wPGFA" role="3clF46">
+          <property role="TrG5h" value="index" />
+          <property role="3TUv4t" value="true" />
+          <node concept="10Oyi0" id="475Xz0wPGFB" role="1tU5fm" />
+        </node>
+        <node concept="37vLTG" id="475Xz0wPGFC" role="3clF46">
+          <property role="TrG5h" value="c" />
+          <node concept="3uibUv" id="475Xz0wPGFD" role="1tU5fm">
+            <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+            <node concept="3qUE_q" id="475Xz0wPGFE" role="11_B2D">
+              <node concept="3uibUv" id="475Xz0wPGFG" role="3qUE_r">
+                <ref role="3uigEE" node="50smQ1VbaN9" resolve="SliceValue" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbS" id="475Xz0wPGFH" role="3clF47">
+          <node concept="3cpWs8" id="475Xz0wS9RF" role="3cqZAp">
+            <node concept="3cpWsn" id="475Xz0wS9RG" role="3cpWs9">
+              <property role="TrG5h" value="oldsize" />
+              <node concept="10Oyi0" id="475Xz0wS9RH" role="1tU5fm" />
+              <node concept="1rXfSq" id="475Xz0wS9RI" role="33vP2m">
+                <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="475Xz0wS9RJ" role="3cqZAp">
+            <node concept="3cpWsn" id="475Xz0wS9RK" role="3cpWs9">
+              <property role="TrG5h" value="cons" />
+              <node concept="3uibUv" id="475Xz0wS9RL" role="1tU5fm">
+                <ref role="3uigEE" to="82uw:~Consumer" resolve="Consumer" />
+                <node concept="3uibUv" id="475Xz0wS9RM" role="11_B2D">
+                  <ref role="3uigEE" node="50smQ1VbaN9" resolve="SliceValue" />
+                </node>
+              </node>
+              <node concept="2ShNRf" id="475Xz0wS9RN" role="33vP2m">
+                <node concept="YeOm9" id="475Xz0wS9RO" role="2ShVmc">
+                  <node concept="1Y3b0j" id="475Xz0wS9RP" role="YeSDq">
+                    <property role="2bfB8j" value="true" />
+                    <property role="373rjd" value="true" />
+                    <ref role="1Y3XeK" to="82uw:~Consumer" resolve="Consumer" />
+                    <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                    <node concept="3Tm1VV" id="475Xz0wS9RQ" role="1B3o_S" />
+                    <node concept="3clFb_" id="475Xz0wS9RR" role="jymVt">
+                      <property role="TrG5h" value="accept" />
+                      <node concept="3Tm1VV" id="475Xz0wS9RS" role="1B3o_S" />
+                      <node concept="3cqZAl" id="475Xz0wS9RT" role="3clF45" />
+                      <node concept="37vLTG" id="475Xz0wS9RU" role="3clF46">
+                        <property role="TrG5h" value="p1" />
+                        <node concept="3uibUv" id="475Xz0wS9RV" role="1tU5fm">
+                          <ref role="3uigEE" node="50smQ1VbaN9" resolve="SliceValue" />
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="475Xz0wS9RW" role="3clF47">
+                        <node concept="3clFbF" id="475Xz0wS9RX" role="3cqZAp">
+                          <node concept="1rXfSq" id="475Xz0wS9RY" role="3clFbG">
+                            <ref role="37wK5l" node="475Xz0wPGF5" resolve="add" />
+                            <node concept="37vLTw" id="475Xz0wSi8C" role="37wK5m">
+                              <ref role="3cqZAo" node="475Xz0wPGFA" resolve="index" />
+                            </node>
+                            <node concept="37vLTw" id="475Xz0wS9RZ" role="37wK5m">
+                              <ref role="3cqZAo" node="475Xz0wS9RU" resolve="p1" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2AHcQZ" id="475Xz0wS9S0" role="2AJF6D">
+                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                      </node>
+                    </node>
+                    <node concept="3uibUv" id="475Xz0wS9S1" role="2Ghqu4">
+                      <ref role="3uigEE" node="50smQ1VbaN9" resolve="SliceValue" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="475Xz0wS9S2" role="3cqZAp">
+            <node concept="2OqwBi" id="475Xz0wS9S3" role="3clFbG">
+              <node concept="37vLTw" id="475Xz0wS9S4" role="2Oq$k0">
+                <ref role="3cqZAo" node="475Xz0wPGFC" resolve="c" />
+              </node>
+              <node concept="liA8E" id="475Xz0wS9S5" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~Iterable.forEach(java.util.function.Consumer)" resolve="forEach" />
+                <node concept="37vLTw" id="475Xz0wS9S6" role="37wK5m">
+                  <ref role="3cqZAo" node="475Xz0wS9RK" resolve="cons" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="475Xz0wS9S7" role="3cqZAp">
+            <node concept="3clFbC" id="475Xz0wS9S8" role="3cqZAk">
+              <node concept="3cpWs3" id="475Xz0wS9S9" role="3uHU7w">
+                <node concept="2OqwBi" id="475Xz0wS9Sa" role="3uHU7w">
+                  <node concept="37vLTw" id="475Xz0wS9Sb" role="2Oq$k0">
+                    <ref role="3cqZAo" node="475Xz0wPGFC" resolve="c" />
+                  </node>
+                  <node concept="liA8E" id="475Xz0wS9Sc" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Collection.size()" resolve="size" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="475Xz0wS9Sd" role="3uHU7B">
+                  <ref role="3cqZAo" node="475Xz0wS9RG" resolve="oldsize" />
+                </node>
+              </node>
+              <node concept="1rXfSq" id="475Xz0wS9Se" role="3uHU7B">
+                <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2AHcQZ" id="475Xz0wPGFI" role="2AJF6D">
+          <ref role="2AI5Lk" to="wyt6:~Override" />
         </node>
       </node>
     </node>
@@ -3403,7 +3733,7 @@
               <ref role="3cqZAo" node="50smQ1V9OxE" resolve="slices" />
             </node>
             <node concept="liA8E" id="4OwGieAyngJ" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+              <ref role="37wK5l" node="475Xz0wPGET" resolve="add" />
               <node concept="2ShNRf" id="50smQ1Vbxfm" role="37wK5m">
                 <node concept="1pGfFk" id="50smQ1Vbxfn" role="2ShVmc">
                   <ref role="37wK5l" node="50smQ1VbaTB" resolve="SliceValue" />
@@ -3468,7 +3798,7 @@
                   </node>
                 </node>
                 <node concept="liA8E" id="4OwGieAyuPl" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                  <ref role="37wK5l" node="475Xz0wPGET" resolve="add" />
                   <node concept="2OqwBi" id="4OwGieAyvdH" role="37wK5m">
                     <node concept="37vLTw" id="4OwGieAyv0g" role="2Oq$k0">
                       <ref role="3cqZAo" node="4OwGieAyr$s" resolve="slice" />
@@ -3538,7 +3868,7 @@
               </node>
             </node>
             <node concept="liA8E" id="4OwGieAyx4J" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+              <ref role="37wK5l" node="475Xz0wPGET" resolve="add" />
               <node concept="2ShNRf" id="50smQ1VbCRH" role="37wK5m">
                 <node concept="1pGfFk" id="50smQ1VbDd6" role="2ShVmc">
                   <ref role="37wK5l" node="50smQ1VbaTB" resolve="SliceValue" />
@@ -3769,7 +4099,7 @@
                 </node>
               </node>
               <node concept="liA8E" id="4OwGieAyXRe" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.size()" resolve="size" />
+                <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
               </node>
             </node>
             <node concept="2OqwBi" id="4OwGieAyVXk" role="3uHU7B">
@@ -3782,7 +4112,7 @@
                 </node>
               </node>
               <node concept="liA8E" id="4OwGieAyWst" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.size()" resolve="size" />
+                <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
               </node>
             </node>
           </node>
@@ -4084,7 +4414,7 @@
               </node>
             </node>
             <node concept="liA8E" id="4OwGieAz3YW" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~List.size()" resolve="size" />
+              <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
             </node>
           </node>
         </node>
@@ -4121,7 +4451,7 @@
                     <ref role="3cqZAo" node="50smQ1V9OxE" resolve="slices" />
                   </node>
                   <node concept="liA8E" id="4OwGieABMXH" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~List.size()" resolve="size" />
+                    <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
                   </node>
                 </node>
               </node>
@@ -4192,7 +4522,7 @@
                 </node>
               </node>
               <node concept="liA8E" id="4OwGieABUzk" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.size()" resolve="size" />
+                <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
               </node>
             </node>
           </node>
@@ -4246,7 +4576,7 @@
                 <ref role="3cqZAo" node="50smQ1V9OxE" resolve="slices" />
               </node>
               <node concept="liA8E" id="4OwGieACjvr" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
+                <ref role="37wK5l" to="33ny:~ArrayList.get(int)" resolve="get" />
                 <node concept="3cmrfG" id="4OwGieACnEa" role="37wK5m">
                   <property role="3cmrfH" value="0" />
                 </node>
@@ -4267,7 +4597,7 @@
                     <ref role="3cqZAo" node="50smQ1V9OxE" resolve="slices" />
                   </node>
                   <node concept="liA8E" id="4OwGieACKAq" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
+                    <ref role="37wK5l" to="33ny:~ArrayList.get(int)" resolve="get" />
                     <node concept="37vLTw" id="4OwGieACLr4" role="37wK5m">
                       <ref role="3cqZAo" node="4OwGieACC0b" resolve="i" />
                     </node>
@@ -4324,7 +4654,7 @@
                 <ref role="3cqZAo" node="50smQ1V9OxE" resolve="slices" />
               </node>
               <node concept="liA8E" id="4OwGieACHKf" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.size()" resolve="size" />
+                <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
               </node>
             </node>
             <node concept="37vLTw" id="4OwGieACGfH" role="3uHU7B">
@@ -4379,7 +4709,7 @@
                 </node>
               </node>
               <node concept="liA8E" id="4OwGieA_KxI" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.size()" resolve="size" />
+                <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
               </node>
             </node>
           </node>
@@ -4462,7 +4792,7 @@
                 </node>
               </node>
               <node concept="liA8E" id="4OwGieA_LfY" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.size()" resolve="size" />
+                <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
               </node>
             </node>
           </node>
@@ -4494,7 +4824,7 @@
                           <ref role="3cqZAo" node="50smQ1V9OxE" resolve="slices" />
                         </node>
                         <node concept="liA8E" id="4OwGieAAIox" role="2OqNvi">
-                          <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
+                          <ref role="37wK5l" to="33ny:~ArrayList.get(int)" resolve="get" />
                           <node concept="37vLTw" id="4OwGieAAILF" role="37wK5m">
                             <ref role="3cqZAo" node="4OwGieAA_D3" resolve="i" />
                           </node>
@@ -4579,7 +4909,7 @@
                         <ref role="3cqZAo" node="50smQ1V9OxE" resolve="slices" />
                       </node>
                       <node concept="liA8E" id="4OwGieAAF4P" role="2OqNvi">
-                        <ref role="37wK5l" to="33ny:~List.size()" resolve="size" />
+                        <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
                       </node>
                     </node>
                   </node>
@@ -4635,7 +4965,7 @@
                 </node>
               </node>
               <node concept="liA8E" id="4OwGieAzSgR" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.size()" resolve="size" />
+                <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
               </node>
             </node>
           </node>
@@ -4676,7 +5006,7 @@
                     </node>
                   </node>
                   <node concept="liA8E" id="4OwGieAzZZ1" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
+                    <ref role="37wK5l" to="33ny:~ArrayList.get(int)" resolve="get" />
                     <node concept="3cmrfG" id="4OwGieAzZZ2" role="37wK5m">
                       <property role="3cmrfH" value="0" />
                     </node>
@@ -4862,10 +5192,7 @@
     <node concept="3clFb_" id="4voqclTDifZ" role="jymVt">
       <property role="TrG5h" value="slices" />
       <node concept="3uibUv" id="4OwGieAxKUf" role="3clF45">
-        <ref role="3uigEE" to="33ny:~List" resolve="List" />
-        <node concept="3uibUv" id="4OwGieAzlzA" role="11_B2D">
-          <ref role="3uigEE" node="50smQ1VbaN9" resolve="SliceValue" />
-        </node>
+        <ref role="3uigEE" node="475Xz0wPy4m" resolve="SliceArray" />
       </node>
       <node concept="3Tm1VV" id="4voqclTDig2" role="1B3o_S" />
       <node concept="3clFbS" id="4voqclTDig3" role="3clF47">
@@ -4898,7 +5225,7 @@
               </node>
             </node>
             <node concept="liA8E" id="4OwGieA_IiK" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~List.isEmpty()" resolve="isEmpty" />
+              <ref role="37wK5l" to="33ny:~ArrayList.isEmpty()" resolve="isEmpty" />
             </node>
           </node>
         </node>
@@ -4911,7 +5238,7 @@
               </node>
             </node>
             <node concept="liA8E" id="4OwGieA$ceo" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
+              <ref role="37wK5l" to="33ny:~ArrayList.get(int)" resolve="get" />
               <node concept="3cpWsd" id="4OwGieA$eJL" role="37wK5m">
                 <node concept="3cmrfG" id="4OwGieA$eK2" role="3uHU7w">
                   <property role="3cmrfH" value="1" />
@@ -4924,7 +5251,7 @@
                     </node>
                   </node>
                   <node concept="liA8E" id="4OwGieA$dJs" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~List.size()" resolve="size" />
+                    <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
                   </node>
                 </node>
               </node>
@@ -4955,7 +5282,7 @@
               </node>
             </node>
             <node concept="liA8E" id="4OwGieA_IGb" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~List.isEmpty()" resolve="isEmpty" />
+              <ref role="37wK5l" to="33ny:~ArrayList.isEmpty()" resolve="isEmpty" />
             </node>
           </node>
         </node>
@@ -4968,7 +5295,7 @@
               </node>
             </node>
             <node concept="liA8E" id="4OwGieA_JCY" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~List.get(int)" resolve="get" />
+              <ref role="37wK5l" to="33ny:~ArrayList.get(int)" resolve="get" />
               <node concept="3cmrfG" id="4OwGieA_Kbq" role="37wK5m">
                 <property role="3cmrfH" value="0" />
               </node>
@@ -5036,7 +5363,7 @@
               </node>
             </node>
             <node concept="liA8E" id="1ZlHRbjY2Tn" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~List.isEmpty()" resolve="isEmpty" />
+              <ref role="37wK5l" to="33ny:~ArrayList.isEmpty()" resolve="isEmpty" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.temporal.runtime/org.iets3.core.expr.temporal.runtime.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.temporal.runtime/org.iets3.core.expr.temporal.runtime.msd
@@ -16,6 +16,7 @@
     <dependency reexport="false">957f018c-4561-4081-9ad3-b8618bf1160d(org.iets3.core.expr.datetime.runtime)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)</dependency>
+    <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -23,6 +24,7 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="957f018c-4561-4081-9ad3-b8618bf1160d(org.iets3.core.expr.datetime.runtime)" version="0" />
     <module reference="52a8c4c0-f4b0-4243-bf00-9dfac3472876(org.iets3.core.expr.simpleTypes.runtime)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -2403,11 +2403,6 @@
             <ref role="3bR37D" node="5wLtKNeSRQd" resolve="org.iets3.core.expr.simpleTypes" />
           </node>
         </node>
-        <node concept="1SiIV0" id="4d0E9wpdsM0" role="3bR37C">
-          <node concept="3bR9La" id="4d0E9wpdsM1" role="1SiIV1">
-            <ref role="3bR37D" to="90a9:29so9Vb$6Th" resolve="de.slisson.mps.tables" />
-          </node>
-        </node>
         <node concept="1BupzO" id="1RMC8GHEw_g" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -2428,6 +2423,11 @@
             <node concept="3qWCbU" id="1RMC8GHEw_i" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4d0E9wpdsM0" role="3bR37C">
+          <node concept="3bR9La" id="4d0E9wpdsM1" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:29so9Vb$6Th" resolve="de.slisson.mps.tables" />
           </node>
         </node>
         <node concept="1SiIV0" id="5yPljRYr6G_" role="3bR37C">
@@ -4243,11 +4243,6 @@
             <ref role="3bR37D" node="5a_u3OzLedQ" resolve="org.iets3.core.expr.adt" />
           </node>
         </node>
-        <node concept="1SiIV0" id="3MqEfsXeLmv" role="3bR37C">
-          <node concept="3bR9La" id="3MqEfsXeLmw" role="1SiIV1">
-            <ref role="3bR37D" node="5khwDRKS378" resolve="org.iets3.core.expr.base.collections.stubs" />
-          </node>
-        </node>
         <node concept="1BupzO" id="1RMC8GHEwEL" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -4268,6 +4263,11 @@
             <node concept="3qWCbU" id="1RMC8GHEwEN" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3MqEfsXeLmv" role="3bR37C">
+          <node concept="3bR9La" id="3MqEfsXeLmw" role="1SiIV1">
+            <ref role="3bR37D" node="5khwDRKS378" resolve="org.iets3.core.expr.base.collections.stubs" />
           </node>
         </node>
       </node>
@@ -4858,11 +4858,6 @@
             <ref role="3bR37D" node="5FYd8xZZj2s" resolve="org.iets3.core.expr.path" />
           </node>
         </node>
-        <node concept="1SiIV0" id="4QSPQ53Vque" role="3bR37C">
-          <node concept="3bR9La" id="4QSPQ53Vquf" role="1SiIV1">
-            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
-          </node>
-        </node>
         <node concept="1BupzO" id="1RMC8GHEwH3" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -4883,6 +4878,11 @@
             <node concept="3qWCbU" id="1RMC8GHEwH5" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4QSPQ53Vque" role="3bR37C">
+          <node concept="3bR9La" id="4QSPQ53Vquf" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KYb" resolve="jetbrains.mps.baseLanguage" />
           </node>
         </node>
         <node concept="1SiIV0" id="67zm2VGhJPn" role="3bR37C">
@@ -6125,11 +6125,6 @@
             <ref role="3bR37D" node="4C_RnzfEE1P" resolve="org.iets3.core.expr.base.runtime" />
           </node>
         </node>
-        <node concept="1SiIV0" id="2YKwwo9i8R$" role="3bR37C">
-          <node concept="3bR9La" id="2YKwwo9i8R_" role="1SiIV1">
-            <ref role="3bR37D" node="5khwDRKS378" resolve="org.iets3.core.expr.base.collections.stubs" />
-          </node>
-        </node>
         <node concept="1BupzO" id="1RMC8GHEwKV" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -6150,6 +6145,11 @@
             <node concept="3qWCbU" id="1RMC8GHEwKX" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="2YKwwo9i8R$" role="3bR37C">
+          <node concept="3bR9La" id="2YKwwo9i8R_" role="1SiIV1">
+            <ref role="3bR37D" node="5khwDRKS378" resolve="org.iets3.core.expr.base.collections.stubs" />
           </node>
         </node>
         <node concept="1SiIV0" id="2xddOZL76J_" role="3bR37C">
@@ -6235,6 +6235,11 @@
         <node concept="1SiIV0" id="5s2FNgb$bxc" role="3bR37C">
           <node concept="3bR9La" id="5s2FNgb$bxd" role="1SiIV1">
             <ref role="3bR37D" node="7jAOwAVRc2S" resolve="org.iets3.core.expr.simpleTypes.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="3BA76Yi2vu3" role="3bR37C">
+          <node concept="3bR9La" id="3BA76Yi2vu4" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:44LXwdzyvTi" resolve="Annotations" />
           </node>
         </node>
       </node>
@@ -6486,16 +6491,6 @@
             <ref role="3bR37D" to="90a9:5vQ_hAOOn52" resolve="de.slisson.mps.conditionalEditor.hints" />
           </node>
         </node>
-        <node concept="1SiIV0" id="6jT4GDvBXCB" role="3bR37C">
-          <node concept="3bR9La" id="6jT4GDvBXCC" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:1oM0ei222QR" resolve="com.mbeddr.mpsutil.spreferences.runtime" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="6jT4GDvBXCD" role="3bR37C">
-          <node concept="3bR9La" id="6jT4GDvBXCE" role="1SiIV1">
-            <ref role="3bR37D" to="al5i:1oM0ei22dHk" resolve="com.mbeddr.mpsutil.spreferences" />
-          </node>
-        </node>
         <node concept="1BupzO" id="1RMC8GHEwLP" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -6516,6 +6511,16 @@
             <node concept="3qWCbU" id="1RMC8GHEwLR" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6jT4GDvBXCB" role="3bR37C">
+          <node concept="3bR9La" id="6jT4GDvBXCC" role="1SiIV1">
+            <ref role="3bR37D" to="al5i:1oM0ei222QR" resolve="com.mbeddr.mpsutil.spreferences.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6jT4GDvBXCD" role="3bR37C">
+          <node concept="3bR9La" id="6jT4GDvBXCE" role="1SiIV1">
+            <ref role="3bR37D" to="al5i:1oM0ei22dHk" resolve="com.mbeddr.mpsutil.spreferences" />
           </node>
         </node>
         <node concept="1SiIV0" id="6ycJs$Ayp9W" role="3bR37C">
@@ -9489,16 +9494,6 @@
             </node>
           </node>
         </node>
-        <node concept="1SiIV0" id="7pfuzNDFAyo" role="3bR37C">
-          <node concept="3bR9La" id="7pfuzNDFAyp" role="1SiIV1">
-            <ref role="3bR37D" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
-          </node>
-        </node>
-        <node concept="1SiIV0" id="7pfuzNDFAyq" role="3bR37C">
-          <node concept="3bR9La" id="7pfuzNDFAyr" role="1SiIV1">
-            <ref role="3bR37D" node="3vxfdxbuEmk" resolve="org.iets3.core.expr.messages" />
-          </node>
-        </node>
         <node concept="1BupzO" id="1RMC8GHEwTu" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -9535,6 +9530,16 @@
                 </node>
               </node>
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7pfuzNDFAyo" role="3bR37C">
+          <node concept="3bR9La" id="7pfuzNDFAyp" role="1SiIV1">
+            <ref role="3bR37D" node="5wLtKNeSRPD" resolve="org.iets3.core.expr.base" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="7pfuzNDFAyq" role="3bR37C">
+          <node concept="3bR9La" id="7pfuzNDFAyr" role="1SiIV1">
+            <ref role="3bR37D" node="3vxfdxbuEmk" resolve="org.iets3.core.expr.messages" />
           </node>
         </node>
         <node concept="1SiIV0" id="4W3jsc44qHX" role="3bR37C">
@@ -10456,11 +10461,6 @@
             <ref role="3bR37D" node="23q4CrmMjed" resolve="org.iets3.core.expr.genjava.messages.rt" />
           </node>
         </node>
-        <node concept="1SiIV0" id="6s5DoQgJR2K" role="3bR37C">
-          <node concept="3bR9La" id="6s5DoQgJR2L" role="1SiIV1">
-            <ref role="3bR37D" node="5khwDRKS378" resolve="org.iets3.core.expr.base.collections.stubs" />
-          </node>
-        </node>
         <node concept="1BupzO" id="1RMC8GHEwWK" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -10481,6 +10481,11 @@
             <node concept="3qWCbU" id="1RMC8GHEwWM" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6s5DoQgJR2K" role="3bR37C">
+          <node concept="3bR9La" id="6s5DoQgJR2L" role="1SiIV1">
+            <ref role="3bR37D" node="5khwDRKS378" resolve="org.iets3.core.expr.base.collections.stubs" />
           </node>
         </node>
       </node>
@@ -10702,11 +10707,6 @@
             <ref role="3bR37D" node="2uR5X5azttH" resolve="org.iets3.core.expr.toplevel" />
           </node>
         </node>
-        <node concept="1SiIV0" id="23q4CrmMjsd" role="3bR37C">
-          <node concept="3bR9La" id="23q4CrmMjse" role="1SiIV1">
-            <ref role="3bR37D" node="23q4CrmMjed" resolve="org.iets3.core.expr.genjava.messages.rt" />
-          </node>
-        </node>
         <node concept="1BupzO" id="1RMC8GHEwY3" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -10727,6 +10727,11 @@
             <node concept="3qWCbU" id="1RMC8GHEwY5" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="23q4CrmMjsd" role="3bR37C">
+          <node concept="3bR9La" id="23q4CrmMjse" role="1SiIV1">
+            <ref role="3bR37D" node="23q4CrmMjed" resolve="org.iets3.core.expr.genjava.messages.rt" />
           </node>
         </node>
       </node>
@@ -10840,11 +10845,6 @@
               <ref role="3bR37D" node="44Ryrhr_Yca" resolve="org.iets3.core.expr.util" />
             </node>
           </node>
-          <node concept="1SiIV0" id="32Mgz$buMoE" role="3bR37C">
-            <node concept="3bR9La" id="32Mgz$buMoF" role="1SiIV1">
-              <ref role="3bR37D" node="5khwDRKS378" resolve="org.iets3.core.expr.base.collections.stubs" />
-            </node>
-          </node>
           <node concept="1BupzO" id="1RMC8GHEwZd" role="3bR31x">
             <property role="3ZfqAx" value="generator/template" />
             <property role="1Hdu6h" value="true" />
@@ -10868,6 +10868,11 @@
               <node concept="3qWCbU" id="1RMC8GHEwZf" role="3LXTna">
                 <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
               </node>
+            </node>
+          </node>
+          <node concept="1SiIV0" id="32Mgz$buMoE" role="3bR37C">
+            <node concept="3bR9La" id="32Mgz$buMoF" role="1SiIV1">
+              <ref role="3bR37D" node="5khwDRKS378" resolve="org.iets3.core.expr.base.collections.stubs" />
             </node>
           </node>
           <node concept="1SiIV0" id="7vcJOhhDvMi" role="3bR37C">
@@ -11665,11 +11670,6 @@
             <ref role="3bR37D" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
           </node>
         </node>
-        <node concept="1SiIV0" id="6HTRljZ_OXI" role="3bR37C">
-          <node concept="3bR9La" id="6HTRljZ_OXJ" role="1SiIV1">
-            <ref role="3bR37D" to="90a9:F1NWDqq_DA" resolve="com.mbeddr.mpsutil.grammarcells.runtime" />
-          </node>
-        </node>
         <node concept="1BupzO" id="1RMC8GHEx0Y" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -11690,6 +11690,11 @@
             <node concept="3qWCbU" id="1RMC8GHEx10" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6HTRljZ_OXI" role="3bR37C">
+          <node concept="3bR9La" id="6HTRljZ_OXJ" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:F1NWDqq_DA" resolve="com.mbeddr.mpsutil.grammarcells.runtime" />
           </node>
         </node>
         <node concept="1SiIV0" id="7ocMcpFtjTb" role="3bR37C">
@@ -13255,11 +13260,6 @@
           <ref role="3bR37D" node="5wLtKNeSRRr" resolve="org.iets3.components.core" />
         </node>
       </node>
-      <node concept="1SiIV0" id="7LbZKOmTk98" role="3bR37C">
-        <node concept="3bR9La" id="7LbZKOmTk99" role="1SiIV1">
-          <ref role="3bR37D" node="48ZWgAGrsoI" resolve="test.iest3.component.attribute" />
-        </node>
-      </node>
       <node concept="1BupzO" id="1RMC8GHIDGY" role="3bR31x">
         <property role="3ZfqAx" value="models" />
         <property role="1Hdu6h" value="true" />
@@ -13280,6 +13280,11 @@
           <node concept="3qWCbU" id="1RMC8GHIDH0" role="3LXTna">
             <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
           </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="7LbZKOmTk98" role="3bR37C">
+        <node concept="3bR9La" id="7LbZKOmTk99" role="1SiIV1">
+          <ref role="3bR37D" node="48ZWgAGrsoI" resolve="test.iest3.component.attribute" />
         </node>
       </node>
     </node>
@@ -13325,11 +13330,6 @@
           <ref role="1Busuk" node="5wLtKNeSRRr" resolve="org.iets3.components.core" />
         </node>
       </node>
-      <node concept="1SiIV0" id="7LbZKOmTk9s" role="3bR37C">
-        <node concept="3bR9La" id="7LbZKOmTk9t" role="1SiIV1">
-          <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
-        </node>
-      </node>
       <node concept="1BupzO" id="1RMC8GHIDHj" role="3bR31x">
         <property role="3ZfqAx" value="models" />
         <property role="1Hdu6h" value="true" />
@@ -13350,6 +13350,11 @@
           <node concept="3qWCbU" id="1RMC8GHIDHl" role="3LXTna">
             <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
           </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="7LbZKOmTk9s" role="3bR37C">
+        <node concept="3bR9La" id="7LbZKOmTk9t" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
         </node>
       </node>
     </node>
@@ -13560,8 +13565,8 @@
     <property role="TrG5h" value="iets3.os.prebuild" />
     <property role="turDy" value="prebuild.xml" />
     <node concept="2igEWh" id="sIFyDYHT4z" role="1hWBAP">
-      <property role="3UIfUI" value="10000" />
       <property role="1YnnvL" value="1024" />
+      <property role="3UIfUI" value="10000" />
     </node>
     <node concept="1E1JtD" id="1YwzPHwBxpc" role="3989C9">
       <property role="BnDLt" value="true" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/temporal@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/temporal@tests.mps
@@ -8017,7 +8017,7 @@
             </node>
             <node concept="3_1$Yv" id="3BA76YhD$YQ" role="3_9lra">
               <node concept="Xl_RD" id="3BA76YhD_6O" role="3_1BAH">
-                <property role="Xl_RC" value="TemporalValue should contain 2x identical slices" />
+                <property role="Xl_RC" value="Amount of contained slices wrong" />
               </node>
             </node>
             <node concept="3cmrfG" id="475Xz0zF4Y_" role="3tpDZB">
@@ -8071,6 +8071,24 @@
               </node>
             </node>
           </node>
+          <node concept="3clFbF" id="4dF$g$BIPPz" role="3cqZAp">
+            <node concept="2OqwBi" id="4dF$g$BIPP$" role="3clFbG">
+              <node concept="2OqwBi" id="4dF$g$BIPP_" role="2Oq$k0">
+                <node concept="37vLTw" id="4dF$g$BIPPA" role="2Oq$k0">
+                  <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
+                </node>
+                <node concept="liA8E" id="4dF$g$BIPPB" role="2OqNvi">
+                  <ref role="37wK5l" to="8rdi:4voqclTDifZ" resolve="slices" />
+                </node>
+              </node>
+              <node concept="liA8E" id="4dF$g$BIPPC" role="2OqNvi">
+                <ref role="37wK5l" to="8rdi:475Xz0wPGET" resolve="add" />
+                <node concept="37vLTw" id="4dF$g$BIPPD" role="37wK5m">
+                  <ref role="3cqZAo" node="x6l$anF22h" resolve="slice1" />
+                </node>
+              </node>
+            </node>
+          </node>
           <node concept="3clFbF" id="475Xz0wOLA1" role="3cqZAp">
             <node concept="2OqwBi" id="475Xz0wOLA2" role="3clFbG">
               <node concept="2OqwBi" id="475Xz0wOLA3" role="2Oq$k0">
@@ -8117,11 +8135,11 @@
             </node>
             <node concept="3_1$Yv" id="475Xz0wOLAl" role="3_9lra">
               <node concept="Xl_RD" id="475Xz0wOLAm" role="3_1BAH">
-                <property role="Xl_RC" value="TemporalValue should contain 2x identical slices" />
+                <property role="Xl_RC" value="Amount of contained slices wrong" />
               </node>
             </node>
             <node concept="3cmrfG" id="475Xz0zDlDK" role="3tpDZB">
-              <property role="3cmrfH" value="2" />
+              <property role="3cmrfH" value="3" />
             </node>
           </node>
           <node concept="3vlDli" id="475Xz0wOLAn" role="3cqZAp">
@@ -8222,7 +8240,7 @@
             </node>
             <node concept="3_1$Yv" id="3BA76YhII07" role="3_9lra">
               <node concept="Xl_RD" id="3BA76YhII08" role="3_1BAH">
-                <property role="Xl_RC" value="TemporalValue should contain 2x identical slices" />
+                <property role="Xl_RC" value="Amount of contained slices wrong" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/temporal@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/temporal@tests.mps
@@ -15,6 +15,7 @@
     <import index="l462" ref="r:d6904536-4de8-40ba-b54e-09fcdfe1b62a(org.iets3.core.expr.temporal.structure)" />
     <import index="28m1" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time(JDK/)" />
     <import index="8rdi" ref="r:f17e1021-3869-4fe5-b3c7-0b2a9149a478(org.iets3.core.expr.temporal.runtime)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -121,6 +122,11 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+    </language>
+    <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
+      <concept id="3693790620639876318" name="com.mbeddr.mpsutil.blutil.structure.BLDoc" flags="ng" index="2aEySx">
+        <child id="3693790620639876319" name="text" index="2aEySw" />
+      </concept>
     </language>
     <language id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base">
       <concept id="7831630342157089621" name="org.iets3.core.base.structure.IDetectNeedToRunManually" flags="ng" index="0Rz4o">
@@ -7636,6 +7642,56 @@
         </node>
       </node>
     </node>
+    <node concept="312cEg" id="3BA76YhIuEc" role="jymVt">
+      <property role="TrG5h" value="slice5WithNulLValue" />
+      <node concept="3Tm6S6" id="3BA76YhItn2" role="1B3o_S" />
+      <node concept="3uibUv" id="3BA76YhIuD7" role="1tU5fm">
+        <ref role="3uigEE" to="8rdi:50smQ1VbaN9" resolve="SliceValue" />
+      </node>
+      <node concept="2ShNRf" id="3BA76YhIva7" role="33vP2m">
+        <node concept="1pGfFk" id="3BA76YhIx4d" role="2ShVmc">
+          <property role="373rjd" value="true" />
+          <ref role="37wK5l" to="8rdi:50smQ1VbaTB" resolve="SliceValue" />
+          <node concept="37vLTw" id="3BA76YhIx5$" role="37wK5m">
+            <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
+          </node>
+          <node concept="2YIFZM" id="3BA76YhIxCt" role="37wK5m">
+            <ref role="1Pybhc" to="28m1:~LocalDate" resolve="LocalDate" />
+            <ref role="37wK5l" to="28m1:~LocalDate.parse(java.lang.CharSequence)" resolve="parse" />
+            <node concept="Xl_RD" id="3BA76YhIxCu" role="37wK5m">
+              <property role="Xl_RC" value="2002-01-01" />
+            </node>
+          </node>
+          <node concept="10Nm6u" id="3BA76YhIxL6" role="37wK5m" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="3BA76YhXaEH" role="jymVt">
+      <property role="TrG5h" value="slice6" />
+      <node concept="3Tm6S6" id="3BA76YhXaEI" role="1B3o_S" />
+      <node concept="3uibUv" id="3BA76YhXaEJ" role="1tU5fm">
+        <ref role="3uigEE" to="8rdi:50smQ1VbaN9" resolve="SliceValue" />
+      </node>
+      <node concept="2ShNRf" id="3BA76YhXaEK" role="33vP2m">
+        <node concept="1pGfFk" id="3BA76YhXaEL" role="2ShVmc">
+          <property role="373rjd" value="true" />
+          <ref role="37wK5l" to="8rdi:50smQ1VbaTB" resolve="SliceValue" />
+          <node concept="37vLTw" id="3BA76YhXaEM" role="37wK5m">
+            <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
+          </node>
+          <node concept="2YIFZM" id="3BA76YhXaEN" role="37wK5m">
+            <ref role="1Pybhc" to="28m1:~LocalDate" resolve="LocalDate" />
+            <ref role="37wK5l" to="28m1:~LocalDate.parse(java.lang.CharSequence)" resolve="parse" />
+            <node concept="Xl_RD" id="3BA76YhXaEO" role="37wK5m">
+              <property role="Xl_RC" value="2024-01-01" />
+            </node>
+          </node>
+          <node concept="3cmrfG" id="3BA76YhXbZz" role="37wK5m">
+            <property role="3cmrfH" value="22" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="x6l$anF220" role="jymVt" />
     <node concept="3Tm1VV" id="x6l$anpf0a" role="1B3o_S" />
     <node concept="3s_gsd" id="x6l$anpf0b" role="3s_ewO">
@@ -7887,6 +7943,217 @@
                   </node>
                 </node>
               </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3s$Bmu" id="_Xxt9afg6U" role="3s_gse">
+        <property role="3s$Bm0" value="TestingJoinSlices" />
+        <node concept="3cqZAl" id="_Xxt9afg6V" role="3clF45" />
+        <node concept="3Tm1VV" id="_Xxt9afg6W" role="1B3o_S" />
+        <node concept="3clFbS" id="_Xxt9afg6X" role="3clF47">
+          <node concept="3clFbF" id="3BA76Yh$CDC" role="3cqZAp">
+            <node concept="2OqwBi" id="3BA76Yh$OvM" role="3clFbG">
+              <node concept="2OqwBi" id="3BA76Yh$CSj" role="2Oq$k0">
+                <node concept="37vLTw" id="3BA76Yh$CDA" role="2Oq$k0">
+                  <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
+                </node>
+                <node concept="liA8E" id="3BA76Yh$MV$" role="2OqNvi">
+                  <ref role="37wK5l" to="8rdi:4voqclTDifZ" resolve="slices" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3BA76Yh$PN5" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                <node concept="37vLTw" id="3BA76Yh$PUS" role="37wK5m">
+                  <ref role="3cqZAo" node="x6l$anF22h" resolve="slice1" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="3BA76YhBYx8" role="3cqZAp">
+            <node concept="2OqwBi" id="3BA76YhBYx9" role="3clFbG">
+              <node concept="2OqwBi" id="3BA76YhBYxa" role="2Oq$k0">
+                <node concept="37vLTw" id="3BA76YhBYxb" role="2Oq$k0">
+                  <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
+                </node>
+                <node concept="liA8E" id="3BA76YhBYxc" role="2OqNvi">
+                  <ref role="37wK5l" to="8rdi:4voqclTDifZ" resolve="slices" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3BA76YhBYxd" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                <node concept="37vLTw" id="3BA76YhBYxe" role="37wK5m">
+                  <ref role="3cqZAo" node="x6l$anF22h" resolve="slice1" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="3BA76YhVoLK" role="3cqZAp">
+            <node concept="2OqwBi" id="3BA76YhVoLL" role="3clFbG">
+              <node concept="2OqwBi" id="3BA76YhVoLM" role="2Oq$k0">
+                <node concept="37vLTw" id="3BA76YhVoLN" role="2Oq$k0">
+                  <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
+                </node>
+                <node concept="liA8E" id="3BA76YhVoLO" role="2OqNvi">
+                  <ref role="37wK5l" to="8rdi:4voqclTDifZ" resolve="slices" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3BA76YhVoLP" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                <node concept="37vLTw" id="3BA76YhVoLQ" role="37wK5m">
+                  <ref role="3cqZAo" node="3BA76YhXaEH" resolve="slice6" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="3BA76YhVrPw" role="3cqZAp" />
+          <node concept="3vlDli" id="3BA76YhDy3K" role="3cqZAp">
+            <node concept="3cmrfG" id="3BA76YhVrpi" role="3tpDZB">
+              <property role="3cmrfH" value="3" />
+            </node>
+            <node concept="2OqwBi" id="3BA76YhDzgr" role="3tpDZA">
+              <node concept="37vLTw" id="3BA76YhDzgs" role="2Oq$k0">
+                <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
+              </node>
+              <node concept="liA8E" id="3BA76YhDzgt" role="2OqNvi">
+                <ref role="37wK5l" to="8rdi:50smQ1VcK3N" resolve="numberOfSlices" />
+              </node>
+            </node>
+            <node concept="3_1$Yv" id="3BA76YhD$YQ" role="3_9lra">
+              <node concept="Xl_RD" id="3BA76YhD_6O" role="3_1BAH">
+                <property role="Xl_RC" value="TemporalValue should contain 2x identical slices" />
+              </node>
+            </node>
+          </node>
+          <node concept="3vlDli" id="3BA76YhDDHB" role="3cqZAp">
+            <node concept="3cmrfG" id="3BA76YhDDVh" role="3tpDZB">
+              <property role="3cmrfH" value="2" />
+            </node>
+            <node concept="2OqwBi" id="3BA76YhFaQy" role="3tpDZA">
+              <node concept="2YIFZM" id="_Xxt9afncN" role="2Oq$k0">
+                <ref role="37wK5l" to="8rdi:3KgQFIkaiVk" resolve="joinSlices" />
+                <ref role="1Pybhc" to="8rdi:3nGzaxUs53y" resolve="TemporalOps" />
+                <node concept="37vLTw" id="_Xxt9afncO" role="37wK5m">
+                  <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3BA76YhFbhd" role="2OqNvi">
+                <ref role="37wK5l" to="8rdi:50smQ1VcK3N" resolve="numberOfSlices" />
+              </node>
+            </node>
+            <node concept="3_1$Yv" id="3BA76YhDEiD" role="3_9lra">
+              <node concept="Xl_RD" id="3BA76YhDEux" role="3_1BAH">
+                <property role="Xl_RC" value="TemporalValue should contain 1x slides after joining identical slices" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3s$Bmu" id="3BA76YhIqYQ" role="3s_gse">
+        <property role="3s$Bm0" value="TestingJoinSlicesWithNull" />
+        <node concept="3cqZAl" id="3BA76YhIqYR" role="3clF45" />
+        <node concept="3Tm1VV" id="3BA76YhIqYS" role="1B3o_S" />
+        <node concept="3clFbS" id="3BA76YhIqYT" role="3clF47">
+          <node concept="3clFbF" id="3BA76YhIIvA" role="3cqZAp">
+            <node concept="2OqwBi" id="3BA76YhIIvB" role="3clFbG">
+              <node concept="2OqwBi" id="3BA76YhIIvC" role="2Oq$k0">
+                <node concept="37vLTw" id="3BA76YhIIvD" role="2Oq$k0">
+                  <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
+                </node>
+                <node concept="liA8E" id="3BA76YhIIvE" role="2OqNvi">
+                  <ref role="37wK5l" to="8rdi:4voqclTDifZ" resolve="slices" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3BA76YhIIvF" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                <node concept="37vLTw" id="3BA76YhIJF2" role="37wK5m">
+                  <ref role="3cqZAo" node="3BA76YhIuEc" resolve="slice5WithNulLValue" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="3BA76YhTouy" role="3cqZAp">
+            <node concept="2OqwBi" id="3BA76YhTouz" role="3clFbG">
+              <node concept="2OqwBi" id="3BA76YhTou$" role="2Oq$k0">
+                <node concept="37vLTw" id="3BA76YhTou_" role="2Oq$k0">
+                  <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
+                </node>
+                <node concept="liA8E" id="3BA76YhTouA" role="2OqNvi">
+                  <ref role="37wK5l" to="8rdi:4voqclTDifZ" resolve="slices" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3BA76YhTouB" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                <node concept="37vLTw" id="3BA76YhTouC" role="37wK5m">
+                  <ref role="3cqZAo" node="3BA76YhIuEc" resolve="slice5WithNulLValue" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="3BA76YhVsgE" role="3cqZAp">
+            <node concept="2OqwBi" id="3BA76YhVsgF" role="3clFbG">
+              <node concept="2OqwBi" id="3BA76YhVsgG" role="2Oq$k0">
+                <node concept="37vLTw" id="3BA76YhVsgH" role="2Oq$k0">
+                  <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
+                </node>
+                <node concept="liA8E" id="3BA76YhVsgI" role="2OqNvi">
+                  <ref role="37wK5l" to="8rdi:4voqclTDifZ" resolve="slices" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3BA76YhVsgJ" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                <node concept="37vLTw" id="3BA76YhVsgK" role="37wK5m">
+                  <ref role="3cqZAo" node="3BA76YhXaEH" resolve="slice6" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="3BA76YhOkBl" role="3cqZAp" />
+          <node concept="3vlDli" id="3BA76YhII02" role="3cqZAp">
+            <node concept="3cmrfG" id="3BA76YhVtnN" role="3tpDZB">
+              <property role="3cmrfH" value="3" />
+            </node>
+            <node concept="2OqwBi" id="3BA76YhII04" role="3tpDZA">
+              <node concept="37vLTw" id="3BA76YhII05" role="2Oq$k0">
+                <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
+              </node>
+              <node concept="liA8E" id="3BA76YhII06" role="2OqNvi">
+                <ref role="37wK5l" to="8rdi:50smQ1VcK3N" resolve="numberOfSlices" />
+              </node>
+            </node>
+            <node concept="3_1$Yv" id="3BA76YhII07" role="3_9lra">
+              <node concept="Xl_RD" id="3BA76YhII08" role="3_1BAH">
+                <property role="Xl_RC" value="TemporalValue should contain 2x identical slices" />
+              </node>
+            </node>
+          </node>
+          <node concept="3vlDli" id="3BA76YhII09" role="3cqZAp">
+            <node concept="3cmrfG" id="3BA76YhII0a" role="3tpDZB">
+              <property role="3cmrfH" value="2" />
+            </node>
+            <node concept="2OqwBi" id="3BA76YhII0b" role="3tpDZA">
+              <node concept="2YIFZM" id="3BA76YhII0c" role="2Oq$k0">
+                <ref role="37wK5l" to="8rdi:3KgQFIkaiVk" resolve="joinSlices" />
+                <ref role="1Pybhc" to="8rdi:3nGzaxUs53y" resolve="TemporalOps" />
+                <node concept="37vLTw" id="3BA76YhII0d" role="37wK5m">
+                  <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
+                </node>
+              </node>
+              <node concept="liA8E" id="3BA76YhII0e" role="2OqNvi">
+                <ref role="37wK5l" to="8rdi:50smQ1VcK3N" resolve="numberOfSlices" />
+              </node>
+            </node>
+            <node concept="3_1$Yv" id="3BA76YhII0f" role="3_9lra">
+              <node concept="Xl_RD" id="3BA76YhII0g" role="3_1BAH">
+                <property role="Xl_RC" value="TemporalValue should contain 1x slides after joining identical slices" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2aEySx" id="3BA76YhYMv5" role="lGtFl">
+          <node concept="19SGf9" id="3BA76YhYMv6" role="2aEySw">
+            <node concept="19SUe$" id="3BA76YhYMv7" role="19SJt6">
+              <property role="19SUeA" value="should not fail with a NPE " />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/temporal@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/temporal@tests.mps
@@ -15,7 +15,6 @@
     <import index="l462" ref="r:d6904536-4de8-40ba-b54e-09fcdfe1b62a(org.iets3.core.expr.temporal.structure)" />
     <import index="28m1" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time(JDK/)" />
     <import index="8rdi" ref="r:f17e1021-3869-4fe5-b3c7-0b2a9149a478(org.iets3.core.expr.temporal.runtime)" />
-    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -7963,7 +7962,7 @@
                 </node>
               </node>
               <node concept="liA8E" id="3BA76Yh$PN5" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                <ref role="37wK5l" to="8rdi:475Xz0wPGET" resolve="add" />
                 <node concept="37vLTw" id="3BA76Yh$PUS" role="37wK5m">
                   <ref role="3cqZAo" node="x6l$anF22h" resolve="slice1" />
                 </node>
@@ -7981,7 +7980,7 @@
                 </node>
               </node>
               <node concept="liA8E" id="3BA76YhBYxd" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                <ref role="37wK5l" to="8rdi:475Xz0wPGET" resolve="add" />
                 <node concept="37vLTw" id="3BA76YhBYxe" role="37wK5m">
                   <ref role="3cqZAo" node="x6l$anF22h" resolve="slice1" />
                 </node>
@@ -7999,7 +7998,7 @@
                 </node>
               </node>
               <node concept="liA8E" id="3BA76YhVoLP" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                <ref role="37wK5l" to="8rdi:475Xz0wPGET" resolve="add" />
                 <node concept="37vLTw" id="3BA76YhVoLQ" role="37wK5m">
                   <ref role="3cqZAo" node="3BA76YhXaEH" resolve="slice6" />
                 </node>
@@ -8008,9 +8007,6 @@
           </node>
           <node concept="3clFbH" id="3BA76YhVrPw" role="3cqZAp" />
           <node concept="3vlDli" id="3BA76YhDy3K" role="3cqZAp">
-            <node concept="3cmrfG" id="3BA76YhVrpi" role="3tpDZB">
-              <property role="3cmrfH" value="3" />
-            </node>
             <node concept="2OqwBi" id="3BA76YhDzgr" role="3tpDZA">
               <node concept="37vLTw" id="3BA76YhDzgs" role="2Oq$k0">
                 <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
@@ -8023,6 +8019,9 @@
               <node concept="Xl_RD" id="3BA76YhD_6O" role="3_1BAH">
                 <property role="Xl_RC" value="TemporalValue should contain 2x identical slices" />
               </node>
+            </node>
+            <node concept="3cmrfG" id="475Xz0zF4Y_" role="3tpDZB">
+              <property role="3cmrfH" value="2" />
             </node>
           </node>
           <node concept="3vlDli" id="3BA76YhDDHB" role="3cqZAp">
@@ -8049,6 +8048,106 @@
           </node>
         </node>
       </node>
+      <node concept="3s$Bmu" id="475Xz0wOL_Q" role="3s_gse">
+        <property role="3s$Bm0" value="TestingJoinSlicesContainingNull" />
+        <node concept="3cqZAl" id="475Xz0wOL_R" role="3clF45" />
+        <node concept="3Tm1VV" id="475Xz0wOL_S" role="1B3o_S" />
+        <node concept="3clFbS" id="475Xz0wOL_T" role="3clF47">
+          <node concept="3clFbF" id="475Xz0wOL_U" role="3cqZAp">
+            <node concept="2OqwBi" id="475Xz0wOL_V" role="3clFbG">
+              <node concept="2OqwBi" id="475Xz0wOL_W" role="2Oq$k0">
+                <node concept="37vLTw" id="475Xz0wOL_X" role="2Oq$k0">
+                  <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
+                </node>
+                <node concept="liA8E" id="475Xz0wOL_Y" role="2OqNvi">
+                  <ref role="37wK5l" to="8rdi:4voqclTDifZ" resolve="slices" />
+                </node>
+              </node>
+              <node concept="liA8E" id="475Xz0wOL_Z" role="2OqNvi">
+                <ref role="37wK5l" to="8rdi:475Xz0wPGET" resolve="add" />
+                <node concept="37vLTw" id="475Xz0wOLA0" role="37wK5m">
+                  <ref role="3cqZAo" node="x6l$anF22h" resolve="slice1" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="475Xz0wOLA1" role="3cqZAp">
+            <node concept="2OqwBi" id="475Xz0wOLA2" role="3clFbG">
+              <node concept="2OqwBi" id="475Xz0wOLA3" role="2Oq$k0">
+                <node concept="37vLTw" id="475Xz0wOLA4" role="2Oq$k0">
+                  <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
+                </node>
+                <node concept="liA8E" id="475Xz0wOLA5" role="2OqNvi">
+                  <ref role="37wK5l" to="8rdi:4voqclTDifZ" resolve="slices" />
+                </node>
+              </node>
+              <node concept="liA8E" id="475Xz0wOLA6" role="2OqNvi">
+                <ref role="37wK5l" to="8rdi:475Xz0wPGET" resolve="add" />
+                <node concept="10Nm6u" id="475Xz0wOPC9" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="475Xz0wOLA8" role="3cqZAp">
+            <node concept="2OqwBi" id="475Xz0wOLA9" role="3clFbG">
+              <node concept="2OqwBi" id="475Xz0wOLAa" role="2Oq$k0">
+                <node concept="37vLTw" id="475Xz0wOLAb" role="2Oq$k0">
+                  <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
+                </node>
+                <node concept="liA8E" id="475Xz0wOLAc" role="2OqNvi">
+                  <ref role="37wK5l" to="8rdi:4voqclTDifZ" resolve="slices" />
+                </node>
+              </node>
+              <node concept="liA8E" id="475Xz0wOLAd" role="2OqNvi">
+                <ref role="37wK5l" to="8rdi:475Xz0wPGET" resolve="add" />
+                <node concept="37vLTw" id="475Xz0wOLAe" role="37wK5m">
+                  <ref role="3cqZAo" node="3BA76YhXaEH" resolve="slice6" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="475Xz0wOLAf" role="3cqZAp" />
+          <node concept="3vlDli" id="475Xz0wOLAg" role="3cqZAp">
+            <node concept="2OqwBi" id="475Xz0wOLAi" role="3tpDZA">
+              <node concept="37vLTw" id="475Xz0wOLAj" role="2Oq$k0">
+                <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
+              </node>
+              <node concept="liA8E" id="475Xz0wOLAk" role="2OqNvi">
+                <ref role="37wK5l" to="8rdi:50smQ1VcK3N" resolve="numberOfSlices" />
+              </node>
+            </node>
+            <node concept="3_1$Yv" id="475Xz0wOLAl" role="3_9lra">
+              <node concept="Xl_RD" id="475Xz0wOLAm" role="3_1BAH">
+                <property role="Xl_RC" value="TemporalValue should contain 2x identical slices" />
+              </node>
+            </node>
+            <node concept="3cmrfG" id="475Xz0zDlDK" role="3tpDZB">
+              <property role="3cmrfH" value="3" />
+            </node>
+          </node>
+          <node concept="3vlDli" id="475Xz0wOLAn" role="3cqZAp">
+            <node concept="3cmrfG" id="475Xz0wOLAo" role="3tpDZB">
+              <property role="3cmrfH" value="2" />
+            </node>
+            <node concept="2OqwBi" id="475Xz0wOLAp" role="3tpDZA">
+              <node concept="2YIFZM" id="475Xz0wOLAq" role="2Oq$k0">
+                <ref role="37wK5l" to="8rdi:3KgQFIkaiVk" resolve="joinSlices" />
+                <ref role="1Pybhc" to="8rdi:3nGzaxUs53y" resolve="TemporalOps" />
+                <node concept="37vLTw" id="475Xz0wOLAr" role="37wK5m">
+                  <ref role="3cqZAo" node="x6l$anF22e" resolve="TT" />
+                </node>
+              </node>
+              <node concept="liA8E" id="475Xz0wOLAs" role="2OqNvi">
+                <ref role="37wK5l" to="8rdi:50smQ1VcK3N" resolve="numberOfSlices" />
+              </node>
+            </node>
+            <node concept="3_1$Yv" id="475Xz0wOLAt" role="3_9lra">
+              <node concept="Xl_RD" id="475Xz0wOLAu" role="3_1BAH">
+                <property role="Xl_RC" value="TemporalValue should contain 1x slides after joining identical slices" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
       <node concept="3s$Bmu" id="3BA76YhIqYQ" role="3s_gse">
         <property role="3s$Bm0" value="TestingJoinSlicesWithNull" />
         <node concept="3cqZAl" id="3BA76YhIqYR" role="3clF45" />
@@ -8065,7 +8164,7 @@
                 </node>
               </node>
               <node concept="liA8E" id="3BA76YhIIvF" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                <ref role="37wK5l" to="8rdi:475Xz0wPGET" resolve="add" />
                 <node concept="37vLTw" id="3BA76YhIJF2" role="37wK5m">
                   <ref role="3cqZAo" node="3BA76YhIuEc" resolve="slice5WithNulLValue" />
                 </node>
@@ -8083,7 +8182,7 @@
                 </node>
               </node>
               <node concept="liA8E" id="3BA76YhTouB" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                <ref role="37wK5l" to="8rdi:475Xz0wPGET" resolve="add" />
                 <node concept="37vLTw" id="3BA76YhTouC" role="37wK5m">
                   <ref role="3cqZAo" node="3BA76YhIuEc" resolve="slice5WithNulLValue" />
                 </node>
@@ -8101,7 +8200,7 @@
                 </node>
               </node>
               <node concept="liA8E" id="3BA76YhVsgJ" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                <ref role="37wK5l" to="8rdi:475Xz0wPGET" resolve="add" />
                 <node concept="37vLTw" id="3BA76YhVsgK" role="37wK5m">
                   <ref role="3cqZAo" node="3BA76YhXaEH" resolve="slice6" />
                 </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/temporal@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/temporal@tests.mps
@@ -8021,7 +8021,7 @@
               </node>
             </node>
             <node concept="3cmrfG" id="475Xz0zF4Y_" role="3tpDZB">
-              <property role="3cmrfH" value="2" />
+              <property role="3cmrfH" value="3" />
             </node>
           </node>
           <node concept="3vlDli" id="3BA76YhDDHB" role="3cqZAp">
@@ -8121,7 +8121,7 @@
               </node>
             </node>
             <node concept="3cmrfG" id="475Xz0zDlDK" role="3tpDZB">
-              <property role="3cmrfH" value="3" />
+              <property role="3cmrfH" value="2" />
             </node>
           </node>
           <node concept="3vlDli" id="475Xz0wOLAn" role="3cqZAp">


### PR DESCRIPTION
The old impl. would lead to a NPE due to in `!res.lastSlice().value().equals(ithSlice.value())` in case the value was null. Switching to a null save comparision fixes this problem.

Addition tests were added to cover the newly added functionality. 