### PR TITLE
TraceExplorer: weakens too restricted interface again (#1032)

### DIFF
--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/models/org.iets3.core.expr.tracing.plugin.plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/models/org.iets3.core.expr.tracing.plugin.plugin.mps
@@ -7683,14 +7683,21 @@
         <node concept="3uibUv" id="2a_JeWFLjVf" role="1tU5fm">
           <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
         </node>
-        <node concept="2AHcQZ" id="2a_JeWFLjVg" role="2AJF6D">
-          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="2a_JeWFLjVh" role="2AJF6D">
-        <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
       </node>
       <node concept="3clFbS" id="2a_JeWFLjVi" role="3clF47">
+        <node concept="3clFbJ" id="6fyeJ0bjmGv" role="3cqZAp">
+          <node concept="3clFbS" id="6fyeJ0bjmGx" role="3clFbx">
+            <node concept="3cpWs6" id="6fyeJ0bjs7f" role="3cqZAp">
+              <node concept="10Nm6u" id="6fyeJ0bjuE4" role="3cqZAk" />
+            </node>
+          </node>
+          <node concept="3clFbC" id="6fyeJ0bjpeH" role="3clFbw">
+            <node concept="10Nm6u" id="6fyeJ0bjq5K" role="3uHU7w" />
+            <node concept="37vLTw" id="6fyeJ0bjoA7" role="3uHU7B">
+              <ref role="3cqZAo" node="2a_JeWFLjVe" resolve="givenNode" />
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="2a_JeWFLmG0" role="3cqZAp">
           <node concept="3cpWsn" id="2a_JeWFLmG1" role="3cpWs9">
             <property role="TrG5h" value="node" />


### PR DESCRIPTION
addresses issue: #1032 

This PR is required to get the changes (for the TraceExplorer) in mps20223 versions and upwards.
(These were cherry picked from datev-loon-staging-20222)