### PR TITLE
 Enable override of Tracing editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 - Tuple types now support a new method `nTimes` to ease initialization of long tuples.
 
+### Fixed
+
+- Tracing editor can be exchanged by customers using editor hints.
+
 ## June 2024
 
 ### Fixed

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tracing/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tracing/models/editor.mps
@@ -26,6 +26,7 @@
     <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="90j9" ref="r:f2db22e1-5ffd-4b44-94b1-21c00f016390(org.iets3.core.expr.tracing.plugin.plugin)" />
+    <import index="461n" ref="r:3b46a963-6deb-4d82-bdc0-36b5d9297fcf(de.slisson.mps.conditionalEditor.hints.editor)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="epcs" ref="b33d119e-196d-4497-977c-5c167b21fe33/r:b7f325a3-1f57-46bc-8b14-d2d7c5ff6714(com.mbeddr.mpsutil.framecell/com.mbeddr.mpsutil.framecell.editor)" implicit="true" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
@@ -56,6 +57,13 @@
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
+      </concept>
+      <concept id="5944657839000868711" name="jetbrains.mps.lang.editor.structure.ConceptEditorContextHints" flags="ig" index="2ABfQD">
+        <child id="5944657839000877563" name="hints" index="2ABdcP" />
+      </concept>
+      <concept id="5944657839003601246" name="jetbrains.mps.lang.editor.structure.ConceptEditorHintDeclaration" flags="ig" index="2BsEeg">
+        <property id="168363875802087287" name="showInUI" index="2gpH_U" />
+        <property id="5944657839012629576" name="presentation" index="2BUmq6" />
       </concept>
       <concept id="1235728439575" name="jetbrains.mps.lang.editor.structure.BaseLineCell" flags="ln" index="2R9Tw8" />
       <concept id="1186403694788" name="jetbrains.mps.lang.editor.structure.ColorStyleClassItem" flags="ln" index="VaVBg">
@@ -99,6 +107,9 @@
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
         <child id="1073389446424" name="childCellModel" index="3EZMnx" />
+      </concept>
+      <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn">
+        <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
@@ -471,6 +482,9 @@
             </node>
           </node>
         </node>
+        <node concept="3F0ifn" id="3g9zm40MqdR" role="3EZMnx">
+          <property role="3F0ifm" value="ORIG:" />
+        </node>
         <node concept="2iRkQZ" id="5U8d23QoQxc" role="2iSdaV" />
         <node concept="2R9Tw8" id="5U8d23Qp9cO" role="3F10Kt">
           <property role="VOm3f" value="true" />
@@ -632,6 +646,9 @@
         <node concept="VPM3Z" id="5U8d23Qpo43" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
+        <node concept="3F0ifn" id="3g9zm40Mqqx" role="3EZMnx">
+          <property role="3F0ifm" value="ORIG:" />
+        </node>
         <node concept="1HlG4h" id="5U8d23Qpo44" role="3EZMnx">
           <ref role="1ERwB7" node="4p7g2DNgDod" resolve="ClickValue" />
           <node concept="Veino" id="5U8d23Qpo45" role="3F10Kt">
@@ -783,6 +800,9 @@
       </node>
     </node>
     <node concept="Rtstu" id="1OitGwf5Zbs" role="6VMZX" />
+    <node concept="2aJ2om" id="3g9zm40OZqi" role="CpUAK">
+      <ref role="2$4xQ3" node="3g9zm40OYvO" resolve="IETS3Tracing" />
+    </node>
   </node>
   <node concept="RtYIR" id="2CFPPn7pH83">
     <property role="Rtri_" value="100" />
@@ -1990,6 +2010,14 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="2ABfQD" id="3g9zm40OYvA">
+    <property role="TrG5h" value="TracingHints" />
+    <node concept="2BsEeg" id="3g9zm40OYvO" role="2ABdcP">
+      <property role="2gpH_U" value="true" />
+      <property role="TrG5h" value="IETS3Tracing" />
+      <property role="2BUmq6" value="Default trace values of nodes [IETS3]" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tracing/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tracing/models/editor.mps
@@ -108,9 +108,6 @@
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
         <child id="1073389446424" name="childCellModel" index="3EZMnx" />
       </concept>
-      <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn">
-        <property id="1073389577007" name="text" index="3F0ifm" />
-      </concept>
       <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
@@ -482,9 +479,6 @@
             </node>
           </node>
         </node>
-        <node concept="3F0ifn" id="3g9zm40MqdR" role="3EZMnx">
-          <property role="3F0ifm" value="ORIG:" />
-        </node>
         <node concept="2iRkQZ" id="5U8d23QoQxc" role="2iSdaV" />
         <node concept="2R9Tw8" id="5U8d23Qp9cO" role="3F10Kt">
           <property role="VOm3f" value="true" />
@@ -645,9 +639,6 @@
         </node>
         <node concept="VPM3Z" id="5U8d23Qpo43" role="3F10Kt">
           <property role="VOm3f" value="false" />
-        </node>
-        <node concept="3F0ifn" id="3g9zm40Mqqx" role="3EZMnx">
-          <property role="3F0ifm" value="ORIG:" />
         </node>
         <node concept="1HlG4h" id="5U8d23Qpo44" role="3EZMnx">
           <ref role="1ERwB7" node="4p7g2DNgDod" resolve="ClickValue" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tracing/org.iets3.core.expr.tracing.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tracing/org.iets3.core.expr.tracing.mpl
@@ -21,6 +21,7 @@
     <dependency reexport="false">726886d1-ef90-4249-a08f-1e3ec23a7113(com.mbeddr.mpsutil.traceExplorer)</dependency>
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
     <dependency reexport="false">b0e7c6a8-b47d-4637-b0e8-e5bfd486c4e8(org.iets3.core.expr.tracing.plugin)</dependency>
+    <dependency reexport="false">5474e4cd-6621-4b33-a39a-75552543ba57(de.slisson.mps.conditionalEditor.hints)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:b33d119e-196d-4497-977c-5c167b21fe33:com.mbeddr.mpsutil.framecell" version="0" />
@@ -82,6 +83,7 @@
     <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
     <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
     <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
+    <module reference="5474e4cd-6621-4b33-a39a-75552543ba57(de.slisson.mps.conditionalEditor.hints)" version="0" />
     <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/models/org.iets3.core.expr.tracing.plugin.plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/models/org.iets3.core.expr.tracing.plugin.plugin.mps
@@ -17,6 +17,7 @@
     <use id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples" version="0" />
     <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
   </languages>
   <imports>
     <import index="809" ref="r:17df6789-37fa-4b2d-96c9-2916c357c53b(org.iets3.core.expr.tracing.structure)" />
@@ -68,6 +69,11 @@
     <import index="2sud" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui.treeStructure(MPS.IDEA/)" />
     <import index="rgfa" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing.tree(JDK/)" />
     <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" />
+    <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
+    <import index="zwau" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.hintsSettings(MPS.Editor/)" />
+    <import index="461n" ref="r:3b46a963-6deb-4d82-bdc0-36b5d9297fcf(de.slisson.mps.conditionalEditor.hints.editor)" />
+    <import index="stm0" ref="r:e2d5029d-edd9-44e0-9764-dc3ac8433eaf(org.iets3.core.expr.tracing.editor)" />
+    <import index="6iy5" ref="r:f0a80b34-9760-42b8-9ee6-d5b0d1582551(de.slisson.mps.conditionalEditor.runtime.plugin)" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -134,11 +140,21 @@
         <reference id="1217252646389" name="key" index="1DUlNI" />
       </concept>
       <concept id="1217252428768" name="jetbrains.mps.lang.plugin.structure.ActionDataParameterReferenceOperation" flags="nn" index="1DTwFV" />
+      <concept id="1204478074808" name="jetbrains.mps.lang.plugin.structure.ConceptFunctionParameter_MPSProject" flags="nn" index="1KvdUw" />
       <concept id="1217413147516" name="jetbrains.mps.lang.plugin.structure.ActionParameter" flags="ng" index="1NuADB">
         <child id="5538333046911298738" name="condition" index="1oa70y" />
       </concept>
     </language>
+    <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="4820515453818318288" name="jetbrains.mps.lang.editor.structure.ConceptEditorHintDeclarationReferenceExpression" flags="ng" index="2pYGij">
+        <reference id="4820515453818318891" name="hint" index="2pYH_C" />
+      </concept>
+    </language>
     <language id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone">
+      <concept id="481983775135178834" name="jetbrains.mps.lang.plugin.standalone.structure.ProjectPluginDeclaration" flags="ng" index="2uRRBy">
+        <child id="481983775135178836" name="initBlock" index="2uRRB$" />
+      </concept>
+      <concept id="481983775135178825" name="jetbrains.mps.lang.plugin.standalone.structure.ProjectPluginInitBlock" flags="in" index="2uRRBT" />
       <concept id="7520713872864775836" name="jetbrains.mps.lang.plugin.standalone.structure.StandalonePluginDescriptor" flags="ng" index="2DaZZR" />
       <concept id="681855071694758165" name="jetbrains.mps.lang.plugin.standalone.structure.GetToolInProjectOperation" flags="nn" index="LR4U6">
         <reference id="681855071694758166" name="tool" index="LR4U5" />
@@ -7306,6 +7322,126 @@
       <node concept="TZ5HA" id="3UUf8EJumG9" role="TZ5H$">
         <node concept="1dT_AC" id="3UUf8EJumGa" role="1dT_Ay">
           <property role="1dT_AB" value="Attaches trace information from a trace record to MPS nodes as user objects." />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2uRRBy" id="3g9zm40PKtH">
+    <property role="TrG5h" value="IETS3Tracing" />
+    <node concept="2uRRBT" id="3g9zm40PKzo" role="2uRRB$">
+      <node concept="3clFbS" id="3g9zm40PKzp" role="2VODD2">
+        <node concept="3SKdUt" id="7SbG$tCPpkP" role="3cqZAp">
+          <node concept="1PaTwC" id="7WTFIQIcX$1" role="1aUNEU">
+            <node concept="3oM_SD" id="7WTFIQIcX$2" role="1PaTwD">
+              <property role="3oM_SC" value="enable" />
+            </node>
+            <node concept="3oM_SD" id="7WTFIQIcX$3" role="1PaTwD">
+              <property role="3oM_SC" value="conditional" />
+            </node>
+            <node concept="3oM_SD" id="7WTFIQIcX$4" role="1PaTwD">
+              <property role="3oM_SC" value="editor" />
+            </node>
+            <node concept="3oM_SD" id="7WTFIQIcX$5" role="1PaTwD">
+              <property role="3oM_SC" value="hint" />
+            </node>
+            <node concept="3oM_SD" id="7WTFIQIcX$6" role="1PaTwD">
+              <property role="3oM_SC" value="by" />
+            </node>
+            <node concept="3oM_SD" id="7WTFIQIcX$7" role="1PaTwD">
+              <property role="3oM_SC" value="default:" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7SbG$tCPl6v" role="3cqZAp">
+          <node concept="3cpWsn" id="7SbG$tCPl6w" role="3cpWs9">
+            <property role="TrG5h" value="settingsComponent" />
+            <node concept="3uibUv" id="7SbG$tCPl6s" role="1tU5fm">
+              <ref role="3uigEE" to="zwau:~ConceptEditorHintSettingsComponent" resolve="ConceptEditorHintSettingsComponent" />
+            </node>
+            <node concept="2YIFZM" id="7SbG$tCPl6x" role="33vP2m">
+              <ref role="37wK5l" to="zwau:~ConceptEditorHintSettingsComponent.getInstance(com.intellij.openapi.project.Project)" resolve="getInstance" />
+              <ref role="1Pybhc" to="zwau:~ConceptEditorHintSettingsComponent" resolve="ConceptEditorHintSettingsComponent" />
+              <node concept="2YIFZM" id="7SbG$tCPl6y" role="37wK5m">
+                <ref role="37wK5l" to="alof:~ProjectHelper.toIdeaProject(jetbrains.mps.project.Project)" resolve="toIdeaProject" />
+                <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                <node concept="1KvdUw" id="7SbG$tCPl6z" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7SbG$tCPlHn" role="3cqZAp">
+          <node concept="3cpWsn" id="7SbG$tCPlHo" role="3cpWs9">
+            <property role="TrG5h" value="state" />
+            <node concept="3uibUv" id="7SbG$tCPlHm" role="1tU5fm">
+              <ref role="3uigEE" to="zwau:~ConceptEditorHintSettingsComponent$HintsState" resolve="HintsState" />
+            </node>
+            <node concept="2OqwBi" id="7SbG$tCPlHp" role="33vP2m">
+              <node concept="37vLTw" id="7SbG$tCPlHq" role="2Oq$k0">
+                <ref role="3cqZAo" node="7SbG$tCPl6w" resolve="settingsComponent" />
+              </node>
+              <node concept="liA8E" id="7SbG$tCPlHr" role="2OqNvi">
+                <ref role="37wK5l" to="zwau:~ConceptEditorHintSettingsComponent.getState()" resolve="getState" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7SbG$tCPm1O" role="3cqZAp">
+          <node concept="3cpWsn" id="7SbG$tCPm1P" role="3cpWs9">
+            <property role="TrG5h" value="enabledHints" />
+            <node concept="3uibUv" id="7SbG$tCPm1E" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+              <node concept="3uibUv" id="7SbG$tCPm1H" role="11_B2D">
+                <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7SbG$tCPm1Q" role="33vP2m">
+              <node concept="37vLTw" id="7SbG$tCPm1R" role="2Oq$k0">
+                <ref role="3cqZAo" node="7SbG$tCPlHo" resolve="state" />
+              </node>
+              <node concept="liA8E" id="7SbG$tCPm1S" role="2OqNvi">
+                <ref role="37wK5l" to="zwau:~ConceptEditorHintSettingsComponent$HintsState.getEnabledHints()" resolve="getEnabledHints" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7SbG$tCPiAN" role="3cqZAp">
+          <node concept="2OqwBi" id="7SbG$tCPmfB" role="3clFbG">
+            <node concept="37vLTw" id="7SbG$tCPm1T" role="2Oq$k0">
+              <ref role="3cqZAo" node="7SbG$tCPm1P" resolve="enabledHints" />
+            </node>
+            <node concept="liA8E" id="7SbG$tCPnkt" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Set.add(java.lang.Object)" resolve="add" />
+              <node concept="2pYGij" id="3g9zm40Q9ac" role="37wK5m">
+                <ref role="2pYH_C" to="stm0:3g9zm40OYvO" resolve="IETS3Tracing" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7SbG$tCPo3R" role="3cqZAp">
+          <node concept="2OqwBi" id="7SbG$tCPo8R" role="3clFbG">
+            <node concept="37vLTw" id="7SbG$tCPo3P" role="2Oq$k0">
+              <ref role="3cqZAo" node="7SbG$tCPlHo" resolve="state" />
+            </node>
+            <node concept="liA8E" id="7SbG$tCPoic" role="2OqNvi">
+              <ref role="37wK5l" to="zwau:~ConceptEditorHintSettingsComponent$HintsState.setEnabledHints(java.util.Set)" resolve="setEnabledHints" />
+              <node concept="37vLTw" id="7SbG$tCPonf" role="37wK5m">
+                <ref role="3cqZAo" node="7SbG$tCPm1P" resolve="enabledHints" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7SbG$tCPozw" role="3cqZAp">
+          <node concept="2OqwBi" id="7SbG$tCPoGv" role="3clFbG">
+            <node concept="37vLTw" id="7SbG$tCPozu" role="2Oq$k0">
+              <ref role="3cqZAo" node="7SbG$tCPl6w" resolve="settingsComponent" />
+            </node>
+            <node concept="liA8E" id="7SbG$tCPpaC" role="2OqNvi">
+              <ref role="37wK5l" to="zwau:~ConceptEditorHintSettingsComponent.loadState(jetbrains.mps.nodeEditor.hintsSettings.ConceptEditorHintSettingsComponent$HintsState)" resolve="loadState" />
+              <node concept="37vLTw" id="7SbG$tCPpb1" role="37wK5m">
+                <ref role="3cqZAo" node="7SbG$tCPlHo" resolve="state" />
+              </node>
+            </node>
+          </node>
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/org.iets3.core.expr.tracing.plugin.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/org.iets3.core.expr.tracing.plugin.msd
@@ -22,6 +22,10 @@
     <dependency reexport="false">c0080a47-7e37-4558-bee9-9ae18e690549(jetbrains.mps.lang.extension)</dependency>
     <dependency reexport="true">726886d1-ef90-4249-a08f-1e3ec23a7113(com.mbeddr.mpsutil.traceExplorer)</dependency>
     <dependency reexport="false">c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)</dependency>
+    <dependency reexport="false">742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)</dependency>
+    <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
+    <dependency reexport="false">5474e4cd-6621-4b33-a39a-75552543ba57(de.slisson.mps.conditionalEditor.hints)</dependency>
+    <dependency reexport="false">9d368018-badb-4569-9884-4b463e4f6696(de.slisson.mps.conditionalEditor.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -33,12 +37,14 @@
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />
     <language slang="l:c0080a47-7e37-4558-bee9-9ae18e690549:jetbrains.mps.lang.extension" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="5" />
     <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />
     <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
@@ -62,6 +68,8 @@
     <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
     <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
     <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
+    <module reference="5474e4cd-6621-4b33-a39a-75552543ba57(de.slisson.mps.conditionalEditor.hints)" version="0" />
+    <module reference="9d368018-badb-4569-9884-4b463e4f6696(de.slisson.mps.conditionalEditor.runtime)" version="0" />
     <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -8754,6 +8754,11 @@
             <ref role="3bR37D" node="72k3qZIaGXV" resolve="org.iets3.core.expr.tracing.plugin" />
           </node>
         </node>
+        <node concept="1SiIV0" id="5vABvvjT9ZU" role="3bR37C">
+          <node concept="3bR9La" id="5vABvvjT9ZV" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:5vQ_hAOOn52" resolve="de.slisson.mps.conditionalEditor.hints" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="72k3qZIaGXV" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -8858,6 +8863,26 @@
         <node concept="1SiIV0" id="1qHsIyRg7UQ" role="3bR37C">
           <node concept="3bR9La" id="1qHsIyRg7UR" role="1SiIV1">
             <ref role="3bR37D" to="ffeo:7Kfy9QB6LaO" resolve="jetbrains.mps.lang.structure" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5vABvvjTa07" role="3bR37C">
+          <node concept="3bR9La" id="5vABvvjTa08" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbJb" resolve="MPS.Platform" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5vABvvjTa09" role="3bR37C">
+          <node concept="3bR9La" id="5vABvvjTa0a" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:5vQ_hAOOn52" resolve="de.slisson.mps.conditionalEditor.hints" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5vABvvjTa0b" role="3bR37C">
+          <node concept="3bR9La" id="5vABvvjTa0c" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:7klUZA6XM5K" resolve="de.slisson.mps.conditionalEditor.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="5vABvvjTa0d" role="3bR37C">
+          <node concept="3bR9La" id="5vABvvjTa0e" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
           </node>
         </node>
       </node>


### PR DESCRIPTION
This Ticket addresses: https://github.com/JetBrains/MPS-extensions/issues/855

A ConditionalEditor by default has the hints `conditionalEditor` and `conditionalEditor_doNotUseThisHint`. These hints are enabled by default when the plugin becomes initialized.
If someone wants to overload a conditionalEditor it is not enough to just give it a higher priority. The priority just defines the order of the applied editors (a conditionalEditor uses [NextEditor]) see http://127.0.0.1:63320/node?ref=r%3A8d20232d-87e2-425b-b4d7-a9790e401b85%28de.slisson.mps.conditionalEditor.structure%29%2F2877762237607058140)" (s. screenshot on the mps-extension ticket above). So these can be cascaded somehow.

To enable overloading:
Generally an implementation of a conditional editor should also get an new defined editor hint if this editor should be able to be overloadable. The editor implementation that overloads that one must disable that and enable its own editor hint. 

For the Tracing editor this is done here.