### PR TITLE
Updating HasValue_OP to not propogate optional type to dot expression

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/org.iets3.analysis.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/org.iets3.analysis.base.mpl
@@ -28,6 +28,7 @@
     <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="2" />
     <language slang="l:b4f35ed8-45af-4efa-abe4-00ac26956e69:com.mbeddr.mpsutil.grammarcells.runtimelang" version="0" />
     <language slang="l:b92f861d-0184-446d-b88b-6dcf0e070241:com.mbeddr.mpsutil.intentions" version="0" />
+    <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -26920,6 +26920,19 @@
     <node concept="13hLZK" id="3nVyItrZ_mz" role="13h7CW">
       <node concept="3clFbS" id="3nVyItrZ_m$" role="2VODD2" />
     </node>
+    <node concept="13i0hz" id="OLKSRNAeKy" role="13h7CS">
+      <property role="TrG5h" value="neverMakeOption" />
+      <ref role="13i0hy" node="2MYd19bkVBY" resolve="neverMakeOption" />
+      <node concept="3Tm1VV" id="OLKSRNAeKz" role="1B3o_S" />
+      <node concept="3clFbS" id="OLKSRNAeKC" role="3clF47">
+        <node concept="3clFbF" id="OLKSRNAeKH" role="3cqZAp">
+          <node concept="3clFbT" id="OLKSRNAf2P" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="OLKSRNAeKD" role="3clF45" />
+    </node>
   </node>
   <node concept="13h7C7" id="3nVyItrZCNO">
     <property role="3GE5qa" value="nix" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.nix@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.nix@tests.mps
@@ -33,6 +33,9 @@
       <concept id="7089558164905593724" name="org.iets3.core.expr.base.structure.IOptionallyTyped" flags="ng" index="2zM23E">
         <child id="7089558164905593725" name="type" index="2zM23F" />
       </concept>
+      <concept id="2807135271607939856" name="org.iets3.core.expr.base.structure.OptionType" flags="ng" index="Uns6S">
+        <child id="2807135271607939857" name="baseType" index="Uns6T" />
+      </concept>
       <concept id="5115872837156802409" name="org.iets3.core.expr.base.structure.UnaryExpression" flags="ng" index="30czhk">
         <child id="5115872837156802411" name="expr" index="30czhm" />
       </concept>
@@ -168,6 +171,41 @@
       </node>
       <node concept="30bXR$" id="3nVyIts6lQd" role="2zM23F" />
     </node>
+    <node concept="2zPypq" id="OLKSRN_Ss9" role="_iOnB">
+      <property role="TrG5h" value="a3" />
+      <node concept="Uns6S" id="OLKSRN_Ssu" role="2zM23F">
+        <node concept="30bXR$" id="OLKSRN_SsL" role="Uns6T" />
+      </node>
+      <node concept="1I1voI" id="OLKSRN_Tz9" role="2zPyp_" />
+    </node>
+    <node concept="2zPypq" id="OLKSRNFqmU" role="_iOnB">
+      <property role="TrG5h" value="a3HasValue" />
+      <node concept="1QScDb" id="OLKSRNFqo7" role="2zPyp_">
+        <node concept="1I1Gy4" id="OLKSRNFqqs" role="1QScD9" />
+        <node concept="_emDc" id="OLKSRNFqnC" role="30czhm">
+          <ref role="_emDf" node="OLKSRN_Ss9" resolve="a3" />
+        </node>
+      </node>
+      <node concept="2vmvy5" id="OLKSRNFqnn" role="2zM23F" />
+    </node>
+    <node concept="2zPypq" id="OLKSRNFA0N" role="_iOnB">
+      <property role="TrG5h" value="a4" />
+      <node concept="30bXRB" id="OLKSRNFA1I" role="2zPyp_">
+        <property role="30bXRw" value="1" />
+      </node>
+      <node concept="Uns6S" id="OLKSRNFA16" role="2zM23F">
+        <node concept="30bXR$" id="OLKSRNFA1p" role="Uns6T" />
+      </node>
+    </node>
+    <node concept="2zPypq" id="OLKSRNFA2H" role="_iOnB">
+      <property role="TrG5h" value="a4HasValue" />
+      <node concept="1QScDb" id="OLKSRNFA3t" role="2zPyp_">
+        <node concept="1I1Gy4" id="OLKSRNFA67" role="1QScD9" />
+        <node concept="_emDc" id="OLKSRNFA38" role="30czhm">
+          <ref role="_emDf" node="OLKSRNFA0N" resolve="a4" />
+        </node>
+      </node>
+    </node>
     <node concept="_ixoA" id="3nVyIts6jPN" role="_iOnB" />
     <node concept="_fkuM" id="3nVyIts6jQ2" role="_iOnB">
       <property role="TrG5h" value="TestNix" />
@@ -190,6 +228,30 @@
           </node>
         </node>
         <node concept="2vmpnb" id="3nVyIts6lT8" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="OLKSRN_S$0" role="_fkp5">
+        <node concept="_fku$" id="OLKSRN_S$1" role="_fkur" />
+        <node concept="1QScDb" id="OLKSRN_S$q" role="_fkuY">
+          <node concept="1I1Gy4" id="OLKSRN_SCf" role="1QScD9" />
+          <node concept="_emDc" id="OLKSRN_S$d" role="30czhm">
+            <ref role="_emDf" node="OLKSRN_Ss9" resolve="a3" />
+          </node>
+        </node>
+        <node concept="2vmpn$" id="OLKSRN_Uok" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="OLKSRNFtPR" role="_fkp5">
+        <node concept="_fku$" id="OLKSRNFtPS" role="_fkur" />
+        <node concept="_emDc" id="OLKSRNFtQg" role="_fkuY">
+          <ref role="_emDf" node="OLKSRNFqmU" resolve="a3HasValue" />
+        </node>
+        <node concept="2vmpn$" id="OLKSRNFtQv" role="_fkuS" />
+      </node>
+      <node concept="_fkuZ" id="OLKSRNFA7m" role="_fkp5">
+        <node concept="_fku$" id="OLKSRNFA7n" role="_fkur" />
+        <node concept="_emDc" id="OLKSRNFA7$" role="_fkuY">
+          <ref role="_emDf" node="OLKSRNFA2H" resolve="a4HasValue" />
+        </node>
+        <node concept="2vmpnb" id="OLKSRNFA7L" role="_fkuS" />
       </node>
       <node concept="_fkuZ" id="3nVyIts6lTw" role="_fkp5">
         <node concept="_fku$" id="3nVyIts6lTx" role="_fkur" />


### PR DESCRIPTION
Updating HasValue_OP to not propogate optional type to dot expression

When HasValue_OP was being used on a expression tyoe that was an optional, the resulting type of the dot expression also became an optional -this can be seen in the below screenshot
![Screenshot from 2024-11-12 12-27-33](https://github.com/user-attachments/assets/7b6d84b8-5ce4-43cf-a3b1-05a85acdceb2)

This made it difficult to work with since you had provide x.hashValue :? false etc everywhere



By checking the DotExpression Type system aspect i could see reference to the dot expression method neverMakeOption, which default to false but for this case HasValue presumably should be true.

![Screenshot from 2024-11-12 13-43-37](https://github.com/user-attachments/assets/e75ccc80-e362-4368-97a5-028f5abe4458)


I added sometests within the existing test suite

![Screenshot from 2024-11-12 13-42-08](https://github.com/user-attachments/assets/f0c35b9a-8405-4b61-b20c-80a9b8ae82e7)
