### PR TITLE
Implement an ncopies operation for tuples to ease initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## July 2024
+
+### Added
+
+- Tuple types now support a new method `nTimes` to ease initialization of long tuples.
+
 ## June 2024
 
-### Fixes
+### Fixed
 
 - An issue was fixed where the substitute menu entries of `IDotTarget` were duplicated because two default menus were created.
 - The same issue was fixed for the right transformation menu of `IDotTarget`.

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -27819,5 +27819,77 @@
     </node>
     <node concept="3Tm1VV" id="2nydsCfyYD1" role="1B3o_S" />
   </node>
+  <node concept="13h7C7" id="25rRV02ygTq">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="13h7C2" to="hm2y:25rRV02ooIM" resolve="NCopiesOp" />
+    <node concept="13hLZK" id="25rRV02ygTr" role="13h7CW">
+      <node concept="3clFbS" id="25rRV02ygTs" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="25rRV02ygVl" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" node="6kR0qIbI2yi" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="25rRV02ygVm" role="1B3o_S" />
+      <node concept="3clFbS" id="25rRV02ygVp" role="3clF47">
+        <node concept="3cpWs6" id="7SygLIkQvL7" role="3cqZAp">
+          <node concept="3cpWs3" id="7SygLIkTd2k" role="3cqZAk">
+            <node concept="Xl_RD" id="7SygLIkTdn1" role="3uHU7w">
+              <property role="Xl_RC" value=")" />
+            </node>
+            <node concept="3cpWs3" id="7SygLIkT6C1" role="3uHU7B">
+              <node concept="3cpWs3" id="7SygLIkT6fw" role="3uHU7B">
+                <node concept="2OqwBi" id="7SygLIkT5xF" role="3uHU7B">
+                  <node concept="2OqwBi" id="7SygLIkT4X3" role="2Oq$k0">
+                    <node concept="13iPFW" id="7SygLIkT4Ng" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="7SygLIkT5fu" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="7SygLIkT5WO" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="7SygLIkT6fJ" role="3uHU7w">
+                  <property role="Xl_RC" value="(" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7SygLIkT7$Q" role="3uHU7w">
+                <node concept="2OqwBi" id="7SygLIkT6Wl" role="2Oq$k0">
+                  <node concept="13iPFW" id="7SygLIkT6H_" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="25rRV02yiIz" role="2OqNvi">
+                    <ref role="3Tt5mk" to="hm2y:25rRV02osES" resolve="times" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="7SygLIkT80i" role="2OqNvi">
+                  <ref role="37wK5l" node="4Y0vh0cfqjE" resolve="renderReadable" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="25rRV02ygVq" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="ijyib_dOXX" role="13h7CS">
+      <property role="TrG5h" value="expression" />
+      <node concept="3Tm1VV" id="ijyib_dOXY" role="1B3o_S" />
+      <node concept="3Tqbb2" id="ijyib_dOXZ" role="3clF45">
+        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+      </node>
+      <node concept="3clFbS" id="ijyib_dOY0" role="3clF47">
+        <node concept="3clFbF" id="ijyib_dOY1" role="3cqZAp">
+          <node concept="2OqwBi" id="ijyib_dOY2" role="3clFbG">
+            <node concept="1PxgMI" id="ijyib_dOY3" role="2Oq$k0">
+              <node concept="chp4Y" id="ijyib_dOY4" role="3oSUPX">
+                <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+              </node>
+              <node concept="2OqwBi" id="ijyib_dOY5" role="1m5AlR">
+                <node concept="13iPFW" id="ijyib_dOY6" role="2Oq$k0" />
+                <node concept="1mfA1w" id="ijyib_dOY7" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="3TrEf2" id="ijyib_dOY8" role="2OqNvi">
+              <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/constraints.mps
@@ -1125,5 +1125,32 @@
       </node>
     </node>
   </node>
+  <node concept="1M2fIO" id="25rRV02ojcu">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="1M2myG" to="hm2y:25rRV02oe$f" resolve="ITupleOp" />
+    <node concept="9S07l" id="25rRV02okuJ" role="9Vyp8">
+      <node concept="3clFbS" id="25rRV02okuK" role="2VODD2">
+        <node concept="3clFbF" id="6b_jefnKylm" role="3cqZAp">
+          <node concept="2OqwBi" id="6b_jefnKyln" role="3clFbG">
+            <node concept="1PxgMI" id="6b_jefnKylo" role="2Oq$k0">
+              <node concept="nLn13" id="6b_jefnKylp" role="1m5AlR" />
+              <node concept="chp4Y" id="6b_jefnKyoa" role="3oSUPX">
+                <ref role="cht4Q" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="6b_jefnKylq" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:5WNmJ7DokMG" resolve="expectType" />
+              <node concept="35c_gC" id="6b_jefnKylr" role="37wK5m">
+                <ref role="35c_gD" to="hm2y:S$tO8ocniU" resolve="TupleType" />
+              </node>
+              <node concept="3clFbT" id="6b_jefnKyls" role="37wK5m">
+                <property role="3clFbU" value="false" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
@@ -7688,5 +7688,33 @@
     </node>
     <node concept="3Tm1VV" id="Ss0aue3Qrt" role="1B3o_S" />
   </node>
+  <node concept="24kQdi" id="25rRV02o$Gx">
+    <property role="3GE5qa" value="tuples" />
+    <ref role="1XX52x" to="hm2y:25rRV02ooIM" resolve="NCopiesOp" />
+    <node concept="3EZMnI" id="25rRV02oBq3" role="2wV5jI">
+      <node concept="2iRfu4" id="25rRV02oBq4" role="2iSdaV" />
+      <node concept="PMmxH" id="25rRV02oA23" role="3EZMnx">
+        <ref role="PMmxG" node="12bsjhgd0dR" resolve="OpAlias" />
+      </node>
+      <node concept="3F0ifn" id="25rRV02oCH4" role="3EZMnx">
+        <property role="3F0ifm" value="(" />
+        <node concept="11L4FC" id="6zmBjqUjnOY" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="11LMrY" id="6zmBjqUjnOZ" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F1sOY" id="25rRV02oE44" role="3EZMnx">
+        <ref role="1NtTu8" to="hm2y:25rRV02osES" resolve="times" />
+      </node>
+      <node concept="3F0ifn" id="25rRV02oE64" role="3EZMnx">
+        <property role="3F0ifm" value=")" />
+        <node concept="11L4FC" id="25rRV02vnNt" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/structure.mps
@@ -2218,5 +2218,30 @@
       <ref role="PrY4T" node="6KxoTHgLv_I" resolve="IMayHaveEffect" />
     </node>
   </node>
+  <node concept="PlHQZ" id="25rRV02oe$f">
+    <property role="EcuMT" value="2403760773179435279" />
+    <property role="3GE5qa" value="tuples" />
+    <property role="TrG5h" value="ITupleOp" />
+    <node concept="PrWs8" id="25rRV02ohmw" role="PrDN$">
+      <ref role="PrY4T" node="7NJy08a3O9a" resolve="IDotTarget" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="25rRV02ooIM">
+    <property role="EcuMT" value="2403760773179476914" />
+    <property role="3GE5qa" value="tuples" />
+    <property role="TrG5h" value="NCopiesOp" />
+    <property role="34LRSv" value="nTimes" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="25rRV02osES" role="1TKVEi">
+      <property role="IQ2ns" value="2403760773179493048" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="times" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="6sdnDbSla17" resolve="Expression" />
+    </node>
+    <node concept="PrWs8" id="25rRV02oy5O" role="PzmwI">
+      <ref role="PrY4T" node="25rRV02oe$f" resolve="ITupleOp" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
@@ -26,7 +26,9 @@
     <import index="3673" ref="r:78633c85-d020-485e-aaa3-59e2daa3b826(com.mbeddr.mpsutil.interpreter.structure)" />
     <import index="kqnq" ref="r:7628c3bd-6988-4d33-9682-86b8cef4b8c0(com.mbeddr.mpsutil.interpreter.behavior)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="xlxw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.math(JDK/)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -51,12 +53,18 @@
       <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
       </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
@@ -71,6 +79,10 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
@@ -82,6 +94,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -7240,17 +7255,6 @@
       <node concept="3clFbS" id="1ufrWYcLZ2q" role="2VODD2">
         <node concept="3clFbF" id="1ufrWYcLZE3" role="3cqZAp">
           <node concept="3clFbC" id="1ufrWYcM3YN" role="3clFbG">
-            <node concept="2OqwBi" id="1ufrWYcM6QZ" role="3uHU7w">
-              <node concept="2OqwBi" id="1ufrWYcM4C9" role="2Oq$k0">
-                <node concept="1YBJjd" id="1ufrWYcM4d7" role="2Oq$k0">
-                  <ref role="1YBMHb" node="1ufrWYcLZ1D" resolve="exp" />
-                </node>
-                <node concept="3Tsc0h" id="1ufrWYcM4V9" role="2OqNvi">
-                  <ref role="3TtcxE" to="hm2y:S$tO8ocniV" resolve="elementTypes" />
-                </node>
-              </node>
-              <node concept="34oBXx" id="1ufrWYcM9Hs" role="2OqNvi" />
-            </node>
             <node concept="2OqwBi" id="1ufrWYcM1MG" role="3uHU7B">
               <node concept="2OqwBi" id="1ufrWYcLZPZ" role="2Oq$k0">
                 <node concept="1YBJjd" id="1ufrWYcLZE2" role="2Oq$k0">
@@ -7261,6 +7265,17 @@
                 </node>
               </node>
               <node concept="34oBXx" id="1ufrWYcM3gC" role="2OqNvi" />
+            </node>
+            <node concept="2OqwBi" id="1ufrWYcM6QZ" role="3uHU7w">
+              <node concept="2OqwBi" id="1ufrWYcM4C9" role="2Oq$k0">
+                <node concept="1YBJjd" id="1ufrWYcM4d7" role="2Oq$k0">
+                  <ref role="1YBMHb" node="1ufrWYcLZ1D" resolve="exp" />
+                </node>
+                <node concept="3Tsc0h" id="1ufrWYcM4V9" role="2OqNvi">
+                  <ref role="3TtcxE" to="hm2y:S$tO8ocniV" resolve="elementTypes" />
+                </node>
+              </node>
+              <node concept="34oBXx" id="1ufrWYcM9Hs" role="2OqNvi" />
             </node>
           </node>
         </node>
@@ -10631,6 +10646,299 @@
     <node concept="1YaCAy" id="6GiZkUz7CB4" role="1YuTPh">
       <property role="TrG5h" value="inta" />
       <ref role="1YaFvo" to="hm2y:6GiZkUz7qWO" resolve="InlineNamedTupleAccess" />
+    </node>
+  </node>
+  <node concept="1YbPZF" id="25rRV02oFps">
+    <property role="TrG5h" value="typeof_NCopies" />
+    <property role="3GE5qa" value="tuples" />
+    <node concept="3clFbS" id="25rRV02oFpt" role="18ibNy">
+      <node concept="nvevp" id="7GwCuf2y0wh" role="3cqZAp">
+        <node concept="3clFbS" id="7GwCuf2y0wj" role="nvhr_">
+          <node concept="3clFbJ" id="25rRV02vcXJ" role="3cqZAp">
+            <node concept="3clFbS" id="25rRV02vcXL" role="3clFbx">
+              <node concept="3cpWs6" id="25rRV02vn_a" role="3cqZAp" />
+            </node>
+            <node concept="2OqwBi" id="25rRV02vl47" role="3clFbw">
+              <node concept="2OqwBi" id="25rRV02vgTf" role="2Oq$k0">
+                <node concept="2OqwBi" id="25rRV02vdla" role="2Oq$k0">
+                  <node concept="1YBJjd" id="25rRV02vd8t" role="2Oq$k0">
+                    <ref role="1YBMHb" node="25rRV02oFpv" resolve="nCopies" />
+                  </node>
+                  <node concept="3TrEf2" id="25rRV02vgfA" role="2OqNvi">
+                    <ref role="3Tt5mk" to="hm2y:25rRV02osES" resolve="times" />
+                  </node>
+                </node>
+                <node concept="2yIwOk" id="25rRV02vkpi" role="2OqNvi" />
+              </node>
+              <node concept="liA8E" id="25rRV02vmtA" role="2OqNvi">
+                <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
+              </node>
+            </node>
+          </node>
+          <node concept="nvevp" id="xNPLfvZ3U" role="3cqZAp">
+            <node concept="3clFbS" id="xNPLfvZ3W" role="nvhr_">
+              <node concept="3cpWs8" id="25rRV02p6Kg" role="3cqZAp">
+                <node concept="3cpWsn" id="25rRV02p6Kh" role="3cpWs9">
+                  <property role="TrG5h" value="timesValue" />
+                  <node concept="3uibUv" id="25rRV02p5rK" role="1tU5fm">
+                    <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                  </node>
+                  <node concept="2OqwBi" id="25rRV02p6Ki" role="33vP2m">
+                    <node concept="2OqwBi" id="25rRV02p6Kj" role="2Oq$k0">
+                      <node concept="2ShNRf" id="25rRV02p6Kk" role="2Oq$k0">
+                        <node concept="HV5vD" id="25rRV02p6Kl" role="2ShVmc">
+                          <property role="373rjd" value="true" />
+                          <ref role="HV5vE" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="25rRV02p6Km" role="2OqNvi">
+                        <ref role="37wK5l" to="pbu6:2nydsCfz7eH" resolve="evaluate" />
+                        <node concept="2OqwBi" id="25rRV02p6Kn" role="37wK5m">
+                          <node concept="1YBJjd" id="25rRV02p6Ko" role="2Oq$k0">
+                            <ref role="1YBMHb" node="25rRV02oFpv" resolve="nCopies" />
+                          </node>
+                          <node concept="3TrEf2" id="25rRV02p6Kp" role="2OqNvi">
+                            <ref role="3Tt5mk" to="hm2y:25rRV02osES" resolve="times" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OwXpG" id="25rRV02p6Kq" role="2OqNvi">
+                      <ref role="2Oxat5" to="pbu6:7lHetQyBz3x" resolve="value" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="25rRV02pc3w" role="3cqZAp">
+                <node concept="3clFbS" id="25rRV02pc3y" role="3clFbx">
+                  <node concept="3cpWs8" id="25rRV02pKbN" role="3cqZAp">
+                    <node concept="3cpWsn" id="25rRV02pKbO" role="3cpWs9">
+                      <property role="TrG5h" value="times" />
+                      <node concept="10Oyi0" id="25rRV02pX9n" role="1tU5fm" />
+                      <node concept="2OqwBi" id="25rRV02pTU0" role="33vP2m">
+                        <node concept="1eOMI4" id="25rRV02pO2H" role="2Oq$k0">
+                          <node concept="10QFUN" id="25rRV02pO2E" role="1eOMHV">
+                            <node concept="3uibUv" id="25rRV02pO2J" role="10QFUM">
+                              <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                            </node>
+                            <node concept="37vLTw" id="25rRV02pPme" role="10QFUP">
+                              <ref role="3cqZAo" node="25rRV02p6Kh" resolve="timesValue" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="25rRV02pV_o" role="2OqNvi">
+                          <ref role="37wK5l" to="xlxw:~BigInteger.intValue()" resolve="intValue" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="25rRV02pwa8" role="3cqZAp">
+                    <node concept="3cpWsn" id="25rRV02pwab" role="3cpWs9">
+                      <property role="TrG5h" value="tupleType" />
+                      <node concept="3Tqbb2" id="25rRV02pwa6" role="1tU5fm">
+                        <ref role="ehGHo" to="hm2y:S$tO8ocniU" resolve="TupleType" />
+                      </node>
+                      <node concept="1PxgMI" id="7GwCuf2y0Pb" role="33vP2m">
+                        <node concept="chp4Y" id="6b_jefnKyoH" role="3oSUPX">
+                          <ref role="cht4Q" to="hm2y:S$tO8ocniU" resolve="TupleType" />
+                        </node>
+                        <node concept="2X3wrD" id="7GwCuf2y0Pc" role="1m5AlR">
+                          <ref role="2X3Bk0" node="7GwCuf2y0wn" resolve="ctxType" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="25rRV02qVo6" role="3cqZAp">
+                    <node concept="3cpWsn" id="25rRV02qVo7" role="3cpWs9">
+                      <property role="TrG5h" value="newElementTypes" />
+                      <node concept="2OqwBi" id="25rRV02rtv7" role="33vP2m">
+                        <node concept="2OqwBi" id="25rRV02r0zO" role="2Oq$k0">
+                          <node concept="2OqwBi" id="25rRV02qVo8" role="2Oq$k0">
+                            <node concept="37vLTw" id="25rRV02qVo9" role="2Oq$k0">
+                              <ref role="3cqZAo" node="25rRV02pwab" resolve="tupleType" />
+                            </node>
+                            <node concept="3Tsc0h" id="25rRV02qVoa" role="2OqNvi">
+                              <ref role="3TtcxE" to="hm2y:S$tO8ocniV" resolve="elementTypes" />
+                            </node>
+                          </node>
+                          <node concept="3$u5V9" id="25rRV02r3PO" role="2OqNvi">
+                            <node concept="1bVj0M" id="25rRV02r3PQ" role="23t8la">
+                              <node concept="3clFbS" id="25rRV02r3PR" role="1bW5cS">
+                                <node concept="3clFbF" id="25rRV02r7zD" role="3cqZAp">
+                                  <node concept="2OqwBi" id="25rRV02r9re" role="3clFbG">
+                                    <node concept="37vLTw" id="25rRV02r7zC" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="25rRV02r3PS" resolve="it" />
+                                    </node>
+                                    <node concept="1$rogu" id="25rRV02rbW2" role="2OqNvi" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="Rh6nW" id="25rRV02r3PS" role="1bW2Oz">
+                                <property role="TrG5h" value="it" />
+                                <node concept="2jxLKc" id="25rRV02r3PT" role="1tU5fm" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="ANE8D" id="25rRV02rwmW" role="2OqNvi" />
+                      </node>
+                      <node concept="_YKpA" id="ijyib_aZNv" role="1tU5fm">
+                        <node concept="3Tqbb2" id="ijyib_b0Co" role="_ZDj9">
+                          <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1Dw8fO" id="25rRV02qswS" role="3cqZAp">
+                    <node concept="3clFbS" id="25rRV02qswU" role="2LFqv$">
+                      <node concept="3cpWs8" id="ijyib_b31c" role="3cqZAp">
+                        <node concept="3cpWsn" id="ijyib_b31d" role="3cpWs9">
+                          <property role="TrG5h" value="newElements" />
+                          <node concept="_YKpA" id="ijyib_b5XT" role="1tU5fm">
+                            <node concept="3Tqbb2" id="ijyib_b5XV" role="_ZDj9">
+                              <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="ijyib_b57L" role="33vP2m">
+                            <node concept="2OqwBi" id="ijyib_b31e" role="2Oq$k0">
+                              <node concept="37vLTw" id="ijyib_b31f" role="2Oq$k0">
+                                <ref role="3cqZAo" node="25rRV02qVo7" resolve="newElementTypes" />
+                              </node>
+                              <node concept="3$u5V9" id="ijyib_b31g" role="2OqNvi">
+                                <node concept="1bVj0M" id="ijyib_b31h" role="23t8la">
+                                  <node concept="3clFbS" id="ijyib_b31i" role="1bW5cS">
+                                    <node concept="3clFbF" id="ijyib_b31j" role="3cqZAp">
+                                      <node concept="2OqwBi" id="ijyib_b31k" role="3clFbG">
+                                        <node concept="37vLTw" id="ijyib_b31l" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="ijyib_b31n" resolve="it" />
+                                        </node>
+                                        <node concept="1$rogu" id="ijyib_b31m" role="2OqNvi" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="Rh6nW" id="ijyib_b31n" role="1bW2Oz">
+                                    <property role="TrG5h" value="it" />
+                                    <node concept="2jxLKc" id="ijyib_b31o" role="1tU5fm" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="ANE8D" id="ijyib_b5J6" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="25rRV02qC4x" role="3cqZAp">
+                        <node concept="2OqwBi" id="25rRV02qHBl" role="3clFbG">
+                          <node concept="37vLTw" id="25rRV02qVob" role="2Oq$k0">
+                            <ref role="3cqZAo" node="25rRV02qVo7" resolve="newElementTypes" />
+                          </node>
+                          <node concept="X8dFx" id="25rRV02rEC_" role="2OqNvi">
+                            <node concept="37vLTw" id="ijyib_b31p" role="25WWJ7">
+                              <ref role="3cqZAo" node="ijyib_b31d" resolve="newElements" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWsn" id="25rRV02qswV" role="1Duv9x">
+                      <property role="TrG5h" value="i" />
+                      <node concept="10Oyi0" id="25rRV02qszM" role="1tU5fm" />
+                      <node concept="3cmrfG" id="25rRV02qwnz" role="33vP2m">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                    </node>
+                    <node concept="3eOVzh" id="25rRV02qzTe" role="1Dwp0S">
+                      <node concept="37vLTw" id="25rRV02q_ch" role="3uHU7w">
+                        <ref role="3cqZAo" node="25rRV02pKbO" resolve="times" />
+                      </node>
+                      <node concept="37vLTw" id="25rRV02qxDc" role="3uHU7B">
+                        <ref role="3cqZAo" node="25rRV02qswV" resolve="i" />
+                      </node>
+                    </node>
+                    <node concept="3uNrnE" id="25rRV02qAFb" role="1Dwrff">
+                      <node concept="37vLTw" id="25rRV02qAFd" role="2$L3a6">
+                        <ref role="3cqZAo" node="25rRV02qswV" resolve="i" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1Z5TYs" id="25rRV02plzI" role="3cqZAp">
+                    <node concept="mw_s8" id="25rRV02pmS$" role="1ZfhKB">
+                      <node concept="2pJPEk" id="25rRV02pmSw" role="mwGJk">
+                        <node concept="2pJPED" id="25rRV02pmSy" role="2pJPEn">
+                          <ref role="2pJxaS" to="hm2y:S$tO8ocniU" resolve="TupleType" />
+                          <node concept="2pIpSj" id="25rRV02ps6H" role="2pJxcM">
+                            <ref role="2pIpSl" to="hm2y:S$tO8ocniV" resolve="elementTypes" />
+                            <node concept="36biLy" id="25rRV02rJ1e" role="28nt2d">
+                              <node concept="37vLTw" id="25rRV02rPTB" role="36biLW">
+                                <ref role="3cqZAo" node="25rRV02qVo7" resolve="newElementTypes" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="mw_s8" id="25rRV02plzL" role="1ZfhK$">
+                      <node concept="1Z2H0r" id="25rRV02oHO$" role="mwGJk">
+                        <node concept="1YBJjd" id="25rRV02oJGq" role="1Z2MuG">
+                          <ref role="1YBMHb" node="25rRV02oFpv" resolve="nCopies" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1Wc70l" id="25rRV02p$5N" role="3clFbw">
+                  <node concept="2ZW3vV" id="25rRV02pAO1" role="3uHU7w">
+                    <node concept="3uibUv" id="25rRV02pChj" role="2ZW6by">
+                      <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                    </node>
+                    <node concept="37vLTw" id="25rRV02p_qJ" role="2ZW6bz">
+                      <ref role="3cqZAo" node="25rRV02p6Kh" resolve="timesValue" />
+                    </node>
+                  </node>
+                  <node concept="3y3z36" id="25rRV02$YaK" role="3uHU7B">
+                    <node concept="37vLTw" id="25rRV02pdoB" role="3uHU7B">
+                      <ref role="3cqZAo" node="25rRV02p6Kh" resolve="timesValue" />
+                    </node>
+                    <node concept="10Nm6u" id="25rRV02pgbo" role="3uHU7w" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1Z2H0r" id="xNPLfvZee" role="nvjzm">
+              <node concept="2OqwBi" id="xNPLfvZtK" role="1Z2MuG">
+                <node concept="1YBJjd" id="xNPLfvZhw" role="2Oq$k0">
+                  <ref role="1YBMHb" node="25rRV02oFpv" resolve="nCopies" />
+                </node>
+                <node concept="3TrEf2" id="xNPLfw14$" role="2OqNvi">
+                  <ref role="3Tt5mk" to="hm2y:25rRV02osES" resolve="times" />
+                </node>
+              </node>
+            </node>
+            <node concept="2X1qdy" id="xNPLfvZ40" role="2X0Ygz">
+              <property role="TrG5h" value="timesType" />
+              <node concept="2jxLKc" id="xNPLfvZ41" role="1tU5fm" />
+            </node>
+          </node>
+        </node>
+        <node concept="2X1qdy" id="7GwCuf2y0wn" role="2X0Ygz">
+          <property role="TrG5h" value="ctxType" />
+          <node concept="2jxLKc" id="7GwCuf2y0wo" role="1tU5fm" />
+        </node>
+        <node concept="1Z2H0r" id="7GwCuf2y0tK" role="nvjzm">
+          <node concept="2OqwBi" id="7GwCuf2y0rS" role="1Z2MuG">
+            <node concept="1YBJjd" id="7GwCuf2y0rT" role="2Oq$k0">
+              <ref role="1YBMHb" node="25rRV02oFpv" resolve="nCopies" />
+            </node>
+            <node concept="2qgKlT" id="7GwCuf2y0rU" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:6zmBjqUivyF" resolve="contextExpression" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="25rRV02oFpv" role="1YuTPh">
+      <property role="TrG5h" value="nCopies" />
+      <ref role="1YaFvo" to="hm2y:25rRV02ooIM" resolve="NCopiesOp" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
@@ -70,6 +70,12 @@
       <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
         <child id="1239714902950" name="expression" index="2$L3a6" />
       </concept>
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -200,6 +206,7 @@
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
+      <concept id="1171903607971" name="jetbrains.mps.baseLanguage.structure.WildCardType" flags="in" index="3qTvmN" />
       <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
         <property id="8355037393041754995" name="isNative" index="2aFKle" />
       </concept>
@@ -4601,19 +4608,6 @@
         <node concept="3clFbS" id="4lRNjFWNlD3" role="2VODD2">
           <node concept="3clFbF" id="4lRNjFWNlKc" role="3cqZAp">
             <node concept="22lmx$" id="5wDe8w_Tjzu" role="3clFbG">
-              <node concept="2OqwBi" id="5wDe8w_Tmis" role="3uHU7w">
-                <node concept="2OqwBi" id="5wDe8w_TkOh" role="2Oq$k0">
-                  <node concept="30H73N" id="5wDe8w_TkfL" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="5wDe8w_Tllm" role="2OqNvi">
-                    <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
-                  </node>
-                </node>
-                <node concept="1mIQ4w" id="5wDe8w_Tnwy" role="2OqNvi">
-                  <node concept="chp4Y" id="5wDe8w_TnUn" role="cj9EA">
-                    <ref role="cht4Q" to="700h:LrvgQhjFyf" resolve="ListInsertOp" />
-                  </node>
-                </node>
-              </node>
               <node concept="22lmx$" id="5wDe8w_$Bc5" role="3uHU7B">
                 <node concept="22lmx$" id="1OIQ931yj0" role="3uHU7B">
                   <node concept="22lmx$" id="1OIQ931p$K" role="3uHU7B">
@@ -4789,6 +4783,19 @@
                     <node concept="chp4Y" id="5wDe8w_$Fs0" role="cj9EA">
                       <ref role="cht4Q" to="700h:6IBT1wUeDJz" resolve="MapContainsKeyOp" />
                     </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5wDe8w_Tmis" role="3uHU7w">
+                <node concept="2OqwBi" id="5wDe8w_TkOh" role="2Oq$k0">
+                  <node concept="30H73N" id="5wDe8w_TkfL" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="5wDe8w_Tllm" role="2OqNvi">
+                    <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                  </node>
+                </node>
+                <node concept="1mIQ4w" id="5wDe8w_Tnwy" role="2OqNvi">
+                  <node concept="chp4Y" id="5wDe8w_TnUn" role="cj9EA">
+                    <ref role="cht4Q" to="700h:LrvgQhjFyf" resolve="ListInsertOp" />
                   </node>
                 </node>
               </node>
@@ -5026,6 +5033,259 @@
                 </node>
                 <node concept="1Bd96e" id="7Pk458DHwfS" role="2OqNvi" />
                 <node concept="raruj" id="7Pk458Ef9K8" role="lGtFl" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3aamgX" id="ijyib_sPUU" role="3aUrZf">
+      <property role="36QftV" value="true" />
+      <ref role="30HIoZ" to="hm2y:7NJy08a3O99" resolve="DotExpression" />
+      <node concept="30G5F_" id="ijyib_sPUV" role="30HLyM">
+        <node concept="3clFbS" id="ijyib_sPUW" role="2VODD2">
+          <node concept="3clFbF" id="ijyib_sPUX" role="3cqZAp">
+            <node concept="2OqwBi" id="ijyib_sPUY" role="3clFbG">
+              <node concept="2OqwBi" id="ijyib_sPUZ" role="2Oq$k0">
+                <node concept="30H73N" id="ijyib_sPV0" role="2Oq$k0" />
+                <node concept="3TrEf2" id="ijyib_sPV1" role="2OqNvi">
+                  <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                </node>
+              </node>
+              <node concept="1mIQ4w" id="ijyib_sPV2" role="2OqNvi">
+                <node concept="chp4Y" id="ijyib_sPV3" role="cj9EA">
+                  <ref role="cht4Q" to="hm2y:25rRV02ooIM" resolve="NCopiesOp" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1Koe21" id="ijyib_sPV4" role="1lVwrX">
+        <node concept="3clFb_" id="ijyib_sPV5" role="1Koe22">
+          <property role="DiZV1" value="false" />
+          <property role="od$2w" value="false" />
+          <property role="2aFKle" value="false" />
+          <property role="TrG5h" value="foo" />
+          <node concept="3Tm1VV" id="ijyib_sPV6" role="1B3o_S" />
+          <node concept="3cqZAl" id="ijyib_sPV7" role="3clF45" />
+          <node concept="3clFbS" id="ijyib_sPV8" role="3clF47">
+            <node concept="3cpWs8" id="ijyib_sPV9" role="3cqZAp">
+              <node concept="3cpWsn" id="ijyib_sPVa" role="3cpWs9">
+                <property role="TrG5h" value="tpv" />
+                <node concept="3uibUv" id="ijyib_sPVb" role="1tU5fm">
+                  <ref role="3uigEE" to="j10v:~PVector" resolve="PVector" />
+                </node>
+                <node concept="2YIFZM" id="ijyib_sPVc" role="33vP2m">
+                  <ref role="1Pybhc" to="j10v:~TreePVector" resolve="TreePVector" />
+                  <ref role="37wK5l" to="j10v:~TreePVector.empty()" resolve="empty" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="ijyib_sPVd" role="3cqZAp" />
+            <node concept="3clFbF" id="ijyib_sPVe" role="3cqZAp">
+              <node concept="2OqwBi" id="ijyib_sPVf" role="3clFbG">
+                <node concept="1bVj0M" id="ijyib_sPVg" role="2Oq$k0">
+                  <node concept="3clFbS" id="ijyib_sPVh" role="1bW5cS">
+                    <node concept="3cpWs8" id="ijyib_sPVF" role="3cqZAp">
+                      <node concept="3cpWsn" id="ijyib_sPVG" role="3cpWs9">
+                        <property role="TrG5h" value="times" />
+                        <node concept="10Oyi0" id="ijyib_sPVH" role="1tU5fm" />
+                        <node concept="2OqwBi" id="ijyib_sPVI" role="33vP2m">
+                          <node concept="2ShNRf" id="ijyib_sPVJ" role="2Oq$k0">
+                            <node concept="1pGfFk" id="ijyib_sPVK" role="2ShVmc">
+                              <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
+                              <node concept="Xl_RD" id="ijyib_sPVL" role="37wK5m">
+                                <property role="Xl_RC" value="5" />
+                              </node>
+                            </node>
+                            <node concept="29HgVG" id="ijyib_sPVM" role="lGtFl">
+                              <node concept="3NFfHV" id="ijyib_sPVN" role="3NFExx">
+                                <node concept="3clFbS" id="ijyib_sPVO" role="2VODD2">
+                                  <node concept="3clFbF" id="ijyib_sPVP" role="3cqZAp">
+                                    <node concept="2OqwBi" id="ijyib_sPVQ" role="3clFbG">
+                                      <node concept="1PxgMI" id="ijyib_sPVR" role="2Oq$k0">
+                                        <node concept="2OqwBi" id="ijyib_sPVT" role="1m5AlR">
+                                          <node concept="3TrEf2" id="ijyib_sPVU" role="2OqNvi">
+                                            <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                                          </node>
+                                          <node concept="30H73N" id="ijyib_sPVV" role="2Oq$k0" />
+                                        </node>
+                                        <node concept="chp4Y" id="ijyib_vhMj" role="3oSUPX">
+                                          <ref role="cht4Q" to="hm2y:25rRV02ooIM" resolve="NCopiesOp" />
+                                        </node>
+                                      </node>
+                                      <node concept="3TrEf2" id="ijyib_vn9r" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="hm2y:25rRV02osES" resolve="times" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="ijyib_sPVX" role="2OqNvi">
+                            <ref role="37wK5l" to="xlxw:~BigInteger.intValue()" resolve="intValue" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="ijyibAKtQ6" role="3cqZAp">
+                      <node concept="3clFbS" id="ijyibAKtQ8" role="3clFbx">
+                        <node concept="3clFbF" id="ijyibATDdr" role="3cqZAp">
+                          <node concept="2YIFZM" id="ijyibANwJV" role="3clFbG">
+                            <ref role="37wK5l" to="vsv5:6jT4GDw1gm8" resolve="fail" />
+                            <ref role="1Pybhc" to="vsv5:6jT4GDw1g66" resolve="FailException" />
+                            <node concept="Xl_RD" id="ijyibANzy3" role="37wK5m">
+                              <property role="Xl_RC" value="the argument must be greater than 0" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2dkUwp" id="ijyibAKxUY" role="3clFbw">
+                        <node concept="3cmrfG" id="ijyibAKz09" role="3uHU7w">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                        <node concept="37vLTw" id="ijyibAKuIJ" role="3uHU7B">
+                          <ref role="3cqZAo" node="ijyib_sPVG" resolve="times" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs6" id="ijyibA4cwT" role="3cqZAp">
+                      <node concept="2YIFZM" id="ijyib_w3of" role="3cqZAk">
+                        <ref role="37wK5l" to="j10v:~TreePVector.from(java.util.Collection)" resolve="from" />
+                        <ref role="1Pybhc" to="j10v:~TreePVector" resolve="TreePVector" />
+                        <node concept="2OqwBi" id="ijyib_$QlR" role="37wK5m">
+                          <node concept="2OqwBi" id="ijyibA89jC" role="2Oq$k0">
+                            <node concept="2OqwBi" id="ijyib_wDYK" role="2Oq$k0">
+                              <node concept="2YIFZM" id="ijyib_w_aw" role="2Oq$k0">
+                                <ref role="37wK5l" to="1ctc:~Stream.generate(java.util.function.Supplier)" resolve="generate" />
+                                <ref role="1Pybhc" to="1ctc:~Stream" resolve="Stream" />
+                                <node concept="2ShNRf" id="ijyibA2mKS" role="37wK5m">
+                                  <node concept="YeOm9" id="ijyibA2nqp" role="2ShVmc">
+                                    <node concept="1Y3b0j" id="ijyibA2nqs" role="YeSDq">
+                                      <property role="2bfB8j" value="true" />
+                                      <property role="373rjd" value="true" />
+                                      <ref role="1Y3XeK" to="82uw:~Supplier" resolve="Supplier" />
+                                      <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                                      <node concept="3Tm1VV" id="ijyibA2nqt" role="1B3o_S" />
+                                      <node concept="3clFb_" id="ijyibA2nqE" role="jymVt">
+                                        <property role="TrG5h" value="get" />
+                                        <node concept="3Tm1VV" id="ijyibA2nqF" role="1B3o_S" />
+                                        <node concept="3uibUv" id="ijyibA2AJ9" role="3clF45">
+                                          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                                        </node>
+                                        <node concept="3clFbS" id="ijyibA2nqI" role="3clF47">
+                                          <node concept="3cpWs6" id="ijyib_XI_P" role="3cqZAp">
+                                            <node concept="37vLTw" id="ijyib_YLex" role="3cqZAk">
+                                              <ref role="3cqZAo" node="ijyib_sPVa" resolve="tpv" />
+                                              <node concept="29HgVG" id="ijyib_YLey" role="lGtFl">
+                                                <node concept="3NFfHV" id="ijyib_YLez" role="3NFExx">
+                                                  <node concept="3clFbS" id="ijyib_YLe$" role="2VODD2">
+                                                    <node concept="3clFbF" id="ijyib_YLe_" role="3cqZAp">
+                                                      <node concept="2OqwBi" id="ijyib_YLeA" role="3clFbG">
+                                                        <node concept="3TrEf2" id="ijyib_YLeB" role="2OqNvi">
+                                                          <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                                                        </node>
+                                                        <node concept="30H73N" id="ijyib_YLeC" role="2Oq$k0" />
+                                                      </node>
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                        <node concept="2AHcQZ" id="ijyibA2nqK" role="2AJF6D">
+                                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                        </node>
+                                      </node>
+                                      <node concept="3uibUv" id="ijyibA2Oh5" role="2Ghqu4">
+                                        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="ijyib_wJek" role="2OqNvi">
+                                <ref role="37wK5l" to="1ctc:~Stream.limit(long)" resolve="limit" />
+                                <node concept="37vLTw" id="ijyib_wNfP" role="37wK5m">
+                                  <ref role="3cqZAo" node="ijyib_sPVG" resolve="times" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="ijyibAcVyA" role="2OqNvi">
+                              <ref role="37wK5l" to="1ctc:~Stream.flatMap(java.util.function.Function)" resolve="flatMap" />
+                              <node concept="2ShNRf" id="ijyibAulBP" role="37wK5m">
+                                <node concept="YeOm9" id="ijyibAumCE" role="2ShVmc">
+                                  <node concept="1Y3b0j" id="ijyibAumCH" role="YeSDq">
+                                    <property role="2bfB8j" value="true" />
+                                    <property role="373rjd" value="true" />
+                                    <ref role="1Y3XeK" to="82uw:~Function" resolve="Function" />
+                                    <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                                    <node concept="3Tm1VV" id="ijyibAumCI" role="1B3o_S" />
+                                    <node concept="3clFb_" id="ijyibAumD0" role="jymVt">
+                                      <property role="TrG5h" value="apply" />
+                                      <node concept="3Tm1VV" id="ijyibAumD1" role="1B3o_S" />
+                                      <node concept="3uibUv" id="ijyibAumDr" role="3clF45">
+                                        <ref role="3uigEE" to="1ctc:~Stream" resolve="Stream" />
+                                        <node concept="3qTvmN" id="ijyibALlPd" role="11_B2D" />
+                                      </node>
+                                      <node concept="37vLTG" id="ijyibAumD4" role="3clF46">
+                                        <property role="TrG5h" value="obj" />
+                                        <node concept="3uibUv" id="ijyibAumDm" role="1tU5fm">
+                                          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                                        </node>
+                                      </node>
+                                      <node concept="3clFbS" id="ijyibAumD6" role="3clF47">
+                                        <node concept="3cpWs6" id="ijyibAvtjV" role="3cqZAp">
+                                          <node concept="2OqwBi" id="ijyibAHOnE" role="3cqZAk">
+                                            <node concept="1eOMI4" id="ijyibAHfCP" role="2Oq$k0">
+                                              <node concept="10QFUN" id="ijyibAHfCM" role="1eOMHV">
+                                                <node concept="3uibUv" id="ijyibAHfCR" role="10QFUM">
+                                                  <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+                                                </node>
+                                                <node concept="37vLTw" id="ijyibAHLXh" role="10QFUP">
+                                                  <ref role="3cqZAo" node="ijyibAumD4" resolve="obj" />
+                                                </node>
+                                              </node>
+                                            </node>
+                                            <node concept="liA8E" id="ijyibAHVBb" role="2OqNvi">
+                                              <ref role="37wK5l" to="33ny:~Collection.stream()" resolve="stream" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="2AHcQZ" id="ijyibAumD8" role="2AJF6D">
+                                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                      </node>
+                                    </node>
+                                    <node concept="3uibUv" id="ijyibAumDl" role="2Ghqu4">
+                                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                                    </node>
+                                    <node concept="3uibUv" id="ijyibAumDo" role="2Ghqu4">
+                                      <ref role="3uigEE" to="1ctc:~Stream" resolve="Stream" />
+                                      <node concept="3qTvmN" id="ijyibAL7li" role="11_B2D" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="ijyib_$XxH" role="2OqNvi">
+                            <ref role="37wK5l" to="1ctc:~Stream.collect(java.util.stream.Collector)" resolve="collect" />
+                            <node concept="2YIFZM" id="ijyib__5Dt" role="37wK5m">
+                              <ref role="37wK5l" to="1ctc:~Collectors.toList()" resolve="toList" />
+                              <ref role="1Pybhc" to="1ctc:~Collectors" resolve="Collectors" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1Bd96e" id="ijyib_sPWd" role="2OqNvi" />
+                <node concept="raruj" id="ijyib_sPWe" role="lGtFl" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.interpreter/models/plugin.mps
@@ -22,9 +22,14 @@
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="j10v" ref="b76a0f63-5959-456b-993a-c796cc0d0c13/java:org.pcollections(org.iets3.core.expr.base.collections.stubs/)" />
     <import index="ppzb" ref="r:5db517a0-f62d-4841-a421-11bb7269799d(org.iets3.core.expr.base.shared.runtime)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
+        <child id="1224071154657" name="classifierType" index="0kSFW" />
+        <child id="1224071154656" name="expression" index="0kSFX" />
+      </concept>
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
@@ -86,6 +91,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -286,6 +294,7 @@
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
@@ -307,6 +316,7 @@
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
@@ -3167,6 +3177,215 @@
                 <ref role="3cqZAo" node="49WTic8m0ug" resolve="list" />
               </node>
             </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="qq9P1" id="ijyib_dDXp" role="qq9xR">
+      <property role="2TnfIJ" value="true" />
+      <ref role="qq9wM" to="hm2y:25rRV02ooIM" resolve="NCopiesOp" />
+      <node concept="3vetai" id="ijyib_gR_q" role="3vQZUl">
+        <node concept="2OqwBi" id="ijyib_gB0V" role="3vdyny">
+          <node concept="2ShNRf" id="ijyib_dLKq" role="2Oq$k0">
+            <node concept="1pGfFk" id="ijyib_dLKr" role="2ShVmc">
+              <ref role="37wK5l" to="xfg9:3nVyItrYOln" resolve="NixSupport" />
+              <node concept="2OqwBi" id="ijyib_dLKs" role="37wK5m">
+                <node concept="oxGPV" id="ijyib_dLKt" role="2Oq$k0" />
+                <node concept="2qgKlT" id="ijyib_dLKu" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:ijyib_dOXX" resolve="expression" />
+                </node>
+              </node>
+              <node concept="oxGPV" id="ijyib_dLKv" role="37wK5m" />
+              <node concept="1bVj0M" id="ijyib_dLKw" role="37wK5m">
+                <node concept="37vLTG" id="ijyib_dLKx" role="1bW2Oz">
+                  <property role="TrG5h" value="ns" />
+                  <node concept="3uibUv" id="ijyib_dLKy" role="1tU5fm">
+                    <ref role="3uigEE" to="xfg9:3nVyItrYOkv" resolve="NixSupport" />
+                  </node>
+                </node>
+                <node concept="3clFbS" id="ijyib_dLKz" role="1bW5cS">
+                  <node concept="3cpWs8" id="ijyib_dLK$" role="3cqZAp">
+                    <node concept="3cpWsn" id="ijyib_dLK_" role="3cpWs9">
+                      <property role="TrG5h" value="list" />
+                      <node concept="_YKpA" id="ijyib_dLKA" role="1tU5fm">
+                        <node concept="3uibUv" id="ijyib_dLKB" role="_ZDj9">
+                          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                        </node>
+                      </node>
+                      <node concept="1eOMI4" id="ijyib_dLKC" role="33vP2m">
+                        <node concept="10QFUN" id="ijyib_dLKD" role="1eOMHV">
+                          <node concept="_YKpA" id="ijyib_dLKE" role="10QFUM">
+                            <node concept="3uibUv" id="ijyib_dLKF" role="_ZDj9">
+                              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                            </node>
+                          </node>
+                          <node concept="qpA2v" id="ijyib_dLKG" role="10QFUP">
+                            <node concept="2OqwBi" id="ijyib_dLKH" role="3SLO0q">
+                              <node concept="oxGPV" id="ijyib_dLKI" role="2Oq$k0" />
+                              <node concept="2qgKlT" id="ijyib_dLKJ" role="2OqNvi">
+                                <ref role="37wK5l" to="pbu6:6zmBjqUivyF" resolve="contextExpression" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="ijyib_dFTS" role="3cqZAp">
+                    <node concept="3cpWsn" id="ijyib_dFTT" role="3cpWs9">
+                      <property role="TrG5h" value="timesValue" />
+                      <node concept="3uibUv" id="ijyib_dFTU" role="1tU5fm">
+                        <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                      </node>
+                      <node concept="0kSF2" id="ijyib_dGe3" role="33vP2m">
+                        <node concept="3uibUv" id="ijyib_dGe6" role="0kSFW">
+                          <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                        </node>
+                        <node concept="rqRoa" id="ijyib_dG2s" role="0kSFX">
+                          <ref role="rqRob" to="hm2y:25rRV02osES" resolve="times" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="ijyib_dGiw" role="3cqZAp">
+                    <node concept="3clFbS" id="ijyib_dGiy" role="3clFbx">
+                      <node concept="3cpWs6" id="ijyibAZsvz" role="3cqZAp">
+                        <node concept="10Nm6u" id="ijyibAZtcb" role="3cqZAk" />
+                      </node>
+                    </node>
+                    <node concept="3clFbC" id="ijyib_dGzI" role="3clFbw">
+                      <node concept="10Nm6u" id="ijyib_dGG_" role="3uHU7w" />
+                      <node concept="37vLTw" id="ijyib_dGjX" role="3uHU7B">
+                        <ref role="3cqZAo" node="ijyib_dFTT" resolve="timesValue" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="ijyib_dGHx" role="3cqZAp">
+                    <node concept="3cpWsn" id="ijyib_dGH$" role="3cpWs9">
+                      <property role="TrG5h" value="times" />
+                      <node concept="10Oyi0" id="ijyib_dGHv" role="1tU5fm" />
+                      <node concept="2OqwBi" id="ijyib_dH72" role="33vP2m">
+                        <node concept="37vLTw" id="ijyib_dGP9" role="2Oq$k0">
+                          <ref role="3cqZAo" node="ijyib_dFTT" resolve="timesValue" />
+                        </node>
+                        <node concept="liA8E" id="ijyib_dHoQ" role="2OqNvi">
+                          <ref role="37wK5l" to="xlxw:~BigInteger.intValue()" resolve="intValue" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="ijyib_k_J2" role="3cqZAp">
+                    <node concept="3clFbS" id="ijyib_k_J4" role="3clFbx">
+                      <node concept="YS8fn" id="ijyibAW8ut" role="3cqZAp">
+                        <node concept="2ShNRf" id="ijyibAW8Eu" role="YScLw">
+                          <node concept="1pGfFk" id="ijyibAW99U" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="37wK5l" to="oq0c:2jL$v5BnAFT" resolve="ConstraintFailedException" />
+                            <node concept="10M0yZ" id="ijyibAW$az" role="37wK5m">
+                              <ref role="3cqZAo" to="oq0c:4945UtRC2RH" resolve="PLAIN" />
+                              <ref role="1PxDUh" to="oq0c:3Y6fbK1oSAh" resolve="ConstraintFailedException" />
+                            </node>
+                            <node concept="37vLTw" id="3QN6lkyHQBO" role="37wK5m">
+                              <ref role="3cqZAo" node="ijyib_dFTT" resolve="timesValue" />
+                            </node>
+                            <node concept="oxGPV" id="ijyibAWajD" role="37wK5m" />
+                            <node concept="Xl_RD" id="ijyibAW9Ar" role="37wK5m">
+                              <property role="Xl_RC" value="the argument must be greater than 0" />
+                            </node>
+                            <node concept="oxNuS" id="ijyibAW_u5" role="37wK5m" />
+                            <node concept="2dz_u5" id="ijyibAWA3V" role="37wK5m" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2dkUwp" id="ijyib_lsEe" role="3clFbw">
+                      <node concept="3cmrfG" id="ijyib_ltes" role="3uHU7w">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                      <node concept="37vLTw" id="ijyib_kAkO" role="3uHU7B">
+                        <ref role="3cqZAo" node="ijyib_dGH$" resolve="times" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="ijyib_hACJ" role="3cqZAp">
+                    <node concept="3cpWsn" id="ijyib_hACK" role="3cpWs9">
+                      <property role="TrG5h" value="nCopies" />
+                      <node concept="2YIFZM" id="ijyib_hACL" role="33vP2m">
+                        <ref role="37wK5l" to="33ny:~Collections.nCopies(int,java.lang.Object)" resolve="nCopies" />
+                        <ref role="1Pybhc" to="33ny:~Collections" resolve="Collections" />
+                        <node concept="37vLTw" id="ijyib_hACM" role="37wK5m">
+                          <ref role="3cqZAo" node="ijyib_dGH$" resolve="times" />
+                        </node>
+                        <node concept="37vLTw" id="ijyib_hACN" role="37wK5m">
+                          <ref role="3cqZAo" node="ijyib_dLK_" resolve="list" />
+                        </node>
+                      </node>
+                      <node concept="_YKpA" id="ijyib_hCl2" role="1tU5fm">
+                        <node concept="_YKpA" id="ijyib_hCy$" role="_ZDj9">
+                          <node concept="3uibUv" id="ijyib_hCK4" role="_ZDj9">
+                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="ijyib_hBrW" role="3cqZAp">
+                    <node concept="3cpWsn" id="ijyib_hBrZ" role="3cpWs9">
+                      <property role="TrG5h" value="res" />
+                      <node concept="_YKpA" id="ijyib_hBrS" role="1tU5fm">
+                        <node concept="3uibUv" id="ijyib_hCWn" role="_ZDj9">
+                          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                        </node>
+                      </node>
+                      <node concept="2ShNRf" id="ijyib_hDdh" role="33vP2m">
+                        <node concept="Tc6Ow" id="ijyib_hExo" role="2ShVmc">
+                          <node concept="3uibUv" id="ijyib_hFp8" role="HW$YZ">
+                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="ijyib_hFGj" role="3cqZAp">
+                    <node concept="2OqwBi" id="ijyib_hGzw" role="3clFbG">
+                      <node concept="37vLTw" id="ijyib_hFGh" role="2Oq$k0">
+                        <ref role="3cqZAo" node="ijyib_hACK" resolve="nCopies" />
+                      </node>
+                      <node concept="2es0OD" id="ijyib_hHxZ" role="2OqNvi">
+                        <node concept="1bVj0M" id="ijyib_hHy1" role="23t8la">
+                          <node concept="3clFbS" id="ijyib_hHy2" role="1bW5cS">
+                            <node concept="3clFbF" id="ijyib_hHEL" role="3cqZAp">
+                              <node concept="2OqwBi" id="ijyib_hIt2" role="3clFbG">
+                                <node concept="37vLTw" id="ijyib_hHEK" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="ijyib_hBrZ" resolve="res" />
+                                </node>
+                                <node concept="X8dFx" id="ijyib_hJzO" role="2OqNvi">
+                                  <node concept="37vLTw" id="ijyib_hJKA" role="25WWJ7">
+                                    <ref role="3cqZAo" node="ijyib_hHy3" resolve="it" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="Rh6nW" id="ijyib_hHy3" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="ijyib_hHy4" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs6" id="ijyib_hKyw" role="3cqZAp">
+                    <node concept="37vLTw" id="ijyib_hKzD" role="3cqZAk">
+                      <ref role="3cqZAo" node="ijyib_hBrZ" resolve="res" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="liA8E" id="ijyib_gBWr" role="2OqNvi">
+            <ref role="37wK5l" to="xfg9:26cjRABQZG3" resolve="run" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tuples@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tuples@tests.mps
@@ -14,6 +14,11 @@
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
       </concept>
     </language>
+    <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
+      <concept id="7554398283339759319" name="org.iets3.core.expr.collections.structure.ListLiteral" flags="ng" index="3iBYfx">
+        <child id="7554398283339759320" name="elements" index="3iBYfI" />
+      </concept>
+    </language>
     <language id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base">
       <concept id="229512757698888199" name="org.iets3.core.base.structure.IOptionallyNamed" flags="ng" index="pfQq$">
         <child id="229512757698888936" name="optionalName" index="pfQ1b" />
@@ -29,15 +34,33 @@
       <concept id="1019070541450015930" name="org.iets3.core.expr.base.structure.TupleType" flags="ng" index="m5gfS">
         <child id="1019070541450015931" name="elementTypes" index="m5gfT" />
       </concept>
+      <concept id="2403760773179476914" name="org.iets3.core.expr.base.structure.NCopiesOp" flags="ng" index="ze_g2">
+        <child id="2403760773179493048" name="times" index="zexk8" />
+      </concept>
       <concept id="7089558164905593724" name="org.iets3.core.expr.base.structure.IOptionallyTyped" flags="ng" index="2zM23E">
         <child id="7089558164905593725" name="type" index="2zM23F" />
+      </concept>
+      <concept id="5115872837156802409" name="org.iets3.core.expr.base.structure.UnaryExpression" flags="ng" index="30czhk">
+        <child id="5115872837156802411" name="expr" index="30czhm" />
+      </concept>
+      <concept id="5115872837156578546" name="org.iets3.core.expr.base.structure.PlusExpression" flags="ng" index="30dDZf" />
+      <concept id="5115872837156576277" name="org.iets3.core.expr.base.structure.BinaryExpression" flags="ng" index="30dEsC">
+        <child id="5115872837156576280" name="right" index="30dEs_" />
+        <child id="5115872837156576278" name="left" index="30dEsF" />
       </concept>
       <concept id="2527679671886479690" name="org.iets3.core.expr.base.structure.TupleAccessExpr" flags="ng" index="3nOhSe">
         <property id="2527679671886575030" name="index" index="3nOAFM" />
         <child id="2527679671886479717" name="tuple" index="3nOhSx" />
       </concept>
+      <concept id="9002563722476995145" name="org.iets3.core.expr.base.structure.DotExpression" flags="ng" index="1QScDb">
+        <child id="9002563722476995147" name="target" index="1QScD9" />
+      </concept>
     </language>
     <language id="d441fba0-f46b-43cd-b723-dad7b65da615" name="org.iets3.core.expr.tests">
+      <concept id="8219602584783477663" name="org.iets3.core.expr.tests.structure.ConstraintFailedTestItem" flags="ng" index="mXNUv">
+        <property id="5974682372640371252" name="errmsg" index="xVyv2" />
+        <child id="8219602584783494093" name="actual" index="mXJVd" />
+      </concept>
       <concept id="543569365052056273" name="org.iets3.core.expr.tests.structure.EqualsTestOp" flags="ng" index="_fku$" />
       <concept id="543569365052056263" name="org.iets3.core.expr.tests.structure.TestCase" flags="ng" index="_fkuM">
         <child id="543569365052056368" name="items" index="_fkp5" />
@@ -100,7 +123,153 @@
       </node>
     </node>
     <node concept="_ixoA" id="6HHp2WmY4cE" role="_iOnB" />
-    <node concept="_ixoA" id="6HHp2WmY4cB" role="_iOnB" />
+    <node concept="_fkuM" id="ijyib_knuu" role="_iOnB">
+      <property role="TrG5h" value="nCopies" />
+      <node concept="_fkuZ" id="ijyib_YgV9" role="_fkp5">
+        <node concept="_fku$" id="ijyib_YgVa" role="_fkur" />
+        <node concept="30bXRB" id="ijyib_YgWd" role="_fkuY">
+          <property role="30bXRw" value="1" />
+        </node>
+        <node concept="30bXRB" id="ijyib_YgWv" role="_fkuS">
+          <property role="30bXRw" value="1" />
+        </node>
+      </node>
+      <node concept="mXNUv" id="ijyib_loZT" role="_fkp5">
+        <property role="xVyv2" value="the argument must be greater than 0" />
+        <node concept="1QScDb" id="ijyib_lp0K" role="mXJVd">
+          <node concept="ze_g2" id="ijyib_lp0L" role="1QScD9">
+            <node concept="30bXRB" id="ijyib_lp0M" role="zexk8">
+              <property role="30bXRw" value="0" />
+            </node>
+          </node>
+          <node concept="m5g4o" id="ijyib_lp0N" role="30czhm">
+            <node concept="30bXRB" id="ijyib_lp0O" role="m5g4p">
+              <property role="30bXRw" value="1" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="mXNUv" id="ijyib_lPJh" role="_fkp5">
+        <node concept="1QScDb" id="ijyib_lPJi" role="mXJVd">
+          <node concept="ze_g2" id="ijyib_lPJj" role="1QScD9">
+            <node concept="30bXRB" id="ijyib_lPM_" role="zexk8">
+              <property role="30bXRw" value="-1" />
+            </node>
+          </node>
+          <node concept="m5g4o" id="ijyib_lPJl" role="30czhm">
+            <node concept="30bXRB" id="ijyib_lPJm" role="m5g4p">
+              <property role="30bXRw" value="1" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="_fkuZ" id="ijyib_kqA1" role="_fkp5">
+        <node concept="_fku$" id="ijyib_kqA2" role="_fkur" />
+        <node concept="1QScDb" id="ijyib_kqCs" role="_fkuY">
+          <node concept="ze_g2" id="ijyib_kqE0" role="1QScD9">
+            <node concept="30dDZf" id="xNPLfwAb9" role="zexk8">
+              <node concept="30bXRB" id="xNPLfwAbu" role="30dEs_">
+                <property role="30bXRw" value="2" />
+              </node>
+              <node concept="30bXRB" id="ijyib_kqFg" role="30dEsF">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+          </node>
+          <node concept="m5g4o" id="ijyib_kqAC" role="30czhm">
+            <node concept="30bXRB" id="ijyib_kqAM" role="m5g4p">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="ijyib_kqBj" role="m5g4p">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+        </node>
+        <node concept="m5g4o" id="ijyib_kqSq" role="_fkuS">
+          <node concept="30bXRB" id="ijyib_kqSy" role="m5g4p">
+            <property role="30bXRw" value="1" />
+          </node>
+          <node concept="30bXRB" id="ijyib_kqT3" role="m5g4p">
+            <property role="30bXRw" value="2" />
+          </node>
+          <node concept="30bXRB" id="ijyib_kqUj" role="m5g4p">
+            <property role="30bXRw" value="1" />
+          </node>
+          <node concept="30bXRB" id="ijyib_kqW5" role="m5g4p">
+            <property role="30bXRw" value="2" />
+          </node>
+          <node concept="30bXRB" id="ijyib_kqYp" role="m5g4p">
+            <property role="30bXRw" value="1" />
+          </node>
+          <node concept="30bXRB" id="ijyib_lQQc" role="m5g4p">
+            <property role="30bXRw" value="2" />
+          </node>
+        </node>
+      </node>
+      <node concept="_fkuZ" id="ijyib_kjre" role="_fkp5">
+        <node concept="_fku$" id="ijyib_kjrf" role="_fkur" />
+        <node concept="1QScDb" id="25rRV02oaSa" role="_fkuY">
+          <node concept="m5g4o" id="25rRV02iiW_" role="30czhm">
+            <node concept="m5g4o" id="ijyib_ia$A" role="m5g4p">
+              <node concept="30bXRB" id="ijyib_ia$N" role="m5g4p">
+                <property role="30bXRw" value="1" />
+              </node>
+              <node concept="30bXRB" id="ijyib_ia_p" role="m5g4p">
+                <property role="30bXRw" value="2" />
+              </node>
+            </node>
+            <node concept="m5g4o" id="ijyib_iaNw" role="m5g4p">
+              <node concept="30bXRB" id="ijyib_iaPf" role="m5g4p">
+                <property role="30bXRw" value="3" />
+              </node>
+              <node concept="30bXRB" id="ijyib_ib8j" role="m5g4p">
+                <property role="30bXRw" value="4" />
+              </node>
+            </node>
+          </node>
+          <node concept="ze_g2" id="25rRV02v9Zh" role="1QScD9">
+            <node concept="30bXRB" id="25rRV02ybfx" role="zexk8">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+        </node>
+        <node concept="3iBYfx" id="ijyib_klet" role="_fkuS">
+          <node concept="3iBYfx" id="ijyib_kle$" role="3iBYfI">
+            <node concept="30bXRB" id="ijyib_kleI" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="ijyib_kleT" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="ijyib_klim" role="3iBYfI">
+            <node concept="30bXRB" id="ijyib_kljR" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="ijyib_klWR" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="ijyib_kmdV" role="3iBYfI">
+            <node concept="30bXRB" id="ijyib_kmgM" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="ijyib_kmgX" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="ijyib_kmr3" role="3iBYfI">
+            <node concept="30bXRB" id="ijyib_kmvg" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="ijyib_kmvr" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="_ixoA" id="ijyib_knts" role="_iOnB" />
     <node concept="_fkuM" id="6HHp2WmY4bj" role="_iOnB">
       <property role="TrG5h" value="utils_tuples" />
       <node concept="_fkuZ" id="1IomA9w$4TS" role="_fkp5">


### PR DESCRIPTION
The use case is long initializers with the same values such as initializing a tuple with zeros.                                                                                                      

Example: `assert [1, 2].nTimes(3) equals [1, 2, 1, 2, 1, 2]`