### PR TITLE
Remove push-y from EndCell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 - The prevision loss when converting units in the interpreter was fixed.
 - An editor issue in NumberRangeSpec was fixed that also prevented adding a precision to a number type.
+- A layouting issue with the class EndCell was fixed.
 
 ## April 2024
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -4620,22 +4620,6 @@
               </node>
             </node>
           </node>
-          <node concept="3clFbF" id="3AY9Typr_xR" role="3cqZAp">
-            <node concept="2OqwBi" id="3AY9Typr_xS" role="3clFbG">
-              <node concept="1rXfSq" id="3AY9Typr_xT" role="2Oq$k0">
-                <ref role="37wK5l" to="g51k:~EditorCell_Basic.getStyle()" resolve="getStyle" />
-              </node>
-              <node concept="liA8E" id="3AY9Typr_xU" role="2OqNvi">
-                <ref role="37wK5l" to="hox0:~Style.set(jetbrains.mps.openapi.editor.style.StyleAttribute,java.lang.Object)" resolve="set" />
-                <node concept="1Z6Ecs" id="3AY9Typr_xV" role="37wK5m">
-                  <ref role="1Z6EpT" to="z0fb:7lS0O5066uD" resolve="_push-y" />
-                </node>
-                <node concept="3clFbT" id="3AY9Typr_xW" role="37wK5m">
-                  <property role="3clFbU" value="true" />
-                </node>
-              </node>
-            </node>
-          </node>
           <node concept="3clFbH" id="3AY9TypibfP" role="3cqZAp" />
           <node concept="3clFbF" id="68WEpgCCRhE" role="3cqZAp">
             <node concept="1rXfSq" id="68WEpgCCRhF" role="3clFbG">


### PR DESCRIPTION
We have to look carefully if it is indeed not needed or otherwise other editors will break. What happened is that the last entry of a collection was not selectable with the mouse because the end cell was visible in the editor and forced layout changes because of the` push-y` attribute.