### PR TITLE
New String type with constraints

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/models/typesystem.mps
@@ -1688,18 +1688,18 @@
     <property role="TrG5h" value="typeof_LocDotTarget" />
     <property role="3GE5qa" value="dot" />
     <node concept="3clFbS" id="7aipPVpFzey" role="18ibNy">
-      <node concept="1Z5TYs" id="7aipPVpFz$w" role="3cqZAp">
-        <node concept="mw_s8" id="7aipPVpFz$L" role="1ZfhKB">
-          <node concept="2YIFZM" id="5wDe8wA6zrB" role="mwGJk">
-            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
-            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-          </node>
-        </node>
-        <node concept="mw_s8" id="7aipPVpFz$z" role="1ZfhK$">
-          <node concept="1Z2H0r" id="7aipPVpFzeO" role="mwGJk">
-            <node concept="1YBJjd" id="7aipPVpFzeV" role="1Z2MuG">
+      <node concept="1ZobV4" id="hTGlT9FXl2" role="3cqZAp">
+        <node concept="mw_s8" id="hTGlT9FXl4" role="1ZfhK$">
+          <node concept="1Z2H0r" id="hTGlT9FXl5" role="mwGJk">
+            <node concept="1YBJjd" id="hTGlT9FXl6" role="1Z2MuG">
               <ref role="1YBMHb" node="7aipPVpFze$" resolve="loc" />
             </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="hTGlT9FXl7" role="1ZfhKB">
+          <node concept="2YIFZM" id="hTGlT9FXl8" role="mwGJk">
+            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
+            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -7826,9 +7826,7 @@
       </node>
       <node concept="37vLTG" id="ZYPG76w9Y2" role="3clF46">
         <property role="TrG5h" value="expectedType" />
-        <node concept="3Tqbb2" id="ZYPG76w9Y1" role="1tU5fm">
-          <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
-        </node>
+        <node concept="3Tqbb2" id="ZYPG76w9Y1" role="1tU5fm" />
       </node>
       <node concept="37vLTG" id="ZYPG76wazA" role="3clF46">
         <property role="TrG5h" value="actualType" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
@@ -5457,7 +5457,9 @@
       <node concept="37vLTG" id="12WRc293zz9" role="3clF46">
         <property role="TrG5h" value="types" />
         <node concept="A3Dl8" id="12WRc293zz7" role="1tU5fm">
-          <node concept="3Tqbb2" id="12WRc293zzj" role="A3Ik2" />
+          <node concept="3Tqbb2" id="12WRc293zzj" role="A3Ik2">
+            <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+          </node>
         </node>
       </node>
     </node>
@@ -5660,7 +5662,9 @@
       <node concept="37vLTG" id="3eH6BL4$poT" role="3clF46">
         <property role="TrG5h" value="types" />
         <node concept="_YKpA" id="3eH6BL4_yIQ" role="1tU5fm">
-          <node concept="3Tqbb2" id="3eH6BL4_$Nd" role="_ZDj9" />
+          <node concept="3Tqbb2" id="3eH6BL4_$Nd" role="_ZDj9">
+            <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+          </node>
         </node>
       </node>
       <node concept="37vLTG" id="2NHHcg2KyB1" role="3clF46">
@@ -5681,7 +5685,9 @@
       <node concept="37vLTG" id="7Xf3oOLUG1v" role="3clF46">
         <property role="TrG5h" value="types" />
         <node concept="A3Dl8" id="7Xf3oOLUG1w" role="1tU5fm">
-          <node concept="3Tqbb2" id="7Xf3oOLUG1x" role="A3Ik2" />
+          <node concept="3Tqbb2" id="7Xf3oOLUG1x" role="A3Ik2">
+            <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+          </node>
         </node>
       </node>
       <node concept="3clFbS" id="7Xf3oOLUFUf" role="3clF47">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
@@ -9723,18 +9723,18 @@
     <property role="TrG5h" value="typeof_ProgramLocationUrlOp" />
     <property role="3GE5qa" value="loc" />
     <node concept="3clFbS" id="4AahbtUR$jq" role="18ibNy">
-      <node concept="1Z5TYs" id="4AahbtUR$Ud" role="3cqZAp">
-        <node concept="mw_s8" id="4AahbtUR$Uv" role="1ZfhKB">
-          <node concept="2YIFZM" id="5wDe8wA6zrT" role="mwGJk">
-            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
-            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-          </node>
-        </node>
-        <node concept="mw_s8" id="4AahbtUR$Ug" role="1ZfhK$">
-          <node concept="1Z2H0r" id="4AahbtUR$Fr" role="mwGJk">
-            <node concept="1YBJjd" id="4AahbtUR$Hd" role="1Z2MuG">
+      <node concept="1ZobV4" id="hTGlT9FXrx" role="3cqZAp">
+        <node concept="mw_s8" id="hTGlT9FXrz" role="1ZfhK$">
+          <node concept="1Z2H0r" id="hTGlT9FXr$" role="mwGJk">
+            <node concept="1YBJjd" id="hTGlT9FXr_" role="1Z2MuG">
               <ref role="1YBMHb" node="4AahbtUR$js" resolve="url" />
             </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="hTGlT9FXrA" role="1ZfhKB">
+          <node concept="2YIFZM" id="hTGlT9FXrB" role="mwGJk">
+            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
+            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/intentions.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/intentions.mps
@@ -68,7 +68,7 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/typesystem.mps
@@ -4309,16 +4309,16 @@
         <node concept="3clFbS" id="4ptnK4ii9yt" role="nvhr_">
           <node concept="3clFbJ" id="4ptnK4iiaiO" role="3cqZAp">
             <node concept="3clFbS" id="4ptnK4iiaiQ" role="3clFbx">
-              <node concept="1Z5TYs" id="4ptnK4ii9gR" role="3cqZAp">
-                <node concept="mw_s8" id="4ptnK4ii9gS" role="1ZfhK$">
-                  <node concept="1Z2H0r" id="4ptnK4ii9gT" role="mwGJk">
-                    <node concept="1YBJjd" id="4ptnK4ii9i1" role="1Z2MuG">
+              <node concept="1ZobV4" id="hTGlT9FZFD" role="3cqZAp">
+                <node concept="mw_s8" id="hTGlT9FZFF" role="1ZfhK$">
+                  <node concept="1Z2H0r" id="hTGlT9FZFG" role="mwGJk">
+                    <node concept="1YBJjd" id="hTGlT9FZFH" role="1Z2MuG">
                       <ref role="1YBMHb" node="4ptnK4ii9gx" resolve="joiner" />
                     </node>
                   </node>
                 </node>
-                <node concept="mw_s8" id="4ptnK4ii9gV" role="1ZfhKB">
-                  <node concept="2YIFZM" id="5wDe8wA6zr_" role="mwGJk">
+                <node concept="mw_s8" id="hTGlT9FZFI" role="1ZfhKB">
+                  <node concept="2YIFZM" id="hTGlT9FZFJ" role="mwGJk">
                     <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
                     <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
                   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.datetime/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.datetime/models/typesystem.mps
@@ -1558,16 +1558,16 @@
     <property role="TrG5h" value="typeof_ToStringOp" />
     <property role="3GE5qa" value="date.op" />
     <node concept="3clFbS" id="7baKnR5m9ki" role="18ibNy">
-      <node concept="1Z5TYs" id="7baKnR5m9$G" role="3cqZAp">
-        <node concept="mw_s8" id="7baKnR5m9$J" role="1ZfhK$">
-          <node concept="1Z2H0r" id="7baKnR5m9kr" role="mwGJk">
-            <node concept="1YBJjd" id="7baKnR5m9mg" role="1Z2MuG">
+      <node concept="1ZobV4" id="hTGlT9FZOY" role="3cqZAp">
+        <node concept="mw_s8" id="hTGlT9FZP0" role="1ZfhK$">
+          <node concept="1Z2H0r" id="hTGlT9FZP1" role="mwGJk">
+            <node concept="1YBJjd" id="hTGlT9FZP2" role="1Z2MuG">
               <ref role="1YBMHb" node="7baKnR5m9kk" resolve="tso" />
             </node>
           </node>
         </node>
-        <node concept="mw_s8" id="7baKnR5m9_6" role="1ZfhKB">
-          <node concept="2YIFZM" id="5wDe8wA6zr$" role="mwGJk">
+        <node concept="mw_s8" id="hTGlT9FZP3" role="1ZfhKB">
+          <node concept="2YIFZM" id="hTGlT9FZP4" role="mwGJk">
             <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
             <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
           </node>
@@ -2910,18 +2910,18 @@
     <property role="TrG5h" value="typeof_TimeToStringOp" />
     <property role="3GE5qa" value="time.op" />
     <node concept="3clFbS" id="3HiHZeyqRqK" role="18ibNy">
-      <node concept="1Z5TYs" id="3HiHZeyqR_M" role="3cqZAp">
-        <node concept="mw_s8" id="3HiHZeyqRA3" role="1ZfhKB">
-          <node concept="2YIFZM" id="3HiHZeyqRCw" role="mwGJk">
-            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
-            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-          </node>
-        </node>
-        <node concept="mw_s8" id="3HiHZeyqR_P" role="1ZfhK$">
-          <node concept="1Z2H0r" id="3HiHZeyqRqQ" role="mwGJk">
-            <node concept="1YBJjd" id="3HiHZeyqRsI" role="1Z2MuG">
+      <node concept="1ZobV4" id="hTGlT9FZLB" role="3cqZAp">
+        <node concept="mw_s8" id="hTGlT9FZLF" role="1ZfhK$">
+          <node concept="1Z2H0r" id="hTGlT9FZLG" role="mwGJk">
+            <node concept="1YBJjd" id="hTGlT9FZLH" role="1Z2MuG">
               <ref role="1YBMHb" node="3HiHZeyqRqM" resolve="timeToStringOp" />
             </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="hTGlT9FZLD" role="1ZfhKB">
+          <node concept="2YIFZM" id="hTGlT9FZLE" role="mwGJk">
+            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
+            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.simpleTypes/generator/template/org.iets3.core.expr.genjava.simpleTypes@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.simpleTypes/generator/template/org.iets3.core.expr.genjava.simpleTypes@generator.mps
@@ -7101,6 +7101,7 @@
     <property role="TrG5h" value="SwitchPrimitiveType" />
     <ref role="phYkn" to="rw5i:10wUh3ORqUF" resolve="Type" />
     <node concept="3aamgX" id="2bLbgty8Z8R" role="3aUrZf">
+      <property role="36QftV" value="true" />
       <ref role="30HIoZ" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
       <node concept="1Koe21" id="2oTl_D$0r$1" role="1lVwrX">
         <node concept="3clFb_" id="2oTl_D$0r$h" role="1Koe22">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
@@ -3383,9 +3383,7 @@
       </node>
       <node concept="37vLTG" id="ZYPG76BgMI" role="3clF46">
         <property role="TrG5h" value="expectedType" />
-        <node concept="3Tqbb2" id="ZYPG76BgMJ" role="1tU5fm">
-          <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
-        </node>
+        <node concept="3Tqbb2" id="ZYPG76BgMJ" role="1tU5fm" />
       </node>
       <node concept="37vLTG" id="ZYPG76BgMK" role="3clF46">
         <property role="TrG5h" value="actualType" />
@@ -5663,15 +5661,11 @@
       </node>
       <node concept="37vLTG" id="ZYPG76Nzqw" role="3clF46">
         <property role="TrG5h" value="expectedType" />
-        <node concept="3Tqbb2" id="ZYPG76Nzqx" role="1tU5fm">
-          <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
-        </node>
+        <node concept="3Tqbb2" id="ZYPG76Nzqx" role="1tU5fm" />
       </node>
       <node concept="37vLTG" id="ZYPG76Nzqy" role="3clF46">
         <property role="TrG5h" value="actualType" />
-        <node concept="3Tqbb2" id="ZYPG76Nzqz" role="1tU5fm">
-          <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
-        </node>
+        <node concept="3Tqbb2" id="ZYPG76Nzqz" role="1tU5fm" />
       </node>
       <node concept="17QB3L" id="ZYPG76Nzq$" role="3clF45" />
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/typesystem.mps
@@ -104,6 +104,7 @@
       <concept id="1175517767210" name="jetbrains.mps.lang.typesystem.structure.ReportErrorStatement" flags="nn" index="2MkqsV">
         <child id="1175517851849" name="errorString" index="2MkJ7o" />
       </concept>
+      <concept id="1179832490862" name="jetbrains.mps.lang.typesystem.structure.CreateStrongLessThanInequationStatement" flags="nn" index="2NvLDW" />
       <concept id="1195213580585" name="jetbrains.mps.lang.typesystem.structure.AbstractCheckingRule" flags="ig" index="18hYwZ">
         <child id="1195213635060" name="body" index="18ibNy" />
       </concept>
@@ -602,18 +603,18 @@
                 </node>
               </node>
             </node>
-            <node concept="1Z5TYs" id="3vxfdxbtkR2" role="3cqZAp">
-              <node concept="mw_s8" id="3vxfdxbtkR3" role="1ZfhKB">
-                <node concept="2YIFZM" id="5wDe8wA6zrI" role="mwGJk">
-                  <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
-                  <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-                </node>
-              </node>
-              <node concept="mw_s8" id="3vxfdxbtkR5" role="1ZfhK$">
-                <node concept="1Z2H0r" id="3vxfdxbtkR6" role="mwGJk">
-                  <node concept="1YBJjd" id="3vxfdxbtkR7" role="1Z2MuG">
+            <node concept="1ZobV4" id="hTGlT9G0uY" role="3cqZAp">
+              <node concept="mw_s8" id="hTGlT9G0v2" role="1ZfhK$">
+                <node concept="1Z2H0r" id="hTGlT9G0v3" role="mwGJk">
+                  <node concept="1YBJjd" id="hTGlT9G0v4" role="1Z2MuG">
                     <ref role="1YBMHb" node="3vxfdxbeBg6" resolve="mar" />
                   </node>
+                </node>
+              </node>
+              <node concept="mw_s8" id="hTGlT9G0v0" role="1ZfhKB">
+                <node concept="2YIFZM" id="hTGlT9G0v1" role="mwGJk">
+                  <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
+                  <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
                 </node>
               </node>
             </node>
@@ -675,23 +676,23 @@
   <node concept="1YbPZF" id="3vxfdxbgQrM">
     <property role="TrG5h" value="typeof_Message" />
     <node concept="3clFbS" id="3vxfdxbgQrN" role="18ibNy">
-      <node concept="1Z5TYs" id="3vxfdxbgRiw" role="3cqZAp">
-        <node concept="mw_s8" id="3vxfdxbgRj2" role="1ZfhKB">
-          <node concept="2YIFZM" id="5wDe8wA6zrJ" role="mwGJk">
-            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
-            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-          </node>
-        </node>
-        <node concept="mw_s8" id="3vxfdxbgRiz" role="1ZfhK$">
-          <node concept="1Z2H0r" id="3vxfdxbgQrW" role="mwGJk">
-            <node concept="2OqwBi" id="3vxfdxbgQAi" role="1Z2MuG">
-              <node concept="1YBJjd" id="3vxfdxbgQsf" role="2Oq$k0">
+      <node concept="2NvLDW" id="hTGlT9FUh_" role="3cqZAp">
+        <node concept="mw_s8" id="hTGlT9FUhB" role="1ZfhK$">
+          <node concept="1Z2H0r" id="hTGlT9FUhC" role="mwGJk">
+            <node concept="2OqwBi" id="hTGlT9FUhD" role="1Z2MuG">
+              <node concept="1YBJjd" id="hTGlT9FUhE" role="2Oq$k0">
                 <ref role="1YBMHb" node="3vxfdxbgQrP" resolve="msg" />
               </node>
-              <node concept="3TrEf2" id="3vxfdxbgR1v" role="2OqNvi">
+              <node concept="3TrEf2" id="hTGlT9FUhF" role="2OqNvi">
                 <ref role="3Tt5mk" to="kelk:3vxfdxbdM7Q" resolve="text" />
               </node>
             </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="hTGlT9FUhG" role="1ZfhKB">
+          <node concept="2YIFZM" id="hTGlT9FUhH" role="mwGJk">
+            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
+            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
           </node>
         </node>
       </node>
@@ -742,23 +743,23 @@
   <node concept="1YbPZF" id="3vxfdxblP5O">
     <property role="TrG5h" value="typeof_TypeCoercion" />
     <node concept="3clFbS" id="3vxfdxblP5P" role="18ibNy">
-      <node concept="1Z5TYs" id="3vxfdxblPRi" role="3cqZAp">
-        <node concept="mw_s8" id="3vxfdxblPRO" role="1ZfhKB">
-          <node concept="2YIFZM" id="5wDe8wA6zrK" role="mwGJk">
-            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
-            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-          </node>
-        </node>
-        <node concept="mw_s8" id="3vxfdxblPRl" role="1ZfhK$">
-          <node concept="1Z2H0r" id="3vxfdxblP61" role="mwGJk">
-            <node concept="2OqwBi" id="3vxfdxblPfg" role="1Z2MuG">
-              <node concept="1YBJjd" id="3vxfdxblP7Q" role="2Oq$k0">
+      <node concept="1ZobV4" id="hTGlT9G0JE" role="3cqZAp">
+        <node concept="mw_s8" id="hTGlT9G0JI" role="1ZfhK$">
+          <node concept="1Z2H0r" id="hTGlT9G0JJ" role="mwGJk">
+            <node concept="2OqwBi" id="hTGlT9G0JK" role="1Z2MuG">
+              <node concept="1YBJjd" id="hTGlT9G0JL" role="2Oq$k0">
                 <ref role="1YBMHb" node="3vxfdxblP5R" resolve="tc" />
               </node>
-              <node concept="3TrEf2" id="3vxfdxblPnS" role="2OqNvi">
+              <node concept="3TrEf2" id="hTGlT9G0JM" role="2OqNvi">
                 <ref role="3Tt5mk" to="kelk:3vxfdxblP40" resolve="expr" />
               </node>
             </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="hTGlT9G0JG" role="1ZfhKB">
+          <node concept="2YIFZM" id="hTGlT9G0JH" role="mwGJk">
+            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
+            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
           </node>
         </node>
       </node>
@@ -841,18 +842,18 @@
   <node concept="1YbPZF" id="4AahbtUN3uG">
     <property role="TrG5h" value="typeof_MessageValueTextOp" />
     <node concept="3clFbS" id="4AahbtUN3uH" role="18ibNy">
-      <node concept="1Z5TYs" id="4AahbtUN3Je" role="3cqZAp">
-        <node concept="mw_s8" id="4AahbtUN3Jv" role="1ZfhKB">
-          <node concept="2YIFZM" id="5wDe8wA6zrL" role="mwGJk">
-            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
-            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-          </node>
-        </node>
-        <node concept="mw_s8" id="4AahbtUN3Jh" role="1ZfhK$">
-          <node concept="1Z2H0r" id="4AahbtUN3uT" role="mwGJk">
-            <node concept="1YBJjd" id="4AahbtUN3wF" role="1Z2MuG">
+      <node concept="1ZobV4" id="hTGlT9G0E8" role="3cqZAp">
+        <node concept="mw_s8" id="hTGlT9G0Ec" role="1ZfhK$">
+          <node concept="1Z2H0r" id="hTGlT9G0Ed" role="mwGJk">
+            <node concept="1YBJjd" id="hTGlT9G0Ee" role="1Z2MuG">
               <ref role="1YBMHb" node="4AahbtUN3uJ" resolve="mvto" />
             </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="hTGlT9G0Ea" role="1ZfhKB">
+          <node concept="2YIFZM" id="hTGlT9G0Eb" role="mwGJk">
+            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
+            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/typesystem.mps
@@ -1550,18 +1550,18 @@
     <property role="TrG5h" value="typeof_LabelExpression" />
     <property role="3GE5qa" value="sheet" />
     <node concept="3clFbS" id="7HzLUeHoJVa" role="18ibNy">
-      <node concept="1Z5TYs" id="7HzLUeHoK9M" role="3cqZAp">
-        <node concept="mw_s8" id="7HzLUeHoKa3" role="1ZfhKB">
-          <node concept="2YIFZM" id="5wDe8wA6zrC" role="mwGJk">
-            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
-            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-          </node>
-        </node>
-        <node concept="mw_s8" id="7HzLUeHoK9P" role="1ZfhK$">
-          <node concept="1Z2H0r" id="7HzLUeHoJVj" role="mwGJk">
-            <node concept="1YBJjd" id="7HzLUeHoJVz" role="1Z2MuG">
+      <node concept="1ZobV4" id="hTGlT9G0MY" role="3cqZAp">
+        <node concept="mw_s8" id="hTGlT9G0N2" role="1ZfhK$">
+          <node concept="1Z2H0r" id="hTGlT9G0N3" role="mwGJk">
+            <node concept="1YBJjd" id="hTGlT9G0N4" role="1Z2MuG">
               <ref role="1YBMHb" node="7HzLUeHoJVc" resolve="le" />
             </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="hTGlT9G0N0" role="1ZfhKB">
+          <node concept="2YIFZM" id="hTGlT9G0N1" role="mwGJk">
+            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
+            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
@@ -6232,137 +6232,6 @@
     <node concept="13hLZK" id="8XWEtestMU" role="13h7CW">
       <node concept="3clFbS" id="8XWEtestMV" role="2VODD2" />
     </node>
-    <node concept="13i0hz" id="6pSOa4rtvfE" role="13h7CS">
-      <property role="TrG5h" value="getPresentation" />
-      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
-      <node concept="3Tm1VV" id="6pSOa4rtvfF" role="1B3o_S" />
-      <node concept="3clFbS" id="6pSOa4rtvfM" role="3clF47">
-        <node concept="3cpWs8" id="6pSOa4rtwWh" role="3cqZAp">
-          <node concept="3cpWsn" id="6pSOa4rtwWi" role="3cpWs9">
-            <property role="TrG5h" value="builder" />
-            <node concept="3uibUv" id="6pSOa4rtwWj" role="1tU5fm">
-              <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
-            </node>
-            <node concept="2ShNRf" id="6pSOa4rtwW$" role="33vP2m">
-              <node concept="1pGfFk" id="6pSOa4rtxHo" role="2ShVmc">
-                <property role="373rjd" value="true" />
-                <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="6pSOa4rtxIu" role="3cqZAp">
-          <node concept="2OqwBi" id="6pSOa4rtz34" role="3clFbG">
-            <node concept="37vLTw" id="6pSOa4rtxIs" role="2Oq$k0">
-              <ref role="3cqZAo" node="6pSOa4rtwWi" resolve="builder" />
-            </node>
-            <node concept="liA8E" id="6pSOa4rt$23" role="2OqNvi">
-              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
-              <node concept="Xl_RD" id="6pSOa4rt$2b" role="37wK5m">
-                <property role="Xl_RC" value="string" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="6pSOa4rt_yl" role="3cqZAp">
-          <node concept="3clFbS" id="6pSOa4rt_yn" role="3clFbx">
-            <node concept="3cpWs8" id="3g7FMHm$BvL" role="3cqZAp">
-              <node concept="3cpWsn" id="3g7FMHm$BvM" role="3cpWs9">
-                <property role="TrG5h" value="regex" />
-                <node concept="17QB3L" id="3g7FMHm$Arj" role="1tU5fm" />
-                <node concept="2OqwBi" id="3g7FMHm$BvN" role="33vP2m">
-                  <node concept="2OqwBi" id="3g7FMHm$BvO" role="2Oq$k0">
-                    <node concept="13iPFW" id="3g7FMHm$BvP" role="2Oq$k0" />
-                    <node concept="3TrEf2" id="3g7FMHm$BvQ" role="2OqNvi">
-                      <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
-                    </node>
-                  </node>
-                  <node concept="2qgKlT" id="3g7FMHm$BvR" role="2OqNvi">
-                    <ref role="37wK5l" to="tpfs:hMuDF1A" resolve="getString" />
-                    <node concept="2ShNRf" id="3g7FMHm$BvS" role="37wK5m">
-                      <node concept="2T8Vx0" id="3g7FMHm$BvT" role="2ShVmc">
-                        <node concept="2I9FWS" id="3g7FMHm$BvU" role="2T96Bj">
-                          <ref role="2I9WkF" to="tpfo:h5Tukr7" resolve="MatchParensRegexp" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="3g7FMHm$CN2" role="3cqZAp">
-              <node concept="3clFbS" id="3g7FMHm$CN4" role="3clFbx">
-                <node concept="3clFbF" id="6pSOa4rtFLa" role="3cqZAp">
-                  <node concept="2OqwBi" id="6pSOa4rtG58" role="3clFbG">
-                    <node concept="37vLTw" id="6pSOa4rtFL8" role="2Oq$k0">
-                      <ref role="3cqZAo" node="6pSOa4rtwWi" resolve="builder" />
-                    </node>
-                    <node concept="liA8E" id="6pSOa4rtG82" role="2OqNvi">
-                      <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
-                      <node concept="Xl_RD" id="6pSOa4rtG84" role="37wK5m">
-                        <property role="Xl_RC" value="/" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="6pSOa4rtBl0" role="3cqZAp">
-                  <node concept="2OqwBi" id="6pSOa4rtCsi" role="3clFbG">
-                    <node concept="37vLTw" id="6pSOa4rtBkY" role="2Oq$k0">
-                      <ref role="3cqZAo" node="6pSOa4rtwWi" resolve="builder" />
-                    </node>
-                    <node concept="liA8E" id="6pSOa4rtDsP" role="2OqNvi">
-                      <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
-                      <node concept="37vLTw" id="3g7FMHm$BvV" role="37wK5m">
-                        <ref role="3cqZAo" node="3g7FMHm$BvM" resolve="string" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="6pSOa4rtGZ0" role="3cqZAp">
-                  <node concept="2OqwBi" id="6pSOa4rtH0Z" role="3clFbG">
-                    <node concept="37vLTw" id="6pSOa4rtGYY" role="2Oq$k0">
-                      <ref role="3cqZAo" node="6pSOa4rtwWi" resolve="builder" />
-                    </node>
-                    <node concept="liA8E" id="6pSOa4rtH6S" role="2OqNvi">
-                      <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
-                      <node concept="Xl_RD" id="6pSOa4rtHbp" role="37wK5m">
-                        <property role="Xl_RC" value="/" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="3g7FMHm$E5g" role="3clFbw">
-                <node concept="37vLTw" id="3g7FMHm$CN7" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3g7FMHm$BvM" resolve="regex" />
-                </node>
-                <node concept="17RvpY" id="3g7FMHm$FMD" role="2OqNvi" />
-              </node>
-            </node>
-          </node>
-          <node concept="2OqwBi" id="6pSOa4rtAmQ" role="3clFbw">
-            <node concept="2OqwBi" id="6pSOa4rt_Nw" role="2Oq$k0">
-              <node concept="13iPFW" id="6pSOa4rt_$0" role="2Oq$k0" />
-              <node concept="3TrEf2" id="6pSOa4rtAbG" role="2OqNvi">
-                <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
-              </node>
-            </node>
-            <node concept="3x8VRR" id="6pSOa4rtABt" role="2OqNvi" />
-          </node>
-        </node>
-        <node concept="3cpWs6" id="6pSOa4rtHzh" role="3cqZAp">
-          <node concept="2OqwBi" id="6pSOa4rtHNM" role="3cqZAk">
-            <node concept="37vLTw" id="6pSOa4rtHzx" role="2Oq$k0">
-              <ref role="3cqZAo" node="6pSOa4rtwWi" resolve="builder" />
-            </node>
-            <node concept="liA8E" id="6pSOa4rtHS3" role="2OqNvi">
-              <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="17QB3L" id="6pSOa4rtvfN" role="3clF45" />
-    </node>
   </node>
   <node concept="13h7C7" id="IMhG9rtjum">
     <property role="3GE5qa" value="string" />
@@ -7369,6 +7238,144 @@
         </node>
       </node>
       <node concept="17QB3L" id="5bvGQanjOYJ" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="2xPWNWpq33M">
+    <property role="3GE5qa" value="string" />
+    <ref role="13h7C2" to="5qo5:2xPWNWpoRmG" resolve="StringTypeWithConstraint" />
+    <node concept="13i0hz" id="6pSOa4rtvfE" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="6pSOa4rtvfF" role="1B3o_S" />
+      <node concept="3clFbS" id="6pSOa4rtvfM" role="3clF47">
+        <node concept="3cpWs8" id="6pSOa4rtwWh" role="3cqZAp">
+          <node concept="3cpWsn" id="6pSOa4rtwWi" role="3cpWs9">
+            <property role="TrG5h" value="builder" />
+            <node concept="3uibUv" id="6pSOa4rtwWj" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+            </node>
+            <node concept="2ShNRf" id="6pSOa4rtwW$" role="33vP2m">
+              <node concept="1pGfFk" id="6pSOa4rtxHo" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6pSOa4rtxIu" role="3cqZAp">
+          <node concept="2OqwBi" id="6pSOa4rtz34" role="3clFbG">
+            <node concept="37vLTw" id="6pSOa4rtxIs" role="2Oq$k0">
+              <ref role="3cqZAo" node="6pSOa4rtwWi" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="6pSOa4rt$23" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="6pSOa4rt$2b" role="37wK5m">
+                <property role="Xl_RC" value="string" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6pSOa4rt_yl" role="3cqZAp">
+          <node concept="3clFbS" id="6pSOa4rt_yn" role="3clFbx">
+            <node concept="3cpWs8" id="3g7FMHm$BvL" role="3cqZAp">
+              <node concept="3cpWsn" id="3g7FMHm$BvM" role="3cpWs9">
+                <property role="TrG5h" value="regex" />
+                <node concept="17QB3L" id="3g7FMHm$Arj" role="1tU5fm" />
+                <node concept="2OqwBi" id="3g7FMHm$BvN" role="33vP2m">
+                  <node concept="2OqwBi" id="3g7FMHm$BvO" role="2Oq$k0">
+                    <node concept="13iPFW" id="3g7FMHm$BvP" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="3g7FMHm$BvQ" role="2OqNvi">
+                      <ref role="3Tt5mk" to="5qo5:2xPWNWprAOp" resolve="constraint" />
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="3g7FMHm$BvR" role="2OqNvi">
+                    <ref role="37wK5l" to="tpfs:hMuDF1A" resolve="getString" />
+                    <node concept="2ShNRf" id="3g7FMHm$BvS" role="37wK5m">
+                      <node concept="2T8Vx0" id="3g7FMHm$BvT" role="2ShVmc">
+                        <node concept="2I9FWS" id="3g7FMHm$BvU" role="2T96Bj">
+                          <ref role="2I9WkF" to="tpfo:h5Tukr7" resolve="MatchParensRegexp" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="3g7FMHm$CN2" role="3cqZAp">
+              <node concept="3clFbS" id="3g7FMHm$CN4" role="3clFbx">
+                <node concept="3clFbF" id="6pSOa4rtFLa" role="3cqZAp">
+                  <node concept="2OqwBi" id="6pSOa4rtG58" role="3clFbG">
+                    <node concept="37vLTw" id="6pSOa4rtFL8" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6pSOa4rtwWi" resolve="builder" />
+                    </node>
+                    <node concept="liA8E" id="6pSOa4rtG82" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                      <node concept="Xl_RD" id="6pSOa4rtG84" role="37wK5m">
+                        <property role="Xl_RC" value="/" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="6pSOa4rtBl0" role="3cqZAp">
+                  <node concept="2OqwBi" id="6pSOa4rtCsi" role="3clFbG">
+                    <node concept="37vLTw" id="6pSOa4rtBkY" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6pSOa4rtwWi" resolve="builder" />
+                    </node>
+                    <node concept="liA8E" id="6pSOa4rtDsP" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                      <node concept="37vLTw" id="3g7FMHm$BvV" role="37wK5m">
+                        <ref role="3cqZAo" node="3g7FMHm$BvM" resolve="regex" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="6pSOa4rtGZ0" role="3cqZAp">
+                  <node concept="2OqwBi" id="6pSOa4rtH0Z" role="3clFbG">
+                    <node concept="37vLTw" id="6pSOa4rtGYY" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6pSOa4rtwWi" resolve="builder" />
+                    </node>
+                    <node concept="liA8E" id="6pSOa4rtH6S" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                      <node concept="Xl_RD" id="6pSOa4rtHbp" role="37wK5m">
+                        <property role="Xl_RC" value="/" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="3g7FMHm$E5g" role="3clFbw">
+                <node concept="37vLTw" id="3g7FMHm$CN7" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3g7FMHm$BvM" resolve="regex" />
+                </node>
+                <node concept="17RvpY" id="3g7FMHm$FMD" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="6pSOa4rtAmQ" role="3clFbw">
+            <node concept="2OqwBi" id="6pSOa4rt_Nw" role="2Oq$k0">
+              <node concept="13iPFW" id="6pSOa4rt_$0" role="2Oq$k0" />
+              <node concept="3TrEf2" id="6pSOa4rtAbG" role="2OqNvi">
+                <ref role="3Tt5mk" to="5qo5:2xPWNWprAOp" resolve="constraint" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="6pSOa4rtABt" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6pSOa4rtHzh" role="3cqZAp">
+          <node concept="2OqwBi" id="6pSOa4rtHNM" role="3cqZAk">
+            <node concept="37vLTw" id="6pSOa4rtHzx" role="2Oq$k0">
+              <ref role="3cqZAo" node="6pSOa4rtwWi" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="6pSOa4rtHS3" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="6pSOa4rtvfN" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="2xPWNWpq33N" role="13h7CW">
+      <node concept="3clFbS" id="2xPWNWpq33O" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
@@ -26,14 +26,8 @@
     <import index="kqnq" ref="r:7628c3bd-6988-4d33-9682-86b8cef4b8c0(com.mbeddr.mpsutil.interpreter.behavior)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" />
-    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
-    <import index="pjrh" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter(MPS.Core/)" />
-    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
-    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
-    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
-    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
-    <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
-    <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" />
+    <import index="tpfs" ref="r:00000000-0000-4000-0000-011c89590514(jetbrains.mps.baseLanguage.regexp.behavior)" implicit="true" />
+    <import index="tpfo" ref="r:00000000-0000-4000-0000-011c89590518(jetbrains.mps.baseLanguage.regexp.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -6237,6 +6231,137 @@
     </node>
     <node concept="13hLZK" id="8XWEtestMU" role="13h7CW">
       <node concept="3clFbS" id="8XWEtestMV" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="6pSOa4rtvfE" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="6pSOa4rtvfF" role="1B3o_S" />
+      <node concept="3clFbS" id="6pSOa4rtvfM" role="3clF47">
+        <node concept="3cpWs8" id="6pSOa4rtwWh" role="3cqZAp">
+          <node concept="3cpWsn" id="6pSOa4rtwWi" role="3cpWs9">
+            <property role="TrG5h" value="builder" />
+            <node concept="3uibUv" id="6pSOa4rtwWj" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~StringBuilder" resolve="StringBuilder" />
+            </node>
+            <node concept="2ShNRf" id="6pSOa4rtwW$" role="33vP2m">
+              <node concept="1pGfFk" id="6pSOa4rtxHo" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;()" resolve="StringBuilder" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6pSOa4rtxIu" role="3cqZAp">
+          <node concept="2OqwBi" id="6pSOa4rtz34" role="3clFbG">
+            <node concept="37vLTw" id="6pSOa4rtxIs" role="2Oq$k0">
+              <ref role="3cqZAo" node="6pSOa4rtwWi" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="6pSOa4rt$23" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+              <node concept="Xl_RD" id="6pSOa4rt$2b" role="37wK5m">
+                <property role="Xl_RC" value="string" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6pSOa4rt_yl" role="3cqZAp">
+          <node concept="3clFbS" id="6pSOa4rt_yn" role="3clFbx">
+            <node concept="3cpWs8" id="3g7FMHm$BvL" role="3cqZAp">
+              <node concept="3cpWsn" id="3g7FMHm$BvM" role="3cpWs9">
+                <property role="TrG5h" value="regex" />
+                <node concept="17QB3L" id="3g7FMHm$Arj" role="1tU5fm" />
+                <node concept="2OqwBi" id="3g7FMHm$BvN" role="33vP2m">
+                  <node concept="2OqwBi" id="3g7FMHm$BvO" role="2Oq$k0">
+                    <node concept="13iPFW" id="3g7FMHm$BvP" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="3g7FMHm$BvQ" role="2OqNvi">
+                      <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="3g7FMHm$BvR" role="2OqNvi">
+                    <ref role="37wK5l" to="tpfs:hMuDF1A" resolve="getString" />
+                    <node concept="2ShNRf" id="3g7FMHm$BvS" role="37wK5m">
+                      <node concept="2T8Vx0" id="3g7FMHm$BvT" role="2ShVmc">
+                        <node concept="2I9FWS" id="3g7FMHm$BvU" role="2T96Bj">
+                          <ref role="2I9WkF" to="tpfo:h5Tukr7" resolve="MatchParensRegexp" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="3g7FMHm$CN2" role="3cqZAp">
+              <node concept="3clFbS" id="3g7FMHm$CN4" role="3clFbx">
+                <node concept="3clFbF" id="6pSOa4rtFLa" role="3cqZAp">
+                  <node concept="2OqwBi" id="6pSOa4rtG58" role="3clFbG">
+                    <node concept="37vLTw" id="6pSOa4rtFL8" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6pSOa4rtwWi" resolve="builder" />
+                    </node>
+                    <node concept="liA8E" id="6pSOa4rtG82" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                      <node concept="Xl_RD" id="6pSOa4rtG84" role="37wK5m">
+                        <property role="Xl_RC" value="/" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="6pSOa4rtBl0" role="3cqZAp">
+                  <node concept="2OqwBi" id="6pSOa4rtCsi" role="3clFbG">
+                    <node concept="37vLTw" id="6pSOa4rtBkY" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6pSOa4rtwWi" resolve="builder" />
+                    </node>
+                    <node concept="liA8E" id="6pSOa4rtDsP" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                      <node concept="37vLTw" id="3g7FMHm$BvV" role="37wK5m">
+                        <ref role="3cqZAo" node="3g7FMHm$BvM" resolve="string" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="6pSOa4rtGZ0" role="3cqZAp">
+                  <node concept="2OqwBi" id="6pSOa4rtH0Z" role="3clFbG">
+                    <node concept="37vLTw" id="6pSOa4rtGYY" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6pSOa4rtwWi" resolve="builder" />
+                    </node>
+                    <node concept="liA8E" id="6pSOa4rtH6S" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                      <node concept="Xl_RD" id="6pSOa4rtHbp" role="37wK5m">
+                        <property role="Xl_RC" value="/" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="3g7FMHm$E5g" role="3clFbw">
+                <node concept="37vLTw" id="3g7FMHm$CN7" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3g7FMHm$BvM" resolve="regex" />
+                </node>
+                <node concept="17RvpY" id="3g7FMHm$FMD" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="6pSOa4rtAmQ" role="3clFbw">
+            <node concept="2OqwBi" id="6pSOa4rt_Nw" role="2Oq$k0">
+              <node concept="13iPFW" id="6pSOa4rt_$0" role="2Oq$k0" />
+              <node concept="3TrEf2" id="6pSOa4rtAbG" role="2OqNvi">
+                <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="6pSOa4rtABt" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="6pSOa4rtHzh" role="3cqZAp">
+          <node concept="2OqwBi" id="6pSOa4rtHNM" role="3cqZAk">
+            <node concept="37vLTw" id="6pSOa4rtHzx" role="2Oq$k0">
+              <ref role="3cqZAo" node="6pSOa4rtwWi" resolve="builder" />
+            </node>
+            <node concept="liA8E" id="6pSOa4rtHS3" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~StringBuilder.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="6pSOa4rtvfN" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="IMhG9rtjum">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/constraints.mps
@@ -20,6 +20,7 @@
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
+    <import index="tpfo" ref="r:00000000-0000-4000-0000-011c89590518(jetbrains.mps.baseLanguage.regexp.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -152,8 +153,10 @@
     </language>
     <language id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints">
       <concept id="6702802731807351367" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAChild" flags="in" index="9S07l" />
+      <concept id="6702802731807424858" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_CanBeAnAncestor" flags="in" index="9SQb8" />
       <concept id="1202989658459" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_parentNode" flags="nn" index="nLn13" />
       <concept id="4303308395523343364" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_link" flags="ng" index="2DA6wF" />
+      <concept id="4303308395523096213" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_childConcept" flags="ng" index="2DD5aU" />
       <concept id="1147467115080" name="jetbrains.mps.lang.constraints.structure.NodePropertyConstraint" flags="ng" index="EnEH3">
         <reference id="1147467295099" name="applicableProperty" index="EomxK" />
         <child id="1147468630220" name="propertyGetter" index="EtsB7" />
@@ -166,6 +169,7 @@
       <concept id="1152959968041" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_PropertySetter" flags="in" index="1LLf8_" />
       <concept id="1213093968558" name="jetbrains.mps.lang.constraints.structure.ConceptConstraints" flags="ng" index="1M2fIO">
         <reference id="1213093996982" name="concept" index="1M2myG" />
+        <child id="6702802731807532730" name="canBeAncestor" index="9SGkC" />
         <child id="6702802731807737306" name="canBeChild" index="9Vyp8" />
         <child id="1213098023997" name="property" index="1MhHOB" />
       </concept>
@@ -184,6 +188,9 @@
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
+        <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
+      </concept>
       <concept id="2644386474302386080" name="jetbrains.mps.lang.smodel.structure.PropertyIdRefExpression" flags="nn" index="355D3s">
         <reference id="2644386474302386081" name="conceptDeclaration" index="355D3t" />
         <reference id="2644386474302386082" name="propertyDeclaration" index="355D3u" />
@@ -1319,6 +1326,26 @@
                 <ref role="359W_F" to="hm2y:4rZeNQ6MpKo" resolve="right" />
               </node>
               <node concept="2DA6wF" id="4399ITSA0wd" role="3uHU7B" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="46RgPUMwnoS">
+    <property role="3GE5qa" value="string" />
+    <ref role="1M2myG" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
+    <node concept="9SQb8" id="46RgPUMwnoT" role="9SGkC">
+      <node concept="3clFbS" id="46RgPUMwnoU" role="2VODD2">
+        <node concept="3clFbF" id="46RgPUMwnA_" role="3cqZAp">
+          <node concept="3fqX7Q" id="46RgPUMwpON" role="3clFbG">
+            <node concept="2OqwBi" id="46RgPUMwpOP" role="3fr31v">
+              <node concept="2DD5aU" id="46RgPUMwpOQ" role="2Oq$k0" />
+              <node concept="2Zo12i" id="46RgPUMwpOR" role="2OqNvi">
+                <node concept="chp4Y" id="46RgPUMwpOS" role="2Zo12j">
+                  <ref role="cht4Q" to="tpfo:h5Tukr7" resolve="MatchParensRegexp" />
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/editor.mps
@@ -32,6 +32,7 @@
     <import index="4kwy" ref="r:657c9fde-2f36-4e61-ae17-20f02b8630ad(org.iets3.core.base.structure)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="uddc" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.menus.transformation(MPS.Editor/)" implicit="true" />
     <import index="tpfo" ref="r:00000000-0000-4000-0000-011c89590518(jetbrains.mps.baseLanguage.regexp.structure)" implicit="true" />
   </imports>
   <registry>
@@ -41,6 +42,7 @@
       </concept>
     </language>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="1402906326895675325" name="jetbrains.mps.lang.editor.structure.CellActionMap_FunctionParm_selectedNode" flags="nn" index="0IXxy" />
       <concept id="5991739802479784074" name="jetbrains.mps.lang.editor.structure.MenuTypeNamed" flags="ng" index="22hDWg" />
       <concept id="5991739802479784073" name="jetbrains.mps.lang.editor.structure.MenuTypeDefault" flags="ng" index="22hDWj" />
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
@@ -89,6 +91,7 @@
       <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
         <property id="1186414551515" name="flag" index="VOm3f" />
       </concept>
+      <concept id="1186414928363" name="jetbrains.mps.lang.editor.structure.SelectableStyleSheetItem" flags="ln" index="VPM3Z" />
       <concept id="1186414949600" name="jetbrains.mps.lang.editor.structure.AutoDeletableStyleClassItem" flags="ln" index="VPRnO" />
       <concept id="4647688914602775700" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_TransformationMenu_targetNode" flags="ng" index="X5bN_" />
       <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ngI" index="2Z_bC8">
@@ -118,6 +121,15 @@
         <child id="772883491827840107" name="customizeFunction" index="3l$a4r" />
       </concept>
       <concept id="7342352913006985500" name="jetbrains.mps.lang.editor.structure.TransformationLocation_Completion" flags="ng" index="3eGOoe" />
+      <concept id="1139535219966" name="jetbrains.mps.lang.editor.structure.CellActionMapDeclaration" flags="ig" index="1h_SRR">
+        <reference id="1139535219968" name="applicableConcept" index="1h_SK9" />
+        <child id="1139535219969" name="item" index="1h_SK8" />
+      </concept>
+      <concept id="1139535280617" name="jetbrains.mps.lang.editor.structure.CellActionMapItem" flags="lg" index="1hA7zw">
+        <property id="1139535298778" name="actionId" index="1hAc7j" />
+        <child id="1139535280620" name="executeFunction" index="1hA7z_" />
+      </concept>
+      <concept id="1139535439104" name="jetbrains.mps.lang.editor.structure.CellActionMap_ExecuteFunction" flags="in" index="1hAIg9" />
       <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ngI" index="1k5N5V">
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
       </concept>
@@ -145,6 +157,7 @@
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
+        <reference id="1139959269582" name="actionMap" index="1ERwB7" />
         <child id="1164826688380" name="menuDescriptor" index="P5bDN" />
         <child id="4202667662392416064" name="transformationMenu" index="3vIgyS" />
       </concept>
@@ -241,6 +254,9 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
@@ -275,12 +291,12 @@
       <concept id="1381973545438177171" name="com.mbeddr.mpsutil.grammarcells.structure.NumberLiteralTokenizer" flags="ng" index="bYqod" />
       <concept id="1381973545438177151" name="com.mbeddr.mpsutil.grammarcells.structure.StringLiteralTokenizer" flags="ng" index="bYqrx" />
       <concept id="1984422498404534858" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell_TransformationText" flags="ig" index="2ee1ZP" />
+      <concept id="7272510943426093121" name="com.mbeddr.mpsutil.grammarcells.structure.Parameter_SideTransformActionsBuilderContext" flags="ng" index="2kS8pE" />
       <concept id="3921456275302774825" name="com.mbeddr.mpsutil.grammarcells.structure.SplittableCell" flags="sg" stub="3921456275302774831" index="2lNzut">
         <child id="3921456275305506525" name="tokenizer" index="2lD6_D" />
       </concept>
       <concept id="9041925471455857605" name="com.mbeddr.mpsutil.grammarcells.structure.Cell_DescriptionText" flags="ig" index="uPpia" />
       <concept id="5083944728298846680" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell" flags="ng" index="_tjkj">
-        <child id="7011566904921631440" name="postprocess" index="vWNKz" />
         <child id="5083944728298846681" name="option" index="_tjki" />
         <child id="8945098465480008160" name="transformationText" index="ZWbT9" />
       </concept>
@@ -293,6 +309,14 @@
       <concept id="848437706375087728" name="com.mbeddr.mpsutil.grammarcells.structure.ICanHaveDescriptionText" flags="ngI" index="1djCvD">
         <child id="848437706375087729" name="descriptionText" index="1djCvC" />
       </concept>
+      <concept id="4874944647490522665" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell_IsApplicable" flags="ig" index="1eYwpX" />
+      <concept id="4874944647490524676" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell_Execute" flags="ig" index="1eYxTg" />
+      <concept id="4874944647490471126" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell" flags="ng" index="1eYWM2">
+        <child id="4874944647490523335" name="matchingText" index="1eYxyj" />
+        <child id="4874944647490523330" name="isApplicable" index="1eYxym" />
+        <child id="4874944647490524677" name="execute" index="1eYxTh" />
+      </concept>
+      <concept id="4874944647490471525" name="com.mbeddr.mpsutil.grammarcells.structure.SideTransformationCell_MatchingText" flags="ig" index="1eYWSL" />
       <concept id="7363578995839435357" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell" flags="ng" index="1kIj98">
         <child id="1954385921685817946" name="postprocessNodeSubstitute" index="31dnY" />
         <child id="1984422498404562223" name="rightTransformationText" index="2ee62g" />
@@ -311,14 +335,24 @@
         <child id="2490242408670937967" name="factoryMethod" index="3ZZHOD" />
       </concept>
     </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+        <child id="1595412875168045827" name="initValue" index="28nt2d" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
-      <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC">
-        <reference id="1139880128956" name="concept" index="1A9B2P" />
-      </concept>
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
@@ -335,6 +369,9 @@
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
+      <concept id="1139867745658" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithNewOperation" flags="nn" index="1_qnLN">
+        <reference id="1139867957129" name="concept" index="1_rbq0" />
+      </concept>
       <concept id="1140131837776" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithAnotherOperation" flags="nn" index="1P9Npp">
         <child id="1140131861877" name="replacementNode" index="1P9ThW" />
       </concept>
@@ -346,9 +383,6 @@
       </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
-      </concept>
-      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
-        <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -1849,51 +1883,139 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="_tjkj" id="7J8ctKuJvtZ" role="3EZMnx">
-        <node concept="3EZMnI" id="7J8ctKuJvuc" role="_tjki">
-          <node concept="2iRfu4" id="7J8ctKuJvud" role="2iSdaV" />
-          <node concept="3F0ifn" id="7J8ctKuJvu9" role="3EZMnx">
-            <property role="3F0ifm" value="with constraint" />
-            <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
-          </node>
-          <node concept="3F0ifn" id="3OxSopg1c7e" role="3EZMnx">
-            <property role="3F0ifm" value="/" />
-            <node concept="11LMrY" id="3OxSopg1c7z" role="3F10Kt">
-              <property role="VOm3f" value="true" />
-            </node>
-          </node>
-          <node concept="3F1sOY" id="7J8ctKuJvul" role="3EZMnx">
-            <ref role="1NtTu8" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
-          </node>
-          <node concept="3F0ifn" id="3OxSopg1c7q" role="3EZMnx">
-            <property role="3F0ifm" value="/" />
-            <node concept="11L4FC" id="3OxSopg1c7x" role="3F10Kt">
-              <property role="VOm3f" value="true" />
-            </node>
-          </node>
-        </node>
-        <node concept="uPpia" id="3OxSopfZRr4" role="1djCvC">
-          <node concept="3clFbS" id="3OxSopfZRr5" role="2VODD2">
-            <node concept="3clFbF" id="3OxSopfZTeZ" role="3cqZAp">
-              <node concept="Xl_RD" id="3OxSopfZTeY" role="3clFbG">
-                <property role="Xl_RC" value="add a constraint in the form of a regular expression" />
+      <node concept="1eYWM2" id="2xPWNWp$vnN" role="3EZMnx">
+        <node concept="1eYwpX" id="2xPWNWp$vnO" role="1eYxym">
+          <node concept="3clFbS" id="2xPWNWp$vnP" role="2VODD2">
+            <node concept="3clFbF" id="2xPWNWp$MrS" role="3cqZAp">
+              <node concept="3clFbT" id="2xPWNWp$MrR" role="3clFbG">
+                <property role="3clFbU" value="true" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="315t4" id="3OxSopg2kwp" role="vWNKz">
-          <node concept="3clFbS" id="3OxSopg2kwq" role="2VODD2">
-            <node concept="3clFbF" id="3OxSopg2kzz" role="3cqZAp">
-              <node concept="2OqwBi" id="3OxSopg2lfo" role="3clFbG">
-                <node concept="2OqwBi" id="3OxSopg2kJZ" role="2Oq$k0">
-                  <node concept="313q4" id="3OxSopg2kzy" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="3OxSopg2l6u" role="2OqNvi">
-                    <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
+        <node concept="1eYWSL" id="2xPWNWp$vnQ" role="1eYxyj">
+          <node concept="3clFbS" id="2xPWNWp$vnR" role="2VODD2">
+            <node concept="3clFbF" id="2xPWNWp$$qV" role="3cqZAp">
+              <node concept="Xl_RD" id="2xPWNWp$$qU" role="3clFbG">
+                <property role="Xl_RC" value="with constraint" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1eYxTg" id="2xPWNWp$vnS" role="1eYxTh">
+          <node concept="3clFbS" id="2xPWNWp$vnT" role="2VODD2">
+            <node concept="3cpWs8" id="2xPWNWpA1nx" role="3cqZAp">
+              <node concept="3cpWsn" id="2xPWNWpA1ny" role="3cpWs9">
+                <property role="TrG5h" value="node" />
+                <node concept="3Tqbb2" id="2xPWNWpA33w" role="1tU5fm" />
+                <node concept="2OqwBi" id="2xPWNWpA1nz" role="33vP2m">
+                  <node concept="2kS8pE" id="2xPWNWpA1n$" role="2Oq$k0" />
+                  <node concept="liA8E" id="2xPWNWpA1n_" role="2OqNvi">
+                    <ref role="37wK5l" to="uddc:~TransformationMenuContext.getNode()" resolve="getNode" />
                   </node>
                 </node>
-                <node concept="zfrQC" id="3OxSopg2lJ1" role="2OqNvi">
-                  <ref role="1A9B2P" to="tpfo:h5OC9$H" resolve="StringLiteralRegexp" />
+              </node>
+            </node>
+            <node concept="3cpWs8" id="2xPWNWpBdUu" role="3cqZAp">
+              <node concept="3cpWsn" id="2xPWNWpBdUx" role="3cpWs9">
+                <property role="TrG5h" value="newNode" />
+                <node concept="3Tqbb2" id="2xPWNWpBdUs" role="1tU5fm" />
+                <node concept="2pJPEk" id="2xPWNWpBiCA" role="33vP2m">
+                  <node concept="2pJPED" id="2xPWNWpBiCC" role="2pJPEn">
+                    <ref role="2pJxaS" to="5qo5:2xPWNWpoRmG" resolve="StringTypeWithConstraint" />
+                    <node concept="2pIpSj" id="2xPWNWpBlOg" role="2pJxcM">
+                      <ref role="2pIpSl" to="5qo5:2xPWNWprAOp" resolve="constraint" />
+                      <node concept="2pJPED" id="2xPWNWpBp6J" role="28nt2d">
+                        <ref role="2pJxaS" to="tpfo:h5OC9$H" resolve="StringLiteralRegexp" />
+                      </node>
+                    </node>
+                  </node>
                 </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="2xPWNWpA6jt" role="3cqZAp">
+              <node concept="2OqwBi" id="2xPWNWpA6tO" role="3clFbG">
+                <node concept="37vLTw" id="2xPWNWpA6jr" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2xPWNWpA1ny" resolve="node" />
+                </node>
+                <node concept="1P9Npp" id="2xPWNWpBsN4" role="2OqNvi">
+                  <node concept="37vLTw" id="2xPWNWpBup9" role="1P9ThW">
+                    <ref role="3cqZAo" node="2xPWNWpBdUx" resolve="newNode" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="uPpia" id="2xPWNWp_2CX" role="1djCvC">
+          <node concept="3clFbS" id="2xPWNWp_2CY" role="2VODD2">
+            <node concept="3clFbF" id="2xPWNWp_2Fj" role="3cqZAp">
+              <node concept="Xl_RD" id="2xPWNWp_2Fi" role="3clFbG">
+                <property role="Xl_RC" value="add a constraint" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="2xPWNWpoS4X">
+    <property role="3GE5qa" value="string" />
+    <ref role="1XX52x" to="5qo5:2xPWNWpoRmG" resolve="StringTypeWithConstraint" />
+    <node concept="3EZMnI" id="2xPWNWpoS6H" role="2wV5jI">
+      <node concept="2iRfu4" id="2xPWNWpoS6I" role="2iSdaV" />
+      <node concept="PMmxH" id="2xPWNWpoS6J" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+        <node concept="3Xmtl4" id="2xPWNWpoS6K" role="3F10Kt">
+          <node concept="1wgc9g" id="2xPWNWpoS6L" role="3XvnJa">
+            <ref role="1wgcnl" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
+          </node>
+        </node>
+        <node concept="VPRnO" id="2xPWNWpoS6M" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3EZMnI" id="2xPWNWpoS6O" role="3EZMnx">
+        <node concept="2iRfu4" id="2xPWNWpoS6P" role="2iSdaV" />
+        <node concept="3F0ifn" id="2xPWNWpoS6Q" role="3EZMnx">
+          <property role="3F0ifm" value="with constraint" />
+          <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
+          <ref role="1ERwB7" node="2xPWNWpwXd_" resolve="ReplaceWithStringType" />
+        </node>
+        <node concept="3F0ifn" id="2xPWNWpoS6R" role="3EZMnx">
+          <property role="3F0ifm" value="/" />
+          <ref role="1ERwB7" node="2xPWNWpwXd_" resolve="ReplaceWithStringType" />
+          <node concept="11LMrY" id="2xPWNWpoS6S" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F1sOY" id="2xPWNWpoS6T" role="3EZMnx">
+          <ref role="1NtTu8" to="5qo5:2xPWNWprAOp" resolve="constraint" />
+        </node>
+        <node concept="3F0ifn" id="2xPWNWpxiH$" role="3EZMnx">
+          <property role="3F0ifm" value="/" />
+          <ref role="1ERwB7" node="2xPWNWpwXd_" resolve="ReplaceWithStringType" />
+          <node concept="11L4FC" id="2xPWNWpxiH_" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="VPM3Z" id="2xPWNWpMhPk" role="3F10Kt" />
+      </node>
+    </node>
+  </node>
+  <node concept="1h_SRR" id="2xPWNWpwXd_">
+    <property role="3GE5qa" value="string" />
+    <property role="TrG5h" value="ReplaceWithStringType" />
+    <ref role="1h_SK9" to="5qo5:2xPWNWpoRmG" resolve="StringTypeWithConstraint" />
+    <node concept="1hA7zw" id="2xPWNWpx56r" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <node concept="1hAIg9" id="2xPWNWpx56s" role="1hA7z_">
+        <node concept="3clFbS" id="2xPWNWpx56t" role="2VODD2">
+          <node concept="3clFbF" id="2xPWNWpy0PP" role="3cqZAp">
+            <node concept="2OqwBi" id="2xPWNWpy137" role="3clFbG">
+              <node concept="0IXxy" id="2xPWNWpy0PO" role="2Oq$k0" />
+              <node concept="1_qnLN" id="2xPWNWpy37l" role="2OqNvi">
+                <ref role="1_rbq0" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/editor.mps
@@ -32,6 +32,7 @@
     <import index="4kwy" ref="r:657c9fde-2f36-4e61-ae17-20f02b8630ad(org.iets3.core.base.structure)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="tpfo" ref="r:00000000-0000-4000-0000-011c89590518(jetbrains.mps.baseLanguage.regexp.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection">
@@ -279,6 +280,7 @@
       </concept>
       <concept id="9041925471455857605" name="com.mbeddr.mpsutil.grammarcells.structure.Cell_DescriptionText" flags="ig" index="uPpia" />
       <concept id="5083944728298846680" name="com.mbeddr.mpsutil.grammarcells.structure.OptionalCell" flags="ng" index="_tjkj">
+        <child id="7011566904921631440" name="postprocess" index="vWNKz" />
         <child id="5083944728298846681" name="option" index="_tjki" />
         <child id="8945098465480008160" name="transformationText" index="ZWbT9" />
       </concept>
@@ -314,6 +316,9 @@
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC">
+        <reference id="1139880128956" name="concept" index="1A9B2P" />
+      </concept>
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
@@ -341,6 +346,9 @@
       </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -1821,6 +1829,74 @@
         </node>
         <node concept="2kknPJ" id="6mBw0A_8NeM" role="3c8P5H">
           <ref role="2ZyFGn" to="5qo5:4rZeNQ6Oerq" resolve="NumberLiteral" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="7J8ctKuJvtt">
+    <property role="3GE5qa" value="string" />
+    <ref role="1XX52x" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
+    <node concept="3EZMnI" id="7J8ctKuJvt_" role="2wV5jI">
+      <node concept="2iRfu4" id="7J8ctKuJvtA" role="2iSdaV" />
+      <node concept="PMmxH" id="6sdnDbSlMTe" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+        <node concept="3Xmtl4" id="4rZeNQ6MfS9" role="3F10Kt">
+          <node concept="1wgc9g" id="7D7uZV2hwIg" role="3XvnJa">
+            <ref role="1wgcnl" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
+          </node>
+        </node>
+        <node concept="VPRnO" id="2KGel$S9Weg" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="_tjkj" id="7J8ctKuJvtZ" role="3EZMnx">
+        <node concept="3EZMnI" id="7J8ctKuJvuc" role="_tjki">
+          <node concept="2iRfu4" id="7J8ctKuJvud" role="2iSdaV" />
+          <node concept="3F0ifn" id="7J8ctKuJvu9" role="3EZMnx">
+            <property role="3F0ifm" value="with constraint" />
+            <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
+          </node>
+          <node concept="3F0ifn" id="3OxSopg1c7e" role="3EZMnx">
+            <property role="3F0ifm" value="/" />
+            <node concept="11LMrY" id="3OxSopg1c7z" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+          <node concept="3F1sOY" id="7J8ctKuJvul" role="3EZMnx">
+            <ref role="1NtTu8" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
+          </node>
+          <node concept="3F0ifn" id="3OxSopg1c7q" role="3EZMnx">
+            <property role="3F0ifm" value="/" />
+            <node concept="11L4FC" id="3OxSopg1c7x" role="3F10Kt">
+              <property role="VOm3f" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="uPpia" id="3OxSopfZRr4" role="1djCvC">
+          <node concept="3clFbS" id="3OxSopfZRr5" role="2VODD2">
+            <node concept="3clFbF" id="3OxSopfZTeZ" role="3cqZAp">
+              <node concept="Xl_RD" id="3OxSopfZTeY" role="3clFbG">
+                <property role="Xl_RC" value="add a constraint in the form of a regular expression" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="315t4" id="3OxSopg2kwp" role="vWNKz">
+          <node concept="3clFbS" id="3OxSopg2kwq" role="2VODD2">
+            <node concept="3clFbF" id="3OxSopg2kzz" role="3cqZAp">
+              <node concept="2OqwBi" id="3OxSopg2lfo" role="3clFbG">
+                <node concept="2OqwBi" id="3OxSopg2kJZ" role="2Oq$k0">
+                  <node concept="313q4" id="3OxSopg2kzy" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="3OxSopg2l6u" role="2OqNvi">
+                    <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
+                  </node>
+                </node>
+                <node concept="zfrQC" id="3OxSopg2lJ1" role="2OqNvi">
+                  <ref role="1A9B2P" to="tpfo:h5OC9$H" resolve="StringLiteralRegexp" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/plugin.mps
@@ -258,6 +258,9 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
         <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
@@ -270,6 +273,7 @@
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
+      <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
       <concept id="1145567426890" name="jetbrains.mps.lang.smodel.structure.SNodeListCreator" flags="nn" index="2T8Vx0">
         <child id="1145567471833" name="createdType" index="2T96Bj" />
       </concept>
@@ -282,6 +286,10 @@
       </concept>
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
+      <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
@@ -302,6 +310,7 @@
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
+      <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -333,6 +342,7 @@
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
       <concept id="1176923520476" name="jetbrains.mps.baseLanguage.collections.structure.ExcludeOperation" flags="nn" index="66VNe" />
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
       <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
         <child id="1226511765987" name="elementType" index="2hN53Y" />
       </concept>
@@ -1596,7 +1606,122 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="1cX0cm8WlgN" role="3cqZAp" />
+        <node concept="3SKdUt" id="6pSOa4rJRLC" role="3cqZAp">
+          <node concept="1PaTwC" id="6pSOa4rJRLD" role="1aUNEU">
+            <node concept="3oM_SD" id="6pSOa4rJRLG" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJRLH" role="1PaTwD">
+              <property role="3oM_SC" value="constraint-less" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWc5" role="1PaTwD">
+              <property role="3oM_SC" value="supertype" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWcz" role="1PaTwD">
+              <property role="3oM_SC" value="string" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWcE" role="1PaTwD">
+              <property role="3oM_SC" value="for" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWcF" role="1PaTwD">
+              <property role="3oM_SC" value="all" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWcG" role="1PaTwD">
+              <property role="3oM_SC" value="string" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWeh" role="1PaTwD">
+              <property role="3oM_SC" value="types" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWcJ" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWcK" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWcL" role="1PaTwD">
+              <property role="3oM_SC" value="enough," />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWdp" role="1PaTwD">
+              <property role="3oM_SC" value="we" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWdq" role="1PaTwD">
+              <property role="3oM_SC" value="need" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWdr" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWds" role="1PaTwD">
+              <property role="3oM_SC" value="remove" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWeD" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWeE" role="1PaTwD">
+              <property role="3oM_SC" value="constraint" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWeF" role="1PaTwD">
+              <property role="3oM_SC" value="manually" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6pSOa4rB9R1" role="3cqZAp">
+          <node concept="2OqwBi" id="6pSOa4rGFLY" role="3clFbG">
+            <node concept="37vLTw" id="6pSOa4rGAT8" role="2Oq$k0">
+              <ref role="3cqZAo" node="1PW6P0ZOp4z" resolve="resultTypes" />
+            </node>
+            <node concept="2es0OD" id="6pSOa4rGKPh" role="2OqNvi">
+              <node concept="1bVj0M" id="6pSOa4rGKPj" role="23t8la">
+                <node concept="3clFbS" id="6pSOa4rGKPk" role="1bW5cS">
+                  <node concept="3clFbF" id="6pSOa4rGL6j" role="3cqZAp">
+                    <node concept="2OqwBi" id="6pSOa4rH1pG" role="3clFbG">
+                      <node concept="2OqwBi" id="6pSOa4rGN4e" role="2Oq$k0">
+                        <node concept="37vLTw" id="6pSOa4rGL6i" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6pSOa4rGKPl" resolve="it" />
+                        </node>
+                        <node concept="2Rf3mk" id="6pSOa4rGPC8" role="2OqNvi">
+                          <node concept="1xMEDy" id="6pSOa4rGPCa" role="1xVPHs">
+                            <node concept="chp4Y" id="6pSOa4rGSKG" role="ri$Ld">
+                              <ref role="cht4Q" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
+                            </node>
+                          </node>
+                          <node concept="1xIGOp" id="6pSOa4rGUp4" role="1xVPHs" />
+                        </node>
+                      </node>
+                      <node concept="2es0OD" id="6pSOa4rH7US" role="2OqNvi">
+                        <node concept="1bVj0M" id="6pSOa4rH7UU" role="23t8la">
+                          <node concept="3clFbS" id="6pSOa4rH7UV" role="1bW5cS">
+                            <node concept="3clFbF" id="6pSOa4rH9Qr" role="3cqZAp">
+                              <node concept="2OqwBi" id="6pSOa4rHi5x" role="3clFbG">
+                                <node concept="2OqwBi" id="6pSOa4rHc6y" role="2Oq$k0">
+                                  <node concept="37vLTw" id="6pSOa4rH9Qq" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="6pSOa4rH7UW" resolve="it" />
+                                  </node>
+                                  <node concept="3TrEf2" id="6pSOa4rHfdm" role="2OqNvi">
+                                    <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
+                                  </node>
+                                </node>
+                                <node concept="3YRAZt" id="6pSOa4rHkHl" role="2OqNvi" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="gl6BB" id="6pSOa4rH7UW" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="6pSOa4rH7UX" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="6pSOa4rGKPl" role="1bW2Oz">
+                  <property role="TrG5h" value="resultType" />
+                  <node concept="2jxLKc" id="6pSOa4rGKPm" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6pSOa4rB0K9" role="3cqZAp" />
         <node concept="3cpWs8" id="1cX0cm8UVFq" role="3cqZAp">
           <node concept="3cpWsn" id="1cX0cm8UVFr" role="3cpWs9">
             <property role="TrG5h" value="resultTupleTypes" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/plugin.mps
@@ -287,7 +287,6 @@
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
-      <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
@@ -295,6 +294,9 @@
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
       <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
+      <concept id="1140131837776" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithAnotherOperation" flags="nn" index="1P9Npp">
+        <child id="1140131861877" name="replacementNode" index="1P9ThW" />
+      </concept>
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
         <property id="1238684351431" name="asCast" index="1BlNFB" />
       </concept>
@@ -310,7 +312,6 @@
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
-      <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -378,6 +379,7 @@
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="1225711141656" name="jetbrains.mps.baseLanguage.collections.structure.ListElementAccessExpression" flags="nn" index="1y4W85">
@@ -1606,121 +1608,6 @@
             </node>
           </node>
         </node>
-        <node concept="3SKdUt" id="6pSOa4rJRLC" role="3cqZAp">
-          <node concept="1PaTwC" id="6pSOa4rJRLD" role="1aUNEU">
-            <node concept="3oM_SD" id="6pSOa4rJRLG" role="1PaTwD">
-              <property role="3oM_SC" value="the" />
-            </node>
-            <node concept="3oM_SD" id="6pSOa4rJRLH" role="1PaTwD">
-              <property role="3oM_SC" value="constraint-less" />
-            </node>
-            <node concept="3oM_SD" id="6pSOa4rJWc5" role="1PaTwD">
-              <property role="3oM_SC" value="supertype" />
-            </node>
-            <node concept="3oM_SD" id="6pSOa4rJWcz" role="1PaTwD">
-              <property role="3oM_SC" value="string" />
-            </node>
-            <node concept="3oM_SD" id="6pSOa4rJWcE" role="1PaTwD">
-              <property role="3oM_SC" value="for" />
-            </node>
-            <node concept="3oM_SD" id="6pSOa4rJWcF" role="1PaTwD">
-              <property role="3oM_SC" value="all" />
-            </node>
-            <node concept="3oM_SD" id="6pSOa4rJWcG" role="1PaTwD">
-              <property role="3oM_SC" value="string" />
-            </node>
-            <node concept="3oM_SD" id="6pSOa4rJWeh" role="1PaTwD">
-              <property role="3oM_SC" value="types" />
-            </node>
-            <node concept="3oM_SD" id="6pSOa4rJWcJ" role="1PaTwD">
-              <property role="3oM_SC" value="is" />
-            </node>
-            <node concept="3oM_SD" id="6pSOa4rJWcK" role="1PaTwD">
-              <property role="3oM_SC" value="not" />
-            </node>
-            <node concept="3oM_SD" id="6pSOa4rJWcL" role="1PaTwD">
-              <property role="3oM_SC" value="enough," />
-            </node>
-            <node concept="3oM_SD" id="6pSOa4rJWdp" role="1PaTwD">
-              <property role="3oM_SC" value="we" />
-            </node>
-            <node concept="3oM_SD" id="6pSOa4rJWdq" role="1PaTwD">
-              <property role="3oM_SC" value="need" />
-            </node>
-            <node concept="3oM_SD" id="6pSOa4rJWdr" role="1PaTwD">
-              <property role="3oM_SC" value="to" />
-            </node>
-            <node concept="3oM_SD" id="6pSOa4rJWds" role="1PaTwD">
-              <property role="3oM_SC" value="remove" />
-            </node>
-            <node concept="3oM_SD" id="6pSOa4rJWeD" role="1PaTwD">
-              <property role="3oM_SC" value="the" />
-            </node>
-            <node concept="3oM_SD" id="6pSOa4rJWeE" role="1PaTwD">
-              <property role="3oM_SC" value="constraint" />
-            </node>
-            <node concept="3oM_SD" id="6pSOa4rJWeF" role="1PaTwD">
-              <property role="3oM_SC" value="manually" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="6pSOa4rB9R1" role="3cqZAp">
-          <node concept="2OqwBi" id="6pSOa4rGFLY" role="3clFbG">
-            <node concept="37vLTw" id="6pSOa4rGAT8" role="2Oq$k0">
-              <ref role="3cqZAo" node="1PW6P0ZOp4z" resolve="resultTypes" />
-            </node>
-            <node concept="2es0OD" id="6pSOa4rGKPh" role="2OqNvi">
-              <node concept="1bVj0M" id="6pSOa4rGKPj" role="23t8la">
-                <node concept="3clFbS" id="6pSOa4rGKPk" role="1bW5cS">
-                  <node concept="3clFbF" id="6pSOa4rGL6j" role="3cqZAp">
-                    <node concept="2OqwBi" id="6pSOa4rH1pG" role="3clFbG">
-                      <node concept="2OqwBi" id="6pSOa4rGN4e" role="2Oq$k0">
-                        <node concept="37vLTw" id="6pSOa4rGL6i" role="2Oq$k0">
-                          <ref role="3cqZAo" node="6pSOa4rGKPl" resolve="resultType" />
-                        </node>
-                        <node concept="2Rf3mk" id="6pSOa4rGPC8" role="2OqNvi">
-                          <node concept="1xMEDy" id="6pSOa4rGPCa" role="1xVPHs">
-                            <node concept="chp4Y" id="6pSOa4rGSKG" role="ri$Ld">
-                              <ref role="cht4Q" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
-                            </node>
-                          </node>
-                          <node concept="1xIGOp" id="6pSOa4rGUp4" role="1xVPHs" />
-                        </node>
-                      </node>
-                      <node concept="2es0OD" id="6pSOa4rH7US" role="2OqNvi">
-                        <node concept="1bVj0M" id="6pSOa4rH7UU" role="23t8la">
-                          <node concept="3clFbS" id="6pSOa4rH7UV" role="1bW5cS">
-                            <node concept="3clFbF" id="6pSOa4rH9Qr" role="3cqZAp">
-                              <node concept="2OqwBi" id="6pSOa4rHi5x" role="3clFbG">
-                                <node concept="2OqwBi" id="6pSOa4rHc6y" role="2Oq$k0">
-                                  <node concept="37vLTw" id="6pSOa4rH9Qq" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="6pSOa4rH7UW" resolve="it" />
-                                  </node>
-                                  <node concept="3TrEf2" id="6pSOa4rHfdm" role="2OqNvi">
-                                    <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
-                                  </node>
-                                </node>
-                                <node concept="3YRAZt" id="6pSOa4rHkHl" role="2OqNvi" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="gl6BB" id="6pSOa4rH7UW" role="1bW2Oz">
-                            <property role="TrG5h" value="it" />
-                            <node concept="2jxLKc" id="6pSOa4rH7UX" role="1tU5fm" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="gl6BB" id="6pSOa4rGKPl" role="1bW2Oz">
-                  <property role="TrG5h" value="resultType" />
-                  <node concept="2jxLKc" id="6pSOa4rGKPm" role="1tU5fm" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3clFbH" id="6pSOa4rB0K9" role="3cqZAp" />
         <node concept="3cpWs8" id="1cX0cm8UVFq" role="3cqZAp">
           <node concept="3cpWsn" id="1cX0cm8UVFr" role="3cpWs9">
@@ -1804,6 +1691,191 @@
           </node>
         </node>
         <node concept="3clFbH" id="1PW6P0ZLV5u" role="3cqZAp" />
+        <node concept="3SKdUt" id="6pSOa4rJRLC" role="3cqZAp">
+          <node concept="1PaTwC" id="6pSOa4rJRLD" role="1aUNEU">
+            <node concept="3oM_SD" id="6pSOa4rJRLG" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJRLH" role="1PaTwD">
+              <property role="3oM_SC" value="constraint-less" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWc5" role="1PaTwD">
+              <property role="3oM_SC" value="supertype" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWcz" role="1PaTwD">
+              <property role="3oM_SC" value="string" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWcE" role="1PaTwD">
+              <property role="3oM_SC" value="for" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWcF" role="1PaTwD">
+              <property role="3oM_SC" value="all" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWcG" role="1PaTwD">
+              <property role="3oM_SC" value="string" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWeh" role="1PaTwD">
+              <property role="3oM_SC" value="types" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWcJ" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWcK" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWcL" role="1PaTwD">
+              <property role="3oM_SC" value="enough," />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWdp" role="1PaTwD">
+              <property role="3oM_SC" value="we" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWdq" role="1PaTwD">
+              <property role="3oM_SC" value="need" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWdr" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWds" role="1PaTwD">
+              <property role="3oM_SC" value="remove" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWeD" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWeE" role="1PaTwD">
+              <property role="3oM_SC" value="constraint" />
+            </node>
+            <node concept="3oM_SD" id="6pSOa4rJWeF" role="1PaTwD">
+              <property role="3oM_SC" value="manually" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7LIXz$ntnAQ" role="3cqZAp">
+          <node concept="3cpWsn" id="7LIXz$ntnAR" role="3cpWs9">
+            <property role="TrG5h" value="stringType" />
+            <node concept="3Tqbb2" id="7LIXz$ntlL5" role="1tU5fm">
+              <ref role="ehGHo" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
+            </node>
+            <node concept="2ShNRf" id="7LIXz$ntnAS" role="33vP2m">
+              <node concept="3zrR0B" id="7LIXz$ntnAT" role="2ShVmc">
+                <node concept="3Tqbb2" id="7LIXz$ntnAU" role="3zrR0E">
+                  <ref role="ehGHo" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6pSOa4rB9R1" role="3cqZAp">
+          <node concept="2OqwBi" id="6pSOa4rGFLY" role="3clFbG">
+            <node concept="37vLTw" id="6pSOa4rGAT8" role="2Oq$k0">
+              <ref role="3cqZAo" node="1PW6P0ZOp4z" resolve="resultTypes" />
+            </node>
+            <node concept="2es0OD" id="6pSOa4rGKPh" role="2OqNvi">
+              <node concept="1bVj0M" id="6pSOa4rGKPj" role="23t8la">
+                <node concept="3clFbS" id="6pSOa4rGKPk" role="1bW5cS">
+                  <node concept="3clFbF" id="6pSOa4rGL6j" role="3cqZAp">
+                    <node concept="2OqwBi" id="6pSOa4rH1pG" role="3clFbG">
+                      <node concept="2OqwBi" id="6pSOa4rGN4e" role="2Oq$k0">
+                        <node concept="37vLTw" id="6pSOa4rGL6i" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6pSOa4rGKPl" resolve="resultType" />
+                        </node>
+                        <node concept="2Rf3mk" id="6pSOa4rGPC8" role="2OqNvi">
+                          <node concept="1xMEDy" id="6pSOa4rGPCa" role="1xVPHs">
+                            <node concept="chp4Y" id="6pSOa4rGSKG" role="ri$Ld">
+                              <ref role="cht4Q" to="5qo5:2xPWNWpoRmG" resolve="StringTypeWithConstraint" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2es0OD" id="6pSOa4rH7US" role="2OqNvi">
+                        <node concept="1bVj0M" id="6pSOa4rH7UU" role="23t8la">
+                          <node concept="3clFbS" id="6pSOa4rH7UV" role="1bW5cS">
+                            <node concept="3clFbF" id="6pSOa4rH9Qr" role="3cqZAp">
+                              <node concept="2OqwBi" id="6pSOa4rHc6y" role="3clFbG">
+                                <node concept="37vLTw" id="6pSOa4rH9Qq" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="6pSOa4rH7UW" resolve="it" />
+                                </node>
+                                <node concept="1P9Npp" id="7LIXz$nuPV8" role="2OqNvi">
+                                  <node concept="2OqwBi" id="7LIXz$nRgrQ" role="1P9ThW">
+                                    <node concept="37vLTw" id="7LIXz$nRcTW" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="7LIXz$ntnAR" resolve="stringType" />
+                                    </node>
+                                    <node concept="1$rogu" id="7LIXz$nRmo6" role="2OqNvi" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="gl6BB" id="6pSOa4rH7UW" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="6pSOa4rH7UX" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="6pSOa4rGKPl" role="1bW2Oz">
+                  <property role="TrG5h" value="resultType" />
+                  <node concept="2jxLKc" id="6pSOa4rGKPm" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7LIXz$mAlsQ" role="3cqZAp">
+          <node concept="37vLTI" id="7LIXz$mAu0z" role="3clFbG">
+            <node concept="2OqwBi" id="7LIXz$mBWGC" role="37vLTx">
+              <node concept="2OqwBi" id="7LIXz$mACmz" role="2Oq$k0">
+                <node concept="37vLTw" id="7LIXz$mAztq" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1PW6P0ZOp4z" resolve="resultTypes" />
+                </node>
+                <node concept="3$u5V9" id="7LIXz$mALvh" role="2OqNvi">
+                  <node concept="1bVj0M" id="7LIXz$mALvj" role="23t8la">
+                    <node concept="3clFbS" id="7LIXz$mALvk" role="1bW5cS">
+                      <node concept="3clFbJ" id="7LIXz$mANmd" role="3cqZAp">
+                        <node concept="2OqwBi" id="7LIXz$mB14_" role="3clFbw">
+                          <node concept="37vLTw" id="7LIXz$mAY9P" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7LIXz$mALvl" resolve="it" />
+                          </node>
+                          <node concept="1mIQ4w" id="7LIXz$mB5x2" role="2OqNvi">
+                            <node concept="chp4Y" id="7LIXz$mBc6L" role="cj9EA">
+                              <ref role="cht4Q" to="5qo5:2xPWNWpoRmG" resolve="StringTypeWithConstraint" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbS" id="7LIXz$mANmf" role="3clFbx">
+                          <node concept="3cpWs6" id="7LIXz$mBhSR" role="3cqZAp">
+                            <node concept="37vLTw" id="7LIXz$ntnAV" role="3cqZAk">
+                              <ref role="3cqZAo" node="7LIXz$ntnAR" resolve="stringType" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="9aQIb" id="7LIXz$mB$Tf" role="9aQIa">
+                          <node concept="3clFbS" id="7LIXz$mB$Tg" role="9aQI4">
+                            <node concept="3cpWs6" id="7LIXz$mBHfT" role="3cqZAp">
+                              <node concept="37vLTw" id="7LIXz$mBQC9" role="3cqZAk">
+                                <ref role="3cqZAo" node="7LIXz$mALvl" resolve="it" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="7LIXz$mALvl" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="7LIXz$mALvm" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="ANE8D" id="7LIXz$mCh1Q" role="2OqNvi" />
+            </node>
+            <node concept="37vLTw" id="7LIXz$mAlsO" role="37vLTJ">
+              <ref role="3cqZAo" node="1PW6P0ZOp4z" resolve="resultTypes" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7LIXz$mAglX" role="3cqZAp" />
         <node concept="3SKdUt" id="670RODgQSGW" role="3cqZAp">
           <node concept="1PaTwC" id="670RODgQSGX" role="1aUNEU">
             <node concept="3oM_SD" id="670RODgR72B" role="1PaTwD">
@@ -2255,7 +2327,6 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="6unC0YG1a$j" role="3cqZAp" />
         <node concept="3cpWs8" id="1cX0cm8Zurv" role="3cqZAp">
           <node concept="3cpWsn" id="1cX0cm8Zurw" role="3cpWs9">
             <property role="TrG5h" value="jt" />
@@ -2389,6 +2460,82 @@
             </node>
             <node concept="2qgKlT" id="738HPfgQB1O" role="2OqNvi">
               <ref role="37wK5l" to="pbu6:H8GgRpqbgk" resolve="sortTypes" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7LIXz$n_Hue" role="3cqZAp">
+          <node concept="3cpWsn" id="7LIXz$n_Huh" role="3cpWs9">
+            <property role="TrG5h" value="stringTypeFound" />
+            <node concept="10P_77" id="7LIXz$n_Huc" role="1tU5fm" />
+            <node concept="3clFbT" id="7LIXz$n_ZlS" role="33vP2m" />
+          </node>
+        </node>
+        <node concept="2Gpval" id="7LIXz$nA5Qp" role="3cqZAp">
+          <node concept="2GrKxI" id="7LIXz$nA5Qr" role="2Gsz3X">
+            <property role="TrG5h" value="type" />
+          </node>
+          <node concept="2OqwBi" id="7LIXz$nAqc_" role="2GsD0m">
+            <node concept="37vLTw" id="7LIXz$nAo4Y" role="2Oq$k0">
+              <ref role="3cqZAo" node="1cX0cm8Zurw" resolve="jt" />
+            </node>
+            <node concept="3Tsc0h" id="7LIXz$nAvBK" role="2OqNvi">
+              <ref role="3TtcxE" to="hm2y:7VuYlCQZ3lm" resolve="types" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="7LIXz$nA5Qv" role="2LFqv$">
+            <node concept="3clFbJ" id="7LIXz$nA$zR" role="3cqZAp">
+              <node concept="3clFbS" id="7LIXz$nA$zT" role="3clFbx">
+                <node concept="3clFbJ" id="7LIXz$nBgZF" role="3cqZAp">
+                  <node concept="3fqX7Q" id="7LIXz$nBBLQ" role="3clFbw">
+                    <node concept="37vLTw" id="7LIXz$nBBLS" role="3fr31v">
+                      <ref role="3cqZAo" node="7LIXz$n_Huh" resolve="stringTypeFound" />
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="7LIXz$nBgZH" role="3clFbx">
+                    <node concept="3clFbF" id="7LIXz$nBIql" role="3cqZAp">
+                      <node concept="37vLTI" id="7LIXz$nBQaB" role="3clFbG">
+                        <node concept="3clFbT" id="7LIXz$nBTRg" role="37vLTx">
+                          <property role="3clFbU" value="true" />
+                        </node>
+                        <node concept="37vLTw" id="7LIXz$nBIqk" role="37vLTJ">
+                          <ref role="3cqZAo" node="7LIXz$n_Huh" resolve="stringTypeFound" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="9aQIb" id="7LIXz$nC170" role="9aQIa">
+                    <node concept="3clFbS" id="7LIXz$nC171" role="9aQI4">
+                      <node concept="3clFbF" id="7LIXz$nC5R8" role="3cqZAp">
+                        <node concept="2OqwBi" id="7LIXz$nCh8S" role="3clFbG">
+                          <node concept="2OqwBi" id="7LIXz$nC7YB" role="2Oq$k0">
+                            <node concept="37vLTw" id="7LIXz$nC5R7" role="2Oq$k0">
+                              <ref role="3cqZAo" node="1cX0cm8Zurw" resolve="jt" />
+                            </node>
+                            <node concept="3Tsc0h" id="7LIXz$nCbMF" role="2OqNvi">
+                              <ref role="3TtcxE" to="hm2y:7VuYlCQZ3lm" resolve="types" />
+                            </node>
+                          </node>
+                          <node concept="3dhRuq" id="7LIXz$nCo3V" role="2OqNvi">
+                            <node concept="2GrUjf" id="7LIXz$nCrKc" role="25WWJ7">
+                              <ref role="2Gs0qQ" node="7LIXz$nA5Qr" resolve="type" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="7LIXz$nB4yJ" role="3clFbw">
+                <node concept="2GrUjf" id="7LIXz$nB2sj" role="2Oq$k0">
+                  <ref role="2Gs0qQ" node="7LIXz$nA5Qr" resolve="type" />
+                </node>
+                <node concept="1mIQ4w" id="7LIXz$nB8uw" role="2OqNvi">
+                  <node concept="chp4Y" id="7LIXz$nBc1E" role="cj9EA">
+                    <ref role="cht4Q" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/plugin.mps
@@ -1676,7 +1676,7 @@
                     <node concept="2OqwBi" id="6pSOa4rH1pG" role="3clFbG">
                       <node concept="2OqwBi" id="6pSOa4rGN4e" role="2Oq$k0">
                         <node concept="37vLTw" id="6pSOa4rGL6i" role="2Oq$k0">
-                          <ref role="3cqZAo" node="6pSOa4rGKPl" resolve="it" />
+                          <ref role="3cqZAo" node="6pSOa4rGKPl" resolve="resultType" />
                         </node>
                         <node concept="2Rf3mk" id="6pSOa4rGPC8" role="2OqNvi">
                           <node concept="1xMEDy" id="6pSOa4rGPCa" role="1xVPHs">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/structure.mps
@@ -12,6 +12,7 @@
     <import index="l80j" ref="r:9e71c0de-f9ab-4b67-96cc-7d9c857513f6(org.iets3.analysis.base.structure)" />
     <import index="87nw" ref="r:ca2ab6bb-f6e7-4c0f-a88c-b78b9b31fff3(de.slisson.mps.richtext.structure)" />
     <import index="4kwy" ref="r:657c9fde-2f36-4e61-ae17-20f02b8630ad(org.iets3.core.base.structure)" />
+    <import index="tpfo" ref="r:00000000-0000-4000-0000-011c89590518(jetbrains.mps.baseLanguage.regexp.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
@@ -157,6 +158,12 @@
     <property role="EcuMT" value="5115872837157252551" />
     <property role="R4oN_" value="a sequence of characters type" />
     <ref role="1TJDcQ" to="hm2y:6sdnDbSlMSN" resolve="PrimitiveType" />
+    <node concept="1TJgyj" id="7J8ctKuJsiI" role="1TKVEi">
+      <property role="IQ2ns" value="8919433883485586606" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="constraint" />
+      <ref role="20lvS9" to="tpfo:h5OC6VX" resolve="Regexp" />
+    </node>
     <node concept="PrWs8" id="60Qa1k_vswP" role="PzmwI">
       <ref role="PrY4T" to="hm2y:60Qa1k_nI2f" resolve="ITypeSupportsDefaultValue" />
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/structure.mps
@@ -158,12 +158,6 @@
     <property role="EcuMT" value="5115872837157252551" />
     <property role="R4oN_" value="a sequence of characters type" />
     <ref role="1TJDcQ" to="hm2y:6sdnDbSlMSN" resolve="PrimitiveType" />
-    <node concept="1TJgyj" id="7J8ctKuJsiI" role="1TKVEi">
-      <property role="IQ2ns" value="8919433883485586606" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="constraint" />
-      <ref role="20lvS9" to="tpfo:h5OC6VX" resolve="Regexp" />
-    </node>
     <node concept="PrWs8" id="60Qa1k_vswP" role="PzmwI">
       <ref role="PrY4T" to="hm2y:60Qa1k_nI2f" resolve="ITypeSupportsDefaultValue" />
     </node>
@@ -516,6 +510,21 @@
       <property role="20kJfa" value="value" />
       <property role="20lbJX" value="fLJekj4/_1" />
       <ref role="20lvS9" to="hm2y:6sdnDbSla17" resolve="Expression" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2xPWNWpoRmG">
+    <property role="TrG5h" value="StringTypeWithConstraint" />
+    <property role="34LRSv" value="string" />
+    <property role="3GE5qa" value="string" />
+    <property role="EcuMT" value="2915503786126701996" />
+    <property role="R4oN_" value="a sequence of characters type with a constraint" />
+    <ref role="1TJDcQ" node="4rZeNQ6OYR7" resolve="StringType" />
+    <node concept="1TJgyj" id="2xPWNWprAOp" role="1TKVEi">
+      <property role="IQ2ns" value="8919433883485586606" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="constraint" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" to="tpfo:h5OC6VX" resolve="Regexp" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/typesystem.mps
@@ -152,6 +152,10 @@
       </concept>
     </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+        <child id="1595412875168045827" name="initValue" index="28nt2d" />
+      </concept>
       <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
         <reference id="5455284157993911078" name="property" index="2pJxcJ" />
         <child id="1595412875168045201" name="initValue" index="28ntcv" />
@@ -165,6 +169,9 @@
       </concept>
       <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
         <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
+      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
+        <child id="8182547171709752112" name="expression" index="36biLW" />
       </concept>
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
@@ -552,76 +559,6 @@
     <property role="TrG5h" value="typeof_StringLiteral" />
     <property role="3GE5qa" value="string" />
     <node concept="3clFbS" id="4rZeNQ6Pjwj" role="18ibNy">
-      <node concept="3cpWs8" id="hTGlT9TY5l" role="3cqZAp">
-        <node concept="3cpWsn" id="hTGlT9TY5o" role="3cpWs9">
-          <property role="TrG5h" value="type" />
-          <node concept="3Tqbb2" id="hTGlT9TY5j" role="1tU5fm">
-            <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
-          </node>
-          <node concept="2YIFZM" id="hTGlT9U2gW" role="33vP2m">
-            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
-            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-          </node>
-        </node>
-      </node>
-      <node concept="Jncv_" id="hTGlT9TYck" role="3cqZAp">
-        <ref role="JncvD" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
-        <node concept="37vLTw" id="hTGlT9TYdJ" role="JncvB">
-          <ref role="3cqZAo" node="hTGlT9TY5o" resolve="type" />
-        </node>
-        <node concept="3clFbS" id="hTGlT9TYco" role="Jncv$">
-          <node concept="3clFbF" id="hTGlT9TZjp" role="3cqZAp">
-            <node concept="37vLTI" id="hTGlT9U07G" role="3clFbG">
-              <node concept="2OqwBi" id="hTGlT9TZyy" role="37vLTJ">
-                <node concept="Jnkvi" id="hTGlT9TZjo" role="2Oq$k0">
-                  <ref role="1M0zk5" node="hTGlT9TYcq" resolve="stringType" />
-                </node>
-                <node concept="3TrEf2" id="hTGlT9TZTF" role="2OqNvi">
-                  <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
-                </node>
-              </node>
-              <node concept="2pJPEk" id="hTGlT9U0Ol" role="37vLTx">
-                <node concept="2pJPED" id="hTGlT9U0On" role="2pJPEn">
-                  <ref role="2pJxaS" to="tpfo:h5OC9$H" resolve="StringLiteralRegexp" />
-                  <node concept="2pJxcG" id="hTGlT9U0SX" role="2pJxcM">
-                    <ref role="2pJxcJ" to="tpfo:h5OCbxf" resolve="text" />
-                    <node concept="WxPPo" id="hTGlT9U0Vy" role="28ntcv">
-                      <node concept="3K4zz7" id="3g7FMHmyHgA" role="WxPPp">
-                        <node concept="2OqwBi" id="3g7FMHmyHwR" role="3K4E3e">
-                          <node concept="1YBJjd" id="3g7FMHmyHkd" role="2Oq$k0">
-                            <ref role="1YBMHb" node="4rZeNQ6Pjwl" resolve="sl" />
-                          </node>
-                          <node concept="3TrcHB" id="3g7FMHmyHyi" role="2OqNvi">
-                            <ref role="3TsBF5" to="5qo5:4rZeNQ6OYRb" resolve="value" />
-                          </node>
-                        </node>
-                        <node concept="Xl_RD" id="3g7FMHmyHB3" role="3K4GZi">
-                          <property role="Xl_RC" value="" />
-                        </node>
-                        <node concept="2OqwBi" id="3g7FMHmyF9a" role="3K4Cdx">
-                          <node concept="2OqwBi" id="hTGlT9U1bJ" role="2Oq$k0">
-                            <node concept="1YBJjd" id="hTGlT9U0Vw" role="2Oq$k0">
-                              <ref role="1YBMHb" node="4rZeNQ6Pjwl" resolve="sl" />
-                            </node>
-                            <node concept="3TrcHB" id="hTGlT9U1$E" role="2OqNvi">
-                              <ref role="3TsBF5" to="5qo5:4rZeNQ6OYRb" resolve="value" />
-                            </node>
-                          </node>
-                          <node concept="17RvpY" id="3g7FMHmyG0L" role="2OqNvi" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="JncvC" id="hTGlT9TYcq" role="JncvA">
-          <property role="TrG5h" value="stringType" />
-          <node concept="2jxLKc" id="hTGlT9TYcr" role="1tU5fm" />
-        </node>
-      </node>
       <node concept="1Z5TYs" id="4rZeNQ6Pj$q" role="3cqZAp">
         <node concept="mw_s8" id="4rZeNQ6Pj$t" role="1ZfhK$">
           <node concept="1Z2H0r" id="4rZeNQ6Pjwv" role="mwGJk">
@@ -631,8 +568,49 @@
           </node>
         </node>
         <node concept="mw_s8" id="hTGlT9U4aN" role="1ZfhKB">
-          <node concept="37vLTw" id="hTGlT9U4aM" role="mwGJk">
-            <ref role="3cqZAo" node="hTGlT9TY5o" resolve="type" />
+          <node concept="2pJPEk" id="2xPWNWpqoAU" role="mwGJk">
+            <node concept="2pJPED" id="2xPWNWpqoAW" role="2pJPEn">
+              <ref role="2pJxaS" to="5qo5:2xPWNWpoRmG" resolve="StringTypeWithConstraint" />
+              <node concept="2pIpSj" id="2xPWNWpqoOr" role="2pJxcM">
+                <ref role="2pIpSl" to="5qo5:2xPWNWprAOp" resolve="constraint" />
+                <node concept="36biLy" id="2xPWNWpqpxY" role="28nt2d">
+                  <node concept="2pJPEk" id="hTGlT9U0Ol" role="36biLW">
+                    <node concept="2pJPED" id="hTGlT9U0On" role="2pJPEn">
+                      <ref role="2pJxaS" to="tpfo:h5OC9$H" resolve="StringLiteralRegexp" />
+                      <node concept="2pJxcG" id="hTGlT9U0SX" role="2pJxcM">
+                        <ref role="2pJxcJ" to="tpfo:h5OCbxf" resolve="text" />
+                        <node concept="WxPPo" id="hTGlT9U0Vy" role="28ntcv">
+                          <node concept="3K4zz7" id="3g7FMHmyHgA" role="WxPPp">
+                            <node concept="2OqwBi" id="3g7FMHmyHwR" role="3K4E3e">
+                              <node concept="1YBJjd" id="3g7FMHmyHkd" role="2Oq$k0">
+                                <ref role="1YBMHb" node="4rZeNQ6Pjwl" resolve="sl" />
+                              </node>
+                              <node concept="3TrcHB" id="3g7FMHmyHyi" role="2OqNvi">
+                                <ref role="3TsBF5" to="5qo5:4rZeNQ6OYRb" resolve="value" />
+                              </node>
+                            </node>
+                            <node concept="Xl_RD" id="3g7FMHmyHB3" role="3K4GZi">
+                              <property role="Xl_RC" value="" />
+                            </node>
+                            <node concept="2OqwBi" id="3g7FMHmyF9a" role="3K4Cdx">
+                              <node concept="2OqwBi" id="hTGlT9U1bJ" role="2Oq$k0">
+                                <node concept="1YBJjd" id="hTGlT9U0Vw" role="2Oq$k0">
+                                  <ref role="1YBMHb" node="4rZeNQ6Pjwl" resolve="sl" />
+                                </node>
+                                <node concept="3TrcHB" id="hTGlT9U1$E" role="2OqNvi">
+                                  <ref role="3TsBF5" to="5qo5:4rZeNQ6OYRb" resolve="value" />
+                                </node>
+                              </node>
+                              <node concept="17RvpY" id="3g7FMHmyG0L" role="2OqNvi" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -5316,8 +5294,8 @@
     <property role="3GE5qa" value="string" />
     <property role="TrG5h" value="checkStringConstraint" />
     <node concept="1YaCAy" id="7J8ctKuSW2R" role="35pZ6h">
-      <property role="TrG5h" value="otherStringType" />
-      <ref role="1YaFvo" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
+      <property role="TrG5h" value="stringTypeWithConstraint" />
+      <ref role="1YaFvo" to="5qo5:2xPWNWpoRmG" resolve="StringTypeWithConstraint" />
     </node>
     <node concept="3clFbS" id="7J8ctKuSW1h" role="2sgrp5">
       <node concept="3clFbJ" id="3OxSopfXBdX" role="3cqZAp">
@@ -5329,10 +5307,10 @@
             <node concept="2OqwBi" id="3OxSopfZ04k" role="3fr31v">
               <node concept="2OqwBi" id="3OxSopfZ04l" role="2Oq$k0">
                 <node concept="1YBJjd" id="3OxSopfZ04m" role="2Oq$k0">
-                  <ref role="1YBMHb" node="7J8ctKuSW2R" resolve="otherStringType" />
+                  <ref role="1YBMHb" node="7J8ctKuSW2R" resolve="stringTypeWithConstraint" />
                 </node>
                 <node concept="3TrEf2" id="3OxSopfZ04n" role="2OqNvi">
-                  <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
+                  <ref role="3Tt5mk" to="5qo5:2xPWNWprAOp" resolve="constraint" />
                 </node>
               </node>
               <node concept="2qgKlT" id="3OxSopfZ04o" role="2OqNvi">
@@ -5343,10 +5321,10 @@
           <node concept="2OqwBi" id="3OxSopfXBZu" role="3uHU7B">
             <node concept="2OqwBi" id="3OxSopfXBtO" role="2Oq$k0">
               <node concept="1YBJjd" id="3OxSopfXBez" role="2Oq$k0">
-                <ref role="1YBMHb" node="7J8ctKuSW2R" resolve="otherStringType" />
+                <ref role="1YBMHb" node="7J8ctKuSW2R" resolve="stringTypeWithConstraint" />
               </node>
               <node concept="3TrEf2" id="3OxSopfXBOp" role="2OqNvi">
-                <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
+                <ref role="3Tt5mk" to="5qo5:2xPWNWprAOp" resolve="constraint" />
               </node>
             </node>
             <node concept="3w_OXm" id="3OxSopfXCcO" role="2OqNvi" />
@@ -5377,10 +5355,10 @@
               <node concept="2OqwBi" id="3OxSopfYa2Z" role="33vP2m">
                 <node concept="2OqwBi" id="3OxSopfYa30" role="2Oq$k0">
                   <node concept="1YBJjd" id="3OxSopfYa31" role="2Oq$k0">
-                    <ref role="1YBMHb" node="7J8ctKuSW2R" resolve="otherStringType" />
+                    <ref role="1YBMHb" node="7J8ctKuSW2R" resolve="stringTypeWithConstraint" />
                   </node>
                   <node concept="3TrEf2" id="3OxSopfYa32" role="2OqNvi">
-                    <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
+                    <ref role="3Tt5mk" to="5qo5:2xPWNWprAOp" resolve="constraint" />
                   </node>
                 </node>
                 <node concept="2qgKlT" id="7NPLlCCxHcd" role="2OqNvi">
@@ -5503,72 +5481,34 @@
         </node>
         <node concept="2OqwBi" id="3OxSopfXB96" role="JncvB">
           <node concept="1YBJjd" id="3OxSopfXB97" role="2Oq$k0">
-            <ref role="1YBMHb" node="7J8ctKuSW1j" resolve="stringType" />
+            <ref role="1YBMHb" node="7J8ctKuSW1j" resolve="stringTypeWithConstraint" />
           </node>
           <node concept="3TrEf2" id="3OxSopfXB98" role="2OqNvi">
-            <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
+            <ref role="3Tt5mk" to="5qo5:2xPWNWprAOp" resolve="constraint" />
           </node>
         </node>
       </node>
     </node>
     <node concept="1YaCAy" id="7J8ctKuSW1j" role="1YuTPh">
-      <property role="TrG5h" value="stringType" />
-      <ref role="1YaFvo" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
+      <property role="TrG5h" value="stringTypeWithConstraint" />
+      <ref role="1YaFvo" to="5qo5:2xPWNWpoRmG" resolve="StringTypeWithConstraint" />
     </node>
   </node>
-  <node concept="2sgARr" id="6pSOa4r7dHX">
+  <node concept="2sgARr" id="2xPWNWpD3Pq">
     <property role="3GE5qa" value="string" />
-    <property role="TrG5h" value="superTypeOf_String" />
-    <node concept="3clFbS" id="6pSOa4r7dHY" role="2sgrp5">
-      <node concept="3cpWs8" id="6pSOa4r8c5Y" role="3cqZAp">
-        <node concept="3cpWsn" id="6pSOa4r8c61" role="3cpWs9">
-          <property role="TrG5h" value="types" />
-          <node concept="2I9FWS" id="6pSOa4r8c5X" role="1tU5fm" />
-          <node concept="2ShNRf" id="6pSOa4r8c73" role="33vP2m">
-            <node concept="2T8Vx0" id="6pSOa4r8dj1" role="2ShVmc">
-              <node concept="2I9FWS" id="6pSOa4r8dj3" role="2T96Bj" />
-            </node>
+    <property role="TrG5h" value="superTypeOf_StringtypeWithConstraint" />
+    <node concept="3clFbS" id="2xPWNWpD3Pr" role="2sgrp5">
+      <node concept="3clFbF" id="2xPWNWpDgA3" role="3cqZAp">
+        <node concept="2pJPEk" id="2xPWNWpDgA1" role="3clFbG">
+          <node concept="2pJPED" id="2xPWNWpDgA2" role="2pJPEn">
+            <ref role="2pJxaS" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
           </node>
-        </node>
-      </node>
-      <node concept="3clFbJ" id="6pSOa4r8doA" role="3cqZAp">
-        <node concept="3clFbS" id="6pSOa4r8doC" role="3clFbx">
-          <node concept="3clFbF" id="6pSOa4r8evi" role="3cqZAp">
-            <node concept="2OqwBi" id="6pSOa4r8gnf" role="3clFbG">
-              <node concept="37vLTw" id="6pSOa4r8evg" role="2Oq$k0">
-                <ref role="3cqZAo" node="6pSOa4r8c61" resolve="types" />
-              </node>
-              <node concept="TSZUe" id="6pSOa4r8hMY" role="2OqNvi">
-                <node concept="2pJPEk" id="6pSOa4r7dLu" role="25WWJ7">
-                  <node concept="2pJPED" id="6pSOa4r7dLv" role="2pJPEn">
-                    <ref role="2pJxaS" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2OqwBi" id="6pSOa4r8ed2" role="3clFbw">
-          <node concept="2OqwBi" id="6pSOa4r8dCj" role="2Oq$k0">
-            <node concept="1YBJjd" id="6pSOa4r8dpd" role="2Oq$k0">
-              <ref role="1YBMHb" node="6pSOa4r7dI0" resolve="stringType" />
-            </node>
-            <node concept="3TrEf2" id="6pSOa4r8dYT" role="2OqNvi">
-              <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
-            </node>
-          </node>
-          <node concept="3x8VRR" id="6pSOa4r8eql" role="2OqNvi" />
-        </node>
-      </node>
-      <node concept="3cpWs6" id="6pSOa4r8dm0" role="3cqZAp">
-        <node concept="37vLTw" id="6pSOa4r8dmI" role="3cqZAk">
-          <ref role="3cqZAo" node="6pSOa4r8c61" resolve="types" />
         </node>
       </node>
     </node>
-    <node concept="1YaCAy" id="6pSOa4r7dI0" role="1YuTPh">
-      <property role="TrG5h" value="stringType" />
-      <ref role="1YaFvo" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
+    <node concept="1YaCAy" id="2xPWNWpD3Pt" role="1YuTPh">
+      <property role="TrG5h" value="stringTypeWithConstraint" />
+      <ref role="1YaFvo" to="5qo5:2xPWNWpoRmG" resolve="StringTypeWithConstraint" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/typesystem.mps
@@ -4,6 +4,7 @@
   <languages>
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="df345b11-b8c7-4213-ac66-48d2a9b75d88" name="jetbrains.mps.baseLanguageInternal" version="0" />
+    <use id="daafa647-f1f7-4b0b-b096-69cd7c8408c0" name="jetbrains.mps.baseLanguage.regexp" version="0" />
     <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
   </languages>
   <imports>
@@ -18,8 +19,10 @@
     <import index="tpd4" ref="r:00000000-0000-4000-0000-011c895902b4(jetbrains.mps.lang.typesystem.structure)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" />
     <import index="gdgh" ref="r:e4d9478b-ae0e-416e-be60-73d136571015(org.iets3.core.base.behavior)" />
+    <import index="tpfo" ref="r:00000000-0000-4000-0000-011c89590518(jetbrains.mps.baseLanguage.regexp.structure)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="tpfs" ref="r:00000000-0000-4000-0000-011c89590514(jetbrains.mps.baseLanguage.regexp.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -34,6 +37,9 @@
       <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
+        <child id="8118189177080264854" name="alternative" index="nSUat" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -51,6 +57,7 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
@@ -64,6 +71,7 @@
       </concept>
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -107,11 +115,30 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
+        <child id="8276990574895933173" name="catchBody" index="1zc67A" />
+        <child id="8276990574895933172" name="throwable" index="1zc67B" />
+      </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+        <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
+        <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
@@ -188,6 +215,7 @@
         <child id="1201607798918" name="supertypeNode" index="35pZ6h" />
         <child id="3592071576955708909" name="isApplicableClause" index="1xSnZW" />
       </concept>
+      <concept id="1201618299781" name="jetbrains.mps.lang.typesystem.structure.ErrorInfoExpression" flags="nn" index="3622Ei" />
       <concept id="1195213580585" name="jetbrains.mps.lang.typesystem.structure.AbstractCheckingRule" flags="ig" index="18hYwZ">
         <child id="1195213635060" name="body" index="18ibNy" />
       </concept>
@@ -255,7 +283,17 @@
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
       </concept>
-      <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS" />
+      <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
+        <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
+      </concept>
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1145567426890" name="jetbrains.mps.lang.smodel.structure.SNodeListCreator" flags="nn" index="2T8Vx0">
         <child id="1145567471833" name="createdType" index="2T96Bj" />
       </concept>
@@ -270,6 +308,7 @@
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
@@ -513,19 +552,87 @@
     <property role="TrG5h" value="typeof_StringLiteral" />
     <property role="3GE5qa" value="string" />
     <node concept="3clFbS" id="4rZeNQ6Pjwj" role="18ibNy">
-      <node concept="1Z5TYs" id="4rZeNQ6Pj$q" role="3cqZAp">
-        <node concept="mw_s8" id="4rZeNQ6Pj$I" role="1ZfhKB">
-          <node concept="2pJPEk" id="4rZeNQ6Pj$E" role="mwGJk">
-            <node concept="2pJPED" id="4rZeNQ6Pj$T" role="2pJPEn">
-              <ref role="2pJxaS" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
+      <node concept="3cpWs8" id="hTGlT9TY5l" role="3cqZAp">
+        <node concept="3cpWsn" id="hTGlT9TY5o" role="3cpWs9">
+          <property role="TrG5h" value="type" />
+          <node concept="3Tqbb2" id="hTGlT9TY5j" role="1tU5fm">
+            <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+          </node>
+          <node concept="2YIFZM" id="hTGlT9U2gW" role="33vP2m">
+            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
+            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+          </node>
+        </node>
+      </node>
+      <node concept="Jncv_" id="hTGlT9TYck" role="3cqZAp">
+        <ref role="JncvD" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
+        <node concept="37vLTw" id="hTGlT9TYdJ" role="JncvB">
+          <ref role="3cqZAo" node="hTGlT9TY5o" resolve="type" />
+        </node>
+        <node concept="3clFbS" id="hTGlT9TYco" role="Jncv$">
+          <node concept="3clFbF" id="hTGlT9TZjp" role="3cqZAp">
+            <node concept="37vLTI" id="hTGlT9U07G" role="3clFbG">
+              <node concept="2OqwBi" id="hTGlT9TZyy" role="37vLTJ">
+                <node concept="Jnkvi" id="hTGlT9TZjo" role="2Oq$k0">
+                  <ref role="1M0zk5" node="hTGlT9TYcq" resolve="stringType" />
+                </node>
+                <node concept="3TrEf2" id="hTGlT9TZTF" role="2OqNvi">
+                  <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
+                </node>
+              </node>
+              <node concept="2pJPEk" id="hTGlT9U0Ol" role="37vLTx">
+                <node concept="2pJPED" id="hTGlT9U0On" role="2pJPEn">
+                  <ref role="2pJxaS" to="tpfo:h5OC9$H" resolve="StringLiteralRegexp" />
+                  <node concept="2pJxcG" id="hTGlT9U0SX" role="2pJxcM">
+                    <ref role="2pJxcJ" to="tpfo:h5OCbxf" resolve="text" />
+                    <node concept="WxPPo" id="hTGlT9U0Vy" role="28ntcv">
+                      <node concept="3K4zz7" id="3g7FMHmyHgA" role="WxPPp">
+                        <node concept="2OqwBi" id="3g7FMHmyHwR" role="3K4E3e">
+                          <node concept="1YBJjd" id="3g7FMHmyHkd" role="2Oq$k0">
+                            <ref role="1YBMHb" node="4rZeNQ6Pjwl" resolve="sl" />
+                          </node>
+                          <node concept="3TrcHB" id="3g7FMHmyHyi" role="2OqNvi">
+                            <ref role="3TsBF5" to="5qo5:4rZeNQ6OYRb" resolve="value" />
+                          </node>
+                        </node>
+                        <node concept="Xl_RD" id="3g7FMHmyHB3" role="3K4GZi">
+                          <property role="Xl_RC" value="" />
+                        </node>
+                        <node concept="2OqwBi" id="3g7FMHmyF9a" role="3K4Cdx">
+                          <node concept="2OqwBi" id="hTGlT9U1bJ" role="2Oq$k0">
+                            <node concept="1YBJjd" id="hTGlT9U0Vw" role="2Oq$k0">
+                              <ref role="1YBMHb" node="4rZeNQ6Pjwl" resolve="sl" />
+                            </node>
+                            <node concept="3TrcHB" id="hTGlT9U1$E" role="2OqNvi">
+                              <ref role="3TsBF5" to="5qo5:4rZeNQ6OYRb" resolve="value" />
+                            </node>
+                          </node>
+                          <node concept="17RvpY" id="3g7FMHmyG0L" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
+        <node concept="JncvC" id="hTGlT9TYcq" role="JncvA">
+          <property role="TrG5h" value="stringType" />
+          <node concept="2jxLKc" id="hTGlT9TYcr" role="1tU5fm" />
+        </node>
+      </node>
+      <node concept="1Z5TYs" id="4rZeNQ6Pj$q" role="3cqZAp">
         <node concept="mw_s8" id="4rZeNQ6Pj$t" role="1ZfhK$">
           <node concept="1Z2H0r" id="4rZeNQ6Pjwv" role="mwGJk">
             <node concept="1YBJjd" id="4rZeNQ6PjwJ" role="1Z2MuG">
               <ref role="1YBMHb" node="4rZeNQ6Pjwl" resolve="sl" />
             </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="hTGlT9U4aN" role="1ZfhKB">
+          <node concept="37vLTw" id="hTGlT9U4aM" role="mwGJk">
+            <ref role="3cqZAo" node="hTGlT9TY5o" resolve="type" />
           </node>
         </node>
       </node>
@@ -4534,17 +4641,17 @@
     <property role="3GE5qa" value="string.interpol" />
     <node concept="3clFbS" id="7cphKbL6iiy" role="18ibNy">
       <node concept="1Z5TYs" id="7cphKbL6ixU" role="3cqZAp">
-        <node concept="mw_s8" id="7cphKbL6iye" role="1ZfhKB">
-          <node concept="2pJPEk" id="7cphKbL6iya" role="mwGJk">
-            <node concept="2pJPED" id="7cphKbL6iyp" role="2pJPEn">
-              <ref role="2pJxaS" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
-            </node>
-          </node>
-        </node>
         <node concept="mw_s8" id="7cphKbL6ixX" role="1ZfhK$">
           <node concept="1Z2H0r" id="7cphKbL6iiF" role="mwGJk">
             <node concept="1YBJjd" id="7cphKbL6ikr" role="1Z2MuG">
               <ref role="1YBMHb" node="7cphKbL6ii$" resolve="ipe" />
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="7cphKbL6iye" role="1ZfhKB">
+          <node concept="2pJPEk" id="7cphKbL6iya" role="mwGJk">
+            <node concept="2pJPED" id="7cphKbL6iyp" role="2pJPEn">
+              <ref role="2pJxaS" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
             </node>
           </node>
         </node>
@@ -4560,13 +4667,6 @@
     <property role="3GE5qa" value="string.interpol" />
     <node concept="3clFbS" id="7cphKbL6khD" role="18ibNy">
       <node concept="1ZobV4" id="7cphKbL6m4S" role="3cqZAp">
-        <node concept="mw_s8" id="7cphKbL6m5g" role="1ZfhKB">
-          <node concept="2pJPEk" id="7cphKbL6m5c" role="mwGJk">
-            <node concept="2pJPED" id="7cphKbL6m5r" role="2pJPEn">
-              <ref role="2pJxaS" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
-            </node>
-          </node>
-        </node>
         <node concept="mw_s8" id="7cphKbL6m4V" role="1ZfhK$">
           <node concept="1Z2H0r" id="7cphKbL6khS" role="mwGJk">
             <node concept="2OqwBi" id="7cphKbL6kDQ" role="1Z2MuG">
@@ -4576,6 +4676,13 @@
               <node concept="3TrEf2" id="7cphKbL6kNK" role="2OqNvi">
                 <ref role="3Tt5mk" to="5qo5:7cphKbL6izz" resolve="expr" />
               </node>
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="7cphKbL6m5g" role="1ZfhKB">
+          <node concept="2pJPEk" id="7cphKbL6m5c" role="mwGJk">
+            <node concept="2pJPED" id="7cphKbL6m5r" role="2pJPEn">
+              <ref role="2pJxaS" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
             </node>
           </node>
         </node>
@@ -5205,6 +5312,265 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="35pCF_" id="7J8ctKuSW1f">
+    <property role="3GE5qa" value="string" />
+    <property role="TrG5h" value="checkStringConstraint" />
+    <node concept="1YaCAy" id="7J8ctKuSW2R" role="35pZ6h">
+      <property role="TrG5h" value="otherStringType" />
+      <ref role="1YaFvo" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
+    </node>
+    <node concept="3clFbS" id="7J8ctKuSW1h" role="2sgrp5">
+      <node concept="3clFbJ" id="3OxSopfXBdX" role="3cqZAp">
+        <node concept="3clFbS" id="3OxSopfXBdZ" role="3clFbx">
+          <node concept="3cpWs6" id="3OxSopfXChn" role="3cqZAp" />
+        </node>
+        <node concept="22lmx$" id="3OxSopfYXSp" role="3clFbw">
+          <node concept="3fqX7Q" id="3OxSopfZ04i" role="3uHU7w">
+            <node concept="2OqwBi" id="3OxSopfZ04k" role="3fr31v">
+              <node concept="2OqwBi" id="3OxSopfZ04l" role="2Oq$k0">
+                <node concept="1YBJjd" id="3OxSopfZ04m" role="2Oq$k0">
+                  <ref role="1YBMHb" node="7J8ctKuSW2R" resolve="otherStringType" />
+                </node>
+                <node concept="3TrEf2" id="3OxSopfZ04n" role="2OqNvi">
+                  <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="3OxSopfZ04o" role="2OqNvi">
+                <ref role="37wK5l" to="tpfs:48bMILtL4il" resolve="isValid" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="3OxSopfXBZu" role="3uHU7B">
+            <node concept="2OqwBi" id="3OxSopfXBtO" role="2Oq$k0">
+              <node concept="1YBJjd" id="3OxSopfXBez" role="2Oq$k0">
+                <ref role="1YBMHb" node="7J8ctKuSW2R" resolve="otherStringType" />
+              </node>
+              <node concept="3TrEf2" id="3OxSopfXBOp" role="2OqNvi">
+                <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
+              </node>
+            </node>
+            <node concept="3w_OXm" id="3OxSopfXCcO" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="Jncv_" id="3OxSopfXB8l" role="3cqZAp">
+        <ref role="JncvD" to="tpfo:h5OC9$H" resolve="StringLiteralRegexp" />
+        <node concept="3clFbS" id="3OxSopfXB8p" role="Jncv$">
+          <node concept="3cpWs8" id="3OxSopfXCk6" role="3cqZAp">
+            <node concept="3cpWsn" id="3OxSopfXCk9" role="3cpWs9">
+              <property role="TrG5h" value="value" />
+              <node concept="17QB3L" id="3OxSopfXCk5" role="1tU5fm" />
+              <node concept="2OqwBi" id="3OxSopfXCvD" role="33vP2m">
+                <node concept="Jnkvi" id="3OxSopfXCla" role="2Oq$k0">
+                  <ref role="1M0zk5" node="3OxSopfXB8r" resolve="literalRegex" />
+                </node>
+                <node concept="3TrcHB" id="3OxSopfXCFr" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpfo:h5OCbxf" resolve="text" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="3OxSopfYa2X" role="3cqZAp">
+            <node concept="3cpWsn" id="3OxSopfYa2Y" role="3cpWs9">
+              <property role="TrG5h" value="regex" />
+              <node concept="17QB3L" id="3OxSopfY8FV" role="1tU5fm" />
+              <node concept="2OqwBi" id="3OxSopfYa2Z" role="33vP2m">
+                <node concept="2OqwBi" id="3OxSopfYa30" role="2Oq$k0">
+                  <node concept="1YBJjd" id="3OxSopfYa31" role="2Oq$k0">
+                    <ref role="1YBMHb" node="7J8ctKuSW2R" resolve="otherStringType" />
+                  </node>
+                  <node concept="3TrEf2" id="3OxSopfYa32" role="2OqNvi">
+                    <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="7NPLlCCxHcd" role="2OqNvi">
+                  <ref role="37wK5l" to="tpfs:hMuDF1A" resolve="getString" />
+                  <node concept="2ShNRf" id="7NPLlCCxHcf" role="37wK5m">
+                    <node concept="2T8Vx0" id="7NPLlCCxI3j" role="2ShVmc">
+                      <node concept="2I9FWS" id="7NPLlCCxI3l" role="2T96Bj">
+                        <ref role="2I9WkF" to="tpfo:h5Tukr7" resolve="MatchParensRegexp" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3J1_TO" id="3OxSopg2WdF" role="3cqZAp">
+            <node concept="3uVAMA" id="3OxSopg2WhG" role="1zxBo5">
+              <node concept="XOnhg" id="3OxSopg2WhH" role="1zc67B">
+                <property role="TrG5h" value="e" />
+                <node concept="nSUau" id="3OxSopg2WhI" role="1tU5fm">
+                  <node concept="3uibUv" id="3OxSopg2Wiq" role="nSUat">
+                    <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="3OxSopg2WhJ" role="1zc67A">
+                <node concept="2MkqsV" id="46RgPUMnflX" role="3cqZAp">
+                  <node concept="3cpWs3" id="46RgPUMngqh" role="2MkJ7o">
+                    <node concept="2OqwBi" id="46RgPUMngTp" role="3uHU7w">
+                      <node concept="37vLTw" id="46RgPUMngqk" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3OxSopg2WhH" resolve="e" />
+                      </node>
+                      <node concept="liA8E" id="46RgPUMnhc1" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~Throwable.getMessage()" resolve="getMessage" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="46RgPUMnfmL" role="3uHU7B">
+                      <property role="Xl_RC" value="Error evaluation constraint:" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="46RgPUMnh_4" role="1urrMF">
+                    <node concept="3622Ei" id="46RgPUMnht4" role="2Oq$k0" />
+                    <node concept="liA8E" id="46RgPUMnhHJ" role="2OqNvi">
+                      <ref role="37wK5l" to="u78q:~EquationInfo.getNodeWithError()" resolve="getNodeWithError" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3SKdUt" id="3OxSopg2WGp" role="3cqZAp">
+                  <node concept="1PaTwC" id="3OxSopg2WGq" role="1aUNEU">
+                    <node concept="3oM_SD" id="3OxSopg2WGu" role="1PaTwD">
+                      <property role="3oM_SC" value="Nothing" />
+                    </node>
+                    <node concept="3oM_SD" id="3OxSopg2WGw" role="1PaTwD">
+                      <property role="3oM_SC" value="to" />
+                    </node>
+                    <node concept="3oM_SD" id="3OxSopg2WGz" role="1PaTwD">
+                      <property role="3oM_SC" value="do" />
+                    </node>
+                    <node concept="3oM_SD" id="3OxSopg2WGB" role="1PaTwD">
+                      <property role="3oM_SC" value="here." />
+                    </node>
+                    <node concept="3oM_SD" id="3OxSopg2WHW" role="1PaTwD">
+                      <property role="3oM_SC" value="The" />
+                    </node>
+                    <node concept="3oM_SD" id="3OxSopg2WI2" role="1PaTwD">
+                      <property role="3oM_SC" value="regex" />
+                    </node>
+                    <node concept="3oM_SD" id="3OxSopg2WI9" role="1PaTwD">
+                      <property role="3oM_SC" value="is" />
+                    </node>
+                    <node concept="3oM_SD" id="3OxSopg2WIh" role="1PaTwD">
+                      <property role="3oM_SC" value="invalid" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="3OxSopg2WdH" role="1zxBo7">
+              <node concept="3clFbJ" id="3OxSopfXCZT" role="3cqZAp">
+                <node concept="3clFbS" id="3OxSopfXCZV" role="3clFbx">
+                  <node concept="2MkqsV" id="3OxSopfY8Ho" role="3cqZAp">
+                    <node concept="2OqwBi" id="3OxSopfY8Pq" role="1urrMF">
+                      <node concept="3622Ei" id="3OxSopfY8HR" role="2Oq$k0" />
+                      <node concept="liA8E" id="3OxSopfY8X9" role="2OqNvi">
+                        <ref role="37wK5l" to="u78q:~EquationInfo.getNodeWithError()" resolve="getNodeWithError" />
+                      </node>
+                    </node>
+                    <node concept="2YIFZM" id="3OxSopfY9W_" role="2MkJ7o">
+                      <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
+                      <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                      <node concept="Xl_RD" id="3OxSopfY9Xg" role="37wK5m">
+                        <property role="Xl_RC" value="The string doesn't match the regular expression: %s" />
+                      </node>
+                      <node concept="37vLTw" id="3OxSopfYcnQ" role="37wK5m">
+                        <ref role="3cqZAo" node="3OxSopfYa2Y" resolve="regex" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3fqX7Q" id="3OxSopfY8EF" role="3clFbw">
+                  <node concept="2OqwBi" id="3OxSopfY8EH" role="3fr31v">
+                    <node concept="37vLTw" id="3OxSopfY8EI" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3OxSopfXCk9" resolve="value" />
+                    </node>
+                    <node concept="liA8E" id="3OxSopfY8EJ" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.matches(java.lang.String)" resolve="matches" />
+                      <node concept="37vLTw" id="3OxSopfYa34" role="37wK5m">
+                        <ref role="3cqZAo" node="3OxSopfYa2Y" resolve="regex" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="JncvC" id="3OxSopfXB8r" role="JncvA">
+          <property role="TrG5h" value="literalRegex" />
+          <node concept="2jxLKc" id="3OxSopfXB8s" role="1tU5fm" />
+        </node>
+        <node concept="2OqwBi" id="3OxSopfXB96" role="JncvB">
+          <node concept="1YBJjd" id="3OxSopfXB97" role="2Oq$k0">
+            <ref role="1YBMHb" node="7J8ctKuSW1j" resolve="stringType" />
+          </node>
+          <node concept="3TrEf2" id="3OxSopfXB98" role="2OqNvi">
+            <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="7J8ctKuSW1j" role="1YuTPh">
+      <property role="TrG5h" value="stringType" />
+      <ref role="1YaFvo" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
+    </node>
+  </node>
+  <node concept="2sgARr" id="6pSOa4r7dHX">
+    <property role="3GE5qa" value="string" />
+    <property role="TrG5h" value="superTypeOf_String" />
+    <node concept="3clFbS" id="6pSOa4r7dHY" role="2sgrp5">
+      <node concept="3cpWs8" id="6pSOa4r8c5Y" role="3cqZAp">
+        <node concept="3cpWsn" id="6pSOa4r8c61" role="3cpWs9">
+          <property role="TrG5h" value="types" />
+          <node concept="2I9FWS" id="6pSOa4r8c5X" role="1tU5fm" />
+          <node concept="2ShNRf" id="6pSOa4r8c73" role="33vP2m">
+            <node concept="2T8Vx0" id="6pSOa4r8dj1" role="2ShVmc">
+              <node concept="2I9FWS" id="6pSOa4r8dj3" role="2T96Bj" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbJ" id="6pSOa4r8doA" role="3cqZAp">
+        <node concept="3clFbS" id="6pSOa4r8doC" role="3clFbx">
+          <node concept="3clFbF" id="6pSOa4r8evi" role="3cqZAp">
+            <node concept="2OqwBi" id="6pSOa4r8gnf" role="3clFbG">
+              <node concept="37vLTw" id="6pSOa4r8evg" role="2Oq$k0">
+                <ref role="3cqZAo" node="6pSOa4r8c61" resolve="types" />
+              </node>
+              <node concept="TSZUe" id="6pSOa4r8hMY" role="2OqNvi">
+                <node concept="2pJPEk" id="6pSOa4r7dLu" role="25WWJ7">
+                  <node concept="2pJPED" id="6pSOa4r7dLv" role="2pJPEn">
+                    <ref role="2pJxaS" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2OqwBi" id="6pSOa4r8ed2" role="3clFbw">
+          <node concept="2OqwBi" id="6pSOa4r8dCj" role="2Oq$k0">
+            <node concept="1YBJjd" id="6pSOa4r8dpd" role="2Oq$k0">
+              <ref role="1YBMHb" node="6pSOa4r7dI0" resolve="stringType" />
+            </node>
+            <node concept="3TrEf2" id="6pSOa4r8dYT" role="2OqNvi">
+              <ref role="3Tt5mk" to="5qo5:7J8ctKuJsiI" resolve="constraint" />
+            </node>
+          </node>
+          <node concept="3x8VRR" id="6pSOa4r8eql" role="2OqNvi" />
+        </node>
+      </node>
+      <node concept="3cpWs6" id="6pSOa4r8dm0" role="3cqZAp">
+        <node concept="37vLTw" id="6pSOa4r8dmI" role="3cqZAk">
+          <ref role="3cqZAo" node="6pSOa4r8c61" resolve="types" />
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="6pSOa4r7dI0" role="1YuTPh">
+      <property role="TrG5h" value="stringType" />
+      <ref role="1YaFvo" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/typesystem.mps
@@ -4648,11 +4648,10 @@
             </node>
           </node>
         </node>
-        <node concept="mw_s8" id="7cphKbL6iye" role="1ZfhKB">
-          <node concept="2pJPEk" id="7cphKbL6iya" role="mwGJk">
-            <node concept="2pJPED" id="7cphKbL6iyp" role="2pJPEn">
-              <ref role="2pJxaS" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
-            </node>
+        <node concept="mw_s8" id="hTGlT9TXUr" role="1ZfhKB">
+          <node concept="2YIFZM" id="hTGlT9TXUs" role="mwGJk">
+            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
+            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
           </node>
         </node>
       </node>
@@ -4679,11 +4678,10 @@
             </node>
           </node>
         </node>
-        <node concept="mw_s8" id="7cphKbL6m5g" role="1ZfhKB">
-          <node concept="2pJPEk" id="7cphKbL6m5c" role="mwGJk">
-            <node concept="2pJPED" id="7cphKbL6m5r" role="2pJPEn">
-              <ref role="2pJxaS" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
-            </node>
+        <node concept="mw_s8" id="hTGlT9G0v0" role="1ZfhKB">
+          <node concept="2YIFZM" id="hTGlT9G0v1" role="mwGJk">
+            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
+            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -2750,15 +2750,11 @@
       </node>
       <node concept="37vLTG" id="ZYPG76BgMI" role="3clF46">
         <property role="TrG5h" value="expectedType" />
-        <node concept="3Tqbb2" id="ZYPG76BgMJ" role="1tU5fm">
-          <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
-        </node>
+        <node concept="3Tqbb2" id="ZYPG76BgMJ" role="1tU5fm" />
       </node>
       <node concept="37vLTG" id="ZYPG76BgMK" role="3clF46">
         <property role="TrG5h" value="actualType" />
-        <node concept="3Tqbb2" id="ZYPG76BgML" role="1tU5fm">
-          <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
-        </node>
+        <node concept="3Tqbb2" id="ZYPG76BgML" role="1tU5fm" />
       </node>
       <node concept="17QB3L" id="ZYPG76BgMM" role="3clF45" />
     </node>
@@ -4699,9 +4695,7 @@
       </node>
       <node concept="37vLTG" id="ZYPG76NAql" role="3clF46">
         <property role="TrG5h" value="actualType" />
-        <node concept="3Tqbb2" id="ZYPG76NAqm" role="1tU5fm">
-          <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
-        </node>
+        <node concept="3Tqbb2" id="ZYPG76NAqm" role="1tU5fm" />
       </node>
       <node concept="17QB3L" id="ZYPG76NAqn" role="3clF45" />
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.lib/models/org/iets3/core/expr/typetags/lib/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.lib/models/org/iets3/core/expr/typetags/lib/typesystem.mps
@@ -109,6 +109,7 @@
         <child id="1174660783413" name="leftExpression" index="1ZfhK$" />
         <child id="1174660783414" name="rightExpression" index="1ZfhKB" />
       </concept>
+      <concept id="1174663118805" name="jetbrains.mps.lang.typesystem.structure.CreateLessThanInequationStatement" flags="nn" index="1ZobV4" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
@@ -146,23 +147,23 @@
   <node concept="1YbPZF" id="1xEzHAktRKd">
     <property role="TrG5h" value="typeof_TaintExpression" />
     <node concept="3clFbS" id="1xEzHAktRKe" role="18ibNy">
-      <node concept="1Z5TYs" id="6KxoTHgIOLy" role="3cqZAp">
-        <node concept="mw_s8" id="6KxoTHgIPW8" role="1ZfhKB">
-          <node concept="2YIFZM" id="5wDe8wA6zrO" role="mwGJk">
-            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
-            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
-          </node>
-        </node>
-        <node concept="mw_s8" id="6KxoTHgIOL_" role="1ZfhK$">
-          <node concept="1Z2H0r" id="6KxoTHgIOv9" role="mwGJk">
-            <node concept="2OqwBi" id="6KxoTHgIO$H" role="1Z2MuG">
-              <node concept="1YBJjd" id="6KxoTHgIOxQ" role="2Oq$k0">
+      <node concept="1ZobV4" id="hTGlT9G23K" role="3cqZAp">
+        <node concept="mw_s8" id="hTGlT9G23O" role="1ZfhK$">
+          <node concept="1Z2H0r" id="hTGlT9G23P" role="mwGJk">
+            <node concept="2OqwBi" id="hTGlT9G23Q" role="1Z2MuG">
+              <node concept="1YBJjd" id="hTGlT9G23R" role="2Oq$k0">
                 <ref role="1YBMHb" node="1xEzHAktRKg" resolve="expression" />
               </node>
-              <node concept="3TrEf2" id="6KxoTHgIOHD" role="2OqNvi">
+              <node concept="3TrEf2" id="hTGlT9G23S" role="2OqNvi">
                 <ref role="3Tt5mk" to="hm2y:4rZeNQ6NgXF" resolve="expr" />
               </node>
             </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="hTGlT9G23M" role="1ZfhKB">
+          <node concept="2YIFZM" id="hTGlT9G23N" role="mwGJk">
+            <ref role="37wK5l" to="xfg9:2Qbt$1tTQdA" resolve="createStringType" />
+            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.LeastCommonSuperType@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.LeastCommonSuperType@tests.mps
@@ -104,12 +104,13 @@
       <concept id="7425695345928358745" name="org.iets3.core.expr.simpleTypes.structure.TrueLiteral" flags="ng" index="2vmpnb" />
       <concept id="7425695345928358774" name="org.iets3.core.expr.simpleTypes.structure.FalseLiteral" flags="ng" index="2vmpn$" />
       <concept id="7425695345928349207" name="org.iets3.core.expr.simpleTypes.structure.BooleanType" flags="ng" index="2vmvy5" />
+      <concept id="2915503786126701996" name="org.iets3.core.expr.simpleTypes.structure.StringTypeWithConstraint" flags="ng" index="L5Cqj">
+        <child id="8919433883485586606" name="constraint" index="1_tvlM" />
+      </concept>
       <concept id="5115872837157252552" name="org.iets3.core.expr.simpleTypes.structure.StringLiteral" flags="ng" index="30bdrP">
         <property id="5115872837157252555" name="value" index="30bdrQ" />
       </concept>
-      <concept id="5115872837157252551" name="org.iets3.core.expr.simpleTypes.structure.StringType" flags="ng" index="30bdrU">
-        <child id="8919433883485586606" name="constraint" index="1_tvlM" />
-      </concept>
+      <concept id="5115872837157252551" name="org.iets3.core.expr.simpleTypes.structure.StringType" flags="ng" index="30bdrU" />
       <concept id="5115872837157054169" name="org.iets3.core.expr.simpleTypes.structure.IntegerType" flags="ng" index="30bXR$" />
       <concept id="5115872837157054170" name="org.iets3.core.expr.simpleTypes.structure.NumberLiteral" flags="ng" index="30bXRB">
         <property id="5115872837157054173" name="value" index="30bXRw" />
@@ -383,13 +384,13 @@
                     <property role="2gteVv" value="0" />
                   </node>
                 </node>
-                <node concept="30bdrU" id="1wgc0l$LiN9" role="m5gfT">
-                  <node concept="1OC9wW" id="3g7FMHmm_BL" role="1_tvlM">
+                <node concept="L5Cqj" id="2xPWNWppPtd" role="m5gfT">
+                  <node concept="1OC9wW" id="2xPWNWppPte" role="1_tvlM">
                     <property role="1OCb_u" value="a" />
                   </node>
                 </node>
-                <node concept="30bdrU" id="1wgc0l$LiNa" role="m5gfT">
-                  <node concept="1OC9wW" id="3g7FMHmmWSp" role="1_tvlM">
+                <node concept="L5Cqj" id="2xPWNWppPtf" role="m5gfT">
+                  <node concept="1OC9wW" id="2xPWNWppPtg" role="1_tvlM">
                     <property role="1OCb_u" value="b" />
                   </node>
                 </node>
@@ -442,13 +443,13 @@
                     <property role="2gteVv" value="0" />
                   </node>
                 </node>
-                <node concept="30bdrU" id="1wgc0l$Ljm8" role="m5gfT">
-                  <node concept="1OC9wW" id="3g7FMHmmWU0" role="1_tvlM">
+                <node concept="L5Cqj" id="2xPWNWppPth" role="m5gfT">
+                  <node concept="1OC9wW" id="2xPWNWppPti" role="1_tvlM">
                     <property role="1OCb_u" value="a" />
                   </node>
                 </node>
-                <node concept="30bdrU" id="1wgc0l$Ljm9" role="m5gfT">
-                  <node concept="1OC9wW" id="3g7FMHmmWUL" role="1_tvlM">
+                <node concept="L5Cqj" id="2xPWNWppPtj" role="m5gfT">
+                  <node concept="1OC9wW" id="2xPWNWppPtk" role="1_tvlM">
                     <property role="1OCb_u" value="b" />
                   </node>
                 </node>
@@ -496,13 +497,13 @@
                       <property role="2gteVv" value="0" />
                     </node>
                   </node>
-                  <node concept="30bdrU" id="1wgc0l$NbLo" role="m5gfT">
-                    <node concept="1OC9wW" id="3g7FMHmt3ug" role="1_tvlM">
+                  <node concept="L5Cqj" id="2xPWNWppPtl" role="m5gfT">
+                    <node concept="1OC9wW" id="2xPWNWppPtm" role="1_tvlM">
                       <property role="1OCb_u" value="a" />
                     </node>
                   </node>
-                  <node concept="30bdrU" id="1wgc0l$NbLp" role="m5gfT">
-                    <node concept="1OC9wW" id="3g7FMHmt3$q" role="1_tvlM">
+                  <node concept="L5Cqj" id="2xPWNWppPtn" role="m5gfT">
+                    <node concept="1OC9wW" id="2xPWNWppPto" role="1_tvlM">
                       <property role="1OCb_u" value="b" />
                     </node>
                   </node>
@@ -526,13 +527,13 @@
                       <property role="2gteVv" value="0" />
                     </node>
                   </node>
-                  <node concept="30bdrU" id="1wgc0l$NbOs" role="m5gfT">
-                    <node concept="1OC9wW" id="3g7FMHmmWWo" role="1_tvlM">
+                  <node concept="L5Cqj" id="2xPWNWppPtp" role="m5gfT">
+                    <node concept="1OC9wW" id="2xPWNWppPtq" role="1_tvlM">
                       <property role="1OCb_u" value="a" />
                     </node>
                   </node>
-                  <node concept="30bdrU" id="1wgc0l$NbOt" role="m5gfT">
-                    <node concept="1OC9wW" id="3g7FMHmmWYS" role="1_tvlM">
+                  <node concept="L5Cqj" id="2xPWNWppPtr" role="m5gfT">
+                    <node concept="1OC9wW" id="2xPWNWppPts" role="1_tvlM">
                       <property role="1OCb_u" value="b" />
                     </node>
                   </node>
@@ -776,8 +777,8 @@
                   <node concept="30bdrU" id="1wgc0l$Looq" role="m5gfT" />
                 </node>
                 <node concept="m5gfS" id="1wgc0l$On0D" role="188GKc">
-                  <node concept="30bdrU" id="1wgc0l$On5v" role="m5gfT">
-                    <node concept="1OC9wW" id="3g7FMHmmXpH" role="1_tvlM">
+                  <node concept="L5Cqj" id="2xPWNWppPtt" role="m5gfT">
+                    <node concept="1OC9wW" id="2xPWNWppPtu" role="1_tvlM">
                       <property role="1OCb_u" value="a" />
                     </node>
                   </node>
@@ -790,13 +791,13 @@
                       <property role="2gteVv" value="0" />
                     </node>
                   </node>
-                  <node concept="30bdrU" id="1wgc0l$On0K" role="m5gfT">
-                    <node concept="1OC9wW" id="3g7FMHmmXtS" role="1_tvlM">
+                  <node concept="L5Cqj" id="2xPWNWppPtv" role="m5gfT">
+                    <node concept="1OC9wW" id="2xPWNWppPtw" role="1_tvlM">
                       <property role="1OCb_u" value="b" />
                     </node>
                   </node>
-                  <node concept="30bdrU" id="1wgc0l$On0L" role="m5gfT">
-                    <node concept="1OC9wW" id="3g7FMHmmXwc" role="1_tvlM">
+                  <node concept="L5Cqj" id="2xPWNWppPtx" role="m5gfT">
+                    <node concept="1OC9wW" id="2xPWNWppPty" role="1_tvlM">
                       <property role="1OCb_u" value="c" />
                     </node>
                   </node>
@@ -1176,8 +1177,8 @@
                   <node concept="30bdrU" id="6unC0YG7J0H" role="m5gfT" />
                 </node>
                 <node concept="m5gfS" id="6unC0YG7J0I" role="188GKc">
-                  <node concept="30bdrU" id="6unC0YG7J0J" role="m5gfT">
-                    <node concept="1OC9wW" id="3g7FMHmmXyG" role="1_tvlM">
+                  <node concept="L5Cqj" id="2xPWNWppPtz" role="m5gfT">
+                    <node concept="1OC9wW" id="2xPWNWppPt$" role="1_tvlM">
                       <property role="1OCb_u" value="a" />
                     </node>
                   </node>
@@ -1190,8 +1191,8 @@
                       <property role="2gteVv" value="0" />
                     </node>
                   </node>
-                  <node concept="30bdrU" id="6unC0YG7J0N" role="m5gfT">
-                    <node concept="1OC9wW" id="3g7FMHmmXAR" role="1_tvlM">
+                  <node concept="L5Cqj" id="2xPWNWppPt_" role="m5gfT">
+                    <node concept="1OC9wW" id="2xPWNWppPtA" role="1_tvlM">
                       <property role="1OCb_u" value="b" />
                     </node>
                   </node>
@@ -1436,13 +1437,13 @@
                         <property role="2gteVv" value="0" />
                       </node>
                     </node>
-                    <node concept="30bdrU" id="2Ml_6NDRQZf" role="m5gfT">
-                      <node concept="1OC9wW" id="3g7FMHmmXFq" role="1_tvlM">
+                    <node concept="L5Cqj" id="2xPWNWppPtB" role="m5gfT">
+                      <node concept="1OC9wW" id="2xPWNWppPtC" role="1_tvlM">
                         <property role="1OCb_u" value="a" />
                       </node>
                     </node>
-                    <node concept="30bdrU" id="2Ml_6NDRQZg" role="m5gfT">
-                      <node concept="1OC9wW" id="3g7FMHmmXJ3" role="1_tvlM">
+                    <node concept="L5Cqj" id="2xPWNWppPtD" role="m5gfT">
+                      <node concept="1OC9wW" id="2xPWNWppPtE" role="1_tvlM">
                         <property role="1OCb_u" value="b" />
                       </node>
                     </node>
@@ -1468,8 +1469,8 @@
                         <property role="2gteVv" value="0" />
                       </node>
                     </node>
-                    <node concept="30bdrU" id="2Ml_6NDRQZ5" role="m5gfT">
-                      <node concept="1OC9wW" id="3g7FMHmmXQU" role="1_tvlM">
+                    <node concept="L5Cqj" id="2xPWNWppPtF" role="m5gfT">
+                      <node concept="1OC9wW" id="2xPWNWppPtG" role="1_tvlM">
                         <property role="1OCb_u" value="b" />
                       </node>
                     </node>
@@ -3017,13 +3018,13 @@
                     </node>
                   </node>
                 </node>
-                <node concept="30bdrU" id="7iQqdOBdT4r" role="m5gfT">
-                  <node concept="1OC9wW" id="3g7FMHmosak" role="1_tvlM">
+                <node concept="L5Cqj" id="2xPWNWppPtH" role="m5gfT">
+                  <node concept="1OC9wW" id="2xPWNWppPtI" role="1_tvlM">
                     <property role="1OCb_u" value="a" />
                   </node>
                 </node>
-                <node concept="30bdrU" id="7iQqdOBesGv" role="m5gfT">
-                  <node concept="1OC9wW" id="3g7FMHmosbJ" role="1_tvlM">
+                <node concept="L5Cqj" id="2xPWNWppPtJ" role="m5gfT">
+                  <node concept="1OC9wW" id="2xPWNWppPtK" role="1_tvlM">
                     <property role="1OCb_u" value="b" />
                   </node>
                 </node>
@@ -3105,13 +3106,13 @@
                     </node>
                   </node>
                 </node>
-                <node concept="30bdrU" id="7iQqdOBerW9" role="m5gfT">
-                  <node concept="1OC9wW" id="3g7FMHmoseE" role="1_tvlM">
+                <node concept="L5Cqj" id="2xPWNWppPtL" role="m5gfT">
+                  <node concept="1OC9wW" id="2xPWNWppPtM" role="1_tvlM">
                     <property role="1OCb_u" value="a" />
                   </node>
                 </node>
-                <node concept="30bdrU" id="7iQqdOBexqv" role="m5gfT">
-                  <node concept="1OC9wW" id="3g7FMHmosiS" role="1_tvlM">
+                <node concept="L5Cqj" id="2xPWNWppPtN" role="m5gfT">
+                  <node concept="1OC9wW" id="2xPWNWppPtO" role="1_tvlM">
                     <property role="1OCb_u" value="b" />
                   </node>
                 </node>
@@ -3174,13 +3175,13 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="30bdrU" id="7iQqdOBeEMQ" role="m5gfT">
-                    <node concept="1OC9wW" id="3g7FMHmt3Nm" role="1_tvlM">
+                  <node concept="L5Cqj" id="2xPWNWppPtP" role="m5gfT">
+                    <node concept="1OC9wW" id="2xPWNWppPtQ" role="1_tvlM">
                       <property role="1OCb_u" value="a" />
                     </node>
                   </node>
-                  <node concept="30bdrU" id="7iQqdOBeEMR" role="m5gfT">
-                    <node concept="1OC9wW" id="3g7FMHmt3VQ" role="1_tvlM">
+                  <node concept="L5Cqj" id="2xPWNWppPtR" role="m5gfT">
+                    <node concept="1OC9wW" id="2xPWNWppPtS" role="1_tvlM">
                       <property role="1OCb_u" value="b" />
                     </node>
                   </node>
@@ -3218,13 +3219,13 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="30bdrU" id="7iQqdOBeEMZ" role="m5gfT">
-                    <node concept="1OC9wW" id="3g7FMHmosko" role="1_tvlM">
+                  <node concept="L5Cqj" id="2xPWNWppPtT" role="m5gfT">
+                    <node concept="1OC9wW" id="2xPWNWppPtU" role="1_tvlM">
                       <property role="1OCb_u" value="a" />
                     </node>
                   </node>
-                  <node concept="30bdrU" id="7iQqdOBeEN0" role="m5gfT">
-                    <node concept="1OC9wW" id="3g7FMHmostZ" role="1_tvlM">
+                  <node concept="L5Cqj" id="2xPWNWppPtV" role="m5gfT">
+                    <node concept="1OC9wW" id="2xPWNWppPtW" role="1_tvlM">
                       <property role="1OCb_u" value="b" />
                     </node>
                   </node>
@@ -3470,13 +3471,13 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="30bdrU" id="7iQqdOBeReV" role="m5gfT">
-                    <node concept="1OC9wW" id="3g7FMHmosz1" role="1_tvlM">
+                  <node concept="L5Cqj" id="2xPWNWppPtX" role="m5gfT">
+                    <node concept="1OC9wW" id="2xPWNWppPtY" role="1_tvlM">
                       <property role="1OCb_u" value="a" />
                     </node>
                   </node>
-                  <node concept="30bdrU" id="7iQqdOBeReW" role="m5gfT">
-                    <node concept="1OC9wW" id="3g7FMHmosGC" role="1_tvlM">
+                  <node concept="L5Cqj" id="2xPWNWppPtZ" role="m5gfT">
+                    <node concept="1OC9wW" id="2xPWNWppPu0" role="1_tvlM">
                       <property role="1OCb_u" value="b" />
                     </node>
                   </node>
@@ -3766,8 +3767,8 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="30bdrU" id="x6NxUzqOzI" role="m5gfT">
-                    <node concept="1OC9wW" id="3g7FMHmosQB" role="1_tvlM">
+                  <node concept="L5Cqj" id="2xPWNWppPu1" role="m5gfT">
+                    <node concept="1OC9wW" id="2xPWNWppPu2" role="1_tvlM">
                       <property role="1OCb_u" value="a" />
                     </node>
                   </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.LeastCommonSuperType@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.LeastCommonSuperType@tests.mps
@@ -107,7 +107,9 @@
       <concept id="5115872837157252552" name="org.iets3.core.expr.simpleTypes.structure.StringLiteral" flags="ng" index="30bdrP">
         <property id="5115872837157252555" name="value" index="30bdrQ" />
       </concept>
-      <concept id="5115872837157252551" name="org.iets3.core.expr.simpleTypes.structure.StringType" flags="ng" index="30bdrU" />
+      <concept id="5115872837157252551" name="org.iets3.core.expr.simpleTypes.structure.StringType" flags="ng" index="30bdrU">
+        <child id="8919433883485586606" name="constraint" index="1_tvlM" />
+      </concept>
       <concept id="5115872837157054169" name="org.iets3.core.expr.simpleTypes.structure.IntegerType" flags="ng" index="30bXR$" />
       <concept id="5115872837157054170" name="org.iets3.core.expr.simpleTypes.structure.NumberLiteral" flags="ng" index="30bXRB">
         <property id="5115872837157054173" name="value" index="30bXRw" />
@@ -165,6 +167,11 @@
       <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7">
         <property id="8575328350543493365" name="message" index="huDt6" />
         <property id="2423417345669755629" name="filter" index="1eyWvh" />
+      </concept>
+    </language>
+    <language id="daafa647-f1f7-4b0b-b096-69cd7c8408c0" name="jetbrains.mps.baseLanguage.regexp">
+      <concept id="1174482753837" name="jetbrains.mps.baseLanguage.regexp.structure.StringLiteralRegexp" flags="ng" index="1OC9wW">
+        <property id="1174482761807" name="text" index="1OCb_u" />
       </concept>
     </language>
     <language id="9464fa06-5ab9-409b-9274-64ab29588457" name="org.iets3.core.expr.lambda">
@@ -376,8 +383,16 @@
                     <property role="2gteVv" value="0" />
                   </node>
                 </node>
-                <node concept="30bdrU" id="1wgc0l$LiN9" role="m5gfT" />
-                <node concept="30bdrU" id="1wgc0l$LiNa" role="m5gfT" />
+                <node concept="30bdrU" id="1wgc0l$LiN9" role="m5gfT">
+                  <node concept="1OC9wW" id="3g7FMHmm_BL" role="1_tvlM">
+                    <property role="1OCb_u" value="a" />
+                  </node>
+                </node>
+                <node concept="30bdrU" id="1wgc0l$LiNa" role="m5gfT">
+                  <node concept="1OC9wW" id="3g7FMHmmWSp" role="1_tvlM">
+                    <property role="1OCb_u" value="b" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -427,8 +442,16 @@
                     <property role="2gteVv" value="0" />
                   </node>
                 </node>
-                <node concept="30bdrU" id="1wgc0l$Ljm8" role="m5gfT" />
-                <node concept="30bdrU" id="1wgc0l$Ljm9" role="m5gfT" />
+                <node concept="30bdrU" id="1wgc0l$Ljm8" role="m5gfT">
+                  <node concept="1OC9wW" id="3g7FMHmmWU0" role="1_tvlM">
+                    <property role="1OCb_u" value="a" />
+                  </node>
+                </node>
+                <node concept="30bdrU" id="1wgc0l$Ljm9" role="m5gfT">
+                  <node concept="1OC9wW" id="3g7FMHmmWUL" role="1_tvlM">
+                    <property role="1OCb_u" value="b" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -473,8 +496,16 @@
                       <property role="2gteVv" value="0" />
                     </node>
                   </node>
-                  <node concept="30bdrU" id="1wgc0l$NbLo" role="m5gfT" />
-                  <node concept="30bdrU" id="1wgc0l$NbLp" role="m5gfT" />
+                  <node concept="30bdrU" id="1wgc0l$NbLo" role="m5gfT">
+                    <node concept="1OC9wW" id="3g7FMHmt3ug" role="1_tvlM">
+                      <property role="1OCb_u" value="a" />
+                    </node>
+                  </node>
+                  <node concept="30bdrU" id="1wgc0l$NbLp" role="m5gfT">
+                    <node concept="1OC9wW" id="3g7FMHmt3$q" role="1_tvlM">
+                      <property role="1OCb_u" value="b" />
+                    </node>
+                  </node>
                 </node>
                 <node concept="m5gfS" id="1wgc0l$NbOl" role="m5gfT">
                   <node concept="mLuIC" id="1wgc0l$NbOm" role="m5gfT">
@@ -495,8 +526,16 @@
                       <property role="2gteVv" value="0" />
                     </node>
                   </node>
-                  <node concept="30bdrU" id="1wgc0l$NbOs" role="m5gfT" />
-                  <node concept="30bdrU" id="1wgc0l$NbOt" role="m5gfT" />
+                  <node concept="30bdrU" id="1wgc0l$NbOs" role="m5gfT">
+                    <node concept="1OC9wW" id="3g7FMHmmWWo" role="1_tvlM">
+                      <property role="1OCb_u" value="a" />
+                    </node>
+                  </node>
+                  <node concept="30bdrU" id="1wgc0l$NbOt" role="m5gfT">
+                    <node concept="1OC9wW" id="3g7FMHmmWYS" role="1_tvlM">
+                      <property role="1OCb_u" value="b" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -737,7 +776,11 @@
                   <node concept="30bdrU" id="1wgc0l$Looq" role="m5gfT" />
                 </node>
                 <node concept="m5gfS" id="1wgc0l$On0D" role="188GKc">
-                  <node concept="30bdrU" id="1wgc0l$On5v" role="m5gfT" />
+                  <node concept="30bdrU" id="1wgc0l$On5v" role="m5gfT">
+                    <node concept="1OC9wW" id="3g7FMHmmXpH" role="1_tvlM">
+                      <property role="1OCb_u" value="a" />
+                    </node>
+                  </node>
                   <node concept="mLuIC" id="1wgc0l$On0H" role="m5gfT">
                     <node concept="2gteSW" id="1wgc0l$On0I" role="2gteSx">
                       <property role="2gteSQ" value="1" />
@@ -747,8 +790,16 @@
                       <property role="2gteVv" value="0" />
                     </node>
                   </node>
-                  <node concept="30bdrU" id="1wgc0l$On0K" role="m5gfT" />
-                  <node concept="30bdrU" id="1wgc0l$On0L" role="m5gfT" />
+                  <node concept="30bdrU" id="1wgc0l$On0K" role="m5gfT">
+                    <node concept="1OC9wW" id="3g7FMHmmXtS" role="1_tvlM">
+                      <property role="1OCb_u" value="b" />
+                    </node>
+                  </node>
+                  <node concept="30bdrU" id="1wgc0l$On0L" role="m5gfT">
+                    <node concept="1OC9wW" id="3g7FMHmmXwc" role="1_tvlM">
+                      <property role="1OCb_u" value="c" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -1125,7 +1176,11 @@
                   <node concept="30bdrU" id="6unC0YG7J0H" role="m5gfT" />
                 </node>
                 <node concept="m5gfS" id="6unC0YG7J0I" role="188GKc">
-                  <node concept="30bdrU" id="6unC0YG7J0J" role="m5gfT" />
+                  <node concept="30bdrU" id="6unC0YG7J0J" role="m5gfT">
+                    <node concept="1OC9wW" id="3g7FMHmmXyG" role="1_tvlM">
+                      <property role="1OCb_u" value="a" />
+                    </node>
+                  </node>
                   <node concept="mLuIC" id="6unC0YG7J0K" role="m5gfT">
                     <node concept="2gteSW" id="6unC0YG7J0L" role="2gteSx">
                       <property role="2gteSQ" value="1" />
@@ -1135,7 +1190,11 @@
                       <property role="2gteVv" value="0" />
                     </node>
                   </node>
-                  <node concept="30bdrU" id="6unC0YG7J0N" role="m5gfT" />
+                  <node concept="30bdrU" id="6unC0YG7J0N" role="m5gfT">
+                    <node concept="1OC9wW" id="3g7FMHmmXAR" role="1_tvlM">
+                      <property role="1OCb_u" value="b" />
+                    </node>
+                  </node>
                   <node concept="Unsod" id="6unC0YG7PgD" role="m5gfT" />
                 </node>
               </node>
@@ -1377,8 +1436,16 @@
                         <property role="2gteVv" value="0" />
                       </node>
                     </node>
-                    <node concept="30bdrU" id="2Ml_6NDRQZf" role="m5gfT" />
-                    <node concept="30bdrU" id="2Ml_6NDRQZg" role="m5gfT" />
+                    <node concept="30bdrU" id="2Ml_6NDRQZf" role="m5gfT">
+                      <node concept="1OC9wW" id="3g7FMHmmXFq" role="1_tvlM">
+                        <property role="1OCb_u" value="a" />
+                      </node>
+                    </node>
+                    <node concept="30bdrU" id="2Ml_6NDRQZg" role="m5gfT">
+                      <node concept="1OC9wW" id="3g7FMHmmXJ3" role="1_tvlM">
+                        <property role="1OCb_u" value="b" />
+                      </node>
+                    </node>
                   </node>
                 </node>
                 <node concept="m5gfS" id="2Ml_6NDRQYX" role="188GKc">
@@ -1401,7 +1468,11 @@
                         <property role="2gteVv" value="0" />
                       </node>
                     </node>
-                    <node concept="30bdrU" id="2Ml_6NDRQZ5" role="m5gfT" />
+                    <node concept="30bdrU" id="2Ml_6NDRQZ5" role="m5gfT">
+                      <node concept="1OC9wW" id="3g7FMHmmXQU" role="1_tvlM">
+                        <property role="1OCb_u" value="b" />
+                      </node>
+                    </node>
                     <node concept="2vmvy5" id="2Ml_6NDRQZ6" role="m5gfT" />
                   </node>
                 </node>
@@ -2946,8 +3017,16 @@
                     </node>
                   </node>
                 </node>
-                <node concept="30bdrU" id="7iQqdOBdT4r" role="m5gfT" />
-                <node concept="30bdrU" id="7iQqdOBesGv" role="m5gfT" />
+                <node concept="30bdrU" id="7iQqdOBdT4r" role="m5gfT">
+                  <node concept="1OC9wW" id="3g7FMHmosak" role="1_tvlM">
+                    <property role="1OCb_u" value="a" />
+                  </node>
+                </node>
+                <node concept="30bdrU" id="7iQqdOBesGv" role="m5gfT">
+                  <node concept="1OC9wW" id="3g7FMHmosbJ" role="1_tvlM">
+                    <property role="1OCb_u" value="b" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -3026,8 +3105,16 @@
                     </node>
                   </node>
                 </node>
-                <node concept="30bdrU" id="7iQqdOBerW9" role="m5gfT" />
-                <node concept="30bdrU" id="7iQqdOBexqv" role="m5gfT" />
+                <node concept="30bdrU" id="7iQqdOBerW9" role="m5gfT">
+                  <node concept="1OC9wW" id="3g7FMHmoseE" role="1_tvlM">
+                    <property role="1OCb_u" value="a" />
+                  </node>
+                </node>
+                <node concept="30bdrU" id="7iQqdOBexqv" role="m5gfT">
+                  <node concept="1OC9wW" id="3g7FMHmosiS" role="1_tvlM">
+                    <property role="1OCb_u" value="b" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -3087,8 +3174,16 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="30bdrU" id="7iQqdOBeEMQ" role="m5gfT" />
-                  <node concept="30bdrU" id="7iQqdOBeEMR" role="m5gfT" />
+                  <node concept="30bdrU" id="7iQqdOBeEMQ" role="m5gfT">
+                    <node concept="1OC9wW" id="3g7FMHmt3Nm" role="1_tvlM">
+                      <property role="1OCb_u" value="a" />
+                    </node>
+                  </node>
+                  <node concept="30bdrU" id="7iQqdOBeEMR" role="m5gfT">
+                    <node concept="1OC9wW" id="3g7FMHmt3VQ" role="1_tvlM">
+                      <property role="1OCb_u" value="b" />
+                    </node>
+                  </node>
                 </node>
                 <node concept="m5gfS" id="7iQqdOBeEMS" role="m5gfT">
                   <node concept="2c7tTJ" id="7iQqdOBeFLy" role="m5gfT">
@@ -3123,8 +3218,16 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="30bdrU" id="7iQqdOBeEMZ" role="m5gfT" />
-                  <node concept="30bdrU" id="7iQqdOBeEN0" role="m5gfT" />
+                  <node concept="30bdrU" id="7iQqdOBeEMZ" role="m5gfT">
+                    <node concept="1OC9wW" id="3g7FMHmosko" role="1_tvlM">
+                      <property role="1OCb_u" value="a" />
+                    </node>
+                  </node>
+                  <node concept="30bdrU" id="7iQqdOBeEN0" role="m5gfT">
+                    <node concept="1OC9wW" id="3g7FMHmostZ" role="1_tvlM">
+                      <property role="1OCb_u" value="b" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -3367,8 +3470,16 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="30bdrU" id="7iQqdOBeReV" role="m5gfT" />
-                  <node concept="30bdrU" id="7iQqdOBeReW" role="m5gfT" />
+                  <node concept="30bdrU" id="7iQqdOBeReV" role="m5gfT">
+                    <node concept="1OC9wW" id="3g7FMHmosz1" role="1_tvlM">
+                      <property role="1OCb_u" value="a" />
+                    </node>
+                  </node>
+                  <node concept="30bdrU" id="7iQqdOBeReW" role="m5gfT">
+                    <node concept="1OC9wW" id="3g7FMHmosGC" role="1_tvlM">
+                      <property role="1OCb_u" value="b" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
@@ -3655,7 +3766,11 @@
                       </node>
                     </node>
                   </node>
-                  <node concept="30bdrU" id="x6NxUzqOzI" role="m5gfT" />
+                  <node concept="30bdrU" id="x6NxUzqOzI" role="m5gfT">
+                    <node concept="1OC9wW" id="3g7FMHmosQB" role="1_tvlM">
+                      <property role="1OCb_u" value="a" />
+                    </node>
+                  </node>
                   <node concept="Unsod" id="x6NxUzqOG0" role="m5gfT" />
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -491,12 +491,13 @@
       <concept id="7425695345928358745" name="org.iets3.core.expr.simpleTypes.structure.TrueLiteral" flags="ng" index="2vmpnb" />
       <concept id="7425695345928358774" name="org.iets3.core.expr.simpleTypes.structure.FalseLiteral" flags="ng" index="2vmpn$" />
       <concept id="7425695345928349207" name="org.iets3.core.expr.simpleTypes.structure.BooleanType" flags="ng" index="2vmvy5" />
+      <concept id="2915503786126701996" name="org.iets3.core.expr.simpleTypes.structure.StringTypeWithConstraint" flags="ng" index="L5Cqj">
+        <child id="8919433883485586606" name="constraint" index="1_tvlM" />
+      </concept>
       <concept id="5115872837157252552" name="org.iets3.core.expr.simpleTypes.structure.StringLiteral" flags="ng" index="30bdrP">
         <property id="5115872837157252555" name="value" index="30bdrQ" />
       </concept>
-      <concept id="5115872837157252551" name="org.iets3.core.expr.simpleTypes.structure.StringType" flags="ng" index="30bdrU">
-        <child id="8919433883485586606" name="constraint" index="1_tvlM" />
-      </concept>
+      <concept id="5115872837157252551" name="org.iets3.core.expr.simpleTypes.structure.StringType" flags="ng" index="30bdrU" />
       <concept id="5115872837157054284" name="org.iets3.core.expr.simpleTypes.structure.RealType" flags="ng" index="30bXLL" />
       <concept id="5115872837157054169" name="org.iets3.core.expr.simpleTypes.structure.IntegerType" flags="ng" index="30bXR$" />
       <concept id="5115872837157054170" name="org.iets3.core.expr.simpleTypes.structure.NumberLiteral" flags="ng" index="30bXRB">
@@ -22542,8 +22543,8 @@
         <property role="TrG5h" value="stringConstraintsTests" />
         <node concept="1WbbD7" id="3OxSopfZRqA" role="_iOnC">
           <property role="TrG5h" value="x" />
-          <node concept="30bdrU" id="3OxSopfZRqK" role="1WbbD4">
-            <node concept="1OC9wW" id="3OxSopg2V1D" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPu3" role="1WbbD4">
+            <node concept="1OC9wW" id="2xPWNWppPu4" role="1_tvlM">
               <property role="1OCb_u" value="x" />
             </node>
           </node>
@@ -22584,8 +22585,8 @@
           <node concept="30bdrP" id="46RgPUM6Vn9" role="2zPyp_">
             <property role="30bdrQ" value="x" />
           </node>
-          <node concept="30bdrU" id="46RgPUM6VtD" role="2zM23F">
-            <node concept="1OC9wW" id="46RgPUM6Vxb" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPu5" role="2zM23F">
+            <node concept="1OC9wW" id="2xPWNWppPu6" role="1_tvlM">
               <property role="1OCb_u" value="x" />
             </node>
           </node>
@@ -22598,16 +22599,16 @@
         <node concept="_ixoA" id="46RgPUM6Vn3" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctvHpy" role="_iOnC">
           <property role="TrG5h" value="existingRegexp" />
-          <node concept="30bdrU" id="45$ooctvHpz" role="1WbbD4">
-            <node concept="1OJ37Q" id="45$ooctvHwW" role="1_tvlM">
-              <node concept="1OC9wW" id="45$ooctvHzs" role="1OLqdY">
+          <node concept="L5Cqj" id="2xPWNWppPu7" role="1WbbD4">
+            <node concept="1OJ37Q" id="2xPWNWppPu8" role="1_tvlM">
+              <node concept="1OC9wW" id="2xPWNWppPu9" role="1OLqdY">
                 <property role="1OCb_u" value="world" />
               </node>
-              <node concept="1OJ37Q" id="45$ooctvH_U" role="1OLpdg">
-                <node concept="1SYyG9" id="45$ooctvHEa" role="1OLqdY">
+              <node concept="1OJ37Q" id="2xPWNWppPua" role="1OLpdg">
+                <node concept="1SYyG9" id="2xPWNWppPub" role="1OLqdY">
                   <ref role="1SYXPG" to="tpfp:h5SUD2M" resolve="\s" />
                 </node>
-                <node concept="1ZmeGV" id="45$ooctvHvH" role="1OLpdg">
+                <node concept="1ZmeGV" id="2xPWNWppPuc" role="1OLpdg">
                   <ref role="1ZmksB" node="45$ooctvHpr" resolve="hello" />
                 </node>
               </node>
@@ -22647,8 +22648,8 @@
         <node concept="_ixoA" id="45$ooctvHpu" role="_iOnC" />
         <node concept="1WbbD7" id="3OxSopg2Ve8" role="_iOnC">
           <property role="TrG5h" value="slash" />
-          <node concept="30bdrU" id="3OxSopg2Ve9" role="1WbbD4">
-            <node concept="1OC9wW" id="3OxSopg36$d" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPud" role="1WbbD4">
+            <node concept="1OC9wW" id="2xPWNWppPue" role="1_tvlM">
               <property role="1OCb_u" value="\\" />
             </node>
           </node>
@@ -22686,8 +22687,8 @@
         <node concept="_ixoA" id="3OxSopfZR0f" role="_iOnC" />
         <node concept="1WbbD7" id="58ackBplczB" role="_iOnC">
           <property role="TrG5h" value="hexadecimal" />
-          <node concept="30bdrU" id="58ackBplczC" role="1WbbD4">
-            <node concept="2bnNQ_" id="58ackBpmOMJ" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPuf" role="1WbbD4">
+            <node concept="2bnNQ_" id="2xPWNWppPug" role="1_tvlM">
               <property role="2bnNQ$" value="41" />
             </node>
           </node>
@@ -22725,8 +22726,8 @@
         <node concept="_ixoA" id="58ackBpocQ4" role="_iOnC" />
         <node concept="1WbbD7" id="7NPLlCCLWR0" role="_iOnC">
           <property role="TrG5h" value="unicode" />
-          <node concept="30bdrU" id="7NPLlCCLWR1" role="1WbbD4">
-            <node concept="L9wo0" id="7NPLlCCLWWp" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPuh" role="1WbbD4">
+            <node concept="L9wo0" id="2xPWNWppPui" role="1_tvlM">
               <property role="L9Okz" value="2190" />
             </node>
           </node>
@@ -22764,8 +22765,8 @@
         <node concept="_ixoA" id="7NPLlCCM0GA" role="_iOnC" />
         <node concept="1WbbD7" id="7NPLlCCM0GE" role="_iOnC">
           <property role="TrG5h" value="unicodeByName" />
-          <node concept="30bdrU" id="7NPLlCCM0GF" role="1WbbD4">
-            <node concept="1kfouk" id="45$ooctgk09" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPuj" role="1WbbD4">
+            <node concept="1kfouk" id="2xPWNWppPuk" role="1_tvlM">
               <property role="1kfoul" value="WHITE SMILING FACE" />
             </node>
           </node>
@@ -22803,8 +22804,8 @@
         <node concept="_ixoA" id="7NPLlCCLWQY" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctjR98" role="_iOnC">
           <property role="TrG5h" value="controlCharacter" />
-          <node concept="30bdrU" id="45$ooctjR99" role="1WbbD4">
-            <node concept="2bqMZ4" id="45$ooctjRcE" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPul" role="1WbbD4">
+            <node concept="2bqMZ4" id="2xPWNWppPum" role="1_tvlM">
               <property role="2bqMZ7" value="M" />
             </node>
           </node>
@@ -22842,8 +22843,8 @@
         <node concept="_ixoA" id="45$ooctjR96" role="_iOnC" />
         <node concept="1WbbD7" id="58ackBpocQc" role="_iOnC">
           <property role="TrG5h" value="tab" />
-          <node concept="30bdrU" id="58ackBpocQd" role="1WbbD4">
-            <node concept="1SYyG9" id="58ackBpocTK" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPun" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPuo" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:horMtjF" resolve="\t" />
             </node>
           </node>
@@ -22881,8 +22882,8 @@
         <node concept="_ixoA" id="58ackBpoddp" role="_iOnC" />
         <node concept="1WbbD7" id="58ackBpoddx" role="_iOnC">
           <property role="TrG5h" value="newline" />
-          <node concept="30bdrU" id="58ackBpoddy" role="1WbbD4">
-            <node concept="1SYyG9" id="58ackBpoddz" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPup" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPuq" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:horMmBM" resolve="\n" />
             </node>
           </node>
@@ -22920,8 +22921,8 @@
         <node concept="_ixoA" id="58ackBpodqM" role="_iOnC" />
         <node concept="1WbbD7" id="58ackBpodps" role="_iOnC">
           <property role="TrG5h" value="carriageReturn" />
-          <node concept="30bdrU" id="58ackBpodpt" role="1WbbD4">
-            <node concept="1SYyG9" id="58ackBpodpu" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPur" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPus" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:horMquy" resolve="\r" />
             </node>
           </node>
@@ -22959,15 +22960,15 @@
         <node concept="_ixoA" id="7NPLlCCx09Q" role="_iOnC" />
         <node concept="1WbbD7" id="7NPLlCCx09W" role="_iOnC">
           <property role="TrG5h" value="characterClass" />
-          <node concept="30bdrU" id="7NPLlCCx09X" role="1WbbD4">
-            <node concept="1SSJmt" id="7NPLlCCx0eC" role="1_tvlM">
-              <node concept="1T6I$Y" id="7NPLlCCx0fS" role="1T5LoC">
+          <node concept="L5Cqj" id="2xPWNWppPut" role="1WbbD4">
+            <node concept="1SSJmt" id="2xPWNWppPuu" role="1_tvlM">
+              <node concept="1T6I$Y" id="2xPWNWppPuv" role="1T5LoC">
                 <property role="1T6KD9" value="a" />
               </node>
-              <node concept="1T6I$Y" id="7NPLlCCx0hM" role="1T5LoC">
+              <node concept="1T6I$Y" id="2xPWNWppPuw" role="1T5LoC">
                 <property role="1T6KD9" value="b" />
               </node>
-              <node concept="1T6I$Y" id="7NPLlCCx0kk" role="1T5LoC">
+              <node concept="1T6I$Y" id="2xPWNWppPux" role="1T5LoC">
                 <property role="1T6KD9" value="c" />
               </node>
             </node>
@@ -23006,15 +23007,15 @@
         <node concept="_ixoA" id="7NPLlCCx09T" role="_iOnC" />
         <node concept="1WbbD7" id="7NPLlCCx2CM" role="_iOnC">
           <property role="TrG5h" value="exceptcharacterClass" />
-          <node concept="30bdrU" id="7NPLlCCx2CN" role="1WbbD4">
-            <node concept="1SSPPM" id="7NPLlCCx3fv" role="1_tvlM">
-              <node concept="1T6I$Y" id="7NPLlCCx3gJ" role="1T5LoC">
+          <node concept="L5Cqj" id="2xPWNWppPuy" role="1WbbD4">
+            <node concept="1SSPPM" id="2xPWNWppPuz" role="1_tvlM">
+              <node concept="1T6I$Y" id="2xPWNWppPu$" role="1T5LoC">
                 <property role="1T6KD9" value="a" />
               </node>
-              <node concept="1T6I$Y" id="7NPLlCCx3gP" role="1T5LoC">
+              <node concept="1T6I$Y" id="2xPWNWppPu_" role="1T5LoC">
                 <property role="1T6KD9" value="b" />
               </node>
-              <node concept="1T6I$Y" id="7NPLlCCx3gV" role="1T5LoC">
+              <node concept="1T6I$Y" id="2xPWNWppPuA" role="1T5LoC">
                 <property role="1T6KD9" value="c" />
               </node>
             </node>
@@ -23053,13 +23054,13 @@
         <node concept="_ixoA" id="58ackBppQ$y" role="_iOnC" />
         <node concept="1WbbD7" id="7NPLlCCx5J9" role="_iOnC">
           <property role="TrG5h" value="range" />
-          <node concept="30bdrU" id="7NPLlCCx5Ja" role="1WbbD4">
-            <node concept="1SSJmt" id="7NPLlCCx6Dt" role="1_tvlM">
-              <node concept="1T8lYq" id="7NPLlCCx6EL" role="1T5LoC">
+          <node concept="L5Cqj" id="2xPWNWppPuB" role="1WbbD4">
+            <node concept="1SSJmt" id="2xPWNWppPuC" role="1_tvlM">
+              <node concept="1T8lYq" id="2xPWNWppPuD" role="1T5LoC">
                 <property role="1T8p8b" value="a" />
                 <property role="1T8pRJ" value="z" />
               </node>
-              <node concept="1T8lYq" id="7NPLlCCx6KZ" role="1T5LoC">
+              <node concept="1T8lYq" id="2xPWNWppPuE" role="1T5LoC">
                 <property role="1T8p8b" value="A" />
                 <property role="1T8pRJ" value="Z" />
               </node>
@@ -23099,21 +23100,21 @@
         <node concept="_ixoA" id="7NPLlCCx6XM" role="_iOnC" />
         <node concept="1WbbD7" id="7NPLlCCx7x_" role="_iOnC">
           <property role="TrG5h" value="intersection" />
-          <node concept="30bdrU" id="7NPLlCCx7xA" role="1WbbD4">
-            <node concept="1SSJmt" id="7NPLlCCx7xB" role="1_tvlM">
-              <node concept="eXZkP" id="7NPLlCCx7Db" role="1T5LoC">
-                <node concept="1T8lYq" id="7NPLlCCx7Ks" role="ySOMi">
+          <node concept="L5Cqj" id="2xPWNWppPuF" role="1WbbD4">
+            <node concept="1SSJmt" id="2xPWNWppPuG" role="1_tvlM">
+              <node concept="eXZkP" id="2xPWNWppPuH" role="1T5LoC">
+                <node concept="1T8lYq" id="2xPWNWppPuI" role="ySOMi">
                   <property role="1T8p8b" value="a" />
                   <property role="1T8pRJ" value="z" />
                 </node>
-                <node concept="1SSJmt" id="7NPLlCCx7RD" role="ySIhK">
-                  <node concept="1T6I$Y" id="7NPLlCCx7RG" role="1T5LoC">
+                <node concept="1SSJmt" id="2xPWNWppPuJ" role="ySIhK">
+                  <node concept="1T6I$Y" id="2xPWNWppPuK" role="1T5LoC">
                     <property role="1T6KD9" value="d" />
                   </node>
-                  <node concept="1T6I$Y" id="7NPLlCCx7Ws" role="1T5LoC">
+                  <node concept="1T6I$Y" id="2xPWNWppPuL" role="1T5LoC">
                     <property role="1T6KD9" value="e" />
                   </node>
-                  <node concept="1T6I$Y" id="7NPLlCCx7Ww" role="1T5LoC">
+                  <node concept="1T6I$Y" id="2xPWNWppPuM" role="1T5LoC">
                     <property role="1T6KD9" value="f" />
                   </node>
                 </node>
@@ -23154,18 +23155,18 @@
         <node concept="_ixoA" id="7NPLlCCx7xz" role="_iOnC" />
         <node concept="1WbbD7" id="7NPLlCCx8vg" role="_iOnC">
           <property role="TrG5h" value="intersection2" />
-          <node concept="30bdrU" id="7NPLlCCx8vh" role="1WbbD4">
-            <node concept="1SSJmt" id="7NPLlCCx9Gy" role="1_tvlM">
-              <node concept="eXZkP" id="7NPLlCCx9HL" role="1T5LoC">
-                <node concept="1T8lYq" id="7NPLlCCx9Lu" role="ySOMi">
+          <node concept="L5Cqj" id="2xPWNWppPuN" role="1WbbD4">
+            <node concept="1SSJmt" id="2xPWNWppPuO" role="1_tvlM">
+              <node concept="eXZkP" id="2xPWNWppPuP" role="1T5LoC">
+                <node concept="1T8lYq" id="2xPWNWppPuQ" role="ySOMi">
                   <property role="1T8p8b" value="a" />
                   <property role="1T8pRJ" value="z" />
                 </node>
-                <node concept="1SSPPM" id="7NPLlCCx9SD" role="ySIhK">
-                  <node concept="1T6I$Y" id="7NPLlCCx9Wg" role="1T5LoC">
+                <node concept="1SSPPM" id="2xPWNWppPuR" role="ySIhK">
+                  <node concept="1T6I$Y" id="2xPWNWppPuS" role="1T5LoC">
                     <property role="1T6KD9" value="b" />
                   </node>
-                  <node concept="1T6I$Y" id="7NPLlCCxa10" role="1T5LoC">
+                  <node concept="1T6I$Y" id="2xPWNWppPuT" role="1T5LoC">
                     <property role="1T6KD9" value="c" />
                   </node>
                 </node>
@@ -23206,16 +23207,16 @@
         <node concept="_ixoA" id="7NPLlCCx8ve" role="_iOnC" />
         <node concept="1WbbD7" id="7NPLlCCx8Az" role="_iOnC">
           <property role="TrG5h" value="intersection3" />
-          <node concept="30bdrU" id="7NPLlCCx8A$" role="1WbbD4">
-            <node concept="1SSJmt" id="7NPLlCCxaiu" role="1_tvlM">
-              <node concept="eXZkP" id="7NPLlCCxayI" role="1T5LoC">
-                <node concept="1SSPPM" id="7NPLlCCxaAn" role="ySIhK">
-                  <node concept="1T8lYq" id="7NPLlCCxaE3" role="1T5LoC">
+          <node concept="L5Cqj" id="2xPWNWppPuU" role="1WbbD4">
+            <node concept="1SSJmt" id="2xPWNWppPuV" role="1_tvlM">
+              <node concept="eXZkP" id="2xPWNWppPuW" role="1T5LoC">
+                <node concept="1SSPPM" id="2xPWNWppPuX" role="ySIhK">
+                  <node concept="1T8lYq" id="2xPWNWppPuY" role="1T5LoC">
                     <property role="1T8p8b" value="m" />
                     <property role="1T8pRJ" value="p" />
                   </node>
                 </node>
-                <node concept="1T8lYq" id="7NPLlCCxaiw" role="ySOMi">
+                <node concept="1T8lYq" id="2xPWNWppPuZ" role="ySOMi">
                   <property role="1T8p8b" value="a" />
                   <property role="1T8pRJ" value="z" />
                 </node>
@@ -23256,8 +23257,8 @@
         <node concept="_ixoA" id="7NPLlCCxaSa" role="_iOnC" />
         <node concept="1WbbD7" id="7NPLlCCxaSe" role="_iOnC">
           <property role="TrG5h" value="any" />
-          <node concept="30bdrU" id="7NPLlCCxaSf" role="1WbbD4">
-            <node concept="1T2EwR" id="7NPLlCCxb5c" role="1_tvlM" />
+          <node concept="L5Cqj" id="2xPWNWppPv0" role="1WbbD4">
+            <node concept="1T2EwR" id="2xPWNWppPv1" role="1_tvlM" />
           </node>
         </node>
         <node concept="2zPypq" id="7NPLlCCxaSl" role="_iOnC">
@@ -23277,8 +23278,8 @@
         <node concept="_ixoA" id="7NPLlCCxb9Z" role="_iOnC" />
         <node concept="1WbbD7" id="7NPLlCCxba3" role="_iOnC">
           <property role="TrG5h" value="digit" />
-          <node concept="30bdrU" id="7NPLlCCxba4" role="1WbbD4">
-            <node concept="1SYyG9" id="7NPLlCCxbh4" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPv2" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPv3" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SUwpi" resolve="\d" />
             </node>
           </node>
@@ -23316,8 +23317,8 @@
         <node concept="_ixoA" id="7NPLlCCxba1" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctjVAf" role="_iOnC">
           <property role="TrG5h" value="nonDigit" />
-          <node concept="30bdrU" id="45$ooctjVAg" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctjVAh" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPv4" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPv5" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SU_Du" resolve="\D" />
             </node>
           </node>
@@ -23355,8 +23356,8 @@
         <node concept="_ixoA" id="45$ooctjVAd" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctjVK7" role="_iOnC">
           <property role="TrG5h" value="horizontalWhitespace" />
-          <node concept="30bdrU" id="45$ooctjVK8" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctjVK9" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPv6" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPv7" role="1_tvlM">
               <ref role="1SYXPG" to="ji8m:45$ooctLm3v" resolve="\h" />
             </node>
           </node>
@@ -23394,8 +23395,8 @@
         <node concept="_ixoA" id="45$ooctjVST" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctjVRu" role="_iOnC">
           <property role="TrG5h" value="nonHorizontalWhitespace" />
-          <node concept="30bdrU" id="45$ooctjVRv" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctjVRw" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPv8" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPv9" role="1_tvlM">
               <ref role="1SYXPG" to="ji8m:45$ooctLm3y" resolve="\H" />
             </node>
           </node>
@@ -23433,8 +23434,8 @@
         <node concept="_ixoA" id="45$ooctjVK5" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctjW05" role="_iOnC">
           <property role="TrG5h" value="whitespace" />
-          <node concept="30bdrU" id="45$ooctjW06" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctjW07" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPva" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvb" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SUD2M" resolve="\s" />
             </node>
           </node>
@@ -23472,8 +23473,8 @@
         <node concept="_ixoA" id="45$ooctjW03" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctjWb4" role="_iOnC">
           <property role="TrG5h" value="nonwhitespace" />
-          <node concept="30bdrU" id="45$ooctjWb5" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctjWb6" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvc" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvd" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SUH0W" resolve="\S" />
             </node>
           </node>
@@ -23511,8 +23512,8 @@
         <node concept="_ixoA" id="45$ooctjWb2" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctjWne" role="_iOnC">
           <property role="TrG5h" value="verticalWhitespace" />
-          <node concept="30bdrU" id="45$ooctjWnf" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctjWng" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPve" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvf" role="1_tvlM">
               <ref role="1SYXPG" to="ji8m:45$ooctk4Lu" resolve="\v" />
             </node>
           </node>
@@ -23550,8 +23551,8 @@
         <node concept="_ixoA" id="45$ooctjWns" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctjWnt" role="_iOnC">
           <property role="TrG5h" value="nonVerticalWhitespace" />
-          <node concept="30bdrU" id="45$ooctjWnu" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctjWnv" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvg" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvh" role="1_tvlM">
               <ref role="1SYXPG" to="ji8m:45$ooctk4Lx" resolve="\V" />
             </node>
           </node>
@@ -23589,8 +23590,8 @@
         <node concept="_ixoA" id="45$ooctk97k" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctk97o" role="_iOnC">
           <property role="TrG5h" value="word" />
-          <node concept="30bdrU" id="45$ooctk97p" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctk97q" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvi" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvj" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SUJUw" resolve="\w" />
             </node>
           </node>
@@ -23628,8 +23629,8 @@
         <node concept="_ixoA" id="45$ooctk97m" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctk9im" role="_iOnC">
           <property role="TrG5h" value="nonWord" />
-          <node concept="30bdrU" id="45$ooctk9in" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctk9io" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvk" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvl" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SUNgp" resolve="\W" />
             </node>
           </node>
@@ -23667,8 +23668,8 @@
         <node concept="_ixoA" id="45$ooctk9ik" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctk9tk" role="_iOnC">
           <property role="TrG5h" value="lower" />
-          <node concept="30bdrU" id="45$ooctk9tl" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctk9BX" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvm" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvn" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SUPxr" resolve="\p{Lower}" />
             </node>
           </node>
@@ -23706,8 +23707,8 @@
         <node concept="_ixoA" id="45$ooctk9ti" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctk9De" role="_iOnC">
           <property role="TrG5h" value="upper" />
-          <node concept="30bdrU" id="45$ooctk9Df" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctk9Dg" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvo" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvp" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SUTG3" resolve="\p{Upper}" />
             </node>
           </node>
@@ -23745,8 +23746,8 @@
         <node concept="_ixoA" id="45$ooctk9LM" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctk9LQ" role="_iOnC">
           <property role="TrG5h" value="ascii" />
-          <node concept="30bdrU" id="45$ooctk9LR" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctk9LS" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvq" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvr" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SUY37" resolve="\p{ASCII}" />
             </node>
           </node>
@@ -23784,8 +23785,8 @@
         <node concept="_ixoA" id="45$ooctk9Dc" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctk9WP" role="_iOnC">
           <property role="TrG5h" value="alphabetic" />
-          <node concept="30bdrU" id="45$ooctk9WQ" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctk9WR" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvs" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvt" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SV1SY" resolve="\p{Alpha}" />
             </node>
           </node>
@@ -23823,8 +23824,8 @@
         <node concept="_ixoA" id="45$ooctk9WN" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctka4f" role="_iOnC">
           <property role="TrG5h" value="decimalDigit" />
-          <node concept="30bdrU" id="45$ooctka4g" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctka4h" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvu" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvv" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SV6x8" resolve="\p{Digit}" />
             </node>
           </node>
@@ -23862,8 +23863,8 @@
         <node concept="_ixoA" id="45$ooctkaiJ" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctkaiO" role="_iOnC">
           <property role="TrG5h" value="alphanumeric" />
-          <node concept="30bdrU" id="45$ooctkaiP" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctkaiQ" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvw" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvx" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SVbIa" resolve="\p{Alnum}" />
             </node>
           </node>
@@ -23901,8 +23902,8 @@
         <node concept="_ixoA" id="45$ooctkaiL" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctkatM" role="_iOnC">
           <property role="TrG5h" value="punctuation" />
-          <node concept="30bdrU" id="45$ooctkatN" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctkatO" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvy" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvz" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SVgIf" resolve="\p{Punct}" />
             </node>
           </node>
@@ -23940,8 +23941,8 @@
         <node concept="_ixoA" id="45$ooctkatK" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctkaB$" role="_iOnC">
           <property role="TrG5h" value="visible" />
-          <node concept="30bdrU" id="45$ooctkaB_" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctkaBA" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPv$" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPv_" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SV_hV" resolve="\p{Graph}" />
             </node>
           </node>
@@ -23979,8 +23980,8 @@
         <node concept="_ixoA" id="45$ooctkaBy" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctkaOU" role="_iOnC">
           <property role="TrG5h" value="printable" />
-          <node concept="30bdrU" id="45$ooctkaOV" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctkaOW" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvA" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvB" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SVFd6" resolve="\p{Print}" />
             </node>
           </node>
@@ -24018,8 +24019,8 @@
         <node concept="_ixoA" id="45$ooctkaV7" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctkaVb" role="_iOnC">
           <property role="TrG5h" value="blank" />
-          <node concept="30bdrU" id="45$ooctkaVc" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctkaVd" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvC" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvD" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SVI3f" resolve="\p{Blank}" />
             </node>
           </node>
@@ -24057,8 +24058,8 @@
         <node concept="_ixoA" id="45$ooctkaV9" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctkb4X" role="_iOnC">
           <property role="TrG5h" value="controlCharacter2" />
-          <node concept="30bdrU" id="45$ooctkb4Y" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctkb4Z" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvE" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvF" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SVKFX" resolve="\p{Cntrl}" />
             </node>
           </node>
@@ -24096,8 +24097,8 @@
         <node concept="_ixoA" id="45$ooctkfvu" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctkfvy" role="_iOnC">
           <property role="TrG5h" value="hexDigit" />
-          <node concept="30bdrU" id="45$ooctkfvz" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctkfv$" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvG" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvH" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SVPmk" resolve="\p{XDigit}" />
             </node>
           </node>
@@ -24135,8 +24136,8 @@
         <node concept="_ixoA" id="45$ooctkfvw" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctkfJg" role="_iOnC">
           <property role="TrG5h" value="space" />
-          <node concept="30bdrU" id="45$ooctkfJh" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctkfJi" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvI" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvJ" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SVUvV" resolve="\p{Space}" />
             </node>
           </node>
@@ -24174,8 +24175,8 @@
         <node concept="_ixoA" id="45$ooctkfJe" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctkfRQ" role="_iOnC">
           <property role="TrG5h" value="javaLowerCase" />
-          <node concept="30bdrU" id="45$ooctkfRR" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctkfRS" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvK" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvL" role="1_tvlM">
               <ref role="1SYXPG" to="ji8m:45$ooctkfUt" resolve="\p{javaLowerCase}" />
             </node>
           </node>
@@ -24213,8 +24214,8 @@
         <node concept="_ixoA" id="45$ooctkfRO" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctkg31" role="_iOnC">
           <property role="TrG5h" value="javaUpperCase" />
-          <node concept="30bdrU" id="45$ooctkg32" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctkg33" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvM" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvN" role="1_tvlM">
               <ref role="1SYXPG" to="ji8m:45$ooctkfUx" resolve="\p{javaUpperCase}" />
             </node>
           </node>
@@ -24252,8 +24253,8 @@
         <node concept="_ixoA" id="45$ooctkh8x" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctkh76" role="_iOnC">
           <property role="TrG5h" value="javaWhitespace" />
-          <node concept="30bdrU" id="45$ooctkh77" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctkh78" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvO" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvP" role="1_tvlM">
               <ref role="1SYXPG" to="ji8m:45$ooctkfU$" resolve="\p{javaWhitespace}" />
             </node>
           </node>
@@ -24291,8 +24292,8 @@
         <node concept="_ixoA" id="45$ooctkg2Z" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctkhfI" role="_iOnC">
           <property role="TrG5h" value="javaMirrored" />
-          <node concept="30bdrU" id="45$ooctkhfJ" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctkhfK" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvQ" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvR" role="1_tvlM">
               <ref role="1SYXPG" to="ji8m:45$ooctkfUB" resolve="\p{javaMirrored}" />
             </node>
           </node>
@@ -24330,8 +24331,8 @@
         <node concept="_ixoA" id="45$ooctkhfG" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctkhqG" role="_iOnC">
           <property role="TrG5h" value="isLatin" />
-          <node concept="30bdrU" id="45$ooctkhqH" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctkhqI" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvS" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvT" role="1_tvlM">
               <ref role="1SYXPG" to="ji8m:45$ooctkhy3" resolve="\p{IsLatin}" />
             </node>
           </node>
@@ -24369,8 +24370,8 @@
         <node concept="_ixoA" id="45$ooctkhqE" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctkhAU" role="_iOnC">
           <property role="TrG5h" value="inGreek" />
-          <node concept="30bdrU" id="45$ooctkhAV" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctkhAW" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvU" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvV" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SVZIT" resolve="\p{InGreek}" />
             </node>
           </node>
@@ -24408,8 +24409,8 @@
         <node concept="_ixoA" id="45$ooctkhAS" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctkiwS" role="_iOnC">
           <property role="TrG5h" value="notInGreek" />
-          <node concept="30bdrU" id="45$ooctkiwT" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctkiwU" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvW" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvX" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SW6BB" resolve="\P{InGreek}" />
             </node>
           </node>
@@ -24447,8 +24448,8 @@
         <node concept="_ixoA" id="45$ooctkiwQ" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctkhJw" role="_iOnC">
           <property role="TrG5h" value="uppercaseLetter" />
-          <node concept="30bdrU" id="45$ooctkhJx" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctkhJy" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPvY" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPvZ" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SW2RA" resolve="\p{Lu}" />
             </node>
           </node>
@@ -24486,8 +24487,8 @@
         <node concept="_ixoA" id="45$ooctkhJu" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctkhUu" role="_iOnC">
           <property role="TrG5h" value="isAlphabetic" />
-          <node concept="30bdrU" id="45$ooctkhUv" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctki6m" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPw0" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPw1" role="1_tvlM">
               <ref role="1SYXPG" to="ji8m:45$ooctki31" resolve="\p{IsAlphabetic}" />
             </node>
           </node>
@@ -24525,8 +24526,8 @@
         <node concept="_ixoA" id="45$ooctkhUs" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctki8N" role="_iOnC">
           <property role="TrG5h" value="currency" />
-          <node concept="30bdrU" id="45$ooctki8O" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctki8P" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPw2" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPw3" role="1_tvlM">
               <ref role="1SYXPG" to="tpfp:h5SW4Gk" resolve="\p{Sc}" />
             </node>
           </node>
@@ -24564,25 +24565,25 @@
         <node concept="_ixoA" id="45$ooctki8L" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctkiH3" role="_iOnC">
           <property role="TrG5h" value="boundary" />
-          <node concept="30bdrU" id="45$ooctkiH4" role="1WbbD4">
-            <node concept="1OJ37Q" id="45$ooctkiOb" role="1_tvlM">
-              <node concept="1OJ37Q" id="45$ooctkiVC" role="1OLqdY">
-                <node concept="1OJ37Q" id="45$ooctlgXS" role="1OLqdY">
-                  <node concept="2t4AhP" id="45$ooctlh6C" role="1OLqdY" />
-                  <node concept="1OC9wW" id="45$ooctkiZS" role="1OLpdg">
+          <node concept="L5Cqj" id="2xPWNWppPw4" role="1WbbD4">
+            <node concept="1OJ37Q" id="2xPWNWppPw5" role="1_tvlM">
+              <node concept="1OJ37Q" id="2xPWNWppPw6" role="1OLqdY">
+                <node concept="1OJ37Q" id="2xPWNWppPw7" role="1OLqdY">
+                  <node concept="2t4AhP" id="2xPWNWppPw8" role="1OLqdY" />
+                  <node concept="1OC9wW" id="2xPWNWppPw9" role="1OLpdg">
                     <property role="1OCb_u" value="world" />
                   </node>
                 </node>
-                <node concept="1OJ37Q" id="45$ooctlaUF" role="1OLpdg">
-                  <node concept="1SYyG9" id="45$ooctlb1b" role="1OLqdY">
+                <node concept="1OJ37Q" id="2xPWNWppPwa" role="1OLpdg">
+                  <node concept="1SYyG9" id="2xPWNWppPwb" role="1OLqdY">
                     <ref role="1SYXPG" to="tpfp:h5SUD2M" resolve="\s" />
                   </node>
-                  <node concept="1OC9wW" id="45$ooctkiQF" role="1OLpdg">
+                  <node concept="1OC9wW" id="2xPWNWppPwc" role="1OLpdg">
                     <property role="1OCb_u" value="Hello" />
                   </node>
                 </node>
               </node>
-              <node concept="2t4tHJ" id="45$ooctkiMW" role="1OLpdg" />
+              <node concept="2t4tHJ" id="2xPWNWppPwd" role="1OLpdg" />
             </node>
           </node>
         </node>
@@ -24619,26 +24620,26 @@
         <node concept="_ixoA" id="45$ooctkiH1" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctlhfp" role="_iOnC">
           <property role="TrG5h" value="wordBoundary" />
-          <node concept="30bdrU" id="45$ooctlhfq" role="1WbbD4">
-            <node concept="1OJ37Q" id="45$ooctliS$" role="1_tvlM">
-              <node concept="1OJ37Q" id="45$ooctlj2s" role="1OLqdY">
-                <node concept="1OJ37Q" id="45$ooctljAr" role="1OLqdY">
-                  <node concept="1OCmVF" id="45$ooctljJS" role="1OLqdY">
-                    <node concept="1T2EwR" id="45$ooctljAv" role="1OLDsb" />
+          <node concept="L5Cqj" id="2xPWNWppPwe" role="1WbbD4">
+            <node concept="1OJ37Q" id="2xPWNWppPwf" role="1_tvlM">
+              <node concept="1OJ37Q" id="2xPWNWppPwg" role="1OLqdY">
+                <node concept="1OJ37Q" id="2xPWNWppPwh" role="1OLqdY">
+                  <node concept="1OCmVF" id="2xPWNWppPwi" role="1OLqdY">
+                    <node concept="1T2EwR" id="2xPWNWppPwj" role="1OLDsb" />
                   </node>
-                  <node concept="1SYyG9" id="45$ooctlj6G" role="1OLpdg">
+                  <node concept="1SYyG9" id="2xPWNWppPwk" role="1OLpdg">
                     <ref role="1SYXPG" to="tpfp:hvJKwDd" resolve="\b" />
                   </node>
                 </node>
-                <node concept="1OC9wW" id="45$ooctliXy" role="1OLpdg">
+                <node concept="1OC9wW" id="2xPWNWppPwl" role="1OLpdg">
                   <property role="1OCb_u" value="world" />
                 </node>
               </node>
-              <node concept="1OJ37Q" id="45$ooctljjj" role="1OLpdg">
-                <node concept="1OCmVF" id="45$ooctljvk" role="1OLpdg">
-                  <node concept="1T2EwR" id="45$ooctljpj" role="1OLDsb" />
+              <node concept="1OJ37Q" id="2xPWNWppPwm" role="1OLpdg">
+                <node concept="1OCmVF" id="2xPWNWppPwn" role="1OLpdg">
+                  <node concept="1T2EwR" id="2xPWNWppPwo" role="1OLDsb" />
                 </node>
-                <node concept="1SYyG9" id="45$ooctliRl" role="1OLqdY">
+                <node concept="1SYyG9" id="2xPWNWppPwp" role="1OLqdY">
                   <ref role="1SYXPG" to="tpfp:hvJKwDd" resolve="\b" />
                 </node>
               </node>
@@ -24678,14 +24679,14 @@
         <node concept="_ixoA" id="45$ooctlhfn" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctlkg1" role="_iOnC">
           <property role="TrG5h" value="nonWordBoundary" />
-          <node concept="30bdrU" id="45$ooctlkg2" role="1WbbD4">
-            <node concept="1OJ37Q" id="45$ooctlkg3" role="1_tvlM">
-              <node concept="1OC9wW" id="45$ooctlkg9" role="1OLqdY">
+          <node concept="L5Cqj" id="2xPWNWppPwq" role="1WbbD4">
+            <node concept="1OJ37Q" id="2xPWNWppPwr" role="1_tvlM">
+              <node concept="1OC9wW" id="2xPWNWppPws" role="1OLqdY">
                 <property role="1OCb_u" value="h" />
               </node>
-              <node concept="1OJ37Q" id="45$ooctlvt8" role="1OLpdg">
-                <node concept="1T2EwR" id="45$ooctlvxo" role="1OLpdg" />
-                <node concept="1SYyG9" id="45$ooctlkgd" role="1OLqdY">
+              <node concept="1OJ37Q" id="2xPWNWppPwt" role="1OLpdg">
+                <node concept="1T2EwR" id="2xPWNWppPwu" role="1OLpdg" />
+                <node concept="1SYyG9" id="2xPWNWppPwv" role="1OLqdY">
                   <ref role="1SYXPG" to="tpfp:hvJL1ap" resolve="\B" />
                 </node>
               </node>
@@ -24725,17 +24726,17 @@
         <node concept="_ixoA" id="45$ooctlkfZ" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctllKE" role="_iOnC">
           <property role="TrG5h" value="beginning" />
-          <node concept="30bdrU" id="45$ooctllKF" role="1WbbD4">
-            <node concept="1OJ37Q" id="45$ooctlmzS" role="1_tvlM">
-              <node concept="1OJ37Q" id="45$ooctlmCQ" role="1OLqdY">
-                <node concept="1OCmVF" id="45$ooctlmLn" role="1OLqdY">
-                  <node concept="1T2EwR" id="45$ooctlmH6" role="1OLDsb" />
+          <node concept="L5Cqj" id="2xPWNWppPww" role="1WbbD4">
+            <node concept="1OJ37Q" id="2xPWNWppPwx" role="1_tvlM">
+              <node concept="1OJ37Q" id="2xPWNWppPwy" role="1OLqdY">
+                <node concept="1OCmVF" id="2xPWNWppPwz" role="1OLqdY">
+                  <node concept="1T2EwR" id="2xPWNWppPw$" role="1OLDsb" />
                 </node>
-                <node concept="1OC9wW" id="45$ooctlmAo" role="1OLpdg">
+                <node concept="1OC9wW" id="2xPWNWppPw_" role="1OLpdg">
                   <property role="1OCb_u" value="Hello" />
                 </node>
               </node>
-              <node concept="1SYyG9" id="45$ooctlmv5" role="1OLpdg">
+              <node concept="1SYyG9" id="2xPWNWppPwA" role="1OLpdg">
                 <ref role="1SYXPG" to="tpfp:hvJL4EY" resolve="\A" />
               </node>
             </node>
@@ -24774,12 +24775,12 @@
         <node concept="_ixoA" id="45$ooctllKC" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctlvDP" role="_iOnC">
           <property role="TrG5h" value="end" />
-          <node concept="30bdrU" id="45$ooctlvDQ" role="1WbbD4">
-            <node concept="1OJ37Q" id="45$ooctlw4_" role="1_tvlM">
-              <node concept="1OC9wW" id="45$ooctlvDV" role="1OLpdg">
+          <node concept="L5Cqj" id="2xPWNWppPwB" role="1WbbD4">
+            <node concept="1OJ37Q" id="2xPWNWppPwC" role="1_tvlM">
+              <node concept="1OC9wW" id="2xPWNWppPwD" role="1OLpdg">
                 <property role="1OCb_u" value="Hello" />
               </node>
-              <node concept="1SYyG9" id="45$ooctlw4C" role="1OLqdY">
+              <node concept="1SYyG9" id="2xPWNWppPwE" role="1OLqdY">
                 <ref role="1SYXPG" to="tpfp:hvJLuQE" resolve="\z" />
               </node>
             </node>
@@ -24818,8 +24819,8 @@
         <node concept="_ixoA" id="45$ooctlvDN" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctlwc0" role="_iOnC">
           <property role="TrG5h" value="linebreak" />
-          <node concept="30bdrU" id="45$ooctlwc1" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctlwuf" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPwF" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPwG" role="1_tvlM">
               <ref role="1SYXPG" to="ji8m:45$ooctlwuc" resolve="\R" />
             </node>
           </node>
@@ -24857,8 +24858,8 @@
         <node concept="_ixoA" id="45$ooctlwbY" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctl_yo" role="_iOnC">
           <property role="TrG5h" value="unicodeLineBreak" />
-          <node concept="30bdrU" id="45$ooctl_yp" role="1WbbD4">
-            <node concept="1SYyG9" id="45$ooctl_yq" role="1_tvlM">
+          <node concept="L5Cqj" id="2xPWNWppPwH" role="1WbbD4">
+            <node concept="1SYyG9" id="2xPWNWppPwI" role="1_tvlM">
               <ref role="1SYXPG" to="ji8m:45$ooctlwuc" resolve="\R" />
             </node>
           </node>
@@ -24896,47 +24897,47 @@
         <node concept="_ixoA" id="45$ooctl_ym" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctlFxl" role="_iOnC">
           <property role="TrG5h" value="greedy" />
-          <node concept="30bdrU" id="45$ooctlFxm" role="1WbbD4">
-            <node concept="1OJ37Q" id="45$ooctlFHr" role="1_tvlM">
-              <node concept="1OJ37Q" id="45$ooctlG6h" role="1OLqdY">
-                <node concept="1OJ37Q" id="45$ooctlGq8" role="1OLqdY">
-                  <node concept="1OJ37Q" id="45$ooctlH4j" role="1OLqdY">
-                    <node concept="1OJ37Q" id="45$ooctlI0u" role="1OLqdY">
-                      <node concept="2dLoPZ" id="45$ooctlID6" role="1OLqdY">
+          <node concept="L5Cqj" id="2xPWNWppPwJ" role="1WbbD4">
+            <node concept="1OJ37Q" id="2xPWNWppPwK" role="1_tvlM">
+              <node concept="1OJ37Q" id="2xPWNWppPwL" role="1OLqdY">
+                <node concept="1OJ37Q" id="2xPWNWppPwM" role="1OLqdY">
+                  <node concept="1OJ37Q" id="2xPWNWppPwN" role="1OLqdY">
+                    <node concept="1OJ37Q" id="2xPWNWppPwO" role="1OLqdY">
+                      <node concept="2dLoPZ" id="2xPWNWppPwP" role="1OLqdY">
                         <property role="2dLrT$" value="1" />
                         <property role="2dLsHy" value="2" />
-                        <node concept="1OC9wW" id="45$ooctlIjQ" role="1OLDsb">
+                        <node concept="1OC9wW" id="2xPWNWppPwQ" role="1OLDsb">
                           <property role="1OCb_u" value="f" />
                         </node>
                       </node>
-                      <node concept="2dKKZN" id="45$ooctlHwN" role="1OLpdg">
+                      <node concept="2dKKZN" id="2xPWNWppPwR" role="1OLpdg">
                         <property role="2dKT$$" value="3" />
-                        <node concept="1OC9wW" id="45$ooctlHiz" role="1OLDsb">
+                        <node concept="1OC9wW" id="2xPWNWppPwS" role="1OLDsb">
                           <property role="1OCb_u" value="e" />
                         </node>
                       </node>
                     </node>
-                    <node concept="2dJHH6" id="45$ooctlGHS" role="1OLpdg">
+                    <node concept="2dJHH6" id="2xPWNWppPwT" role="1OLpdg">
                       <property role="2dJM4W" value="2" />
-                      <node concept="1OC9wW" id="45$ooctlG$0" role="1OLDsb">
+                      <node concept="1OC9wW" id="2xPWNWppPwU" role="1OLDsb">
                         <property role="1OCb_u" value="d" />
                       </node>
                     </node>
                   </node>
-                  <node concept="1OClNT" id="45$ooctlGiL" role="1OLpdg">
-                    <node concept="1OC9wW" id="45$ooctlGcx" role="1OLDsb">
+                  <node concept="1OClNT" id="2xPWNWppPwV" role="1OLpdg">
+                    <node concept="1OC9wW" id="2xPWNWppPwW" role="1OLDsb">
                       <property role="1OCb_u" value="c" />
                     </node>
                   </node>
                 </node>
-                <node concept="1OCmVF" id="45$ooctlG22" role="1OLpdg">
-                  <node concept="1OC9wW" id="45$ooctlFTH" role="1OLDsb">
+                <node concept="1OCmVF" id="2xPWNWppPwX" role="1OLpdg">
+                  <node concept="1OC9wW" id="2xPWNWppPwY" role="1OLDsb">
                     <property role="1OCb_u" value="b" />
                   </node>
                 </node>
               </node>
-              <node concept="1SLe3L" id="45$ooctlFYD" role="1OLpdg">
-                <node concept="1OC9wW" id="45$ooctlFGd" role="1OLDsb">
+              <node concept="1SLe3L" id="2xPWNWppPwZ" role="1OLpdg">
+                <node concept="1OC9wW" id="2xPWNWppPx0" role="1OLDsb">
                   <property role="1OCb_u" value="a" />
                 </node>
               </node>
@@ -24976,47 +24977,47 @@
         <node concept="_ixoA" id="45$ooctlFxj" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctlMif" role="_iOnC">
           <property role="TrG5h" value="reluctant" />
-          <node concept="30bdrU" id="45$ooctlMig" role="1WbbD4">
-            <node concept="1OJ37Q" id="45$ooctlMih" role="1_tvlM">
-              <node concept="1OJ37Q" id="45$ooctlMii" role="1OLqdY">
-                <node concept="1OJ37Q" id="45$ooctlMij" role="1OLqdY">
-                  <node concept="1OJ37Q" id="45$ooctlMik" role="1OLqdY">
-                    <node concept="1OJ37Q" id="45$ooctlMil" role="1OLqdY">
-                      <node concept="2dLoPZ" id="45$ooctlMim" role="1OLqdY">
+          <node concept="L5Cqj" id="2xPWNWppPx1" role="1WbbD4">
+            <node concept="1OJ37Q" id="2xPWNWppPx2" role="1_tvlM">
+              <node concept="1OJ37Q" id="2xPWNWppPx3" role="1OLqdY">
+                <node concept="1OJ37Q" id="2xPWNWppPx4" role="1OLqdY">
+                  <node concept="1OJ37Q" id="2xPWNWppPx5" role="1OLqdY">
+                    <node concept="1OJ37Q" id="2xPWNWppPx6" role="1OLqdY">
+                      <node concept="2dLoPZ" id="2xPWNWppPx7" role="1OLqdY">
                         <property role="2dLrT$" value="1" />
                         <property role="2dLsHy" value="2" />
-                        <node concept="1OC9wW" id="45$ooctlMin" role="1OLDsb">
+                        <node concept="1OC9wW" id="2xPWNWppPx8" role="1OLDsb">
                           <property role="1OCb_u" value="f" />
                         </node>
                       </node>
-                      <node concept="2dKKZN" id="45$ooctlMio" role="1OLpdg">
+                      <node concept="2dKKZN" id="2xPWNWppPx9" role="1OLpdg">
                         <property role="2dKT$$" value="3" />
-                        <node concept="1OC9wW" id="45$ooctlMip" role="1OLDsb">
+                        <node concept="1OC9wW" id="2xPWNWppPxa" role="1OLDsb">
                           <property role="1OCb_u" value="e" />
                         </node>
                       </node>
                     </node>
-                    <node concept="2dJHH6" id="45$ooctlMiq" role="1OLpdg">
+                    <node concept="2dJHH6" id="2xPWNWppPxb" role="1OLpdg">
                       <property role="2dJM4W" value="2" />
-                      <node concept="1OC9wW" id="45$ooctlMir" role="1OLDsb">
+                      <node concept="1OC9wW" id="2xPWNWppPxc" role="1OLDsb">
                         <property role="1OCb_u" value="d" />
                       </node>
                     </node>
                   </node>
-                  <node concept="1Zee5B" id="45$ooctlOBa" role="1OLpdg">
-                    <node concept="1OC9wW" id="45$ooctlOBc" role="1OLDsb">
+                  <node concept="1Zee5B" id="2xPWNWppPxd" role="1OLpdg">
+                    <node concept="1OC9wW" id="2xPWNWppPxe" role="1OLDsb">
                       <property role="1OCb_u" value="c" />
                     </node>
                   </node>
                 </node>
-                <node concept="1Ze39Q" id="45$ooctlOhU" role="1OLpdg">
-                  <node concept="1OC9wW" id="45$ooctlOhW" role="1OLDsb">
+                <node concept="1Ze39Q" id="2xPWNWppPxf" role="1OLpdg">
+                  <node concept="1OC9wW" id="2xPWNWppPxg" role="1OLDsb">
                     <property role="1OCb_u" value="b" />
                   </node>
                 </node>
               </node>
-              <node concept="1ZekDQ" id="45$ooctlNWE" role="1OLpdg">
-                <node concept="1OC9wW" id="45$ooctlNWG" role="1OLDsb">
+              <node concept="1ZekDQ" id="2xPWNWppPxh" role="1OLpdg">
+                <node concept="1OC9wW" id="2xPWNWppPxi" role="1OLDsb">
                   <property role="1OCb_u" value="a" />
                 </node>
               </node>
@@ -25056,12 +25057,12 @@
         <node concept="_ixoA" id="45$ooctlMid" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctlT3A" role="_iOnC">
           <property role="TrG5h" value="or" />
-          <node concept="30bdrU" id="45$ooctlT3B" role="1WbbD4">
-            <node concept="1OCdqh" id="45$ooctlUL5" role="1_tvlM">
-              <node concept="1OC9wW" id="45$ooctlUN_" role="1OLqdY">
+          <node concept="L5Cqj" id="2xPWNWppPxj" role="1WbbD4">
+            <node concept="1OCdqh" id="2xPWNWppPxk" role="1_tvlM">
+              <node concept="1OC9wW" id="2xPWNWppPxl" role="1OLqdY">
                 <property role="1OCb_u" value="b" />
               </node>
-              <node concept="1OC9wW" id="45$ooctlT3S" role="1OLpdg">
+              <node concept="1OC9wW" id="2xPWNWppPxm" role="1OLpdg">
                 <property role="1OCb_u" value="a" />
               </node>
             </node>
@@ -25100,15 +25101,15 @@
         <node concept="_ixoA" id="45$ooctlPEX" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctlUXp" role="_iOnC">
           <property role="TrG5h" value="captureGroup" />
-          <node concept="30bdrU" id="45$ooctlUXq" role="1WbbD4">
-            <node concept="1OCdqh" id="45$ooctlUXr" role="1_tvlM">
-              <node concept="1P8g2y" id="45$ooctlVjP" role="1OLqdY">
-                <node concept="1OC9wW" id="45$ooctlVjQ" role="1P8hpE">
+          <node concept="L5Cqj" id="2xPWNWppPxn" role="1WbbD4">
+            <node concept="1OCdqh" id="2xPWNWppPxo" role="1_tvlM">
+              <node concept="1P8g2y" id="2xPWNWppPxp" role="1OLqdY">
+                <node concept="1OC9wW" id="2xPWNWppPxq" role="1P8hpE">
                   <property role="1OCb_u" value="(b" />
                 </node>
               </node>
-              <node concept="1P8g2y" id="45$ooctlV9Q" role="1OLpdg">
-                <node concept="1OC9wW" id="45$ooctlV9R" role="1P8hpE">
+              <node concept="1P8g2y" id="2xPWNWppPxr" role="1OLpdg">
+                <node concept="1OC9wW" id="2xPWNWppPxs" role="1P8hpE">
                   <property role="1OCb_u" value="a" />
                 </node>
               </node>
@@ -25148,25 +25149,25 @@
         <node concept="_ixoA" id="45$ooctlUXn" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctlVCQ" role="_iOnC">
           <property role="TrG5h" value="backReference" />
-          <node concept="30bdrU" id="45$ooctlVCR" role="1WbbD4">
-            <node concept="1OJ37Q" id="45$ooctn_oD" role="1_tvlM">
-              <node concept="1OJ37Q" id="45$ooctscIg" role="1OLpdg">
-                <node concept="1P8g2x" id="45$ooctscPo" role="1OLqdY">
-                  <node concept="1OC9wW" id="45$ooctscXB" role="1P8hpE">
+          <node concept="L5Cqj" id="2xPWNWppPxt" role="1WbbD4">
+            <node concept="1OJ37Q" id="2xPWNWppPxu" role="1_tvlM">
+              <node concept="1OJ37Q" id="2xPWNWppPxv" role="1OLpdg">
+                <node concept="1P8g2x" id="2xPWNWppPxw" role="1OLqdY">
+                  <node concept="1OC9wW" id="2xPWNWppPxx" role="1P8hpE">
                     <property role="1OCb_u" value="B" />
                   </node>
                 </node>
-                <node concept="1P8g2x" id="45$ooctscgy" role="1OLpdg">
-                  <node concept="1OC9wW" id="45$ooctscoL" role="1P8hpE">
+                <node concept="1P8g2x" id="2xPWNWppPxy" role="1OLpdg">
+                  <node concept="1OC9wW" id="2xPWNWppPxz" role="1P8hpE">
                     <property role="1OCb_u" value="A" />
                   </node>
                 </node>
               </node>
-              <node concept="1OJ37Q" id="45$ooctoYxX" role="1OLqdY">
-                <node concept="1scXMP" id="45$ooctoYEe" role="1OLqdY">
+              <node concept="1OJ37Q" id="2xPWNWppPx$" role="1OLqdY">
+                <node concept="1scXMP" id="2xPWNWppPx_" role="1OLqdY">
                   <property role="1scXMU" value="2" />
                 </node>
-                <node concept="1scXMP" id="45$ooctn_nq" role="1OLpdg">
+                <node concept="1scXMP" id="2xPWNWppPxA" role="1OLpdg">
                   <property role="1scXMU" value="1" />
                 </node>
               </node>
@@ -25206,26 +25207,26 @@
         <node concept="_ixoA" id="45$ooctlVCO" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctsdAB" role="_iOnC">
           <property role="TrG5h" value="namedBackReference" />
-          <node concept="30bdrU" id="45$ooctsdAC" role="1WbbD4">
-            <node concept="1OJ37Q" id="45$ooctuO4Q" role="1_tvlM">
-              <node concept="1OJ37Q" id="45$ooctuObh" role="1OLqdY">
-                <node concept="1s447l" id="46RgPUMu085" role="1OLpdg">
-                  <ref role="1s447o" node="46RgPUMtxG3" resolve="A" />
+          <node concept="L5Cqj" id="2xPWNWppPxB" role="1WbbD4">
+            <node concept="1OJ37Q" id="2xPWNWppPxC" role="1_tvlM">
+              <node concept="1OJ37Q" id="2xPWNWppPxD" role="1OLqdY">
+                <node concept="1s447l" id="2xPWNWppPxE" role="1OLpdg">
+                  <ref role="1s447o" node="2xPWNWppPxJ" resolve="A" />
                 </node>
-                <node concept="1s447l" id="46RgPUMvmgN" role="1OLqdY">
-                  <ref role="1s447o" node="46RgPUMtZpq" resolve="B" />
+                <node concept="1s447l" id="2xPWNWppPxF" role="1OLqdY">
+                  <ref role="1s447o" node="2xPWNWppPxH" resolve="B" />
                 </node>
               </node>
-              <node concept="1OJ37Q" id="46RgPUMtZih" role="1OLpdg">
-                <node concept="3NQvFP" id="46RgPUMtZpq" role="1OLqdY">
+              <node concept="1OJ37Q" id="2xPWNWppPxG" role="1OLpdg">
+                <node concept="3NQvFP" id="2xPWNWppPxH" role="1OLqdY">
                   <property role="TrG5h" value="B" />
-                  <node concept="1OC9wW" id="46RgPUMtZM2" role="1P8hpE">
+                  <node concept="1OC9wW" id="2xPWNWppPxI" role="1P8hpE">
                     <property role="1OCb_u" value="B" />
                   </node>
                 </node>
-                <node concept="3NQvFP" id="46RgPUMtxG3" role="1OLpdg">
+                <node concept="3NQvFP" id="2xPWNWppPxJ" role="1OLpdg">
                   <property role="TrG5h" value="A" />
-                  <node concept="1OC9wW" id="46RgPUMtZ4W" role="1P8hpE">
+                  <node concept="1OC9wW" id="2xPWNWppPxK" role="1P8hpE">
                     <property role="1OCb_u" value="A" />
                   </node>
                 </node>
@@ -25266,23 +25267,23 @@
         <node concept="_ixoA" id="45$ooctuOso" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctv5$c" role="_iOnC">
           <property role="TrG5h" value="positiveLookahead" />
-          <node concept="30bdrU" id="45$ooctv5$d" role="1WbbD4">
-            <node concept="1OJ37Q" id="45$ooctv6eM" role="1_tvlM">
-              <node concept="1OJ37Q" id="45$ooctvbFr" role="1OLqdY">
-                <node concept="1OCmVF" id="45$ooctvbXf" role="1OLqdY">
-                  <node concept="1T2EwR" id="45$ooctvbNK" role="1OLDsb" />
+          <node concept="L5Cqj" id="2xPWNWppPxL" role="1WbbD4">
+            <node concept="1OJ37Q" id="2xPWNWppPxM" role="1_tvlM">
+              <node concept="1OJ37Q" id="2xPWNWppPxN" role="1OLqdY">
+                <node concept="1OCmVF" id="2xPWNWppPxO" role="1OLqdY">
+                  <node concept="1T2EwR" id="2xPWNWppPxP" role="1OLDsb" />
                 </node>
-                <node concept="2dRVxy" id="45$ooctv6hn" role="1OLpdg">
-                  <node concept="1OC9wW" id="45$ooctv6kN" role="2dSRqD">
+                <node concept="2dRVxy" id="2xPWNWppPxQ" role="1OLpdg">
+                  <node concept="1OC9wW" id="2xPWNWppPxR" role="2dSRqD">
                     <property role="1OCb_u" value="b" />
                   </node>
                 </node>
               </node>
-              <node concept="1OJ37Q" id="45$ooctvbqD" role="1OLpdg">
-                <node concept="1OCmVF" id="45$ooctvb_5" role="1OLpdg">
-                  <node concept="1T2EwR" id="45$ooctvbvQ" role="1OLDsb" />
+              <node concept="1OJ37Q" id="2xPWNWppPxS" role="1OLpdg">
+                <node concept="1OCmVF" id="2xPWNWppPxT" role="1OLpdg">
+                  <node concept="1T2EwR" id="2xPWNWppPxU" role="1OLDsb" />
                 </node>
-                <node concept="1OC9wW" id="45$ooctv6ai" role="1OLqdY">
+                <node concept="1OC9wW" id="2xPWNWppPxV" role="1OLqdY">
                   <property role="1OCb_u" value="a" />
                 </node>
               </node>
@@ -25322,22 +25323,22 @@
         <node concept="_ixoA" id="45$ooctuOst" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctvd8u" role="_iOnC">
           <property role="TrG5h" value="negativeLookahead" />
-          <node concept="30bdrU" id="45$ooctvd8v" role="1WbbD4">
-            <node concept="1OJ37Q" id="45$ooctvd8w" role="1_tvlM">
-              <node concept="1OCmVF" id="45$ooctvd8y" role="1OLqdY">
-                <node concept="1T2EwR" id="45$ooctvd8z" role="1OLDsb" />
+          <node concept="L5Cqj" id="2xPWNWppPxW" role="1WbbD4">
+            <node concept="1OJ37Q" id="2xPWNWppPxX" role="1_tvlM">
+              <node concept="1OCmVF" id="2xPWNWppPxY" role="1OLqdY">
+                <node concept="1T2EwR" id="2xPWNWppPxZ" role="1OLDsb" />
               </node>
-              <node concept="1OJ37Q" id="45$ooctvd8A" role="1OLpdg">
-                <node concept="1OCmVF" id="45$ooctvd8B" role="1OLpdg">
-                  <node concept="1T2EwR" id="45$ooctvd8C" role="1OLDsb" />
+              <node concept="1OJ37Q" id="2xPWNWppPy0" role="1OLpdg">
+                <node concept="1OCmVF" id="2xPWNWppPy1" role="1OLpdg">
+                  <node concept="1T2EwR" id="2xPWNWppPy2" role="1OLDsb" />
                 </node>
-                <node concept="1OJ37Q" id="45$ooctvf3b" role="1OLqdY">
-                  <node concept="2dSvw$" id="45$ooctvfbK" role="1OLqdY">
-                    <node concept="1OC9wW" id="45$ooctvfbS" role="2dSRqD">
+                <node concept="1OJ37Q" id="2xPWNWppPy3" role="1OLqdY">
+                  <node concept="2dSvw$" id="2xPWNWppPy4" role="1OLqdY">
+                    <node concept="1OC9wW" id="2xPWNWppPy5" role="2dSRqD">
                       <property role="1OCb_u" value="b" />
                     </node>
                   </node>
-                  <node concept="1OC9wW" id="45$ooctvd8D" role="1OLpdg">
+                  <node concept="1OC9wW" id="2xPWNWppPy6" role="1OLpdg">
                     <property role="1OCb_u" value="a" />
                   </node>
                 </node>
@@ -25378,21 +25379,21 @@
         <node concept="_ixoA" id="45$ooctvd8p" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctvfE4" role="_iOnC">
           <property role="TrG5h" value="positiveLookbehind" />
-          <node concept="30bdrU" id="45$ooctvfE5" role="1WbbD4">
-            <node concept="1OJ37Q" id="45$ooctvfE6" role="1_tvlM">
-              <node concept="1OCmVF" id="45$ooctvfE7" role="1OLqdY">
-                <node concept="1T2EwR" id="45$ooctvfE8" role="1OLDsb" />
+          <node concept="L5Cqj" id="2xPWNWppPy7" role="1WbbD4">
+            <node concept="1OJ37Q" id="2xPWNWppPy8" role="1_tvlM">
+              <node concept="1OCmVF" id="2xPWNWppPy9" role="1OLqdY">
+                <node concept="1T2EwR" id="2xPWNWppPya" role="1OLDsb" />
               </node>
-              <node concept="1OJ37Q" id="45$ooctvfE9" role="1OLpdg">
-                <node concept="1OCmVF" id="45$ooctvfEa" role="1OLpdg">
-                  <node concept="1T2EwR" id="45$ooctvfEb" role="1OLDsb" />
+              <node concept="1OJ37Q" id="2xPWNWppPyb" role="1OLpdg">
+                <node concept="1OCmVF" id="2xPWNWppPyc" role="1OLpdg">
+                  <node concept="1T2EwR" id="2xPWNWppPyd" role="1OLDsb" />
                 </node>
-                <node concept="1OJ37Q" id="45$ooctvhgh" role="1OLqdY">
-                  <node concept="1OC9wW" id="45$ooctvhqe" role="1OLqdY">
+                <node concept="1OJ37Q" id="2xPWNWppPye" role="1OLqdY">
+                  <node concept="1OC9wW" id="2xPWNWppPyf" role="1OLqdY">
                     <property role="1OCb_u" value="b" />
                   </node>
-                  <node concept="2dTBkY" id="45$ooctvgP4" role="1OLpdg">
-                    <node concept="1OC9wW" id="45$ooctvgZ0" role="2dSRqD">
+                  <node concept="2dTBkY" id="2xPWNWppPyg" role="1OLpdg">
+                    <node concept="1OC9wW" id="2xPWNWppPyh" role="2dSRqD">
                       <property role="1OCb_u" value="a" />
                     </node>
                   </node>
@@ -25434,22 +25435,22 @@
         <node concept="_ixoA" id="45$ooctvi8N" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctvi8X" role="_iOnC">
           <property role="TrG5h" value="negativeLookbehind" />
-          <node concept="30bdrU" id="45$ooctvi8Y" role="1WbbD4">
-            <node concept="1OJ37Q" id="45$ooctvi8Z" role="1_tvlM">
-              <node concept="1OCmVF" id="45$ooctvi90" role="1OLqdY">
-                <node concept="1T2EwR" id="45$ooctvi91" role="1OLDsb" />
+          <node concept="L5Cqj" id="2xPWNWppPyi" role="1WbbD4">
+            <node concept="1OJ37Q" id="2xPWNWppPyj" role="1_tvlM">
+              <node concept="1OCmVF" id="2xPWNWppPyk" role="1OLqdY">
+                <node concept="1T2EwR" id="2xPWNWppPyl" role="1OLDsb" />
               </node>
-              <node concept="1OJ37Q" id="45$ooctvi92" role="1OLpdg">
-                <node concept="1OCmVF" id="45$ooctvi93" role="1OLpdg">
-                  <node concept="1T2EwR" id="45$ooctvi94" role="1OLDsb" />
+              <node concept="1OJ37Q" id="2xPWNWppPym" role="1OLpdg">
+                <node concept="1OCmVF" id="2xPWNWppPyn" role="1OLpdg">
+                  <node concept="1T2EwR" id="2xPWNWppPyo" role="1OLDsb" />
                 </node>
-                <node concept="1OJ37Q" id="45$ooctviM8" role="1OLqdY">
-                  <node concept="2dTIbB" id="45$ooctviUH" role="1OLpdg">
-                    <node concept="1OC9wW" id="45$ooctvj4D" role="2dSRqD">
+                <node concept="1OJ37Q" id="2xPWNWppPyp" role="1OLqdY">
+                  <node concept="2dTIbB" id="2xPWNWppPyq" role="1OLpdg">
+                    <node concept="1OC9wW" id="2xPWNWppPyr" role="2dSRqD">
                       <property role="1OCb_u" value="a" />
                     </node>
                   </node>
-                  <node concept="1OC9wW" id="45$ooctvi96" role="1OLqdY">
+                  <node concept="1OC9wW" id="2xPWNWppPys" role="1OLqdY">
                     <property role="1OCb_u" value="b" />
                   </node>
                 </node>
@@ -25490,26 +25491,26 @@
         <node concept="_ixoA" id="45$ooctvi8S" role="_iOnC" />
         <node concept="1WbbD7" id="45$ooctvlmu" role="_iOnC">
           <property role="TrG5h" value="independentNonCapturingGroup" />
-          <node concept="30bdrU" id="45$ooctvlmv" role="1WbbD4">
-            <node concept="1OJ37Q" id="45$ooctvlmw" role="1_tvlM">
-              <node concept="1OCmVF" id="45$ooctvlmx" role="1OLqdY">
-                <node concept="1T2EwR" id="45$ooctvlmy" role="1OLDsb" />
+          <node concept="L5Cqj" id="2xPWNWppPyt" role="1WbbD4">
+            <node concept="1OJ37Q" id="2xPWNWppPyu" role="1_tvlM">
+              <node concept="1OCmVF" id="2xPWNWppPyv" role="1OLqdY">
+                <node concept="1T2EwR" id="2xPWNWppPyw" role="1OLDsb" />
               </node>
-              <node concept="1OJ37Q" id="45$ooctvmrf" role="1OLpdg">
-                <node concept="1OJ37Q" id="45$ooctvyL3" role="1OLqdY">
-                  <node concept="1OC9wW" id="45$ooctvyLc" role="1OLqdY">
+              <node concept="1OJ37Q" id="2xPWNWppPyx" role="1OLpdg">
+                <node concept="1OJ37Q" id="2xPWNWppPyy" role="1OLqdY">
+                  <node concept="1OC9wW" id="2xPWNWppPyz" role="1OLqdY">
                     <property role="1OCb_u" value="b" />
                   </node>
-                  <node concept="1OClNT" id="45$ooctvCkW" role="1OLpdg">
-                    <node concept="1s6jiO" id="45$ooctvyyc" role="1OLDsb">
-                      <node concept="1OC9wW" id="45$ooctvyDC" role="2dSRqD">
+                  <node concept="1OClNT" id="2xPWNWppPy$" role="1OLpdg">
+                    <node concept="1s6jiO" id="2xPWNWppPy_" role="1OLDsb">
+                      <node concept="1OC9wW" id="2xPWNWppPyA" role="2dSRqD">
                         <property role="1OCb_u" value="a" />
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="1OCmVF" id="45$ooctvCRz" role="1OLpdg">
-                  <node concept="1T2EwR" id="45$ooctvCR_" role="1OLDsb" />
+                <node concept="1OCmVF" id="2xPWNWppPyB" role="1OLpdg">
+                  <node concept="1T2EwR" id="2xPWNWppPyC" role="1OLDsb" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -18,6 +18,8 @@
     <use id="e776175c-3bf6-498e-ad36-e4c7dfa5fbe9" name="com.mbeddr.mpsutil.httpsupport" version="0" />
     <use id="817e4e70-961e-4a95-98a1-15e9f32231f1" name="jetbrains.mps.ide.httpsupport" version="0" />
     <use id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base" version="6" />
+    <use id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil" version="3" />
+    <use id="daafa647-f1f7-4b0b-b096-69cd7c8408c0" name="jetbrains.mps.baseLanguage.regexp" version="0" />
     <devkit ref="c4e521ab-b605-4ef9-a7c3-68075da058f0(org.iets3.core.expr.core.devkit)" />
   </languages>
   <imports>
@@ -37,10 +39,13 @@
     <import index="bg10" ref="r:a71eb8ca-1a88-4b3c-85ef-63f23e5a12e0(org.iets3.core.expr.mutable.typesystem)" />
     <import index="iyw" ref="r:3b5d2a4d-f539-4854-bc25-c43da4b5202c(org.iets3.core.expr.lambda.typesystem)" />
     <import index="n0yb" ref="r:1fd78142-d7d8-42c9-9cbb-0609b1bc5311(org.iets3.core.expr.collections.typesystem)" />
+    <import index="ym7l" ref="r:050f6d52-a81b-4b31-9a1c-531c1a04708e(org.iets3.core.expr.simpleTypes.typesystem)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
     <import index="xlxw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.math(JDK/)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
+    <import index="tpfp" ref="r:00000000-0000-4000-0000-011c89590519(jetbrains.mps.baseLanguage.regexp.jetbrains.mps.regexp.accessory)" implicit="true" />
+    <import index="ji8m" ref="r:1e7c5960-15a6-42cc-930a-1c74551c2ace(com.mbeddr.mpsutil.blutil.accessory)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -232,6 +237,26 @@
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="63e0e566-5131-447e-90e3-12ea330e1a00" name="com.mbeddr.mpsutil.blutil">
+      <concept id="5911591654125800684" name="com.mbeddr.mpsutil.blutil.structure.HexadecimalRegex" flags="ng" index="2bnNQ_">
+        <property id="5911591654125800685" name="value" index="2bnNQ$" />
+      </concept>
+      <concept id="5911591654126591629" name="com.mbeddr.mpsutil.blutil.structure.ControlCharacterRegex" flags="ng" index="2bqMZ4">
+        <property id="5911591654126591630" name="value" index="2bqMZ7" />
+      </concept>
+      <concept id="9004320021019116238" name="com.mbeddr.mpsutil.blutil.structure.UnicodeByNameRegex" flags="ng" index="1kfouk">
+        <property id="9004320021019116239" name="name" index="1kfoul" />
+      </concept>
+      <concept id="4711998325899141206" name="com.mbeddr.mpsutil.blutil.structure.NamedBackReferenceRegexp" flags="ng" index="1s447l">
+        <reference id="4711998325899141211" name="group" index="1s447o" />
+      </concept>
+      <concept id="4711998325899744567" name="com.mbeddr.mpsutil.blutil.structure.IndependentNonCapturingGroup" flags="ng" index="1s6jiO" />
+      <concept id="4711998325897280822" name="com.mbeddr.mpsutil.blutil.structure.BackReferenceRegexp" flags="ng" index="1scXMP">
+        <property id="4711998325897280825" name="index" index="1scXMU" />
+      </concept>
+      <concept id="4735327607202953643" name="com.mbeddr.mpsutil.blutil.structure.NamedGroupRegexp" flags="ng" index="3NQvFP" />
+      <concept id="1174491169200" name="com.mbeddr.mpsutil.blutil.structure.GroupRegexp" flags="ng" index="1P8g2x" />
     </language>
     <language id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base">
       <concept id="7831630342157089621" name="org.iets3.core.base.structure.IDetectNeedToRunManually" flags="ngI" index="0Rz4o">
@@ -469,7 +494,9 @@
       <concept id="5115872837157252552" name="org.iets3.core.expr.simpleTypes.structure.StringLiteral" flags="ng" index="30bdrP">
         <property id="5115872837157252555" name="value" index="30bdrQ" />
       </concept>
-      <concept id="5115872837157252551" name="org.iets3.core.expr.simpleTypes.structure.StringType" flags="ng" index="30bdrU" />
+      <concept id="5115872837157252551" name="org.iets3.core.expr.simpleTypes.structure.StringType" flags="ng" index="30bdrU">
+        <child id="8919433883485586606" name="constraint" index="1_tvlM" />
+      </concept>
       <concept id="5115872837157054284" name="org.iets3.core.expr.simpleTypes.structure.RealType" flags="ng" index="30bXLL" />
       <concept id="5115872837157054169" name="org.iets3.core.expr.simpleTypes.structure.IntegerType" flags="ng" index="30bXR$" />
       <concept id="5115872837157054170" name="org.iets3.core.expr.simpleTypes.structure.NumberLiteral" flags="ng" index="30bXRB">
@@ -743,6 +770,81 @@
       </concept>
       <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
         <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
+      </concept>
+    </language>
+    <language id="daafa647-f1f7-4b0b-b096-69cd7c8408c0" name="jetbrains.mps.baseLanguage.regexp">
+      <concept id="1174904166999" name="jetbrains.mps.baseLanguage.regexp.structure.NTimesRegexp" flags="ng" index="2dJHH6">
+        <property id="1174904184877" name="n" index="2dJM4W" />
+      </concept>
+      <concept id="1174904442594" name="jetbrains.mps.baseLanguage.regexp.structure.AtLeastNTimesRegexp" flags="ng" index="2dKKZN">
+        <property id="1174904477749" name="n" index="2dKT$$" />
+      </concept>
+      <concept id="1174904605806" name="jetbrains.mps.baseLanguage.regexp.structure.FromNToMTimesRegexp" flags="ng" index="2dLoPZ">
+        <property id="1174904618869" name="n" index="2dLrT$" />
+        <property id="1174904621683" name="m" index="2dLsHy" />
+      </concept>
+      <concept id="1174906321267" name="jetbrains.mps.baseLanguage.regexp.structure.PositiveLookAheadRegexp" flags="ng" index="2dRVxy" />
+      <concept id="1174906468661" name="jetbrains.mps.baseLanguage.regexp.structure.NegativeLookAheadRegexp" flags="ng" index="2dSvw$" />
+      <concept id="1174906544517" name="jetbrains.mps.baseLanguage.regexp.structure.LookRegexp" flags="ng" index="2dSM2k">
+        <child id="1174906566584" name="regexp" index="2dSRqD" />
+      </concept>
+      <concept id="1174906762287" name="jetbrains.mps.baseLanguage.regexp.structure.PositiveLookBehindRegexp" flags="ng" index="2dTBkY" />
+      <concept id="1174906790902" name="jetbrains.mps.baseLanguage.regexp.structure.NegativeLookBehindRegexp" flags="ng" index="2dTIbB" />
+      <concept id="1220021842985" name="jetbrains.mps.baseLanguage.regexp.structure.IntersectionSymbolClassPart" flags="ng" index="eXZkP">
+        <child id="1220356007276" name="right" index="ySIhK" />
+        <child id="1220356033934" name="left" index="ySOMi" />
+      </concept>
+      <concept id="1175161264766" name="jetbrains.mps.baseLanguage.regexp.structure.LineStartRegexp" flags="ng" index="2t4tHJ" />
+      <concept id="1175161300324" name="jetbrains.mps.baseLanguage.regexp.structure.LineEndRegexp" flags="ng" index="2t4AhP" />
+      <concept id="1203415418648" name="jetbrains.mps.baseLanguage.regexp.structure.UnicodeCharacterRegexp" flags="ng" index="L9wo0">
+        <property id="1203415499835" name="code" index="L9Okz" />
+      </concept>
+      <concept id="1174482753837" name="jetbrains.mps.baseLanguage.regexp.structure.StringLiteralRegexp" flags="ng" index="1OC9wW">
+        <property id="1174482761807" name="text" index="1OCb_u" />
+      </concept>
+      <concept id="1174482769792" name="jetbrains.mps.baseLanguage.regexp.structure.OrRegexp" flags="ng" index="1OCdqh" />
+      <concept id="1174482804200" name="jetbrains.mps.baseLanguage.regexp.structure.PlusRegexp" flags="ng" index="1OClNT" />
+      <concept id="1174482808826" name="jetbrains.mps.baseLanguage.regexp.structure.StarRegexp" flags="ng" index="1OCmVF" />
+      <concept id="1174483125581" name="jetbrains.mps.baseLanguage.regexp.structure.RegexpDeclaration" flags="ng" index="1OD$hs">
+        <property id="1174662978120" name="description" index="1ZnDHp" />
+        <child id="1174483133849" name="regexp" index="1ODAi8" />
+      </concept>
+      <concept id="1174484562151" name="jetbrains.mps.baseLanguage.regexp.structure.SeqRegexp" flags="ng" index="1OJ37Q" />
+      <concept id="1174485167097" name="jetbrains.mps.baseLanguage.regexp.structure.BinaryRegexp" flags="ng" index="1OLmFC">
+        <child id="1174485176897" name="left" index="1OLpdg" />
+        <child id="1174485181039" name="right" index="1OLqdY" />
+      </concept>
+      <concept id="1174485235885" name="jetbrains.mps.baseLanguage.regexp.structure.UnaryRegexp" flags="ng" index="1OLBAW">
+        <child id="1174485243418" name="regexp" index="1OLDsb" />
+      </concept>
+      <concept id="1174491169200" name="jetbrains.mps.baseLanguage.regexp.structure.ParensRegexp" flags="ng" index="1P8g2y">
+        <child id="1174491174779" name="expr" index="1P8hpE" />
+      </concept>
+      <concept id="1174552240608" name="jetbrains.mps.baseLanguage.regexp.structure.QuestionRegexp" flags="ng" index="1SLe3L" />
+      <concept id="1174554186090" name="jetbrains.mps.baseLanguage.regexp.structure.SymbolClassRegexp" flags="ng" index="1SSD1V">
+        <child id="1174557628217" name="part" index="1T5LoC" />
+      </concept>
+      <concept id="1174554211468" name="jetbrains.mps.baseLanguage.regexp.structure.PositiveSymbolClassRegexp" flags="ng" index="1SSJmt" />
+      <concept id="1174554238051" name="jetbrains.mps.baseLanguage.regexp.structure.NegativeSymbolClassRegexp" flags="ng" index="1SSPPM" />
+      <concept id="1174555732504" name="jetbrains.mps.baseLanguage.regexp.structure.PredefinedSymbolClassRegexp" flags="ng" index="1SYyG9">
+        <reference id="1174555843709" name="symbolClass" index="1SYXPG" />
+      </concept>
+      <concept id="1174556813606" name="jetbrains.mps.baseLanguage.regexp.structure.DotRegexp" flags="ng" index="1T2EwR" />
+      <concept id="1174557878319" name="jetbrains.mps.baseLanguage.regexp.structure.CharacterSymbolClassPart" flags="ng" index="1T6I$Y">
+        <property id="1174557887320" name="character" index="1T6KD9" />
+      </concept>
+      <concept id="1174558301835" name="jetbrains.mps.baseLanguage.regexp.structure.IntervalSymbolClassPart" flags="ng" index="1T8lYq">
+        <property id="1174558315290" name="start" index="1T8p8b" />
+        <property id="1174558317822" name="end" index="1T8pRJ" />
+      </concept>
+      <concept id="1174660461415" name="jetbrains.mps.baseLanguage.regexp.structure.LazyStarRegexp" flags="ng" index="1Ze39Q" />
+      <concept id="1174660505718" name="jetbrains.mps.baseLanguage.regexp.structure.LazyPlusRegexp" flags="ng" index="1Zee5B" />
+      <concept id="1174660533095" name="jetbrains.mps.baseLanguage.regexp.structure.LazyQuestionRegexp" flags="ng" index="1ZekDQ" />
+      <concept id="1174662351725" name="jetbrains.mps.baseLanguage.regexp.structure.Regexps" flags="ng" index="1ZlgDW">
+        <child id="1174662369010" name="regexp" index="1ZlkZz" />
+      </concept>
+      <concept id="1174662605354" name="jetbrains.mps.baseLanguage.regexp.structure.RegexpDeclarationReferenceRegexp" flags="ng" index="1ZmeGV">
+        <reference id="1174662628918" name="regexp" index="1ZmksB" />
       </concept>
     </language>
     <language id="b25b8ad1-4d3d-4e45-8c78-72091b39fdda" name="org.iets3.core.expr.data">
@@ -22429,6 +22531,3032 @@
           </node>
         </node>
         <node concept="_ixoA" id="5a86BD1gwrz" role="_iOnC" />
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="3OxSopfZQZs">
+    <property role="TrG5h" value="stringConstraintsTests" />
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <node concept="1qefOq" id="3OxSopfZQZt" role="1SKRRt">
+      <node concept="_iOnV" id="3OxSopfZQZu" role="1qenE9">
+        <property role="TrG5h" value="stringConstraintsTests" />
+        <node concept="1WbbD7" id="3OxSopfZRqA" role="_iOnC">
+          <property role="TrG5h" value="x" />
+          <node concept="30bdrU" id="3OxSopfZRqK" role="1WbbD4">
+            <node concept="1OC9wW" id="3OxSopg2V1D" role="1_tvlM">
+              <property role="1OCb_u" value="x" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="3OxSopg2V29" role="_iOnC">
+          <property role="TrG5h" value="xValid" />
+          <node concept="30bdrP" id="3OxSopg2V2P" role="2zPyp_">
+            <property role="30bdrQ" value="x" />
+          </node>
+          <node concept="1WbbFT" id="3OxSopg2V2x" role="2zM23F">
+            <ref role="1WbbFS" node="3OxSopfZRqA" resolve="x" />
+          </node>
+          <node concept="7CXmI" id="3OxSopg2Vbf" role="lGtFl">
+            <node concept="7OXhh" id="3OxSopg2Vcp" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="3OxSopg2V33" role="_iOnC">
+          <property role="TrG5h" value="xInvalid" />
+          <node concept="30bdrP" id="3OxSopg2V4k" role="2zPyp_">
+            <property role="30bdrQ" value="y" />
+            <node concept="7CXmI" id="3OxSopg2V6D" role="lGtFl">
+              <node concept="1TM$A" id="3OxSopg2V8S" role="7EUXB">
+                <node concept="2PYRI3" id="3OxSopg2V8T" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="3OxSopg2V42" role="2zM23F">
+            <ref role="1WbbFS" node="3OxSopfZRqA" resolve="x" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="3OxSopg2Vdz" role="_iOnC" />
+        <node concept="2zPypq" id="46RgPUM6Vn8" role="_iOnC">
+          <property role="TrG5h" value="stringDirectly" />
+          <node concept="30bdrP" id="46RgPUM6Vn9" role="2zPyp_">
+            <property role="30bdrQ" value="x" />
+          </node>
+          <node concept="30bdrU" id="46RgPUM6VtD" role="2zM23F">
+            <node concept="1OC9wW" id="46RgPUM6Vxb" role="1_tvlM">
+              <property role="1OCb_u" value="x" />
+            </node>
+          </node>
+          <node concept="7CXmI" id="46RgPUM6Vnb" role="lGtFl">
+            <node concept="7OXhh" id="46RgPUM6Vnc" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="46RgPUM6Vn3" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctvHpy" role="_iOnC">
+          <property role="TrG5h" value="existingRegexp" />
+          <node concept="30bdrU" id="45$ooctvHpz" role="1WbbD4">
+            <node concept="1OJ37Q" id="45$ooctvHwW" role="1_tvlM">
+              <node concept="1OC9wW" id="45$ooctvHzs" role="1OLqdY">
+                <property role="1OCb_u" value="world" />
+              </node>
+              <node concept="1OJ37Q" id="45$ooctvH_U" role="1OLpdg">
+                <node concept="1SYyG9" id="45$ooctvHEa" role="1OLqdY">
+                  <ref role="1SYXPG" to="tpfp:h5SUD2M" resolve="\s" />
+                </node>
+                <node concept="1ZmeGV" id="45$ooctvHvH" role="1OLpdg">
+                  <ref role="1ZmksB" node="45$ooctvHpr" resolve="hello" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctvHp_" role="_iOnC">
+          <property role="TrG5h" value="existingRegexpValid" />
+          <node concept="30bdrP" id="45$ooctvHpA" role="2zPyp_">
+            <property role="30bdrQ" value="hello world" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctvHpB" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctvHpy" resolve="existingRegexp" />
+          </node>
+          <node concept="7CXmI" id="45$ooctvHpC" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctvHpD" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctvHpE" role="_iOnC">
+          <property role="TrG5h" value="existingRegexpInvalid" />
+          <node concept="30bdrP" id="45$ooctvHpF" role="2zPyp_">
+            <property role="30bdrQ" value="hi world" />
+            <node concept="7CXmI" id="45$ooctvHpG" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctvHpH" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctvHpI" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctvHpJ" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctvHpy" resolve="existingRegexp" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctvHpu" role="_iOnC" />
+        <node concept="1WbbD7" id="3OxSopg2Ve8" role="_iOnC">
+          <property role="TrG5h" value="slash" />
+          <node concept="30bdrU" id="3OxSopg2Ve9" role="1WbbD4">
+            <node concept="1OC9wW" id="3OxSopg36$d" role="1_tvlM">
+              <property role="1OCb_u" value="\\" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="3OxSopg2Veb" role="_iOnC">
+          <property role="TrG5h" value="slashValid" />
+          <node concept="30bdrP" id="3OxSopg2Vec" role="2zPyp_">
+            <property role="30bdrQ" value="\\" />
+          </node>
+          <node concept="1WbbFT" id="3OxSopg2Ved" role="2zM23F">
+            <ref role="1WbbFS" node="3OxSopg2Ve8" resolve="slash" />
+          </node>
+          <node concept="7CXmI" id="3OxSopg2Vee" role="lGtFl">
+            <node concept="7OXhh" id="3OxSopg2Vef" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="3OxSopg2Veg" role="_iOnC">
+          <property role="TrG5h" value="slashInvalid" />
+          <node concept="30bdrP" id="3OxSopg2Veh" role="2zPyp_">
+            <property role="30bdrQ" value="x" />
+            <node concept="7CXmI" id="3OxSopg2Vei" role="lGtFl">
+              <node concept="1TM$A" id="3OxSopg2Vej" role="7EUXB">
+                <node concept="2PYRI3" id="3OxSopg2Vek" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="3OxSopg2Vel" role="2zM23F">
+            <ref role="1WbbFS" node="3OxSopg2Ve8" resolve="slash" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="3OxSopfZR0f" role="_iOnC" />
+        <node concept="1WbbD7" id="58ackBplczB" role="_iOnC">
+          <property role="TrG5h" value="hexadecimal" />
+          <node concept="30bdrU" id="58ackBplczC" role="1WbbD4">
+            <node concept="2bnNQ_" id="58ackBpmOMJ" role="1_tvlM">
+              <property role="2bnNQ$" value="41" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="58ackBplczE" role="_iOnC">
+          <property role="TrG5h" value="hexadecimalValid" />
+          <node concept="30bdrP" id="58ackBplczF" role="2zPyp_">
+            <property role="30bdrQ" value="A" />
+          </node>
+          <node concept="1WbbFT" id="58ackBplczG" role="2zM23F">
+            <ref role="1WbbFS" node="58ackBplczB" resolve="hexadecimal" />
+          </node>
+          <node concept="7CXmI" id="58ackBplczH" role="lGtFl">
+            <node concept="7OXhh" id="58ackBplczI" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="58ackBplczJ" role="_iOnC">
+          <property role="TrG5h" value="hexadecimalInvalid" />
+          <node concept="30bdrP" id="58ackBplczK" role="2zPyp_">
+            <property role="30bdrQ" value="0" />
+            <node concept="7CXmI" id="58ackBplczL" role="lGtFl">
+              <node concept="1TM$A" id="58ackBplczM" role="7EUXB">
+                <node concept="2PYRI3" id="58ackBplczN" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="58ackBplczO" role="2zM23F">
+            <ref role="1WbbFS" node="58ackBplczB" resolve="hexadecimal" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="58ackBpocQ4" role="_iOnC" />
+        <node concept="1WbbD7" id="7NPLlCCLWR0" role="_iOnC">
+          <property role="TrG5h" value="unicode" />
+          <node concept="30bdrU" id="7NPLlCCLWR1" role="1WbbD4">
+            <node concept="L9wo0" id="7NPLlCCLWWp" role="1_tvlM">
+              <property role="L9Okz" value="2190" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCLWR3" role="_iOnC">
+          <property role="TrG5h" value="unicodeValid" />
+          <node concept="30bdrP" id="7NPLlCCLWR4" role="2zPyp_">
+            <property role="30bdrQ" value="←" />
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCLWR5" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCLWR0" resolve="unicode" />
+          </node>
+          <node concept="7CXmI" id="7NPLlCCLWR6" role="lGtFl">
+            <node concept="7OXhh" id="7NPLlCCLWR7" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCLWR8" role="_iOnC">
+          <property role="TrG5h" value="unicodeInvalid" />
+          <node concept="30bdrP" id="7NPLlCCLWR9" role="2zPyp_">
+            <property role="30bdrQ" value="0" />
+            <node concept="7CXmI" id="7NPLlCCLWRa" role="lGtFl">
+              <node concept="1TM$A" id="7NPLlCCLWRb" role="7EUXB">
+                <node concept="2PYRI3" id="7NPLlCCLWRc" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCLWRd" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCLWR0" resolve="unicode" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="7NPLlCCM0GA" role="_iOnC" />
+        <node concept="1WbbD7" id="7NPLlCCM0GE" role="_iOnC">
+          <property role="TrG5h" value="unicodeByName" />
+          <node concept="30bdrU" id="7NPLlCCM0GF" role="1WbbD4">
+            <node concept="1kfouk" id="45$ooctgk09" role="1_tvlM">
+              <property role="1kfoul" value="WHITE SMILING FACE" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCM0GH" role="_iOnC">
+          <property role="TrG5h" value="unicodeByNameValid" />
+          <node concept="30bdrP" id="7NPLlCCM0GI" role="2zPyp_">
+            <property role="30bdrQ" value="☺" />
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCM0GJ" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCM0GE" resolve="unicodeByName" />
+          </node>
+          <node concept="7CXmI" id="7NPLlCCM0GK" role="lGtFl">
+            <node concept="7OXhh" id="7NPLlCCM0GL" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCM0GM" role="_iOnC">
+          <property role="TrG5h" value="unicodeByNameInvalid" />
+          <node concept="30bdrP" id="7NPLlCCM0GN" role="2zPyp_">
+            <property role="30bdrQ" value="😎" />
+            <node concept="7CXmI" id="7NPLlCCM0GO" role="lGtFl">
+              <node concept="1TM$A" id="7NPLlCCM0GP" role="7EUXB">
+                <node concept="2PYRI3" id="7NPLlCCM0GQ" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCM0GR" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCM0GE" resolve="unicodeByName" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="7NPLlCCLWQY" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctjR98" role="_iOnC">
+          <property role="TrG5h" value="controlCharacter" />
+          <node concept="30bdrU" id="45$ooctjR99" role="1WbbD4">
+            <node concept="2bqMZ4" id="45$ooctjRcE" role="1_tvlM">
+              <property role="2bqMZ7" value="M" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctjR9b" role="_iOnC">
+          <property role="TrG5h" value="controlCharacterValid" />
+          <node concept="1WbbFT" id="45$ooctjR9d" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctjR98" resolve="controlCharacter" />
+          </node>
+          <node concept="7CXmI" id="45$ooctjR9e" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctjR9f" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+          <node concept="30bdrP" id="45$ooctjRoE" role="2zPyp_">
+            <property role="30bdrQ" value="&#13;" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctjR9g" role="_iOnC">
+          <property role="TrG5h" value="controlCharacterInvalid" />
+          <node concept="30bdrP" id="45$ooctjR9h" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="45$ooctjR9i" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctjR9j" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctjR9k" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctjR9l" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctjR98" resolve="controlCharacter" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctjR96" role="_iOnC" />
+        <node concept="1WbbD7" id="58ackBpocQc" role="_iOnC">
+          <property role="TrG5h" value="tab" />
+          <node concept="30bdrU" id="58ackBpocQd" role="1WbbD4">
+            <node concept="1SYyG9" id="58ackBpocTK" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:horMtjF" resolve="\t" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="58ackBpocQf" role="_iOnC">
+          <property role="TrG5h" value="tabValid" />
+          <node concept="30bdrP" id="58ackBpocQg" role="2zPyp_">
+            <property role="30bdrQ" value="&#9;" />
+          </node>
+          <node concept="1WbbFT" id="58ackBpocQh" role="2zM23F">
+            <ref role="1WbbFS" node="58ackBpocQc" resolve="tab" />
+          </node>
+          <node concept="7CXmI" id="58ackBpocQi" role="lGtFl">
+            <node concept="7OXhh" id="58ackBpocQj" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="58ackBpocQk" role="_iOnC">
+          <property role="TrG5h" value="tabInvalid" />
+          <node concept="30bdrP" id="58ackBpocQl" role="2zPyp_">
+            <property role="30bdrQ" value="\s" />
+            <node concept="7CXmI" id="58ackBpocQm" role="lGtFl">
+              <node concept="1TM$A" id="58ackBpocQn" role="7EUXB">
+                <node concept="2PYRI3" id="58ackBpocQo" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="58ackBpocQp" role="2zM23F">
+            <ref role="1WbbFS" node="58ackBpocQc" resolve="tab" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="58ackBpoddp" role="_iOnC" />
+        <node concept="1WbbD7" id="58ackBpoddx" role="_iOnC">
+          <property role="TrG5h" value="newline" />
+          <node concept="30bdrU" id="58ackBpoddy" role="1WbbD4">
+            <node concept="1SYyG9" id="58ackBpoddz" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:horMmBM" resolve="\n" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="58ackBpodd$" role="_iOnC">
+          <property role="TrG5h" value="newlineValid" />
+          <node concept="30bdrP" id="58ackBpodd_" role="2zPyp_">
+            <property role="30bdrQ" value="&#10;" />
+          </node>
+          <node concept="1WbbFT" id="58ackBpoddA" role="2zM23F">
+            <ref role="1WbbFS" node="58ackBpoddx" resolve="newline" />
+          </node>
+          <node concept="7CXmI" id="58ackBpoddB" role="lGtFl">
+            <node concept="7OXhh" id="58ackBpoddC" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="58ackBpoddD" role="_iOnC">
+          <property role="TrG5h" value="newlineInvalid" />
+          <node concept="30bdrP" id="58ackBpoddE" role="2zPyp_">
+            <property role="30bdrQ" value="\r" />
+            <node concept="7CXmI" id="58ackBpoddF" role="lGtFl">
+              <node concept="1TM$A" id="58ackBpoddG" role="7EUXB">
+                <node concept="2PYRI3" id="58ackBpoddH" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="58ackBpoddI" role="2zM23F">
+            <ref role="1WbbFS" node="58ackBpoddx" resolve="newline" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="58ackBpodqM" role="_iOnC" />
+        <node concept="1WbbD7" id="58ackBpodps" role="_iOnC">
+          <property role="TrG5h" value="carriageReturn" />
+          <node concept="30bdrU" id="58ackBpodpt" role="1WbbD4">
+            <node concept="1SYyG9" id="58ackBpodpu" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:horMquy" resolve="\r" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="58ackBpodpv" role="_iOnC">
+          <property role="TrG5h" value="carriageReturnValid" />
+          <node concept="30bdrP" id="58ackBpodpw" role="2zPyp_">
+            <property role="30bdrQ" value="&#13;" />
+          </node>
+          <node concept="1WbbFT" id="58ackBpodpx" role="2zM23F">
+            <ref role="1WbbFS" node="58ackBpodps" resolve="carriageReturn" />
+          </node>
+          <node concept="7CXmI" id="58ackBpodpy" role="lGtFl">
+            <node concept="7OXhh" id="58ackBpodpz" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="58ackBpodp$" role="_iOnC">
+          <property role="TrG5h" value="carriageReturnInvalid" />
+          <node concept="30bdrP" id="58ackBpodp_" role="2zPyp_">
+            <property role="30bdrQ" value="\n" />
+            <node concept="7CXmI" id="58ackBpodpA" role="lGtFl">
+              <node concept="1TM$A" id="58ackBpodpB" role="7EUXB">
+                <node concept="2PYRI3" id="58ackBpodpC" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="58ackBpodpD" role="2zM23F">
+            <ref role="1WbbFS" node="58ackBpodps" resolve="carriageReturn" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="7NPLlCCx09Q" role="_iOnC" />
+        <node concept="1WbbD7" id="7NPLlCCx09W" role="_iOnC">
+          <property role="TrG5h" value="characterClass" />
+          <node concept="30bdrU" id="7NPLlCCx09X" role="1WbbD4">
+            <node concept="1SSJmt" id="7NPLlCCx0eC" role="1_tvlM">
+              <node concept="1T6I$Y" id="7NPLlCCx0fS" role="1T5LoC">
+                <property role="1T6KD9" value="a" />
+              </node>
+              <node concept="1T6I$Y" id="7NPLlCCx0hM" role="1T5LoC">
+                <property role="1T6KD9" value="b" />
+              </node>
+              <node concept="1T6I$Y" id="7NPLlCCx0kk" role="1T5LoC">
+                <property role="1T6KD9" value="c" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCx09Z" role="_iOnC">
+          <property role="TrG5h" value="characterClassValid" />
+          <node concept="30bdrP" id="7NPLlCCx0a0" role="2zPyp_">
+            <property role="30bdrQ" value="b" />
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCx0a1" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCx09W" resolve="characterClass" />
+          </node>
+          <node concept="7CXmI" id="7NPLlCCx0a2" role="lGtFl">
+            <node concept="7OXhh" id="7NPLlCCx0a3" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCx0a4" role="_iOnC">
+          <property role="TrG5h" value="characterClassInvalid" />
+          <node concept="30bdrP" id="7NPLlCCx0a5" role="2zPyp_">
+            <property role="30bdrQ" value="d" />
+            <node concept="7CXmI" id="7NPLlCCx0a6" role="lGtFl">
+              <node concept="1TM$A" id="7NPLlCCx0a7" role="7EUXB">
+                <node concept="2PYRI3" id="7NPLlCCx0a8" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCx0a9" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCx09W" resolve="characterClass" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="7NPLlCCx09T" role="_iOnC" />
+        <node concept="1WbbD7" id="7NPLlCCx2CM" role="_iOnC">
+          <property role="TrG5h" value="exceptcharacterClass" />
+          <node concept="30bdrU" id="7NPLlCCx2CN" role="1WbbD4">
+            <node concept="1SSPPM" id="7NPLlCCx3fv" role="1_tvlM">
+              <node concept="1T6I$Y" id="7NPLlCCx3gJ" role="1T5LoC">
+                <property role="1T6KD9" value="a" />
+              </node>
+              <node concept="1T6I$Y" id="7NPLlCCx3gP" role="1T5LoC">
+                <property role="1T6KD9" value="b" />
+              </node>
+              <node concept="1T6I$Y" id="7NPLlCCx3gV" role="1T5LoC">
+                <property role="1T6KD9" value="c" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCx2CS" role="_iOnC">
+          <property role="TrG5h" value="exceptCharacterClassValid" />
+          <node concept="30bdrP" id="7NPLlCCx2CT" role="2zPyp_">
+            <property role="30bdrQ" value="d" />
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCx2CU" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCx2CM" resolve="exceptcharacterClass" />
+          </node>
+          <node concept="7CXmI" id="7NPLlCCx2CV" role="lGtFl">
+            <node concept="7OXhh" id="7NPLlCCx2CW" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCx2CX" role="_iOnC">
+          <property role="TrG5h" value="exceptCharacterClassInvalid" />
+          <node concept="30bdrP" id="7NPLlCCx2CY" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="7NPLlCCx2CZ" role="lGtFl">
+              <node concept="1TM$A" id="7NPLlCCx2D0" role="7EUXB">
+                <node concept="2PYRI3" id="7NPLlCCx2D1" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCx2D2" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCx2CM" resolve="exceptcharacterClass" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="58ackBppQ$y" role="_iOnC" />
+        <node concept="1WbbD7" id="7NPLlCCx5J9" role="_iOnC">
+          <property role="TrG5h" value="range" />
+          <node concept="30bdrU" id="7NPLlCCx5Ja" role="1WbbD4">
+            <node concept="1SSJmt" id="7NPLlCCx6Dt" role="1_tvlM">
+              <node concept="1T8lYq" id="7NPLlCCx6EL" role="1T5LoC">
+                <property role="1T8p8b" value="a" />
+                <property role="1T8pRJ" value="z" />
+              </node>
+              <node concept="1T8lYq" id="7NPLlCCx6KZ" role="1T5LoC">
+                <property role="1T8p8b" value="A" />
+                <property role="1T8pRJ" value="Z" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCx5Jf" role="_iOnC">
+          <property role="TrG5h" value="rangeValid" />
+          <node concept="30bdrP" id="7NPLlCCx5Jg" role="2zPyp_">
+            <property role="30bdrQ" value="Z" />
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCx5Jh" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCx5J9" resolve="range" />
+          </node>
+          <node concept="7CXmI" id="7NPLlCCx5Ji" role="lGtFl">
+            <node concept="7OXhh" id="7NPLlCCx5Jj" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCx5Jk" role="_iOnC">
+          <property role="TrG5h" value="rangeInvalid" />
+          <node concept="30bdrP" id="7NPLlCCx5Jl" role="2zPyp_">
+            <property role="30bdrQ" value="¿" />
+            <node concept="7CXmI" id="7NPLlCCx5Jm" role="lGtFl">
+              <node concept="1TM$A" id="7NPLlCCx5Jn" role="7EUXB">
+                <node concept="2PYRI3" id="7NPLlCCx5Jo" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCx5Jp" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCx5J9" resolve="range" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="7NPLlCCx6XM" role="_iOnC" />
+        <node concept="1WbbD7" id="7NPLlCCx7x_" role="_iOnC">
+          <property role="TrG5h" value="intersection" />
+          <node concept="30bdrU" id="7NPLlCCx7xA" role="1WbbD4">
+            <node concept="1SSJmt" id="7NPLlCCx7xB" role="1_tvlM">
+              <node concept="eXZkP" id="7NPLlCCx7Db" role="1T5LoC">
+                <node concept="1T8lYq" id="7NPLlCCx7Ks" role="ySOMi">
+                  <property role="1T8p8b" value="a" />
+                  <property role="1T8pRJ" value="z" />
+                </node>
+                <node concept="1SSJmt" id="7NPLlCCx7RD" role="ySIhK">
+                  <node concept="1T6I$Y" id="7NPLlCCx7RG" role="1T5LoC">
+                    <property role="1T6KD9" value="d" />
+                  </node>
+                  <node concept="1T6I$Y" id="7NPLlCCx7Ws" role="1T5LoC">
+                    <property role="1T6KD9" value="e" />
+                  </node>
+                  <node concept="1T6I$Y" id="7NPLlCCx7Ww" role="1T5LoC">
+                    <property role="1T6KD9" value="f" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCx7xE" role="_iOnC">
+          <property role="TrG5h" value="intersectionValid" />
+          <node concept="30bdrP" id="7NPLlCCx7xF" role="2zPyp_">
+            <property role="30bdrQ" value="e" />
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCx7xG" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCx7x_" resolve="intersection" />
+          </node>
+          <node concept="7CXmI" id="7NPLlCCx7xH" role="lGtFl">
+            <node concept="7OXhh" id="7NPLlCCx7xI" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCx7xJ" role="_iOnC">
+          <property role="TrG5h" value="intersectionInvalid" />
+          <node concept="30bdrP" id="7NPLlCCx7xK" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="7NPLlCCx7xL" role="lGtFl">
+              <node concept="1TM$A" id="7NPLlCCx7xM" role="7EUXB">
+                <node concept="2PYRI3" id="7NPLlCCx7xN" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCx7xO" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCx7x_" resolve="intersection" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="7NPLlCCx7xz" role="_iOnC" />
+        <node concept="1WbbD7" id="7NPLlCCx8vg" role="_iOnC">
+          <property role="TrG5h" value="intersection2" />
+          <node concept="30bdrU" id="7NPLlCCx8vh" role="1WbbD4">
+            <node concept="1SSJmt" id="7NPLlCCx9Gy" role="1_tvlM">
+              <node concept="eXZkP" id="7NPLlCCx9HL" role="1T5LoC">
+                <node concept="1T8lYq" id="7NPLlCCx9Lu" role="ySOMi">
+                  <property role="1T8p8b" value="a" />
+                  <property role="1T8pRJ" value="z" />
+                </node>
+                <node concept="1SSPPM" id="7NPLlCCx9SD" role="ySIhK">
+                  <node concept="1T6I$Y" id="7NPLlCCx9Wg" role="1T5LoC">
+                    <property role="1T6KD9" value="b" />
+                  </node>
+                  <node concept="1T6I$Y" id="7NPLlCCxa10" role="1T5LoC">
+                    <property role="1T6KD9" value="c" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCx8vp" role="_iOnC">
+          <property role="TrG5h" value="intersection2Valid" />
+          <node concept="30bdrP" id="7NPLlCCx8vq" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCx8vr" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCx8vg" resolve="intersection2" />
+          </node>
+          <node concept="7CXmI" id="7NPLlCCx8vs" role="lGtFl">
+            <node concept="7OXhh" id="7NPLlCCx8vt" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCx8vu" role="_iOnC">
+          <property role="TrG5h" value="intersection2Invalid" />
+          <node concept="30bdrP" id="7NPLlCCx8vv" role="2zPyp_">
+            <property role="30bdrQ" value="b" />
+            <node concept="7CXmI" id="7NPLlCCx8vw" role="lGtFl">
+              <node concept="1TM$A" id="7NPLlCCx8vx" role="7EUXB">
+                <node concept="2PYRI3" id="7NPLlCCx8vy" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCx8vz" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCx8vg" resolve="intersection2" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="7NPLlCCx8ve" role="_iOnC" />
+        <node concept="1WbbD7" id="7NPLlCCx8Az" role="_iOnC">
+          <property role="TrG5h" value="intersection3" />
+          <node concept="30bdrU" id="7NPLlCCx8A$" role="1WbbD4">
+            <node concept="1SSJmt" id="7NPLlCCxaiu" role="1_tvlM">
+              <node concept="eXZkP" id="7NPLlCCxayI" role="1T5LoC">
+                <node concept="1SSPPM" id="7NPLlCCxaAn" role="ySIhK">
+                  <node concept="1T8lYq" id="7NPLlCCxaE3" role="1T5LoC">
+                    <property role="1T8p8b" value="m" />
+                    <property role="1T8pRJ" value="p" />
+                  </node>
+                </node>
+                <node concept="1T8lYq" id="7NPLlCCxaiw" role="ySOMi">
+                  <property role="1T8p8b" value="a" />
+                  <property role="1T8pRJ" value="z" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCx8AG" role="_iOnC">
+          <property role="TrG5h" value="intersection3Valid" />
+          <node concept="30bdrP" id="7NPLlCCx8AH" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCx8AI" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCx8Az" resolve="intersection3" />
+          </node>
+          <node concept="7CXmI" id="7NPLlCCx8AJ" role="lGtFl">
+            <node concept="7OXhh" id="7NPLlCCx8AK" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCx8AL" role="_iOnC">
+          <property role="TrG5h" value="intersection3Invalid" />
+          <node concept="30bdrP" id="7NPLlCCx8AM" role="2zPyp_">
+            <property role="30bdrQ" value="m" />
+            <node concept="7CXmI" id="7NPLlCCx8AN" role="lGtFl">
+              <node concept="1TM$A" id="7NPLlCCx8AO" role="7EUXB">
+                <node concept="2PYRI3" id="7NPLlCCx8AP" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCx8AQ" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCx8Az" resolve="intersection3" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="7NPLlCCxaSa" role="_iOnC" />
+        <node concept="1WbbD7" id="7NPLlCCxaSe" role="_iOnC">
+          <property role="TrG5h" value="any" />
+          <node concept="30bdrU" id="7NPLlCCxaSf" role="1WbbD4">
+            <node concept="1T2EwR" id="7NPLlCCxb5c" role="1_tvlM" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCxaSl" role="_iOnC">
+          <property role="TrG5h" value="anyValid" />
+          <node concept="30bdrP" id="7NPLlCCxaSm" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCxaSn" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCxaSe" resolve="any" />
+          </node>
+          <node concept="7CXmI" id="7NPLlCCxaSo" role="lGtFl">
+            <node concept="7OXhh" id="7NPLlCCxaSp" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="7NPLlCCxb9Z" role="_iOnC" />
+        <node concept="1WbbD7" id="7NPLlCCxba3" role="_iOnC">
+          <property role="TrG5h" value="digit" />
+          <node concept="30bdrU" id="7NPLlCCxba4" role="1WbbD4">
+            <node concept="1SYyG9" id="7NPLlCCxbh4" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SUwpi" resolve="\d" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCxba6" role="_iOnC">
+          <property role="TrG5h" value="digitValid" />
+          <node concept="30bdrP" id="7NPLlCCxba7" role="2zPyp_">
+            <property role="30bdrQ" value="1" />
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCxba8" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCxba3" resolve="digit" />
+          </node>
+          <node concept="7CXmI" id="7NPLlCCxba9" role="lGtFl">
+            <node concept="7OXhh" id="7NPLlCCxbaa" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7NPLlCCxbab" role="_iOnC">
+          <property role="TrG5h" value="digitInvalid" />
+          <node concept="30bdrP" id="7NPLlCCxbac" role="2zPyp_">
+            <property role="30bdrQ" value="A" />
+            <node concept="7CXmI" id="7NPLlCCxbad" role="lGtFl">
+              <node concept="1TM$A" id="7NPLlCCxbae" role="7EUXB">
+                <node concept="2PYRI3" id="7NPLlCCxbaf" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="7NPLlCCxbag" role="2zM23F">
+            <ref role="1WbbFS" node="7NPLlCCxba3" resolve="digit" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="7NPLlCCxba1" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctjVAf" role="_iOnC">
+          <property role="TrG5h" value="nonDigit" />
+          <node concept="30bdrU" id="45$ooctjVAg" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctjVAh" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SU_Du" resolve="\D" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctjVAi" role="_iOnC">
+          <property role="TrG5h" value="nonDigitValid" />
+          <node concept="30bdrP" id="45$ooctjVAj" role="2zPyp_">
+            <property role="30bdrQ" value="A" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctjVAk" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctjVAf" resolve="nonDigit" />
+          </node>
+          <node concept="7CXmI" id="45$ooctjVAl" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctjVAm" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctjVAn" role="_iOnC">
+          <property role="TrG5h" value="nonDigitInvalid" />
+          <node concept="30bdrP" id="45$ooctjVAo" role="2zPyp_">
+            <property role="30bdrQ" value="1" />
+            <node concept="7CXmI" id="45$ooctjVAp" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctjVAq" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctjVAr" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctjVAs" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctjVAf" resolve="nonDigit" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctjVAd" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctjVK7" role="_iOnC">
+          <property role="TrG5h" value="horizontalWhitespace" />
+          <node concept="30bdrU" id="45$ooctjVK8" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctjVK9" role="1_tvlM">
+              <ref role="1SYXPG" to="ji8m:45$ooctLm3v" resolve="\h" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctjVKa" role="_iOnC">
+          <property role="TrG5h" value="horizontalWhitespaceValid" />
+          <node concept="30bdrP" id="45$ooctjVKb" role="2zPyp_">
+            <property role="30bdrQ" value=" " />
+          </node>
+          <node concept="1WbbFT" id="45$ooctjVKc" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctjVK7" resolve="horizontalWhitespace" />
+          </node>
+          <node concept="7CXmI" id="45$ooctjVKd" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctjVKe" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctjVKf" role="_iOnC">
+          <property role="TrG5h" value="horizontalWhitespaceInvalid" />
+          <node concept="30bdrP" id="45$ooctjVKg" role="2zPyp_">
+            <property role="30bdrQ" value="no" />
+            <node concept="7CXmI" id="45$ooctjVKh" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctjVKi" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctjVKj" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctjVKk" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctjVK7" resolve="horizontalWhitespace" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctjVST" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctjVRu" role="_iOnC">
+          <property role="TrG5h" value="nonHorizontalWhitespace" />
+          <node concept="30bdrU" id="45$ooctjVRv" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctjVRw" role="1_tvlM">
+              <ref role="1SYXPG" to="ji8m:45$ooctLm3y" resolve="\H" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctjVRx" role="_iOnC">
+          <property role="TrG5h" value="nonHorizontalWhitespaceValid" />
+          <node concept="30bdrP" id="45$ooctjVRy" role="2zPyp_">
+            <property role="30bdrQ" value="n" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctjVRz" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctjVRu" resolve="nonHorizontalWhitespace" />
+          </node>
+          <node concept="7CXmI" id="45$ooctjVR$" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctjVR_" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctjVRA" role="_iOnC">
+          <property role="TrG5h" value="nonHorizontalWhitespaceInvalid" />
+          <node concept="30bdrP" id="45$ooctjVRB" role="2zPyp_">
+            <property role="30bdrQ" value=" " />
+            <node concept="7CXmI" id="45$ooctjVRC" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctjVRD" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctjVRE" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctjVRF" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctjVRu" resolve="nonHorizontalWhitespace" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctjVK5" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctjW05" role="_iOnC">
+          <property role="TrG5h" value="whitespace" />
+          <node concept="30bdrU" id="45$ooctjW06" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctjW07" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SUD2M" resolve="\s" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctjW08" role="_iOnC">
+          <property role="TrG5h" value="whitespaceValid" />
+          <node concept="30bdrP" id="45$ooctjW09" role="2zPyp_">
+            <property role="30bdrQ" value=" " />
+          </node>
+          <node concept="1WbbFT" id="45$ooctjW0a" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctjW05" resolve="whitespace" />
+          </node>
+          <node concept="7CXmI" id="45$ooctjW0b" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctjW0c" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctjW0d" role="_iOnC">
+          <property role="TrG5h" value="whitespaceInvalid" />
+          <node concept="30bdrP" id="45$ooctjW0e" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="45$ooctjW0f" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctjW0g" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctjW0h" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctjW0i" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctjW05" resolve="whitespace" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctjW03" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctjWb4" role="_iOnC">
+          <property role="TrG5h" value="nonwhitespace" />
+          <node concept="30bdrU" id="45$ooctjWb5" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctjWb6" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SUH0W" resolve="\S" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctjWb7" role="_iOnC">
+          <property role="TrG5h" value="nonwhitespaceValid" />
+          <node concept="30bdrP" id="45$ooctjWb8" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctjWb9" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctjWb4" resolve="nonwhitespace" />
+          </node>
+          <node concept="7CXmI" id="45$ooctjWba" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctjWbb" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctjWbc" role="_iOnC">
+          <property role="TrG5h" value="nonwhitespaceInvalid" />
+          <node concept="30bdrP" id="45$ooctjWbd" role="2zPyp_">
+            <property role="30bdrQ" value=" " />
+            <node concept="7CXmI" id="45$ooctjWbe" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctjWbf" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctjWbg" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctjWbh" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctjWb4" resolve="nonwhitespace" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctjWb2" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctjWne" role="_iOnC">
+          <property role="TrG5h" value="verticalWhitespace" />
+          <node concept="30bdrU" id="45$ooctjWnf" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctjWng" role="1_tvlM">
+              <ref role="1SYXPG" to="ji8m:45$ooctk4Lu" resolve="\v" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctjWnh" role="_iOnC">
+          <property role="TrG5h" value="verticalWhitespaceValid" />
+          <node concept="30bdrP" id="45$ooctjWni" role="2zPyp_">
+            <property role="30bdrQ" value="&#10;" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctjWnj" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctjWne" resolve="verticalWhitespace" />
+          </node>
+          <node concept="7CXmI" id="45$ooctjWnk" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctjWnl" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctjWnm" role="_iOnC">
+          <property role="TrG5h" value="verticalWhitespaceInvalid" />
+          <node concept="30bdrP" id="45$ooctjWnn" role="2zPyp_">
+            <property role="30bdrQ" value="no" />
+            <node concept="7CXmI" id="45$ooctjWno" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctjWnp" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctjWnq" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctjWnr" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctjWne" resolve="verticalWhitespace" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctjWns" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctjWnt" role="_iOnC">
+          <property role="TrG5h" value="nonVerticalWhitespace" />
+          <node concept="30bdrU" id="45$ooctjWnu" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctjWnv" role="1_tvlM">
+              <ref role="1SYXPG" to="ji8m:45$ooctk4Lx" resolve="\V" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctjWnw" role="_iOnC">
+          <property role="TrG5h" value="nonVerticalWhitespaceValid" />
+          <node concept="30bdrP" id="45$ooctjWnx" role="2zPyp_">
+            <property role="30bdrQ" value="n" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctjWny" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctjWnt" resolve="nonVerticalWhitespace" />
+          </node>
+          <node concept="7CXmI" id="45$ooctjWnz" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctjWn$" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctjWn_" role="_iOnC">
+          <property role="TrG5h" value="nonVerticalWhitespaceInvalid" />
+          <node concept="30bdrP" id="45$ooctjWnA" role="2zPyp_">
+            <property role="30bdrQ" value="&#10;" />
+            <node concept="7CXmI" id="45$ooctjWnB" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctjWnC" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctjWnD" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctjWnE" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctjWnt" resolve="nonVerticalWhitespace" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctk97k" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctk97o" role="_iOnC">
+          <property role="TrG5h" value="word" />
+          <node concept="30bdrU" id="45$ooctk97p" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctk97q" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SUJUw" resolve="\w" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctk97r" role="_iOnC">
+          <property role="TrG5h" value="wordValid" />
+          <node concept="30bdrP" id="45$ooctk97s" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctk97t" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctk97o" resolve="word" />
+          </node>
+          <node concept="7CXmI" id="45$ooctk97u" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctk97v" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctk97w" role="_iOnC">
+          <property role="TrG5h" value="wordInvalid" />
+          <node concept="30bdrP" id="45$ooctk97x" role="2zPyp_">
+            <property role="30bdrQ" value="$" />
+            <node concept="7CXmI" id="45$ooctk97y" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctk97z" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctk97$" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctk97_" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctk97o" resolve="word" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctk97m" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctk9im" role="_iOnC">
+          <property role="TrG5h" value="nonWord" />
+          <node concept="30bdrU" id="45$ooctk9in" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctk9io" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SUNgp" resolve="\W" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctk9ip" role="_iOnC">
+          <property role="TrG5h" value="nonWordValid" />
+          <node concept="30bdrP" id="45$ooctk9iq" role="2zPyp_">
+            <property role="30bdrQ" value="$" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctk9ir" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctk9im" resolve="nonWord" />
+          </node>
+          <node concept="7CXmI" id="45$ooctk9is" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctk9it" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctk9iu" role="_iOnC">
+          <property role="TrG5h" value="nonWordInvalid" />
+          <node concept="30bdrP" id="45$ooctk9iv" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="45$ooctk9iw" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctk9ix" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctk9iy" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctk9iz" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctk9im" resolve="nonWord" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctk9ik" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctk9tk" role="_iOnC">
+          <property role="TrG5h" value="lower" />
+          <node concept="30bdrU" id="45$ooctk9tl" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctk9BX" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SUPxr" resolve="\p{Lower}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctk9tn" role="_iOnC">
+          <property role="TrG5h" value="lowerValid" />
+          <node concept="30bdrP" id="45$ooctk9to" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctk9tp" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctk9tk" resolve="lower" />
+          </node>
+          <node concept="7CXmI" id="45$ooctk9tq" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctk9tr" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctk9ts" role="_iOnC">
+          <property role="TrG5h" value="lowerInvalid" />
+          <node concept="30bdrP" id="45$ooctk9tt" role="2zPyp_">
+            <property role="30bdrQ" value="A" />
+            <node concept="7CXmI" id="45$ooctk9tu" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctk9tv" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctk9tw" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctk9tx" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctk9tk" resolve="lower" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctk9ti" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctk9De" role="_iOnC">
+          <property role="TrG5h" value="upper" />
+          <node concept="30bdrU" id="45$ooctk9Df" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctk9Dg" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SUTG3" resolve="\p{Upper}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctk9Dh" role="_iOnC">
+          <property role="TrG5h" value="upperValid" />
+          <node concept="30bdrP" id="45$ooctk9Di" role="2zPyp_">
+            <property role="30bdrQ" value="A" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctk9Dj" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctk9De" resolve="upper" />
+          </node>
+          <node concept="7CXmI" id="45$ooctk9Dk" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctk9Dl" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctk9Dm" role="_iOnC">
+          <property role="TrG5h" value="upperInvalid" />
+          <node concept="30bdrP" id="45$ooctk9Dn" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="45$ooctk9Do" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctk9Dp" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctk9Dq" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctk9Dr" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctk9De" resolve="upper" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctk9LM" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctk9LQ" role="_iOnC">
+          <property role="TrG5h" value="ascii" />
+          <node concept="30bdrU" id="45$ooctk9LR" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctk9LS" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SUY37" resolve="\p{ASCII}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctk9LT" role="_iOnC">
+          <property role="TrG5h" value="asciiValid" />
+          <node concept="30bdrP" id="45$ooctk9LU" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctk9LV" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctk9LQ" resolve="ascii" />
+          </node>
+          <node concept="7CXmI" id="45$ooctk9LW" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctk9LX" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctk9LY" role="_iOnC">
+          <property role="TrG5h" value="asciiInvalid" />
+          <node concept="30bdrP" id="45$ooctk9LZ" role="2zPyp_">
+            <property role="30bdrQ" value="€" />
+            <node concept="7CXmI" id="45$ooctk9M0" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctk9M1" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctk9M2" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctk9M3" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctk9LQ" resolve="ascii" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctk9Dc" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctk9WP" role="_iOnC">
+          <property role="TrG5h" value="alphabetic" />
+          <node concept="30bdrU" id="45$ooctk9WQ" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctk9WR" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SV1SY" resolve="\p{Alpha}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctk9WS" role="_iOnC">
+          <property role="TrG5h" value="alphabeticValid" />
+          <node concept="30bdrP" id="45$ooctk9WT" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctk9WU" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctk9WP" resolve="alphabetic" />
+          </node>
+          <node concept="7CXmI" id="45$ooctk9WV" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctk9WW" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctk9WX" role="_iOnC">
+          <property role="TrG5h" value="alphabeticInvalid" />
+          <node concept="30bdrP" id="45$ooctk9WY" role="2zPyp_">
+            <property role="30bdrQ" value="1" />
+            <node concept="7CXmI" id="45$ooctk9WZ" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctk9X0" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctk9X1" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctk9X2" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctk9WP" resolve="alphabetic" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctk9WN" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctka4f" role="_iOnC">
+          <property role="TrG5h" value="decimalDigit" />
+          <node concept="30bdrU" id="45$ooctka4g" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctka4h" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SV6x8" resolve="\p{Digit}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctka4i" role="_iOnC">
+          <property role="TrG5h" value="decimalDigitValid" />
+          <node concept="30bdrP" id="45$ooctka4j" role="2zPyp_">
+            <property role="30bdrQ" value="1" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctka4k" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctka4f" resolve="decimalDigit" />
+          </node>
+          <node concept="7CXmI" id="45$ooctka4l" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctka4m" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctka4n" role="_iOnC">
+          <property role="TrG5h" value="decimalDigitInvalid" />
+          <node concept="30bdrP" id="45$ooctka4o" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="45$ooctka4p" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctka4q" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctka4r" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctka4s" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctka4f" resolve="decimalDigit" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkaiJ" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctkaiO" role="_iOnC">
+          <property role="TrG5h" value="alphanumeric" />
+          <node concept="30bdrU" id="45$ooctkaiP" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctkaiQ" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SVbIa" resolve="\p{Alnum}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkaiR" role="_iOnC">
+          <property role="TrG5h" value="alphanumericValid" />
+          <node concept="30bdrP" id="45$ooctkaiS" role="2zPyp_">
+            <property role="30bdrQ" value="1" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctkaiT" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkaiO" resolve="alphanumeric" />
+          </node>
+          <node concept="7CXmI" id="45$ooctkaiU" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctkaiV" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkaiW" role="_iOnC">
+          <property role="TrG5h" value="alphanumericInvalid" />
+          <node concept="30bdrP" id="45$ooctkaiX" role="2zPyp_">
+            <property role="30bdrQ" value="$" />
+            <node concept="7CXmI" id="45$ooctkaiY" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctkaiZ" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctkaj0" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctkaj1" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkaiO" resolve="alphanumeric" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkaiL" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctkatM" role="_iOnC">
+          <property role="TrG5h" value="punctuation" />
+          <node concept="30bdrU" id="45$ooctkatN" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctkatO" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SVgIf" resolve="\p{Punct}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkatP" role="_iOnC">
+          <property role="TrG5h" value="punctuationValid" />
+          <node concept="30bdrP" id="45$ooctkatQ" role="2zPyp_">
+            <property role="30bdrQ" value="." />
+          </node>
+          <node concept="1WbbFT" id="45$ooctkatR" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkatM" resolve="punctuation" />
+          </node>
+          <node concept="7CXmI" id="45$ooctkatS" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctkatT" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkatU" role="_iOnC">
+          <property role="TrG5h" value="punctuationInvalid" />
+          <node concept="30bdrP" id="45$ooctkatV" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="45$ooctkatW" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctkatX" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctkatY" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctkatZ" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkatM" resolve="punctuation" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkatK" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctkaB$" role="_iOnC">
+          <property role="TrG5h" value="visible" />
+          <node concept="30bdrU" id="45$ooctkaB_" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctkaBA" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SV_hV" resolve="\p{Graph}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkaBB" role="_iOnC">
+          <property role="TrG5h" value="visibleValid" />
+          <node concept="30bdrP" id="45$ooctkaBC" role="2zPyp_">
+            <property role="30bdrQ" value="." />
+          </node>
+          <node concept="1WbbFT" id="45$ooctkaBD" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkaB$" resolve="visible" />
+          </node>
+          <node concept="7CXmI" id="45$ooctkaBE" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctkaBF" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkaBG" role="_iOnC">
+          <property role="TrG5h" value="visibleInvalid" />
+          <node concept="30bdrP" id="45$ooctkaBH" role="2zPyp_">
+            <property role="30bdrQ" value=" " />
+            <node concept="7CXmI" id="45$ooctkaBI" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctkaBJ" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctkaBK" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctkaBL" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkaB$" resolve="visible" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkaBy" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctkaOU" role="_iOnC">
+          <property role="TrG5h" value="printable" />
+          <node concept="30bdrU" id="45$ooctkaOV" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctkaOW" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SVFd6" resolve="\p{Print}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkaOX" role="_iOnC">
+          <property role="TrG5h" value="printableValid" />
+          <node concept="30bdrP" id="45$ooctkaOY" role="2zPyp_">
+            <property role="30bdrQ" value="." />
+          </node>
+          <node concept="1WbbFT" id="45$ooctkaOZ" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkaOU" resolve="printable" />
+          </node>
+          <node concept="7CXmI" id="45$ooctkaP0" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctkaP1" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkaP2" role="_iOnC">
+          <property role="TrG5h" value="printableInvalid" />
+          <node concept="30bdrP" id="45$ooctkaP3" role="2zPyp_">
+            <property role="30bdrQ" value="&#10;" />
+            <node concept="7CXmI" id="45$ooctkaP4" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctkaP5" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctkaP6" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctkaP7" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkaOU" resolve="printable" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkaV7" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctkaVb" role="_iOnC">
+          <property role="TrG5h" value="blank" />
+          <node concept="30bdrU" id="45$ooctkaVc" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctkaVd" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SVI3f" resolve="\p{Blank}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkaVe" role="_iOnC">
+          <property role="TrG5h" value="blankValid" />
+          <node concept="30bdrP" id="45$ooctkaVf" role="2zPyp_">
+            <property role="30bdrQ" value=" " />
+          </node>
+          <node concept="1WbbFT" id="45$ooctkaVg" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkaVb" resolve="blank" />
+          </node>
+          <node concept="7CXmI" id="45$ooctkaVh" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctkaVi" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkaVj" role="_iOnC">
+          <property role="TrG5h" value="blankInvalid" />
+          <node concept="30bdrP" id="45$ooctkaVk" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="45$ooctkaVl" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctkaVm" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctkaVn" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctkaVo" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkaVb" resolve="blank" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkaV9" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctkb4X" role="_iOnC">
+          <property role="TrG5h" value="controlCharacter2" />
+          <node concept="30bdrU" id="45$ooctkb4Y" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctkb4Z" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SVKFX" resolve="\p{Cntrl}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkb50" role="_iOnC">
+          <property role="TrG5h" value="controlCharacter2Valid" />
+          <node concept="30bdrP" id="45$ooctkb51" role="2zPyp_">
+            <property role="30bdrQ" value="&#10;" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctkb52" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkb4X" resolve="controlCharacter2" />
+          </node>
+          <node concept="7CXmI" id="45$ooctkb53" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctkb54" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkb55" role="_iOnC">
+          <property role="TrG5h" value="controlCharacter2Invalid" />
+          <node concept="30bdrP" id="45$ooctkb56" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="45$ooctkb57" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctkb58" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctkb59" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctkb5a" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkb4X" resolve="controlCharacter2" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkfvu" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctkfvy" role="_iOnC">
+          <property role="TrG5h" value="hexDigit" />
+          <node concept="30bdrU" id="45$ooctkfvz" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctkfv$" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SVPmk" resolve="\p{XDigit}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkfv_" role="_iOnC">
+          <property role="TrG5h" value="hexDigitValid" />
+          <node concept="30bdrP" id="45$ooctkfvA" role="2zPyp_">
+            <property role="30bdrQ" value="F" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctkfvB" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkfvy" resolve="hexDigit" />
+          </node>
+          <node concept="7CXmI" id="45$ooctkfvC" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctkfvD" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkfvE" role="_iOnC">
+          <property role="TrG5h" value="hexDigitInvalid" />
+          <node concept="30bdrP" id="45$ooctkfvF" role="2zPyp_">
+            <property role="30bdrQ" value="G" />
+            <node concept="7CXmI" id="45$ooctkfvG" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctkfvH" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctkfvI" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctkfvJ" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkfvy" resolve="hexDigit" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkfvw" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctkfJg" role="_iOnC">
+          <property role="TrG5h" value="space" />
+          <node concept="30bdrU" id="45$ooctkfJh" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctkfJi" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SVUvV" resolve="\p{Space}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkfJj" role="_iOnC">
+          <property role="TrG5h" value="spaceValid" />
+          <node concept="30bdrP" id="45$ooctkfJk" role="2zPyp_">
+            <property role="30bdrQ" value=" " />
+          </node>
+          <node concept="1WbbFT" id="45$ooctkfJl" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkfJg" resolve="space" />
+          </node>
+          <node concept="7CXmI" id="45$ooctkfJm" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctkfJn" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkfJo" role="_iOnC">
+          <property role="TrG5h" value="spaceInvalid" />
+          <node concept="30bdrP" id="45$ooctkfJp" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="45$ooctkfJq" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctkfJr" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctkfJs" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctkfJt" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkfJg" resolve="space" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkfJe" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctkfRQ" role="_iOnC">
+          <property role="TrG5h" value="javaLowerCase" />
+          <node concept="30bdrU" id="45$ooctkfRR" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctkfRS" role="1_tvlM">
+              <ref role="1SYXPG" to="ji8m:45$ooctkfUt" resolve="\p{javaLowerCase}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkfRT" role="_iOnC">
+          <property role="TrG5h" value="javaLowerCaseValid" />
+          <node concept="30bdrP" id="45$ooctkfRU" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctkfRV" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkfRQ" resolve="javaLowerCase" />
+          </node>
+          <node concept="7CXmI" id="45$ooctkfRW" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctkfRX" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkfRY" role="_iOnC">
+          <property role="TrG5h" value="javaLowerCaseInvalid" />
+          <node concept="30bdrP" id="45$ooctkfRZ" role="2zPyp_">
+            <property role="30bdrQ" value="A" />
+            <node concept="7CXmI" id="45$ooctkfS0" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctkfS1" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctkfS2" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctkfS3" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkfRQ" resolve="javaLowerCase" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkfRO" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctkg31" role="_iOnC">
+          <property role="TrG5h" value="javaUpperCase" />
+          <node concept="30bdrU" id="45$ooctkg32" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctkg33" role="1_tvlM">
+              <ref role="1SYXPG" to="ji8m:45$ooctkfUx" resolve="\p{javaUpperCase}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkg34" role="_iOnC">
+          <property role="TrG5h" value="javaUpperCaseValid" />
+          <node concept="30bdrP" id="45$ooctkg35" role="2zPyp_">
+            <property role="30bdrQ" value="A" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctkg36" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkg31" resolve="javaUpperCase" />
+          </node>
+          <node concept="7CXmI" id="45$ooctkg37" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctkg38" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkg39" role="_iOnC">
+          <property role="TrG5h" value="javaUpperCaseInvalid" />
+          <node concept="30bdrP" id="45$ooctkg3a" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="45$ooctkg3b" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctkg3c" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctkg3d" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctkg3e" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkg31" resolve="javaUpperCase" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkh8x" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctkh76" role="_iOnC">
+          <property role="TrG5h" value="javaWhitespace" />
+          <node concept="30bdrU" id="45$ooctkh77" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctkh78" role="1_tvlM">
+              <ref role="1SYXPG" to="ji8m:45$ooctkfU$" resolve="\p{javaWhitespace}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkh79" role="_iOnC">
+          <property role="TrG5h" value="javaWhitespaceValid" />
+          <node concept="30bdrP" id="45$ooctkh7a" role="2zPyp_">
+            <property role="30bdrQ" value=" " />
+          </node>
+          <node concept="1WbbFT" id="45$ooctkh7b" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkh76" resolve="javaWhitespace" />
+          </node>
+          <node concept="7CXmI" id="45$ooctkh7c" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctkh7d" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkh7e" role="_iOnC">
+          <property role="TrG5h" value="javaWhitespaceInvalid" />
+          <node concept="30bdrP" id="45$ooctkh7f" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="45$ooctkh7g" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctkh7h" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctkh7i" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctkh7j" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkh76" resolve="javaWhitespace" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkg2Z" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctkhfI" role="_iOnC">
+          <property role="TrG5h" value="javaMirrored" />
+          <node concept="30bdrU" id="45$ooctkhfJ" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctkhfK" role="1_tvlM">
+              <ref role="1SYXPG" to="ji8m:45$ooctkfUB" resolve="\p{javaMirrored}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkhfL" role="_iOnC">
+          <property role="TrG5h" value="javaMirroredValid" />
+          <node concept="30bdrP" id="45$ooctkhfM" role="2zPyp_">
+            <property role="30bdrQ" value="(" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctkhfN" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkhfI" resolve="javaMirrored" />
+          </node>
+          <node concept="7CXmI" id="45$ooctkhfO" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctkhfP" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkhfQ" role="_iOnC">
+          <property role="TrG5h" value="javaMirroredInvalid" />
+          <node concept="30bdrP" id="45$ooctkhfR" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="45$ooctkhfS" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctkhfT" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctkhfU" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctkhfV" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkhfI" resolve="javaMirrored" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkhfG" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctkhqG" role="_iOnC">
+          <property role="TrG5h" value="isLatin" />
+          <node concept="30bdrU" id="45$ooctkhqH" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctkhqI" role="1_tvlM">
+              <ref role="1SYXPG" to="ji8m:45$ooctkhy3" resolve="\p{IsLatin}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkhqJ" role="_iOnC">
+          <property role="TrG5h" value="isLatinValid" />
+          <node concept="30bdrP" id="45$ooctkhqK" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctkhqL" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkhqG" resolve="isLatin" />
+          </node>
+          <node concept="7CXmI" id="45$ooctkhqM" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctkhqN" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkhqO" role="_iOnC">
+          <property role="TrG5h" value="isLatinIsInvalid" />
+          <node concept="30bdrP" id="45$ooctkhqP" role="2zPyp_">
+            <property role="30bdrQ" value="$" />
+            <node concept="7CXmI" id="45$ooctkhqQ" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctkhqR" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctkhqS" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctkhqT" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkhqG" resolve="isLatin" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkhqE" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctkhAU" role="_iOnC">
+          <property role="TrG5h" value="inGreek" />
+          <node concept="30bdrU" id="45$ooctkhAV" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctkhAW" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SVZIT" resolve="\p{InGreek}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkhAX" role="_iOnC">
+          <property role="TrG5h" value="inGreekValid" />
+          <node concept="30bdrP" id="45$ooctkhAY" role="2zPyp_">
+            <property role="30bdrQ" value="α" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctkhAZ" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkhAU" resolve="inGreek" />
+          </node>
+          <node concept="7CXmI" id="45$ooctkhB0" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctkhB1" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkhB2" role="_iOnC">
+          <property role="TrG5h" value="inGreekIsInvalid" />
+          <node concept="30bdrP" id="45$ooctkhB3" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="45$ooctkhB4" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctkhB5" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctkhB6" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctkhB7" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkhAU" resolve="inGreek" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkhAS" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctkiwS" role="_iOnC">
+          <property role="TrG5h" value="notInGreek" />
+          <node concept="30bdrU" id="45$ooctkiwT" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctkiwU" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SW6BB" resolve="\P{InGreek}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkiwV" role="_iOnC">
+          <property role="TrG5h" value="notInGreekValid" />
+          <node concept="30bdrP" id="45$ooctkiwW" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctkiwX" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkiwS" resolve="notInGreek" />
+          </node>
+          <node concept="7CXmI" id="45$ooctkiwY" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctkiwZ" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkix0" role="_iOnC">
+          <property role="TrG5h" value="notInGreekIsInvalid" />
+          <node concept="30bdrP" id="45$ooctkix1" role="2zPyp_">
+            <property role="30bdrQ" value="α" />
+            <node concept="7CXmI" id="45$ooctkix2" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctkix3" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctkix4" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctkix5" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkiwS" resolve="notInGreek" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkiwQ" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctkhJw" role="_iOnC">
+          <property role="TrG5h" value="uppercaseLetter" />
+          <node concept="30bdrU" id="45$ooctkhJx" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctkhJy" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SW2RA" resolve="\p{Lu}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkhJz" role="_iOnC">
+          <property role="TrG5h" value="uppercaseLetterValid" />
+          <node concept="30bdrP" id="45$ooctkhJ$" role="2zPyp_">
+            <property role="30bdrQ" value="A" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctkhJ_" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkhJw" resolve="uppercaseLetter" />
+          </node>
+          <node concept="7CXmI" id="45$ooctkhJA" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctkhJB" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkhJC" role="_iOnC">
+          <property role="TrG5h" value="uppercaseLetterInvalid" />
+          <node concept="30bdrP" id="45$ooctkhJD" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="45$ooctkhJE" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctkhJF" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctkhJG" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctkhJH" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkhJw" resolve="uppercaseLetter" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkhJu" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctkhUu" role="_iOnC">
+          <property role="TrG5h" value="isAlphabetic" />
+          <node concept="30bdrU" id="45$ooctkhUv" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctki6m" role="1_tvlM">
+              <ref role="1SYXPG" to="ji8m:45$ooctki31" resolve="\p{IsAlphabetic}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkhUx" role="_iOnC">
+          <property role="TrG5h" value="isAlphabeticValid" />
+          <node concept="30bdrP" id="45$ooctkhUy" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctkhUz" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkhUu" resolve="isAlphabetic" />
+          </node>
+          <node concept="7CXmI" id="45$ooctkhU$" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctkhU_" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkhUA" role="_iOnC">
+          <property role="TrG5h" value="isAlphabeticInvalid" />
+          <node concept="30bdrP" id="45$ooctkhUB" role="2zPyp_">
+            <property role="30bdrQ" value="$" />
+            <node concept="7CXmI" id="45$ooctkhUC" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctkhUD" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctkhUE" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctkhUF" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkhUu" resolve="isAlphabetic" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkhUs" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctki8N" role="_iOnC">
+          <property role="TrG5h" value="currency" />
+          <node concept="30bdrU" id="45$ooctki8O" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctki8P" role="1_tvlM">
+              <ref role="1SYXPG" to="tpfp:h5SW4Gk" resolve="\p{Sc}" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctki8Q" role="_iOnC">
+          <property role="TrG5h" value="currencyValid" />
+          <node concept="30bdrP" id="45$ooctki8R" role="2zPyp_">
+            <property role="30bdrQ" value="€" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctki8S" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctki8N" resolve="currency" />
+          </node>
+          <node concept="7CXmI" id="45$ooctki8T" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctki8U" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctki8V" role="_iOnC">
+          <property role="TrG5h" value="currencyInvalid" />
+          <node concept="30bdrP" id="45$ooctki8W" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="45$ooctki8X" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctki8Y" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctki8Z" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctki90" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctki8N" resolve="currency" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctki8L" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctkiH3" role="_iOnC">
+          <property role="TrG5h" value="boundary" />
+          <node concept="30bdrU" id="45$ooctkiH4" role="1WbbD4">
+            <node concept="1OJ37Q" id="45$ooctkiOb" role="1_tvlM">
+              <node concept="1OJ37Q" id="45$ooctkiVC" role="1OLqdY">
+                <node concept="1OJ37Q" id="45$ooctlgXS" role="1OLqdY">
+                  <node concept="2t4AhP" id="45$ooctlh6C" role="1OLqdY" />
+                  <node concept="1OC9wW" id="45$ooctkiZS" role="1OLpdg">
+                    <property role="1OCb_u" value="world" />
+                  </node>
+                </node>
+                <node concept="1OJ37Q" id="45$ooctlaUF" role="1OLpdg">
+                  <node concept="1SYyG9" id="45$ooctlb1b" role="1OLqdY">
+                    <ref role="1SYXPG" to="tpfp:h5SUD2M" resolve="\s" />
+                  </node>
+                  <node concept="1OC9wW" id="45$ooctkiQF" role="1OLpdg">
+                    <property role="1OCb_u" value="Hello" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2t4tHJ" id="45$ooctkiMW" role="1OLpdg" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkiH6" role="_iOnC">
+          <property role="TrG5h" value="boundaryValid" />
+          <node concept="30bdrP" id="45$ooctkiH7" role="2zPyp_">
+            <property role="30bdrQ" value="Hello world" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctkiH8" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkiH3" resolve="boundary" />
+          </node>
+          <node concept="7CXmI" id="45$ooctkiH9" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctkiHa" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctkiHb" role="_iOnC">
+          <property role="TrG5h" value="boundaryInvalid" />
+          <node concept="30bdrP" id="45$ooctkiHc" role="2zPyp_">
+            <property role="30bdrQ" value="world" />
+            <node concept="7CXmI" id="45$ooctkiHd" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctkiHe" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctkiHf" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctkiHg" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctkiH3" resolve="boundary" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctkiH1" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctlhfp" role="_iOnC">
+          <property role="TrG5h" value="wordBoundary" />
+          <node concept="30bdrU" id="45$ooctlhfq" role="1WbbD4">
+            <node concept="1OJ37Q" id="45$ooctliS$" role="1_tvlM">
+              <node concept="1OJ37Q" id="45$ooctlj2s" role="1OLqdY">
+                <node concept="1OJ37Q" id="45$ooctljAr" role="1OLqdY">
+                  <node concept="1OCmVF" id="45$ooctljJS" role="1OLqdY">
+                    <node concept="1T2EwR" id="45$ooctljAv" role="1OLDsb" />
+                  </node>
+                  <node concept="1SYyG9" id="45$ooctlj6G" role="1OLpdg">
+                    <ref role="1SYXPG" to="tpfp:hvJKwDd" resolve="\b" />
+                  </node>
+                </node>
+                <node concept="1OC9wW" id="45$ooctliXy" role="1OLpdg">
+                  <property role="1OCb_u" value="world" />
+                </node>
+              </node>
+              <node concept="1OJ37Q" id="45$ooctljjj" role="1OLpdg">
+                <node concept="1OCmVF" id="45$ooctljvk" role="1OLpdg">
+                  <node concept="1T2EwR" id="45$ooctljpj" role="1OLDsb" />
+                </node>
+                <node concept="1SYyG9" id="45$ooctliRl" role="1OLqdY">
+                  <ref role="1SYXPG" to="tpfp:hvJKwDd" resolve="\b" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctlhf$" role="_iOnC">
+          <property role="TrG5h" value="wordBoundaryValid" />
+          <node concept="30bdrP" id="45$ooctlhf_" role="2zPyp_">
+            <property role="30bdrQ" value="hello world" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctlhfA" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctlhfp" resolve="wordBoundary" />
+          </node>
+          <node concept="7CXmI" id="45$ooctlhfB" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctlhfC" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctlhfD" role="_iOnC">
+          <property role="TrG5h" value="wordBoundaryInvalid" />
+          <node concept="30bdrP" id="45$ooctlhfE" role="2zPyp_">
+            <property role="30bdrQ" value="helloworld" />
+            <node concept="7CXmI" id="45$ooctlhfF" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctlhfG" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctlhfH" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctlhfI" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctlhfp" resolve="wordBoundary" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctlhfn" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctlkg1" role="_iOnC">
+          <property role="TrG5h" value="nonWordBoundary" />
+          <node concept="30bdrU" id="45$ooctlkg2" role="1WbbD4">
+            <node concept="1OJ37Q" id="45$ooctlkg3" role="1_tvlM">
+              <node concept="1OC9wW" id="45$ooctlkg9" role="1OLqdY">
+                <property role="1OCb_u" value="h" />
+              </node>
+              <node concept="1OJ37Q" id="45$ooctlvt8" role="1OLpdg">
+                <node concept="1T2EwR" id="45$ooctlvxo" role="1OLpdg" />
+                <node concept="1SYyG9" id="45$ooctlkgd" role="1OLqdY">
+                  <ref role="1SYXPG" to="tpfp:hvJL1ap" resolve="\B" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctlkge" role="_iOnC">
+          <property role="TrG5h" value="nonWordBoundaryValid" />
+          <node concept="30bdrP" id="45$ooctlkgf" role="2zPyp_">
+            <property role="30bdrQ" value="ah" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctlkgg" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctlkg1" resolve="nonWordBoundary" />
+          </node>
+          <node concept="7CXmI" id="45$ooctlkgh" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctlkgi" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctlkgj" role="_iOnC">
+          <property role="TrG5h" value="nonWordBoundaryInvalid" />
+          <node concept="30bdrP" id="45$ooctlkgk" role="2zPyp_">
+            <property role="30bdrQ" value="hello world" />
+            <node concept="7CXmI" id="45$ooctlkgl" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctlkgm" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctlkgn" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctlkgo" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctlkg1" resolve="nonWordBoundary" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctlkfZ" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctllKE" role="_iOnC">
+          <property role="TrG5h" value="beginning" />
+          <node concept="30bdrU" id="45$ooctllKF" role="1WbbD4">
+            <node concept="1OJ37Q" id="45$ooctlmzS" role="1_tvlM">
+              <node concept="1OJ37Q" id="45$ooctlmCQ" role="1OLqdY">
+                <node concept="1OCmVF" id="45$ooctlmLn" role="1OLqdY">
+                  <node concept="1T2EwR" id="45$ooctlmH6" role="1OLDsb" />
+                </node>
+                <node concept="1OC9wW" id="45$ooctlmAo" role="1OLpdg">
+                  <property role="1OCb_u" value="Hello" />
+                </node>
+              </node>
+              <node concept="1SYyG9" id="45$ooctlmv5" role="1OLpdg">
+                <ref role="1SYXPG" to="tpfp:hvJL4EY" resolve="\A" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctllKR" role="_iOnC">
+          <property role="TrG5h" value="beginningValid" />
+          <node concept="30bdrP" id="45$ooctllKS" role="2zPyp_">
+            <property role="30bdrQ" value="HelloWorld" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctllKT" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctllKE" resolve="beginning" />
+          </node>
+          <node concept="7CXmI" id="45$ooctllKU" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctllKV" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctllKW" role="_iOnC">
+          <property role="TrG5h" value="beginningInvalid" />
+          <node concept="30bdrP" id="45$ooctllKX" role="2zPyp_">
+            <property role="30bdrQ" value="hello world" />
+            <node concept="7CXmI" id="45$ooctllKY" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctllKZ" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctllL0" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctllL1" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctllKE" resolve="beginning" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctllKC" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctlvDP" role="_iOnC">
+          <property role="TrG5h" value="end" />
+          <node concept="30bdrU" id="45$ooctlvDQ" role="1WbbD4">
+            <node concept="1OJ37Q" id="45$ooctlw4_" role="1_tvlM">
+              <node concept="1OC9wW" id="45$ooctlvDV" role="1OLpdg">
+                <property role="1OCb_u" value="Hello" />
+              </node>
+              <node concept="1SYyG9" id="45$ooctlw4C" role="1OLqdY">
+                <ref role="1SYXPG" to="tpfp:hvJLuQE" resolve="\z" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctlvDX" role="_iOnC">
+          <property role="TrG5h" value="endValid" />
+          <node concept="30bdrP" id="45$ooctlvDY" role="2zPyp_">
+            <property role="30bdrQ" value="Hello" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctlvDZ" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctlvDP" resolve="end" />
+          </node>
+          <node concept="7CXmI" id="45$ooctlvE0" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctlvE1" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctlvE2" role="_iOnC">
+          <property role="TrG5h" value="endInvalid" />
+          <node concept="30bdrP" id="45$ooctlvE3" role="2zPyp_">
+            <property role="30bdrQ" value="hello world" />
+            <node concept="7CXmI" id="45$ooctlvE4" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctlvE5" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctlvE6" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctlvE7" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctlvDP" resolve="end" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctlvDN" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctlwc0" role="_iOnC">
+          <property role="TrG5h" value="linebreak" />
+          <node concept="30bdrU" id="45$ooctlwc1" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctlwuf" role="1_tvlM">
+              <ref role="1SYXPG" to="ji8m:45$ooctlwuc" resolve="\R" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctlwc5" role="_iOnC">
+          <property role="TrG5h" value="linebreakValid" />
+          <node concept="30bdrP" id="45$ooctlwc6" role="2zPyp_">
+            <property role="30bdrQ" value="&#10;" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctlwc7" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctlwc0" resolve="linebreak" />
+          </node>
+          <node concept="7CXmI" id="45$ooctlwc8" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctlwc9" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctlwca" role="_iOnC">
+          <property role="TrG5h" value="linebreakInvalid" />
+          <node concept="30bdrP" id="45$ooctlwcb" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="45$ooctlwcc" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctlwcd" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctlwce" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctlwcf" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctlwc0" resolve="linebreak" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctlwbY" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctl_yo" role="_iOnC">
+          <property role="TrG5h" value="unicodeLineBreak" />
+          <node concept="30bdrU" id="45$ooctl_yp" role="1WbbD4">
+            <node concept="1SYyG9" id="45$ooctl_yq" role="1_tvlM">
+              <ref role="1SYXPG" to="ji8m:45$ooctlwuc" resolve="\R" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctl_yr" role="_iOnC">
+          <property role="TrG5h" value="unicodeLineBreakValid" />
+          <node concept="30bdrP" id="45$ooctl_ys" role="2zPyp_">
+            <property role="30bdrQ" value="&#10;" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctl_yt" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctl_yo" resolve="unicodeLineBreak" />
+          </node>
+          <node concept="7CXmI" id="45$ooctl_yu" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctl_yv" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctl_yw" role="_iOnC">
+          <property role="TrG5h" value="unicodeLineBreakInvalid" />
+          <node concept="30bdrP" id="45$ooctl_yx" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+            <node concept="7CXmI" id="45$ooctl_yy" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctl_yz" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctl_y$" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctl_y_" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctl_yo" resolve="unicodeLineBreak" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctl_ym" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctlFxl" role="_iOnC">
+          <property role="TrG5h" value="greedy" />
+          <node concept="30bdrU" id="45$ooctlFxm" role="1WbbD4">
+            <node concept="1OJ37Q" id="45$ooctlFHr" role="1_tvlM">
+              <node concept="1OJ37Q" id="45$ooctlG6h" role="1OLqdY">
+                <node concept="1OJ37Q" id="45$ooctlGq8" role="1OLqdY">
+                  <node concept="1OJ37Q" id="45$ooctlH4j" role="1OLqdY">
+                    <node concept="1OJ37Q" id="45$ooctlI0u" role="1OLqdY">
+                      <node concept="2dLoPZ" id="45$ooctlID6" role="1OLqdY">
+                        <property role="2dLrT$" value="1" />
+                        <property role="2dLsHy" value="2" />
+                        <node concept="1OC9wW" id="45$ooctlIjQ" role="1OLDsb">
+                          <property role="1OCb_u" value="f" />
+                        </node>
+                      </node>
+                      <node concept="2dKKZN" id="45$ooctlHwN" role="1OLpdg">
+                        <property role="2dKT$$" value="3" />
+                        <node concept="1OC9wW" id="45$ooctlHiz" role="1OLDsb">
+                          <property role="1OCb_u" value="e" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2dJHH6" id="45$ooctlGHS" role="1OLpdg">
+                      <property role="2dJM4W" value="2" />
+                      <node concept="1OC9wW" id="45$ooctlG$0" role="1OLDsb">
+                        <property role="1OCb_u" value="d" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1OClNT" id="45$ooctlGiL" role="1OLpdg">
+                    <node concept="1OC9wW" id="45$ooctlGcx" role="1OLDsb">
+                      <property role="1OCb_u" value="c" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="1OCmVF" id="45$ooctlG22" role="1OLpdg">
+                  <node concept="1OC9wW" id="45$ooctlFTH" role="1OLDsb">
+                    <property role="1OCb_u" value="b" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1SLe3L" id="45$ooctlFYD" role="1OLpdg">
+                <node concept="1OC9wW" id="45$ooctlFGd" role="1OLDsb">
+                  <property role="1OCb_u" value="a" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctlFxo" role="_iOnC">
+          <property role="TrG5h" value="greedyValid" />
+          <node concept="30bdrP" id="45$ooctlFxp" role="2zPyp_">
+            <property role="30bdrQ" value="abcddeeef" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctlFxq" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctlFxl" resolve="greedy" />
+          </node>
+          <node concept="7CXmI" id="45$ooctlFxr" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctlFxs" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctlFxt" role="_iOnC">
+          <property role="TrG5h" value="greedyInvalid" />
+          <node concept="30bdrP" id="45$ooctlFxu" role="2zPyp_">
+            <property role="30bdrQ" value="babcddeeef" />
+            <node concept="7CXmI" id="45$ooctlFxv" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctlFxw" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctlFxx" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctlFxy" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctlFxl" resolve="greedy" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctlFxj" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctlMif" role="_iOnC">
+          <property role="TrG5h" value="reluctant" />
+          <node concept="30bdrU" id="45$ooctlMig" role="1WbbD4">
+            <node concept="1OJ37Q" id="45$ooctlMih" role="1_tvlM">
+              <node concept="1OJ37Q" id="45$ooctlMii" role="1OLqdY">
+                <node concept="1OJ37Q" id="45$ooctlMij" role="1OLqdY">
+                  <node concept="1OJ37Q" id="45$ooctlMik" role="1OLqdY">
+                    <node concept="1OJ37Q" id="45$ooctlMil" role="1OLqdY">
+                      <node concept="2dLoPZ" id="45$ooctlMim" role="1OLqdY">
+                        <property role="2dLrT$" value="1" />
+                        <property role="2dLsHy" value="2" />
+                        <node concept="1OC9wW" id="45$ooctlMin" role="1OLDsb">
+                          <property role="1OCb_u" value="f" />
+                        </node>
+                      </node>
+                      <node concept="2dKKZN" id="45$ooctlMio" role="1OLpdg">
+                        <property role="2dKT$$" value="3" />
+                        <node concept="1OC9wW" id="45$ooctlMip" role="1OLDsb">
+                          <property role="1OCb_u" value="e" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2dJHH6" id="45$ooctlMiq" role="1OLpdg">
+                      <property role="2dJM4W" value="2" />
+                      <node concept="1OC9wW" id="45$ooctlMir" role="1OLDsb">
+                        <property role="1OCb_u" value="d" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1Zee5B" id="45$ooctlOBa" role="1OLpdg">
+                    <node concept="1OC9wW" id="45$ooctlOBc" role="1OLDsb">
+                      <property role="1OCb_u" value="c" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="1Ze39Q" id="45$ooctlOhU" role="1OLpdg">
+                  <node concept="1OC9wW" id="45$ooctlOhW" role="1OLDsb">
+                    <property role="1OCb_u" value="b" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1ZekDQ" id="45$ooctlNWE" role="1OLpdg">
+                <node concept="1OC9wW" id="45$ooctlNWG" role="1OLDsb">
+                  <property role="1OCb_u" value="a" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctlMiy" role="_iOnC">
+          <property role="TrG5h" value="reluctantValid" />
+          <node concept="30bdrP" id="45$ooctlMiz" role="2zPyp_">
+            <property role="30bdrQ" value="abcddeeef" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctlMi$" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctlMif" resolve="reluctant" />
+          </node>
+          <node concept="7CXmI" id="45$ooctlMi_" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctlMiA" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctlMiB" role="_iOnC">
+          <property role="TrG5h" value="reluctantInvalid" />
+          <node concept="30bdrP" id="45$ooctlMiC" role="2zPyp_">
+            <property role="30bdrQ" value="babcddeeef" />
+            <node concept="7CXmI" id="45$ooctlMiD" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctlMiE" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctlMiF" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctlMiG" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctlMif" resolve="reluctant" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctlMid" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctlT3A" role="_iOnC">
+          <property role="TrG5h" value="or" />
+          <node concept="30bdrU" id="45$ooctlT3B" role="1WbbD4">
+            <node concept="1OCdqh" id="45$ooctlUL5" role="1_tvlM">
+              <node concept="1OC9wW" id="45$ooctlUN_" role="1OLqdY">
+                <property role="1OCb_u" value="b" />
+              </node>
+              <node concept="1OC9wW" id="45$ooctlT3S" role="1OLpdg">
+                <property role="1OCb_u" value="a" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctlT3T" role="_iOnC">
+          <property role="TrG5h" value="orValid" />
+          <node concept="30bdrP" id="45$ooctlT3U" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctlT3V" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctlT3A" resolve="or" />
+          </node>
+          <node concept="7CXmI" id="45$ooctlT3W" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctlT3X" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctlT3Y" role="_iOnC">
+          <property role="TrG5h" value="orInvalid" />
+          <node concept="30bdrP" id="45$ooctlT3Z" role="2zPyp_">
+            <property role="30bdrQ" value="c" />
+            <node concept="7CXmI" id="45$ooctlT40" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctlT41" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctlT42" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctlT43" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctlT3A" resolve="or" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctlPEX" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctlUXp" role="_iOnC">
+          <property role="TrG5h" value="captureGroup" />
+          <node concept="30bdrU" id="45$ooctlUXq" role="1WbbD4">
+            <node concept="1OCdqh" id="45$ooctlUXr" role="1_tvlM">
+              <node concept="1P8g2y" id="45$ooctlVjP" role="1OLqdY">
+                <node concept="1OC9wW" id="45$ooctlVjQ" role="1P8hpE">
+                  <property role="1OCb_u" value="(b" />
+                </node>
+              </node>
+              <node concept="1P8g2y" id="45$ooctlV9Q" role="1OLpdg">
+                <node concept="1OC9wW" id="45$ooctlV9R" role="1P8hpE">
+                  <property role="1OCb_u" value="a" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctlUXu" role="_iOnC">
+          <property role="TrG5h" value="captureGroupValid" />
+          <node concept="30bdrP" id="45$ooctlUXv" role="2zPyp_">
+            <property role="30bdrQ" value="a" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctlUXw" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctlUXp" resolve="captureGroup" />
+          </node>
+          <node concept="7CXmI" id="45$ooctlUXx" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctlUXy" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctlUXz" role="_iOnC">
+          <property role="TrG5h" value="captureGroupInvalid" />
+          <node concept="30bdrP" id="45$ooctlUX$" role="2zPyp_">
+            <property role="30bdrQ" value="c" />
+            <node concept="7CXmI" id="45$ooctlUX_" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctlUXA" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctlUXB" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctlUXC" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctlUXp" resolve="captureGroup" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctlUXn" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctlVCQ" role="_iOnC">
+          <property role="TrG5h" value="backReference" />
+          <node concept="30bdrU" id="45$ooctlVCR" role="1WbbD4">
+            <node concept="1OJ37Q" id="45$ooctn_oD" role="1_tvlM">
+              <node concept="1OJ37Q" id="45$ooctscIg" role="1OLpdg">
+                <node concept="1P8g2x" id="45$ooctscPo" role="1OLqdY">
+                  <node concept="1OC9wW" id="45$ooctscXB" role="1P8hpE">
+                    <property role="1OCb_u" value="B" />
+                  </node>
+                </node>
+                <node concept="1P8g2x" id="45$ooctscgy" role="1OLpdg">
+                  <node concept="1OC9wW" id="45$ooctscoL" role="1P8hpE">
+                    <property role="1OCb_u" value="A" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1OJ37Q" id="45$ooctoYxX" role="1OLqdY">
+                <node concept="1scXMP" id="45$ooctoYEe" role="1OLqdY">
+                  <property role="1scXMU" value="2" />
+                </node>
+                <node concept="1scXMP" id="45$ooctn_nq" role="1OLpdg">
+                  <property role="1scXMU" value="1" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctlVCX" role="_iOnC">
+          <property role="TrG5h" value="backReferenceValid" />
+          <node concept="30bdrP" id="45$ooctlVCY" role="2zPyp_">
+            <property role="30bdrQ" value="ABAB" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctlVCZ" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctlVCQ" resolve="backReference" />
+          </node>
+          <node concept="7CXmI" id="45$ooctlVD0" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctlVD1" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctlVD2" role="_iOnC">
+          <property role="TrG5h" value="backReferenceValidInvalid" />
+          <node concept="30bdrP" id="45$ooctlVD3" role="2zPyp_">
+            <property role="30bdrQ" value="ABA" />
+            <node concept="7CXmI" id="45$ooctlVD4" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctlVD5" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctlVD6" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctlVD7" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctlVCQ" resolve="backReference" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctlVCO" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctsdAB" role="_iOnC">
+          <property role="TrG5h" value="namedBackReference" />
+          <node concept="30bdrU" id="45$ooctsdAC" role="1WbbD4">
+            <node concept="1OJ37Q" id="45$ooctuO4Q" role="1_tvlM">
+              <node concept="1OJ37Q" id="45$ooctuObh" role="1OLqdY">
+                <node concept="1s447l" id="46RgPUMu085" role="1OLpdg">
+                  <ref role="1s447o" node="46RgPUMtxG3" resolve="A" />
+                </node>
+                <node concept="1s447l" id="46RgPUMvmgN" role="1OLqdY">
+                  <ref role="1s447o" node="46RgPUMtZpq" resolve="B" />
+                </node>
+              </node>
+              <node concept="1OJ37Q" id="46RgPUMtZih" role="1OLpdg">
+                <node concept="3NQvFP" id="46RgPUMtZpq" role="1OLqdY">
+                  <property role="TrG5h" value="B" />
+                  <node concept="1OC9wW" id="46RgPUMtZM2" role="1P8hpE">
+                    <property role="1OCb_u" value="B" />
+                  </node>
+                </node>
+                <node concept="3NQvFP" id="46RgPUMtxG3" role="1OLpdg">
+                  <property role="TrG5h" value="A" />
+                  <node concept="1OC9wW" id="46RgPUMtZ4W" role="1P8hpE">
+                    <property role="1OCb_u" value="A" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctsdAM" role="_iOnC">
+          <property role="TrG5h" value="namedBackReferenceValid" />
+          <node concept="30bdrP" id="45$ooctsdAN" role="2zPyp_">
+            <property role="30bdrQ" value="ABAB" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctsdAO" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctsdAB" resolve="namedBackReference" />
+          </node>
+          <node concept="7CXmI" id="45$ooctsdAP" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctsdAQ" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctsdAR" role="_iOnC">
+          <property role="TrG5h" value="namedBackReferenceValidInvalid" />
+          <node concept="30bdrP" id="45$ooctsdAS" role="2zPyp_">
+            <property role="30bdrQ" value="AAA" />
+            <node concept="7CXmI" id="45$ooctsdAT" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctsdAU" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctsdAV" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctsdAW" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctsdAB" resolve="namedBackReference" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctuOso" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctv5$c" role="_iOnC">
+          <property role="TrG5h" value="positiveLookahead" />
+          <node concept="30bdrU" id="45$ooctv5$d" role="1WbbD4">
+            <node concept="1OJ37Q" id="45$ooctv6eM" role="1_tvlM">
+              <node concept="1OJ37Q" id="45$ooctvbFr" role="1OLqdY">
+                <node concept="1OCmVF" id="45$ooctvbXf" role="1OLqdY">
+                  <node concept="1T2EwR" id="45$ooctvbNK" role="1OLDsb" />
+                </node>
+                <node concept="2dRVxy" id="45$ooctv6hn" role="1OLpdg">
+                  <node concept="1OC9wW" id="45$ooctv6kN" role="2dSRqD">
+                    <property role="1OCb_u" value="b" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1OJ37Q" id="45$ooctvbqD" role="1OLpdg">
+                <node concept="1OCmVF" id="45$ooctvb_5" role="1OLpdg">
+                  <node concept="1T2EwR" id="45$ooctvbvQ" role="1OLDsb" />
+                </node>
+                <node concept="1OC9wW" id="45$ooctv6ai" role="1OLqdY">
+                  <property role="1OCb_u" value="a" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctv5$n" role="_iOnC">
+          <property role="TrG5h" value="positiveLookaheadValid" />
+          <node concept="30bdrP" id="45$ooctv5$o" role="2zPyp_">
+            <property role="30bdrQ" value="abacaba" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctv5$p" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctv5$c" resolve="positiveLookahead" />
+          </node>
+          <node concept="7CXmI" id="45$ooctv5$q" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctv5$r" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctv5$s" role="_iOnC">
+          <property role="TrG5h" value="positiveLookaheadInvalid" />
+          <node concept="30bdrP" id="45$ooctv5$t" role="2zPyp_">
+            <property role="30bdrQ" value="accaccaaca" />
+            <node concept="7CXmI" id="45$ooctv5$u" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctv5$v" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctv5$w" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctv5$x" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctv5$c" resolve="positiveLookahead" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctuOst" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctvd8u" role="_iOnC">
+          <property role="TrG5h" value="negativeLookahead" />
+          <node concept="30bdrU" id="45$ooctvd8v" role="1WbbD4">
+            <node concept="1OJ37Q" id="45$ooctvd8w" role="1_tvlM">
+              <node concept="1OCmVF" id="45$ooctvd8y" role="1OLqdY">
+                <node concept="1T2EwR" id="45$ooctvd8z" role="1OLDsb" />
+              </node>
+              <node concept="1OJ37Q" id="45$ooctvd8A" role="1OLpdg">
+                <node concept="1OCmVF" id="45$ooctvd8B" role="1OLpdg">
+                  <node concept="1T2EwR" id="45$ooctvd8C" role="1OLDsb" />
+                </node>
+                <node concept="1OJ37Q" id="45$ooctvf3b" role="1OLqdY">
+                  <node concept="2dSvw$" id="45$ooctvfbK" role="1OLqdY">
+                    <node concept="1OC9wW" id="45$ooctvfbS" role="2dSRqD">
+                      <property role="1OCb_u" value="b" />
+                    </node>
+                  </node>
+                  <node concept="1OC9wW" id="45$ooctvd8D" role="1OLpdg">
+                    <property role="1OCb_u" value="a" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctvd8E" role="_iOnC">
+          <property role="TrG5h" value="negativeLookaheadValid" />
+          <node concept="30bdrP" id="45$ooctvd8F" role="2zPyp_">
+            <property role="30bdrQ" value="abacaba" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctvd8G" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctvd8u" resolve="negativeLookahead" />
+          </node>
+          <node concept="7CXmI" id="45$ooctvd8H" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctvd8I" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctvd8J" role="_iOnC">
+          <property role="TrG5h" value="negativeLookaheadInvalid" />
+          <node concept="30bdrP" id="45$ooctvd8K" role="2zPyp_">
+            <property role="30bdrQ" value="abc" />
+            <node concept="7CXmI" id="45$ooctvd8L" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctvd8M" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctvd8N" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctvd8O" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctvd8u" resolve="negativeLookahead" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctvd8p" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctvfE4" role="_iOnC">
+          <property role="TrG5h" value="positiveLookbehind" />
+          <node concept="30bdrU" id="45$ooctvfE5" role="1WbbD4">
+            <node concept="1OJ37Q" id="45$ooctvfE6" role="1_tvlM">
+              <node concept="1OCmVF" id="45$ooctvfE7" role="1OLqdY">
+                <node concept="1T2EwR" id="45$ooctvfE8" role="1OLDsb" />
+              </node>
+              <node concept="1OJ37Q" id="45$ooctvfE9" role="1OLpdg">
+                <node concept="1OCmVF" id="45$ooctvfEa" role="1OLpdg">
+                  <node concept="1T2EwR" id="45$ooctvfEb" role="1OLDsb" />
+                </node>
+                <node concept="1OJ37Q" id="45$ooctvhgh" role="1OLqdY">
+                  <node concept="1OC9wW" id="45$ooctvhqe" role="1OLqdY">
+                    <property role="1OCb_u" value="b" />
+                  </node>
+                  <node concept="2dTBkY" id="45$ooctvgP4" role="1OLpdg">
+                    <node concept="1OC9wW" id="45$ooctvgZ0" role="2dSRqD">
+                      <property role="1OCb_u" value="a" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctvfEg" role="_iOnC">
+          <property role="TrG5h" value="positiveLookbehindValid" />
+          <node concept="30bdrP" id="45$ooctvfEh" role="2zPyp_">
+            <property role="30bdrQ" value="abacaba" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctvfEi" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctvfE4" resolve="positiveLookbehind" />
+          </node>
+          <node concept="7CXmI" id="45$ooctvfEj" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctvfEk" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctvfEl" role="_iOnC">
+          <property role="TrG5h" value="positiveLookbehindInvalid" />
+          <node concept="30bdrP" id="45$ooctvfEm" role="2zPyp_">
+            <property role="30bdrQ" value="acc" />
+            <node concept="7CXmI" id="45$ooctvfEn" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctvfEo" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctvfEp" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctvfEq" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctvfE4" resolve="positiveLookbehind" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctvi8N" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctvi8X" role="_iOnC">
+          <property role="TrG5h" value="negativeLookbehind" />
+          <node concept="30bdrU" id="45$ooctvi8Y" role="1WbbD4">
+            <node concept="1OJ37Q" id="45$ooctvi8Z" role="1_tvlM">
+              <node concept="1OCmVF" id="45$ooctvi90" role="1OLqdY">
+                <node concept="1T2EwR" id="45$ooctvi91" role="1OLDsb" />
+              </node>
+              <node concept="1OJ37Q" id="45$ooctvi92" role="1OLpdg">
+                <node concept="1OCmVF" id="45$ooctvi93" role="1OLpdg">
+                  <node concept="1T2EwR" id="45$ooctvi94" role="1OLDsb" />
+                </node>
+                <node concept="1OJ37Q" id="45$ooctviM8" role="1OLqdY">
+                  <node concept="2dTIbB" id="45$ooctviUH" role="1OLpdg">
+                    <node concept="1OC9wW" id="45$ooctvj4D" role="2dSRqD">
+                      <property role="1OCb_u" value="a" />
+                    </node>
+                  </node>
+                  <node concept="1OC9wW" id="45$ooctvi96" role="1OLqdY">
+                    <property role="1OCb_u" value="b" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctvi99" role="_iOnC">
+          <property role="TrG5h" value="negativeLookbehindValid" />
+          <node concept="30bdrP" id="45$ooctvi9a" role="2zPyp_">
+            <property role="30bdrQ" value="bbacaba" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctvi9b" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctvi8X" resolve="negativeLookbehind" />
+          </node>
+          <node concept="7CXmI" id="45$ooctvi9c" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctvi9d" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctvi9e" role="_iOnC">
+          <property role="TrG5h" value="negativeLookbehindInvalid" />
+          <node concept="30bdrP" id="45$ooctvi9f" role="2zPyp_">
+            <property role="30bdrQ" value="ab" />
+            <node concept="7CXmI" id="45$ooctvi9g" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctvi9h" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctvi9i" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctvi9j" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctvi8X" resolve="negativeLookbehind" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctvi8S" role="_iOnC" />
+        <node concept="1WbbD7" id="45$ooctvlmu" role="_iOnC">
+          <property role="TrG5h" value="independentNonCapturingGroup" />
+          <node concept="30bdrU" id="45$ooctvlmv" role="1WbbD4">
+            <node concept="1OJ37Q" id="45$ooctvlmw" role="1_tvlM">
+              <node concept="1OCmVF" id="45$ooctvlmx" role="1OLqdY">
+                <node concept="1T2EwR" id="45$ooctvlmy" role="1OLDsb" />
+              </node>
+              <node concept="1OJ37Q" id="45$ooctvmrf" role="1OLpdg">
+                <node concept="1OJ37Q" id="45$ooctvyL3" role="1OLqdY">
+                  <node concept="1OC9wW" id="45$ooctvyLc" role="1OLqdY">
+                    <property role="1OCb_u" value="b" />
+                  </node>
+                  <node concept="1OClNT" id="45$ooctvCkW" role="1OLpdg">
+                    <node concept="1s6jiO" id="45$ooctvyyc" role="1OLDsb">
+                      <node concept="1OC9wW" id="45$ooctvyDC" role="2dSRqD">
+                        <property role="1OCb_u" value="a" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="1OCmVF" id="45$ooctvCRz" role="1OLpdg">
+                  <node concept="1T2EwR" id="45$ooctvCR_" role="1OLDsb" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctvlmE" role="_iOnC">
+          <property role="TrG5h" value="independentNonCapturingGroupValid" />
+          <node concept="30bdrP" id="45$ooctvlmF" role="2zPyp_">
+            <property role="30bdrQ" value="aaaaab" />
+          </node>
+          <node concept="1WbbFT" id="45$ooctvlmG" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctvlmu" resolve="independentNonCapturingGroup" />
+          </node>
+          <node concept="7CXmI" id="45$ooctvlmH" role="lGtFl">
+            <node concept="7OXhh" id="45$ooctvlmI" role="7EUXB">
+              <property role="GvXf4" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="45$ooctvlmJ" role="_iOnC">
+          <property role="TrG5h" value="independentNonCapturingGroupInvalid" />
+          <node concept="30bdrP" id="45$ooctvlmK" role="2zPyp_">
+            <property role="30bdrQ" value="bb" />
+            <node concept="7CXmI" id="45$ooctvlmL" role="lGtFl">
+              <node concept="1TM$A" id="45$ooctvlmM" role="7EUXB">
+                <node concept="2PYRI3" id="45$ooctvlmN" role="3lydEf">
+                  <ref role="39XzEq" to="ym7l:3OxSopfY8Ho" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1WbbFT" id="45$ooctvlmO" role="2zM23F">
+            <ref role="1WbbFS" node="45$ooctvlmu" resolve="independentNonCapturingGroup" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="45$ooctvjey" role="_iOnC" />
+        <node concept="7CXmI" id="3OxSopfZR0g" role="lGtFl" />
+      </node>
+    </node>
+  </node>
+  <node concept="1ZlgDW" id="45$ooctvHpq">
+    <property role="TrG5h" value="Regex" />
+    <node concept="1OD$hs" id="45$ooctvHpr" role="1ZlkZz">
+      <property role="TrG5h" value="hello" />
+      <property role="1ZnDHp" value="hello literal" />
+      <node concept="1OC9wW" id="45$ooctvHpt" role="1ODAi8">
+        <property role="1OCb_u" value="hello" />
       </node>
     </node>
   </node>


### PR DESCRIPTION
This PR enables adding a regular expression to string types using the built-in regexp language + some extensions in [MPS-Extensions](https://github.com/JetBrains/MPS-extensions/pull/994) to enable most of the features of the [Java regex language]([docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Pattern.html](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Pattern.html)).

You can add the constraint manually when you use the string type or add the constraint dynamically when calculation a type. When one string type has a constant text constraint it can be matched against the constraint of another string type (see implementation of string literal type).

One implementation note: a removed the support for parenthesis in those regexes and added groups instead. In practice, parentheses are non-capturing groups which is super confusing when you try to refer to them by index such as \1 or \2 and it doesn't work. You can also create an external regexp as a root node and refer to it from your constraint. This is the first time we are mixing a base language-related language into KernelF.

Some examples from the tests:
<img width="826" alt="Screenshot 2024-10-25 at 01 20 53" src="https://github.com/user-attachments/assets/194b312d-1f04-4ff7-8624-823a7cce9e32">