### PR TITLE
datetime.runtime: Fixed compareTo in ArbitraryDateRangeValue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ def major = "2022"
 def minor = "2"
 
 // Dependency versions
-ext.mpsVersion = '2022.2.3'
+ext.mpsVersion = '2022.2.4'
 
 def mbeddrVersion = "2022.2+"
 def mpsQAVersion = "$major.$minor+"

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.datetime.runtime/models/org.iets3.core.expr.datetime.runtime.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.datetime.runtime/models/org.iets3.core.expr.datetime.runtime.mps
@@ -3304,8 +3304,8 @@
                   <node concept="37vLTw" id="6vUyz1z0zvA" role="2Oq$k0">
                     <ref role="3cqZAo" node="6vUyz1ySVhx" resolve="value" />
                   </node>
-                  <node concept="liA8E" id="6vUyz1z0zvB" role="2OqNvi">
-                    <ref role="37wK5l" node="7khFtBHIiHK" resolve="begin" />
+                  <node concept="liA8E" id="3fu9FvalQ8J" role="2OqNvi">
+                    <ref role="37wK5l" node="7khFtBHIiHR" resolve="end" />
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/datetime@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/datetime@tests.mps
@@ -6605,6 +6605,84 @@
           <property role="pfQqC" value="timespan2" />
         </node>
       </node>
+      <node concept="_fkuZ" id="3fu9FvasmkH" role="_fkp5">
+        <node concept="_fku$" id="3fu9FvasmkF" role="_fkur" />
+        <node concept="1QScDb" id="3fu9FvasmkD" role="_fkuY">
+          <node concept="3$AVBo" id="3fu9FvasmkB" role="1QScD9" />
+          <node concept="3iBYfx" id="3fu9Fvasmk_" role="30czhm">
+            <node concept="1QScDb" id="3fu9Fvasmkr" role="3iBYfI">
+              <node concept="2oxMaX" id="3fu9Fvasmkp" role="1QScD9">
+                <node concept="1fc2QT" id="3fu9Fvasmkn" role="2oxMaW">
+                  <property role="1fc2QY" value="2023" />
+                  <property role="1fc2QX" value="01" />
+                  <property role="1fc2QW" value="01" />
+                </node>
+              </node>
+              <node concept="1fc2QT" id="3fu9Fvasmkl" role="30czhm">
+                <property role="1fc2QY" value="2021" />
+                <property role="1fc2QX" value="01" />
+                <property role="1fc2QW" value="01" />
+              </node>
+            </node>
+            <node concept="1QScDb" id="3fu9Fvasmkz" role="3iBYfI">
+              <node concept="2oxMaX" id="3fu9Fvasmkx" role="1QScD9">
+                <node concept="1fc2QT" id="3fu9Fvasmkv" role="2oxMaW">
+                  <property role="1fc2QY" value="2022" />
+                  <property role="1fc2QX" value="01" />
+                  <property role="1fc2QW" value="01" />
+                </node>
+              </node>
+              <node concept="1fc2QT" id="3fu9Fvasmkt" role="30czhm">
+                <property role="1fc2QY" value="2021" />
+                <property role="1fc2QX" value="01" />
+                <property role="1fc2QW" value="01" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="pfQqD" id="3fu9Fvasmkj" role="pfQ1b">
+          <property role="pfQqC" value="timespan3" />
+        </node>
+        <node concept="3iBYfx" id="3fu9Fvasmkh" role="_fkuS">
+          <node concept="1QScDb" id="3fu9Fvasmkf" role="3iBYfI">
+            <node concept="2oxMaX" id="3fu9Fvasml1" role="1QScD9">
+              <node concept="1fc2QT" id="3fu9FvasmkZ" role="2oxMaW">
+                <property role="1fc2QY" value="2022" />
+                <property role="1fc2QX" value="01" />
+                <property role="1fc2QW" value="01" />
+              </node>
+            </node>
+            <node concept="1fc2QT" id="3fu9FvasmkX" role="30czhm">
+              <property role="1fc2QY" value="2021" />
+              <property role="1fc2QX" value="01" />
+              <property role="1fc2QW" value="01" />
+            </node>
+          </node>
+          <node concept="1QScDb" id="3fu9FvasmkV" role="3iBYfI">
+            <node concept="2oxMaX" id="3fu9FvasmkT" role="1QScD9">
+              <node concept="1fc2QT" id="3fu9FvarfgA" role="2oxMaW">
+                <property role="1fc2QY" value="2023" />
+                <property role="1fc2QX" value="01" />
+                <property role="1fc2QW" value="01" />
+              </node>
+            </node>
+            <node concept="1fc2QT" id="3fu9FvasmkR" role="30czhm">
+              <property role="1fc2QY" value="2021" />
+              <property role="1fc2QX" value="01" />
+              <property role="1fc2QW" value="01" />
+            </node>
+          </node>
+        </node>
+        <node concept="1z9TsT" id="3fu9FvasmkP" role="lGtFl">
+          <node concept="OjmMv" id="3fu9FvasmkN" role="1w35rA">
+            <node concept="19SGf9" id="3fu9FvasmkL" role="OjmMu">
+              <node concept="19SUe$" id="3fu9FvasmkJ" role="19SJt6">
+                <property role="19SUeA" value="start date identical --&gt; use end date fpr comparison and sorting " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
       <node concept="3dYjL0" id="6vUyz1ySMi$" role="_fkp5" />
       <node concept="_fkuZ" id="6vUyz1ySMi_" role="_fkp5">
         <node concept="_fku$" id="6vUyz1ySMiA" role="_fkur" />


### PR DESCRIPTION
The [endComparison](http://127.0.0.1:63320/node?ref=r%3Aa9ac3767-b241-4aa4-a973-d04bb5ce184c%28org.iets3.core.expr.datetime.runtime%29%2F7492452870508394462) was using wrong value. 

In addition I've also bumped up the MPS version to 2022.2.**4**