### PR TITLE
Bugfix/1032 trace explorer show evaluations of lambda nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## August 2024
+
+### Fixed
+
+- TraceExplorer can decorate editors of lambda nodes with their values. 
+
 ## July 2024
 
 ### Added

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
@@ -5,6 +5,7 @@
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -31,6 +32,9 @@
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="sxpq" ref="r:51edfe99-0380-475c-a3e9-1d4425eac12f(org.iets3.core.expr.lambda.plugin)" />
+    <import index="webo" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing.text.html(JDK/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -90,6 +94,10 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
@@ -98,6 +106,10 @@
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534760951" name="jetbrains.mps.baseLanguage.structure.ArrayType" flags="in" index="10Q1$e">
         <child id="1070534760952" name="componentType" index="10Q1$1" />
+      </concept>
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
       </concept>
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
@@ -610,6 +622,96 @@
         <node concept="3Tqbb2" id="6NpHfQ5Cb7u" role="1tU5fm" />
       </node>
       <node concept="17QB3L" id="6NpHfQ5Cb7v" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="3u8VfJfplfS" role="13h7CS">
+      <property role="TrG5h" value="getNodeMapping" />
+      <node concept="3Tm1VV" id="3u8VfJfplfT" role="1B3o_S" />
+      <node concept="3rvAFt" id="3u8VfJfpqwp" role="3clF45">
+        <node concept="3Tqbb2" id="3u8VfJfpqBG" role="3rvQeY" />
+        <node concept="3Tqbb2" id="3u8VfJfpqFf" role="3rvSg0" />
+      </node>
+      <node concept="3clFbS" id="3u8VfJfplfV" role="3clF47">
+        <node concept="3clFbJ" id="3u8VfJfpsNd" role="3cqZAp">
+          <node concept="3clFbS" id="3u8VfJfpsNf" role="3clFbx">
+            <node concept="3cpWs6" id="3u8VfJfpxjr" role="3cqZAp">
+              <node concept="10QFUN" id="3u8VfJfpwac" role="3cqZAk">
+                <node concept="3rvAFt" id="3u8VfJfpwhk" role="10QFUM">
+                  <node concept="3Tqbb2" id="3u8VfJfpwnX" role="3rvQeY" />
+                  <node concept="3Tqbb2" id="3u8VfJfpwwv" role="3rvSg0" />
+                </node>
+                <node concept="1eOMI4" id="3u8VfJfpw0_" role="10QFUP">
+                  <node concept="2OqwBi" id="3u8VfJfprtZ" role="1eOMHV">
+                    <node concept="2JrnkZ" id="3u8VfJfpr_H" role="2Oq$k0">
+                      <node concept="13iPFW" id="3u8VfJfpGfx" role="2JrQYb" />
+                    </node>
+                    <node concept="liA8E" id="3u8VfJfprU6" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SNode.getUserObject(java.lang.Object)" resolve="getUserObject" />
+                      <node concept="10M0yZ" id="3u8VfJfps64" role="37wK5m">
+                        <ref role="3cqZAo" to="sxpq:6ITtBskT0za" resolve="USER_OBJECT_KEY" />
+                        <ref role="1PxDUh" to="sxpq:$yb$20f$a5" resolve="LambdaValue" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2ZW3vV" id="3u8VfJfptdT" role="3clFbw">
+            <node concept="2OqwBi" id="3u8VfJfpsYt" role="2ZW6bz">
+              <node concept="2JrnkZ" id="3u8VfJfpsYu" role="2Oq$k0">
+                <node concept="13iPFW" id="3u8VfJfpFOV" role="2JrQYb" />
+              </node>
+              <node concept="liA8E" id="3u8VfJfpsYw" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SNode.getUserObject(java.lang.Object)" resolve="getUserObject" />
+                <node concept="10M0yZ" id="3u8VfJfpsYx" role="37wK5m">
+                  <ref role="3cqZAo" to="sxpq:6ITtBskT0za" resolve="USER_OBJECT_KEY" />
+                  <ref role="1PxDUh" to="sxpq:$yb$20f$a5" resolve="LambdaValue" />
+                </node>
+              </node>
+            </node>
+            <node concept="3uibUv" id="3u8VfJfvFDa" role="2ZW6by">
+              <ref role="3uigEE" to="33ny:~Map" resolve="Map" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="3u8VfJfpy7y" role="3cqZAp">
+          <node concept="10Nm6u" id="3u8VfJfpyjR" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1ZCJf$ekk4l" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="1ZCJf$ej28Z" role="13h7CS">
+      <property role="TrG5h" value="putNodeMapping" />
+      <node concept="3Tm1VV" id="1ZCJf$ej290" role="1B3o_S" />
+      <node concept="3cqZAl" id="1ZCJf$ej58z" role="3clF45" />
+      <node concept="3clFbS" id="1ZCJf$ej294" role="3clF47">
+        <node concept="3clFbF" id="1ZCJf$ej4Qg" role="3cqZAp">
+          <node concept="2OqwBi" id="1ZCJf$ej29d" role="3clFbG">
+            <node concept="2JrnkZ" id="1ZCJf$ej29e" role="2Oq$k0">
+              <node concept="13iPFW" id="1ZCJf$ej29f" role="2JrQYb" />
+            </node>
+            <node concept="liA8E" id="1ZCJf$ej29g" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.putUserObject(java.lang.Object,java.lang.Object)" resolve="putUserObject" />
+              <node concept="10M0yZ" id="1ZCJf$ej29h" role="37wK5m">
+                <ref role="3cqZAo" to="sxpq:6ITtBskT0za" resolve="USER_OBJECT_KEY" />
+                <ref role="1PxDUh" to="sxpq:$yb$20f$a5" resolve="LambdaValue" />
+              </node>
+              <node concept="37vLTw" id="1ZCJf$ej4xr" role="37wK5m">
+                <ref role="3cqZAo" node="1ZCJf$ej44i" resolve="map" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="1ZCJf$ej44i" role="3clF46">
+        <property role="TrG5h" value="map" />
+        <node concept="3rvAFt" id="1ZCJf$ej44f" role="1tU5fm">
+          <node concept="3Tqbb2" id="1ZCJf$ej4ay" role="3rvQeY" />
+          <node concept="3Tqbb2" id="1ZCJf$ej49T" role="3rvSg0" />
+        </node>
+      </node>
     </node>
   </node>
   <node concept="13h7C7" id="6zmBjqUkS0K">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/plugin.mps
@@ -17,10 +17,12 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
-    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -64,10 +66,6 @@
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
-      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
-        <child id="1070534934091" name="type" index="10QFUM" />
-        <child id="1070534934092" name="expression" index="10QFUP" />
-      </concept>
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg">
         <property id="8606350594693632173" name="isTransient" index="eg7rD" />
         <property id="1240249534625" name="isVolatile" index="34CwA1" />
@@ -103,8 +101,8 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
-      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
@@ -145,7 +143,6 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
-      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
@@ -155,9 +152,6 @@
       <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
         <child id="1144231399730" name="condition" index="1Dwp0S" />
         <child id="1144231408325" name="iteration" index="1Dwrff" />
-      </concept>
-      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
-        <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
@@ -203,9 +197,6 @@
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
-      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
-        <child id="1145404616321" name="leftExpression" index="2JrQYb" />
-      </concept>
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
@@ -237,14 +228,6 @@
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
-      </concept>
-    </language>
-    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
-      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
-        <property id="155656958578482949" name="value" index="3oM_SC" />
-      </concept>
-      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
-        <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
@@ -334,12 +317,6 @@
         <node concept="3Tqbb2" id="dsAFRk0GwE" role="3rvQeY" />
         <node concept="3Tqbb2" id="dsAFRk0GAX" role="3rvSg0" />
       </node>
-      <node concept="2ShNRf" id="dsAFRk0Iml" role="33vP2m">
-        <node concept="3rGOSV" id="dsAFRk0R9K" role="2ShVmc">
-          <node concept="3Tqbb2" id="dsAFRk0RF5" role="3rHrn6" />
-          <node concept="3Tqbb2" id="dsAFRk0RZv" role="3rHtpV" />
-        </node>
-      </node>
     </node>
     <node concept="312cEg" id="5ya_dKps6p1" role="jymVt">
       <property role="34CwA1" value="false" />
@@ -379,29 +356,94 @@
       <node concept="3cqZAl" id="$yb$20fE3B" role="3clF45" />
       <node concept="3Tm1VV" id="$yb$20fE3C" role="1B3o_S" />
       <node concept="3clFbS" id="$yb$20fE3D" role="3clF47">
-        <node concept="3clFbF" id="dsAFRk0SAw" role="3cqZAp">
-          <node concept="37vLTI" id="dsAFRk0Ts4" role="3clFbG">
-            <node concept="1PxgMI" id="dsAFRk0VI3" role="37vLTx">
-              <property role="1BlNFB" value="true" />
-              <node concept="chp4Y" id="dsAFRk0W3j" role="3oSUPX">
-                <ref role="cht4Q" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
+        <node concept="3clFbF" id="3u8VfJfq07n" role="3cqZAp">
+          <node concept="37vLTI" id="3u8VfJfq1JI" role="3clFbG">
+            <node concept="2OqwBi" id="3u8VfJfq4DF" role="37vLTx">
+              <node concept="37vLTw" id="3u8VfJfq3hs" role="2Oq$k0">
+                <ref role="3cqZAo" node="$yb$20fE4t" resolve="le" />
               </node>
-              <node concept="2YIFZM" id="dsAFRk0U1J" role="1m5AlR">
-                <ref role="1Pybhc" to="w1kc:~CopyUtil" resolve="CopyUtil" />
-                <ref role="37wK5l" to="w1kc:~CopyUtil.copy(org.jetbrains.mps.openapi.model.SNode,java.util.Map,boolean)" resolve="copy" />
-                <node concept="37vLTw" id="dsAFRk0U5W" role="37wK5m">
-                  <ref role="3cqZAo" node="$yb$20fE4t" resolve="le" />
+              <node concept="2qgKlT" id="3u8VfJfq6pn" role="2OqNvi">
+                <ref role="37wK5l" to="5s8v:3u8VfJfplfS" resolve="getMap" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="3u8VfJfq07l" role="37vLTJ">
+              <ref role="3cqZAo" node="dsAFRk0GB0" resolve="mapping" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="3u8VfJfqbfu" role="3cqZAp">
+          <node concept="3clFbS" id="3u8VfJfqbfw" role="3clFbx">
+            <node concept="3clFbF" id="3u8VfJfqhGS" role="3cqZAp">
+              <node concept="37vLTI" id="3u8VfJfqj6G" role="3clFbG">
+                <node concept="2ShNRf" id="3u8VfJfqkHA" role="37vLTx">
+                  <node concept="3rGOSV" id="3u8VfJfqkFP" role="2ShVmc">
+                    <node concept="3Tqbb2" id="3u8VfJfqkFQ" role="3rHrn6" />
+                    <node concept="3Tqbb2" id="3u8VfJfqkFR" role="3rHtpV" />
+                  </node>
                 </node>
-                <node concept="37vLTw" id="dsAFRk0UmX" role="37wK5m">
+                <node concept="37vLTw" id="3u8VfJfqhGQ" role="37vLTJ">
                   <ref role="3cqZAo" node="dsAFRk0GB0" resolve="mapping" />
-                </node>
-                <node concept="3clFbT" id="dsAFRk0UO1" role="37wK5m">
-                  <property role="3clFbU" value="true" />
                 </node>
               </node>
             </node>
-            <node concept="37vLTw" id="dsAFRk0SAu" role="37vLTJ">
-              <ref role="3cqZAo" node="$yb$20fATA" resolve="lambda" />
+            <node concept="3clFbF" id="1ZCJf$ejaT0" role="3cqZAp">
+              <node concept="2OqwBi" id="1ZCJf$ejdxs" role="3clFbG">
+                <node concept="37vLTw" id="1ZCJf$ejaSY" role="2Oq$k0">
+                  <ref role="3cqZAo" node="$yb$20fE4t" resolve="le" />
+                </node>
+                <node concept="2qgKlT" id="1ZCJf$ejg$k" role="2OqNvi">
+                  <ref role="37wK5l" to="5s8v:1ZCJf$ej28Z" resolve="putMap" />
+                  <node concept="37vLTw" id="1ZCJf$ejhqU" role="37wK5m">
+                    <ref role="3cqZAo" node="dsAFRk0GB0" resolve="mapping" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="dsAFRk0SAw" role="3cqZAp">
+              <node concept="37vLTI" id="dsAFRk0Ts4" role="3clFbG">
+                <node concept="37vLTw" id="dsAFRk0SAu" role="37vLTJ">
+                  <ref role="3cqZAo" node="$yb$20fATA" resolve="lambda" />
+                </node>
+                <node concept="1PxgMI" id="14bmjk2oWAH" role="37vLTx">
+                  <property role="1BlNFB" value="true" />
+                  <node concept="chp4Y" id="14bmjk2oWAI" role="3oSUPX">
+                    <ref role="cht4Q" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
+                  </node>
+                  <node concept="2YIFZM" id="14bmjk2oWAJ" role="1m5AlR">
+                    <ref role="1Pybhc" to="w1kc:~CopyUtil" resolve="CopyUtil" />
+                    <ref role="37wK5l" to="w1kc:~CopyUtil.copy(org.jetbrains.mps.openapi.model.SNode,java.util.Map,boolean)" resolve="copy" />
+                    <node concept="37vLTw" id="14bmjk2oWAK" role="37wK5m">
+                      <ref role="3cqZAo" node="$yb$20fE4t" resolve="le" />
+                    </node>
+                    <node concept="37vLTw" id="14bmjk2oWAL" role="37wK5m">
+                      <ref role="3cqZAo" node="dsAFRk0GB0" resolve="mapping" />
+                    </node>
+                    <node concept="3clFbT" id="14bmjk2oWAM" role="37wK5m">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="3u8VfJfqeg9" role="3clFbw">
+            <node concept="10Nm6u" id="3u8VfJfqfSK" role="3uHU7w" />
+            <node concept="37vLTw" id="3u8VfJfqd6n" role="3uHU7B">
+              <ref role="3cqZAo" node="dsAFRk0GB0" resolve="mapping" />
+            </node>
+          </node>
+          <node concept="9aQIb" id="14bmjk2p0S6" role="9aQIa">
+            <node concept="3clFbS" id="14bmjk2p0S7" role="9aQI4">
+              <node concept="3clFbF" id="14bmjk2p2qO" role="3cqZAp">
+                <node concept="37vLTI" id="14bmjk2p4Qk" role="3clFbG">
+                  <node concept="37vLTw" id="14bmjk2y_S4" role="37vLTx">
+                    <ref role="3cqZAo" node="$yb$20fE4t" resolve="le" />
+                  </node>
+                  <node concept="37vLTw" id="14bmjk2p2qN" role="37vLTJ">
+                    <ref role="3cqZAo" node="$yb$20fATA" resolve="lambda" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -935,81 +977,6 @@
             </node>
           </node>
         </node>
-        <node concept="3SKdUt" id="7R7jyNngSfN" role="3cqZAp">
-          <node concept="1PaTwC" id="7R7jyNngSfO" role="1aUNEU">
-            <node concept="3oM_SD" id="7R7jyNngSfP" role="1PaTwD">
-              <property role="3oM_SC" value="get" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngUDm" role="1PaTwD">
-              <property role="3oM_SC" value="the" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngUDy" role="1PaTwD">
-              <property role="3oM_SC" value="oginial" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngUEK" role="1PaTwD">
-              <property role="3oM_SC" value="LambdaExpression" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngUGg" role="1PaTwD">
-              <property role="3oM_SC" value="instead" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngUGv" role="1PaTwD">
-              <property role="3oM_SC" value="the" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngUGA" role="1PaTwD">
-              <property role="3oM_SC" value="constructors" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngUHr" role="1PaTwD">
-              <property role="3oM_SC" value="copy" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="6ITtBskYEkd" role="3cqZAp">
-          <node concept="3cpWsn" id="6ITtBskYEke" role="3cpWs9">
-            <property role="TrG5h" value="originalLE" />
-            <node concept="3Tqbb2" id="6ITtBskY_t$" role="1tU5fm">
-              <ref role="ehGHo" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
-            </node>
-            <node concept="1PxgMI" id="6ITtBskYOSy" role="33vP2m">
-              <property role="1BlNFB" value="true" />
-              <node concept="chp4Y" id="6ITtBskYRiJ" role="3oSUPX">
-                <ref role="cht4Q" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
-              </node>
-              <node concept="2OqwBi" id="6ITtBskYEkf" role="1m5AlR">
-                <node concept="2OqwBi" id="6ITtBskYEkg" role="2Oq$k0">
-                  <node concept="37vLTw" id="6ITtBskYEkh" role="2Oq$k0">
-                    <ref role="3cqZAo" node="dsAFRk0GB0" resolve="mapping" />
-                  </node>
-                  <node concept="3lbrtF" id="6ITtBskYEki" role="2OqNvi" />
-                </node>
-                <node concept="1z4cxt" id="6ITtBskYEkj" role="2OqNvi">
-                  <node concept="1bVj0M" id="6ITtBskYEkk" role="23t8la">
-                    <node concept="3clFbS" id="6ITtBskYEkl" role="1bW5cS">
-                      <node concept="3clFbF" id="6ITtBskYEkm" role="3cqZAp">
-                        <node concept="3clFbC" id="6ITtBskYEkn" role="3clFbG">
-                          <node concept="37vLTw" id="6ITtBskYEko" role="3uHU7w">
-                            <ref role="3cqZAo" node="$yb$20fATA" resolve="lambda" />
-                          </node>
-                          <node concept="3EllGN" id="6ITtBskYEkp" role="3uHU7B">
-                            <node concept="37vLTw" id="6ITtBskYEkq" role="3ElVtu">
-                              <ref role="3cqZAo" node="6ITtBskYEks" resolve="key" />
-                            </node>
-                            <node concept="37vLTw" id="6ITtBskYEkr" role="3ElQJh">
-                              <ref role="3cqZAo" node="dsAFRk0GB0" resolve="mapping" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="Rh6nW" id="6ITtBskYEks" role="1bW2Oz">
-                      <property role="TrG5h" value="key" />
-                      <node concept="2jxLKc" id="6ITtBskYEkt" role="1tU5fm" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3cpWs8" id="5d4Vabvgn7r" role="3cqZAp">
           <node concept="3cpWsn" id="5d4Vabvgn7s" role="3cpWs9">
             <property role="TrG5h" value="tt" />
@@ -1020,170 +987,13 @@
               <node concept="1pGfFk" id="5d4Vabvgn7u" role="2ShVmc">
                 <ref role="37wK5l" to="2ahs:5d4Vabvrrqt" resolve="ComputationTrace" />
                 <node concept="37vLTw" id="6ITtBskYEku" role="37wK5m">
-                  <ref role="3cqZAo" node="6ITtBskYEke" resolve="originalLE" />
+                  <ref role="3cqZAo" node="$yb$20fATA" resolve="lambda" />
                 </node>
                 <node concept="3clFbT" id="5d4Vabvs8X9" role="37wK5m" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3SKdUt" id="7R7jyNngXiz" role="3cqZAp">
-          <node concept="1PaTwC" id="7R7jyNngXi$" role="1aUNEU">
-            <node concept="3oM_SD" id="7R7jyNngXi_" role="1PaTwD">
-              <property role="3oM_SC" value="In" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngZIo" role="1PaTwD">
-              <property role="3oM_SC" value="case" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngZI$" role="1PaTwD">
-              <property role="3oM_SC" value="the" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngZIL" role="1PaTwD">
-              <property role="3oM_SC" value="original" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngZIZ" role="1PaTwD">
-              <property role="3oM_SC" value="LambdaExpression" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngZJw" role="1PaTwD">
-              <property role="3oM_SC" value="was" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngZJK" role="1PaTwD">
-              <property role="3oM_SC" value="build" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngZJS" role="1PaTwD">
-              <property role="3oM_SC" value="from" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngZKa" role="1PaTwD">
-              <property role="3oM_SC" value="a" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngZKt" role="1PaTwD">
-              <property role="3oM_SC" value="ShortLamdaExpression," />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngZOz" role="1PaTwD">
-              <property role="3oM_SC" value="use" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngZP1" role="1PaTwD">
-              <property role="3oM_SC" value="the" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngZPn" role="1PaTwD">
-              <property role="3oM_SC" value="original" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngZPR" role="1PaTwD">
-              <property role="3oM_SC" value="ShortLambdaExpression" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngZRe" role="1PaTwD">
-              <property role="3oM_SC" value="in" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngZRB" role="1PaTwD">
-              <property role="3oM_SC" value="the" />
-            </node>
-            <node concept="3oM_SD" id="7R7jyNngZRS" role="1PaTwD">
-              <property role="3oM_SC" value="ComputationTrace" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="dsAFRk4B7u" role="3cqZAp">
-          <node concept="3cpWsn" id="dsAFRk4B7x" role="3cpWs9">
-            <property role="TrG5h" value="shortLambdaMapping" />
-            <node concept="10QFUN" id="dsAFRk6r$4" role="33vP2m">
-              <node concept="2OqwBi" id="dsAFRk4Foc" role="10QFUP">
-                <node concept="2JrnkZ" id="dsAFRk4EYb" role="2Oq$k0">
-                  <node concept="37vLTw" id="dsAFRk4CC7" role="2JrQYb">
-                    <ref role="3cqZAo" node="$yb$20fATA" resolve="lambda" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="dsAFRk4FYv" role="2OqNvi">
-                  <ref role="37wK5l" to="mhbf:~SNode.getUserObject(java.lang.Object)" resolve="getUserObject" />
-                  <node concept="37vLTw" id="6ITtBskTmss" role="37wK5m">
-                    <ref role="3cqZAo" node="6ITtBskT0za" resolve="USER_OBJECT_KEY" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3rvAFt" id="dsAFRk6_pZ" role="10QFUM">
-                <node concept="3Tqbb2" id="dsAFRk6_Ro" role="3rvQeY" />
-                <node concept="3Tqbb2" id="dsAFRk6Axp" role="3rvSg0" />
-              </node>
-            </node>
-            <node concept="3rvAFt" id="dsAFRk6zt1" role="1tU5fm">
-              <node concept="3Tqbb2" id="dsAFRk6$3w" role="3rvQeY" />
-              <node concept="3Tqbb2" id="dsAFRk6$AJ" role="3rvSg0" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="6ITtBskUXtD" role="3cqZAp">
-          <node concept="3clFbS" id="6ITtBskUXtF" role="3clFbx">
-            <node concept="3cpWs8" id="6ITtBskXoU1" role="3cqZAp">
-              <node concept="3cpWsn" id="6ITtBskXoU2" role="3cpWs9">
-                <property role="TrG5h" value="originalSLE" />
-                <node concept="3Tqbb2" id="6ITtBskXosv" role="1tU5fm">
-                  <ref role="ehGHo" to="zzzn:6zmBjqUm7MQ" resolve="ShortLambdaExpression" />
-                </node>
-                <node concept="1PxgMI" id="6ITtBskXrt9" role="33vP2m">
-                  <property role="1BlNFB" value="true" />
-                  <node concept="chp4Y" id="6ITtBskXs6X" role="3oSUPX">
-                    <ref role="cht4Q" to="zzzn:6zmBjqUm7MQ" resolve="ShortLambdaExpression" />
-                  </node>
-                  <node concept="2OqwBi" id="6ITtBskXoU3" role="1m5AlR">
-                    <node concept="2OqwBi" id="6ITtBskXoU4" role="2Oq$k0">
-                      <node concept="37vLTw" id="6ITtBskXoU5" role="2Oq$k0">
-                        <ref role="3cqZAo" node="dsAFRk4B7x" resolve="shortLambdaMapping" />
-                      </node>
-                      <node concept="3lbrtF" id="6ITtBskXoU6" role="2OqNvi" />
-                    </node>
-                    <node concept="1z4cxt" id="6ITtBskXoU7" role="2OqNvi">
-                      <node concept="1bVj0M" id="6ITtBskXoU8" role="23t8la">
-                        <node concept="3clFbS" id="6ITtBskXoU9" role="1bW5cS">
-                          <node concept="3clFbF" id="6ITtBskXoUa" role="3cqZAp">
-                            <node concept="3clFbC" id="6ITtBskXoUb" role="3clFbG">
-                              <node concept="37vLTw" id="6ITtBskXoUc" role="3uHU7w">
-                                <ref role="3cqZAo" node="6ITtBskYEke" resolve="originalLE" />
-                              </node>
-                              <node concept="3EllGN" id="6ITtBskXoUd" role="3uHU7B">
-                                <node concept="37vLTw" id="6ITtBskXoUe" role="3ElVtu">
-                                  <ref role="3cqZAo" node="6ITtBskXoUg" resolve="key" />
-                                </node>
-                                <node concept="37vLTw" id="6ITtBskXoUf" role="3ElQJh">
-                                  <ref role="3cqZAo" node="dsAFRk4B7x" resolve="shortLambdaMapping" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="Rh6nW" id="6ITtBskXoUg" role="1bW2Oz">
-                          <property role="TrG5h" value="key" />
-                          <node concept="2jxLKc" id="6ITtBskXoUh" role="1tU5fm" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="6ITtBskXsHY" role="3cqZAp">
-              <node concept="37vLTI" id="6ITtBskXtra" role="3clFbG">
-                <node concept="2ShNRf" id="6ITtBskXttH" role="37vLTx">
-                  <node concept="1pGfFk" id="6ITtBskXtS3" role="2ShVmc">
-                    <ref role="37wK5l" to="2ahs:5d4Vabvrrqt" resolve="ComputationTrace" />
-                    <node concept="37vLTw" id="6ITtBskXu01" role="37wK5m">
-                      <ref role="3cqZAo" node="6ITtBskXoU2" resolve="originalSLE" />
-                    </node>
-                    <node concept="3clFbT" id="6ITtBskXuea" role="37wK5m" />
-                  </node>
-                </node>
-                <node concept="37vLTw" id="6ITtBskXsHW" role="37vLTJ">
-                  <ref role="3cqZAo" node="5d4Vabvgn7s" resolve="tt" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3y3z36" id="6ITtBskV7uJ" role="3clFbw">
-            <node concept="10Nm6u" id="6ITtBskV9Mn" role="3uHU7w" />
-            <node concept="37vLTw" id="6ITtBskUZ5h" role="3uHU7B">
-              <ref role="3cqZAo" node="dsAFRk4B7x" resolve="shortLambdaMapping" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="6ITtBskV9O0" role="3cqZAp" />
         <node concept="3clFbF" id="5d4VabvgsFc" role="3cqZAp">
           <node concept="2OqwBi" id="5d4Vabvgv66" role="3clFbG">
             <node concept="37vLTw" id="5d4VabvgtY8" role="2Oq$k0">
@@ -1251,61 +1061,51 @@
             <node concept="2es0OD" id="dsAFRk19bn" role="2OqNvi">
               <node concept="1bVj0M" id="dsAFRk19bp" role="23t8la">
                 <node concept="3clFbS" id="dsAFRk19bq" role="1bW5cS">
-                  <node concept="3clFbJ" id="dsAFRk6qdB" role="3cqZAp">
-                    <node concept="3clFbS" id="dsAFRk6qdD" role="3clFbx">
-                      <node concept="3clFbF" id="dsAFRk6Bi0" role="3cqZAp">
-                        <node concept="2OqwBi" id="dsAFRk6C0Y" role="3clFbG">
-                          <node concept="37vLTw" id="dsAFRk6BhZ" role="2Oq$k0">
-                            <ref role="3cqZAo" node="dsAFRk4B7x" resolve="shortLambdaMapping" />
-                          </node>
-                          <node concept="2es0OD" id="dsAFRk6CI4" role="2OqNvi">
-                            <node concept="1bVj0M" id="dsAFRk6CI6" role="23t8la">
-                              <node concept="3clFbS" id="dsAFRk6CI7" role="1bW5cS">
-                                <node concept="3clFbJ" id="dsAFRk6Dl3" role="3cqZAp">
-                                  <node concept="2YIFZM" id="dsAFRk6Epl" role="3clFbw">
-                                    <ref role="37wK5l" to="pbu6:1WlYLwX3McV" resolve="isNodeCovered" />
-                                    <ref role="1Pybhc" to="pbu6:4_qY3E5IXRD" resolve="DefaultCoverageAnalyzer" />
-                                    <node concept="2OqwBi" id="dsAFRk6FhD" role="37wK5m">
-                                      <node concept="37vLTw" id="dsAFRk6ESX" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="dsAFRk6CI8" resolve="mapping" />
-                                      </node>
-                                      <node concept="3AV6Ez" id="dsAFRka_Qp" role="2OqNvi" />
-                                    </node>
+                  <node concept="3clFbF" id="dsAFRk6Bi0" role="3cqZAp">
+                    <node concept="2OqwBi" id="dsAFRk6C0Y" role="3clFbG">
+                      <node concept="37vLTw" id="dsAFRk6BhZ" role="2Oq$k0">
+                        <ref role="3cqZAo" node="dsAFRk0GB0" resolve="mapping" />
+                      </node>
+                      <node concept="2es0OD" id="dsAFRk6CI4" role="2OqNvi">
+                        <node concept="1bVj0M" id="dsAFRk6CI6" role="23t8la">
+                          <node concept="3clFbS" id="dsAFRk6CI7" role="1bW5cS">
+                            <node concept="3clFbJ" id="dsAFRk6Dl3" role="3cqZAp">
+                              <node concept="2YIFZM" id="dsAFRk6Epl" role="3clFbw">
+                                <ref role="37wK5l" to="pbu6:1WlYLwX3McV" resolve="isNodeCovered" />
+                                <ref role="1Pybhc" to="pbu6:4_qY3E5IXRD" resolve="DefaultCoverageAnalyzer" />
+                                <node concept="2OqwBi" id="dsAFRk6FhD" role="37wK5m">
+                                  <node concept="37vLTw" id="dsAFRk6ESX" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="dsAFRk6CI8" resolve="mapping" />
                                   </node>
-                                  <node concept="3clFbS" id="dsAFRk6Dl5" role="3clFbx">
-                                    <node concept="3clFbF" id="dsAFRk6GdP" role="3cqZAp">
-                                      <node concept="2OqwBi" id="dsAFRk6GXg" role="3clFbG">
-                                        <node concept="37vLTw" id="dsAFRk6GdO" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="4_qY3E6AIcw" resolve="coverage" />
+                                  <node concept="3AV6Ez" id="dsAFRka_Qp" role="2OqNvi" />
+                                </node>
+                              </node>
+                              <node concept="3clFbS" id="dsAFRk6Dl5" role="3clFbx">
+                                <node concept="3clFbF" id="dsAFRk6GdP" role="3cqZAp">
+                                  <node concept="2OqwBi" id="dsAFRk6GXg" role="3clFbG">
+                                    <node concept="37vLTw" id="dsAFRk6GdO" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="4_qY3E6AIcw" resolve="coverage" />
+                                    </node>
+                                    <node concept="liA8E" id="dsAFRk6HHo" role="2OqNvi">
+                                      <ref role="37wK5l" to="2ahs:RaqQlV4lZg" resolve="coverValue" />
+                                      <node concept="2OqwBi" id="dsAFRk6ImD" role="37wK5m">
+                                        <node concept="37vLTw" id="dsAFRk6I05" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="dsAFRk6CI8" resolve="mapping" />
                                         </node>
-                                        <node concept="liA8E" id="dsAFRk6HHo" role="2OqNvi">
-                                          <ref role="37wK5l" to="2ahs:RaqQlV4lZg" resolve="coverValue" />
-                                          <node concept="2OqwBi" id="dsAFRk6ImD" role="37wK5m">
-                                            <node concept="37vLTw" id="dsAFRk6I05" role="2Oq$k0">
-                                              <ref role="3cqZAo" node="dsAFRk6CI8" resolve="mapping" />
-                                            </node>
-                                            <node concept="3AY5_j" id="dsAFRkaAEM" role="2OqNvi" />
-                                          </node>
-                                          <node concept="10Nm6u" id="dsAFRk6Jx6" role="37wK5m" />
-                                        </node>
+                                        <node concept="3AY5_j" id="dsAFRkaAEM" role="2OqNvi" />
                                       </node>
+                                      <node concept="10Nm6u" id="dsAFRk6Jx6" role="37wK5m" />
                                     </node>
                                   </node>
                                 </node>
                               </node>
-                              <node concept="Rh6nW" id="dsAFRk6CI8" role="1bW2Oz">
-                                <property role="TrG5h" value="mapping" />
-                                <node concept="2jxLKc" id="dsAFRk6CI9" role="1tU5fm" />
-                              </node>
                             </node>
                           </node>
+                          <node concept="Rh6nW" id="dsAFRk6CI8" role="1bW2Oz">
+                            <property role="TrG5h" value="mapping" />
+                            <node concept="2jxLKc" id="dsAFRk6CI9" role="1tU5fm" />
+                          </node>
                         </node>
-                      </node>
-                    </node>
-                    <node concept="3y3z36" id="dsAFRk6upl" role="3clFbw">
-                      <node concept="10Nm6u" id="dsAFRk6uWF" role="3uHU7w" />
-                      <node concept="37vLTw" id="dsAFRk6scd" role="3uHU7B">
-                        <ref role="3cqZAo" node="dsAFRk4B7x" resolve="shortLambdaMapping" />
                       </node>
                     </node>
                   </node>
@@ -1415,7 +1215,7 @@
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="$yb$20l8EB" role="jymVt" />
+    <node concept="2tJIrI" id="1ZCJf$e7mTi" role="jymVt" />
     <node concept="3Tm1VV" id="$yb$20f$a6" role="1B3o_S" />
     <node concept="3uibUv" id="$yb$20ngbt" role="1zkMxy">
       <ref role="3uigEE" node="$yb$20kU6$" resolve="ExecutableValue" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/org.iets3.core.expr.lambda.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/org.iets3.core.expr.lambda.mpl
@@ -111,6 +111,7 @@
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/models/org.iets3.core.expr.tracing.plugin.plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/models/org.iets3.core.expr.tracing.plugin.plugin.mps
@@ -72,6 +72,8 @@
     <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
     <import index="zwau" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.hintsSettings(MPS.Editor/)" />
     <import index="stm0" ref="r:e2d5029d-edd9-44e0-9764-dc3ac8433eaf(org.iets3.core.expr.tracing.editor)" />
+    <import index="zzzn" ref="r:af0af2e7-f7e1-4536-83b5-6bf010d4afd2(org.iets3.core.expr.lambda.structure)" implicit="true" />
+    <import index="5s8v" ref="r:06389a24-a77a-450d-bc88-bccec0aae7d8(org.iets3.core.expr.lambda.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -459,10 +461,14 @@
       </concept>
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
       <concept id="1171310072040" name="jetbrains.mps.lang.smodel.structure.Node_GetContainingRootOperation" flags="nn" index="2Rxl7S" />
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
@@ -535,9 +541,20 @@
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1240424373525" name="jetbrains.mps.baseLanguage.collections.structure.MappingType" flags="in" index="3f3tKP">
+        <child id="1240424397093" name="keyType" index="3f3zw5" />
+        <child id="1240424402756" name="valueType" index="3f3$T$" />
+      </concept>
       <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
+      <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
+        <child id="1197683466920" name="keyType" index="3rvQeY" />
+        <child id="1197683475734" name="valueType" index="3rvSg0" />
+      </concept>
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
+      <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
+      <concept id="1240824834947" name="jetbrains.mps.baseLanguage.collections.structure.ValueAccessOperation" flags="nn" index="3AV6Ez" />
+      <concept id="1240825616499" name="jetbrains.mps.baseLanguage.collections.structure.KeyAccessOperation" flags="nn" index="3AY5_j" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
@@ -6893,55 +6910,62 @@
         </node>
       </node>
       <node concept="3clFbS" id="aplxSIo9Av" role="3clF47">
-        <node concept="3clFbJ" id="5d4VabvUcg5" role="3cqZAp">
-          <node concept="3clFbS" id="5d4VabvUcg7" role="3clFbx">
-            <node concept="1QHqEO" id="aplxSIo9Aw" role="3cqZAp">
-              <node concept="1QHqEC" id="aplxSIo9Ax" role="1QHqEI">
-                <node concept="3clFbS" id="aplxSIo9Ay" role="1bW5cS">
-                  <node concept="3clFbF" id="3UUf8EJuz9x" role="3cqZAp">
-                    <node concept="1rXfSq" id="3UUf8EJuz9w" role="3clFbG">
-                      <ref role="37wK5l" node="3UUf8EJuz9s" resolve="decorateValues" />
-                      <node concept="37vLTw" id="3UUf8EJuz9v" role="37wK5m">
+        <node concept="1QHqEO" id="aplxSIo9Aw" role="3cqZAp">
+          <node concept="1QHqEC" id="aplxSIo9Ax" role="1QHqEI">
+            <node concept="3clFbS" id="aplxSIo9Ay" role="1bW5cS">
+              <node concept="3clFbF" id="3UUf8EJuz9x" role="3cqZAp">
+                <node concept="1rXfSq" id="3UUf8EJuz9w" role="3clFbG">
+                  <ref role="37wK5l" node="3UUf8EJuz9s" resolve="decorateValues" />
+                  <node concept="37vLTw" id="3UUf8EJuz9v" role="37wK5m">
+                    <ref role="3cqZAo" node="aplxSIo9As" resolve="record" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="14bmjk2lwk0" role="3cqZAp">
+                <node concept="3cpWsn" id="14bmjk2lwk1" role="3cpWs9">
+                  <property role="TrG5h" value="mappedNode" />
+                  <node concept="3Tqbb2" id="14bmjk2lnFQ" role="1tU5fm" />
+                  <node concept="1rXfSq" id="14bmjk2lwk2" role="33vP2m">
+                    <ref role="37wK5l" node="6$DR8ogdJGg" resolve="getMappedNode" />
+                    <node concept="2OqwBi" id="14bmjk2lwk3" role="37wK5m">
+                      <node concept="37vLTw" id="14bmjk2lwk4" role="2Oq$k0">
                         <ref role="3cqZAo" node="aplxSIo9As" resolve="record" />
                       </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbF" id="5U8d23Q1hO4" role="3cqZAp">
-                    <node concept="2YIFZM" id="5U8d23Q1hO5" role="3clFbG">
-                      <ref role="37wK5l" to="jpm3:5U8d23Q18RH" resolve="updateEditors" />
-                      <ref role="1Pybhc" to="jpm3:5U8d23Q17BS" resolve="EditorUpdater" />
-                      <node concept="2OqwBi" id="5U8d23Q1hO6" role="37wK5m">
-                        <node concept="37vLTw" id="5U8d23Q1hO7" role="2Oq$k0">
-                          <ref role="3cqZAo" node="aplxSIo9As" resolve="record" />
-                        </node>
-                        <node concept="liA8E" id="5U8d23Q1hO8" role="2OqNvi">
-                          <ref role="37wK5l" to="2ahs:7obiejCcDvt" resolve="getTarget" />
-                        </node>
-                      </node>
-                      <node concept="37vLTw" id="5U8d23Q1hO9" role="37wK5m">
-                        <ref role="3cqZAo" node="aplxSIo9A8" resolve="repository" />
-                      </node>
-                      <node concept="37vLTw" id="5U8d23Q1hOa" role="37wK5m">
-                        <ref role="3cqZAo" node="aplxSIp2SF" resolve="fileEditorManager" />
+                      <node concept="liA8E" id="14bmjk2lwk5" role="2OqNvi">
+                        <ref role="37wK5l" to="2ahs:4fb2DFB6IMb" resolve="getTargetNode" />
                       </node>
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="2OqwBi" id="1xikCT4LFu6" role="ukAjM">
-                <node concept="Xjq3P" id="1xikCT4LEVD" role="2Oq$k0" />
-                <node concept="2OwXpG" id="1xikCT4LG4h" role="2OqNvi">
-                  <ref role="2Oxat5" node="aplxSIo9A8" resolve="repository" />
+              <node concept="3clFbF" id="5U8d23Q1hO4" role="3cqZAp">
+                <node concept="2YIFZM" id="1ZCJf$eejp$" role="3clFbG">
+                  <ref role="37wK5l" to="jpm3:5U8d23Q18RH" resolve="updateEditors" />
+                  <ref role="1Pybhc" to="jpm3:5U8d23Q17BS" resolve="EditorUpdater" />
+                  <node concept="2OqwBi" id="1ZCJf$ehFli" role="37wK5m">
+                    <node concept="liA8E" id="1ZCJf$ehGeB" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SNode.getReference()" resolve="getReference" />
+                    </node>
+                    <node concept="2JrnkZ" id="1ZCJf$ehFln" role="2Oq$k0">
+                      <node concept="37vLTw" id="1ZCJf$ehExj" role="2JrQYb">
+                        <ref role="3cqZAo" node="14bmjk2lwk1" resolve="mappedNode" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="1ZCJf$een63" role="37wK5m">
+                    <ref role="3cqZAo" node="aplxSIo9A8" resolve="repository" />
+                  </node>
+                  <node concept="37vLTw" id="1ZCJf$eejpC" role="37wK5m">
+                    <ref role="3cqZAo" node="aplxSIp2SF" resolve="fileEditorManager" />
+                  </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="2OqwBi" id="5d4VabvUqUb" role="3clFbw">
-            <node concept="37vLTw" id="5d4VabvUqyT" role="2Oq$k0">
-              <ref role="3cqZAo" node="aplxSIo9As" resolve="record" />
-            </node>
-            <node concept="liA8E" id="5d4VabvUrcf" role="2OqNvi">
-              <ref role="37wK5l" to="2ahs:5d4VabvUiEx" resolve="isInAnEditor" />
+          <node concept="2OqwBi" id="1xikCT4LFu6" role="ukAjM">
+            <node concept="Xjq3P" id="1xikCT4LEVD" role="2Oq$k0" />
+            <node concept="2OwXpG" id="1xikCT4LG4h" role="2OqNvi">
+              <ref role="2Oxat5" node="aplxSIo9A8" resolve="repository" />
             </node>
           </node>
         </node>
@@ -6951,6 +6975,157 @@
       </node>
     </node>
     <node concept="2tJIrI" id="3UUf8EJu$5h" role="jymVt" />
+    <node concept="3clFb_" id="6$DR8ogdJGg" role="jymVt">
+      <property role="TrG5h" value="getMappedNode" />
+      <node concept="3clFbS" id="6$DR8ogdJGj" role="3clF47">
+        <node concept="3cpWs8" id="6$DR8ogdNbC" role="3cqZAp">
+          <node concept="3cpWsn" id="6$DR8ogdNbF" role="3cpWs9">
+            <property role="TrG5h" value="returnNode" />
+            <node concept="3Tqbb2" id="6$DR8ogdNbB" role="1tU5fm" />
+            <node concept="37vLTw" id="6$DR8ogdQFw" role="33vP2m">
+              <ref role="3cqZAo" node="6$DR8ogdKXS" resolve="recordNode" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1ZCJf$ekpXp" role="3cqZAp">
+          <node concept="3cpWsn" id="1ZCJf$ekpXq" role="3cpWs9">
+            <property role="TrG5h" value="lambdaNode" />
+            <node concept="3Tqbb2" id="1ZCJf$ekp_F" role="1tU5fm">
+              <ref role="ehGHo" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
+            </node>
+            <node concept="2OqwBi" id="1ZCJf$ekpXr" role="33vP2m">
+              <node concept="37vLTw" id="1ZCJf$ekpXs" role="2Oq$k0">
+                <ref role="3cqZAo" node="6$DR8ogdKXS" resolve="recordNode" />
+              </node>
+              <node concept="2Xjw5R" id="1ZCJf$ekpXt" role="2OqNvi">
+                <node concept="1xMEDy" id="1ZCJf$ekpXu" role="1xVPHs">
+                  <node concept="chp4Y" id="1ZCJf$ekpXv" role="ri$Ld">
+                    <ref role="cht4Q" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="14bmjk2mUKI" role="3cqZAp">
+          <node concept="3clFbS" id="14bmjk2mUKK" role="3clFbx">
+            <node concept="3cpWs6" id="14bmjk2n5Jh" role="3cqZAp">
+              <node concept="37vLTw" id="14bmjk2n8aR" role="3cqZAk">
+                <ref role="3cqZAo" node="6$DR8ogdNbF" resolve="returnNode" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="14bmjk2n1kD" role="3clFbw">
+            <node concept="10Nm6u" id="14bmjk2n3o$" role="3uHU7w" />
+            <node concept="37vLTw" id="14bmjk2mW$t" role="3uHU7B">
+              <ref role="3cqZAo" node="1ZCJf$ekpXq" resolve="lambdaNode" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1ZCJf$ek$5X" role="3cqZAp">
+          <node concept="3cpWsn" id="1ZCJf$ek$5Y" role="3cpWs9">
+            <property role="TrG5h" value="m" />
+            <node concept="3rvAFt" id="1ZCJf$ekzKU" role="1tU5fm">
+              <node concept="3Tqbb2" id="1ZCJf$ekzKZ" role="3rvQeY" />
+              <node concept="3Tqbb2" id="1ZCJf$ekzL0" role="3rvSg0" />
+            </node>
+            <node concept="2OqwBi" id="1ZCJf$ek$5Z" role="33vP2m">
+              <node concept="37vLTw" id="1ZCJf$ek$60" role="2Oq$k0">
+                <ref role="3cqZAo" node="1ZCJf$ekpXq" resolve="lambdaNode" />
+              </node>
+              <node concept="2qgKlT" id="1ZCJf$ek$61" role="2OqNvi">
+                <ref role="37wK5l" to="5s8v:3u8VfJfplfS" resolve="getNodeMapping" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6$DR8oge3xE" role="3cqZAp">
+          <node concept="3clFbS" id="6$DR8oge3xG" role="3clFbx">
+            <node concept="3cpWs8" id="6$DR8ogerro" role="3cqZAp">
+              <node concept="3cpWsn" id="6$DR8ogerrp" role="3cpWs9">
+                <property role="TrG5h" value="mv" />
+                <node concept="3f3tKP" id="6$DR8ogerdF" role="1tU5fm">
+                  <node concept="3Tqbb2" id="6$DR8ogerdL" role="3f3zw5" />
+                  <node concept="3Tqbb2" id="6$DR8ogerdK" role="3f3$T$" />
+                </node>
+                <node concept="2OqwBi" id="6$DR8ogerrq" role="33vP2m">
+                  <node concept="37vLTw" id="6$DR8ogerrr" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1ZCJf$ek$5Y" resolve="m" />
+                  </node>
+                  <node concept="1z4cxt" id="6$DR8ogerrs" role="2OqNvi">
+                    <node concept="1bVj0M" id="6$DR8ogerrt" role="23t8la">
+                      <node concept="3clFbS" id="6$DR8ogerru" role="1bW5cS">
+                        <node concept="3clFbF" id="6$DR8ogerrv" role="3cqZAp">
+                          <node concept="3clFbC" id="14bmjk2lloU" role="3clFbG">
+                            <node concept="2OqwBi" id="14bmjk2lloX" role="3uHU7B">
+                              <node concept="37vLTw" id="14bmjk2lloY" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6$DR8ogerr_" resolve="it" />
+                              </node>
+                              <node concept="3AV6Ez" id="14bmjk2lloZ" role="2OqNvi" />
+                            </node>
+                            <node concept="37vLTw" id="14bmjk2lloW" role="3uHU7w">
+                              <ref role="3cqZAo" node="6$DR8ogdKXS" resolve="recordNode" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Rh6nW" id="6$DR8ogerr_" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="6$DR8ogerrA" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="6$DR8ogewXH" role="3cqZAp">
+              <node concept="3clFbS" id="6$DR8ogewXJ" role="3clFbx">
+                <node concept="3clFbF" id="14bmjk2meuT" role="3cqZAp">
+                  <node concept="37vLTI" id="14bmjk2mfzW" role="3clFbG">
+                    <node concept="37vLTw" id="14bmjk2meuR" role="37vLTJ">
+                      <ref role="3cqZAo" node="6$DR8ogdNbF" resolve="returnNode" />
+                    </node>
+                    <node concept="1rXfSq" id="14bmjk2ma5d" role="37vLTx">
+                      <ref role="37wK5l" node="6$DR8ogdJGg" resolve="getMappedNode" />
+                      <node concept="2OqwBi" id="14bmjk2maww" role="37wK5m">
+                        <node concept="37vLTw" id="14bmjk2mawx" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6$DR8ogerrp" resolve="mv" />
+                        </node>
+                        <node concept="3AY5_j" id="14bmjk2mawy" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3y3z36" id="6$DR8ogeASx" role="3clFbw">
+                <node concept="10Nm6u" id="6$DR8ogeCjM" role="3uHU7w" />
+                <node concept="37vLTw" id="6$DR8ogeA09" role="3uHU7B">
+                  <ref role="3cqZAo" node="6$DR8ogerrp" resolve="mv" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="1ZCJf$ekF4A" role="3clFbw">
+            <node concept="10Nm6u" id="1ZCJf$ekGEB" role="3uHU7w" />
+            <node concept="37vLTw" id="1ZCJf$ekEd4" role="3uHU7B">
+              <ref role="3cqZAo" node="1ZCJf$ek$5Y" resolve="m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6$DR8oge8Qo" role="3cqZAp">
+          <node concept="37vLTw" id="6$DR8ogeaQB" role="3cqZAk">
+            <ref role="3cqZAo" node="6$DR8ogdNbF" resolve="returnNode" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="6$DR8ogdH4P" role="1B3o_S" />
+      <node concept="3Tqbb2" id="6$DR8ogdJDL" role="3clF45" />
+      <node concept="37vLTG" id="6$DR8ogdKXS" role="3clF46">
+        <property role="TrG5h" value="recordNode" />
+        <node concept="3Tqbb2" id="6$DR8ogdKXR" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6$DR8ogdEqI" role="jymVt" />
     <node concept="3clFb_" id="3UUf8EJuz9s" role="jymVt">
       <property role="TrG5h" value="decorateValues" />
       <node concept="3Tm6S6" id="3UUf8EJuz9t" role="1B3o_S" />
@@ -7136,14 +7311,26 @@
                 </node>
                 <node concept="3clFbJ" id="YcTL0unsf" role="3cqZAp">
                   <node concept="3clFbS" id="YcTL0unsh" role="3clFbx">
+                    <node concept="3cpWs8" id="1ZCJf$ei1bV" role="3cqZAp">
+                      <node concept="3cpWsn" id="1ZCJf$ei1bY" role="3cpWs9">
+                        <property role="TrG5h" value="mappedNode" />
+                        <node concept="3Tqbb2" id="1ZCJf$ei1bZ" role="1tU5fm" />
+                        <node concept="1rXfSq" id="1ZCJf$ei1c0" role="33vP2m">
+                          <ref role="37wK5l" node="6$DR8ogdJGg" resolve="getMappedNode" />
+                          <node concept="2GrUjf" id="1ZCJf$ei3dv" role="37wK5m">
+                            <ref role="2Gs0qQ" node="3UUf8EJuz8J" resolve="n" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
                     <node concept="3clFbF" id="3UUf8EJuz9j" role="3cqZAp">
                       <node concept="2YIFZM" id="3UUf8EJuz9k" role="3clFbG">
                         <ref role="1Pybhc" to="2gm9:aplxSInHuZ" resolve="TracingValue" />
                         <ref role="37wK5l" to="2gm9:aplxSInIhj" resolve="set" />
-                        <node concept="2GrUjf" id="4fb2DFB6N7r" role="37wK5m">
-                          <ref role="2Gs0qQ" node="3UUf8EJuz8J" resolve="n" />
-                        </node>
                         <node concept="37vLTw" id="3UUf8EJuz9m" role="37wK5m">
+                          <ref role="3cqZAo" node="1ZCJf$ei1bY" resolve="mappedNode" />
+                        </node>
+                        <node concept="37vLTw" id="1ZCJf$eh1RX" role="37wK5m">
                           <ref role="3cqZAo" node="3UUf8EJuz98" resolve="v" />
                         </node>
                       </node>
@@ -7164,7 +7351,6 @@
                 </node>
               </node>
             </node>
-            <node concept="3clFbH" id="7lHetQxM71p" role="3cqZAp" />
           </node>
           <node concept="2OqwBi" id="4fb2DFB6MtL" role="2GsD0m">
             <node concept="37vLTw" id="4fb2DFB6Mn5" role="2Oq$k0">
@@ -7206,16 +7392,35 @@
                   </node>
                 </node>
               </node>
+              <node concept="3cpWs8" id="1ZCJf$ehGT3" role="3cqZAp">
+                <node concept="3cpWsn" id="1ZCJf$ehGT4" role="3cpWs9">
+                  <property role="TrG5h" value="mappedNode" />
+                  <node concept="3Tqbb2" id="1ZCJf$ehGT5" role="1tU5fm" />
+                  <node concept="1rXfSq" id="1ZCJf$ehGT6" role="33vP2m">
+                    <ref role="37wK5l" node="6$DR8ogdJGg" resolve="getMappedNode" />
+                    <node concept="2OqwBi" id="1ZCJf$ehGT7" role="37wK5m">
+                      <node concept="37vLTw" id="1ZCJf$ehGT8" role="2Oq$k0">
+                        <ref role="3cqZAo" node="aplxSIo9Bt" resolve="record" />
+                      </node>
+                      <node concept="liA8E" id="1ZCJf$ehGT9" role="2OqNvi">
+                        <ref role="37wK5l" to="2ahs:4fb2DFB6IMb" resolve="getTargetNode" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
               <node concept="3clFbF" id="5U8d23Q1hxO" role="3cqZAp">
                 <node concept="2YIFZM" id="5U8d23Q1hxP" role="3clFbG">
                   <ref role="1Pybhc" to="jpm3:5U8d23Q17BS" resolve="EditorUpdater" />
                   <ref role="37wK5l" to="jpm3:5U8d23Q18RH" resolve="updateEditors" />
-                  <node concept="2OqwBi" id="5U8d23Q1hxQ" role="37wK5m">
-                    <node concept="37vLTw" id="5U8d23Q1hxR" role="2Oq$k0">
-                      <ref role="3cqZAo" node="aplxSIo9Bt" resolve="record" />
+                  <node concept="2OqwBi" id="1ZCJf$ei97H" role="37wK5m">
+                    <node concept="liA8E" id="1ZCJf$eia65" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SNode.getReference()" resolve="getReference" />
                     </node>
-                    <node concept="liA8E" id="5U8d23Q1hxS" role="2OqNvi">
-                      <ref role="37wK5l" to="2ahs:7obiejCcDvt" resolve="getTarget" />
+                    <node concept="2JrnkZ" id="1ZCJf$ei97M" role="2Oq$k0">
+                      <node concept="37vLTw" id="1ZCJf$ei8c0" role="2JrQYb">
+                        <ref role="3cqZAo" node="1ZCJf$ehGT4" resolve="mappedNode" />
+                      </node>
                     </node>
                   </node>
                   <node concept="37vLTw" id="5U8d23Q1hxT" role="37wK5m">
@@ -7288,12 +7493,24 @@
             <property role="TrG5h" value="n" />
           </node>
           <node concept="3clFbS" id="7cNsFS_fPsO" role="2LFqv$">
+            <node concept="3cpWs8" id="1ZCJf$ehUXT" role="3cqZAp">
+              <node concept="3cpWsn" id="1ZCJf$ehUXU" role="3cpWs9">
+                <property role="TrG5h" value="mappedNode" />
+                <node concept="3Tqbb2" id="1ZCJf$ehUXV" role="1tU5fm" />
+                <node concept="1rXfSq" id="1ZCJf$ehUXW" role="33vP2m">
+                  <ref role="37wK5l" node="6$DR8ogdJGg" resolve="getMappedNode" />
+                  <node concept="2GrUjf" id="1ZCJf$ehXN7" role="37wK5m">
+                    <ref role="2Gs0qQ" node="7cNsFS_fPsN" resolve="n" />
+                  </node>
+                </node>
+              </node>
+            </node>
             <node concept="3clFbF" id="7cNsFS_fPsV" role="3cqZAp">
               <node concept="2YIFZM" id="7cNsFS_fPxV" role="3clFbG">
                 <ref role="37wK5l" to="2gm9:aplxSIo$id" resolve="unset" />
                 <ref role="1Pybhc" to="2gm9:aplxSInHuZ" resolve="TracingValue" />
-                <node concept="2GrUjf" id="7cNsFS_fPxW" role="37wK5m">
-                  <ref role="2Gs0qQ" node="7cNsFS_fPsN" resolve="n" />
+                <node concept="37vLTw" id="1ZCJf$ehSSA" role="37wK5m">
+                  <ref role="3cqZAo" node="1ZCJf$ehUXU" resolve="mappedNode" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/org.iets3.core.expr.tracing.plugin.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/org.iets3.core.expr.tracing.plugin.msd
@@ -90,7 +90,6 @@
     <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
-    <module reference="a1250a4d-c090-42c3-ad7c-d298a3357dd4(jetbrains.mps.make.runtime)" version="0" />
     <module reference="8fe4c62a-2020-4ff4-8eda-f322a55bdc9f(jetbrains.mps.refactoring.runtime)" version="0" />
     <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="1" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />


### PR DESCRIPTION
addresses issue: #1032 

Values of nodes in lambda expression are used decorate the corresponding editor nodes.
 