### PR TITLE
Remove the incorrect punctuation-right from NumberRangeSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 ### Fixed
 
 - The prevision loss when converting units in the interpreter was fixed.
+- An editor issue in NumberRangeSpec was fixed that also prevented adding a precision to a number type.
 
 ## April 2024
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/editor.mps
@@ -767,9 +767,6 @@
         <node concept="11L4FC" id="2MMBR00YG8u" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
-        <node concept="11LMrY" id="2MMBR00YG8v" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
         <node concept="1HfYo3" id="2MMBR00YFMJ" role="1HlULh">
           <node concept="3TQlhw" id="2MMBR00YFMM" role="1Hhtcw">
             <node concept="3clFbS" id="2MMBR00YFMP" role="2VODD2">


### PR DESCRIPTION
The space between the range and, for example, the name of variables was missing + the side transformations for the precision didn't work.