### PR TITLE
expr.base: rewrite NCopies rule to avoid freezes for large numbers

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
@@ -10652,31 +10652,32 @@
     <property role="TrG5h" value="typeof_NCopies" />
     <property role="3GE5qa" value="tuples" />
     <node concept="3clFbS" id="25rRV02oFpt" role="18ibNy">
-      <node concept="nvevp" id="7GwCuf2y0wh" role="3cqZAp">
-        <node concept="3clFbS" id="7GwCuf2y0wj" role="nvhr_">
-          <node concept="3clFbJ" id="25rRV02vcXJ" role="3cqZAp">
-            <node concept="3clFbS" id="25rRV02vcXL" role="3clFbx">
-              <node concept="3cpWs6" id="25rRV02vn_a" role="3cqZAp" />
-            </node>
-            <node concept="2OqwBi" id="25rRV02vl47" role="3clFbw">
-              <node concept="2OqwBi" id="25rRV02vgTf" role="2Oq$k0">
-                <node concept="2OqwBi" id="25rRV02vdla" role="2Oq$k0">
-                  <node concept="1YBJjd" id="25rRV02vd8t" role="2Oq$k0">
-                    <ref role="1YBMHb" node="25rRV02oFpv" resolve="nCopies" />
-                  </node>
-                  <node concept="3TrEf2" id="25rRV02vgfA" role="2OqNvi">
-                    <ref role="3Tt5mk" to="hm2y:25rRV02osES" resolve="times" />
-                  </node>
-                </node>
-                <node concept="2yIwOk" id="25rRV02vkpi" role="2OqNvi" />
+      <node concept="3clFbJ" id="25rRV02vcXJ" role="3cqZAp">
+        <node concept="3clFbS" id="25rRV02vcXL" role="3clFbx">
+          <node concept="3cpWs6" id="25rRV02vn_a" role="3cqZAp" />
+        </node>
+        <node concept="2OqwBi" id="25rRV02vl47" role="3clFbw">
+          <node concept="2OqwBi" id="25rRV02vgTf" role="2Oq$k0">
+            <node concept="2OqwBi" id="25rRV02vdla" role="2Oq$k0">
+              <node concept="1YBJjd" id="25rRV02vd8t" role="2Oq$k0">
+                <ref role="1YBMHb" node="25rRV02oFpv" resolve="nCopies" />
               </node>
-              <node concept="liA8E" id="25rRV02vmtA" role="2OqNvi">
-                <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
+              <node concept="3TrEf2" id="25rRV02vgfA" role="2OqNvi">
+                <ref role="3Tt5mk" to="hm2y:25rRV02osES" resolve="times" />
               </node>
             </node>
+            <node concept="2yIwOk" id="25rRV02vkpi" role="2OqNvi" />
           </node>
-          <node concept="nvevp" id="xNPLfvZ3U" role="3cqZAp">
-            <node concept="3clFbS" id="xNPLfvZ3W" role="nvhr_">
+          <node concept="liA8E" id="25rRV02vmtA" role="2OqNvi">
+            <ref role="37wK5l" to="c17a:~SAbstractConcept.isAbstract()" resolve="isAbstract" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="3cDaBeIllKZ" role="3cqZAp" />
+      <node concept="nvevp" id="xNPLfvZ3U" role="3cqZAp">
+        <node concept="3clFbS" id="xNPLfvZ3W" role="nvhr_">
+          <node concept="nvevp" id="7GwCuf2y0wh" role="3cqZAp">
+            <node concept="3clFbS" id="7GwCuf2y0wj" role="nvhr_">
               <node concept="3cpWs8" id="25rRV02p6Kg" role="3cqZAp">
                 <node concept="3cpWsn" id="25rRV02p6Kh" role="3cpWs9">
                   <property role="TrG5h" value="timesValue" />
@@ -10791,50 +10792,49 @@
                   </node>
                   <node concept="1Dw8fO" id="25rRV02qswS" role="3cqZAp">
                     <node concept="3clFbS" id="25rRV02qswU" role="2LFqv$">
-                      <node concept="3cpWs8" id="ijyib_b31c" role="3cqZAp">
-                        <node concept="3cpWsn" id="ijyib_b31d" role="3cpWs9">
-                          <property role="TrG5h" value="newElements" />
-                          <node concept="_YKpA" id="ijyib_b5XT" role="1tU5fm">
-                            <node concept="3Tqbb2" id="ijyib_b5XV" role="_ZDj9">
-                              <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
-                            </node>
-                          </node>
-                          <node concept="2OqwBi" id="ijyib_b57L" role="33vP2m">
-                            <node concept="2OqwBi" id="ijyib_b31e" role="2Oq$k0">
-                              <node concept="37vLTw" id="ijyib_b31f" role="2Oq$k0">
+                      <node concept="2Gpval" id="3cDaBeIiI9U" role="3cqZAp">
+                        <node concept="2GrKxI" id="3cDaBeIiI9W" role="2Gsz3X">
+                          <property role="TrG5h" value="type" />
+                        </node>
+                        <node concept="3clFbS" id="3cDaBeIiIa0" role="2LFqv$">
+                          <node concept="3clFbF" id="3cDaBeIiJbW" role="3cqZAp">
+                            <node concept="2OqwBi" id="3cDaBeIiLbQ" role="3clFbG">
+                              <node concept="37vLTw" id="3cDaBeIiJbV" role="2Oq$k0">
                                 <ref role="3cqZAo" node="25rRV02qVo7" resolve="newElementTypes" />
                               </node>
-                              <node concept="3$u5V9" id="ijyib_b31g" role="2OqNvi">
-                                <node concept="1bVj0M" id="ijyib_b31h" role="23t8la">
-                                  <node concept="3clFbS" id="ijyib_b31i" role="1bW5cS">
-                                    <node concept="3clFbF" id="ijyib_b31j" role="3cqZAp">
-                                      <node concept="2OqwBi" id="ijyib_b31k" role="3clFbG">
-                                        <node concept="37vLTw" id="ijyib_b31l" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="ijyib_b31n" resolve="it" />
-                                        </node>
-                                        <node concept="1$rogu" id="ijyib_b31m" role="2OqNvi" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="Rh6nW" id="ijyib_b31n" role="1bW2Oz">
-                                    <property role="TrG5h" value="it" />
-                                    <node concept="2jxLKc" id="ijyib_b31o" role="1tU5fm" />
-                                  </node>
+                              <node concept="TSZUe" id="3cDaBeIiMLY" role="2OqNvi">
+                                <node concept="2GrUjf" id="3cDaBeIiMPU" role="25WWJ7">
+                                  <ref role="2Gs0qQ" node="3cDaBeIiI9W" resolve="type" />
                                 </node>
                               </node>
                             </node>
-                            <node concept="ANE8D" id="ijyib_b5J6" role="2OqNvi" />
                           </node>
                         </node>
-                      </node>
-                      <node concept="3clFbF" id="25rRV02qC4x" role="3cqZAp">
-                        <node concept="2OqwBi" id="25rRV02qHBl" role="3clFbG">
-                          <node concept="37vLTw" id="25rRV02qVob" role="2Oq$k0">
-                            <ref role="3cqZAo" node="25rRV02qVo7" resolve="newElementTypes" />
+                        <node concept="2OqwBi" id="3cDaBeIiFIX" role="2GsD0m">
+                          <node concept="2OqwBi" id="3cDaBeIiFIY" role="2Oq$k0">
+                            <node concept="37vLTw" id="3cDaBeIiFIZ" role="2Oq$k0">
+                              <ref role="3cqZAo" node="25rRV02pwab" resolve="tupleType" />
+                            </node>
+                            <node concept="3Tsc0h" id="3cDaBeIiFJ0" role="2OqNvi">
+                              <ref role="3TtcxE" to="hm2y:S$tO8ocniV" resolve="elementTypes" />
+                            </node>
                           </node>
-                          <node concept="X8dFx" id="25rRV02rEC_" role="2OqNvi">
-                            <node concept="37vLTw" id="ijyib_b31p" role="25WWJ7">
-                              <ref role="3cqZAo" node="ijyib_b31d" resolve="newElements" />
+                          <node concept="3$u5V9" id="3cDaBeIiFJ1" role="2OqNvi">
+                            <node concept="1bVj0M" id="3cDaBeIiFJ2" role="23t8la">
+                              <node concept="3clFbS" id="3cDaBeIiFJ3" role="1bW5cS">
+                                <node concept="3clFbF" id="3cDaBeIiFJ4" role="3cqZAp">
+                                  <node concept="2OqwBi" id="3cDaBeIiFJ5" role="3clFbG">
+                                    <node concept="37vLTw" id="3cDaBeIiFJ6" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="3cDaBeIiFJ8" resolve="it" />
+                                    </node>
+                                    <node concept="1$rogu" id="3cDaBeIiFJ7" role="2OqNvi" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="Rh6nW" id="3cDaBeIiFJ8" role="1bW2Oz">
+                                <property role="TrG5h" value="it" />
+                                <node concept="2jxLKc" id="3cDaBeIiFJ9" role="1tU5fm" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -10861,27 +10861,49 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="1Z5TYs" id="25rRV02plzI" role="3cqZAp">
-                    <node concept="mw_s8" id="25rRV02pmS$" role="1ZfhKB">
-                      <node concept="2pJPEk" id="25rRV02pmSw" role="mwGJk">
-                        <node concept="2pJPED" id="25rRV02pmSy" role="2pJPEn">
-                          <ref role="2pJxaS" to="hm2y:S$tO8ocniU" resolve="TupleType" />
-                          <node concept="2pIpSj" id="25rRV02ps6H" role="2pJxcM">
-                            <ref role="2pIpSl" to="hm2y:S$tO8ocniV" resolve="elementTypes" />
-                            <node concept="36biLy" id="25rRV02rJ1e" role="28nt2d">
-                              <node concept="37vLTw" id="25rRV02rPTB" role="36biLW">
-                                <ref role="3cqZAo" node="25rRV02qVo7" resolve="newElementTypes" />
-                              </node>
-                            </node>
+                  <node concept="3cpWs8" id="5gIHvJqm4oK" role="3cqZAp">
+                    <node concept="3cpWsn" id="5gIHvJqm4oN" role="3cpWs9">
+                      <property role="TrG5h" value="returnType" />
+                      <node concept="3Tqbb2" id="5gIHvJqm4oI" role="1tU5fm">
+                        <ref role="ehGHo" to="hm2y:S$tO8ocniU" resolve="TupleType" />
+                      </node>
+                      <node concept="2ShNRf" id="5gIHvJqm4Bw" role="33vP2m">
+                        <node concept="3zrR0B" id="5gIHvJqm6h0" role="2ShVmc">
+                          <node concept="3Tqbb2" id="5gIHvJqm6h2" role="3zrR0E">
+                            <ref role="ehGHo" to="hm2y:S$tO8ocniU" resolve="TupleType" />
                           </node>
                         </node>
                       </node>
                     </node>
+                  </node>
+                  <node concept="3clFbF" id="5gIHvJqm6PZ" role="3cqZAp">
+                    <node concept="2OqwBi" id="5gIHvJqma3q" role="3clFbG">
+                      <node concept="2OqwBi" id="5gIHvJqm7do" role="2Oq$k0">
+                        <node concept="37vLTw" id="5gIHvJqm6PX" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5gIHvJqm4oN" resolve="returnType" />
+                        </node>
+                        <node concept="3Tsc0h" id="5gIHvJqm7xt" role="2OqNvi">
+                          <ref role="3TtcxE" to="hm2y:S$tO8ocniV" resolve="elementTypes" />
+                        </node>
+                      </node>
+                      <node concept="X8dFx" id="5gIHvJqmcBr" role="2OqNvi">
+                        <node concept="37vLTw" id="5gIHvJqmfL1" role="25WWJ7">
+                          <ref role="3cqZAo" node="25rRV02qVo7" resolve="newElementTypes" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1Z5TYs" id="25rRV02plzI" role="3cqZAp">
                     <node concept="mw_s8" id="25rRV02plzL" role="1ZfhK$">
                       <node concept="1Z2H0r" id="25rRV02oHO$" role="mwGJk">
                         <node concept="1YBJjd" id="25rRV02oJGq" role="1Z2MuG">
                           <ref role="1YBMHb" node="25rRV02oFpv" resolve="nCopies" />
                         </node>
+                      </node>
+                    </node>
+                    <node concept="mw_s8" id="5gIHvJqmgOI" role="1ZfhKB">
+                      <node concept="37vLTw" id="5gIHvJqmgOG" role="mwGJk">
+                        <ref role="3cqZAo" node="5gIHvJqm4oN" resolve="returnType" />
                       </node>
                     </node>
                   </node>
@@ -10904,35 +10926,35 @@
                 </node>
               </node>
             </node>
-            <node concept="1Z2H0r" id="xNPLfvZee" role="nvjzm">
-              <node concept="2OqwBi" id="xNPLfvZtK" role="1Z2MuG">
-                <node concept="1YBJjd" id="xNPLfvZhw" role="2Oq$k0">
+            <node concept="2X1qdy" id="7GwCuf2y0wn" role="2X0Ygz">
+              <property role="TrG5h" value="ctxType" />
+              <node concept="2jxLKc" id="7GwCuf2y0wo" role="1tU5fm" />
+            </node>
+            <node concept="1Z2H0r" id="7GwCuf2y0tK" role="nvjzm">
+              <node concept="2OqwBi" id="7GwCuf2y0rS" role="1Z2MuG">
+                <node concept="1YBJjd" id="7GwCuf2y0rT" role="2Oq$k0">
                   <ref role="1YBMHb" node="25rRV02oFpv" resolve="nCopies" />
                 </node>
-                <node concept="3TrEf2" id="xNPLfw14$" role="2OqNvi">
-                  <ref role="3Tt5mk" to="hm2y:25rRV02osES" resolve="times" />
+                <node concept="2qgKlT" id="7GwCuf2y0rU" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:6zmBjqUivyF" resolve="contextExpression" />
                 </node>
               </node>
             </node>
-            <node concept="2X1qdy" id="xNPLfvZ40" role="2X0Ygz">
-              <property role="TrG5h" value="timesType" />
-              <node concept="2jxLKc" id="xNPLfvZ41" role="1tU5fm" />
-            </node>
           </node>
         </node>
-        <node concept="2X1qdy" id="7GwCuf2y0wn" role="2X0Ygz">
-          <property role="TrG5h" value="ctxType" />
-          <node concept="2jxLKc" id="7GwCuf2y0wo" role="1tU5fm" />
-        </node>
-        <node concept="1Z2H0r" id="7GwCuf2y0tK" role="nvjzm">
-          <node concept="2OqwBi" id="7GwCuf2y0rS" role="1Z2MuG">
-            <node concept="1YBJjd" id="7GwCuf2y0rT" role="2Oq$k0">
+        <node concept="1Z2H0r" id="xNPLfvZee" role="nvjzm">
+          <node concept="2OqwBi" id="xNPLfvZtK" role="1Z2MuG">
+            <node concept="1YBJjd" id="xNPLfvZhw" role="2Oq$k0">
               <ref role="1YBMHb" node="25rRV02oFpv" resolve="nCopies" />
             </node>
-            <node concept="2qgKlT" id="7GwCuf2y0rU" role="2OqNvi">
-              <ref role="37wK5l" to="pbu6:6zmBjqUivyF" resolve="contextExpression" />
+            <node concept="3TrEf2" id="xNPLfw14$" role="2OqNvi">
+              <ref role="3Tt5mk" to="hm2y:25rRV02osES" resolve="times" />
             </node>
           </node>
+        </node>
+        <node concept="2X1qdy" id="xNPLfvZ40" role="2X0Ygz">
+          <property role="TrG5h" value="timesType" />
+          <node concept="2jxLKc" id="xNPLfvZ41" role="1tU5fm" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tuples@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tuples@tests.mps
@@ -228,8 +228,8 @@
             </node>
           </node>
           <node concept="ze_g2" id="25rRV02v9Zh" role="1QScD9">
-            <node concept="30bXRB" id="25rRV02ybfx" role="zexk8">
-              <property role="30bXRw" value="2" />
+            <node concept="30bXRB" id="3cDaBeIjnx9" role="zexk8">
+              <property role="30bXRw" value="20" />
             </node>
           </node>
         </node>
@@ -263,6 +263,294 @@
               <property role="30bXRw" value="3" />
             </node>
             <node concept="30bXRB" id="ijyib_kmvr" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIj$MO" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIj$MP" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIj$MQ" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIj$MR" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIj$MS" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIj$MT" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIj_ct" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIj_cu" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIj_cv" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIj_cw" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIj_cx" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIj_cy" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIj_dt" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIj_du" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIj_dv" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIj_dw" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIj_dx" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIj_dy" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIj_eD" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIj_eE" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIj_eF" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIj_eG" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIj_eH" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIj_eI" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIj_g1" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIj_g2" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIj_g3" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIj_g4" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIj_g5" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIj_g6" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIj_h_" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIj_hA" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIj_hB" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIj_hC" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIj_hD" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIj_hE" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIj_jl" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIj_jm" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIj_jn" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIj_jo" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIj_jp" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIj_jq" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIj_Ip" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIj_Iq" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIj_Ir" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIj_Is" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIj_It" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIj_Iu" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIj_Kz" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIj_K$" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIj_K_" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIj_KA" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIj_KB" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIj_KC" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIjAhb" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIjAhc" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIjAhd" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIjAhe" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIjAhf" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIjAhg" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIjAMS" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIjAMT" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIjAMU" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIjAMV" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIjAMW" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIjAMX" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIjBp6" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIjBp7" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIjBp8" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIjBp9" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIjBpa" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIjBpb" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIjC0j" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIjC0k" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIjC0l" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIjC0m" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIjC0n" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIjC0o" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIjC3p" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIjC3q" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIjC3r" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIjC3s" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIjC3t" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIjC3u" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIjCKa" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIjCKb" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIjCKc" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIjCKd" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIjCKe" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIjCKf" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIjCNC" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIjCND" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIjCNE" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIjCNF" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIjCNG" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIjCNH" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIjCRg" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIjCRh" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIjCRi" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIjCRj" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIjCRk" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIjCRl" role="3iBYfI">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIjCV2" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIjCV3" role="3iBYfI">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIjCV4" role="3iBYfI">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="3iBYfx" id="3cDaBeIjCV5" role="3iBYfI">
+            <node concept="30bXRB" id="3cDaBeIjCV6" role="3iBYfI">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="3cDaBeIjCV7" role="3iBYfI">
               <property role="30bXRw" value="4" />
             </node>
           </node>


### PR DESCRIPTION
For example _[[1, 2], [3, 4]].nTimes(20)_ completely froze MPS. I don't know if the order of the when concrete block was the issue or inefficient list operations.