### PR TITLE
add a replacement rule for homogeneous tuples and lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 ### Fixed
 
 - Then precision for number types is now only derived from the finite bounds of the range. The precision of `number[-∞|∞]` is the same as of `number` which is 0.
+- Tuple types where all elements have the same type can now be used interchangeable with list types.
 
 ### Added
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
@@ -142,6 +142,7 @@
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
+      <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
@@ -10919,8 +10920,13 @@
                       </node>
                     </node>
                     <node concept="3eOVzh" id="25rRV02qzTe" role="1Dwp0S">
-                      <node concept="37vLTw" id="25rRV02q_ch" role="3uHU7w">
-                        <ref role="3cqZAo" node="25rRV02pKbO" resolve="times" />
+                      <node concept="3cpWsd" id="5a86BD1aQHT" role="3uHU7w">
+                        <node concept="3cmrfG" id="5a86BD1aQHW" role="3uHU7w">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                        <node concept="37vLTw" id="25rRV02q_ch" role="3uHU7B">
+                          <ref role="3cqZAo" node="25rRV02pKbO" resolve="times" />
+                        </node>
                       </node>
                       <node concept="37vLTw" id="25rRV02qxDc" role="3uHU7B">
                         <ref role="3cqZAo" node="25rRV02qswV" resolve="i" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/typesystem.mps
@@ -4,6 +4,12 @@
   <languages>
     <use id="9464fa06-5ab9-409b-9274-64ab29588457" name="org.iets3.core.expr.lambda" version="-1" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="2" />
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
+    <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
+    <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
     <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
   </languages>
   <imports>
@@ -17,6 +23,7 @@
     <import index="u78q" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.typesystem.inference(MPS.Core/)" />
     <import index="8q4f" ref="r:2c0153cb-f6d9-49f3-b0fe-e4f726698ef0(org.iets3.core.expr.collections.behavior)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="l80j" ref="r:9e71c0de-f9ab-4b67-96cc-7d9c857513f6(org.iets3.analysis.base.structure)" implicit="true" />
     <import index="1jcu" ref="r:729fa0c7-b4e4-42b1-acfe-71017c020a49(org.iets3.analysis.base.behavior)" implicit="true" />
     <import index="5s8v" ref="r:06389a24-a77a-450d-bc88-bccec0aae7d8(org.iets3.core.expr.lambda.behavior)" implicit="true" />
@@ -49,6 +56,8 @@
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
@@ -105,6 +114,7 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="7024111702304501418" name="jetbrains.mps.baseLanguage.structure.AndAssignmentExpression" flags="nn" index="3vZ8ra" />
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
         <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
@@ -215,6 +225,10 @@
         <reference id="1216386999476" name="quickFixArgument" index="QkamJ" />
         <child id="1210784642750" name="value" index="3CoRuB" />
       </concept>
+      <concept id="1176543928247" name="jetbrains.mps.lang.typesystem.structure.IsSubtypeExpression" flags="nn" index="3JuTUA">
+        <child id="1176543945045" name="subtypeExpression" index="3JuY14" />
+        <child id="1176543950311" name="supertypeExpression" index="3JuZjQ" />
+      </concept>
       <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
       <concept id="1178870617262" name="jetbrains.mps.lang.typesystem.structure.CoerceExpression" flags="nn" index="1UaxmW">
         <child id="1178870894644" name="pattern" index="1Ub_4A" />
@@ -274,6 +288,7 @@
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
@@ -318,9 +333,14 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
+      <concept id="1235566831861" name="jetbrains.mps.baseLanguage.collections.structure.AllOperation" flags="nn" index="2HxqBE" />
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
@@ -6750,6 +6770,175 @@
     <node concept="1YaCAy" id="1e59C2QAnjm" role="1YuTPh">
       <property role="TrG5h" value="indexOfOp" />
       <ref role="1YaFvo" to="700h:1e59C2QAniP" resolve="IndexOfOp" />
+    </node>
+  </node>
+  <node concept="35pCF_" id="5a86BD166MG">
+    <property role="3GE5qa" value="tuples" />
+    <property role="TrG5h" value="replace_TupleAndList" />
+    <node concept="3clFbS" id="5a86BD166MI" role="2sgrp5">
+      <node concept="3clFbH" id="5a86BD17PWf" role="3cqZAp" />
+    </node>
+    <node concept="1YaCAy" id="5a86BD166NK" role="1YuTPh">
+      <property role="TrG5h" value="tupleType" />
+      <ref role="1YaFvo" to="hm2y:S$tO8ocniU" resolve="TupleType" />
+    </node>
+    <node concept="1YaCAy" id="5a86BD166O4" role="35pZ6h">
+      <property role="TrG5h" value="listType" />
+      <ref role="1YaFvo" to="700h:6zmBjqUinsw" resolve="ListType" />
+    </node>
+    <node concept="1xSnZT" id="5a86BD166Oo" role="1xSnZW">
+      <node concept="3clFbS" id="5a86BD166Op" role="2VODD2">
+        <node concept="3cpWs8" id="5a86BD14AXj" role="3cqZAp">
+          <node concept="3cpWsn" id="5a86BD14AXm" role="3cpWs9">
+            <property role="TrG5h" value="tupleSize" />
+            <node concept="10Oyi0" id="5a86BD14AXh" role="1tU5fm" />
+            <node concept="2OqwBi" id="5a86BD14DNW" role="33vP2m">
+              <node concept="2OqwBi" id="5a86BD14AXG" role="2Oq$k0">
+                <node concept="1YBJjd" id="5a86BD14AXH" role="2Oq$k0">
+                  <ref role="1YBMHb" node="5a86BD166NK" resolve="tupleType" />
+                </node>
+                <node concept="3Tsc0h" id="5a86BD14AXI" role="2OqNvi">
+                  <ref role="3TtcxE" to="hm2y:S$tO8ocniV" resolve="elementTypes" />
+                </node>
+              </node>
+              <node concept="34oBXx" id="5a86BD14G1F" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5a86BD14wde" role="3cqZAp">
+          <node concept="3cpWsn" id="5a86BD14wdh" role="3cpWs9">
+            <property role="TrG5h" value="tupleSizeRange" />
+            <node concept="3Tqbb2" id="5a86BD14wdc" role="1tU5fm">
+              <ref role="ehGHo" to="700h:19PglA20qX_" resolve="CollectionSizeSpec" />
+            </node>
+            <node concept="2pJPEk" id="5a86BD14wg5" role="33vP2m">
+              <node concept="2pJPED" id="5a86BD14wg7" role="2pJPEn">
+                <ref role="2pJxaS" to="700h:19PglA20qX_" resolve="CollectionSizeSpec" />
+                <node concept="2pJxcG" id="5a86BD14wiP" role="2pJxcM">
+                  <ref role="2pJxcJ" to="700h:19PglA20qXJ" resolve="min" />
+                  <node concept="WxPPo" id="5a86BD14G9$" role="28ntcv">
+                    <node concept="2YIFZM" id="5a86BD14Hh9" role="WxPPp">
+                      <ref role="37wK5l" to="wyt6:~String.valueOf(int)" resolve="valueOf" />
+                      <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                      <node concept="37vLTw" id="5a86BD14HnB" role="37wK5m">
+                        <ref role="3cqZAo" node="5a86BD14AXm" resolve="tupleSize" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pJxcG" id="5a86BD14GkI" role="2pJxcM">
+                  <ref role="2pJxcJ" to="700h:19PglA20qXK" resolve="max" />
+                  <node concept="WxPPo" id="5a86BD14Glz" role="28ntcv">
+                    <node concept="2YIFZM" id="5a86BD14J8e" role="WxPPp">
+                      <ref role="37wK5l" to="wyt6:~String.valueOf(int)" resolve="valueOf" />
+                      <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                      <node concept="37vLTw" id="5a86BD14J9l" role="37wK5m">
+                        <ref role="3cqZAo" node="5a86BD14AXm" resolve="tupleSize" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="5a86BD1ciJp" role="3cqZAp" />
+        <node concept="3cpWs8" id="5a86BD1ciOM" role="3cqZAp">
+          <node concept="3cpWsn" id="5a86BD1ciON" role="3cpWs9">
+            <property role="TrG5h" value="listSizeRange" />
+            <node concept="3Tqbb2" id="5a86BD1ciLP" role="1tU5fm">
+              <ref role="ehGHo" to="700h:19PglA20qX_" resolve="CollectionSizeSpec" />
+            </node>
+            <node concept="2OqwBi" id="5a86BD1ciOO" role="33vP2m">
+              <node concept="1YBJjd" id="5a86BD1ciOP" role="2Oq$k0">
+                <ref role="1YBMHb" node="5a86BD166O4" resolve="listType" />
+              </node>
+              <node concept="3TrEf2" id="5a86BD1ciOQ" role="2OqNvi">
+                <ref role="3Tt5mk" to="700h:3tudP__pYOT" resolve="sizeConstraint" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5a86BD1cVOP" role="3cqZAp">
+          <node concept="3cpWsn" id="5a86BD1cVOS" role="3cpWs9">
+            <property role="TrG5h" value="cond" />
+            <node concept="10P_77" id="5a86BD1cVON" role="1tU5fm" />
+            <node concept="2OqwBi" id="5a86BD12N2B" role="33vP2m">
+              <node concept="2OqwBi" id="5a86BD12Kfm" role="2Oq$k0">
+                <node concept="1YBJjd" id="5a86BD12K2w" role="2Oq$k0">
+                  <ref role="1YBMHb" node="5a86BD166NK" resolve="tupleType" />
+                </node>
+                <node concept="3Tsc0h" id="5a86BD12Kx7" role="2OqNvi">
+                  <ref role="3TtcxE" to="hm2y:S$tO8ocniV" resolve="elementTypes" />
+                </node>
+              </node>
+              <node concept="2HxqBE" id="5a86BD12Pcg" role="2OqNvi">
+                <node concept="1bVj0M" id="5a86BD12Pci" role="23t8la">
+                  <node concept="3clFbS" id="5a86BD12Pcj" role="1bW5cS">
+                    <node concept="3clFbF" id="5a86BD12QlZ" role="3cqZAp">
+                      <node concept="3JuTUA" id="5a86BD12Rel" role="3clFbG">
+                        <node concept="37vLTw" id="5a86BD12ZcD" role="3JuY14">
+                          <ref role="3cqZAo" node="5a86BD12Pck" resolve="it" />
+                        </node>
+                        <node concept="2OqwBi" id="5a86BD1a2Ph" role="3JuZjQ">
+                          <node concept="1YBJjd" id="5a86BD12Zoc" role="2Oq$k0">
+                            <ref role="1YBMHb" node="5a86BD166O4" resolve="listType" />
+                          </node>
+                          <node concept="3TrEf2" id="5a86BD1a4PK" role="2OqNvi">
+                            <ref role="3Tt5mk" to="700h:6zmBjqUily6" resolve="baseType" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Rh6nW" id="5a86BD12Pck" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="5a86BD12Pcl" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5a86BD1cWAG" role="3cqZAp">
+          <node concept="3clFbS" id="5a86BD1cWAI" role="3clFbx">
+            <node concept="3clFbF" id="5a86BD1cY23" role="3cqZAp">
+              <node concept="3vZ8ra" id="5a86BD1cZnZ" role="3clFbG">
+                <node concept="37vLTw" id="5a86BD1cY21" role="37vLTJ">
+                  <ref role="3cqZAo" node="5a86BD1cVOS" resolve="cond" />
+                </node>
+                <node concept="2OqwBi" id="5a86BD14GIy" role="37vLTx">
+                  <node concept="37vLTw" id="5a86BD14G$U" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5a86BD14wdh" resolve="tupleSizeRange" />
+                  </node>
+                  <node concept="2qgKlT" id="5a86BD14GK3" role="2OqNvi">
+                    <ref role="37wK5l" to="8q4f:6eglc2$aoYX" resolve="isSubRangeOf" />
+                    <node concept="37vLTw" id="5a86BD1ciOR" role="37wK5m">
+                      <ref role="3cqZAo" node="5a86BD1ciON" resolve="listSizeRange" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="5a86BD1cXyt" role="3clFbw">
+            <node concept="2OqwBi" id="5a86BD1cWEK" role="2Oq$k0">
+              <node concept="1YBJjd" id="5a86BD1cWEL" role="2Oq$k0">
+                <ref role="1YBMHb" node="5a86BD166O4" resolve="listType" />
+              </node>
+              <node concept="3TrEf2" id="5a86BD1cWEM" role="2OqNvi">
+                <ref role="3Tt5mk" to="700h:3tudP__pYOT" resolve="sizeConstraint" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="5a86BD1cXPM" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="5a86BD1cZNb" role="3cqZAp">
+          <node concept="37vLTw" id="5a86BD1cZN9" role="3clFbG">
+            <ref role="3cqZAo" node="5a86BD1cVOS" resolve="cond" />
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/generator/template/org.iets3.core.expr.genjava.base@generator.mps
@@ -486,6 +486,7 @@
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
       <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7">
+        <property id="8575328350543493365" name="message" index="huDt6" />
         <property id="2423417345669755629" name="filter" index="1eyWvh" />
       </concept>
     </language>
@@ -5084,110 +5085,115 @@
             </node>
             <node concept="3clFbH" id="ijyib_sPVd" role="3cqZAp" />
             <node concept="3clFbF" id="ijyib_sPVe" role="3cqZAp">
-              <node concept="2OqwBi" id="ijyib_sPVf" role="3clFbG">
-                <node concept="1bVj0M" id="ijyib_sPVg" role="2Oq$k0">
-                  <node concept="3clFbS" id="ijyib_sPVh" role="1bW5cS">
-                    <node concept="3cpWs8" id="ijyib_sPVF" role="3cqZAp">
-                      <node concept="3cpWsn" id="ijyib_sPVG" role="3cpWs9">
-                        <property role="TrG5h" value="times" />
-                        <node concept="10Oyi0" id="ijyib_sPVH" role="1tU5fm" />
-                        <node concept="2OqwBi" id="ijyib_sPVI" role="33vP2m">
-                          <node concept="2ShNRf" id="ijyib_sPVJ" role="2Oq$k0">
-                            <node concept="1pGfFk" id="ijyib_sPVK" role="2ShVmc">
-                              <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
-                              <node concept="Xl_RD" id="ijyib_sPVL" role="37wK5m">
-                                <property role="Xl_RC" value="5" />
+              <node concept="10QFUN" id="3mhgBZp0n$A" role="3clFbG">
+                <node concept="3uibUv" id="3mhgBZp0AiE" role="10QFUM">
+                  <ref role="3uigEE" to="j10v:~PVector" resolve="PVector" />
+                </node>
+                <node concept="2OqwBi" id="ijyib_sPVf" role="10QFUP">
+                  <node concept="1bVj0M" id="ijyib_sPVg" role="2Oq$k0">
+                    <node concept="3clFbS" id="ijyib_sPVh" role="1bW5cS">
+                      <node concept="3cpWs8" id="ijyib_sPVF" role="3cqZAp">
+                        <node concept="3cpWsn" id="ijyib_sPVG" role="3cpWs9">
+                          <property role="TrG5h" value="times" />
+                          <node concept="10Oyi0" id="ijyib_sPVH" role="1tU5fm" />
+                          <node concept="2OqwBi" id="ijyib_sPVI" role="33vP2m">
+                            <node concept="2ShNRf" id="ijyib_sPVJ" role="2Oq$k0">
+                              <node concept="1pGfFk" id="ijyib_sPVK" role="2ShVmc">
+                                <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
+                                <node concept="Xl_RD" id="ijyib_sPVL" role="37wK5m">
+                                  <property role="Xl_RC" value="5" />
+                                </node>
                               </node>
-                            </node>
-                            <node concept="29HgVG" id="ijyib_sPVM" role="lGtFl">
-                              <node concept="3NFfHV" id="ijyib_sPVN" role="3NFExx">
-                                <node concept="3clFbS" id="ijyib_sPVO" role="2VODD2">
-                                  <node concept="3clFbF" id="ijyib_sPVP" role="3cqZAp">
-                                    <node concept="2OqwBi" id="ijyib_sPVQ" role="3clFbG">
-                                      <node concept="1PxgMI" id="ijyib_sPVR" role="2Oq$k0">
-                                        <node concept="2OqwBi" id="ijyib_sPVT" role="1m5AlR">
-                                          <node concept="3TrEf2" id="ijyib_sPVU" role="2OqNvi">
-                                            <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                              <node concept="29HgVG" id="ijyib_sPVM" role="lGtFl">
+                                <node concept="3NFfHV" id="ijyib_sPVN" role="3NFExx">
+                                  <node concept="3clFbS" id="ijyib_sPVO" role="2VODD2">
+                                    <node concept="3clFbF" id="ijyib_sPVP" role="3cqZAp">
+                                      <node concept="2OqwBi" id="ijyib_sPVQ" role="3clFbG">
+                                        <node concept="1PxgMI" id="ijyib_sPVR" role="2Oq$k0">
+                                          <node concept="2OqwBi" id="ijyib_sPVT" role="1m5AlR">
+                                            <node concept="3TrEf2" id="ijyib_sPVU" role="2OqNvi">
+                                              <ref role="3Tt5mk" to="hm2y:7NJy08a3O9b" resolve="target" />
+                                            </node>
+                                            <node concept="30H73N" id="ijyib_sPVV" role="2Oq$k0" />
                                           </node>
-                                          <node concept="30H73N" id="ijyib_sPVV" role="2Oq$k0" />
+                                          <node concept="chp4Y" id="ijyib_vhMj" role="3oSUPX">
+                                            <ref role="cht4Q" to="hm2y:25rRV02ooIM" resolve="NCopiesOp" />
+                                          </node>
                                         </node>
-                                        <node concept="chp4Y" id="ijyib_vhMj" role="3oSUPX">
-                                          <ref role="cht4Q" to="hm2y:25rRV02ooIM" resolve="NCopiesOp" />
+                                        <node concept="3TrEf2" id="ijyib_vn9r" role="2OqNvi">
+                                          <ref role="3Tt5mk" to="hm2y:25rRV02osES" resolve="times" />
                                         </node>
-                                      </node>
-                                      <node concept="3TrEf2" id="ijyib_vn9r" role="2OqNvi">
-                                        <ref role="3Tt5mk" to="hm2y:25rRV02osES" resolve="times" />
                                       </node>
                                     </node>
                                   </node>
                                 </node>
                               </node>
                             </node>
-                          </node>
-                          <node concept="liA8E" id="ijyib_sPVX" role="2OqNvi">
-                            <ref role="37wK5l" to="xlxw:~BigInteger.intValue()" resolve="intValue" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbJ" id="ijyibAKtQ6" role="3cqZAp">
-                      <node concept="3clFbS" id="ijyibAKtQ8" role="3clFbx">
-                        <node concept="3clFbF" id="ijyibATDdr" role="3cqZAp">
-                          <node concept="2YIFZM" id="ijyibANwJV" role="3clFbG">
-                            <ref role="37wK5l" to="vsv5:6jT4GDw1gm8" resolve="fail" />
-                            <ref role="1Pybhc" to="vsv5:6jT4GDw1g66" resolve="FailException" />
-                            <node concept="Xl_RD" id="ijyibANzy3" role="37wK5m">
-                              <property role="Xl_RC" value="the argument must be greater than 0" />
+                            <node concept="liA8E" id="ijyib_sPVX" role="2OqNvi">
+                              <ref role="37wK5l" to="xlxw:~BigInteger.intValue()" resolve="intValue" />
                             </node>
                           </node>
                         </node>
                       </node>
-                      <node concept="2dkUwp" id="ijyibAKxUY" role="3clFbw">
-                        <node concept="3cmrfG" id="ijyibAKz09" role="3uHU7w">
-                          <property role="3cmrfH" value="0" />
+                      <node concept="3clFbJ" id="ijyibAKtQ6" role="3cqZAp">
+                        <node concept="3clFbS" id="ijyibAKtQ8" role="3clFbx">
+                          <node concept="3clFbF" id="ijyibATDdr" role="3cqZAp">
+                            <node concept="2YIFZM" id="ijyibANwJV" role="3clFbG">
+                              <ref role="37wK5l" to="vsv5:6jT4GDw1gm8" resolve="fail" />
+                              <ref role="1Pybhc" to="vsv5:6jT4GDw1g66" resolve="FailException" />
+                              <node concept="Xl_RD" id="ijyibANzy3" role="37wK5m">
+                                <property role="Xl_RC" value="the argument must be greater than 0" />
+                              </node>
+                            </node>
+                          </node>
                         </node>
-                        <node concept="37vLTw" id="ijyibAKuIJ" role="3uHU7B">
-                          <ref role="3cqZAo" node="ijyib_sPVG" resolve="times" />
+                        <node concept="2dkUwp" id="ijyibAKxUY" role="3clFbw">
+                          <node concept="3cmrfG" id="ijyibAKz09" role="3uHU7w">
+                            <property role="3cmrfH" value="0" />
+                          </node>
+                          <node concept="37vLTw" id="ijyibAKuIJ" role="3uHU7B">
+                            <ref role="3cqZAo" node="ijyib_sPVG" resolve="times" />
+                          </node>
                         </node>
                       </node>
-                    </node>
-                    <node concept="3cpWs6" id="ijyibA4cwT" role="3cqZAp">
-                      <node concept="2YIFZM" id="ijyib_w3of" role="3cqZAk">
-                        <ref role="37wK5l" to="j10v:~TreePVector.from(java.util.Collection)" resolve="from" />
-                        <ref role="1Pybhc" to="j10v:~TreePVector" resolve="TreePVector" />
-                        <node concept="2OqwBi" id="ijyib_$QlR" role="37wK5m">
-                          <node concept="2OqwBi" id="ijyibA89jC" role="2Oq$k0">
-                            <node concept="2OqwBi" id="ijyib_wDYK" role="2Oq$k0">
-                              <node concept="2YIFZM" id="ijyib_w_aw" role="2Oq$k0">
-                                <ref role="37wK5l" to="1ctc:~Stream.generate(java.util.function.Supplier)" resolve="generate" />
-                                <ref role="1Pybhc" to="1ctc:~Stream" resolve="Stream" />
-                                <node concept="2ShNRf" id="ijyibA2mKS" role="37wK5m">
-                                  <node concept="YeOm9" id="ijyibA2nqp" role="2ShVmc">
-                                    <node concept="1Y3b0j" id="ijyibA2nqs" role="YeSDq">
-                                      <property role="2bfB8j" value="true" />
-                                      <property role="373rjd" value="true" />
-                                      <ref role="1Y3XeK" to="82uw:~Supplier" resolve="Supplier" />
-                                      <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                                      <node concept="3Tm1VV" id="ijyibA2nqt" role="1B3o_S" />
-                                      <node concept="3clFb_" id="ijyibA2nqE" role="jymVt">
-                                        <property role="TrG5h" value="get" />
-                                        <node concept="3Tm1VV" id="ijyibA2nqF" role="1B3o_S" />
-                                        <node concept="3uibUv" id="ijyibA2AJ9" role="3clF45">
-                                          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                                        </node>
-                                        <node concept="3clFbS" id="ijyibA2nqI" role="3clF47">
-                                          <node concept="3cpWs6" id="ijyib_XI_P" role="3cqZAp">
-                                            <node concept="37vLTw" id="ijyib_YLex" role="3cqZAk">
-                                              <ref role="3cqZAo" node="ijyib_sPVa" resolve="tpv" />
-                                              <node concept="29HgVG" id="ijyib_YLey" role="lGtFl">
-                                                <node concept="3NFfHV" id="ijyib_YLez" role="3NFExx">
-                                                  <node concept="3clFbS" id="ijyib_YLe$" role="2VODD2">
-                                                    <node concept="3clFbF" id="ijyib_YLe_" role="3cqZAp">
-                                                      <node concept="2OqwBi" id="ijyib_YLeA" role="3clFbG">
-                                                        <node concept="3TrEf2" id="ijyib_YLeB" role="2OqNvi">
-                                                          <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                      <node concept="3cpWs6" id="ijyibA4cwT" role="3cqZAp">
+                        <node concept="2YIFZM" id="ijyib_w3of" role="3cqZAk">
+                          <ref role="37wK5l" to="j10v:~TreePVector.from(java.util.Collection)" resolve="from" />
+                          <ref role="1Pybhc" to="j10v:~TreePVector" resolve="TreePVector" />
+                          <node concept="2OqwBi" id="ijyib_$QlR" role="37wK5m">
+                            <node concept="2OqwBi" id="ijyibA89jC" role="2Oq$k0">
+                              <node concept="2OqwBi" id="ijyib_wDYK" role="2Oq$k0">
+                                <node concept="2YIFZM" id="ijyib_w_aw" role="2Oq$k0">
+                                  <ref role="37wK5l" to="1ctc:~Stream.generate(java.util.function.Supplier)" resolve="generate" />
+                                  <ref role="1Pybhc" to="1ctc:~Stream" resolve="Stream" />
+                                  <node concept="2ShNRf" id="ijyibA2mKS" role="37wK5m">
+                                    <node concept="YeOm9" id="ijyibA2nqp" role="2ShVmc">
+                                      <node concept="1Y3b0j" id="ijyibA2nqs" role="YeSDq">
+                                        <property role="2bfB8j" value="true" />
+                                        <property role="373rjd" value="true" />
+                                        <ref role="1Y3XeK" to="82uw:~Supplier" resolve="Supplier" />
+                                        <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                                        <node concept="3Tm1VV" id="ijyibA2nqt" role="1B3o_S" />
+                                        <node concept="3clFb_" id="ijyibA2nqE" role="jymVt">
+                                          <property role="TrG5h" value="get" />
+                                          <node concept="3Tm1VV" id="ijyibA2nqF" role="1B3o_S" />
+                                          <node concept="3uibUv" id="ijyibA2AJ9" role="3clF45">
+                                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                                          </node>
+                                          <node concept="3clFbS" id="ijyibA2nqI" role="3clF47">
+                                            <node concept="3cpWs6" id="ijyib_XI_P" role="3cqZAp">
+                                              <node concept="37vLTw" id="ijyib_YLex" role="3cqZAk">
+                                                <ref role="3cqZAo" node="ijyib_sPVa" resolve="tpv" />
+                                                <node concept="29HgVG" id="ijyib_YLey" role="lGtFl">
+                                                  <node concept="3NFfHV" id="ijyib_YLez" role="3NFExx">
+                                                    <node concept="3clFbS" id="ijyib_YLe$" role="2VODD2">
+                                                      <node concept="3clFbF" id="ijyib_YLe_" role="3cqZAp">
+                                                        <node concept="2OqwBi" id="ijyib_YLeA" role="3clFbG">
+                                                          <node concept="3TrEf2" id="ijyib_YLeB" role="2OqNvi">
+                                                            <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
+                                                          </node>
+                                                          <node concept="30H73N" id="ijyib_YLeC" role="2Oq$k0" />
                                                         </node>
-                                                        <node concept="30H73N" id="ijyib_YLeC" role="2Oq$k0" />
                                                       </node>
                                                     </node>
                                                   </node>
@@ -5195,97 +5201,101 @@
                                               </node>
                                             </node>
                                           </node>
+                                          <node concept="2AHcQZ" id="ijyibA2nqK" role="2AJF6D">
+                                            <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                          </node>
                                         </node>
-                                        <node concept="2AHcQZ" id="ijyibA2nqK" role="2AJF6D">
-                                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-                                        </node>
-                                      </node>
-                                      <node concept="3uibUv" id="ijyibA2Oh5" role="2Ghqu4">
-                                        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="liA8E" id="ijyib_wJek" role="2OqNvi">
-                                <ref role="37wK5l" to="1ctc:~Stream.limit(long)" resolve="limit" />
-                                <node concept="37vLTw" id="ijyib_wNfP" role="37wK5m">
-                                  <ref role="3cqZAo" node="ijyib_sPVG" resolve="times" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="liA8E" id="ijyibAcVyA" role="2OqNvi">
-                              <ref role="37wK5l" to="1ctc:~Stream.flatMap(java.util.function.Function)" resolve="flatMap" />
-                              <node concept="2ShNRf" id="ijyibAulBP" role="37wK5m">
-                                <node concept="YeOm9" id="ijyibAumCE" role="2ShVmc">
-                                  <node concept="1Y3b0j" id="ijyibAumCH" role="YeSDq">
-                                    <property role="2bfB8j" value="true" />
-                                    <property role="373rjd" value="true" />
-                                    <ref role="1Y3XeK" to="82uw:~Function" resolve="Function" />
-                                    <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
-                                    <node concept="3Tm1VV" id="ijyibAumCI" role="1B3o_S" />
-                                    <node concept="3clFb_" id="ijyibAumD0" role="jymVt">
-                                      <property role="TrG5h" value="apply" />
-                                      <node concept="3Tm1VV" id="ijyibAumD1" role="1B3o_S" />
-                                      <node concept="3uibUv" id="ijyibAumDr" role="3clF45">
-                                        <ref role="3uigEE" to="1ctc:~Stream" resolve="Stream" />
-                                        <node concept="3qTvmN" id="ijyibALlPd" role="11_B2D" />
-                                      </node>
-                                      <node concept="37vLTG" id="ijyibAumD4" role="3clF46">
-                                        <property role="TrG5h" value="obj" />
-                                        <node concept="3uibUv" id="ijyibAumDm" role="1tU5fm">
+                                        <node concept="3uibUv" id="ijyibA2Oh5" role="2Ghqu4">
                                           <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
                                         </node>
                                       </node>
-                                      <node concept="3clFbS" id="ijyibAumD6" role="3clF47">
-                                        <node concept="3cpWs6" id="ijyibAvtjV" role="3cqZAp">
-                                          <node concept="2OqwBi" id="ijyibAHOnE" role="3cqZAk">
-                                            <node concept="1eOMI4" id="ijyibAHfCP" role="2Oq$k0">
-                                              <node concept="10QFUN" id="ijyibAHfCM" role="1eOMHV">
-                                                <node concept="3uibUv" id="ijyibAHfCR" role="10QFUM">
-                                                  <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
-                                                </node>
-                                                <node concept="37vLTw" id="ijyibAHLXh" role="10QFUP">
-                                                  <ref role="3cqZAo" node="ijyibAumD4" resolve="obj" />
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="ijyib_wJek" role="2OqNvi">
+                                  <ref role="37wK5l" to="1ctc:~Stream.limit(long)" resolve="limit" />
+                                  <node concept="37vLTw" id="ijyib_wNfP" role="37wK5m">
+                                    <ref role="3cqZAo" node="ijyib_sPVG" resolve="times" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="ijyibAcVyA" role="2OqNvi">
+                                <ref role="37wK5l" to="1ctc:~Stream.flatMap(java.util.function.Function)" resolve="flatMap" />
+                                <node concept="2ShNRf" id="ijyibAulBP" role="37wK5m">
+                                  <node concept="YeOm9" id="ijyibAumCE" role="2ShVmc">
+                                    <node concept="1Y3b0j" id="ijyibAumCH" role="YeSDq">
+                                      <property role="2bfB8j" value="true" />
+                                      <property role="373rjd" value="true" />
+                                      <ref role="1Y3XeK" to="82uw:~Function" resolve="Function" />
+                                      <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+                                      <node concept="3Tm1VV" id="ijyibAumCI" role="1B3o_S" />
+                                      <node concept="3clFb_" id="ijyibAumD0" role="jymVt">
+                                        <property role="TrG5h" value="apply" />
+                                        <node concept="3Tm1VV" id="ijyibAumD1" role="1B3o_S" />
+                                        <node concept="3uibUv" id="ijyibAumDr" role="3clF45">
+                                          <ref role="3uigEE" to="1ctc:~Stream" resolve="Stream" />
+                                          <node concept="3qTvmN" id="ijyibALlPd" role="11_B2D" />
+                                        </node>
+                                        <node concept="37vLTG" id="ijyibAumD4" role="3clF46">
+                                          <property role="TrG5h" value="obj" />
+                                          <node concept="3uibUv" id="ijyibAumDm" role="1tU5fm">
+                                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                                          </node>
+                                        </node>
+                                        <node concept="3clFbS" id="ijyibAumD6" role="3clF47">
+                                          <node concept="3cpWs6" id="ijyibAvtjV" role="3cqZAp">
+                                            <node concept="2OqwBi" id="ijyibAHOnE" role="3cqZAk">
+                                              <node concept="1eOMI4" id="ijyibAHfCP" role="2Oq$k0">
+                                                <node concept="10QFUN" id="ijyibAHfCM" role="1eOMHV">
+                                                  <node concept="3uibUv" id="ijyibAHfCR" role="10QFUM">
+                                                    <ref role="3uigEE" to="33ny:~Collection" resolve="Collection" />
+                                                  </node>
+                                                  <node concept="37vLTw" id="ijyibAHLXh" role="10QFUP">
+                                                    <ref role="3cqZAo" node="ijyibAumD4" resolve="obj" />
+                                                  </node>
                                                 </node>
                                               </node>
-                                            </node>
-                                            <node concept="liA8E" id="ijyibAHVBb" role="2OqNvi">
-                                              <ref role="37wK5l" to="33ny:~Collection.stream()" resolve="stream" />
+                                              <node concept="liA8E" id="ijyibAHVBb" role="2OqNvi">
+                                                <ref role="37wK5l" to="33ny:~Collection.stream()" resolve="stream" />
+                                              </node>
                                             </node>
                                           </node>
                                         </node>
+                                        <node concept="2AHcQZ" id="ijyibAumD8" role="2AJF6D">
+                                          <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                        </node>
                                       </node>
-                                      <node concept="2AHcQZ" id="ijyibAumD8" role="2AJF6D">
-                                        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                      <node concept="3uibUv" id="ijyibAumDl" role="2Ghqu4">
+                                        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
                                       </node>
-                                    </node>
-                                    <node concept="3uibUv" id="ijyibAumDl" role="2Ghqu4">
-                                      <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                                    </node>
-                                    <node concept="3uibUv" id="ijyibAumDo" role="2Ghqu4">
-                                      <ref role="3uigEE" to="1ctc:~Stream" resolve="Stream" />
-                                      <node concept="3qTvmN" id="ijyibAL7li" role="11_B2D" />
+                                      <node concept="3uibUv" id="ijyibAumDo" role="2Ghqu4">
+                                        <ref role="3uigEE" to="1ctc:~Stream" resolve="Stream" />
+                                        <node concept="3qTvmN" id="ijyibAL7li" role="11_B2D" />
+                                      </node>
                                     </node>
                                   </node>
                                 </node>
                               </node>
                             </node>
-                          </node>
-                          <node concept="liA8E" id="ijyib_$XxH" role="2OqNvi">
-                            <ref role="37wK5l" to="1ctc:~Stream.collect(java.util.stream.Collector)" resolve="collect" />
-                            <node concept="2YIFZM" id="ijyib__5Dt" role="37wK5m">
-                              <ref role="37wK5l" to="1ctc:~Collectors.toList()" resolve="toList" />
-                              <ref role="1Pybhc" to="1ctc:~Collectors" resolve="Collectors" />
+                            <node concept="liA8E" id="ijyib_$XxH" role="2OqNvi">
+                              <ref role="37wK5l" to="1ctc:~Stream.collect(java.util.stream.Collector)" resolve="collect" />
+                              <node concept="2YIFZM" id="ijyib__5Dt" role="37wK5m">
+                                <ref role="37wK5l" to="1ctc:~Collectors.toList()" resolve="toList" />
+                                <ref role="1Pybhc" to="1ctc:~Collectors" resolve="Collectors" />
+                              </node>
                             </node>
                           </node>
                         </node>
                       </node>
                     </node>
                   </node>
+                  <node concept="1Bd96e" id="ijyib_sPWd" role="2OqNvi" />
                 </node>
-                <node concept="1Bd96e" id="ijyib_sPWd" role="2OqNvi" />
-                <node concept="raruj" id="ijyib_sPWe" role="lGtFl" />
+                <node concept="raruj" id="3mhgBZp0EVK" role="lGtFl" />
+              </node>
+              <node concept="15s5l7" id="3mhgBZp5oif" role="lGtFl">
+                <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;" />
+                <property role="huDt6" value="all typesystem messages" />
               </node>
             </node>
           </node>
@@ -13335,19 +13345,26 @@
         </node>
       </node>
       <node concept="gft3U" id="2ICvjplP1OG" role="1lVwrX">
-        <node concept="2YIFZM" id="2ICvjplP1OH" role="gfFT$">
-          <ref role="1Pybhc" to="j10v:~TreePVector" resolve="TreePVector" />
-          <ref role="37wK5l" to="j10v:~TreePVector.from(java.util.Collection)" resolve="from" />
-          <node concept="2ShNRf" id="2ICvjplP1OI" role="37wK5m">
-            <node concept="1pGfFk" id="2ICvjplP1OJ" role="2ShVmc">
-              <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;()" resolve="ArrayList" />
-              <node concept="3uibUv" id="2ICvjplRjVI" role="1pMfVU">
+        <node concept="1eOMI4" id="3mhgBZpcDt9" role="gfFT$">
+          <node concept="10QFUN" id="3mhgBZpb1n$" role="1eOMHV">
+            <node concept="3uibUv" id="3mhgBZpbf4t" role="10QFUM">
+              <ref role="3uigEE" to="j10v:~TreePVector" resolve="TreePVector" />
+            </node>
+            <node concept="2YIFZM" id="2ICvjplP1OH" role="10QFUP">
+              <ref role="1Pybhc" to="j10v:~TreePVector" resolve="TreePVector" />
+              <ref role="37wK5l" to="j10v:~TreePVector.from(java.util.Collection)" resolve="from" />
+              <node concept="2ShNRf" id="2ICvjplP1OI" role="37wK5m">
+                <node concept="1pGfFk" id="2ICvjplP1OJ" role="2ShVmc">
+                  <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;()" resolve="ArrayList" />
+                  <node concept="3uibUv" id="2ICvjplRjVI" role="1pMfVU">
+                    <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3uibUv" id="71G5B48UGpa" role="3PaCim">
                 <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
               </node>
             </node>
-          </node>
-          <node concept="3uibUv" id="71G5B48UGpa" role="3PaCim">
-            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
           </node>
         </node>
       </node>
@@ -13373,35 +13390,42 @@
         </node>
       </node>
       <node concept="gft3U" id="2ICvjplQsTK" role="1lVwrX">
-        <node concept="2YIFZM" id="2ICvjplQsTL" role="gfFT$">
-          <ref role="1Pybhc" to="j10v:~TreePVector" resolve="TreePVector" />
-          <ref role="37wK5l" to="j10v:~TreePVector.from(java.util.Collection)" resolve="from" />
-          <node concept="2YIFZM" id="2ICvjplQsTM" role="37wK5m">
-            <ref role="1Pybhc" to="33ny:~Arrays" resolve="Arrays" />
-            <ref role="37wK5l" to="33ny:~Arrays.asList(java.lang.Object...)" resolve="asList" />
-            <node concept="Xl_RD" id="2ICvjplQsTN" role="37wK5m">
-              <property role="Xl_RC" value="s" />
-              <node concept="2b32R4" id="2ICvjplQsTO" role="lGtFl">
-                <node concept="3JmXsc" id="2ICvjplQsTP" role="2P8S$">
-                  <node concept="3clFbS" id="2ICvjplQsTQ" role="2VODD2">
-                    <node concept="3clFbF" id="2ICvjplQsTR" role="3cqZAp">
-                      <node concept="2OqwBi" id="2ICvjplQsTS" role="3clFbG">
-                        <node concept="3Tsc0h" id="2ICvjplRl8n" role="2OqNvi">
-                          <ref role="3TtcxE" to="hm2y:S$tO8ocnpr" resolve="values" />
+        <node concept="1eOMI4" id="3mhgBZpcS48" role="gfFT$">
+          <node concept="10QFUN" id="3mhgBZpaxwX" role="1eOMHV">
+            <node concept="3uibUv" id="3mhgBZpaK6Y" role="10QFUM">
+              <ref role="3uigEE" to="j10v:~TreePVector" resolve="TreePVector" />
+            </node>
+            <node concept="2YIFZM" id="2ICvjplQsTL" role="10QFUP">
+              <ref role="1Pybhc" to="j10v:~TreePVector" resolve="TreePVector" />
+              <ref role="37wK5l" to="j10v:~TreePVector.from(java.util.Collection)" resolve="from" />
+              <node concept="2YIFZM" id="2ICvjplQsTM" role="37wK5m">
+                <ref role="1Pybhc" to="33ny:~Arrays" resolve="Arrays" />
+                <ref role="37wK5l" to="33ny:~Arrays.asList(java.lang.Object...)" resolve="asList" />
+                <node concept="Xl_RD" id="2ICvjplQsTN" role="37wK5m">
+                  <property role="Xl_RC" value="s" />
+                  <node concept="2b32R4" id="2ICvjplQsTO" role="lGtFl">
+                    <node concept="3JmXsc" id="2ICvjplQsTP" role="2P8S$">
+                      <node concept="3clFbS" id="2ICvjplQsTQ" role="2VODD2">
+                        <node concept="3clFbF" id="2ICvjplQsTR" role="3cqZAp">
+                          <node concept="2OqwBi" id="2ICvjplQsTS" role="3clFbG">
+                            <node concept="3Tsc0h" id="2ICvjplRl8n" role="2OqNvi">
+                              <ref role="3TtcxE" to="hm2y:S$tO8ocnpr" resolve="values" />
+                            </node>
+                            <node concept="30H73N" id="2ICvjplQsTU" role="2Oq$k0" />
+                          </node>
                         </node>
-                        <node concept="30H73N" id="2ICvjplQsTU" role="2Oq$k0" />
                       </node>
                     </node>
                   </node>
                 </node>
+                <node concept="3uibUv" id="3vaYGVXUNil" role="3PaCim">
+                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                </node>
+              </node>
+              <node concept="3uibUv" id="3vaYGVXUy4c" role="3PaCim">
+                <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
               </node>
             </node>
-            <node concept="3uibUv" id="3vaYGVXUNil" role="3PaCim">
-              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-            </node>
-          </node>
-          <node concept="3uibUv" id="3vaYGVXUy4c" role="3PaCim">
-            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
           </node>
         </node>
       </node>
@@ -16901,9 +16925,6 @@
                 <property role="TrG5h" value="l" />
                 <node concept="3uibUv" id="2ICvjplLKMw" role="1tU5fm">
                   <ref role="3uigEE" to="j10v:~PVector" resolve="PVector" />
-                  <node concept="3uibUv" id="2ICvjplLKNq" role="11_B2D">
-                    <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                  </node>
                   <node concept="raruj" id="2ICvjplLKNO" role="lGtFl" />
                 </node>
               </node>
@@ -16929,9 +16950,6 @@
                 <property role="TrG5h" value="l" />
                 <node concept="3uibUv" id="3r6ed$FPwRp" role="1tU5fm">
                   <ref role="3uigEE" to="j10v:~PVector" resolve="PVector" />
-                  <node concept="3uibUv" id="3r6ed$FPwRq" role="11_B2D">
-                    <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                  </node>
                   <node concept="raruj" id="3r6ed$FPwRr" role="lGtFl" />
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.dectabs@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.dectabs@tests.mps
@@ -66,12 +66,24 @@
         <child id="7862827458318976524" name="range" index="1yl1BA" />
       </concept>
     </language>
+    <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
+      <concept id="5849458724932670346" name="org.iets3.core.expr.collections.structure.BracketOp" flags="ng" index="2yLE0X">
+        <child id="5849458724932670347" name="index" index="2yLE0W" />
+      </concept>
+      <concept id="7554398283339749509" name="org.iets3.core.expr.collections.structure.CollectionType" flags="ng" index="3iBWmN">
+        <child id="7554398283339749510" name="baseType" index="3iBWmK" />
+      </concept>
+      <concept id="7554398283339757344" name="org.iets3.core.expr.collections.structure.ListType" flags="ng" index="3iBYCm" />
+    </language>
     <language id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base">
       <concept id="7831630342157089621" name="org.iets3.core.base.structure.IDetectNeedToRunManually" flags="ng" index="0Rz4o">
         <property id="7831630342157089649" name="__hash" index="0Rz4W" />
       </concept>
     </language>
     <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
+      <concept id="1019070541450016346" name="org.iets3.core.expr.base.structure.TupleValue" flags="ng" index="m5g4o">
+        <child id="1019070541450016347" name="values" index="m5g4p" />
+      </concept>
       <concept id="1019070541450015930" name="org.iets3.core.expr.base.structure.TupleType" flags="ng" index="m5gfS">
         <child id="1019070541450015931" name="elementTypes" index="m5gfT" />
       </concept>
@@ -2559,7 +2571,11 @@
           </node>
           <node concept="1fLbrf" id="1c6hIxyYjfv" role="1fLbpX">
             <ref role="1fLbst" node="1c6hIxyYj9N" resolve="r1" />
-            <node concept="2vmpnb" id="1c6hIxyYjfu" role="1fLbpZ" />
+            <node concept="m5g4o" id="3mhgBZpg4J2" role="1fLbpZ">
+              <node concept="2vmpnb" id="3mhgBZpmTvh" role="m5g4p" />
+              <node concept="2vmpnb" id="3mhgBZpmXxu" role="m5g4p" />
+              <node concept="2vmpnb" id="3mhgBZpmTQr" role="m5g4p" />
+            </node>
           </node>
           <node concept="1fLbrf" id="1c6hIxyYjfK" role="1fLbpX">
             <ref role="1fLbst" node="1c6hIxyYjdA" resolve="r2" />
@@ -2580,7 +2596,9 @@
         </node>
         <node concept="1fMUOM" id="1c6hIxyYj9N" role="1vMDcl">
           <property role="TrG5h" value="r1" />
-          <node concept="2vmvy5" id="1c6hIxyYjae" role="1fMUOZ" />
+          <node concept="3iBYCm" id="3mhgBZpg6Ek" role="1fMUOZ">
+            <node concept="2vmvy5" id="3mhgBZpmTj4" role="3iBWmK" />
+          </node>
         </node>
         <node concept="1fMUOM" id="1c6hIxyYjdA" role="1vMDcl">
           <property role="TrG5h" value="r2" />
@@ -2599,7 +2617,11 @@
           </node>
           <node concept="1fLbrf" id="1c6hIxyYjiM" role="1fLbpX">
             <ref role="1fLbst" node="1c6hIxyYj9N" resolve="r1" />
-            <node concept="2vmpn$" id="1c6hIxyYjiL" role="1fLbpZ" />
+            <node concept="m5g4o" id="3mhgBZpg6mQ" role="1fLbpZ">
+              <node concept="2vmpn$" id="3mhgBZpmXey" role="m5g4p" />
+              <node concept="2vmpn$" id="3mhgBZpmUaX" role="m5g4p" />
+              <node concept="2vmpn$" id="3mhgBZpmXo6" role="m5g4p" />
+            </node>
           </node>
           <node concept="1fLbrf" id="1c6hIxyYjj3" role="1fLbpX">
             <ref role="1fLbst" node="1c6hIxyYjdA" resolve="r2" />
@@ -2639,15 +2661,35 @@
         </node>
       </node>
     </node>
+    <node concept="_ixoA" id="3mhgBZpg58p" role="_iOnB" />
+    <node concept="2zPypq" id="3mhgBZpg58t" role="_iOnB">
+      <property role="TrG5h" value="a" />
+      <node concept="3iBYCm" id="3mhgBZpg6ma" role="2zM23F">
+        <node concept="2vmvy5" id="3mhgBZpmU$l" role="3iBWmK" />
+      </node>
+      <node concept="1QScDb" id="3mhgBZpg70y" role="2zPyp_">
+        <node concept="383P9U" id="3mhgBZpg70z" role="1QScD9">
+          <ref role="383OOP" node="1c6hIxyYj9N" resolve="r1" />
+        </node>
+        <node concept="_emDc" id="3mhgBZpg70$" role="30czhm">
+          <ref role="_emDf" node="1c6hIxyYshT" resolve="res1" />
+        </node>
+      </node>
+    </node>
     <node concept="_ixoA" id="1c6hIxyYug3" role="_iOnB" />
     <node concept="_fkuM" id="1c6hIxyYki5" role="_iOnB">
       <property role="TrG5h" value="multiDecTableResultAccess" />
       <node concept="_fkuZ" id="1c6hIxyYsL3" role="_fkp5">
         <node concept="_fku$" id="1c6hIxyYsL4" role="_fkur" />
-        <node concept="3nOhSe" id="1c6hIxyYwmx" role="_fkuY">
-          <property role="3nOAFM" value="0" />
-          <node concept="_emDc" id="1c6hIxyYsLs" role="3nOhSx">
-            <ref role="_emDf" node="1c6hIxyYshT" resolve="res1" />
+        <node concept="2yLE0X" id="3mhgBZpmWGU" role="_fkuY">
+          <node concept="30bXRB" id="3mhgBZpmWOK" role="2yLE0W">
+            <property role="30bXRw" value="0" />
+          </node>
+          <node concept="3nOhSe" id="1c6hIxyYwmx" role="30czhm">
+            <property role="3nOAFM" value="0" />
+            <node concept="_emDc" id="1c6hIxyYsLs" role="3nOhSx">
+              <ref role="_emDf" node="1c6hIxyYshT" resolve="res1" />
+            </node>
           </node>
         </node>
         <node concept="2vmpnb" id="1c6hIxyYu6n" role="_fkuS" />
@@ -2675,10 +2717,15 @@
       </node>
       <node concept="_fkuZ" id="1c6hIxyYAkW" role="_fkp5">
         <node concept="_fku$" id="1c6hIxyYAkX" role="_fkur" />
-        <node concept="3nOhSe" id="1c6hIxyYAkY" role="_fkuY">
-          <property role="3nOAFM" value="0" />
-          <node concept="_emDc" id="1c6hIxyYAkZ" role="3nOhSx">
-            <ref role="_emDf" node="1c6hIxyYxZW" resolve="res2" />
+        <node concept="2yLE0X" id="3mhgBZpmXF3" role="_fkuY">
+          <node concept="30bXRB" id="3mhgBZpmXNv" role="2yLE0W">
+            <property role="30bXRw" value="0" />
+          </node>
+          <node concept="3nOhSe" id="1c6hIxyYAkY" role="30czhm">
+            <property role="3nOAFM" value="0" />
+            <node concept="_emDc" id="1c6hIxyYAkZ" role="3nOhSx">
+              <ref role="_emDf" node="1c6hIxyYxZW" resolve="res2" />
+            </node>
           </node>
         </node>
         <node concept="2vmpn$" id="1c6hIxyYAu5" role="_fkuS" />
@@ -2698,12 +2745,17 @@
       <node concept="3dYjL0" id="1c6hIxyY_Wf" role="_fkp5" />
       <node concept="_fkuZ" id="1c6hIxyY_FZ" role="_fkp5">
         <node concept="_fku$" id="1c6hIxyY_G0" role="_fkur" />
-        <node concept="1QScDb" id="1c6hIxyY_H2" role="_fkuY">
-          <node concept="383P9U" id="1c6hIxyY_LS" role="1QScD9">
-            <ref role="383OOP" node="1c6hIxyYj9N" resolve="r1" />
+        <node concept="2yLE0X" id="3mhgBZpmXWO" role="_fkuY">
+          <node concept="30bXRB" id="3mhgBZpmY5S" role="2yLE0W">
+            <property role="30bXRw" value="0" />
           </node>
-          <node concept="_emDc" id="1c6hIxyY_GB" role="30czhm">
-            <ref role="_emDf" node="1c6hIxyYshT" resolve="res1" />
+          <node concept="1QScDb" id="1c6hIxyY_H2" role="30czhm">
+            <node concept="383P9U" id="1c6hIxyY_LS" role="1QScD9">
+              <ref role="383OOP" node="1c6hIxyYj9N" resolve="r1" />
+            </node>
+            <node concept="_emDc" id="1c6hIxyY_GB" role="30czhm">
+              <ref role="_emDf" node="1c6hIxyYshT" resolve="res1" />
+            </node>
           </node>
         </node>
         <node concept="2vmpnb" id="1c6hIxyY_P9" role="_fkuS" />
@@ -2733,12 +2785,17 @@
       </node>
       <node concept="_fkuZ" id="1c6hIxyYD_Z" role="_fkp5">
         <node concept="_fku$" id="1c6hIxyYDA0" role="_fkur" />
-        <node concept="1QScDb" id="1c6hIxyYDFG" role="_fkuY">
-          <node concept="383P9U" id="1c6hIxyYDLF" role="1QScD9">
-            <ref role="383OOP" node="1c6hIxyYj9N" resolve="r1" />
+        <node concept="2yLE0X" id="3mhgBZpmYfc" role="_fkuY">
+          <node concept="30bXRB" id="3mhgBZpmYoM" role="2yLE0W">
+            <property role="30bXRw" value="0" />
           </node>
-          <node concept="_emDc" id="1c6hIxyYDA2" role="30czhm">
-            <ref role="_emDf" node="1c6hIxyYxZW" resolve="res2" />
+          <node concept="1QScDb" id="1c6hIxyYDFG" role="30czhm">
+            <node concept="383P9U" id="1c6hIxyYDLF" role="1QScD9">
+              <ref role="383OOP" node="1c6hIxyYj9N" resolve="r1" />
+            </node>
+            <node concept="_emDc" id="1c6hIxyYDA2" role="30czhm">
+              <ref role="_emDf" node="1c6hIxyYxZW" resolve="res2" />
+            </node>
           </node>
         </node>
         <node concept="2vmpn$" id="1c6hIxyYDA3" role="_fkuS" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tuples@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tuples@tests.mps
@@ -15,9 +15,21 @@
       </concept>
     </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
+      <concept id="1330041117646892901" name="org.iets3.core.expr.collections.structure.CollectionSizeSpec" flags="ng" index="2gteSW">
+        <property id="1330041117646892912" name="max" index="2gteSD" />
+        <property id="1330041117646892911" name="min" index="2gteSQ" />
+      </concept>
+      <concept id="5849458724932670346" name="org.iets3.core.expr.collections.structure.BracketOp" flags="ng" index="2yLE0X">
+        <child id="5849458724932670347" name="index" index="2yLE0W" />
+      </concept>
+      <concept id="7554398283339749509" name="org.iets3.core.expr.collections.structure.CollectionType" flags="ng" index="3iBWmN">
+        <child id="3989687176989764921" name="sizeConstraint" index="1ietDw" />
+        <child id="7554398283339749510" name="baseType" index="3iBWmK" />
+      </concept>
       <concept id="7554398283339759319" name="org.iets3.core.expr.collections.structure.ListLiteral" flags="ng" index="3iBYfx">
         <child id="7554398283339759320" name="elements" index="3iBYfI" />
       </concept>
+      <concept id="7554398283339757344" name="org.iets3.core.expr.collections.structure.ListType" flags="ng" index="3iBYCm" />
     </language>
     <language id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base">
       <concept id="229512757698888199" name="org.iets3.core.base.structure.IOptionallyNamed" flags="ng" index="pfQq$">
@@ -77,7 +89,17 @@
       <concept id="5285810042889815162" name="org.iets3.core.expr.tests.structure.EmptyTestItem" flags="ng" index="3dYjL0" />
     </language>
     <language id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes">
-      <concept id="8219602584782245544" name="org.iets3.core.expr.simpleTypes.structure.NumberType" flags="ng" index="mLuIC" />
+      <concept id="1330041117646892924" name="org.iets3.core.expr.simpleTypes.structure.NumberPrecSpec" flags="ng" index="2gteS_">
+        <property id="1330041117646892934" name="prec" index="2gteVv" />
+      </concept>
+      <concept id="1330041117646892901" name="org.iets3.core.expr.simpleTypes.structure.NumberRangeSpec" flags="ng" index="2gteSX">
+        <property id="1330041117646892912" name="max" index="2gteSE" />
+        <property id="1330041117646892911" name="min" index="2gteSR" />
+      </concept>
+      <concept id="8219602584782245544" name="org.iets3.core.expr.simpleTypes.structure.NumberType" flags="ng" index="mLuIC">
+        <child id="1330041117646892920" name="range" index="2gteSx" />
+        <child id="1330041117646892937" name="prec" index="2gteVg" />
+      </concept>
       <concept id="7425695345928358745" name="org.iets3.core.expr.simpleTypes.structure.TrueLiteral" flags="ng" index="2vmpnb" />
       <concept id="7425695345928349207" name="org.iets3.core.expr.simpleTypes.structure.BooleanType" flags="ng" index="2vmvy5" />
       <concept id="5115872837157252552" name="org.iets3.core.expr.simpleTypes.structure.StringLiteral" flags="ng" index="30bdrP">
@@ -122,6 +144,149 @@
         <node concept="mLuIC" id="1ufrWYcQ_$n" role="m5gfT" />
       </node>
     </node>
+    <node concept="2zPypq" id="5a86BD1blUe" role="_iOnB">
+      <property role="TrG5h" value="nCopies1" />
+      <node concept="1QScDb" id="5a86BD1bm5d" role="2zPyp_">
+        <node concept="ze_g2" id="5a86BD1bm5e" role="1QScD9">
+          <node concept="30bXRB" id="5a86BD1bm5f" role="zexk8">
+            <property role="30bXRw" value="0" />
+          </node>
+        </node>
+        <node concept="m5g4o" id="5a86BD1bm5g" role="30czhm">
+          <node concept="30bXRB" id="5a86BD1bm5h" role="m5g4p">
+            <property role="30bXRw" value="1" />
+          </node>
+        </node>
+      </node>
+      <node concept="3iBYCm" id="5a86BD1cbTw" role="2zM23F">
+        <node concept="mLuIC" id="5a86BD1cbDT" role="3iBWmK">
+          <node concept="2gteSX" id="5a86BD1cbDU" role="2gteSx">
+            <property role="2gteSR" value="1" />
+            <property role="2gteSE" value="1" />
+          </node>
+          <node concept="2gteS_" id="5a86BD1cbDV" role="2gteVg">
+            <property role="2gteVv" value="0" />
+          </node>
+        </node>
+        <node concept="2gteSW" id="5a86BD1cfZE" role="1ietDw">
+          <property role="2gteSQ" value="1" />
+          <property role="2gteSD" value="1" />
+        </node>
+      </node>
+    </node>
+    <node concept="2zPypq" id="5a86BD1bm8f" role="_iOnB">
+      <property role="TrG5h" value="nCopies2" />
+      <node concept="1QScDb" id="5a86BD1bm8k" role="2zPyp_">
+        <node concept="ze_g2" id="5a86BD1bm8l" role="1QScD9">
+          <node concept="30bXRB" id="5a86BD1bm8m" role="zexk8">
+            <property role="30bXRw" value="-1" />
+          </node>
+        </node>
+        <node concept="m5g4o" id="5a86BD1bm8n" role="30czhm">
+          <node concept="30bXRB" id="5a86BD1bm8o" role="m5g4p">
+            <property role="30bXRw" value="1" />
+          </node>
+        </node>
+      </node>
+      <node concept="3iBYCm" id="5a86BD1cc61" role="2zM23F">
+        <node concept="mLuIC" id="5a86BD1cbH_" role="3iBWmK">
+          <node concept="2gteSX" id="5a86BD1cbHA" role="2gteSx">
+            <property role="2gteSR" value="1" />
+            <property role="2gteSE" value="1" />
+          </node>
+          <node concept="2gteS_" id="5a86BD1cbHB" role="2gteVg">
+            <property role="2gteVv" value="0" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2zPypq" id="5a86BD12UX4" role="_iOnB">
+      <property role="TrG5h" value="nCopies3" />
+      <node concept="1QScDb" id="ijyib_kqCs" role="2zPyp_">
+        <node concept="ze_g2" id="ijyib_kqE0" role="1QScD9">
+          <node concept="30dDZf" id="xNPLfwAb9" role="zexk8">
+            <node concept="30bXRB" id="xNPLfwAbu" role="30dEs_">
+              <property role="30bXRw" value="2" />
+            </node>
+            <node concept="30bXRB" id="ijyib_kqFg" role="30dEsF">
+              <property role="30bXRw" value="1" />
+            </node>
+          </node>
+        </node>
+        <node concept="m5g4o" id="ijyib_kqAC" role="30czhm">
+          <node concept="30bXRB" id="ijyib_kqAM" role="m5g4p">
+            <property role="30bXRw" value="1" />
+          </node>
+          <node concept="30bXRB" id="ijyib_kqBj" role="m5g4p">
+            <property role="30bXRw" value="2" />
+          </node>
+        </node>
+      </node>
+      <node concept="3iBYCm" id="5a86BD13AsS" role="2zM23F">
+        <node concept="2gteSW" id="5a86BD13DEC" role="1ietDw">
+          <property role="2gteSQ" value="0" />
+          <property role="2gteSD" value="8" />
+        </node>
+        <node concept="mLuIC" id="5a86BD1aH0R" role="3iBWmK">
+          <node concept="2gteSX" id="5a86BD1aHds" role="2gteSx">
+            <property role="2gteSR" value="1" />
+            <property role="2gteSE" value="2" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2zPypq" id="5a86BD1bpn0" role="_iOnB">
+      <property role="TrG5h" value="nCopies4" />
+      <node concept="3iBYCm" id="5a86BD1bpnh" role="2zM23F">
+        <node concept="2gteSW" id="5a86BD1bpni" role="1ietDw">
+          <property role="2gteSQ" value="0" />
+          <property role="2gteSD" value="40" />
+        </node>
+        <node concept="m5gfS" id="5a86BD1bQNz" role="3iBWmK">
+          <node concept="mLuIC" id="5a86BD1bpnj" role="m5gfT" />
+          <node concept="mLuIC" id="5a86BD1c3Bd" role="m5gfT" />
+        </node>
+      </node>
+      <node concept="1QScDb" id="25rRV02oaSa" role="2zPyp_">
+        <node concept="m5g4o" id="25rRV02iiW_" role="30czhm">
+          <node concept="m5g4o" id="ijyib_ia$A" role="m5g4p">
+            <node concept="30bXRB" id="ijyib_ia$N" role="m5g4p">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="30bXRB" id="ijyib_ia_p" role="m5g4p">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="m5g4o" id="ijyib_iaNw" role="m5g4p">
+            <node concept="30bXRB" id="ijyib_iaPf" role="m5g4p">
+              <property role="30bXRw" value="3" />
+            </node>
+            <node concept="30bXRB" id="ijyib_ib8j" role="m5g4p">
+              <property role="30bXRw" value="4" />
+            </node>
+          </node>
+        </node>
+        <node concept="ze_g2" id="25rRV02v9Zh" role="1QScD9">
+          <node concept="30bXRB" id="3cDaBeIjnx9" role="zexk8">
+            <property role="30bXRw" value="20" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2zPypq" id="3mhgBZp5pKq" role="_iOnB">
+      <property role="TrG5h" value="t" />
+      <node concept="m5g4o" id="3mhgBZp5pK$" role="2zPyp_">
+        <node concept="30bXRB" id="3mhgBZp5pKH" role="m5g4p">
+          <property role="30bXRw" value="1" />
+        </node>
+        <node concept="30bXRB" id="3mhgBZp5pMd" role="m5g4p">
+          <property role="30bXRw" value="1" />
+        </node>
+      </node>
+      <node concept="3iBYCm" id="3mhgBZp5pQc" role="2zM23F">
+        <node concept="mLuIC" id="3mhgBZp5pSB" role="3iBWmK" />
+      </node>
+    </node>
     <node concept="_ixoA" id="6HHp2WmY4cE" role="_iOnB" />
     <node concept="_fkuM" id="ijyib_knuu" role="_iOnB">
       <property role="TrG5h" value="nCopies" />
@@ -136,55 +301,17 @@
       </node>
       <node concept="mXNUv" id="ijyib_loZT" role="_fkp5">
         <property role="xVyv2" value="the argument must be greater than 0" />
-        <node concept="1QScDb" id="ijyib_lp0K" role="mXJVd">
-          <node concept="ze_g2" id="ijyib_lp0L" role="1QScD9">
-            <node concept="30bXRB" id="ijyib_lp0M" role="zexk8">
-              <property role="30bXRw" value="0" />
-            </node>
-          </node>
-          <node concept="m5g4o" id="ijyib_lp0N" role="30czhm">
-            <node concept="30bXRB" id="ijyib_lp0O" role="m5g4p">
-              <property role="30bXRw" value="1" />
-            </node>
-          </node>
+        <node concept="_emDc" id="5a86BD1bm7V" role="mXJVd">
+          <ref role="_emDf" node="5a86BD1blUe" resolve="nCopies1" />
         </node>
       </node>
       <node concept="mXNUv" id="ijyib_lPJh" role="_fkp5">
-        <node concept="1QScDb" id="ijyib_lPJi" role="mXJVd">
-          <node concept="ze_g2" id="ijyib_lPJj" role="1QScD9">
-            <node concept="30bXRB" id="ijyib_lPM_" role="zexk8">
-              <property role="30bXRw" value="-1" />
-            </node>
-          </node>
-          <node concept="m5g4o" id="ijyib_lPJl" role="30czhm">
-            <node concept="30bXRB" id="ijyib_lPJm" role="m5g4p">
-              <property role="30bXRw" value="1" />
-            </node>
-          </node>
+        <node concept="_emDc" id="5a86BD1bpmG" role="mXJVd">
+          <ref role="_emDf" node="5a86BD1bm8f" resolve="nCopies2" />
         </node>
       </node>
       <node concept="_fkuZ" id="ijyib_kqA1" role="_fkp5">
         <node concept="_fku$" id="ijyib_kqA2" role="_fkur" />
-        <node concept="1QScDb" id="ijyib_kqCs" role="_fkuY">
-          <node concept="ze_g2" id="ijyib_kqE0" role="1QScD9">
-            <node concept="30dDZf" id="xNPLfwAb9" role="zexk8">
-              <node concept="30bXRB" id="xNPLfwAbu" role="30dEs_">
-                <property role="30bXRw" value="2" />
-              </node>
-              <node concept="30bXRB" id="ijyib_kqFg" role="30dEsF">
-                <property role="30bXRw" value="1" />
-              </node>
-            </node>
-          </node>
-          <node concept="m5g4o" id="ijyib_kqAC" role="30czhm">
-            <node concept="30bXRB" id="ijyib_kqAM" role="m5g4p">
-              <property role="30bXRw" value="1" />
-            </node>
-            <node concept="30bXRB" id="ijyib_kqBj" role="m5g4p">
-              <property role="30bXRw" value="2" />
-            </node>
-          </node>
-        </node>
         <node concept="m5g4o" id="ijyib_kqSq" role="_fkuS">
           <node concept="30bXRB" id="ijyib_kqSy" role="m5g4p">
             <property role="30bXRw" value="1" />
@@ -205,34 +332,12 @@
             <property role="30bXRw" value="2" />
           </node>
         </node>
+        <node concept="_emDc" id="5a86BD12UXi" role="_fkuY">
+          <ref role="_emDf" node="5a86BD12UX4" resolve="t2" />
+        </node>
       </node>
       <node concept="_fkuZ" id="ijyib_kjre" role="_fkp5">
         <node concept="_fku$" id="ijyib_kjrf" role="_fkur" />
-        <node concept="1QScDb" id="25rRV02oaSa" role="_fkuY">
-          <node concept="m5g4o" id="25rRV02iiW_" role="30czhm">
-            <node concept="m5g4o" id="ijyib_ia$A" role="m5g4p">
-              <node concept="30bXRB" id="ijyib_ia$N" role="m5g4p">
-                <property role="30bXRw" value="1" />
-              </node>
-              <node concept="30bXRB" id="ijyib_ia_p" role="m5g4p">
-                <property role="30bXRw" value="2" />
-              </node>
-            </node>
-            <node concept="m5g4o" id="ijyib_iaNw" role="m5g4p">
-              <node concept="30bXRB" id="ijyib_iaPf" role="m5g4p">
-                <property role="30bXRw" value="3" />
-              </node>
-              <node concept="30bXRB" id="ijyib_ib8j" role="m5g4p">
-                <property role="30bXRw" value="4" />
-              </node>
-            </node>
-          </node>
-          <node concept="ze_g2" id="25rRV02v9Zh" role="1QScD9">
-            <node concept="30bXRB" id="3cDaBeIjnx9" role="zexk8">
-              <property role="30bXRw" value="20" />
-            </node>
-          </node>
-        </node>
         <node concept="3iBYfx" id="ijyib_klet" role="_fkuS">
           <node concept="3iBYfx" id="ijyib_kle$" role="3iBYfI">
             <node concept="30bXRB" id="ijyib_kleI" role="3iBYfI">
@@ -554,6 +659,23 @@
               <property role="30bXRw" value="4" />
             </node>
           </node>
+        </node>
+        <node concept="_emDc" id="5a86BD1brBi" role="_fkuY">
+          <ref role="_emDf" node="5a86BD1bpn0" resolve="nCopies4" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="3mhgBZp5pUU" role="_fkp5">
+        <node concept="_fku$" id="3mhgBZp5pUV" role="_fkur" />
+        <node concept="2yLE0X" id="3mhgBZp5pVM" role="_fkuY">
+          <node concept="30bXRB" id="3mhgBZp5pYR" role="2yLE0W">
+            <property role="30bXRw" value="0" />
+          </node>
+          <node concept="_emDc" id="3mhgBZp5pV7" role="30czhm">
+            <ref role="_emDf" node="3mhgBZp5pKq" resolve="t" />
+          </node>
+        </node>
+        <node concept="30bXRB" id="3mhgBZp5q1Q" role="_fkuS">
+          <property role="30bXRw" value="1" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -268,6 +268,9 @@
         <child id="606861080870797310" name="expr" index="pf3We" />
       </concept>
       <concept id="2390066428848651932" name="org.iets3.core.expr.base.structure.BangOp" flags="ng" index="wdKpt" />
+      <concept id="2403760773179476914" name="org.iets3.core.expr.base.structure.NCopiesOp" flags="ng" index="ze_g2">
+        <child id="2403760773179493048" name="times" index="zexk8" />
+      </concept>
       <concept id="7089558164909884363" name="org.iets3.core.expr.base.structure.TryErrorClause" flags="ng" index="2zzUxt">
         <child id="7089558164909884398" name="expr" index="2zzUxS" />
         <child id="7089558164910923907" name="errorLiteral" index="2zBOGl" />
@@ -22207,6 +22210,445 @@
             </node>
           </node>
         </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="5a86BD1caBs">
+    <property role="TrG5h" value="tuplesListComparison" />
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <node concept="1qefOq" id="5a86BD1caBt" role="1SKRRt">
+      <node concept="_iOnV" id="5a86BD1caBu" role="1qenE9">
+        <property role="TrG5h" value="enums" />
+        <node concept="2zPypq" id="5a86BD1blUe" role="_iOnC">
+          <property role="TrG5h" value="correct1" />
+          <node concept="1QScDb" id="5a86BD1bm5d" role="2zPyp_">
+            <node concept="ze_g2" id="5a86BD1bm5e" role="1QScD9">
+              <node concept="30bXRB" id="5a86BD1bm5f" role="zexk8">
+                <property role="30bXRw" value="0" />
+              </node>
+            </node>
+            <node concept="m5g4o" id="5a86BD1bm5g" role="30czhm">
+              <node concept="30bXRB" id="5a86BD1bm5h" role="m5g4p">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+          </node>
+          <node concept="3iBYCm" id="5a86BD1cbTw" role="2zM23F">
+            <node concept="mLuIC" id="5a86BD1cbDT" role="3iBWmK">
+              <node concept="2gteSX" id="5a86BD1cbDU" role="2gteSx">
+                <property role="2gteSR" value="1" />
+                <property role="2gteSE" value="1" />
+              </node>
+              <node concept="2gteS_" id="5a86BD1cbDV" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
+            <node concept="2gteSW" id="5a86BD1cfZE" role="1ietDw">
+              <property role="2gteSQ" value="1" />
+              <property role="2gteSD" value="1" />
+            </node>
+          </node>
+          <node concept="7CXmI" id="5a86BD1dztz" role="lGtFl">
+            <node concept="7OXhh" id="5a86BD1dzxm" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5a86BD1bm8f" role="_iOnC">
+          <property role="TrG5h" value="correct2WithoutListRange" />
+          <node concept="1QScDb" id="5a86BD1bm8k" role="2zPyp_">
+            <node concept="ze_g2" id="5a86BD1bm8l" role="1QScD9">
+              <node concept="30bXRB" id="5a86BD1bm8m" role="zexk8">
+                <property role="30bXRw" value="-1" />
+              </node>
+            </node>
+            <node concept="m5g4o" id="5a86BD1bm8n" role="30czhm">
+              <node concept="30bXRB" id="5a86BD1bm8o" role="m5g4p">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+          </node>
+          <node concept="3iBYCm" id="5a86BD1cc61" role="2zM23F">
+            <node concept="mLuIC" id="5a86BD1cbH_" role="3iBWmK">
+              <node concept="2gteSX" id="5a86BD1cbHA" role="2gteSx">
+                <property role="2gteSR" value="1" />
+                <property role="2gteSE" value="1" />
+              </node>
+              <node concept="2gteS_" id="5a86BD1cbHB" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
+          </node>
+          <node concept="7CXmI" id="5a86BD1dzGq" role="lGtFl">
+            <node concept="7OXhh" id="5a86BD1dzK3" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5a86BD12UX4" role="_iOnC">
+          <property role="TrG5h" value="correct3" />
+          <node concept="1QScDb" id="ijyib_kqCs" role="2zPyp_">
+            <node concept="ze_g2" id="ijyib_kqE0" role="1QScD9">
+              <node concept="30dDZf" id="xNPLfwAb9" role="zexk8">
+                <node concept="30bXRB" id="xNPLfwAbu" role="30dEs_">
+                  <property role="30bXRw" value="2" />
+                </node>
+                <node concept="30bXRB" id="ijyib_kqFg" role="30dEsF">
+                  <property role="30bXRw" value="1" />
+                </node>
+              </node>
+            </node>
+            <node concept="m5g4o" id="ijyib_kqAC" role="30czhm">
+              <node concept="30bXRB" id="ijyib_kqAM" role="m5g4p">
+                <property role="30bXRw" value="1" />
+              </node>
+              <node concept="30bXRB" id="ijyib_kqBj" role="m5g4p">
+                <property role="30bXRw" value="2" />
+              </node>
+            </node>
+          </node>
+          <node concept="3iBYCm" id="5a86BD13AsS" role="2zM23F">
+            <node concept="2gteSW" id="5a86BD13DEC" role="1ietDw">
+              <property role="2gteSQ" value="0" />
+              <property role="2gteSD" value="8" />
+            </node>
+            <node concept="mLuIC" id="5a86BD1aH0R" role="3iBWmK">
+              <node concept="2gteSX" id="5a86BD1aHds" role="2gteSx">
+                <property role="2gteSR" value="1" />
+                <property role="2gteSE" value="2" />
+              </node>
+            </node>
+          </node>
+          <node concept="7CXmI" id="5a86BD1dzNG" role="lGtFl">
+            <node concept="7OXhh" id="5a86BD1dzZl" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5a86BD1bpn0" role="_iOnC">
+          <property role="TrG5h" value="correctWithTupleType" />
+          <node concept="3iBYCm" id="5a86BD1bpnh" role="2zM23F">
+            <node concept="2gteSW" id="5a86BD1bpni" role="1ietDw">
+              <property role="2gteSQ" value="0" />
+              <property role="2gteSD" value="40" />
+            </node>
+            <node concept="m5gfS" id="5a86BD1bQNz" role="3iBWmK">
+              <node concept="mLuIC" id="5a86BD1bpnj" role="m5gfT" />
+              <node concept="mLuIC" id="5a86BD1c3Bd" role="m5gfT" />
+            </node>
+          </node>
+          <node concept="1QScDb" id="25rRV02oaSa" role="2zPyp_">
+            <node concept="m5g4o" id="25rRV02iiW_" role="30czhm">
+              <node concept="m5g4o" id="ijyib_ia$A" role="m5g4p">
+                <node concept="30bXRB" id="ijyib_ia$N" role="m5g4p">
+                  <property role="30bXRw" value="1" />
+                </node>
+                <node concept="30bXRB" id="ijyib_ia_p" role="m5g4p">
+                  <property role="30bXRw" value="2" />
+                </node>
+              </node>
+              <node concept="m5g4o" id="ijyib_iaNw" role="m5g4p">
+                <node concept="30bXRB" id="ijyib_iaPf" role="m5g4p">
+                  <property role="30bXRw" value="3" />
+                </node>
+                <node concept="30bXRB" id="ijyib_ib8j" role="m5g4p">
+                  <property role="30bXRw" value="4" />
+                </node>
+              </node>
+            </node>
+            <node concept="ze_g2" id="25rRV02v9Zh" role="1QScD9">
+              <node concept="30bXRB" id="3cDaBeIjnx9" role="zexk8">
+                <property role="30bXRw" value="20" />
+              </node>
+            </node>
+          </node>
+          <node concept="7CXmI" id="5a86BD1d$9Y" role="lGtFl">
+            <node concept="7OXhh" id="5a86BD1dAoc" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5a86BD1egTW" role="_iOnC">
+          <property role="TrG5h" value="correctWithNestedList" />
+          <node concept="3iBYCm" id="5a86BD1egTX" role="2zM23F">
+            <node concept="2gteSW" id="5a86BD1egTY" role="1ietDw">
+              <property role="2gteSQ" value="0" />
+              <property role="2gteSD" value="40" />
+            </node>
+            <node concept="3iBYCm" id="5a86BD1es0j" role="3iBWmK">
+              <node concept="mLuIC" id="5a86BD1eNrl" role="3iBWmK" />
+            </node>
+          </node>
+          <node concept="1QScDb" id="5a86BD1egU2" role="2zPyp_">
+            <node concept="m5g4o" id="5a86BD1egU3" role="30czhm">
+              <node concept="m5g4o" id="5a86BD1egU4" role="m5g4p">
+                <node concept="30bXRB" id="5a86BD1egU5" role="m5g4p">
+                  <property role="30bXRw" value="1" />
+                </node>
+                <node concept="30bXRB" id="5a86BD1egU6" role="m5g4p">
+                  <property role="30bXRw" value="2" />
+                </node>
+              </node>
+              <node concept="m5g4o" id="5a86BD1egU7" role="m5g4p">
+                <node concept="30bXRB" id="5a86BD1egU8" role="m5g4p">
+                  <property role="30bXRw" value="3" />
+                </node>
+                <node concept="30bXRB" id="5a86BD1egU9" role="m5g4p">
+                  <property role="30bXRw" value="4" />
+                </node>
+              </node>
+            </node>
+            <node concept="ze_g2" id="5a86BD1egUa" role="1QScD9">
+              <node concept="30bXRB" id="5a86BD1egUb" role="zexk8">
+                <property role="30bXRw" value="20" />
+              </node>
+            </node>
+          </node>
+          <node concept="7CXmI" id="5a86BD1egUc" role="lGtFl">
+            <node concept="7OXhh" id="5a86BD1egUd" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5a86BD1ePDl" role="_iOnC">
+          <property role="TrG5h" value="correctWithNestedListAndRange" />
+          <node concept="3iBYCm" id="5a86BD1ePDm" role="2zM23F">
+            <node concept="2gteSW" id="5a86BD1ePDn" role="1ietDw">
+              <property role="2gteSQ" value="0" />
+              <property role="2gteSD" value="40" />
+            </node>
+            <node concept="3iBYCm" id="5a86BD1ePDo" role="3iBWmK">
+              <node concept="mLuIC" id="5a86BD1ePDp" role="3iBWmK" />
+              <node concept="2gteSW" id="5a86BD1eU5v" role="1ietDw">
+                <property role="2gteSQ" value="0" />
+                <property role="2gteSD" value="2" />
+              </node>
+            </node>
+          </node>
+          <node concept="1QScDb" id="5a86BD1ePDq" role="2zPyp_">
+            <node concept="m5g4o" id="5a86BD1ePDr" role="30czhm">
+              <node concept="m5g4o" id="5a86BD1ePDs" role="m5g4p">
+                <node concept="30bXRB" id="5a86BD1ePDt" role="m5g4p">
+                  <property role="30bXRw" value="1" />
+                </node>
+                <node concept="30bXRB" id="5a86BD1ePDu" role="m5g4p">
+                  <property role="30bXRw" value="2" />
+                </node>
+              </node>
+              <node concept="m5g4o" id="5a86BD1ePDv" role="m5g4p">
+                <node concept="30bXRB" id="5a86BD1ePDw" role="m5g4p">
+                  <property role="30bXRw" value="3" />
+                </node>
+                <node concept="30bXRB" id="5a86BD1ePDx" role="m5g4p">
+                  <property role="30bXRw" value="4" />
+                </node>
+              </node>
+            </node>
+            <node concept="ze_g2" id="5a86BD1ePDy" role="1QScD9">
+              <node concept="30bXRB" id="5a86BD1ePDz" role="zexk8">
+                <property role="30bXRw" value="20" />
+              </node>
+            </node>
+          </node>
+          <node concept="7CXmI" id="5a86BD1ePD$" role="lGtFl">
+            <node concept="7OXhh" id="5a86BD1ePD_" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="5a86BD1dU_e" role="_iOnC" />
+        <node concept="2zPypq" id="5a86BD1fa2l" role="_iOnC">
+          <property role="TrG5h" value="wrongListType" />
+          <node concept="1QScDb" id="5a86BD1fa2m" role="2zPyp_">
+            <node concept="ze_g2" id="5a86BD1fa2n" role="1QScD9">
+              <node concept="30bXRB" id="5a86BD1fa2o" role="zexk8">
+                <property role="30bXRw" value="0" />
+              </node>
+            </node>
+            <node concept="m5g4o" id="5a86BD1fa2p" role="30czhm">
+              <node concept="30bXRB" id="5a86BD1fa2q" role="m5g4p">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="7CXmI" id="5a86BD1fjMm" role="lGtFl">
+              <node concept="2DdRWr" id="5a86BD1fAz_" role="7EUXB">
+                <node concept="MGsTx" id="5a86BD1fAzA" role="MJxsd">
+                  <ref role="39XzEq" to="t4jv:5aHkq2w4P8w" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3iBYCm" id="5a86BD1fa2r" role="2zM23F">
+            <node concept="2gteSW" id="5a86BD1fa2v" role="1ietDw">
+              <property role="2gteSQ" value="1" />
+              <property role="2gteSD" value="1" />
+            </node>
+            <node concept="2vmvy5" id="5a86BD1fao_" role="3iBWmK" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="5a86BD1dFeb" role="_iOnC">
+          <property role="TrG5h" value="wrongCollectionRange" />
+          <node concept="1QScDb" id="5a86BD1dFec" role="2zPyp_">
+            <node concept="ze_g2" id="5a86BD1dFed" role="1QScD9">
+              <node concept="30bXRB" id="5a86BD1dFee" role="zexk8">
+                <property role="30bXRw" value="0" />
+              </node>
+            </node>
+            <node concept="m5g4o" id="5a86BD1dFef" role="30czhm">
+              <node concept="30bXRB" id="5a86BD1dFeg" role="m5g4p">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="7CXmI" id="5a86BD1dPhH" role="lGtFl">
+              <node concept="2DdRWr" id="5a86BD1dUxq" role="7EUXB">
+                <node concept="MGsTx" id="5a86BD1dUxr" role="MJxsd">
+                  <ref role="39XzEq" to="t4jv:5aHkq2w4P8w" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3iBYCm" id="5a86BD1dFeh" role="2zM23F">
+            <node concept="mLuIC" id="5a86BD1dFei" role="3iBWmK">
+              <node concept="2gteSX" id="5a86BD1dFej" role="2gteSx">
+                <property role="2gteSR" value="1" />
+                <property role="2gteSE" value="1" />
+              </node>
+              <node concept="2gteS_" id="5a86BD1dFek" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
+            <node concept="2gteSW" id="5a86BD1dFel" role="1ietDw">
+              <property role="2gteSQ" value="0" />
+              <property role="2gteSD" value="0" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5a86BD1dUHQ" role="_iOnC">
+          <property role="TrG5h" value="wrongNumberRange" />
+          <node concept="1QScDb" id="5a86BD1dUHR" role="2zPyp_">
+            <node concept="ze_g2" id="5a86BD1dUHS" role="1QScD9">
+              <node concept="30bXRB" id="5a86BD1dUHT" role="zexk8">
+                <property role="30bXRw" value="-1" />
+              </node>
+            </node>
+            <node concept="m5g4o" id="5a86BD1dUHU" role="30czhm">
+              <node concept="30bXRB" id="5a86BD1dUHV" role="m5g4p">
+                <property role="30bXRw" value="1" />
+              </node>
+            </node>
+            <node concept="7CXmI" id="5a86BD1dVbm" role="lGtFl">
+              <node concept="2DdRWr" id="5a86BD1e0yr" role="7EUXB">
+                <node concept="MGsTx" id="5a86BD1e0ys" role="MJxsd">
+                  <ref role="39XzEq" to="t4jv:5aHkq2w4P8w" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3iBYCm" id="5a86BD1dUHW" role="2zM23F">
+            <node concept="mLuIC" id="5a86BD1dUHX" role="3iBWmK">
+              <node concept="2gteSX" id="5a86BD1dUHY" role="2gteSx">
+                <property role="2gteSR" value="2" />
+                <property role="2gteSE" value="2" />
+              </node>
+              <node concept="2gteS_" id="5a86BD1dUHZ" role="2gteVg">
+                <property role="2gteVv" value="0" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5a86BD1f5Ad" role="_iOnC">
+          <property role="TrG5h" value="wrongTypeWithNestedList" />
+          <node concept="3iBYCm" id="5a86BD1f5Ae" role="2zM23F">
+            <node concept="2gteSW" id="5a86BD1f5Af" role="1ietDw">
+              <property role="2gteSQ" value="0" />
+              <property role="2gteSD" value="40" />
+            </node>
+            <node concept="3iBYCm" id="5a86BD1f5Ag" role="3iBWmK">
+              <node concept="2vmvy5" id="5a86BD1fOnC" role="3iBWmK" />
+            </node>
+          </node>
+          <node concept="1QScDb" id="5a86BD1f5Ai" role="2zPyp_">
+            <node concept="m5g4o" id="5a86BD1f5Aj" role="30czhm">
+              <node concept="m5g4o" id="5a86BD1f5Ak" role="m5g4p">
+                <node concept="30bXRB" id="5a86BD1f5Al" role="m5g4p">
+                  <property role="30bXRw" value="1" />
+                </node>
+                <node concept="30bXRB" id="5a86BD1f5Am" role="m5g4p">
+                  <property role="30bXRw" value="2" />
+                </node>
+              </node>
+              <node concept="m5g4o" id="5a86BD1f5An" role="m5g4p">
+                <node concept="30bXRB" id="5a86BD1f5Ao" role="m5g4p">
+                  <property role="30bXRw" value="3" />
+                </node>
+                <node concept="30bXRB" id="5a86BD1f5Ap" role="m5g4p">
+                  <property role="30bXRw" value="4" />
+                </node>
+              </node>
+            </node>
+            <node concept="ze_g2" id="5a86BD1f5Aq" role="1QScD9">
+              <node concept="30bXRB" id="5a86BD1f5Ar" role="zexk8">
+                <property role="30bXRw" value="20" />
+              </node>
+            </node>
+            <node concept="7CXmI" id="5a86BD1fZUN" role="lGtFl">
+              <node concept="2DdRWr" id="5a86BD1gkQZ" role="7EUXB">
+                <node concept="MGsTx" id="5a86BD1gkR0" role="MJxsd">
+                  <ref role="39XzEq" to="t4jv:5aHkq2w4P8w" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5a86BD1gwr_" role="_iOnC">
+          <property role="TrG5h" value="wrongWithNestedListAndRange" />
+          <node concept="3iBYCm" id="5a86BD1gwrA" role="2zM23F">
+            <node concept="2gteSW" id="5a86BD1gwrB" role="1ietDw">
+              <property role="2gteSQ" value="0" />
+              <property role="2gteSD" value="0" />
+            </node>
+            <node concept="3iBYCm" id="5a86BD1gwrC" role="3iBWmK">
+              <node concept="mLuIC" id="5a86BD1gwrD" role="3iBWmK" />
+              <node concept="2gteSW" id="5a86BD1gwrE" role="1ietDw">
+                <property role="2gteSQ" value="0" />
+                <property role="2gteSD" value="2" />
+              </node>
+            </node>
+          </node>
+          <node concept="1QScDb" id="5a86BD1gwrF" role="2zPyp_">
+            <node concept="m5g4o" id="5a86BD1gwrG" role="30czhm">
+              <node concept="m5g4o" id="5a86BD1gwrH" role="m5g4p">
+                <node concept="30bXRB" id="5a86BD1gwrI" role="m5g4p">
+                  <property role="30bXRw" value="1" />
+                </node>
+                <node concept="30bXRB" id="5a86BD1gwrJ" role="m5g4p">
+                  <property role="30bXRw" value="2" />
+                </node>
+              </node>
+              <node concept="m5g4o" id="5a86BD1gwrK" role="m5g4p">
+                <node concept="30bXRB" id="5a86BD1gwrL" role="m5g4p">
+                  <property role="30bXRw" value="3" />
+                </node>
+                <node concept="30bXRB" id="5a86BD1gwrM" role="m5g4p">
+                  <property role="30bXRw" value="4" />
+                </node>
+              </node>
+            </node>
+            <node concept="ze_g2" id="5a86BD1gwrN" role="1QScD9">
+              <node concept="30bXRB" id="5a86BD1gwrO" role="zexk8">
+                <property role="30bXRw" value="20" />
+              </node>
+            </node>
+            <node concept="7CXmI" id="5a86BD1gFzu" role="lGtFl">
+              <node concept="2DdRWr" id="5a86BD1h4WG" role="7EUXB">
+                <node concept="MGsTx" id="5a86BD1h4WH" role="MJxsd">
+                  <ref role="39XzEq" to="t4jv:5aHkq2w4P8w" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="5a86BD1gwrz" role="_iOnC" />
       </node>
     </node>
   </node>


### PR DESCRIPTION
Tuple types where all elements have the same type can now be used interchangeable with list types. Here is a concrete example where `nTimes` returns a tuple but the result is assigned to a list:

<img width="644" alt="Screenshot 2024-09-26 at 17 54 57" src="https://github.com/user-attachments/assets/3c4e6e21-1507-4804-a7a5-561d042ada4b">

On the generator level this level should also be fine as both tuples and lists use the class `PVector`. I just had to use `PVector` instead of `PVector<Object>` in some places.