### PR TITLE
gradle: fixed mps-qa version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ def minor = "2"
 ext.mpsVersion = '2022.2.3'
 
 def mbeddrVersion = "2022.2+"
+def mpsQAVersion = "$major.$minor+"
 
 // if building a against a special branch from mbeddr is required add the name here
 // the name is enough no trailing "." is required, also the plain name from git can
@@ -132,7 +133,7 @@ configurations {
 
 dependencies {
     mps "com.jetbrains:mps:$mpsVersion"
-    languageLibs "org.mpsqa:all-in-one:$mpsVersion+"
+    languageLibs "org.mpsqa:all-in-one:$mpsQAVersion"
     languageLibs "com.mbeddr:platform:$mbeddrVersionSelector"
     junitAnt 'org.apache.ant:ant-junit:1.10.6'
     pcollections 'org.pcollections:pcollections:4.0.1'


### PR DESCRIPTION
The initial dynamic version `2022.2.3+` was always resulting in this mps-qa version: `2022.2.399.d6e4c4b`. 
This is now fixed.