### PR TITLE
removed math.interpreter lib folder as model folder

### DIFF
--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.math.interpreter/org.iets3.core.expr.math.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.math.interpreter/org.iets3.core.expr.math.interpreter.msd
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solution name="org.iets3.core.expr.math.interpreter" uuid="b804a851-ecf0-4ad4-a0af-ae720b39191a" moduleVersion="0">
   <models>
-    <modelRoot contentPath="${module}" type="default">
-      <sourceRoot location="models" />
-      <sourceRoot location="lib" />
-    </modelRoot>
-    <modelRoot contentPath="${module}/lib" type="java_classes">
+    <modelRoot type="java_classes" contentPath="${module}/lib">
       <sourceRoot location="big-math.jar" />
+    </modelRoot>
+    <modelRoot type="default" contentPath="${module}">
+      <sourceRoot location="models" />
     </modelRoot>
   </models>
   <facets>
@@ -68,6 +67,7 @@
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+    <module reference="daafa647-f1f7-4b0b-b096-69cd7c8408c0(jetbrains.mps.baseLanguage.regexp)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
     <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -1317,28 +1317,6 @@
             </node>
           </node>
         </node>
-        <node concept="1BupzO" id="45pzosSo7eK" role="3bR31x">
-          <property role="3ZfqAx" value="lib" />
-          <property role="1Hdu6h" value="true" />
-          <property role="1HemKv" value="true" />
-          <node concept="3LXTmp" id="45pzosSo7eL" role="1HemKq">
-            <node concept="398BVA" id="45pzosSo7e_" role="3LXTmr">
-              <ref role="398BVh" node="5wLtKNeTaqD" resolve="iets3.lang.opensource" />
-              <node concept="2Ry0Ak" id="45pzosSo7eA" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="45pzosSo7eB" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.iets3.core.expr.math.interpreter" />
-                  <node concept="2Ry0Ak" id="45pzosSo7eC" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3qWCbU" id="45pzosSo7eM" role="3LXTna">
-              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-            </node>
-          </node>
-        </node>
       </node>
       <node concept="1E1JtD" id="5Q45tqZzw3Y" role="2G$12L">
         <property role="BnDLt" value="true" />


### PR DESCRIPTION
For solution `org.iets3.core.expr.math.interpreter`, both the `models` and the `lib` folder were registered as model roots.
However, `lib` doesn't contain any models, which lead to model loading warnings on every MPS startup.