### PR TITLE
Force a empty default completion menu (including the super concepts menu) for IDotTarget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## June 2024
+
+### Fixes
+
+- An issue was fixed where the substitute menu entries of `IDotTarget` were duplicated because two default menus were created.
+
 ## May 2024
 
 ### Added

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
@@ -139,6 +139,7 @@
         <child id="1638911550608610281" name="executeFunction" index="IWgqQ" />
         <child id="5692353713941573325" name="textFunction" index="1hCUd6" />
       </concept>
+      <concept id="8449131619432941427" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_Super" flags="ng" index="L$LW2" />
       <concept id="1160493135005" name="jetbrains.mps.lang.editor.structure.CellMenuPart_PropertyValues_GetValues" flags="in" index="MLZmj" />
       <concept id="1164824717996" name="jetbrains.mps.lang.editor.structure.CellMenuDescriptor" flags="ng" index="OXEIz">
         <child id="1164824815888" name="cellMenuPart" index="OY2wv" />
@@ -221,6 +222,7 @@
       <concept id="2896773699153795590" name="jetbrains.mps.lang.editor.structure.TransformationLocation_SideTransform" flags="ng" index="3cWJ9i">
         <child id="3473224453637651919" name="placeInCell" index="CtIbM" />
       </concept>
+      <concept id="7342352913006985500" name="jetbrains.mps.lang.editor.structure.TransformationLocation_Completion" flags="ng" index="3eGOoe" />
       <concept id="7342352913006985483" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_Action" flags="ng" index="3eGOop">
         <child id="8612453216082699922" name="substituteHandler" index="3aKz83" />
       </concept>
@@ -6946,6 +6948,10 @@
           </node>
         </node>
       </node>
+    </node>
+    <node concept="1Qtc8_" id="1Va40GREEjv" role="IW6Ez">
+      <node concept="3eGOoe" id="1Va40GREEq3" role="1Qtc8$" />
+      <node concept="L$LW2" id="1Va40GS0Bif" role="1Qtc8A" />
     </node>
     <node concept="22hDWj" id="uuJ7IpZtt1" role="22hAXT" />
   </node>


### PR DESCRIPTION
There are some rare cases, where MPS duplicates the transformation menu because it creates two default transformation menus. When we have an explicit transformation menu. I am not sure if we need to include the super concepts menu here like in the automatically generated one but it doesn't seem to hurt.