### PR TITLE
physunits: make it possible to replace ÷ automatically with /

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 # September 2024
 
-### Fixes
+### Fixed
 
 - Then precision for number types is now only derived from the finite bounds of the range. The precision of `number[-∞|∞]` is the same as of `number` which is 0.
+
+### Added
+
+- The extension point `IUnitLangConfig` has a new method useSlashInsteadOfDivisionSymbol that allows to replace the "÷" character in unit names with the more common "/" character.
 
 ## August 2024
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/plugin.mps
@@ -363,7 +363,7 @@
                 <ref role="3cqZAo" node="$yb$20fE4t" resolve="le" />
               </node>
               <node concept="2qgKlT" id="3u8VfJfq6pn" role="2OqNvi">
-                <ref role="37wK5l" to="5s8v:3u8VfJfplfS" resolve="getMap" />
+                <ref role="37wK5l" to="5s8v:3u8VfJfplfS" resolve="getNodeMapping" />
               </node>
             </node>
             <node concept="37vLTw" id="3u8VfJfq07l" role="37vLTJ">
@@ -392,7 +392,7 @@
                   <ref role="3cqZAo" node="$yb$20fE4t" resolve="le" />
                 </node>
                 <node concept="2qgKlT" id="1ZCJf$ejg$k" role="2OqNvi">
-                  <ref role="37wK5l" to="5s8v:1ZCJf$ej28Z" resolve="putMap" />
+                  <ref role="37wK5l" to="5s8v:1ZCJf$ej28Z" resolve="putNodeMapping" />
                   <node concept="37vLTw" id="1ZCJf$ejhqU" role="37wK5m">
                     <ref role="3cqZAo" node="dsAFRk0GB0" resolve="mapping" />
                   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
@@ -22196,7 +22196,7 @@
                 <property role="1XhdNS" value="⁰" />
               </node>
               <node concept="37vLTw" id="TXgXqenLB8" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqekvbx" resolve="numberMapping" />
+                <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptMapping" />
               </node>
             </node>
           </node>
@@ -22211,7 +22211,7 @@
                 <property role="1XhdNS" value="¹" />
               </node>
               <node concept="37vLTw" id="TXgXqenLBf" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqekvbx" resolve="numberMapping" />
+                <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptMapping" />
               </node>
             </node>
           </node>
@@ -22226,7 +22226,7 @@
                 <property role="1XhdNS" value="²" />
               </node>
               <node concept="37vLTw" id="TXgXqenLBm" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqekvbx" resolve="numberMapping" />
+                <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptMapping" />
               </node>
             </node>
           </node>
@@ -22241,7 +22241,7 @@
                 <property role="1XhdNS" value="³" />
               </node>
               <node concept="37vLTw" id="TXgXqenLBt" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqekvbx" resolve="numberMapping" />
+                <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptMapping" />
               </node>
             </node>
           </node>
@@ -22256,7 +22256,7 @@
                 <property role="1XhdNS" value="⁴" />
               </node>
               <node concept="37vLTw" id="TXgXqenLB$" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqekvbx" resolve="numberMapping" />
+                <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptMapping" />
               </node>
             </node>
           </node>
@@ -22271,7 +22271,7 @@
                 <property role="1XhdNS" value="⁵" />
               </node>
               <node concept="37vLTw" id="TXgXqenLBF" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqekvbx" resolve="numberMapping" />
+                <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptMapping" />
               </node>
             </node>
           </node>
@@ -22286,7 +22286,7 @@
                 <property role="1XhdNS" value="⁶" />
               </node>
               <node concept="37vLTw" id="TXgXqenLBM" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqekvbx" resolve="numberMapping" />
+                <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptMapping" />
               </node>
             </node>
           </node>
@@ -22301,7 +22301,7 @@
                 <property role="1XhdNS" value="⁷" />
               </node>
               <node concept="37vLTw" id="TXgXqenLBT" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqekvbx" resolve="numberMapping" />
+                <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptMapping" />
               </node>
             </node>
           </node>
@@ -22316,7 +22316,7 @@
                 <property role="1XhdNS" value="⁸" />
               </node>
               <node concept="37vLTw" id="TXgXqenLC0" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqekvbx" resolve="numberMapping" />
+                <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptMapping" />
               </node>
             </node>
           </node>
@@ -22331,7 +22331,7 @@
                 <property role="1XhdNS" value="⁹" />
               </node>
               <node concept="37vLTw" id="TXgXqenLC7" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqekvbx" resolve="numberMapping" />
+                <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptMapping" />
               </node>
             </node>
           </node>
@@ -22660,7 +22660,7 @@
                 <property role="1XhdNS" value="ᵅ" />
               </node>
               <node concept="37vLTw" id="TXgXqenLCe" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqekvbx" resolve="numberMapping" />
+                <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptMapping" />
               </node>
             </node>
             <node concept="2YIFZM" id="TXgXqeY2ak" role="37vLTx">
@@ -22679,7 +22679,7 @@
                 <property role="1XhdNS" value="ᵝ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXh4O" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptMapping" />
               </node>
             </node>
             <node concept="2YIFZM" id="TXgXqeYiWd" role="37vLTx">
@@ -22698,7 +22698,7 @@
                 <property role="1XhdNS" value="ᵞ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXhZO" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptMapping" />
               </node>
             </node>
             <node concept="2YIFZM" id="TXgXqeYsUc" role="37vLTx">
@@ -22717,7 +22717,7 @@
                 <property role="1XhdNS" value="ᵟ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXim$" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptMapping" />
               </node>
             </node>
             <node concept="2YIFZM" id="TXgXqeYAQ1" role="37vLTx">
@@ -22859,7 +22859,7 @@
                 <property role="1XhdNS" value="₀" />
               </node>
               <node concept="37vLTw" id="TXgXqeWXnc" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZQAt" role="37vLTx">
@@ -22874,7 +22874,7 @@
                 <property role="1XhdNS" value="₁" />
               </node>
               <node concept="37vLTw" id="TXgXqeWYqM" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZQDb" role="37vLTx">
@@ -22889,7 +22889,7 @@
                 <property role="1XhdNS" value="₂" />
               </node>
               <node concept="37vLTw" id="TXgXqeWYBH" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZQFT" role="37vLTx">
@@ -22904,7 +22904,7 @@
                 <property role="1XhdNS" value="₃" />
               </node>
               <node concept="37vLTw" id="TXgXqeWZjO" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZQHM" role="37vLTx">
@@ -22919,7 +22919,7 @@
                 <property role="1XhdNS" value="₄" />
               </node>
               <node concept="37vLTw" id="TXgXqeWZk0" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZQKw" role="37vLTx">
@@ -22934,7 +22934,7 @@
                 <property role="1XhdNS" value="₅" />
               </node>
               <node concept="37vLTw" id="TXgXqeWZLj" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZQNe" role="37vLTx">
@@ -22949,7 +22949,7 @@
                 <property role="1XhdNS" value="₆" />
               </node>
               <node concept="37vLTw" id="TXgXqeWZXm" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZQPW" role="37vLTx">
@@ -22964,7 +22964,7 @@
                 <property role="1XhdNS" value="₇" />
               </node>
               <node concept="37vLTw" id="TXgXqeWZXy" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZR5y" role="37vLTx">
@@ -22979,7 +22979,7 @@
                 <property role="1XhdNS" value="₈" />
               </node>
               <node concept="37vLTw" id="TXgXqeX0au" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZR8g" role="37vLTx">
@@ -22994,7 +22994,7 @@
                 <property role="1XhdNS" value="₉" />
               </node>
               <node concept="37vLTw" id="TXgXqeX0mS" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZRaY" role="37vLTx">
@@ -23040,7 +23040,7 @@
                 <property role="1XhdNS" value="ₐ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXbwX" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZRLC" role="37vLTx">
@@ -23055,7 +23055,7 @@
                 <property role="1XhdNS" value="ₑ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXc3f" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZRNx" role="37vLTx">
@@ -23070,7 +23070,7 @@
                 <property role="1XhdNS" value="ₕ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXc3r" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZRPq" role="37vLTx">
@@ -23085,7 +23085,7 @@
                 <property role="1XhdNS" value="ᵢ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXc3B" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZRRj" role="37vLTx">
@@ -23100,7 +23100,7 @@
                 <property role="1XhdNS" value="ⱼ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXc3N" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZRTc" role="37vLTx">
@@ -23115,7 +23115,7 @@
                 <property role="1XhdNS" value="ₖ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXc3Z" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZRV5" role="37vLTx">
@@ -23130,7 +23130,7 @@
                 <property role="1XhdNS" value="ₗ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXcXb" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZRWY" role="37vLTx">
@@ -23145,7 +23145,7 @@
                 <property role="1XhdNS" value="ₘ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXdbY" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZRYR" role="37vLTx">
@@ -23160,7 +23160,7 @@
                 <property role="1XhdNS" value="ₙ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXdca" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZS0K" role="37vLTx">
@@ -23175,7 +23175,7 @@
                 <property role="1XhdNS" value="ₒ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXdcm" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZS2D" role="37vLTx">
@@ -23190,7 +23190,7 @@
                 <property role="1XhdNS" value="ₚ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXdcy" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZS4y" role="37vLTx">
@@ -23205,7 +23205,7 @@
                 <property role="1XhdNS" value="ᵣ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXdcI" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZS6r" role="37vLTx">
@@ -23220,7 +23220,7 @@
                 <property role="1XhdNS" value="ₛ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXdcU" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZS8k" role="37vLTx">
@@ -23235,7 +23235,7 @@
                 <property role="1XhdNS" value="ₜ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXdd6" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZSad" role="37vLTx">
@@ -23250,7 +23250,7 @@
                 <property role="1XhdNS" value="ᵤ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXddi" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZSc6" role="37vLTx">
@@ -23265,7 +23265,7 @@
                 <property role="1XhdNS" value="ᵥ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXddu" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZSdZ" role="37vLTx">
@@ -23280,7 +23280,7 @@
                 <property role="1XhdNS" value="ₓ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXddE" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="Xl_RD" id="TXgXqeZSfS" role="37vLTx">
@@ -23295,7 +23295,7 @@
                 <property role="1XhdNS" value="ᵦ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXddQ" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="2YIFZM" id="TXgXqeZZ4_" role="37vLTx">
@@ -23314,7 +23314,7 @@
                 <property role="1XhdNS" value="ᵧ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXde2" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="2YIFZM" id="TXgXqf092Q" role="37vLTx">
@@ -23333,7 +23333,7 @@
                 <property role="1XhdNS" value="ᵨ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXdee" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="2YIFZM" id="TXgXqf0iYX" role="37vLTx">
@@ -23352,7 +23352,7 @@
                 <property role="1XhdNS" value="ᵩ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXdeq" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="2YIFZM" id="TXgXqf0sV7" role="37vLTx">
@@ -23371,7 +23371,7 @@
                 <property role="1XhdNS" value="ᵪ" />
               </node>
               <node concept="37vLTw" id="TXgXqeXdn$" role="3ElQJh">
-                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptNumberMapping" />
+                <ref role="3cqZAo" node="TXgXqeWVSs" resolve="subScriptMapping" />
               </node>
             </node>
             <node concept="2YIFZM" id="TXgXqf0ARj" role="37vLTx">
@@ -23394,7 +23394,7 @@
                 <property role="Xl_RC" value="÷" />
               </node>
               <node concept="37vLTw" id="TXgXqd59w2" role="3ElQJh">
-                <ref role="3cqZAo" node="WySbq1M6uf" resolve="nameReplacements" />
+                <ref role="3cqZAo" node="WySbq1M6uf" resolve="specialReplacements" />
               </node>
             </node>
           </node>
@@ -23407,7 +23407,7 @@
                 <property role="Xl_RC" value="⋅" />
               </node>
               <node concept="37vLTw" id="TXgXqd59w8" role="3ElQJh">
-                <ref role="3cqZAo" node="WySbq1M6uf" resolve="nameReplacements" />
+                <ref role="3cqZAo" node="WySbq1M6uf" resolve="specialReplacements" />
               </node>
             </node>
           </node>
@@ -23422,7 +23422,7 @@
                 <property role="Xl_RC" value="μ" />
               </node>
               <node concept="37vLTw" id="TXgXqd778u" role="3ElQJh">
-                <ref role="3cqZAo" node="WySbq1M6uf" resolve="nameReplacements" />
+                <ref role="3cqZAo" node="WySbq1M6uf" resolve="specialReplacements" />
               </node>
             </node>
           </node>
@@ -23437,7 +23437,7 @@
                 <property role="Xl_RC" value="µ" />
               </node>
               <node concept="37vLTw" id="TXgXqd7d6m" role="3ElQJh">
-                <ref role="3cqZAo" node="WySbq1M6uf" resolve="nameReplacements" />
+                <ref role="3cqZAo" node="WySbq1M6uf" resolve="specialReplacements" />
               </node>
             </node>
           </node>
@@ -23593,7 +23593,7 @@
                           <ref role="3cqZAo" node="TXgXqelo4L" resolve="c" />
                         </node>
                         <node concept="37vLTw" id="TXgXqelurX" role="3ElQJh">
-                          <ref role="3cqZAo" node="TXgXqekvbx" resolve="numberMapping" />
+                          <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptMapping" />
                         </node>
                       </node>
                     </node>
@@ -23602,7 +23602,7 @@
               </node>
               <node concept="2OqwBi" id="TXgXqelrJS" role="3clFbw">
                 <node concept="37vLTw" id="TXgXqelrlx" role="2Oq$k0">
-                  <ref role="3cqZAo" node="TXgXqekvbx" resolve="numberMapping" />
+                  <ref role="3cqZAo" node="TXgXqekvbx" resolve="superScriptMapping" />
                 </node>
                 <node concept="2Nt0df" id="TXgXqelso5" role="2OqNvi">
                   <node concept="37vLTw" id="TXgXqelsuX" role="38cxEo">
@@ -23740,13 +23740,13 @@
                       <node concept="37vLTI" id="TXgXqf0Mr3" role="3clFbG">
                         <node concept="3clFbT" id="TXgXqf0Mr4" role="37vLTx" />
                         <node concept="37vLTw" id="TXgXqf0Mr5" role="37vLTJ">
-                          <ref role="3cqZAo" node="TXgXqf0MqC" resolve="needsCaret" />
+                          <ref role="3cqZAo" node="TXgXqf0MqC" resolve="needsUnderScore" />
                         </node>
                       </node>
                     </node>
                   </node>
                   <node concept="37vLTw" id="TXgXqf0Mr6" role="3clFbw">
-                    <ref role="3cqZAo" node="TXgXqf0MqC" resolve="needsCaret" />
+                    <ref role="3cqZAo" node="TXgXqf0MqC" resolve="needsUnderScore" />
                   </node>
                 </node>
                 <node concept="3clFbF" id="TXgXqf0Mr7" role="3cqZAp">
@@ -23855,7 +23855,7 @@
               </node>
               <node concept="Rm8GO" id="TXgXqfDWje" role="37wK5m">
                 <ref role="Rm8GQ" to="25x5:~Normalizer$Form.NFD" resolve="NFD" />
-                <ref role="1Px2BO" to="25x5:~Normalizer$Form" resolve="Form" />
+                <ref role="1Px2BO" to="25x5:~Normalizer$Form" resolve="Normalizer.Form" />
               </node>
             </node>
             <node concept="liA8E" id="TXgXqfDYlB" role="2OqNvi">
@@ -23886,7 +23886,7 @@
             <property role="TrG5h" value="result" />
             <node concept="17QB3L" id="3txiG6nDahr" role="1tU5fm" />
             <node concept="1rXfSq" id="TXgXqfE1yW" role="33vP2m">
-              <ref role="37wK5l" node="TXgXqfDTRo" resolve="replaceSpecialCharacters" />
+              <ref role="37wK5l" node="TXgXqfDTRo" resolve="removeAccents" />
               <node concept="2YIFZM" id="TXgXqdIWul" role="37wK5m">
                 <ref role="37wK5l" node="TXgXqdzCxH" resolve="toGreeklish" />
                 <ref role="1Pybhc" node="TXgXqdzCkF" resolve="Greeklish" />
@@ -23943,7 +23943,7 @@
               </node>
             </node>
             <node concept="37vLTw" id="TXgXqd59wk" role="2Oq$k0">
-              <ref role="3cqZAo" node="WySbq1M6uf" resolve="nameReplacements" />
+              <ref role="3cqZAo" node="WySbq1M6uf" resolve="specialReplacements" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.constraints.mps
@@ -56,6 +56,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
@@ -680,12 +681,55 @@
               </node>
             </node>
           </node>
-          <node concept="3cpWs6" id="3xwfj1ivz4w" role="3cqZAp">
-            <node concept="2OqwBi" id="3xwfj1ivAwP" role="3cqZAk">
-              <node concept="EsrRn" id="3xwfj1ivzaR" role="2Oq$k0" />
-              <node concept="3TrcHB" id="3xwfj1ivB96" role="2OqNvi">
-                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+          <node concept="3cpWs8" id="7YLtdEiHQuU" role="3cqZAp">
+            <node concept="3cpWsn" id="7YLtdEiHQuX" role="3cpWs9">
+              <property role="TrG5h" value="name" />
+              <node concept="17QB3L" id="7YLtdEiHQuS" role="1tU5fm" />
+              <node concept="2OqwBi" id="7YLtdEiHR0P" role="33vP2m">
+                <node concept="EsrRn" id="7YLtdEiHQz9" role="2Oq$k0" />
+                <node concept="3TrcHB" id="7YLtdEiHRCB" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                </node>
               </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="7YLtdEiHMZb" role="3cqZAp">
+            <node concept="3clFbS" id="7YLtdEiHMZd" role="3clFbx">
+              <node concept="3clFbF" id="7YLtdEiHS2Z" role="3cqZAp">
+                <node concept="37vLTI" id="7YLtdEiHT6x" role="3clFbG">
+                  <node concept="2OqwBi" id="7YLtdEiHTxM" role="37vLTx">
+                    <node concept="37vLTw" id="7YLtdEiHTq5" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7YLtdEiHQuX" resolve="name" />
+                    </node>
+                    <node concept="liA8E" id="7YLtdEiHTWN" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.replaceAll(java.lang.String,java.lang.String)" resolve="replaceAll" />
+                      <node concept="Xl_RD" id="7YLtdEiHU0o" role="37wK5m">
+                        <property role="Xl_RC" value="÷" />
+                      </node>
+                      <node concept="Xl_RD" id="7YLtdEiHUPp" role="37wK5m">
+                        <property role="Xl_RC" value="/" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="7YLtdEiHS2Y" role="37vLTJ">
+                    <ref role="3cqZAo" node="7YLtdEiHQuX" resolve="name" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7YLtdEiHNcS" role="3clFbw">
+              <node concept="2YIFZM" id="7YLtdEiHN4g" role="2Oq$k0">
+                <ref role="37wK5l" to="65nr:4qv99IrBnzk" resolve="getConfig" />
+                <ref role="1Pybhc" to="65nr:4qv99IrBkzE" resolve="PhysUnitLangConfigHelper" />
+              </node>
+              <node concept="liA8E" id="7YLtdEiHNlQ" role="2OqNvi">
+                <ref role="37wK5l" to="65nr:7YLtdEiEmwu" resolve="useSlashInsteadOfDivisionSymbol" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="3xwfj1ivz4w" role="3cqZAp">
+            <node concept="37vLTw" id="7YLtdEiHRYu" role="3cqZAk">
+              <ref role="3cqZAo" node="7YLtdEiHQuX" resolve="name" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.plugin.mps
@@ -968,6 +968,25 @@
       </node>
       <node concept="2JFqV2" id="3xwfj1iEU_N" role="2frcjj" />
     </node>
+    <node concept="2tJIrI" id="7YLtdEiElzJ" role="jymVt" />
+    <node concept="3clFb_" id="7YLtdEiEmwu" role="jymVt">
+      <property role="TrG5h" value="useSlashInsteadOfDivisionSymbol" />
+      <node concept="3clFbS" id="7YLtdEiEmwx" role="3clF47">
+        <node concept="3clFbF" id="7YLtdEiEmXl" role="3cqZAp">
+          <node concept="3clFbT" id="7YLtdEiEmXk" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7YLtdEiEmwy" role="1B3o_S" />
+      <node concept="10P_77" id="7YLtdEiEmfA" role="3clF45" />
+      <node concept="2JFqV2" id="7YLtdEiElLB" role="2frcjj" />
+      <node concept="P$JXv" id="7YLtdEiEn2X" role="lGtFl">
+        <node concept="TZ5HA" id="7YLtdEiEn2Y" role="TZ5H$">
+          <node concept="1dT_AC" id="7YLtdEiEn2Z" role="1dT_Ay">
+            <property role="1dT_AB" value="Returns true if &quot;/&quot; should be used in unit names instead of &quot;÷&quot;" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="3xwfj1imSXs" role="jymVt" />
     <node concept="3clFb_" id="3wrpJuqrQh9" role="jymVt">
       <property role="TrG5h" value="implicitConversionIsEnabled" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/models/org.iets3.core.expr.tracing.plugin.plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/models/org.iets3.core.expr.tracing.plugin.plugin.mps
@@ -7739,7 +7739,7 @@
           <node concept="3clFbC" id="2a_JeWFLt3g" role="3clFbw">
             <node concept="10Nm6u" id="2a_JeWFLu5p" role="3uHU7w" />
             <node concept="37vLTw" id="2a_JeWFLsiP" role="3uHU7B">
-              <ref role="3cqZAo" node="2a_JeWFLo38" resolve="lambdaExpression" />
+              <ref role="3cqZAo" node="2a_JeWFLo38" resolve="lambdaNode" />
             </node>
           </node>
         </node>
@@ -7849,7 +7849,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="2a_JeWFLjVj" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.phyunits.si/models/org.iets3.core.expr.typetags.phyunits.si.units.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.phyunits.si/models/org.iets3.core.expr.typetags.phyunits.si.units.mps
@@ -2019,7 +2019,7 @@
             <ref role="CIi3I" node="3xM68GMigWr" resolve="m" />
           </node>
           <node concept="CIsvn" id="70JbBC7emSa" role="wW812">
-            <ref role="CIi3I" node="6EvkZrMO9va" resolve="V÷m" />
+            <ref role="CIi3I" node="6EvkZrMO9va" resolve="V/m" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.linters/models/org.iets3.opensource.linters.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.linters/models/org.iets3.opensource.linters.mps
@@ -139,10 +139,10 @@
       </concept>
       <concept id="2555875871752198907" name="org.mpsqa.lint.generic.structure.ConceptFunctionParameter_MPSProject" flags="ng" index="1MG55F" />
       <concept id="2555875871751836213" name="org.mpsqa.lint.generic.structure.CheckableScript" flags="ng" index="1MIHA_">
-        <child id="1716492013482699988" name="checkingClosure" index="14J5yK" />
-        <child id="2555875871751847640" name="explanation" index="1MIJl8" />
+        <child id="1716492013482699988" name="check" index="14J5yK" />
+        <child id="2555875871751847640" name="documentation" index="1MIJl8" />
       </concept>
-      <concept id="2555875871751904530" name="org.mpsqa.lint.generic.structure.CheckingFunction" flags="ig" index="1MIXq2" />
+      <concept id="2555875871751904530" name="org.mpsqa.lint.generic.structure.GenericCheckingFunction" flags="ig" index="1MIXq2" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.phyunits@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.phyunits@tests.mps
@@ -10837,25 +10837,25 @@
                 <node concept="2rqxmr" id="42$mjgfpDOs" role="lGtFl">
                   <ref role="1BTHP0" to="8ps7:3xM68GMigWr" resolve="m" />
                   <node concept="3KTrbX" id="1eut2v2Jblj" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBC4QW1j" resolve="m÷s" />
+                    <ref role="3AHY9a" to="8ps7:70JbBC4QW1j" resolve="m/s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jblk" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrNU6Dt" resolve="K⁻¹" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbll" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrNT_HS" resolve="W÷(m⋅K)" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrNT_HS" resolve="W/(m⋅K)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jblm" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3xM68GMigYQ" resolve="rad" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbln" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMy$P$" resolve="m³÷mol" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMy$P$" resolve="m³/mol" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jblo" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi1zV" resolve="N⋅m⋅s÷kg" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi1zV" resolve="N⋅m⋅s/kg" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jblp" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi6ys" resolve="W÷(sr⋅m)" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi6ys" resolve="W/(sr⋅m)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jblq" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrMOlo$" resolve="Ω⋅m" />
@@ -10870,10 +10870,10 @@
                     <ref role="3AHY9a" to="8ps7:3xM68GMih0a" resolve="T" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jblu" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMyTlk" resolve="S⋅m²÷mol" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMyTlk" resolve="S⋅m²/mol" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jblv" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMOlUr" resolve="J÷T" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMOlUr" resolve="J/T" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jblw" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrMOSiZ" resolve="Wb⋅m" />
@@ -10882,16 +10882,16 @@
                     <ref role="3AHY9a" to="8ps7:3xM68GMigWr" resolve="m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbly" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0xR" resolve="Gy÷s" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0xR" resolve="Gy/s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jblz" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrLfOxj" resolve="J⋅s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbl$" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBCaPV10" resolve="W÷m³" />
+                    <ref role="3AHY9a" to="8ps7:70JbBCaPV10" resolve="W/m³" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbl_" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMOl7H" resolve="C÷kg" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMOl7H" resolve="C/kg" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblA" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrMOSzZ" resolve="T⋅m" />
@@ -10900,13 +10900,13 @@
                     <ref role="3AHY9a" to="8ps7:70JbBC9kdLY" resolve="m⁻¹" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblC" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrL0D$w" resolve="m÷s" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrL0D$w" resolve="m/s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblD" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLfOEo" resolve="J÷kg" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLfOEo" resolve="J/kg" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblE" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLfONu" resolve="J÷m³" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLfONu" resolve="J/m³" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblF" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrMP3VX" resolve="A⋅rad" />
@@ -10915,7 +10915,7 @@
                     <ref role="3AHY9a" to="8ps7:6EvkZrKS7dV" resolve="ha" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblH" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrNTlg7" resolve="J÷(K⋅kg)" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrNTlg7" resolve="J/(K⋅kg)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblI" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3xM68GMigYL" resolve="Hz" />
@@ -10936,40 +10936,40 @@
                     <ref role="3AHY9a" to="8ps7:14aBVbN55En" resolve="B" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblO" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLfJso" resolve="kg÷m²" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLfJso" resolve="kg/m²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblP" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMyIXO" resolve="J÷(K⋅mol)" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMyIXO" resolve="J/(K⋅mol)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblQ" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrOxRX5" resolve="u" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblR" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMNX_V" resolve="S÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMNX_V" resolve="S/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblS" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3xM68GMigZm" resolve="J" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblT" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLfPeQ" resolve="m²÷s" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLfPeQ" resolve="m²/s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblU" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0Fg" resolve="m÷m³" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0Fg" resolve="m/m³" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblV" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMO8Xv" resolve="F÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMO8Xv" resolve="F/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblW" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLfOof" resolve="m³÷kg" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLfOof" resolve="m³/kg" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblX" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrNU6Yq" resolve="K÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrNU6Yq" resolve="K/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblY" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrKS723" resolve="°" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblZ" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLhVh6" resolve="kg÷s" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLhVh6" resolve="kg/s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbm0" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:14aBVbN55Ep" resolve="b" />
@@ -10993,7 +10993,7 @@
                     <ref role="3AHY9a" to="8ps7:3xM68GMih0s" resolve="lm" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbm7" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLfP5H" resolve="W÷m²" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLfP5H" resolve="W/m²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbm8" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrNFtUu" resolve="lx⋅s" />
@@ -11002,10 +11002,10 @@
                     <ref role="3AHY9a" to="8ps7:3xM68GMigZf" resolve="Pa" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbma" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBC88gSW" resolve="m÷s⁴" />
+                    <ref role="3AHY9a" to="8ps7:70JbBC88gSW" resolve="m/s⁴" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmb" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi05M" resolve="W÷(sr⋅m²)" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi05M" resolve="W/(sr⋅m²)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmc" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrOshH8" resolve="Gal" />
@@ -11023,31 +11023,31 @@
                     <ref role="3AHY9a" to="8ps7:3xM68GMigZr" resolve="W" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmh" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLfOW_" resolve="N÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLfOW_" resolve="N/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmi" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrLfPo0" resolve="Pa⋅s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmj" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLfOfc" resolve="kg÷m³" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLfOfc" resolve="kg/m³" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmk" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrNFuyP" resolve="lm÷W" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrNFuyP" resolve="lm/W" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbml" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMNrvq" resolve="C÷m²" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMNrvq" resolve="C/m²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmm" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLaHz1" resolve="m³÷s" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLaHz1" resolve="m³/s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmn" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrKSbi1" resolve="t" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmo" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi1gY" resolve="J÷m²" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi1gY" resolve="J/m²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmp" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMO9K1" resolve="A÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMO9K1" resolve="A/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmq" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:70JbBC6VE4N" resolve="V" />
@@ -11062,13 +11062,13 @@
                     <ref role="3AHY9a" to="8ps7:FMy9mdSdEf" resolve="B" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmu" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBCa75ni" resolve="W÷m²" />
+                    <ref role="3AHY9a" to="8ps7:70JbBCa75ni" resolve="W/m²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmv" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBCbl6Ny" resolve="A÷m" />
+                    <ref role="3AHY9a" to="8ps7:70JbBCbl6Ny" resolve="A/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmw" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBC9V$B4" resolve="N÷m" />
+                    <ref role="3AHY9a" to="8ps7:70JbBC9V$B4" resolve="N/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmx" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:7F14or$gczd" resolve="B" />
@@ -11083,19 +11083,19 @@
                     <ref role="3AHY9a" to="8ps7:6EvkZrLfrHD" resolve="m²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbm_" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMyTNL" resolve="kg÷mol" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMyTNL" resolve="kg/mol" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbmA" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMyU31" resolve="m³÷(mol⋅s)" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMyU31" resolve="m³/(mol⋅s)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbmB" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBCapJbY" resolve="m²÷s" />
+                    <ref role="3AHY9a" to="8ps7:70JbBCapJbY" resolve="m²/s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbmC" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrL9n4v" resolve="Hz÷s" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrL9n4v" resolve="Hz/s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbmD" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0OE" resolve="W÷m³" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0OE" resolve="W/m³" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbmE" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3xM68GMigWs" resolve="s" />
@@ -11122,28 +11122,28 @@
                     <ref role="3AHY9a" to="8ps7:3xM68GMih0j" resolve="H" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbmM" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0f8" resolve="W÷(sr⋅m³)" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0f8" resolve="W/(sr⋅m³)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbmN" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBCbOELe" resolve="J÷(K⋅kg)" />
+                    <ref role="3AHY9a" to="8ps7:70JbBCbOELe" resolve="J/(K⋅kg)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbmO" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMO9ek" resolve="H÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMO9ek" resolve="H/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbmP" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrO$kho" resolve="var" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbmQ" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrL7D8H" resolve="rad÷s²" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrL7D8H" resolve="rad/s²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbmR" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBC7YcT4" resolve="m÷s³" />
+                    <ref role="3AHY9a" to="8ps7:70JbBC7YcT4" resolve="m/s³" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbmS" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrKS6G2" resolve="au" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbmT" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrNTQbE" resolve="K÷W" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrNTQbE" resolve="K/W" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbmU" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrLf_rV" resolve="N⋅m⋅s" />
@@ -11152,25 +11152,25 @@
                     <ref role="3AHY9a" to="8ps7:3xM68GMih0C" resolve="Bq" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbmW" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrNFueB" resolve="cd÷m²" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrNFueB" resolve="cd/m²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbmX" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBCbCqDR" resolve="J÷K" />
+                    <ref role="3AHY9a" to="8ps7:70JbBCbCqDR" resolve="J/K" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbmY" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:70JbBC5wEk4" resolve="Pa" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbmZ" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMOlDw" resolve="C÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMOlDw" resolve="C/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbn0" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrL6aig" resolve="m÷s²" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrL6aig" resolve="m/s²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbn1" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:70JbBC8k_Ol" resolve="N⋅s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbn2" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMO9va" resolve="V÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMO9va" resolve="V/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbn3" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrNFe93" resolve="lm⋅s" />
@@ -11179,13 +11179,13 @@
                     <ref role="3AHY9a" to="8ps7:6EvkZrKSbem" resolve="l" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbn5" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi6oV" resolve="W÷sr" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi6oV" resolve="W/sr" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbn6" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMOGV5" resolve="Wb÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMOGV5" resolve="Wb/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbn7" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMNAQT" resolve="C÷m³" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMNAQT" resolve="C/m³" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbn8" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrLfJan" resolve="m⁻¹" />
@@ -11194,13 +11194,13 @@
                     <ref role="3AHY9a" to="8ps7:70JbBC9lomP" resolve="m⁻¹" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbna" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrNSOk_" resolve="J÷K" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrNSOk_" resolve="J/K" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbnb" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMOmbn" resolve="m²÷(V⋅s)" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMOmbn" resolve="m²/(V⋅s)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbnc" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLfPxb" resolve="kg÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLfPxb" resolve="kg/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbnd" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrKSbjZ" resolve="Da" />
@@ -11212,13 +11212,13 @@
                     <ref role="3AHY9a" to="8ps7:3xM68GMigWu" resolve="mol" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbng" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMyJd0" resolve="J÷mol" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMyJd0" resolve="J/mol" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbnh" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrL6rgK" resolve="m÷s³" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrL6rgK" resolve="m/s³" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbni" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0ov" resolve="W÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0ov" resolve="W/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbnj" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3xM68GMigZP" resolve="Ω" />
@@ -11227,7 +11227,7 @@
                     <ref role="3AHY9a" to="8ps7:6EvkZrLf_iZ" resolve="N⋅s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbnl" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMyT$w" resolve="mol÷kg" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMyT$w" resolve="mol/kg" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbnm" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:FMy9mdSdEg" resolve="b" />
@@ -11242,13 +11242,13 @@
                     <ref role="3AHY9a" to="8ps7:6EvkZrKS77F" resolve="″" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbnq" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0Y5" resolve="J÷(m²⋅s)" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0Y5" resolve="J/(m²⋅s)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbnr" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrL6GqJ" resolve="m÷s⁴" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrL6GqJ" resolve="m/s⁴" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbns" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMNMep" resolve="A÷m²" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMNMep" resolve="A/m²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbnt" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3xM68GMigWw" resolve="A" />
@@ -11260,13 +11260,13 @@
                     <ref role="3AHY9a" to="8ps7:70JbBC5M$rk" resolve="J" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbnw" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMP4cZ" resolve="m÷H" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMP4cZ" resolve="m/H" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbnx" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3NjH4t$iNJw" resolve="h" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbny" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMe9Xi" resolve="mol÷m³" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMe9Xi" resolve="mol/m³" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbnz" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:70JbBC5NCZ5" resolve="J" />
@@ -11278,7 +11278,7 @@
                     <ref role="3AHY9a" to="8ps7:3NjH4t$iNIu" resolve="min" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JbnA" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrL6XKd" resolve="rad÷s" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrL6XKd" resolve="rad/s" />
                   </node>
                 </node>
               </node>
@@ -11332,25 +11332,25 @@
                 <node concept="2rqxmr" id="42$mjgfs_EZ" role="lGtFl">
                   <ref role="1BTHP0" to="8ps7:3xM68GMih0H" resolve="Gy" />
                   <node concept="3KTrbX" id="1eut2v2JI$o" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBC4QW1j" resolve="m÷s" />
+                    <ref role="3AHY9a" to="8ps7:70JbBC4QW1j" resolve="m/s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$p" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrNU6Dt" resolve="K⁻¹" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$q" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrNT_HS" resolve="W÷(m⋅K)" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrNT_HS" resolve="W/(m⋅K)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$r" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3xM68GMigYQ" resolve="rad" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$s" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMy$P$" resolve="m³÷mol" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMy$P$" resolve="m³/mol" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$t" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi1zV" resolve="N⋅m⋅s÷kg" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi1zV" resolve="N⋅m⋅s/kg" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$u" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi6ys" resolve="W÷(sr⋅m)" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi6ys" resolve="W/(sr⋅m)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$v" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrMOlo$" resolve="Ω⋅m" />
@@ -11365,10 +11365,10 @@
                     <ref role="3AHY9a" to="8ps7:3xM68GMih0a" resolve="T" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$z" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMyTlk" resolve="S⋅m²÷mol" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMyTlk" resolve="S⋅m²/mol" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$$" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMOlUr" resolve="J÷T" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMOlUr" resolve="J/T" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$_" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrMOSiZ" resolve="Wb⋅m" />
@@ -11377,16 +11377,16 @@
                     <ref role="3AHY9a" to="8ps7:3xM68GMigWr" resolve="m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$B" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0xR" resolve="Gy÷s" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0xR" resolve="Gy/s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$C" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrLfOxj" resolve="J⋅s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$D" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBCaPV10" resolve="W÷m³" />
+                    <ref role="3AHY9a" to="8ps7:70JbBCaPV10" resolve="W/m³" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$E" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMOl7H" resolve="C÷kg" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMOl7H" resolve="C/kg" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$F" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrMOSzZ" resolve="T⋅m" />
@@ -11395,13 +11395,13 @@
                     <ref role="3AHY9a" to="8ps7:70JbBC9kdLY" resolve="m⁻¹" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$H" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrL0D$w" resolve="m÷s" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrL0D$w" resolve="m/s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$I" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLfOEo" resolve="J÷kg" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLfOEo" resolve="J/kg" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$J" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLfONu" resolve="J÷m³" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLfONu" resolve="J/m³" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$K" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrMP3VX" resolve="A⋅rad" />
@@ -11410,7 +11410,7 @@
                     <ref role="3AHY9a" to="8ps7:6EvkZrKS7dV" resolve="ha" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$M" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrNTlg7" resolve="J÷(K⋅kg)" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrNTlg7" resolve="J/(K⋅kg)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$N" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3xM68GMigYL" resolve="Hz" />
@@ -11431,40 +11431,40 @@
                     <ref role="3AHY9a" to="8ps7:14aBVbN55En" resolve="B" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$T" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLfJso" resolve="kg÷m²" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLfJso" resolve="kg/m²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$U" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMyIXO" resolve="J÷(K⋅mol)" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMyIXO" resolve="J/(K⋅mol)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$V" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrOxRX5" resolve="u" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$W" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMNX_V" resolve="S÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMNX_V" resolve="S/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$X" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3xM68GMigZm" resolve="J" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$Y" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLfPeQ" resolve="m²÷s" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLfPeQ" resolve="m²/s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$Z" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0Fg" resolve="m÷m³" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0Fg" resolve="m/m³" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_0" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMO8Xv" resolve="F÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMO8Xv" resolve="F/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_1" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLfOof" resolve="m³÷kg" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLfOof" resolve="m³/kg" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_2" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrNU6Yq" resolve="K÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrNU6Yq" resolve="K/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_3" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrKS723" resolve="°" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_4" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLhVh6" resolve="kg÷s" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLhVh6" resolve="kg/s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_5" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:14aBVbN55Ep" resolve="b" />
@@ -11488,7 +11488,7 @@
                     <ref role="3AHY9a" to="8ps7:3xM68GMih0s" resolve="lm" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_c" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLfP5H" resolve="W÷m²" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLfP5H" resolve="W/m²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_d" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrNFtUu" resolve="lx⋅s" />
@@ -11497,10 +11497,10 @@
                     <ref role="3AHY9a" to="8ps7:3xM68GMigZf" resolve="Pa" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_f" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBC88gSW" resolve="m÷s⁴" />
+                    <ref role="3AHY9a" to="8ps7:70JbBC88gSW" resolve="m/s⁴" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_g" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi05M" resolve="W÷(sr⋅m²)" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi05M" resolve="W/(sr⋅m²)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_h" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrOshH8" resolve="Gal" />
@@ -11518,31 +11518,31 @@
                     <ref role="3AHY9a" to="8ps7:3xM68GMigZr" resolve="W" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_m" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLfOW_" resolve="N÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLfOW_" resolve="N/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_n" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrLfPo0" resolve="Pa⋅s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_o" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLfOfc" resolve="kg÷m³" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLfOfc" resolve="kg/m³" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_p" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrNFuyP" resolve="lm÷W" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrNFuyP" resolve="lm/W" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_q" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMNrvq" resolve="C÷m²" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMNrvq" resolve="C/m²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_r" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLaHz1" resolve="m³÷s" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLaHz1" resolve="m³/s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_s" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrKSbi1" resolve="t" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_t" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi1gY" resolve="J÷m²" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi1gY" resolve="J/m²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_u" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMO9K1" resolve="A÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMO9K1" resolve="A/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_v" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:70JbBC6VE4N" resolve="V" />
@@ -11557,13 +11557,13 @@
                     <ref role="3AHY9a" to="8ps7:FMy9mdSdEf" resolve="B" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_z" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBCa75ni" resolve="W÷m²" />
+                    <ref role="3AHY9a" to="8ps7:70JbBCa75ni" resolve="W/m²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_$" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBCbl6Ny" resolve="A÷m" />
+                    <ref role="3AHY9a" to="8ps7:70JbBCbl6Ny" resolve="A/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI__" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBC9V$B4" resolve="N÷m" />
+                    <ref role="3AHY9a" to="8ps7:70JbBC9V$B4" resolve="N/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_A" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:7F14or$gczd" resolve="B" />
@@ -11578,19 +11578,19 @@
                     <ref role="3AHY9a" to="8ps7:6EvkZrLfrHD" resolve="m²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_E" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMyTNL" resolve="kg÷mol" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMyTNL" resolve="kg/mol" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_F" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMyU31" resolve="m³÷(mol⋅s)" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMyU31" resolve="m³/(mol⋅s)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_G" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBCapJbY" resolve="m²÷s" />
+                    <ref role="3AHY9a" to="8ps7:70JbBCapJbY" resolve="m²/s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_H" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrL9n4v" resolve="Hz÷s" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrL9n4v" resolve="Hz/s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_I" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0OE" resolve="W÷m³" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0OE" resolve="W/m³" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_J" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3xM68GMigWs" resolve="s" />
@@ -11617,28 +11617,28 @@
                     <ref role="3AHY9a" to="8ps7:3xM68GMih0j" resolve="H" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_R" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0f8" resolve="W÷(sr⋅m³)" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0f8" resolve="W/(sr⋅m³)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_S" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBCbOELe" resolve="J÷(K⋅kg)" />
+                    <ref role="3AHY9a" to="8ps7:70JbBCbOELe" resolve="J/(K⋅kg)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_T" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMO9ek" resolve="H÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMO9ek" resolve="H/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_U" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrO$kho" resolve="var" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_V" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrL7D8H" resolve="rad÷s²" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrL7D8H" resolve="rad/s²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_W" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBC7YcT4" resolve="m÷s³" />
+                    <ref role="3AHY9a" to="8ps7:70JbBC7YcT4" resolve="m/s³" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_X" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrKS6G2" resolve="au" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_Y" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrNTQbE" resolve="K÷W" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrNTQbE" resolve="K/W" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_Z" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrLf_rV" resolve="N⋅m⋅s" />
@@ -11647,25 +11647,25 @@
                     <ref role="3AHY9a" to="8ps7:3xM68GMih0C" resolve="Bq" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIA1" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrNFueB" resolve="cd÷m²" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrNFueB" resolve="cd/m²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIA2" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:70JbBCbCqDR" resolve="J÷K" />
+                    <ref role="3AHY9a" to="8ps7:70JbBCbCqDR" resolve="J/K" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIA3" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:70JbBC5wEk4" resolve="Pa" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIA4" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMOlDw" resolve="C÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMOlDw" resolve="C/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIA5" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrL6aig" resolve="m÷s²" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrL6aig" resolve="m/s²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIA6" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:70JbBC8k_Ol" resolve="N⋅s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIA7" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMO9va" resolve="V÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMO9va" resolve="V/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIA8" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrNFe93" resolve="lm⋅s" />
@@ -11674,13 +11674,13 @@
                     <ref role="3AHY9a" to="8ps7:6EvkZrKSbem" resolve="l" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAa" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi6oV" resolve="W÷sr" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi6oV" resolve="W/sr" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAb" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMOGV5" resolve="Wb÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMOGV5" resolve="Wb/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAc" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMNAQT" resolve="C÷m³" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMNAQT" resolve="C/m³" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAd" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrLfJan" resolve="m⁻¹" />
@@ -11689,13 +11689,13 @@
                     <ref role="3AHY9a" to="8ps7:70JbBC9lomP" resolve="m⁻¹" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAf" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrNSOk_" resolve="J÷K" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrNSOk_" resolve="J/K" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAg" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMOmbn" resolve="m²÷(V⋅s)" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMOmbn" resolve="m²/(V⋅s)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAh" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLfPxb" resolve="kg÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLfPxb" resolve="kg/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAi" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrKSbjZ" resolve="Da" />
@@ -11707,13 +11707,13 @@
                     <ref role="3AHY9a" to="8ps7:3xM68GMigWu" resolve="mol" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAl" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMyJd0" resolve="J÷mol" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMyJd0" resolve="J/mol" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAm" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrL6rgK" resolve="m÷s³" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrL6rgK" resolve="m/s³" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAn" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0ov" resolve="W÷m" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0ov" resolve="W/m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAo" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3xM68GMigZP" resolve="Ω" />
@@ -11722,7 +11722,7 @@
                     <ref role="3AHY9a" to="8ps7:6EvkZrLf_iZ" resolve="N⋅s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAq" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMyT$w" resolve="mol÷kg" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMyT$w" resolve="mol/kg" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAr" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:FMy9mdSdEg" resolve="b" />
@@ -11737,13 +11737,13 @@
                     <ref role="3AHY9a" to="8ps7:6EvkZrKS77F" resolve="″" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAv" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0Y5" resolve="J÷(m²⋅s)" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrLi0Y5" resolve="J/(m²⋅s)" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAw" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrL6GqJ" resolve="m÷s⁴" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrL6GqJ" resolve="m/s⁴" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAx" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMNMep" resolve="A÷m²" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMNMep" resolve="A/m²" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAy" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3xM68GMigWw" resolve="A" />
@@ -11755,13 +11755,13 @@
                     <ref role="3AHY9a" to="8ps7:70JbBC5M$rk" resolve="J" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIA_" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMP4cZ" resolve="m÷H" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMP4cZ" resolve="m/H" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAA" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3NjH4t$iNJw" resolve="h" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAB" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrMe9Xi" resolve="mol÷m³" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrMe9Xi" resolve="mol/m³" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAC" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:70JbBC5NCZ5" resolve="J" />
@@ -11773,7 +11773,7 @@
                     <ref role="3AHY9a" to="8ps7:3NjH4t$iNIu" resolve="min" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAF" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:6EvkZrL6XKd" resolve="rad÷s" />
+                    <ref role="3AHY9a" to="8ps7:6EvkZrL6XKd" resolve="rad/s" />
                   </node>
                 </node>
               </node>


### PR DESCRIPTION
Some users really don't like seeing, for example, 10 m²÷s instead of 10 m²/s. The other special characters seem to be fine. For generation purposes, they can be replaced by calling `UnitNameReplacementHelper#replaceUnitName`.