### PR TITLE
physunits: Improvements to units of digital information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 ### Changed
 
 - It is now possible to customize where hex values are enabled. With PrimitiveTypeMapper#filterHexadecimalSupportingNodes you can now enable/disable them for specific nodes.
-- The units B and b were renamed to Byte and bit to avoid confusion.
+- The physical units B and b were renamed to byte and bit to avoid confusion.
+- Breaking change: The units of digital information were split into 3 different libraries: UnitsOfInformationIEC, UnitsOfInformationJEDEC, UnitsOfInformationMetric. They are still considered part of the derived units.
+
+### Added 
+
+- Physical units now also support metric scaling for only the positive and negative prefixes. Scaling can also be overwritten for units by overwritten `IUnitLangConfig#getOverwrittenScaling` for the extension point `PhysUnitLangConfig`.
 
 ## October 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 - Hexadecimal attributes are now better visible in the diff view.
 
-### Changes
+### Changed
 
 - It is now possible to customize where hex values are enabled. With PrimitiveTypeMapper#filterHexadecimalSupportingNodes you can now enable/disable them for specific nodes.
+- The units B and b were renamed to Byte and bit to avoid confusion.
 
 ## October 2024
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
@@ -1905,16 +1905,46 @@
         <node concept="3clFbF" id="2hbaSyAVWQK" role="3cqZAp">
           <node concept="22lmx$" id="1eut2uSUzlG" role="3clFbG">
             <node concept="22lmx$" id="2hbaSyAVY1S" role="3uHU7B">
-              <node concept="2OqwBi" id="2hbaSyAVXpv" role="3uHU7B">
-                <node concept="2OqwBi" id="2hbaSyAVXeP" role="2Oq$k0">
-                  <node concept="13iPFW" id="2hbaSyAVWQJ" role="2Oq$k0" />
-                  <node concept="3TrcHB" id="2hbaSyAVXkQ" role="2OqNvi">
-                    <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
+              <node concept="22lmx$" id="4zqoYUyRUB8" role="3uHU7B">
+                <node concept="2OqwBi" id="4zqoYUyRW6p" role="3uHU7w">
+                  <node concept="2OqwBi" id="4zqoYUyRV4t" role="2Oq$k0">
+                    <node concept="13iPFW" id="4zqoYUyRUGW" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="4zqoYUyRVUT" role="2OqNvi">
+                      <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
+                    </node>
+                  </node>
+                  <node concept="21noJN" id="4zqoYUyRWm7" role="2OqNvi">
+                    <node concept="21nZrQ" id="4zqoYUyRWm9" role="21noJM">
+                      <ref role="21nZrZ" to="i3ya:4zqoYUyQ7z4" resolve="metric_negative" />
+                    </node>
                   </node>
                 </node>
-                <node concept="21noJN" id="2hbaSyAVXyq" role="2OqNvi">
-                  <node concept="21nZrQ" id="2hbaSyAVXys" role="21noJM">
-                    <ref role="21nZrZ" to="i3ya:2hbaSyABMZN" resolve="metric" />
+                <node concept="22lmx$" id="4zqoYUyRS$F" role="3uHU7B">
+                  <node concept="2OqwBi" id="2hbaSyAVXpv" role="3uHU7B">
+                    <node concept="2OqwBi" id="2hbaSyAVXeP" role="2Oq$k0">
+                      <node concept="13iPFW" id="2hbaSyAVWQJ" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="2hbaSyAVXkQ" role="2OqNvi">
+                        <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
+                      </node>
+                    </node>
+                    <node concept="21noJN" id="2hbaSyAVXyq" role="2OqNvi">
+                      <node concept="21nZrQ" id="2hbaSyAVXys" role="21noJM">
+                        <ref role="21nZrZ" to="i3ya:2hbaSyABMZN" resolve="metric" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="4zqoYUyRTYF" role="3uHU7w">
+                    <node concept="2OqwBi" id="4zqoYUyRSXn" role="2Oq$k0">
+                      <node concept="13iPFW" id="4zqoYUyRSA8" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="4zqoYUyRTNv" role="2OqNvi">
+                        <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
+                      </node>
+                    </node>
+                    <node concept="21noJN" id="4zqoYUyRUe5" role="2OqNvi">
+                      <node concept="21nZrQ" id="4zqoYUyRUe7" role="21noJM">
+                        <ref role="21nZrZ" to="i3ya:4zqoYUyQ7z3" resolve="metric_positive" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>
@@ -19593,6 +19623,46 @@
       <property role="TrG5h" value="getManager" />
       <node concept="3clFbS" id="5nqK_jUag8I" role="3clF47">
         <node concept="3clFbJ" id="5nqK_jUaghG" role="3cqZAp">
+          <node concept="3eNFk2" id="4zqoYUyR0$J" role="3eNLev">
+            <node concept="2OqwBi" id="4zqoYUyR15E" role="3eO9$A">
+              <node concept="37vLTw" id="4zqoYUyR0Lg" role="2Oq$k0">
+                <ref role="3cqZAo" node="5nqK_jUagcy" resolve="scalingType" />
+              </node>
+              <node concept="21noJN" id="4zqoYUyR1oJ" role="2OqNvi">
+                <node concept="21nZrQ" id="4zqoYUyR1oL" role="21noJM">
+                  <ref role="21nZrZ" to="i3ya:4zqoYUyQ7z3" resolve="metric_positive" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="4zqoYUyR0$L" role="3eOfB_">
+              <node concept="3cpWs6" id="4zqoYUyR1FL" role="3cqZAp">
+                <node concept="2YIFZM" id="4zqoYUyR28X" role="3cqZAk">
+                  <ref role="37wK5l" node="4zqoYUyQezb" resolve="getInstance" />
+                  <ref role="1Pybhc" node="4zqoYUyQez3" resolve="PositiveDecimalMetricUnitPrefixManager" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3eNFk2" id="4zqoYUyR2gg" role="3eNLev">
+            <node concept="3clFbS" id="4zqoYUyR2gi" role="3eOfB_">
+              <node concept="3cpWs6" id="4zqoYUyR2L3" role="3cqZAp">
+                <node concept="2YIFZM" id="4zqoYUyR2L4" role="3cqZAk">
+                  <ref role="37wK5l" node="4zqoYUyQwEX" resolve="getInstance" />
+                  <ref role="1Pybhc" node="4zqoYUyQwEP" resolve="NegativeDecimalMetricUnitPrefixManager" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4zqoYUyR2tU" role="3eO9$A">
+              <node concept="37vLTw" id="4zqoYUyR2tV" role="2Oq$k0">
+                <ref role="3cqZAo" node="5nqK_jUagcy" resolve="scalingType" />
+              </node>
+              <node concept="21noJN" id="4zqoYUyR2tW" role="2OqNvi">
+                <node concept="21nZrQ" id="4zqoYUyR2tX" role="21noJM">
+                  <ref role="21nZrZ" to="i3ya:4zqoYUyQ7z4" resolve="metric_negative" />
+                </node>
+              </node>
+            </node>
+          </node>
           <node concept="22lmx$" id="5nqK_jUagQB" role="3clFbw">
             <node concept="2OqwBi" id="5nqK_jUah3R" role="3uHU7w">
               <node concept="37vLTw" id="5nqK_jUah0a" role="2Oq$k0">
@@ -19702,6 +19772,90 @@
           </node>
         </node>
         <node concept="3clFbH" id="5nqK_jUa7WV" role="3cqZAp" />
+        <node concept="3clFbJ" id="xExe$xgFqx" role="3cqZAp">
+          <node concept="3clFbS" id="xExe$xgFqz" role="3clFbx">
+            <node concept="3cpWs6" id="xExe$xgIL6" role="3cqZAp">
+              <node concept="3clFbT" id="xExe$xgIRa" role="3cqZAk">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="1Wc70l" id="xExe$xgIcD" role="3clFbw">
+            <node concept="1eOMI4" id="xExe$xgHFR" role="3uHU7B">
+              <node concept="22lmx$" id="xExe$xgHln" role="1eOMHV">
+                <node concept="2OqwBi" id="xExe$xgHrr" role="3uHU7w">
+                  <node concept="37vLTw" id="xExe$xgHp_" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5nqK_jUa6uG" resolve="sourceScaling" />
+                  </node>
+                  <node concept="21noJN" id="xExe$xgHvU" role="2OqNvi">
+                    <node concept="21nZrQ" id="xExe$xgHvW" role="21noJM">
+                      <ref role="21nZrZ" to="i3ya:4zqoYUyQ7z3" resolve="metric_positive" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="22lmx$" id="xExe$xgGo$" role="3uHU7B">
+                  <node concept="2OqwBi" id="xExe$xgFFX" role="3uHU7B">
+                    <node concept="37vLTw" id="xExe$xgFuf" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5nqK_jUa6uG" resolve="sourceScaling" />
+                    </node>
+                    <node concept="21noJN" id="xExe$xgFWB" role="2OqNvi">
+                      <node concept="21nZrQ" id="xExe$xgFWD" role="21noJM">
+                        <ref role="21nZrZ" to="i3ya:2hbaSyABMZN" resolve="metric" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="xExe$xgGAH" role="3uHU7w">
+                    <node concept="37vLTw" id="xExe$xgGsx" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5nqK_jUa6uG" resolve="sourceScaling" />
+                    </node>
+                    <node concept="21noJN" id="xExe$xgGSY" role="2OqNvi">
+                      <node concept="21nZrQ" id="xExe$xgGT0" role="21noJM">
+                        <ref role="21nZrZ" to="i3ya:4zqoYUyQ7z4" resolve="metric_negative" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1eOMI4" id="xExe$xgIgo" role="3uHU7w">
+              <node concept="22lmx$" id="xExe$xgIgp" role="1eOMHV">
+                <node concept="2OqwBi" id="xExe$xgIgq" role="3uHU7w">
+                  <node concept="37vLTw" id="xExe$xgIgr" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5nqK_jUa6vN" resolve="targetScaling" />
+                  </node>
+                  <node concept="21noJN" id="xExe$xgIgs" role="2OqNvi">
+                    <node concept="21nZrQ" id="xExe$xgIgt" role="21noJM">
+                      <ref role="21nZrZ" to="i3ya:4zqoYUyQ7z3" resolve="metric_positive" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="22lmx$" id="xExe$xgIgu" role="3uHU7B">
+                  <node concept="2OqwBi" id="xExe$xgIgv" role="3uHU7B">
+                    <node concept="37vLTw" id="xExe$xgIgw" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5nqK_jUa6vN" resolve="targetScaling" />
+                    </node>
+                    <node concept="21noJN" id="xExe$xgIgx" role="2OqNvi">
+                      <node concept="21nZrQ" id="xExe$xgIgy" role="21noJM">
+                        <ref role="21nZrZ" to="i3ya:2hbaSyABMZN" resolve="metric" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="xExe$xgIgz" role="3uHU7w">
+                    <node concept="37vLTw" id="xExe$xgIg$" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5nqK_jUa6vN" resolve="targetScaling" />
+                    </node>
+                    <node concept="21noJN" id="xExe$xgIg_" role="2OqNvi">
+                      <node concept="21nZrQ" id="xExe$xgIgA" role="21noJM">
+                        <ref role="21nZrZ" to="i3ya:4zqoYUyQ7z4" resolve="metric_negative" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="xExe$xgFjA" role="3cqZAp" />
         <node concept="3cpWs6" id="5nqK_jUa80j" role="3cqZAp">
           <node concept="17R0WA" id="5nqK_jUa82Z" role="3cqZAk">
             <node concept="37vLTw" id="5nqK_jUa84t" role="3uHU7w">
@@ -28617,6 +28771,828 @@
       <node concept="10Oyi0" id="6O1cltdz01y" role="3clF45" />
     </node>
     <node concept="3Tm1VV" id="6O1cltd$9$0" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="4zqoYUyQez3">
+    <property role="3GE5qa" value="definition.unit.prefixes" />
+    <property role="TrG5h" value="PositiveDecimalMetricUnitPrefixManager" />
+    <node concept="2tJIrI" id="4zqoYUyQez4" role="jymVt" />
+    <node concept="Wx3nA" id="4zqoYUyQez5" role="jymVt">
+      <property role="TrG5h" value="INSTANCE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="4zqoYUyQez6" role="1B3o_S" />
+      <node concept="2ShNRf" id="4zqoYUyQez7" role="33vP2m">
+        <node concept="1pGfFk" id="4zqoYUyQez8" role="2ShVmc">
+          <ref role="37wK5l" node="4zqoYUyQezh" resolve="DecimalMetricUnitPrefixManager" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="4zqoYUyQez9" role="1tU5fm">
+        <ref role="3uigEE" node="4zqoYUyQez3" resolve="DecimalMetricUnitPrefixManager" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4zqoYUyQeza" role="jymVt" />
+    <node concept="2YIFZL" id="4zqoYUyQezb" role="jymVt">
+      <property role="TrG5h" value="getInstance" />
+      <node concept="3clFbS" id="4zqoYUyQezc" role="3clF47">
+        <node concept="3clFbF" id="4zqoYUyQezd" role="3cqZAp">
+          <node concept="37vLTw" id="4zqoYUyQeBd" role="3clFbG">
+            <ref role="3cqZAo" node="4zqoYUyQez5" resolve="INSTANCE" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4zqoYUyQeze" role="1B3o_S" />
+      <node concept="3uibUv" id="4zqoYUyQezf" role="3clF45">
+        <ref role="3uigEE" node="4zqoYUyQez3" resolve="DecimalMetricUnitPrefixManager" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4zqoYUyQezg" role="jymVt" />
+    <node concept="3clFbW" id="4zqoYUyQezh" role="jymVt">
+      <node concept="3cqZAl" id="4zqoYUyQezi" role="3clF45" />
+      <node concept="3clFbS" id="4zqoYUyQezj" role="3clF47">
+        <node concept="3clFbF" id="4zqoYUyQezk" role="3cqZAp">
+          <node concept="37vLTI" id="4zqoYUyQezl" role="3clFbG">
+            <node concept="37vLTw" id="4zqoYUyQezm" role="37vLTJ">
+              <ref role="3cqZAo" node="6RONOaU4coG" resolve="prefixExps" />
+            </node>
+            <node concept="2ShNRf" id="4zqoYUyQezn" role="37vLTx">
+              <node concept="YeOm9" id="4zqoYUyQezo" role="2ShVmc">
+                <node concept="1Y3b0j" id="4zqoYUyQezp" role="YeSDq">
+                  <property role="2bfB8j" value="true" />
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="33ny:~HashMap.&lt;init&gt;()" resolve="HashMap" />
+                  <ref role="1Y3XeK" to="33ny:~HashMap" resolve="HashMap" />
+                  <node concept="3Tm1VV" id="4zqoYUyQezq" role="1B3o_S" />
+                  <node concept="17QB3L" id="4zqoYUyQezr" role="2Ghqu4" />
+                  <node concept="3uibUv" id="4zqoYUyQezs" role="2Ghqu4">
+                    <ref role="3uigEE" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                  </node>
+                  <node concept="3KIgzJ" id="4zqoYUyQezt" role="jymVt">
+                    <node concept="3clFbS" id="4zqoYUyQezu" role="3KIlGz">
+                      <node concept="3clFbF" id="4zqoYUyQezv" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQezw" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQezx" role="37wK5m">
+                            <property role="Xl_RC" value="Q" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQezy" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQezz" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQez$" role="2r_lH1">
+                                <property role="Xl_RC" value="quetta" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQez_" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQezA" role="2r_lH1">
+                                <property role="3cmrfH" value="30" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQezB" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQezC" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQezD" role="37wK5m">
+                            <property role="Xl_RC" value="R" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQezE" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQezF" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQezG" role="2r_lH1">
+                                <property role="Xl_RC" value="ronna" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQezH" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQezI" role="2r_lH1">
+                                <property role="3cmrfH" value="27" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQezJ" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQezK" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQezL" role="37wK5m">
+                            <property role="Xl_RC" value="Y" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQezM" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQezN" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQezO" role="2r_lH1">
+                                <property role="Xl_RC" value="yotta" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQezP" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQezQ" role="2r_lH1">
+                                <property role="3cmrfH" value="24" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQezR" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQezS" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQezT" role="37wK5m">
+                            <property role="Xl_RC" value="Z" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQezU" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQezV" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQezW" role="2r_lH1">
+                                <property role="Xl_RC" value="zetta" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQezX" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQezY" role="2r_lH1">
+                                <property role="3cmrfH" value="21" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQezZ" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQe$0" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQe$1" role="37wK5m">
+                            <property role="Xl_RC" value="E" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQe$2" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQe$3" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQe$4" role="2r_lH1">
+                                <property role="Xl_RC" value="exa" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQe$5" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQe$6" role="2r_lH1">
+                                <property role="3cmrfH" value="18" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQe$7" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQe$8" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQe$9" role="37wK5m">
+                            <property role="Xl_RC" value="P" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQe$a" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQe$b" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQe$c" role="2r_lH1">
+                                <property role="Xl_RC" value="peta" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQe$d" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQe$e" role="2r_lH1">
+                                <property role="3cmrfH" value="15" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQe$f" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQe$g" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQe$h" role="37wK5m">
+                            <property role="Xl_RC" value="T" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQe$i" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQe$j" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQe$k" role="2r_lH1">
+                                <property role="Xl_RC" value="tera" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQe$l" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQe$m" role="2r_lH1">
+                                <property role="3cmrfH" value="12" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQe$n" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQe$o" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQe$p" role="37wK5m">
+                            <property role="Xl_RC" value="G" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQe$q" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQe$r" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQe$s" role="2r_lH1">
+                                <property role="Xl_RC" value="giga" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQe$t" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQe$u" role="2r_lH1">
+                                <property role="3cmrfH" value="9" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQe$v" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQe$w" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQe$x" role="37wK5m">
+                            <property role="Xl_RC" value="M" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQe$y" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQe$z" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQe$$" role="2r_lH1">
+                                <property role="Xl_RC" value="mega" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQe$_" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQe$A" role="2r_lH1">
+                                <property role="3cmrfH" value="6" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQe$B" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQe$C" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQe$D" role="37wK5m">
+                            <property role="Xl_RC" value="k" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQe$E" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQe$F" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQe$G" role="2r_lH1">
+                                <property role="Xl_RC" value="kilo" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQe$H" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQe$I" role="2r_lH1">
+                                <property role="3cmrfH" value="3" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQe$J" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQe$K" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQe$L" role="37wK5m">
+                            <property role="Xl_RC" value="h" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQe$M" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQe$N" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQe$O" role="2r_lH1">
+                                <property role="Xl_RC" value="hecto" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQe$P" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQe$Q" role="2r_lH1">
+                                <property role="3cmrfH" value="2" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQe$R" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQe$S" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQe$T" role="37wK5m">
+                            <property role="Xl_RC" value="da" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQe$U" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQe$V" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQe$W" role="2r_lH1">
+                                <property role="Xl_RC" value="deca" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQe$X" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQe$Y" role="2r_lH1">
+                                <property role="3cmrfH" value="1" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="4zqoYUyQeAC" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="4zqoYUyQeAD" role="jymVt" />
+    <node concept="3clFb_" id="4zqoYUyQeAE" role="jymVt">
+      <property role="TrG5h" value="supportsPrefix" />
+      <node concept="37vLTG" id="4zqoYUyQeAF" role="3clF46">
+        <property role="TrG5h" value="unit" />
+        <node concept="3Tqbb2" id="4zqoYUyQeAG" role="1tU5fm">
+          <ref role="ehGHo" to="i3ya:7eOyx9r3jsZ" resolve="Unit" />
+        </node>
+      </node>
+      <node concept="10P_77" id="4zqoYUyQeAH" role="3clF45" />
+      <node concept="3Tm1VV" id="4zqoYUyQeAI" role="1B3o_S" />
+      <node concept="3clFbS" id="4zqoYUyQeAJ" role="3clF47">
+        <node concept="3clFbF" id="4zqoYUyQeAK" role="3cqZAp">
+          <node concept="2OqwBi" id="4zqoYUyQeAL" role="3clFbG">
+            <node concept="2OqwBi" id="4zqoYUyQeAM" role="2Oq$k0">
+              <node concept="37vLTw" id="4zqoYUyQeAN" role="2Oq$k0">
+                <ref role="3cqZAo" node="4zqoYUyQeAF" resolve="unit" />
+              </node>
+              <node concept="3TrcHB" id="4zqoYUyQeAO" role="2OqNvi">
+                <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
+              </node>
+            </node>
+            <node concept="21noJN" id="4zqoYUyQeAP" role="2OqNvi">
+              <node concept="21nZrQ" id="4zqoYUyQeAQ" role="21noJM">
+                <ref role="21nZrZ" to="i3ya:4zqoYUyQ7z3" resolve="metric_positive" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="4zqoYUyQeAR" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4zqoYUyQeAS" role="jymVt" />
+    <node concept="3clFb_" id="4zqoYUyQeAT" role="jymVt">
+      <property role="TrG5h" value="getBase" />
+      <node concept="3Tm1VV" id="4zqoYUyQeAU" role="1B3o_S" />
+      <node concept="10Oyi0" id="4zqoYUyQeAV" role="3clF45" />
+      <node concept="3clFbS" id="4zqoYUyQeAW" role="3clF47">
+        <node concept="3clFbF" id="4zqoYUyQeAX" role="3cqZAp">
+          <node concept="3cmrfG" id="4zqoYUyQeAY" role="3clFbG">
+            <property role="3cmrfH" value="10" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="4zqoYUyQeAZ" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="4zqoYUyQeB0" role="1B3o_S" />
+    <node concept="3uibUv" id="4zqoYUyQeB1" role="1zkMxy">
+      <ref role="3uigEE" node="2hbaSyB0mSO" resolve="AbstractUnitPrefixManager" />
+      <node concept="3uibUv" id="4zqoYUyQeB2" role="11_B2D">
+        <ref role="3uigEE" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="4zqoYUyQwEP">
+    <property role="3GE5qa" value="definition.unit.prefixes" />
+    <property role="TrG5h" value="NegativeDecimalMetricUnitPrefixManager" />
+    <node concept="2tJIrI" id="4zqoYUyQwEQ" role="jymVt" />
+    <node concept="Wx3nA" id="4zqoYUyQwER" role="jymVt">
+      <property role="TrG5h" value="INSTANCE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="4zqoYUyQwES" role="1B3o_S" />
+      <node concept="2ShNRf" id="4zqoYUyQwET" role="33vP2m">
+        <node concept="1pGfFk" id="4zqoYUyQwEU" role="2ShVmc">
+          <ref role="37wK5l" node="4zqoYUyQwF3" resolve="DecimalMetricUnitPrefixManager" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="4zqoYUyQwEV" role="1tU5fm">
+        <ref role="3uigEE" node="4zqoYUyQwEP" resolve="DecimalMetricUnitPrefixManager" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4zqoYUyQwEW" role="jymVt" />
+    <node concept="2YIFZL" id="4zqoYUyQwEX" role="jymVt">
+      <property role="TrG5h" value="getInstance" />
+      <node concept="3clFbS" id="4zqoYUyQwEY" role="3clF47">
+        <node concept="3clFbF" id="4zqoYUyQwEZ" role="3cqZAp">
+          <node concept="37vLTw" id="4zqoYUyQwIZ" role="3clFbG">
+            <ref role="3cqZAo" node="4zqoYUyQwER" resolve="INSTANCE" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4zqoYUyQwF0" role="1B3o_S" />
+      <node concept="3uibUv" id="4zqoYUyQwF1" role="3clF45">
+        <ref role="3uigEE" node="4zqoYUyQwEP" resolve="DecimalMetricUnitPrefixManager" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4zqoYUyQwF2" role="jymVt" />
+    <node concept="3clFbW" id="4zqoYUyQwF3" role="jymVt">
+      <node concept="3cqZAl" id="4zqoYUyQwF4" role="3clF45" />
+      <node concept="3clFbS" id="4zqoYUyQwF5" role="3clF47">
+        <node concept="3clFbF" id="4zqoYUyQwF6" role="3cqZAp">
+          <node concept="37vLTI" id="4zqoYUyQwF7" role="3clFbG">
+            <node concept="37vLTw" id="4zqoYUyQwF8" role="37vLTJ">
+              <ref role="3cqZAo" node="6RONOaU4coG" resolve="prefixExps" />
+            </node>
+            <node concept="2ShNRf" id="4zqoYUyQwF9" role="37vLTx">
+              <node concept="YeOm9" id="4zqoYUyQwFa" role="2ShVmc">
+                <node concept="1Y3b0j" id="4zqoYUyQwFb" role="YeSDq">
+                  <property role="2bfB8j" value="true" />
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="33ny:~HashMap.&lt;init&gt;()" resolve="HashMap" />
+                  <ref role="1Y3XeK" to="33ny:~HashMap" resolve="HashMap" />
+                  <node concept="3Tm1VV" id="4zqoYUyQwFc" role="1B3o_S" />
+                  <node concept="17QB3L" id="4zqoYUyQwFd" role="2Ghqu4" />
+                  <node concept="3uibUv" id="4zqoYUyQwFe" role="2Ghqu4">
+                    <ref role="3uigEE" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                  </node>
+                  <node concept="3KIgzJ" id="4zqoYUyQwFf" role="jymVt">
+                    <node concept="3clFbS" id="4zqoYUyQwFg" role="3KIlGz">
+                      <node concept="3clFbF" id="4zqoYUyQwGL" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQwGM" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQwGN" role="37wK5m">
+                            <property role="Xl_RC" value="d" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQwGO" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQwGP" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQwGQ" role="2r_lH1">
+                                <property role="Xl_RC" value="deci" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQwGR" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQwGS" role="2r_lH1">
+                                <property role="3cmrfH" value="-1" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQwGT" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQwGU" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQwGV" role="37wK5m">
+                            <property role="Xl_RC" value="c" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQwGW" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQwGX" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQwGY" role="2r_lH1">
+                                <property role="Xl_RC" value="centi" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQwGZ" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQwH0" role="2r_lH1">
+                                <property role="3cmrfH" value="-2" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQwH1" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQwH2" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQwH3" role="37wK5m">
+                            <property role="Xl_RC" value="m" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQwH4" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQwH5" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQwH6" role="2r_lH1">
+                                <property role="Xl_RC" value="milli" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQwH7" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQwH8" role="2r_lH1">
+                                <property role="3cmrfH" value="-3" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQwH9" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQwHa" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQwHb" role="37wK5m">
+                            <property role="Xl_RC" value="μ" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQwHc" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQwHd" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQwHe" role="2r_lH1">
+                                <property role="Xl_RC" value="micro" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQwHf" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQwHg" role="2r_lH1">
+                                <property role="3cmrfH" value="-6" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQwHh" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQwHi" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQwHj" role="37wK5m">
+                            <property role="Xl_RC" value="µ" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQwHk" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQwHl" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQwHm" role="2r_lH1">
+                                <property role="Xl_RC" value="micro" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQwHn" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQwHo" role="2r_lH1">
+                                <property role="3cmrfH" value="-6" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQwHp" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQwHq" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQwHr" role="37wK5m">
+                            <property role="Xl_RC" value="n" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQwHs" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQwHt" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQwHu" role="2r_lH1">
+                                <property role="Xl_RC" value="nano" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQwHv" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQwHw" role="2r_lH1">
+                                <property role="3cmrfH" value="-9" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQwHx" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQwHy" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQwHz" role="37wK5m">
+                            <property role="Xl_RC" value="p" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQwH$" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQwH_" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQwHA" role="2r_lH1">
+                                <property role="Xl_RC" value="pico" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQwHB" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQwHC" role="2r_lH1">
+                                <property role="3cmrfH" value="-12" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQwHD" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQwHE" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQwHF" role="37wK5m">
+                            <property role="Xl_RC" value="f" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQwHG" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQwHH" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQwHI" role="2r_lH1">
+                                <property role="Xl_RC" value="femto" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQwHJ" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQwHK" role="2r_lH1">
+                                <property role="3cmrfH" value="-15" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQwHL" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQwHM" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQwHN" role="37wK5m">
+                            <property role="Xl_RC" value="a" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQwHO" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQwHP" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQwHQ" role="2r_lH1">
+                                <property role="Xl_RC" value="atto" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQwHR" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQwHS" role="2r_lH1">
+                                <property role="3cmrfH" value="-18" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQwHT" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQwHU" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQwHV" role="37wK5m">
+                            <property role="Xl_RC" value="z" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQwHW" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQwHX" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQwHY" role="2r_lH1">
+                                <property role="Xl_RC" value="zepto" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQwHZ" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQwI0" role="2r_lH1">
+                                <property role="3cmrfH" value="-21" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQwI1" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQwI2" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQwI3" role="37wK5m">
+                            <property role="Xl_RC" value="y" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQwI4" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQwI5" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQwI6" role="2r_lH1">
+                                <property role="Xl_RC" value="yocto" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQwI7" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQwI8" role="2r_lH1">
+                                <property role="3cmrfH" value="-24" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQwI9" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQwIa" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQwIb" role="37wK5m">
+                            <property role="Xl_RC" value="r" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQwIc" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQwId" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQwIe" role="2r_lH1">
+                                <property role="Xl_RC" value="ronto" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQwIf" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQwIg" role="2r_lH1">
+                                <property role="3cmrfH" value="-27" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="4zqoYUyQwIh" role="3cqZAp">
+                        <node concept="1rXfSq" id="4zqoYUyQwIi" role="3clFbG">
+                          <ref role="37wK5l" to="33ny:~HashMap.put(java.lang.Object,java.lang.Object)" resolve="put" />
+                          <node concept="Xl_RD" id="4zqoYUyQwIj" role="37wK5m">
+                            <property role="Xl_RC" value="q" />
+                          </node>
+                          <node concept="2ry78W" id="4zqoYUyQwIk" role="37wK5m">
+                            <ref role="2ryb1Q" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+                            <node concept="2r$n1x" id="4zqoYUyQwIl" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITt" resolve="name" />
+                              <node concept="Xl_RD" id="4zqoYUyQwIm" role="2r_lH1">
+                                <property role="Xl_RC" value="quecto" />
+                              </node>
+                            </node>
+                            <node concept="2r$n1x" id="4zqoYUyQwIn" role="2r_Bvh">
+                              <ref role="2r$qp6" node="2hbaSyB0ITv" resolve="factor" />
+                              <node concept="3cmrfG" id="4zqoYUyQwIo" role="2r_lH1">
+                                <property role="3cmrfH" value="-30" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbH" id="4zqoYUyQwIp" role="3cqZAp" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="4zqoYUyQwIq" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="4zqoYUyQwIr" role="jymVt" />
+    <node concept="3clFb_" id="4zqoYUyQwIs" role="jymVt">
+      <property role="TrG5h" value="supportsPrefix" />
+      <node concept="37vLTG" id="4zqoYUyQwIt" role="3clF46">
+        <property role="TrG5h" value="unit" />
+        <node concept="3Tqbb2" id="4zqoYUyQwIu" role="1tU5fm">
+          <ref role="ehGHo" to="i3ya:7eOyx9r3jsZ" resolve="Unit" />
+        </node>
+      </node>
+      <node concept="10P_77" id="4zqoYUyQwIv" role="3clF45" />
+      <node concept="3Tm1VV" id="4zqoYUyQwIw" role="1B3o_S" />
+      <node concept="3clFbS" id="4zqoYUyQwIx" role="3clF47">
+        <node concept="3clFbF" id="4zqoYUyQwIy" role="3cqZAp">
+          <node concept="2OqwBi" id="4zqoYUyQwIz" role="3clFbG">
+            <node concept="2OqwBi" id="4zqoYUyQwI$" role="2Oq$k0">
+              <node concept="37vLTw" id="4zqoYUyQwI_" role="2Oq$k0">
+                <ref role="3cqZAo" node="4zqoYUyQwIt" resolve="unit" />
+              </node>
+              <node concept="3TrcHB" id="4zqoYUyQwIA" role="2OqNvi">
+                <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
+              </node>
+            </node>
+            <node concept="21noJN" id="4zqoYUyQwIB" role="2OqNvi">
+              <node concept="21nZrQ" id="4zqoYUyQwIC" role="21noJM">
+                <ref role="21nZrZ" to="i3ya:4zqoYUyQ7z4" resolve="metric_negative" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="4zqoYUyQwID" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4zqoYUyQwIE" role="jymVt" />
+    <node concept="3clFb_" id="4zqoYUyQwIF" role="jymVt">
+      <property role="TrG5h" value="getBase" />
+      <node concept="3Tm1VV" id="4zqoYUyQwIG" role="1B3o_S" />
+      <node concept="10Oyi0" id="4zqoYUyQwIH" role="3clF45" />
+      <node concept="3clFbS" id="4zqoYUyQwII" role="3clF47">
+        <node concept="3clFbF" id="4zqoYUyQwIJ" role="3cqZAp">
+          <node concept="3cmrfG" id="4zqoYUyQwIK" role="3clFbG">
+            <property role="3cmrfH" value="10" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="4zqoYUyQwIL" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="4zqoYUyQwIM" role="1B3o_S" />
+    <node concept="3uibUv" id="4zqoYUyQwIN" role="1zkMxy">
+      <ref role="3uigEE" node="2hbaSyB0mSO" resolve="AbstractUnitPrefixManager" />
+      <node concept="3uibUv" id="4zqoYUyQwIO" role="11_B2D">
+        <ref role="3uigEE" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
@@ -502,7 +502,11 @@
       <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
+      <concept id="5045161044515397667" name="jetbrains.mps.lang.smodel.structure.Node_PointerOperation" flags="ng" index="iZEcu" />
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="7400021826771268254" name="jetbrains.mps.lang.smodel.structure.SNodePointerType" flags="ig" index="2sp9CU">
+        <reference id="7400021826771268269" name="concept" index="2sp9C9" />
+      </concept>
       <concept id="7400021826774799413" name="jetbrains.mps.lang.smodel.structure.NodePointerExpression" flags="ng" index="2tJFMh">
         <child id="7400021826774799510" name="ref" index="2tJFKM" />
       </concept>
@@ -1553,22 +1557,21 @@
       <ref role="13i0hy" node="7yw1DU95L3$" resolve="getScalingType" />
       <node concept="3Tm1VV" id="7yw1DU95LTI" role="1B3o_S" />
       <node concept="3clFbS" id="7yw1DU95LTN" role="3clF47">
-        <node concept="3cpWs6" id="7yw1DU95Mc$" role="3cqZAp">
-          <node concept="2OqwBi" id="7i1yFLlzGho" role="3cqZAk">
-            <node concept="1PxgMI" id="7i1yFLlzFS5" role="2Oq$k0">
+        <node concept="3clFbF" id="4zqoYUChHTM" role="3cqZAp">
+          <node concept="2YIFZM" id="4zqoYUChHTO" role="3clFbG">
+            <ref role="37wK5l" node="4zqoYUCdlDz" resolve="getScaling" />
+            <ref role="1Pybhc" node="4jkbLB5RJZL" resolve="UnitConversionUtil" />
+            <node concept="1PxgMI" id="4zqoYUChJER" role="37wK5m">
               <property role="1BlNFB" value="true" />
-              <node concept="chp4Y" id="7i1yFLlzFWb" role="3oSUPX">
+              <node concept="chp4Y" id="4zqoYUChJN3" role="3oSUPX">
                 <ref role="cht4Q" to="i3ya:7eOyx9r3jsZ" resolve="Unit" />
               </node>
-              <node concept="2OqwBi" id="7i1yFLlzFhu" role="1m5AlR">
-                <node concept="13iPFW" id="7i1yFLlzFgI" role="2Oq$k0" />
-                <node concept="3TrEf2" id="7i1yFLlzFlv" role="2OqNvi">
+              <node concept="2OqwBi" id="4zqoYUChIlz" role="1m5AlR">
+                <node concept="13iPFW" id="4zqoYUChI4g" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4zqoYUChIZ_" role="2OqNvi">
                   <ref role="3Tt5mk" to="i3ya:7eOyx9r3qFW" resolve="unit" />
                 </node>
               </node>
-            </node>
-            <node concept="3TrcHB" id="7i1yFLlzGYV" role="2OqNvi">
-              <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
             </node>
           </node>
         </node>
@@ -1902,16 +1905,26 @@
       <node concept="3Tm1VV" id="2hbaSyAVW8t" role="1B3o_S" />
       <node concept="10P_77" id="2hbaSyAVWDb" role="3clF45" />
       <node concept="3clFbS" id="2hbaSyAVW8v" role="3clF47">
+        <node concept="3cpWs8" id="4zqoYUCjfDX" role="3cqZAp">
+          <node concept="3cpWsn" id="4zqoYUCjfDY" role="3cpWs9">
+            <property role="TrG5h" value="scaling" />
+            <node concept="2ZThk1" id="4zqoYUCjfzc" role="1tU5fm">
+              <ref role="2ZWj4r" to="i3ya:2hbaSyABMZL" resolve="UnitScalingType" />
+            </node>
+            <node concept="2YIFZM" id="4zqoYUCjfDZ" role="33vP2m">
+              <ref role="37wK5l" node="4zqoYUCdlDz" resolve="getScaling" />
+              <ref role="1Pybhc" node="4jkbLB5RJZL" resolve="UnitConversionUtil" />
+              <node concept="13iPFW" id="4zqoYUCjfE0" role="37wK5m" />
+            </node>
+          </node>
+        </node>
         <node concept="3clFbF" id="2hbaSyAVWQK" role="3cqZAp">
           <node concept="22lmx$" id="1eut2uSUzlG" role="3clFbG">
             <node concept="22lmx$" id="2hbaSyAVY1S" role="3uHU7B">
               <node concept="22lmx$" id="4zqoYUyRUB8" role="3uHU7B">
                 <node concept="2OqwBi" id="4zqoYUyRW6p" role="3uHU7w">
-                  <node concept="2OqwBi" id="4zqoYUyRV4t" role="2Oq$k0">
-                    <node concept="13iPFW" id="4zqoYUyRUGW" role="2Oq$k0" />
-                    <node concept="3TrcHB" id="4zqoYUyRVUT" role="2OqNvi">
-                      <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
-                    </node>
+                  <node concept="37vLTw" id="4zqoYUCjgu6" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4zqoYUCjfDY" resolve="scaling" />
                   </node>
                   <node concept="21noJN" id="4zqoYUyRWm7" role="2OqNvi">
                     <node concept="21nZrQ" id="4zqoYUyRWm9" role="21noJM">
@@ -1921,11 +1934,8 @@
                 </node>
                 <node concept="22lmx$" id="4zqoYUyRS$F" role="3uHU7B">
                   <node concept="2OqwBi" id="2hbaSyAVXpv" role="3uHU7B">
-                    <node concept="2OqwBi" id="2hbaSyAVXeP" role="2Oq$k0">
-                      <node concept="13iPFW" id="2hbaSyAVWQJ" role="2Oq$k0" />
-                      <node concept="3TrcHB" id="2hbaSyAVXkQ" role="2OqNvi">
-                        <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
-                      </node>
+                    <node concept="37vLTw" id="4zqoYUCjgau" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4zqoYUCjfDY" resolve="scaling" />
                     </node>
                     <node concept="21noJN" id="2hbaSyAVXyq" role="2OqNvi">
                       <node concept="21nZrQ" id="2hbaSyAVXys" role="21noJM">
@@ -1934,11 +1944,8 @@
                     </node>
                   </node>
                   <node concept="2OqwBi" id="4zqoYUyRTYF" role="3uHU7w">
-                    <node concept="2OqwBi" id="4zqoYUyRSXn" role="2Oq$k0">
-                      <node concept="13iPFW" id="4zqoYUyRSA8" role="2Oq$k0" />
-                      <node concept="3TrcHB" id="4zqoYUyRTNv" role="2OqNvi">
-                        <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
-                      </node>
+                    <node concept="37vLTw" id="4zqoYUCjgko" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4zqoYUCjfDY" resolve="scaling" />
                     </node>
                     <node concept="21noJN" id="4zqoYUyRUe5" role="2OqNvi">
                       <node concept="21nZrQ" id="4zqoYUyRUe7" role="21noJM">
@@ -1949,11 +1956,8 @@
                 </node>
               </node>
               <node concept="2OqwBi" id="2hbaSyAVZma" role="3uHU7w">
-                <node concept="2OqwBi" id="2hbaSyAVY8S" role="2Oq$k0">
-                  <node concept="13iPFW" id="2hbaSyAVY49" role="2Oq$k0" />
-                  <node concept="3TrcHB" id="2hbaSyAVZ6F" role="2OqNvi">
-                    <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
-                  </node>
+                <node concept="37vLTw" id="4zqoYUCjgCf" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4zqoYUCjfDY" resolve="scaling" />
                 </node>
                 <node concept="21noJN" id="2hbaSyAVZBB" role="2OqNvi">
                   <node concept="21nZrQ" id="2hbaSyAVZBD" role="21noJM">
@@ -1963,11 +1967,8 @@
               </node>
             </node>
             <node concept="2OqwBi" id="1eut2uSUzB5" role="3uHU7w">
-              <node concept="2OqwBi" id="1eut2uSUzB6" role="2Oq$k0">
-                <node concept="13iPFW" id="1eut2uSUzB7" role="2Oq$k0" />
-                <node concept="3TrcHB" id="1eut2uSUzB8" role="2OqNvi">
-                  <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
-                </node>
+              <node concept="37vLTw" id="4zqoYUCjgIh" role="2Oq$k0">
+                <ref role="3cqZAo" node="4zqoYUCjfDY" resolve="scaling" />
               </node>
               <node concept="21noJN" id="1eut2uSUzB9" role="2OqNvi">
                 <node concept="21nZrQ" id="1eut2uSUzBa" role="21noJM">
@@ -10030,42 +10031,40 @@
                     </node>
                   </node>
                   <node concept="17QLQc" id="6RONOaUlUgY" role="3clFbw">
-                    <node concept="2OqwBi" id="6RONOaUmdwx" role="3uHU7w">
-                      <node concept="1PxgMI" id="6RONOaUm8Qc" role="2Oq$k0">
+                    <node concept="2YIFZM" id="4zqoYUCgB9v" role="3uHU7B">
+                      <ref role="37wK5l" node="4zqoYUCdlDz" resolve="getScaling" />
+                      <ref role="1Pybhc" node="4jkbLB5RJZL" resolve="UnitConversionUtil" />
+                      <node concept="1PxgMI" id="4zqoYUCgH6z" role="37wK5m">
                         <property role="1BlNFB" value="true" />
-                        <node concept="chp4Y" id="6RONOaUmdj6" role="3oSUPX">
+                        <node concept="chp4Y" id="4zqoYUCgH6$" role="3oSUPX">
                           <ref role="cht4Q" to="i3ya:7eOyx9r3jsZ" resolve="Unit" />
                         </node>
-                        <node concept="2OqwBi" id="6RONOaUlZRv" role="1m5AlR">
-                          <node concept="37vLTw" id="6RONOaUlYR0" role="2Oq$k0">
-                            <ref role="3cqZAo" node="5X7HQPSGrDJ" resolve="targetUnitReference" />
-                          </node>
-                          <node concept="3TrEf2" id="6RONOaUm4la" role="2OqNvi">
-                            <ref role="3Tt5mk" to="i3ya:7eOyx9r3qFW" resolve="unit" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3TrcHB" id="6RONOaUmi2k" role="2OqNvi">
-                        <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
-                      </node>
-                    </node>
-                    <node concept="2OqwBi" id="6RONOaUlKki" role="3uHU7B">
-                      <node concept="1PxgMI" id="6RONOaUlFi0" role="2Oq$k0">
-                        <property role="1BlNFB" value="true" />
-                        <node concept="chp4Y" id="6RONOaUlJRD" role="3oSUPX">
-                          <ref role="cht4Q" to="i3ya:7eOyx9r3jsZ" resolve="Unit" />
-                        </node>
-                        <node concept="2OqwBi" id="6RONOaUlqub" role="1m5AlR">
-                          <node concept="Jnkvi" id="6RONOaUlpXD" role="2Oq$k0">
+                        <node concept="2OqwBi" id="4zqoYUCgH6_" role="1m5AlR">
+                          <node concept="Jnkvi" id="4zqoYUCgH6A" role="2Oq$k0">
                             <ref role="1M0zk5" node="5X7HQPSGrFe" resolve="sourceExpression" />
                           </node>
-                          <node concept="3TrEf2" id="6RONOaUlvn4" role="2OqNvi">
+                          <node concept="3TrEf2" id="4zqoYUCgH6B" role="2OqNvi">
                             <ref role="3Tt5mk" to="i3ya:7eOyx9r3qFW" resolve="unit" />
                           </node>
                         </node>
                       </node>
-                      <node concept="3TrcHB" id="6RONOaUlPyJ" role="2OqNvi">
-                        <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
+                    </node>
+                    <node concept="2YIFZM" id="4zqoYUChbSu" role="3uHU7w">
+                      <ref role="37wK5l" node="4zqoYUCdlDz" resolve="getScaling" />
+                      <ref role="1Pybhc" node="4jkbLB5RJZL" resolve="UnitConversionUtil" />
+                      <node concept="1PxgMI" id="4zqoYUChhW8" role="37wK5m">
+                        <property role="1BlNFB" value="true" />
+                        <node concept="chp4Y" id="4zqoYUChhW9" role="3oSUPX">
+                          <ref role="cht4Q" to="i3ya:7eOyx9r3jsZ" resolve="Unit" />
+                        </node>
+                        <node concept="2OqwBi" id="4zqoYUChhWa" role="1m5AlR">
+                          <node concept="37vLTw" id="4zqoYUChhWb" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5X7HQPSGrDJ" resolve="targetUnitReference" />
+                          </node>
+                          <node concept="3TrEf2" id="4zqoYUChhWc" role="2OqNvi">
+                            <ref role="3Tt5mk" to="i3ya:7eOyx9r3qFW" resolve="unit" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -10575,6 +10574,88 @@
         </node>
       </node>
       <node concept="3Tm1VV" id="6rBnJAoiEbu" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="4zqoYUCcXrR" role="jymVt" />
+    <node concept="2YIFZL" id="4zqoYUCdlDz" role="jymVt">
+      <property role="TrG5h" value="getScaling" />
+      <node concept="3clFbS" id="4zqoYUCdlDA" role="3clF47">
+        <node concept="3cpWs8" id="4zqoYUCeb1U" role="3cqZAp">
+          <node concept="3cpWsn" id="4zqoYUCeb1V" role="3cpWs9">
+            <property role="TrG5h" value="overwrittenScalingMap" />
+            <node concept="3rvAFt" id="4zqoYUCe6oK" role="1tU5fm">
+              <node concept="2sp9CU" id="4zqoYUClbpr" role="3rvQeY">
+                <ref role="2sp9C9" to="i3ya:7eOyx9r3jsZ" resolve="Unit" />
+              </node>
+              <node concept="2ZThk1" id="4zqoYUCe6oP" role="3rvSg0">
+                <ref role="2ZWj4r" to="i3ya:2hbaSyABMZL" resolve="UnitScalingType" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4zqoYUCeb1W" role="33vP2m">
+              <node concept="2YIFZM" id="4zqoYUCeb1X" role="2Oq$k0">
+                <ref role="37wK5l" to="65nr:4qv99IrBnzk" resolve="getConfig" />
+                <ref role="1Pybhc" to="65nr:4qv99IrBkzE" resolve="PhysUnitLangConfigHelper" />
+              </node>
+              <node concept="liA8E" id="4zqoYUCeb1Y" role="2OqNvi">
+                <ref role="37wK5l" to="65nr:4zqoYUC7SCk" resolve="getOverwrittenScaling" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4zqoYUCeupn" role="3cqZAp">
+          <node concept="3clFbS" id="4zqoYUCeupp" role="3clFbx">
+            <node concept="3cpWs6" id="4zqoYUCf2CR" role="3cqZAp">
+              <node concept="3EllGN" id="4zqoYUCfhub" role="3cqZAk">
+                <node concept="2OqwBi" id="4zqoYUClsCx" role="3ElVtu">
+                  <node concept="37vLTw" id="4zqoYUCfmm4" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4zqoYUCdt5q" resolve="unit" />
+                  </node>
+                  <node concept="iZEcu" id="4zqoYUClyaT" role="2OqNvi" />
+                </node>
+                <node concept="37vLTw" id="4zqoYUCfce7" role="3ElQJh">
+                  <ref role="3cqZAo" node="4zqoYUCeb1V" resolve="overwrittenScalingMap" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="4zqoYUCeCvj" role="3clFbw">
+            <node concept="37vLTw" id="4zqoYUCezgj" role="2Oq$k0">
+              <ref role="3cqZAo" node="4zqoYUCeb1V" resolve="overwrittenScalingMap" />
+            </node>
+            <node concept="2Nt0df" id="4zqoYUCeS8h" role="2OqNvi">
+              <node concept="2OqwBi" id="4zqoYUClh9p" role="38cxEo">
+                <node concept="37vLTw" id="4zqoYUCeWZx" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4zqoYUCdt5q" resolve="unit" />
+                </node>
+                <node concept="iZEcu" id="4zqoYUClnez" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="4zqoYUCfr4A" role="9aQIa">
+            <node concept="3clFbS" id="4zqoYUCfr4B" role="9aQI4">
+              <node concept="3cpWs6" id="4zqoYUCfwIz" role="3cqZAp">
+                <node concept="2OqwBi" id="4zqoYUCfz12" role="3cqZAk">
+                  <node concept="37vLTw" id="4zqoYUCfyuC" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4zqoYUCdt5q" resolve="unit" />
+                  </node>
+                  <node concept="3TrcHB" id="4zqoYUCfC$o" role="2OqNvi">
+                    <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4zqoYUCd4S3" role="1B3o_S" />
+      <node concept="2ZThk1" id="4zqoYUCdh2B" role="3clF45">
+        <ref role="2ZWj4r" to="i3ya:2hbaSyABMZL" resolve="UnitScalingType" />
+      </node>
+      <node concept="37vLTG" id="4zqoYUCdt5q" role="3clF46">
+        <property role="TrG5h" value="unit" />
+        <node concept="3Tqbb2" id="4zqoYUCdt5p" role="1tU5fm">
+          <ref role="ehGHo" to="i3ya:7eOyx9r3jsZ" resolve="Unit" />
+        </node>
+      </node>
     </node>
     <node concept="3Tm1VV" id="4jkbLB5RJZM" role="1B3o_S" />
   </node>
@@ -16058,17 +16139,16 @@
       <node concept="3clFbS" id="6RONOaU5Hf4" role="3clF47">
         <node concept="3clFbF" id="6RONOaU5UYU" role="3cqZAp">
           <node concept="2OqwBi" id="6RONOaU61_Q" role="3clFbG">
-            <node concept="2OqwBi" id="6RONOaU5WEQ" role="2Oq$k0">
-              <node concept="37vLTw" id="6RONOaU5UYT" role="2Oq$k0">
-                <ref role="3cqZAo" node="6RONOaU5Hf0" resolve="unit" />
-              </node>
-              <node concept="3TrcHB" id="6RONOaU60rj" role="2OqNvi">
-                <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
-              </node>
-            </node>
             <node concept="21noJN" id="6RONOaU64NO" role="2OqNvi">
               <node concept="21nZrQ" id="6RONOaU64NQ" role="21noJM">
                 <ref role="21nZrZ" to="i3ya:2hbaSyABMZN" resolve="metric" />
+              </node>
+            </node>
+            <node concept="2YIFZM" id="4zqoYUCgcct" role="2Oq$k0">
+              <ref role="37wK5l" node="4zqoYUCdlDz" resolve="getScaling" />
+              <ref role="1Pybhc" node="4jkbLB5RJZL" resolve="UnitConversionUtil" />
+              <node concept="37vLTw" id="4zqoYUCgccu" role="37wK5m">
+                <ref role="3cqZAo" node="6RONOaU5Hf0" resolve="unit" />
               </node>
             </node>
           </node>
@@ -19419,17 +19499,16 @@
       <node concept="3clFbS" id="6RONOaUhCcP" role="3clF47">
         <node concept="3clFbF" id="6RONOaUhCcQ" role="3cqZAp">
           <node concept="2OqwBi" id="6RONOaUhCcR" role="3clFbG">
-            <node concept="2OqwBi" id="6RONOaUhCcS" role="2Oq$k0">
-              <node concept="37vLTw" id="6RONOaUhCcT" role="2Oq$k0">
-                <ref role="3cqZAo" node="6RONOaUhCcL" resolve="unit" />
-              </node>
-              <node concept="3TrcHB" id="6RONOaUhCcU" role="2OqNvi">
-                <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
-              </node>
-            </node>
             <node concept="21noJN" id="6RONOaUhCcV" role="2OqNvi">
               <node concept="21nZrQ" id="6RONOaUhCcW" role="21noJM">
                 <ref role="21nZrZ" to="i3ya:6DczoUSGcZl" resolve="binary_memory" />
+              </node>
+            </node>
+            <node concept="2YIFZM" id="4zqoYUCg6hn" role="2Oq$k0">
+              <ref role="37wK5l" node="4zqoYUCdlDz" resolve="getScaling" />
+              <ref role="1Pybhc" node="4jkbLB5RJZL" resolve="UnitConversionUtil" />
+              <node concept="37vLTw" id="4zqoYUCg6ho" role="37wK5m">
+                <ref role="3cqZAo" node="6RONOaUhCcL" resolve="unit" />
               </node>
             </node>
           </node>
@@ -19497,21 +19576,21 @@
     <node concept="2YIFZL" id="6RONOaUjvI9" role="jymVt">
       <property role="TrG5h" value="getManager" />
       <node concept="3clFbS" id="6RONOaUjvIc" role="3clF47">
+        <node concept="3clFbH" id="4zqoYUCgeLE" role="3cqZAp" />
         <node concept="3cpWs8" id="6RONOaUkHnF" role="3cqZAp">
           <node concept="3cpWsn" id="6RONOaUkHnI" role="3cpWs9">
             <property role="TrG5h" value="sourceScaling" />
-            <node concept="2OqwBi" id="5nqK_jUaffu" role="33vP2m">
-              <node concept="1PxgMI" id="6RONOaUkI6p" role="2Oq$k0">
+            <node concept="2YIFZM" id="4zqoYUCgeRE" role="33vP2m">
+              <ref role="37wK5l" node="4zqoYUCdlDz" resolve="getScaling" />
+              <ref role="1Pybhc" node="4jkbLB5RJZL" resolve="UnitConversionUtil" />
+              <node concept="1PxgMI" id="4zqoYUCgf7s" role="37wK5m">
                 <property role="1BlNFB" value="true" />
-                <node concept="chp4Y" id="6RONOaUkIbm" role="3oSUPX">
+                <node concept="chp4Y" id="4zqoYUCgf7t" role="3oSUPX">
                   <ref role="cht4Q" to="i3ya:7eOyx9r3jsZ" resolve="Unit" />
                 </node>
-                <node concept="37vLTw" id="6RONOaUkHv2" role="1m5AlR">
+                <node concept="37vLTw" id="4zqoYUCgf7u" role="1m5AlR">
                   <ref role="3cqZAo" node="6RONOaUjvJ6" resolve="isourceUnit" />
                 </node>
-              </node>
-              <node concept="3TrcHB" id="5nqK_jUafmI" role="2OqNvi">
-                <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
               </node>
             </node>
             <node concept="2ZThk1" id="5nqK_jUaeUU" role="1tU5fm">
@@ -19522,22 +19601,21 @@
         <node concept="3cpWs8" id="5nqK_jUacNs" role="3cqZAp">
           <node concept="3cpWsn" id="5nqK_jUacNt" role="3cpWs9">
             <property role="TrG5h" value="targetScaling" />
-            <node concept="2OqwBi" id="5nqK_jUafwE" role="33vP2m">
-              <node concept="1PxgMI" id="5nqK_jUacNv" role="2Oq$k0">
+            <node concept="2ZThk1" id="5nqK_jUafrm" role="1tU5fm">
+              <ref role="2ZWj4r" to="i3ya:2hbaSyABMZL" resolve="UnitScalingType" />
+            </node>
+            <node concept="2YIFZM" id="4zqoYUCgg$5" role="33vP2m">
+              <ref role="37wK5l" node="4zqoYUCdlDz" resolve="getScaling" />
+              <ref role="1Pybhc" node="4jkbLB5RJZL" resolve="UnitConversionUtil" />
+              <node concept="1PxgMI" id="4zqoYUCgg$6" role="37wK5m">
                 <property role="1BlNFB" value="true" />
-                <node concept="chp4Y" id="5nqK_jUacNw" role="3oSUPX">
+                <node concept="chp4Y" id="4zqoYUCgg$7" role="3oSUPX">
                   <ref role="cht4Q" to="i3ya:7eOyx9r3jsZ" resolve="Unit" />
                 </node>
-                <node concept="37vLTw" id="5nqK_jUacNx" role="1m5AlR">
+                <node concept="37vLTw" id="4zqoYUCgg$8" role="1m5AlR">
                   <ref role="3cqZAo" node="5nqK_jUa7Bc" resolve="itargetUnit" />
                 </node>
               </node>
-              <node concept="3TrcHB" id="5nqK_jUafBd" role="2OqNvi">
-                <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
-              </node>
-            </node>
-            <node concept="2ZThk1" id="5nqK_jUafrm" role="1tU5fm">
-              <ref role="2ZWj4r" to="i3ya:2hbaSyABMZL" resolve="UnitScalingType" />
             </node>
           </node>
         </node>
@@ -20989,18 +21067,17 @@
       <node concept="10P_77" id="FMy9me20mF" role="3clF45" />
       <node concept="3Tm1VV" id="FMy9me20mG" role="1B3o_S" />
       <node concept="3clFbS" id="FMy9me20mH" role="3clF47">
-        <node concept="3clFbF" id="FMy9me20mI" role="3cqZAp">
-          <node concept="2OqwBi" id="FMy9me20mJ" role="3clFbG">
-            <node concept="2OqwBi" id="FMy9me20mK" role="2Oq$k0">
-              <node concept="37vLTw" id="FMy9me20mL" role="2Oq$k0">
+        <node concept="3clFbF" id="4zqoYUCfJlc" role="3cqZAp">
+          <node concept="2OqwBi" id="4zqoYUCfMN1" role="3clFbG">
+            <node concept="2YIFZM" id="4zqoYUCfKxq" role="2Oq$k0">
+              <ref role="37wK5l" node="4zqoYUCdlDz" resolve="getScaling" />
+              <ref role="1Pybhc" node="4jkbLB5RJZL" resolve="UnitConversionUtil" />
+              <node concept="37vLTw" id="4zqoYUCfLBn" role="37wK5m">
                 <ref role="3cqZAo" node="FMy9me20mD" resolve="unit" />
               </node>
-              <node concept="3TrcHB" id="FMy9me20mM" role="2OqNvi">
-                <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
-              </node>
             </node>
-            <node concept="21noJN" id="FMy9me20mN" role="2OqNvi">
-              <node concept="21nZrQ" id="FMy9me20mO" role="21noJM">
+            <node concept="21noJN" id="4zqoYUCfO1J" role="2OqNvi">
+              <node concept="21nZrQ" id="4zqoYUCfO1L" role="21noJM">
                 <ref role="21nZrZ" to="i3ya:2hbaSyABMZQ" resolve="binary_iec" />
               </node>
             </node>
@@ -29127,17 +29204,16 @@
       <node concept="3clFbS" id="4zqoYUyQeAJ" role="3clF47">
         <node concept="3clFbF" id="4zqoYUyQeAK" role="3cqZAp">
           <node concept="2OqwBi" id="4zqoYUyQeAL" role="3clFbG">
-            <node concept="2OqwBi" id="4zqoYUyQeAM" role="2Oq$k0">
-              <node concept="37vLTw" id="4zqoYUyQeAN" role="2Oq$k0">
-                <ref role="3cqZAo" node="4zqoYUyQeAF" resolve="unit" />
-              </node>
-              <node concept="3TrcHB" id="4zqoYUyQeAO" role="2OqNvi">
-                <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
-              </node>
-            </node>
             <node concept="21noJN" id="4zqoYUyQeAP" role="2OqNvi">
               <node concept="21nZrQ" id="4zqoYUyQeAQ" role="21noJM">
                 <ref role="21nZrZ" to="i3ya:4zqoYUyQ7z3" resolve="metric_positive" />
+              </node>
+            </node>
+            <node concept="2YIFZM" id="4zqoYUCgmPk" role="2Oq$k0">
+              <ref role="37wK5l" node="4zqoYUCdlDz" resolve="getScaling" />
+              <ref role="1Pybhc" node="4jkbLB5RJZL" resolve="UnitConversionUtil" />
+              <node concept="37vLTw" id="4zqoYUCgmPl" role="37wK5m">
+                <ref role="3cqZAo" node="4zqoYUyQeAF" resolve="unit" />
               </node>
             </node>
           </node>
@@ -29550,17 +29626,16 @@
       <node concept="3clFbS" id="4zqoYUyQwIx" role="3clF47">
         <node concept="3clFbF" id="4zqoYUyQwIy" role="3cqZAp">
           <node concept="2OqwBi" id="4zqoYUyQwIz" role="3clFbG">
-            <node concept="2OqwBi" id="4zqoYUyQwI$" role="2Oq$k0">
-              <node concept="37vLTw" id="4zqoYUyQwI_" role="2Oq$k0">
-                <ref role="3cqZAo" node="4zqoYUyQwIt" resolve="unit" />
-              </node>
-              <node concept="3TrcHB" id="4zqoYUyQwIA" role="2OqNvi">
-                <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
-              </node>
-            </node>
             <node concept="21noJN" id="4zqoYUyQwIB" role="2OqNvi">
               <node concept="21nZrQ" id="4zqoYUyQwIC" role="21noJM">
                 <ref role="21nZrZ" to="i3ya:4zqoYUyQ7z4" resolve="metric_negative" />
+              </node>
+            </node>
+            <node concept="2YIFZM" id="4zqoYUCgk0L" role="2Oq$k0">
+              <ref role="37wK5l" node="4zqoYUCdlDz" resolve="getScaling" />
+              <ref role="1Pybhc" node="4jkbLB5RJZL" resolve="UnitConversionUtil" />
+              <node concept="37vLTw" id="4zqoYUCgk0M" role="37wK5m">
+                <ref role="3cqZAo" node="4zqoYUyQwIt" resolve="unit" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
@@ -17839,7 +17839,7 @@
             </node>
           </node>
           <node concept="37vLTw" id="2hjX6q5dNf7" role="3clFbw">
-            <ref role="3cqZAo" node="2hjX6q5dNfd" resolve="includeDerived" />
+            <ref role="3cqZAo" node="2hjX6q5dNfd" resolve="includeDerivedAndAdditional" />
           </node>
         </node>
         <node concept="3clFbF" id="2hjX6q5dNf8" role="3cqZAp">
@@ -29115,11 +29115,11 @@
       <node concept="3Tm6S6" id="4zqoYUyQez6" role="1B3o_S" />
       <node concept="2ShNRf" id="4zqoYUyQez7" role="33vP2m">
         <node concept="1pGfFk" id="4zqoYUyQez8" role="2ShVmc">
-          <ref role="37wK5l" node="4zqoYUyQezh" resolve="DecimalMetricUnitPrefixManager" />
+          <ref role="37wK5l" node="4zqoYUyQezh" resolve="PositiveDecimalMetricUnitPrefixManager" />
         </node>
       </node>
       <node concept="3uibUv" id="4zqoYUyQez9" role="1tU5fm">
-        <ref role="3uigEE" node="4zqoYUyQez3" resolve="DecimalMetricUnitPrefixManager" />
+        <ref role="3uigEE" node="4zqoYUyQez3" resolve="PositiveDecimalMetricUnitPrefixManager" />
       </node>
     </node>
     <node concept="2tJIrI" id="4zqoYUyQeza" role="jymVt" />
@@ -29134,7 +29134,7 @@
       </node>
       <node concept="3Tm1VV" id="4zqoYUyQeze" role="1B3o_S" />
       <node concept="3uibUv" id="4zqoYUyQezf" role="3clF45">
-        <ref role="3uigEE" node="4zqoYUyQez3" resolve="DecimalMetricUnitPrefixManager" />
+        <ref role="3uigEE" node="4zqoYUyQez3" resolve="PositiveDecimalMetricUnitPrefixManager" />
       </node>
     </node>
     <node concept="2tJIrI" id="4zqoYUyQezg" role="jymVt" />
@@ -29513,11 +29513,11 @@
       <node concept="3Tm6S6" id="4zqoYUyQwES" role="1B3o_S" />
       <node concept="2ShNRf" id="4zqoYUyQwET" role="33vP2m">
         <node concept="1pGfFk" id="4zqoYUyQwEU" role="2ShVmc">
-          <ref role="37wK5l" node="4zqoYUyQwF3" resolve="DecimalMetricUnitPrefixManager" />
+          <ref role="37wK5l" node="4zqoYUyQwF3" resolve="NegativeDecimalMetricUnitPrefixManager" />
         </node>
       </node>
       <node concept="3uibUv" id="4zqoYUyQwEV" role="1tU5fm">
-        <ref role="3uigEE" node="4zqoYUyQwEP" resolve="DecimalMetricUnitPrefixManager" />
+        <ref role="3uigEE" node="4zqoYUyQwEP" resolve="NegativeDecimalMetricUnitPrefixManager" />
       </node>
     </node>
     <node concept="2tJIrI" id="4zqoYUyQwEW" role="jymVt" />
@@ -29532,7 +29532,7 @@
       </node>
       <node concept="3Tm1VV" id="4zqoYUyQwF0" role="1B3o_S" />
       <node concept="3uibUv" id="4zqoYUyQwF1" role="3clF45">
-        <ref role="3uigEE" node="4zqoYUyQwEP" resolve="DecimalMetricUnitPrefixManager" />
+        <ref role="3uigEE" node="4zqoYUyQwEP" resolve="NegativeDecimalMetricUnitPrefixManager" />
       </node>
     </node>
     <node concept="2tJIrI" id="4zqoYUyQwF2" role="jymVt" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
@@ -681,6 +681,7 @@
         <child id="1240424397093" name="keyType" index="3f3zw5" />
         <child id="1240424402756" name="valueType" index="3f3$T$" />
       </concept>
+      <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
       <concept id="1201872418428" name="jetbrains.mps.baseLanguage.collections.structure.GetKeysOperation" flags="nn" index="3lbrtF" />
       <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
       <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
@@ -17280,7 +17281,7 @@
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="3xM68GM$9PV" role="jymVt" />
+    <node concept="2tJIrI" id="xExe$wOoey" role="jymVt" />
     <node concept="2YIFZL" id="3xM68GM$9Ox" role="jymVt">
       <property role="TrG5h" value="getSIUnitsDerivedAndScaledLibrary" />
       <node concept="3clFbS" id="3xM68GM$9Oy" role="3clF47">
@@ -17312,6 +17313,210 @@
       <node concept="37vLTG" id="3xM68GM$9OH" role="3clF46">
         <property role="TrG5h" value="repository" />
         <node concept="3uibUv" id="3xM68GM$9OI" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="xExe$x2rIf" role="jymVt" />
+    <node concept="2YIFZL" id="xExe$wODTx" role="jymVt">
+      <property role="TrG5h" value="getUnitsOfInformationMetricLibrary" />
+      <node concept="3clFbS" id="xExe$wODTy" role="3clF47">
+        <node concept="3clFbF" id="xExe$wXXUO" role="3cqZAp">
+          <node concept="2OqwBi" id="xExe$wXXUQ" role="3clFbG">
+            <node concept="Vyspw" id="xExe$wXXUK" role="2OqNvi">
+              <node concept="37vLTw" id="xExe$wXXUM" role="Vysub">
+                <ref role="3cqZAo" node="xExe$wODTH" resolve="repository" />
+              </node>
+            </node>
+            <node concept="2tJFMh" id="xExe$wXXUW" role="2Oq$k0">
+              <node concept="1dCxOE" id="xExe$wXXUY" role="2tJFKM">
+                <property role="2OI7jA" value="1140731015761843605" />
+                <node concept="1dCxOl" id="xExe$wXXUS" role="2OI7jE">
+                  <property role="1XweGQ" value="r:4134cae9-4017-4808-bf1c-768cb21cb9ea" />
+                  <node concept="1j_P7g" id="xExe$wXXUU" role="1j$8Uc">
+                    <property role="1j_P7h" value="org.iets3.core.expr.typetags.phyunits.si.units" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="xExe$wODTF" role="1B3o_S" />
+      <node concept="3Tqbb2" id="xExe$wODTG" role="3clF45">
+        <ref role="ehGHo" to="yv47:ub9nkyK62f" resolve="Library" />
+      </node>
+      <node concept="37vLTG" id="xExe$wODTH" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <node concept="3uibUv" id="xExe$wODTI" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="xExe$wWtbJ" role="jymVt" />
+    <node concept="2YIFZL" id="xExe$wOpJv" role="jymVt">
+      <property role="TrG5h" value="getUnitsOfInformationIECLibrary" />
+      <node concept="3clFbS" id="xExe$wOpJw" role="3clF47">
+        <node concept="3clFbF" id="xExe$wOpJx" role="3cqZAp">
+          <node concept="2OqwBi" id="xExe$wOpJy" role="3clFbG">
+            <node concept="Vyspw" id="xExe$wOpJz" role="2OqNvi">
+              <node concept="37vLTw" id="xExe$wOpJ$" role="Vysub">
+                <ref role="3cqZAo" node="xExe$wOpJF" resolve="repository" />
+              </node>
+            </node>
+            <node concept="2tJFMh" id="xExe$wOpJ_" role="2Oq$k0">
+              <node concept="1dCxOE" id="xExe$wOpJA" role="2tJFKM">
+                <property role="2OI7jA" value="1140731015761843608" />
+                <node concept="1dCxOl" id="xExe$wOpJB" role="2OI7jE">
+                  <property role="1XweGQ" value="r:4134cae9-4017-4808-bf1c-768cb21cb9ea" />
+                  <node concept="1j_P7g" id="xExe$wOpJC" role="1j$8Uc">
+                    <property role="1j_P7h" value="org.iets3.core.expr.typetags.phyunits.si.units" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="xExe$wOpJD" role="1B3o_S" />
+      <node concept="3Tqbb2" id="xExe$wOpJE" role="3clF45">
+        <ref role="ehGHo" to="yv47:ub9nkyK62f" resolve="Library" />
+      </node>
+      <node concept="37vLTG" id="xExe$wOpJF" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <node concept="3uibUv" id="xExe$wOpJG" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="xExe$wOoez" role="jymVt" />
+    <node concept="2YIFZL" id="xExe$wO$Om" role="jymVt">
+      <property role="TrG5h" value="getUnitsOfInformationJEDECLibrary" />
+      <node concept="3clFbS" id="xExe$wO$On" role="3clF47">
+        <node concept="3clFbF" id="xExe$wO$Oo" role="3cqZAp">
+          <node concept="2OqwBi" id="xExe$wO$Op" role="3clFbG">
+            <node concept="Vyspw" id="xExe$wO$Oq" role="2OqNvi">
+              <node concept="37vLTw" id="xExe$wO$Or" role="Vysub">
+                <ref role="3cqZAo" node="xExe$wO$Oy" resolve="repository" />
+              </node>
+            </node>
+            <node concept="2tJFMh" id="xExe$wO$Os" role="2Oq$k0">
+              <node concept="1dCxOE" id="xExe$wO$Ot" role="2tJFKM">
+                <property role="2OI7jA" value="1140731015761843610" />
+                <node concept="1dCxOl" id="xExe$wO$Ou" role="2OI7jE">
+                  <property role="1XweGQ" value="r:4134cae9-4017-4808-bf1c-768cb21cb9ea" />
+                  <node concept="1j_P7g" id="xExe$wO$Ov" role="1j$8Uc">
+                    <property role="1j_P7h" value="org.iets3.core.expr.typetags.phyunits.si.units" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="xExe$wO$Ow" role="1B3o_S" />
+      <node concept="3Tqbb2" id="xExe$wO$Ox" role="3clF45">
+        <ref role="ehGHo" to="yv47:ub9nkyK62f" resolve="Library" />
+      </node>
+      <node concept="37vLTG" id="xExe$wO$Oy" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <node concept="3uibUv" id="xExe$wO$Oz" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="xExe$x1xXJ" role="jymVt" />
+    <node concept="2YIFZL" id="xExe$x1AxM" role="jymVt">
+      <property role="TrG5h" value="getAllAdditionalLibraries" />
+      <node concept="3clFbS" id="xExe$x1AxP" role="3clF47">
+        <node concept="3cpWs8" id="xExe$x1CvK" role="3cqZAp">
+          <node concept="3cpWsn" id="xExe$x1CvN" role="3cpWs9">
+            <property role="TrG5h" value="libraries" />
+            <node concept="2I9FWS" id="xExe$x1CvJ" role="1tU5fm">
+              <ref role="2I9WkF" to="yv47:ub9nkyK62f" resolve="Library" />
+            </node>
+            <node concept="2ShNRf" id="xExe$x1EVh" role="33vP2m">
+              <node concept="2T8Vx0" id="xExe$x1Pxc" role="2ShVmc">
+                <node concept="2I9FWS" id="xExe$x1Pxe" role="2T96Bj">
+                  <ref role="2I9WkF" to="yv47:ub9nkyK62f" resolve="Library" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="xExe$x1SPp" role="3cqZAp">
+          <node concept="2OqwBi" id="xExe$x1YEc" role="3clFbG">
+            <node concept="37vLTw" id="xExe$x1SPn" role="2Oq$k0">
+              <ref role="3cqZAo" node="xExe$x1CvN" resolve="libraries" />
+            </node>
+            <node concept="TSZUe" id="xExe$x286l" role="2OqNvi">
+              <node concept="1rXfSq" id="xExe$x2wvu" role="25WWJ7">
+                <ref role="37wK5l" node="3xM68GM$9Ox" resolve="getSIUnitsDerivedAndScaledLibrary" />
+                <node concept="37vLTw" id="xExe$x2zzk" role="37wK5m">
+                  <ref role="3cqZAo" node="xExe$x2xq9" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="xExe$x2$xL" role="3cqZAp">
+          <node concept="2OqwBi" id="xExe$x2$xM" role="3clFbG">
+            <node concept="37vLTw" id="xExe$x2$xN" role="2Oq$k0">
+              <ref role="3cqZAo" node="xExe$x1CvN" resolve="libraries" />
+            </node>
+            <node concept="TSZUe" id="xExe$x2$xO" role="2OqNvi">
+              <node concept="1rXfSq" id="xExe$x2$xP" role="25WWJ7">
+                <ref role="37wK5l" node="xExe$wODTx" resolve="getUnitsOfInformationMetricLibrary" />
+                <node concept="37vLTw" id="xExe$x2$xQ" role="37wK5m">
+                  <ref role="3cqZAo" node="xExe$x2xq9" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="xExe$x2_MJ" role="3cqZAp">
+          <node concept="2OqwBi" id="xExe$x2_MK" role="3clFbG">
+            <node concept="37vLTw" id="xExe$x2_ML" role="2Oq$k0">
+              <ref role="3cqZAo" node="xExe$x1CvN" resolve="libraries" />
+            </node>
+            <node concept="TSZUe" id="xExe$x2_MM" role="2OqNvi">
+              <node concept="1rXfSq" id="xExe$x2_MN" role="25WWJ7">
+                <ref role="37wK5l" node="xExe$wOpJv" resolve="getUnitsOfInformationIECLibrary" />
+                <node concept="37vLTw" id="xExe$x2_MO" role="37wK5m">
+                  <ref role="3cqZAo" node="xExe$x2xq9" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="xExe$x2BmO" role="3cqZAp">
+          <node concept="2OqwBi" id="xExe$x2BmP" role="3clFbG">
+            <node concept="37vLTw" id="xExe$x2BmQ" role="2Oq$k0">
+              <ref role="3cqZAo" node="xExe$x1CvN" resolve="libraries" />
+            </node>
+            <node concept="TSZUe" id="xExe$x2BmR" role="2OqNvi">
+              <node concept="1rXfSq" id="xExe$x2BmS" role="25WWJ7">
+                <ref role="37wK5l" node="xExe$wO$Om" resolve="getUnitsOfInformationJEDECLibrary" />
+                <node concept="37vLTw" id="xExe$x2BmT" role="37wK5m">
+                  <ref role="3cqZAo" node="xExe$x2xq9" resolve="repository" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="xExe$x1SdR" role="3cqZAp">
+          <node concept="37vLTw" id="xExe$x1SdP" role="3clFbG">
+            <ref role="3cqZAo" node="xExe$x1CvN" resolve="libraries" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="xExe$x1zIG" role="1B3o_S" />
+      <node concept="2I9FWS" id="xExe$x1_uJ" role="3clF45">
+        <ref role="2I9WkF" to="yv47:ub9nkyK62f" resolve="Library" />
+      </node>
+      <node concept="37vLTG" id="xExe$x2xq9" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <node concept="3uibUv" id="xExe$x2xq8" role="1tU5fm">
           <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
         </node>
       </node>
@@ -17370,21 +17575,38 @@
               <ref role="3cqZAo" node="7GkQwTaI4E7" resolve="quantities" />
             </node>
             <node concept="X8dFx" id="7GkQwTaIkM0" role="2OqNvi">
-              <node concept="2OqwBi" id="7GkQwTaIkM1" role="25WWJ7">
-                <node concept="2OqwBi" id="7GkQwTaIkM2" role="2Oq$k0">
-                  <node concept="1rXfSq" id="7GkQwTaIkM3" role="2Oq$k0">
-                    <ref role="37wK5l" node="3xM68GM$9Ox" resolve="getSIUnitsDerivedAndScaledLibrary" />
-                    <node concept="37vLTw" id="7GkQwTaIkM4" role="37wK5m">
-                      <ref role="3cqZAo" node="3xM68GM$ShD" resolve="repository" />
-                    </node>
-                  </node>
-                  <node concept="3Tsc0h" id="7GkQwTaIkM5" role="2OqNvi">
-                    <ref role="3TtcxE" to="yv47:ub9nkyK62i" resolve="contents" />
+              <node concept="2OqwBi" id="xExe$x2R4p" role="25WWJ7">
+                <node concept="1rXfSq" id="7GkQwTaIkM3" role="2Oq$k0">
+                  <ref role="37wK5l" node="xExe$x1AxM" resolve="getAllAdditionalLibraries" />
+                  <node concept="37vLTw" id="7GkQwTaIkM4" role="37wK5m">
+                    <ref role="3cqZAo" node="3xM68GM$ShD" resolve="repository" />
                   </node>
                 </node>
-                <node concept="v3k3i" id="7GkQwTaIkM6" role="2OqNvi">
-                  <node concept="chp4Y" id="7GkQwTaIkM7" role="v3oSu">
-                    <ref role="cht4Q" to="i3ya:1KUmgSFpwWn" resolve="Quantity" />
+                <node concept="3goQfb" id="xExe$x33yJ" role="2OqNvi">
+                  <node concept="1bVj0M" id="xExe$x33yL" role="23t8la">
+                    <node concept="3clFbS" id="xExe$x33yM" role="1bW5cS">
+                      <node concept="3clFbF" id="xExe$x35zI" role="3cqZAp">
+                        <node concept="2OqwBi" id="xExe$x3hKy" role="3clFbG">
+                          <node concept="2OqwBi" id="xExe$x36lr" role="2Oq$k0">
+                            <node concept="37vLTw" id="xExe$x35zH" role="2Oq$k0">
+                              <ref role="3cqZAo" node="xExe$x33yN" resolve="it" />
+                            </node>
+                            <node concept="3Tsc0h" id="xExe$x39nX" role="2OqNvi">
+                              <ref role="3TtcxE" to="yv47:ub9nkyK62i" resolve="contents" />
+                            </node>
+                          </node>
+                          <node concept="v3k3i" id="xExe$x3o5q" role="2OqNvi">
+                            <node concept="chp4Y" id="xExe$x3t7P" role="v3oSu">
+                              <ref role="cht4Q" to="i3ya:1KUmgSFpwWn" resolve="Quantity" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="xExe$x33yN" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="xExe$x33yO" role="1tU5fm" />
+                    </node>
                   </node>
                 </node>
               </node>
@@ -17464,21 +17686,38 @@
               <ref role="3cqZAo" node="7GkQwTaItQ9" resolve="rules" />
             </node>
             <node concept="X8dFx" id="7GkQwTaIJq1" role="2OqNvi">
-              <node concept="2OqwBi" id="7GkQwTaIJq2" role="25WWJ7">
-                <node concept="2OqwBi" id="7GkQwTaIJq3" role="2Oq$k0">
-                  <node concept="1rXfSq" id="7GkQwTaIJq4" role="2Oq$k0">
-                    <ref role="37wK5l" node="3xM68GM$9Ox" resolve="getSIUnitsDerivedAndScaledLibrary" />
-                    <node concept="37vLTw" id="7GkQwTaIJq5" role="37wK5m">
-                      <ref role="3cqZAo" node="7GkQwTaw3j5" resolve="repository" />
-                    </node>
-                  </node>
-                  <node concept="3Tsc0h" id="7GkQwTaIJq6" role="2OqNvi">
-                    <ref role="3TtcxE" to="yv47:ub9nkyK62i" resolve="contents" />
+              <node concept="2OqwBi" id="xExe$x3OYZ" role="25WWJ7">
+                <node concept="1rXfSq" id="7GkQwTaIJq4" role="2Oq$k0">
+                  <ref role="37wK5l" node="xExe$x1AxM" resolve="getAllAdditionalLibraries" />
+                  <node concept="37vLTw" id="7GkQwTaIJq5" role="37wK5m">
+                    <ref role="3cqZAo" node="7GkQwTaw3j5" resolve="repository" />
                   </node>
                 </node>
-                <node concept="v3k3i" id="7GkQwTaIJq7" role="2OqNvi">
-                  <node concept="chp4Y" id="7GkQwTaIJq8" role="v3oSu">
-                    <ref role="cht4Q" to="i3ya:VmEWGR2Mzb" resolve="ConversionRule" />
+                <node concept="3goQfb" id="xExe$x57Gq" role="2OqNvi">
+                  <node concept="1bVj0M" id="xExe$x57Gs" role="23t8la">
+                    <node concept="3clFbS" id="xExe$x57Gt" role="1bW5cS">
+                      <node concept="3clFbF" id="xExe$x57Gu" role="3cqZAp">
+                        <node concept="2OqwBi" id="xExe$x57Gv" role="3clFbG">
+                          <node concept="2OqwBi" id="xExe$x57Gw" role="2Oq$k0">
+                            <node concept="37vLTw" id="xExe$x57Gx" role="2Oq$k0">
+                              <ref role="3cqZAo" node="xExe$x57G_" resolve="it" />
+                            </node>
+                            <node concept="3Tsc0h" id="xExe$x57Gy" role="2OqNvi">
+                              <ref role="3TtcxE" to="yv47:ub9nkyK62i" resolve="contents" />
+                            </node>
+                          </node>
+                          <node concept="v3k3i" id="xExe$x57Gz" role="2OqNvi">
+                            <node concept="chp4Y" id="xExe$x57G$" role="v3oSu">
+                              <ref role="cht4Q" to="i3ya:VmEWGR2Mzb" resolve="ConversionRule" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Rh6nW" id="xExe$x57G_" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="xExe$x57GA" role="1tU5fm" />
+                    </node>
                   </node>
                 </node>
               </node>
@@ -17560,21 +17799,38 @@
                   <ref role="3cqZAo" node="2hjX6q5dNeD" resolve="units" />
                 </node>
                 <node concept="X8dFx" id="2hjX6q5dNeZ" role="2OqNvi">
-                  <node concept="2OqwBi" id="2hjX6q5dNf0" role="25WWJ7">
-                    <node concept="2OqwBi" id="2hjX6q5dNf1" role="2Oq$k0">
-                      <node concept="1rXfSq" id="2hjX6q5dNf2" role="2Oq$k0">
-                        <ref role="37wK5l" node="3xM68GM$9Ox" resolve="getSIUnitsDerivedAndScaledLibrary" />
-                        <node concept="37vLTw" id="2hjX6q5dNf3" role="37wK5m">
-                          <ref role="3cqZAo" node="2hjX6q5dNff" resolve="repository" />
-                        </node>
-                      </node>
-                      <node concept="3Tsc0h" id="2hjX6q5dNf4" role="2OqNvi">
-                        <ref role="3TtcxE" to="yv47:ub9nkyK62i" resolve="contents" />
+                  <node concept="2OqwBi" id="xExe$x5nN0" role="25WWJ7">
+                    <node concept="1rXfSq" id="2hjX6q5dNf2" role="2Oq$k0">
+                      <ref role="37wK5l" node="xExe$x1AxM" resolve="getAllAdditionalLibraries" />
+                      <node concept="37vLTw" id="2hjX6q5dNf3" role="37wK5m">
+                        <ref role="3cqZAo" node="2hjX6q5dNff" resolve="repository" />
                       </node>
                     </node>
-                    <node concept="v3k3i" id="2hjX6q5dNf5" role="2OqNvi">
-                      <node concept="chp4Y" id="2hjX6q5dNf6" role="v3oSu">
-                        <ref role="cht4Q" to="i3ya:7eOyx9r3jsZ" resolve="Unit" />
+                    <node concept="3goQfb" id="xExe$x6jxp" role="2OqNvi">
+                      <node concept="1bVj0M" id="xExe$x6jxr" role="23t8la">
+                        <node concept="3clFbS" id="xExe$x6jxs" role="1bW5cS">
+                          <node concept="3clFbF" id="xExe$x6jxt" role="3cqZAp">
+                            <node concept="2OqwBi" id="xExe$x6jxu" role="3clFbG">
+                              <node concept="2OqwBi" id="xExe$x6jxv" role="2Oq$k0">
+                                <node concept="37vLTw" id="xExe$x6jxw" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="xExe$x6jx$" resolve="it" />
+                                </node>
+                                <node concept="3Tsc0h" id="xExe$x6jxx" role="2OqNvi">
+                                  <ref role="3TtcxE" to="yv47:ub9nkyK62i" resolve="contents" />
+                                </node>
+                              </node>
+                              <node concept="v3k3i" id="xExe$x6jxy" role="2OqNvi">
+                                <node concept="chp4Y" id="xExe$x6jxz" role="v3oSu">
+                                  <ref role="cht4Q" to="i3ya:7eOyx9r3jsZ" resolve="Unit" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Rh6nW" id="xExe$x6jx$" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="xExe$x6jx_" role="1tU5fm" />
+                        </node>
                       </node>
                     </node>
                   </node>
@@ -17599,7 +17855,7 @@
         </node>
       </node>
       <node concept="37vLTG" id="2hjX6q5dNfd" role="3clF46">
-        <property role="TrG5h" value="includeDerived" />
+        <property role="TrG5h" value="includeDerivedAndAdditional" />
         <node concept="10P_77" id="2hjX6q5dNfe" role="1tU5fm" />
       </node>
       <node concept="37vLTG" id="2hjX6q5dNff" role="3clF46">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.editor.mps
@@ -2465,14 +2465,13 @@
                       <node concept="liA8E" id="4dsOSthqJzd" role="2OqNvi">
                         <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
                         <node concept="2OqwBi" id="4dsOSthr4cu" role="37wK5m">
-                          <node concept="2OqwBi" id="4dsOSthr2SI" role="2Oq$k0">
-                            <node concept="2ZBlsa" id="4dsOSthr0_4" role="2Oq$k0" />
-                            <node concept="3TrcHB" id="4dsOSthr3KS" role="2OqNvi">
-                              <ref role="3TsBF5" to="i3ya:2hbaSyABN4s" resolve="scaling" />
-                            </node>
-                          </node>
                           <node concept="liA8E" id="4dsOSthr4DB" role="2OqNvi">
                             <ref role="37wK5l" to="c17a:~SEnumerationLiteral.getPresentation()" resolve="getPresentation" />
+                          </node>
+                          <node concept="2YIFZM" id="4zqoYUCgk0L" role="2Oq$k0">
+                            <ref role="37wK5l" to="rppw:4zqoYUCdlDz" resolve="getScaling" />
+                            <ref role="1Pybhc" to="rppw:4jkbLB5RJZL" resolve="UnitConversionUtil" />
+                            <node concept="2ZBlsa" id="4zqoYUCjkkJ" role="37wK5m" />
                           </node>
                         </node>
                       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.plugin.mps
@@ -314,6 +314,9 @@
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="7400021826771268254" name="jetbrains.mps.lang.smodel.structure.SNodePointerType" flags="ig" index="2sp9CU">
+        <reference id="7400021826771268269" name="concept" index="2sp9C9" />
+      </concept>
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
@@ -330,6 +333,9 @@
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1240170042401" name="jetbrains.mps.lang.smodel.structure.SEnumerationMemberType" flags="in" index="2ZThk1">
+        <reference id="1240170836027" name="enum" index="2ZWj4r" />
+      </concept>
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
@@ -388,6 +394,14 @@
       </concept>
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
+      <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
+        <child id="1197683466920" name="keyType" index="3rvQeY" />
+        <child id="1197683475734" name="valueType" index="3rvSg0" />
+      </concept>
+      <concept id="1197686869805" name="jetbrains.mps.baseLanguage.collections.structure.HashMapCreator" flags="nn" index="3rGOSV">
+        <child id="1197687026896" name="keyType" index="3rHrn6" />
+        <child id="1197687035757" name="valueType" index="3rHtpV" />
+      </concept>
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
         <child id="1240687658305" name="delimiter" index="3uJOhx" />
@@ -1070,6 +1084,34 @@
           </node>
         </node>
       </node>
+    </node>
+    <node concept="2tJIrI" id="4zqoYUC7Ogg" role="jymVt" />
+    <node concept="3clFb_" id="4zqoYUC7SCk" role="jymVt">
+      <property role="TrG5h" value="getOverwrittenScaling" />
+      <node concept="3clFbS" id="4zqoYUC7SCn" role="3clF47">
+        <node concept="3clFbF" id="4zqoYUC7Tyx" role="3cqZAp">
+          <node concept="2ShNRf" id="4zqoYUC7Tyv" role="3clFbG">
+            <node concept="3rGOSV" id="4zqoYUC82TL" role="2ShVmc">
+              <node concept="2sp9CU" id="4zqoYUCkRrG" role="3rHrn6">
+                <ref role="2sp9C9" to="i3ya:7eOyx9r3jsZ" resolve="Unit" />
+              </node>
+              <node concept="2ZThk1" id="4zqoYUC83yy" role="3rHtpV">
+                <ref role="2ZWj4r" to="i3ya:2hbaSyABMZL" resolve="UnitScalingType" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4zqoYUC7SCo" role="1B3o_S" />
+      <node concept="3rvAFt" id="4zqoYUC7Sjl" role="3clF45">
+        <node concept="2sp9CU" id="4zqoYUCkRhk" role="3rvQeY">
+          <ref role="2sp9C9" to="i3ya:7eOyx9r3jsZ" resolve="Unit" />
+        </node>
+        <node concept="2ZThk1" id="4zqoYUC7SCi" role="3rvSg0">
+          <ref role="2ZWj4r" to="i3ya:2hbaSyABMZL" resolve="UnitScalingType" />
+        </node>
+      </node>
+      <node concept="2JFqV2" id="4zqoYUC7TgQ" role="2frcjj" />
     </node>
     <node concept="3Tm1VV" id="4qv99IryjZp" role="1B3o_S" />
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.plugin.mps
@@ -19,7 +19,7 @@
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
     <import index="3o3z" ref="ecfb9949-7433-4db5-85de-0f84d172e4ce/java:com.google.common.collect(de.q60.mps.collections.libs/)" />
-    <import index="rppw" ref="r:720d563d-1633-46b3-a98e-08d2fde4c4a8(org.iets3.core.expr.typetags.quantities.behavior)" />
+    <import index="rppw" ref="r:720d563d-1633-46b3-a98e-08d2fde4c4a8(org.iets3.core.expr.typetags.physunits.behavior)" />
     <import index="i3ya" ref="r:4f64e2f0-6a4e-4db3-b3bf-7977f44949b6(org.iets3.core.expr.typetags.physunits.structure)" />
     <import index="rxpb" ref="r:31fd8edf-66c5-44d7-84a8-5940badb4d17(org.iets3.core.expr.base.interpreter.plugin)" />
     <import index="km5y" ref="r:78e88ebb-2d27-4b89-867f-623c50619338(org.iets3.core.expr.simpleTypes.interpreter.plugin)" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.structure.mps
@@ -825,6 +825,16 @@
       <property role="TrG5h" value="metric" />
       <property role="1L1pqM" value="metric-scaled" />
     </node>
+    <node concept="25R33" id="4zqoYUyQ7z3" role="25R1y">
+      <property role="3tVfz5" value="5249618192239196355" />
+      <property role="TrG5h" value="metric_positive" />
+      <property role="1L1pqM" value="metric-scaled (positive)" />
+    </node>
+    <node concept="25R33" id="4zqoYUyQ7z4" role="25R1y">
+      <property role="3tVfz5" value="5249618192239196356" />
+      <property role="TrG5h" value="metric_negative" />
+      <property role="1L1pqM" value="metric-scaled (negative)" />
+    </node>
     <node concept="25R33" id="2hbaSyABMZQ" role="25R1y">
       <property role="3tVfz5" value="2615231874529701878" />
       <property role="TrG5h" value="binary_iec" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.typesystem.mps
@@ -68,6 +68,7 @@
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
+      <concept id="1215695189714" name="jetbrains.mps.baseLanguage.structure.PlusAssignmentExpression" flags="nn" index="d57v9" />
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
@@ -141,6 +142,7 @@
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271221393" name="jetbrains.mps.baseLanguage.structure.NPENotEqualsExpression" flags="nn" index="17QLQc" />
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -12786,6 +12788,154 @@
             <property role="huDt6" value="Warning: Unused variable" />
           </node>
         </node>
+        <node concept="3clFbH" id="2xkb_2HRk7c" role="3cqZAp" />
+        <node concept="3cpWs8" id="2xkb_2HRkVB" role="3cqZAp">
+          <node concept="3cpWsn" id="2xkb_2HRkVE" role="3cpWs9">
+            <property role="TrG5h" value="subName" />
+            <node concept="17QB3L" id="2xkb_2HRkV_" role="1tU5fm" />
+            <node concept="2OqwBi" id="2xkb_2HRlpO" role="33vP2m">
+              <node concept="37vLTw" id="2xkb_2HRlpP" role="2Oq$k0">
+                <ref role="3cqZAo" node="6qDtanTTpQ$" resolve="unitRefSub" />
+              </node>
+              <node concept="2Iv5rx" id="2xkb_2HRmKC" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="2xkb_2HRmQK" role="3cqZAp">
+          <node concept="3cpWsn" id="2xkb_2HRmQL" role="3cpWs9">
+            <property role="TrG5h" value="supName" />
+            <node concept="17QB3L" id="2xkb_2HRmQM" role="1tU5fm" />
+            <node concept="2OqwBi" id="2xkb_2HRmQN" role="33vP2m">
+              <node concept="37vLTw" id="2xkb_2HRmQO" role="2Oq$k0">
+                <ref role="3cqZAo" node="6qDtanTTqQ1" resolve="unitRefSup" />
+              </node>
+              <node concept="2Iv5rx" id="2xkb_2HRmQP" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="2xkb_2HRnqw" role="3cqZAp">
+          <node concept="3clFbS" id="2xkb_2HRnqy" role="3clFbx">
+            <node concept="3cpWs8" id="2xkb_2HVGkV" role="3cqZAp">
+              <node concept="3cpWsn" id="2xkb_2HVGkW" role="3cpWs9">
+                <property role="TrG5h" value="subUnitName" />
+                <node concept="17QB3L" id="2xkb_2HVGhY" role="1tU5fm" />
+                <node concept="2OqwBi" id="2xkb_2HVGkX" role="33vP2m">
+                  <node concept="1PxgMI" id="2xkb_2HVGkY" role="2Oq$k0">
+                    <property role="1BlNFB" value="true" />
+                    <node concept="chp4Y" id="2xkb_2HVGkZ" role="3oSUPX">
+                      <ref role="cht4Q" to="i3ya:7eOyx9r3jsZ" resolve="Unit" />
+                    </node>
+                    <node concept="2OqwBi" id="2xkb_2HVGl0" role="1m5AlR">
+                      <node concept="37vLTw" id="2xkb_2HVGl1" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6qDtanTTpQ$" resolve="unitRefSub" />
+                      </node>
+                      <node concept="3TrEf2" id="2xkb_2HVGl2" role="2OqNvi">
+                        <ref role="3Tt5mk" to="i3ya:7eOyx9r3qFW" resolve="unit" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3TrcHB" id="2xkb_2HVGl3" role="2OqNvi">
+                    <ref role="3TsBF5" to="i3ya:3NjH4t$gA9B" resolve="unitName" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="2xkb_2HVGJO" role="3cqZAp">
+              <node concept="3clFbS" id="2xkb_2HVGJQ" role="3clFbx">
+                <node concept="3clFbF" id="2xkb_2HRpAp" role="3cqZAp">
+                  <node concept="d57v9" id="2xkb_2HRuuC" role="3clFbG">
+                    <node concept="37vLTw" id="2xkb_2HRuuL" role="37vLTJ">
+                      <ref role="3cqZAo" node="2xkb_2HRkVE" resolve="subName" />
+                    </node>
+                    <node concept="3cpWs3" id="2xkb_2HRxbz" role="37vLTx">
+                      <node concept="Xl_RD" id="2xkb_2HRxbX" role="3uHU7w">
+                        <property role="Xl_RC" value=")" />
+                      </node>
+                      <node concept="3cpWs3" id="2xkb_2HRuA4" role="3uHU7B">
+                        <node concept="Xl_RD" id="2xkb_2HRuAu" role="3uHU7B">
+                          <property role="Xl_RC" value="(" />
+                        </node>
+                        <node concept="37vLTw" id="2xkb_2HVGl4" role="3uHU7w">
+                          <ref role="3cqZAo" node="2xkb_2HVGkW" resolve="unitName" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="2xkb_2HVHpx" role="3clFbw">
+                <node concept="37vLTw" id="2xkb_2HVGPK" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2xkb_2HVGkW" resolve="subunitName" />
+                </node>
+                <node concept="17RvpY" id="2xkb_2HVHS0" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="3cpWs8" id="2xkb_2HVIq8" role="3cqZAp">
+              <node concept="3cpWsn" id="2xkb_2HVIq9" role="3cpWs9">
+                <property role="TrG5h" value="supUnitName" />
+                <node concept="17QB3L" id="2xkb_2HVF9R" role="1tU5fm" />
+                <node concept="2OqwBi" id="2xkb_2HVIqa" role="33vP2m">
+                  <node concept="1PxgMI" id="2xkb_2HVIqb" role="2Oq$k0">
+                    <property role="1BlNFB" value="true" />
+                    <node concept="chp4Y" id="2xkb_2HVIqc" role="3oSUPX">
+                      <ref role="cht4Q" to="i3ya:7eOyx9r3jsZ" resolve="Unit" />
+                    </node>
+                    <node concept="2OqwBi" id="2xkb_2HVIqd" role="1m5AlR">
+                      <node concept="37vLTw" id="2xkb_2HVIqe" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6qDtanTTqQ1" resolve="unitRefSup" />
+                      </node>
+                      <node concept="3TrEf2" id="2xkb_2HVIqf" role="2OqNvi">
+                        <ref role="3Tt5mk" to="i3ya:7eOyx9r3qFW" resolve="unit" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3TrcHB" id="2xkb_2HVIqg" role="2OqNvi">
+                    <ref role="3TsBF5" to="i3ya:3NjH4t$gA9B" resolve="unitName" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="2xkb_2HVJyV" role="3cqZAp">
+              <node concept="3clFbS" id="2xkb_2HVJyX" role="3clFbx">
+                <node concept="3clFbF" id="2xkb_2HRxq4" role="3cqZAp">
+                  <node concept="d57v9" id="2xkb_2HRxq5" role="3clFbG">
+                    <node concept="37vLTw" id="2xkb_2HRxq6" role="37vLTJ">
+                      <ref role="3cqZAo" node="2xkb_2HRmQL" resolve="supName" />
+                    </node>
+                    <node concept="3cpWs3" id="2xkb_2HRxq7" role="37vLTx">
+                      <node concept="Xl_RD" id="2xkb_2HRxq8" role="3uHU7w">
+                        <property role="Xl_RC" value=")" />
+                      </node>
+                      <node concept="3cpWs3" id="2xkb_2HRxq9" role="3uHU7B">
+                        <node concept="Xl_RD" id="2xkb_2HRxqa" role="3uHU7B">
+                          <property role="Xl_RC" value="(" />
+                        </node>
+                        <node concept="37vLTw" id="2xkb_2HVIqh" role="3uHU7w">
+                          <ref role="3cqZAo" node="2xkb_2HVIq9" resolve="unitName" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="2xkb_2HVKXh" role="3clFbw">
+                <node concept="37vLTw" id="2xkb_2HVJCW" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2xkb_2HVIq9" resolve="supUnitName" />
+                </node>
+                <node concept="17RvpY" id="2xkb_2HVLrP" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="17R0WA" id="2xkb_2HRpol" role="3clFbw">
+            <node concept="37vLTw" id="2xkb_2HRpv1" role="3uHU7w">
+              <ref role="3cqZAo" node="2xkb_2HRmQL" resolve="supName" />
+            </node>
+            <node concept="37vLTw" id="2xkb_2HRnxB" role="3uHU7B">
+              <ref role="3cqZAo" node="2xkb_2HRkVE" resolve="subName" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2xkb_2HRkJG" role="3cqZAp" />
         <node concept="3clFbJ" id="4HbwYNVxkt6" role="3cqZAp">
           <node concept="3clFbS" id="4HbwYNVxkt8" role="3clFbx">
             <node concept="3cpWs6" id="4HbwYNVxljA" role="3cqZAp">
@@ -12795,21 +12945,11 @@
                 <node concept="Xl_RD" id="4HbwYNVz9J0" role="37wK5m">
                   <property role="Xl_RC" value="Unmatched units: ‹%s› and ‹%s›" />
                 </node>
-                <node concept="2OqwBi" id="4HbwYNVzatK" role="37wK5m">
-                  <node concept="37vLTw" id="4HbwYNVza4w" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6qDtanTTpQ$" resolve="unitRefSub" />
-                  </node>
-                  <node concept="2qgKlT" id="4HbwYNVzaW7" role="2OqNvi">
-                    <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                  </node>
+                <node concept="37vLTw" id="2xkb_2HRyxc" role="37wK5m">
+                  <ref role="3cqZAo" node="2xkb_2HRkVE" resolve="subName" />
                 </node>
-                <node concept="2OqwBi" id="4HbwYNVzbyP" role="37wK5m">
-                  <node concept="37vLTw" id="4HbwYNVzbgo" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6qDtanTTqQ1" resolve="unitRefSup" />
-                  </node>
-                  <node concept="2qgKlT" id="4HbwYNVzcqi" role="2OqNvi">
-                    <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                  </node>
+                <node concept="37vLTw" id="2xkb_2HRz_M" role="37wK5m">
+                  <ref role="3cqZAo" node="2xkb_2HRmQL" resolve="supName" />
                 </node>
               </node>
             </node>
@@ -12853,17 +12993,11 @@
                 <node concept="Xl_RD" id="6qDtanTTjMv" role="37wK5m">
                   <property role="Xl_RC" value="the quantities are compatible but no (implicit) conversion between ‹%s› and ‹%s› is available" />
                 </node>
-                <node concept="2OqwBi" id="6qDtanTTjMw" role="37wK5m">
-                  <node concept="2Iv5rx" id="6qDtanTTjMx" role="2OqNvi" />
-                  <node concept="37vLTw" id="6qDtanTTjMy" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6qDtanTTqQ1" resolve="unitRefSup" />
-                  </node>
+                <node concept="37vLTw" id="2xkb_2HR$2r" role="37wK5m">
+                  <ref role="3cqZAo" node="2xkb_2HRkVE" resolve="subName" />
                 </node>
-                <node concept="2OqwBi" id="6qDtanTTjMz" role="37wK5m">
-                  <node concept="37vLTw" id="6qDtanTTjM$" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6qDtanTTpQ$" resolve="unitRefSub" />
-                  </node>
-                  <node concept="2Iv5rx" id="6qDtanTTjM_" role="2OqNvi" />
+                <node concept="37vLTw" id="2xkb_2HR$h4" role="37wK5m">
+                  <ref role="3cqZAo" node="2xkb_2HRmQL" resolve="supName" />
                 </node>
               </node>
             </node>
@@ -12912,17 +13046,11 @@
                   <node concept="Xl_RD" id="6qDtanTTjMV" role="37wK5m">
                     <property role="Xl_RC" value="the quantities ‹%s› and ‹%s› are compatible but implicit conversions are disabled" />
                   </node>
-                  <node concept="2OqwBi" id="6qDtanTTjMW" role="37wK5m">
-                    <node concept="2Iv5rx" id="6qDtanTTjMX" role="2OqNvi" />
-                    <node concept="37vLTw" id="6qDtanTTjMY" role="2Oq$k0">
-                      <ref role="3cqZAo" node="6qDtanTTqQ1" resolve="unitRefSup" />
-                    </node>
+                  <node concept="37vLTw" id="2xkb_2HR_tJ" role="37wK5m">
+                    <ref role="3cqZAo" node="2xkb_2HRkVE" resolve="subName" />
                   </node>
-                  <node concept="2OqwBi" id="6qDtanTTjMZ" role="37wK5m">
-                    <node concept="37vLTw" id="6qDtanTTjN0" role="2Oq$k0">
-                      <ref role="3cqZAo" node="6qDtanTTpQ$" resolve="unitRefSub" />
-                    </node>
-                    <node concept="2Iv5rx" id="6qDtanTTjN1" role="2OqNvi" />
+                  <node concept="37vLTw" id="2xkb_2HR_YW" role="37wK5m">
+                    <ref role="3cqZAo" node="2xkb_2HRmQL" resolve="supName" />
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.runtime/models/runtime.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.runtime/models/runtime.mps
@@ -1360,7 +1360,7 @@
                 <ref role="37wK5l" node="2Qbt$1tTQn5" resolve="resolveMapper" />
               </node>
               <node concept="liA8E" id="CR1XcAv9Nr" role="2OqNvi">
-                <ref role="37wK5l" to="oq0c:CR1XcAuTxl" resolve="filterHexSupportingNodes" />
+                <ref role="37wK5l" to="oq0c:CR1XcAuTxl" resolve="filterHexadecimalSupportingNodes" />
                 <node concept="37vLTw" id="j1$XMexB82" role="37wK5m">
                   <ref role="3cqZAo" node="CR1XcAv4ps" resolve="node" />
                 </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.phyunits.si/models/org.iets3.core.expr.typetags.phyunits.si.units.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.phyunits.si/models/org.iets3.core.expr.typetags.phyunits.si.units.mps
@@ -5861,42 +5861,18 @@
         <ref role="CIi3I" node="3xM68GMigWs" resolve="s" />
       </node>
     </node>
-    <node concept="_ixoA" id="2Yx91N$uiqk" role="_iOnB" />
-    <node concept="1Ws0TD" id="2Yx91N$uADE" role="_iOnB">
-      <property role="1WsWdv" value="Digital information" />
+    <node concept="_ixoA" id="ZkGd2zsDJK" role="_iOnB" />
+    <node concept="1Ws0TD" id="ZkGd2zu6gr" role="_iOnB">
+      <property role="1WsWdv" value="Other Quantities" />
     </node>
-    <node concept="_ixoA" id="2Yx91N$uUMr" role="_iOnB" />
+    <node concept="_ixoA" id="2Yx91N$uiqk" role="_iOnB" />
     <node concept="Rn5op" id="7F14or$gcr1" role="_iOnB">
       <property role="TrG5h" value="digital information" />
       <node concept="2DI3Pg" id="1eut2v1LoK8" role="2DI2Qx" />
     </node>
-    <node concept="_ixoA" id="7F14or$gcz4" role="_iOnB" />
-    <node concept="CIrOH" id="7F14or$gczd" role="_iOnB">
-      <property role="TrG5h" value="byte" />
-      <property role="1o$tow" value="binary byte" />
-      <property role="22P1Ek" value="2hbaSyABMZQ/binary" />
-      <ref role="Rn5ok" node="7F14or$gcr1" resolve="digital information" />
-    </node>
-    <node concept="CIrOH" id="2Yx91N$tLAX" role="_iOnB">
-      <property role="TrG5h" value="bit" />
-      <property role="1o$tow" value="binary bit" />
-      <property role="22P1Ek" value="2hbaSyABMZQ/binary" />
-      <ref role="Rn5ok" node="7F14or$gcr1" resolve="digital information" />
-    </node>
-    <node concept="_ixoA" id="FMy9mdVliQ" role="_iOnB" />
-    <node concept="CIrOH" id="FMy9mdSdEf" role="_iOnB">
-      <property role="TrG5h" value="byte" />
-      <property role="1o$tow" value="binary memory byte" />
-      <property role="22P1Ek" value="6DczoUSGcZl/binary_memory" />
-      <ref role="Rn5ok" node="7F14or$gcr1" resolve="digital information" />
-    </node>
-    <node concept="CIrOH" id="FMy9mdSdEg" role="_iOnB">
-      <property role="TrG5h" value="bit" />
-      <property role="1o$tow" value="binary memory bit" />
-      <property role="22P1Ek" value="6DczoUSGcZl/binary_memory" />
-      <ref role="Rn5ok" node="7F14or$gcr1" resolve="digital information" />
-    </node>
-    <node concept="_ixoA" id="2liNWkVSxfa" role="_iOnB" />
+  </node>
+  <node concept="_iOnU" id="ZkGd2yKlml">
+    <property role="TrG5h" value="UnitsOfInformationMetric" />
     <node concept="CIrOH" id="14aBVbN55En" role="_iOnB">
       <property role="TrG5h" value="byte" />
       <property role="1o$tow" value="byte" />
@@ -5909,80 +5885,7 @@
       <property role="22P1Ek" value="4zqoYUyQ7z3/metric_positive" />
       <ref role="Rn5ok" node="7F14or$gcr1" resolve="digital information" />
     </node>
-    <node concept="_ixoA" id="2liNWkVV20T" role="_iOnB" />
-    <node concept="_ixoA" id="14aBVbNnPLO" role="_iOnB" />
-    <node concept="TRoc0" id="14aBVbN4A4Q" role="_iOnB">
-      <property role="2yp$z_" value="true" />
-      <node concept="27LzZq" id="14aBVbN4A4S" role="27P04L">
-        <node concept="30dDTi" id="14aBVbN4Ue_" role="27K$mF">
-          <node concept="30bXRB" id="3skHlWrr9$I" role="30dEs_">
-            <property role="30bXRw" value="8" />
-          </node>
-          <node concept="2m5Cep" id="14aBVbN4U9V" role="30dEsF" />
-        </node>
-      </node>
-      <node concept="CIsvn" id="2liNWkWnrVB" role="2vOZTa">
-        <ref role="CIi3I" node="7F14or$gczd" resolve="B" />
-      </node>
-      <node concept="CIsvn" id="2liNWkWns0d" role="2vOYbH">
-        <ref role="CIi3I" node="2Yx91N$tLAX" resolve="b" />
-      </node>
-    </node>
-    <node concept="_ixoA" id="2liNWkWir5P" role="_iOnB" />
-    <node concept="TRoc0" id="2liNWkWkUVZ" role="_iOnB">
-      <property role="2yp$z_" value="true" />
-      <node concept="27LzZq" id="2liNWkWkUW0" role="27P04L">
-        <node concept="30dvO6" id="2liNWkWnskZ" role="27K$mF">
-          <node concept="2m5Cep" id="2liNWkWkUW3" role="30dEsF" />
-          <node concept="30bXRB" id="2liNWkWkUW2" role="30dEs_">
-            <property role="30bXRw" value="8" />
-          </node>
-        </node>
-      </node>
-      <node concept="CIsvn" id="2liNWkWns6R" role="2vOZTa">
-        <ref role="CIi3I" node="2Yx91N$tLAX" resolve="b" />
-      </node>
-      <node concept="CIsvn" id="2liNWkWnsel" role="2vOYbH">
-        <ref role="CIi3I" node="7F14or$gczd" resolve="B" />
-      </node>
-    </node>
-    <node concept="_ixoA" id="FMy9me9y9E" role="_iOnB" />
-    <node concept="TRoc0" id="FMy9meaM73" role="_iOnB">
-      <property role="2yp$z_" value="true" />
-      <node concept="27LzZq" id="FMy9meaM74" role="27P04L">
-        <node concept="30dDTi" id="FMy9meaM75" role="27K$mF">
-          <node concept="30bXRB" id="FMy9meaM76" role="30dEs_">
-            <property role="30bXRw" value="8" />
-          </node>
-          <node concept="2m5Cep" id="FMy9meaM77" role="30dEsF" />
-        </node>
-      </node>
-      <node concept="CIsvn" id="FMy9mefLvF" role="2vOZTa">
-        <ref role="CIi3I" node="FMy9mdSdEf" resolve="B" />
-      </node>
-      <node concept="CIsvn" id="FMy9megbV6" role="2vOYbH">
-        <ref role="CIi3I" node="FMy9mdSdEg" resolve="b" />
-      </node>
-    </node>
-    <node concept="_ixoA" id="FMy9meaM7a" role="_iOnB" />
-    <node concept="TRoc0" id="FMy9meaM7b" role="_iOnB">
-      <property role="2yp$z_" value="true" />
-      <node concept="27LzZq" id="FMy9meaM7c" role="27P04L">
-        <node concept="30dvO6" id="FMy9meaM7d" role="27K$mF">
-          <node concept="2m5Cep" id="FMy9meaM7e" role="30dEsF" />
-          <node concept="30bXRB" id="FMy9meaM7f" role="30dEs_">
-            <property role="30bXRw" value="8" />
-          </node>
-        </node>
-      </node>
-      <node concept="CIsvn" id="FMy9mei3NL" role="2vOZTa">
-        <ref role="CIi3I" node="FMy9mdSdEg" resolve="b" />
-      </node>
-      <node concept="CIsvn" id="FMy9mejVGs" role="2vOYbH">
-        <ref role="CIi3I" node="FMy9mdSdEf" resolve="B" />
-      </node>
-    </node>
-    <node concept="_ixoA" id="2liNWkWhb2_" role="_iOnB" />
+    <node concept="_ixoA" id="ZkGd2z_cH$" role="_iOnB" />
     <node concept="TRoc0" id="14aBVbN5r6V" role="_iOnB">
       <property role="2yp$z_" value="true" />
       <node concept="27LzZq" id="14aBVbN5r6W" role="27P04L">
@@ -5994,10 +5897,10 @@
         </node>
       </node>
       <node concept="CIsvn" id="14aBVbN5JeB" role="2vOZTa">
-        <ref role="CIi3I" node="14aBVbN55En" resolve="B" />
+        <ref role="CIi3I" node="14aBVbN55En" resolve="byte" />
       </node>
       <node concept="CIsvn" id="14aBVbNhCkx" role="2vOYbH">
-        <ref role="CIi3I" node="14aBVbN55Ep" resolve="b" />
+        <ref role="CIi3I" node="14aBVbN55Ep" resolve="bit" />
       </node>
     </node>
     <node concept="_ixoA" id="2Yx91N$veEh" role="_iOnB" />
@@ -6012,13 +5915,142 @@
         </node>
       </node>
       <node concept="CIsvn" id="2liNWkWpXE3" role="2vOZTa">
-        <ref role="CIi3I" node="14aBVbN55Ep" resolve="b" />
+        <ref role="CIi3I" node="14aBVbN55Ep" resolve="bit" />
       </node>
       <node concept="CIsvn" id="2liNWkWpXLd" role="2vOYbH">
-        <ref role="CIi3I" node="14aBVbN55En" resolve="B" />
+        <ref role="CIi3I" node="14aBVbN55En" resolve="byte" />
       </node>
     </node>
-    <node concept="_ixoA" id="2liNWkWoGzK" role="_iOnB" />
+    <node concept="3GEVxB" id="ZkGd2z_bdf" role="3i6evy">
+      <ref role="3GEb4d" node="3xM68GMigWy" resolve="SIDerivedUnits" />
+    </node>
+  </node>
+  <node concept="_iOnU" id="ZkGd2yKlmo">
+    <property role="TrG5h" value="UnitsOfInformationIEC" />
+    <node concept="3GEVxB" id="ZkGd2z1qWB" role="3i6evy">
+      <ref role="3GEb4d" node="3xM68GMigWy" resolve="SIDerivedUnits" />
+    </node>
+    <node concept="CIrOH" id="7F14or$gczd" role="_iOnB">
+      <property role="TrG5h" value="byte" />
+      <property role="1o$tow" value="binary byte" />
+      <property role="22P1Ek" value="2hbaSyABMZQ/binary" />
+      <ref role="Rn5ok" node="7F14or$gcr1" resolve="digital information" />
+    </node>
+    <node concept="CIrOH" id="2Yx91N$tLAX" role="_iOnB">
+      <property role="TrG5h" value="bit" />
+      <property role="1o$tow" value="binary bit" />
+      <property role="22P1Ek" value="2hbaSyABMZQ/binary" />
+      <ref role="Rn5ok" node="7F14or$gcr1" resolve="digital information" />
+    </node>
+    <node concept="_ixoA" id="ZkGd2zpC$j" role="_iOnB" />
+    <node concept="TRoc0" id="14aBVbN4A4Q" role="_iOnB">
+      <property role="2yp$z_" value="true" />
+      <node concept="27LzZq" id="14aBVbN4A4S" role="27P04L">
+        <node concept="30dDTi" id="14aBVbN4Ue_" role="27K$mF">
+          <node concept="30bXRB" id="3skHlWrr9$I" role="30dEs_">
+            <property role="30bXRw" value="8" />
+          </node>
+          <node concept="2m5Cep" id="14aBVbN4U9V" role="30dEsF" />
+        </node>
+      </node>
+      <node concept="CIsvn" id="2liNWkWnrVB" role="2vOZTa">
+        <ref role="CIi3I" node="7F14or$gczd" resolve="byte" />
+      </node>
+      <node concept="CIsvn" id="2liNWkWns0d" role="2vOYbH">
+        <ref role="CIi3I" node="2Yx91N$tLAX" resolve="bit" />
+      </node>
+    </node>
+    <node concept="_ixoA" id="2liNWkWir5P" role="_iOnB" />
+    <node concept="TRoc0" id="2liNWkWkUVZ" role="_iOnB">
+      <property role="2yp$z_" value="true" />
+      <node concept="27LzZq" id="2liNWkWkUW0" role="27P04L">
+        <node concept="30dvO6" id="2liNWkWnskZ" role="27K$mF">
+          <node concept="2m5Cep" id="2liNWkWkUW3" role="30dEsF" />
+          <node concept="30bXRB" id="2liNWkWkUW2" role="30dEs_">
+            <property role="30bXRw" value="8" />
+          </node>
+        </node>
+      </node>
+      <node concept="CIsvn" id="2liNWkWns6R" role="2vOZTa">
+        <ref role="CIi3I" node="2Yx91N$tLAX" resolve="bit" />
+      </node>
+      <node concept="CIsvn" id="2liNWkWnsel" role="2vOYbH">
+        <ref role="CIi3I" node="7F14or$gczd" resolve="byte" />
+      </node>
+    </node>
+  </node>
+  <node concept="_iOnU" id="ZkGd2yKlmq">
+    <property role="TrG5h" value="UnitsOfInformationJEDEC" />
+    <node concept="3GEVxB" id="ZkGd2z1qWD" role="3i6evy">
+      <ref role="3GEb4d" node="3xM68GMigWy" resolve="SIDerivedUnits" />
+    </node>
+    <node concept="CIrOH" id="FMy9mdSdEf" role="_iOnB">
+      <property role="TrG5h" value="byte" />
+      <property role="1o$tow" value="binary memory byte" />
+      <property role="22P1Ek" value="6DczoUSGcZl/binary_memory" />
+      <ref role="Rn5ok" node="7F14or$gcr1" resolve="digital information" />
+    </node>
+    <node concept="CIrOH" id="FMy9mdSdEg" role="_iOnB">
+      <property role="TrG5h" value="bit" />
+      <property role="1o$tow" value="binary memory bit" />
+      <property role="22P1Ek" value="6DczoUSGcZl/binary_memory" />
+      <ref role="Rn5ok" node="7F14or$gcr1" resolve="digital information" />
+    </node>
+    <node concept="_ixoA" id="ZkGd2z_9Hs" role="_iOnB" />
+    <node concept="TRoc0" id="FMy9meaM73" role="_iOnB">
+      <property role="2yp$z_" value="true" />
+      <node concept="27LzZq" id="FMy9meaM74" role="27P04L">
+        <node concept="30dDTi" id="FMy9meaM75" role="27K$mF">
+          <node concept="30bXRB" id="FMy9meaM76" role="30dEs_">
+            <property role="30bXRw" value="8" />
+          </node>
+          <node concept="2m5Cep" id="FMy9meaM77" role="30dEsF" />
+        </node>
+      </node>
+      <node concept="CIsvn" id="FMy9mefLvF" role="2vOZTa">
+        <ref role="CIi3I" node="FMy9mdSdEf" resolve="byte" />
+      </node>
+      <node concept="CIsvn" id="FMy9megbV6" role="2vOYbH">
+        <ref role="CIi3I" node="FMy9mdSdEg" resolve="bit" />
+      </node>
+    </node>
+    <node concept="_ixoA" id="FMy9meaM7a" role="_iOnB" />
+    <node concept="TRoc0" id="FMy9meaM7b" role="_iOnB">
+      <property role="2yp$z_" value="true" />
+      <node concept="27LzZq" id="FMy9meaM7c" role="27P04L">
+        <node concept="30dvO6" id="FMy9meaM7d" role="27K$mF">
+          <node concept="2m5Cep" id="FMy9meaM7e" role="30dEsF" />
+          <node concept="30bXRB" id="FMy9meaM7f" role="30dEs_">
+            <property role="30bXRw" value="8" />
+          </node>
+        </node>
+      </node>
+      <node concept="CIsvn" id="FMy9mei3NL" role="2vOZTa">
+        <ref role="CIi3I" node="FMy9mdSdEg" resolve="bit" />
+      </node>
+      <node concept="CIsvn" id="FMy9mejVGs" role="2vOYbH">
+        <ref role="CIi3I" node="FMy9mdSdEf" resolve="byte" />
+      </node>
+    </node>
+  </node>
+  <node concept="_iOnU" id="xExe$xoFsp">
+    <property role="TrG5h" value="UnitsOfInformation" />
+    <node concept="3GEVxB" id="xExe$xuL60" role="3i6evy">
+      <property role="3GEa6x" value="true" />
+      <ref role="3GEb4d" node="3xM68GMigWy" resolve="SIDerivedUnits" />
+    </node>
+    <node concept="3GEVxB" id="xExe$xoFsr" role="3i6evy">
+      <property role="3GEa6x" value="true" />
+      <ref role="3GEb4d" node="ZkGd2yKlmo" resolve="UnitsOfInformationIEC" />
+    </node>
+    <node concept="3GEVxB" id="xExe$xoFst" role="3i6evy">
+      <property role="3GEa6x" value="true" />
+      <ref role="3GEb4d" node="ZkGd2yKlmq" resolve="UnitsOfInformationJEDEC" />
+    </node>
+    <node concept="3GEVxB" id="xExe$xoFsw" role="3i6evy">
+      <property role="3GEa6x" value="true" />
+      <ref role="3GEb4d" node="ZkGd2yKlml" resolve="UnitsOfInformationMetric" />
+    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.phyunits.si/models/org.iets3.core.expr.typetags.phyunits.si.units.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.phyunits.si/models/org.iets3.core.expr.typetags.phyunits.si.units.mps
@@ -5786,39 +5786,39 @@
     </node>
     <node concept="_ixoA" id="7F14or$gcz4" role="_iOnB" />
     <node concept="CIrOH" id="7F14or$gczd" role="_iOnB">
-      <property role="TrG5h" value="B" />
+      <property role="TrG5h" value="byte" />
       <property role="1o$tow" value="binary byte" />
       <property role="22P1Ek" value="2hbaSyABMZQ/binary" />
       <ref role="Rn5ok" node="7F14or$gcr1" resolve="digital information" />
     </node>
     <node concept="CIrOH" id="2Yx91N$tLAX" role="_iOnB">
-      <property role="TrG5h" value="b" />
+      <property role="TrG5h" value="bit" />
       <property role="1o$tow" value="binary bit" />
       <property role="22P1Ek" value="2hbaSyABMZQ/binary" />
       <ref role="Rn5ok" node="7F14or$gcr1" resolve="digital information" />
     </node>
     <node concept="_ixoA" id="FMy9mdVliQ" role="_iOnB" />
     <node concept="CIrOH" id="FMy9mdSdEf" role="_iOnB">
-      <property role="TrG5h" value="B" />
+      <property role="TrG5h" value="byte" />
       <property role="1o$tow" value="binary memory byte" />
       <property role="22P1Ek" value="6DczoUSGcZl/binary_memory" />
       <ref role="Rn5ok" node="7F14or$gcr1" resolve="digital information" />
     </node>
     <node concept="CIrOH" id="FMy9mdSdEg" role="_iOnB">
-      <property role="TrG5h" value="b" />
+      <property role="TrG5h" value="bit" />
       <property role="1o$tow" value="binary memory bit" />
       <property role="22P1Ek" value="6DczoUSGcZl/binary_memory" />
       <ref role="Rn5ok" node="7F14or$gcr1" resolve="digital information" />
     </node>
     <node concept="_ixoA" id="2liNWkVSxfa" role="_iOnB" />
     <node concept="CIrOH" id="14aBVbN55En" role="_iOnB">
-      <property role="TrG5h" value="B" />
+      <property role="TrG5h" value="byte" />
       <property role="1o$tow" value="byte" />
       <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="7F14or$gcr1" resolve="digital information" />
     </node>
     <node concept="CIrOH" id="14aBVbN55Ep" role="_iOnB">
-      <property role="TrG5h" value="b" />
+      <property role="TrG5h" value="bit" />
       <property role="1o$tow" value="bit" />
       <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="7F14or$gcr1" resolve="digital information" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.phyunits.si/models/org.iets3.core.expr.typetags.phyunits.si.units.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.typetags.phyunits.si/models/org.iets3.core.expr.typetags.phyunits.si.units.mps
@@ -232,7 +232,7 @@
     <node concept="CIrOH" id="3xM68GMigWs" role="_iOnB">
       <property role="TrG5h" value="s" />
       <property role="1o$tow" value="second" />
-      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <property role="1xMkt3" value="false" />
       <ref role="Rn5ok" node="3xM68GMigWo" resolve="time" />
     </node>
@@ -268,7 +268,7 @@
     <node concept="CIrOH" id="3xM68GMigWx" role="_iOnB">
       <property role="TrG5h" value="cd" />
       <property role="1o$tow" value="candela" />
-      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="3xM68GMigWl" resolve="luminous intensity" />
     </node>
     <node concept="_ixoA" id="3NjH4t$iJlT" role="_iOnB" />
@@ -838,11 +838,13 @@
     <node concept="CIrOH" id="6EvkZrKSbi1" role="_iOnB">
       <property role="TrG5h" value="t" />
       <property role="1o$tow" value="tonne" />
+      <property role="22P1Ek" value="4zqoYUyQ7z3/metric_positive" />
       <ref role="Rn5ok" node="3xM68GMigWn" resolve="mass" />
     </node>
     <node concept="CIrOH" id="6EvkZrKSbjZ" role="_iOnB">
       <property role="TrG5h" value="Da" />
       <property role="1o$tow" value="dalton" />
+      <property role="22P1Ek" value="4zqoYUyQ7z3/metric_positive" />
       <ref role="Rn5ok" node="3xM68GMigWn" resolve="mass" />
     </node>
     <node concept="_ixoA" id="3eEp8ADg8L3" role="_iOnB" />
@@ -905,6 +907,7 @@
       <property role="TrG5h" value="Gal" />
       <property role="1o$tow" value="gal" />
       <property role="1xMkt3" value="true" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrL3j6r" resolve="acceleration" />
       <node concept="CIsGf" id="6q45UTzs0WN" role="4gtQf">
         <node concept="wW8yL" id="6q45UTzs0WO" role="CIi4h">
@@ -938,6 +941,7 @@
       <property role="TrG5h" value="var" />
       <property role="1o$tow" value="volt-ampere reactive" />
       <property role="1xMkt3" value="true" />
+      <property role="22P1Ek" value="4zqoYUyQ7z3/metric_positive" />
       <ref role="Rn5ok" node="6EvkZrOC$$z" resolve="reactive power" />
       <node concept="CIsGf" id="6q45UTzs0WV" role="4gtQf">
         <node concept="wW8yL" id="6q45UTzs0WW" role="CIi4h">
@@ -1891,7 +1895,7 @@
       <property role="TrG5h" value="J" />
       <property role="1xMkt3" value="true" />
       <property role="1o$tow" value="joule (energy)" />
-      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
+      <property role="22P1Ek" value="4zqoYUyQ7z3/metric_positive" />
       <ref role="Rn5ok" node="3xM68GMigY_" resolve="energy" />
       <node concept="CIsGf" id="6q45UTzs0Xv" role="4gtQf">
         <node concept="wW8yL" id="1eut2v5J4Rq" role="CIi4h">
@@ -1908,7 +1912,7 @@
       <property role="TrG5h" value="J" />
       <property role="1xMkt3" value="true" />
       <property role="1o$tow" value="joule (work)" />
-      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
+      <property role="22P1Ek" value="4zqoYUyQ7z3/metric_positive" />
       <ref role="Rn5ok" node="70JbBC5F9LU" resolve="work" />
       <node concept="CIsGf" id="70JbBC5M$rl" role="4gtQf">
         <node concept="wW8yL" id="1eut2v5SLRx" role="CIi4h">
@@ -1925,7 +1929,7 @@
       <property role="TrG5h" value="J" />
       <property role="1xMkt3" value="true" />
       <property role="1o$tow" value="joule (heat)" />
-      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
+      <property role="22P1Ek" value="4zqoYUyQ7z3/metric_positive" />
       <ref role="Rn5ok" node="70JbBC5GdMI" resolve="heat" />
       <node concept="CIsGf" id="70JbBC5NCZ6" role="4gtQf">
         <node concept="wW8yL" id="1eut2v5W2zx" role="CIi4h">
@@ -1942,7 +1946,7 @@
       <property role="TrG5h" value="W" />
       <property role="1xMkt3" value="true" />
       <property role="1o$tow" value="watt (power)" />
-      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
+      <property role="22P1Ek" value="4zqoYUyQ7z3/metric_positive" />
       <ref role="Rn5ok" node="3xM68GMigYu" resolve="power" />
       <node concept="CIsGf" id="6q45UTzs0Xz" role="4gtQf">
         <node concept="2Wclh2" id="69VksCD_3tA" role="CIi4h">
@@ -1977,7 +1981,7 @@
       <property role="TrG5h" value="C" />
       <property role="1xMkt3" value="true" />
       <property role="1o$tow" value="coulomb" />
-      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
+      <property role="22P1Ek" value="4zqoYUyQ7z3/metric_positive" />
       <ref role="Rn5ok" node="3xM68GMigY7" resolve="electric charge" />
       <node concept="CIsGf" id="6q45UTzs0XD" role="4gtQf">
         <node concept="wW8yL" id="6q45UTzs0XE" role="CIi4h">
@@ -2045,7 +2049,7 @@
       <property role="TrG5h" value="F" />
       <property role="1xMkt3" value="true" />
       <property role="1o$tow" value="farad" />
-      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="3xM68GMigWU" resolve="electrical capacitance" />
       <node concept="CIsGf" id="6q45UTzs0XN" role="4gtQf">
         <node concept="2Wclh2" id="69VksCDCMei" role="CIi4h">
@@ -2079,7 +2083,7 @@
       <property role="TrG5h" value="S" />
       <property role="1xMkt3" value="true" />
       <property role="1o$tow" value="siemens" />
-      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="3xM68GMigWG" resolve="electrical conductance" />
       <node concept="CIsGf" id="6q45UTzs0XZ" role="4gtQf">
         <node concept="2Wclh2" id="69VksCDFgSi" role="CIi4h">
@@ -2096,7 +2100,7 @@
       <property role="TrG5h" value="Wb" />
       <property role="1xMkt3" value="true" />
       <property role="1o$tow" value="weber" />
-      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
+      <property role="22P1Ek" value="4zqoYUyQ7z3/metric_positive" />
       <ref role="Rn5ok" node="3xM68GMigW_" resolve="magnetic flux" />
       <node concept="CIsGf" id="6q45UTzs0Y5" role="4gtQf">
         <node concept="2Wclh2" id="69VksCDGvfs" role="CIi4h">
@@ -2140,7 +2144,7 @@
       <property role="TrG5h" value="H" />
       <property role="1xMkt3" value="true" />
       <property role="1o$tow" value="henry" />
-      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="3xM68GMigX1" resolve="electrical inductance" />
       <node concept="CIsGf" id="6q45UTzs0Yj" role="4gtQf">
         <node concept="2Wclh2" id="69VksCDIWbW" role="CIi4h">
@@ -2162,7 +2166,7 @@
       <property role="TrG5h" value="lm" />
       <property role="1xMkt3" value="true" />
       <property role="1o$tow" value="lumen" />
-      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
+      <property role="22P1Ek" value="4zqoYUyQ7z3/metric_positive" />
       <ref role="Rn5ok" node="3xM68GMigXO" resolve="luminous flux" />
       <node concept="CIsGf" id="6q45UTzs0Yr" role="4gtQf">
         <node concept="wW8yL" id="6q45UTzs0Ys" role="CIi4h">
@@ -2179,7 +2183,7 @@
       <property role="TrG5h" value="lx" />
       <property role="1xMkt3" value="true" />
       <property role="1o$tow" value="lux" />
-      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
+      <property role="22P1Ek" value="4zqoYUyQ7z3/metric_positive" />
       <ref role="Rn5ok" node="3xM68GMigXT" resolve="illuminance" />
       <node concept="CIsGf" id="6q45UTzs0Yv" role="4gtQf">
         <node concept="2Wclh2" id="69VksCDKaNg" role="CIi4h">
@@ -2252,7 +2256,7 @@
       <property role="TrG5h" value="kat" />
       <property role="1xMkt3" value="true" />
       <property role="1o$tow" value="katal" />
-      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="3xM68GMigY0" resolve="catalytic activity" />
       <node concept="CIsGf" id="6q45UTzs0YP" role="4gtQf">
         <node concept="2Wclh2" id="69VksCDNQEo" role="CIi4h">
@@ -2457,6 +2461,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m÷s" />
       <property role="1o$tow" value="metre per second (speed)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrL11H8" resolve="speed" />
       <node concept="CIsGf" id="6q45UTzs0YV" role="4gtQf">
         <node concept="2Wclh2" id="69VksCDXFT7" role="CIi4h">
@@ -2473,6 +2478,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m÷s" />
       <property role="1o$tow" value="metre per second (velocity)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="70JbBC4Iuuo" resolve="velocity" />
       <node concept="CIsGf" id="70JbBC4QW1k" role="4gtQf">
         <node concept="2Wclh2" id="69VksCDYU_B" role="CIi4h">
@@ -2490,6 +2496,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m÷s²" />
       <property role="1o$tow" value="metre per second squared" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrL3j6r" resolve="acceleration" />
       <node concept="CIsGf" id="6q45UTzs0Z1" role="4gtQf">
         <node concept="2Wclh2" id="69VksCE09ic" role="CIi4h">
@@ -2511,6 +2518,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m÷s³" />
       <property role="1o$tow" value="metre per second cubed (jerk)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrL3vn0" resolve="jerk" />
       <node concept="CIsGf" id="6q45UTzs0Z7" role="4gtQf">
         <node concept="2Wclh2" id="69VksCE1o06" role="CIi4h">
@@ -2532,6 +2540,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m÷s³" />
       <property role="1o$tow" value="metre per second cubed (jolt)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="70JbBC7VXcr" resolve="jolt" />
       <node concept="CIsGf" id="70JbBC7YcT5" role="4gtQf">
         <node concept="2Wclh2" id="69VksCE2AJk" role="CIi4h">
@@ -2553,6 +2562,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m÷s⁴" />
       <property role="1o$tow" value="metre per second to the fourth (snap)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrL3FH6" resolve="snap" />
       <node concept="CIsGf" id="6q45UTzs0Zd" role="4gtQf">
         <node concept="2Wclh2" id="69VksCE3Pwz" role="CIi4h">
@@ -2574,6 +2584,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m÷s⁴" />
       <property role="1o$tow" value="metre per second to the fourth (jounce)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="70JbBC860M7" resolve="jounce" />
       <node concept="CIsGf" id="70JbBC88gSX" role="4gtQf">
         <node concept="2Wclh2" id="69VksCE54ko" role="CIi4h">
@@ -2595,6 +2606,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="rad÷s" />
       <property role="1o$tow" value="radian per second" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrL40tx" resolve="angular velocity" />
       <node concept="CIsGf" id="6q45UTzs0Zj" role="4gtQf">
         <node concept="2Wclh2" id="69VksCE6j7v" role="CIi4h">
@@ -2611,6 +2623,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="rad÷s²" />
       <property role="1o$tow" value="radian per second squared" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrL4l8w" resolve="angular acceleration" />
       <node concept="CIsGf" id="6q45UTzs0Zp" role="4gtQf">
         <node concept="2Wclh2" id="69VksCE7xUm" role="CIi4h">
@@ -2632,6 +2645,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="Hz÷s" />
       <property role="1o$tow" value="hertz per second" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrL4DPt" resolve="frequency drift" />
       <node concept="CIsGf" id="6q45UTzs0Zv" role="4gtQf">
         <node concept="2Wclh2" id="69VksCE8KIb" role="CIi4h">
@@ -2648,6 +2662,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m³÷s" />
       <property role="1o$tow" value="cubic metre per second" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrLbmU3" resolve="volumetric flow rate" />
       <node concept="CIsGf" id="6q45UTzs0Z_" role="4gtQf">
         <node concept="2Wclh2" id="69VksCE9ZxN" role="CIi4h">
@@ -3342,6 +3357,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m²" />
       <property role="1o$tow" value="square metre" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrKS7fP" resolve="area" />
       <node concept="CIsGf" id="6q45UTzs0ZH" role="4gtQf">
         <node concept="wWcm2" id="6q45UTzs0ZI" role="CIi4h">
@@ -3358,6 +3374,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m³" />
       <property role="1o$tow" value="cubic metre" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrKSbgd" resolve="volume" />
       <node concept="CIsGf" id="6q45UTzs0ZL" role="4gtQf">
         <node concept="wWcm2" id="6q45UTzs0ZM" role="CIi4h">
@@ -3374,6 +3391,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="N⋅s" />
       <property role="1o$tow" value="newton-second (momentum)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrLmub8" resolve="momentum" />
       <node concept="CIsGf" id="6q45UTzs0ZP" role="4gtQf">
         <node concept="wW8yL" id="6q45UTzs0ZQ" role="CIi4h">
@@ -3390,6 +3408,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="N⋅s" />
       <property role="1o$tow" value="newton-second (impulse)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="70JbBC8ik$W" resolve="impulse" />
       <node concept="CIsGf" id="70JbBC8k_Om" role="4gtQf">
         <node concept="wW8yL" id="70JbBC8k_On" role="CIi4h">
@@ -3406,6 +3425,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="N⋅m⋅s" />
       <property role="1o$tow" value="newton metre second" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrLwzjA" resolve="angular momentum" />
       <node concept="CIsGf" id="6q45UTzs0ZT" role="4gtQf">
         <node concept="wW8yL" id="6q45UTzs0ZU" role="CIi4h">
@@ -3427,6 +3447,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="N⋅m" />
       <property role="1o$tow" value="newton-metre (torque)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrLwMAi" resolve="torque" />
       <node concept="CIsGf" id="6q45UTzs0ZZ" role="4gtQf">
         <node concept="wW8yL" id="70JbBC90UQ5" role="CIi4h">
@@ -3443,6 +3464,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="N⋅m" />
       <property role="1o$tow" value="newton-metre (moment of force)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="70JbBC8uJJT" resolve="moment of force" />
       <node concept="CIsGf" id="70JbBC8_$PU" role="4gtQf">
         <node concept="wW8yL" id="70JbBC95rcG" role="CIi4h">
@@ -3459,6 +3481,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m⁻¹" />
       <property role="1o$tow" value="newton per second (wave number)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="70JbBC8E8T0" resolve="wave number" />
       <node concept="CIsGf" id="6q45UTzs103" role="4gtQf">
         <node concept="wWcm2" id="70JbBC9x3to" role="CIi4h">
@@ -3475,6 +3498,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m⁻¹" />
       <property role="1o$tow" value="newton per second (optical power)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="70JbBC8GrNw" resolve="optical power" />
       <node concept="CIsGf" id="70JbBC9j3pU" role="4gtQf">
         <node concept="wWcm2" id="70JbBC9LiR3" role="CIi4h">
@@ -3491,6 +3515,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m⁻¹" />
       <property role="1o$tow" value="newton per second (curvature)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="70JbBC8IJV2" resolve="curvature" />
       <node concept="CIsGf" id="70JbBC9kdLZ" role="4gtQf">
         <node concept="wWcm2" id="70JbBC9MsfE" role="CIi4h">
@@ -3507,6 +3532,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m⁻¹" />
       <property role="1o$tow" value="newton per second (spatial frequence)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="70JbBC8JTGA" resolve="spatial frequency" />
       <node concept="CIsGf" id="70JbBC9lomQ" role="4gtQf">
         <node concept="wWcm2" id="70JbBC9N_9u" role="CIi4h">
@@ -3565,6 +3591,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m³÷kg" />
       <property role="1o$tow" value="cubic metre per kilogram" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrLxD1m" resolve="specific volume" />
       <node concept="CIsGf" id="6q45UTzs10j" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs10k" role="CIi4h">
@@ -3586,6 +3613,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="J⋅s" />
       <property role="1o$tow" value="joule-second" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrLxKYH" resolve="action" />
       <node concept="CIsGf" id="6q45UTzs10p" role="4gtQf">
         <node concept="wW8yL" id="6q45UTzs10q" role="CIi4h">
@@ -3602,6 +3630,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="J÷kg" />
       <property role="1o$tow" value="joule per kilogram" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrLxT2v" resolve="specific energy" />
       <node concept="CIsGf" id="6q45UTzs10t" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs10u" role="CIi4h">
@@ -3618,6 +3647,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="J÷m³" />
       <property role="1o$tow" value="joule per cubic metre" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrLy1el" resolve="energy density" />
       <node concept="CIsGf" id="6q45UTzs10x" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs10y" role="CIi4h">
@@ -3639,6 +3669,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="N÷m" />
       <property role="1o$tow" value="newton per metre (surface tension)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrLy9zH" resolve="surface tension" />
       <node concept="CIsGf" id="6q45UTzs10B" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs10C" role="CIi4h">
@@ -3655,6 +3686,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="N÷m" />
       <property role="1o$tow" value="newton per metre (stiffness)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="70JbBC9Uq4r" resolve="stiffness" />
       <node concept="CIsGf" id="70JbBC9V$B5" role="4gtQf">
         <node concept="2Wclh2" id="70JbBC9V$B6" role="CIi4h">
@@ -3671,6 +3703,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="W÷m²" />
       <property role="1o$tow" value="watt per square metre (heat flux density)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrLyhZ5" resolve="heat flux density" />
       <node concept="CIsGf" id="6q45UTzs10F" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs10G" role="CIi4h">
@@ -3692,6 +3725,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="W÷m²" />
       <property role="1o$tow" value="watt per square metre (irradiance)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="70JbBCa4Iyj" resolve="irradiance" />
       <node concept="CIsGf" id="70JbBCa75nj" role="4gtQf">
         <node concept="2Wclh2" id="70JbBCa75nk" role="CIi4h">
@@ -3713,6 +3747,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m²÷s" />
       <property role="1o$tow" value="square metre per second (kinematic viscosity)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrLyqxV" resolve="kinematic viscosity" />
       <node concept="CIsGf" id="6q45UTzs10L" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs10M" role="CIi4h">
@@ -3734,6 +3769,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m²÷s" />
       <property role="1o$tow" value="square metre per second (thermal diffusivity)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="70JbBCal2j1" resolve="thermal diffusivity" />
       <node concept="CIsGf" id="70JbBCapJbZ" role="4gtQf">
         <node concept="2Wclh2" id="70JbBCapJc0" role="CIi4h">
@@ -3755,6 +3791,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="Pa⋅s" />
       <property role="1o$tow" value="pascal-second" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrLyz7s" resolve="dynamic viscosity" />
       <node concept="CIsGf" id="6q45UTzs10R" role="4gtQf">
         <node concept="wW8yL" id="6q45UTzs10S" role="CIi4h">
@@ -3803,6 +3840,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="W÷(sr⋅m²)" />
       <property role="1o$tow" value="watt per steradian square metre" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrLyXgB" resolve="radiance" />
       <node concept="CIsGf" id="6q45UTzs113" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs114" role="CIi4h">
@@ -3829,6 +3867,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="W÷(sr⋅m³)" />
       <property role="1o$tow" value="watt per steradian cubic metre" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrLz68$" resolve="spectral radiance" />
       <node concept="CIsGf" id="6q45UTzs11b" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs11c" role="CIi4h">
@@ -3855,6 +3894,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="W÷m" />
       <property role="1o$tow" value="watt per metre" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrLzfbt" resolve="spectral power" />
       <node concept="CIsGf" id="6q45UTzs11j" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs11k" role="CIi4h">
@@ -3871,6 +3911,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="Gy÷s" />
       <property role="1o$tow" value="gray per second" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrLzok8" resolve="absorbed dose rate" />
       <node concept="CIsGf" id="6q45UTzs11n" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs11o" role="CIi4h">
@@ -3887,6 +3928,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m÷m³" />
       <property role="1o$tow" value="metre per cubic metre" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrLzxBN" resolve="fuel efficiency" />
       <node concept="CIsGf" id="6q45UTzs11r" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs11s" role="CIi4h">
@@ -3903,6 +3945,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="W÷m³" />
       <property role="1o$tow" value="watt per cubic metre (special irradiance)" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrLzF0g" resolve="spectral irradiance" />
       <node concept="CIsGf" id="6q45UTzs11x" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs11y" role="CIi4h">
@@ -3929,6 +3972,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="W÷m³" />
       <property role="1o$tow" value="watt per cubic metre (power density)" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="70JbBCaMl_Q" resolve="power density" />
       <node concept="CIsGf" id="70JbBCaPV11" role="4gtQf">
         <node concept="2Wclh2" id="70JbBCaPV12" role="CIi4h">
@@ -3950,6 +3994,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="J÷(m²⋅s)" />
       <property role="1o$tow" value="joule per square metre second" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrLzOyj" resolve="energy flux density" />
       <node concept="CIsGf" id="6q45UTzs11B" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs11C" role="CIi4h">
@@ -3992,6 +4037,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="J÷m²" />
       <property role="1o$tow" value="joule per square metre" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrL$7ZE" resolve="radiant exposure" />
       <node concept="CIsGf" id="6q45UTzs11N" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs11O" role="CIi4h">
@@ -4034,6 +4080,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="N⋅m⋅s÷kg" />
       <property role="1o$tow" value="newton metre second per kilogram" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrL$rLp" resolve="specific angular momentum" />
       <node concept="CIsGf" id="6q45UTzs11Z" role="4gtQf">
         <node concept="wW8yL" id="6q45UTzs120" role="CIi4h">
@@ -4060,6 +4107,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="W÷sr" />
       <property role="1o$tow" value="watt per steradian" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrL$_Rl" resolve="radiant intensity" />
       <node concept="CIsGf" id="6q45UTzs127" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs128" role="CIi4h">
@@ -4076,6 +4124,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="W÷(sr⋅m)" />
       <property role="1o$tow" value="watt per steradian metre" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrL$K4A" resolve="spectral intensity" />
       <node concept="CIsGf" id="6q45UTzs12b" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs12c" role="CIi4h">
@@ -4246,6 +4295,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="mol÷m³" />
       <property role="1o$tow" value="mole per cubic metre" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrMFXkV" resolve="molar concentration" />
       <node concept="CIsGf" id="6q45UTzs12h" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs12i" role="CIi4h">
@@ -4267,6 +4317,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m³÷mol" />
       <property role="1o$tow" value="cubic metre per mole" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrMG849" resolve="molar volume" />
       <node concept="CIsGf" id="6q45UTzs12n" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs12o" role="CIi4h">
@@ -4288,6 +4339,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="J÷(K⋅mol)" />
       <property role="1o$tow" value="joule per kelvin mole" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrMGiQ4" resolve="molar heat capacity" />
       <node concept="CIsGf" id="6q45UTzs12t" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs12u" role="CIi4h">
@@ -4309,6 +4361,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="J÷mol" />
       <property role="1o$tow" value="joule per mole" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrMGtM_" resolve="molar energy" />
       <node concept="CIsGf" id="6q45UTzs12z" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs12$" role="CIi4h">
@@ -4325,6 +4378,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="S⋅m²÷mol" />
       <property role="1o$tow" value="siemens square metre per mole" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrMGCRO" resolve="molar conductivity" />
       <node concept="CIsGf" id="6q45UTzs12B" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs12C" role="CIi4h">
@@ -4351,6 +4405,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="mol÷kg" />
       <property role="1o$tow" value="mole per kilogram" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrMGO8c" resolve="molality" />
       <node concept="CIsGf" id="6q45UTzs12J" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs12K" role="CIi4h">
@@ -4383,6 +4438,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m³÷(mol⋅s)" />
       <property role="1o$tow" value="cubic metre per mole second" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrMHaHq" resolve="catalytic efficiency" />
       <node concept="CIsGf" id="6q45UTzs12R" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs12S" role="CIi4h">
@@ -4768,6 +4824,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="C÷m²" />
       <property role="1o$tow" value="coulomb per square metre" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrMWyB4" resolve="electric displacement field" />
       <node concept="CIsGf" id="6q45UTzs12Z" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs130" role="CIi4h">
@@ -4789,6 +4846,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="C÷m³" />
       <property role="1o$tow" value="coulomb per cubic metre" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrMWK62" resolve="electric charge density" />
       <node concept="CIsGf" id="6q45UTzs135" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs136" role="CIi4h">
@@ -4810,6 +4868,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="A÷m²" />
       <property role="1o$tow" value="ampere per square metre" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrMXpAv" resolve="electric current density" />
       <node concept="CIsGf" id="6q45UTzs13b" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs13c" role="CIi4h">
@@ -4831,6 +4890,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="S÷m" />
       <property role="1o$tow" value="siemens per metre" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrMXP4p" resolve="electrical conductivity" />
       <node concept="CIsGf" id="6q45UTzs13h" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs13i" role="CIi4h">
@@ -4847,6 +4907,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="F÷m" />
       <property role="1o$tow" value="farad per metre" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrMYgYA" resolve="permittivity" />
       <node concept="CIsGf" id="6q45UTzs13l" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs13m" role="CIi4h">
@@ -4863,6 +4924,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="H÷m" />
       <property role="1o$tow" value="henry per metre" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrMYUP8" resolve="magnetic permeability" />
       <node concept="CIsGf" id="6q45UTzs13p" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs13q" role="CIi4h">
@@ -4879,6 +4941,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="V÷m" />
       <property role="1o$tow" value="volt per metre" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrMZnPT" resolve="electric field strength" />
       <node concept="CIsGf" id="6q45UTzs13t" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs13u" role="CIi4h">
@@ -4895,6 +4958,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="A÷m" />
       <property role="1o$tow" value="ampere per metre (magnetization)" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrMZPur" resolve="magnetization" />
       <node concept="CIsGf" id="6q45UTzs13x" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs13y" role="CIi4h">
@@ -4911,6 +4975,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="A÷m" />
       <property role="1o$tow" value="ampere per metre" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="70JbBCbjSzJ" resolve="magnetic field strength" />
       <node concept="CIsGf" id="70JbBCbl6Nz" role="4gtQf">
         <node concept="2Wclh2" id="70JbBCbl6N$" role="CIi4h">
@@ -4927,6 +4992,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="C÷kg" />
       <property role="1o$tow" value="coulomb per kilogram" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrN0jt0" resolve="exposure" />
       <node concept="CIsGf" id="6q45UTzs13_" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs13A" role="CIi4h">
@@ -4943,6 +5009,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="Ω⋅m" />
       <property role="1o$tow" value="ohm metre" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrN0ZDM" resolve="electrical resistivity" />
       <node concept="CIsGf" id="6q45UTzs13D" role="4gtQf">
         <node concept="wW8yL" id="6q45UTzs13E" role="CIi4h">
@@ -4959,6 +5026,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="C÷m" />
       <property role="1o$tow" value="coulomb per metre" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrN1VkH" resolve="linear charge density" />
       <node concept="CIsGf" id="6q45UTzs13H" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs13I" role="CIi4h">
@@ -4975,6 +5043,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="J÷T" />
       <property role="1o$tow" value="joule per tesla" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrN2qKn" resolve="magnetic dipole moment" />
       <node concept="CIsGf" id="6q45UTzs13L" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs13M" role="CIi4h">
@@ -4991,6 +5060,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m²÷(V⋅s)" />
       <property role="1o$tow" value="square metre per volt second" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrN39jP" resolve="electron mobility" />
       <node concept="CIsGf" id="6q45UTzs13P" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs13Q" role="CIi4h">
@@ -5033,6 +5103,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="Wb÷m" />
       <property role="1o$tow" value="weber per metre" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrN5PmY" resolve="magnetic vector potential" />
       <node concept="CIsGf" id="6q45UTzs141" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs142" role="CIi4h">
@@ -5049,6 +5120,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="Wb⋅m" />
       <property role="1o$tow" value="weber metre" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrN7kEx" resolve="magnetic moment" />
       <node concept="CIsGf" id="6q45UTzs145" role="4gtQf">
         <node concept="wW8yL" id="6q45UTzs146" role="CIi4h">
@@ -5065,6 +5137,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="T⋅m" />
       <property role="1o$tow" value="tesla metre" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrN8A5x" resolve="magnetic rigidity" />
       <node concept="CIsGf" id="6q45UTzs149" role="4gtQf">
         <node concept="wW8yL" id="6q45UTzs14a" role="CIi4h">
@@ -5097,6 +5170,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="m÷H" />
       <property role="1o$tow" value="metre per henry" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrNdCaG" resolve="magnetic susceptibility" />
       <node concept="CIsGf" id="6q45UTzs14h" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs14i" role="CIi4h">
@@ -5182,6 +5256,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="lm⋅s" />
       <property role="1o$tow" value="lumen second" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrNL9KI" resolve="luminous energy" />
       <node concept="CIsGf" id="6q45UTzs14l" role="4gtQf">
         <node concept="wW8yL" id="6q45UTzs14m" role="CIi4h">
@@ -5198,6 +5273,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="lx⋅s" />
       <property role="1o$tow" value="lux second" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrNLpUv" resolve="luminous exposure" />
       <node concept="CIsGf" id="6q45UTzs14p" role="4gtQf">
         <node concept="wW8yL" id="6q45UTzs14q" role="CIi4h">
@@ -5214,6 +5290,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="cd÷m²" />
       <property role="1o$tow" value="candela per square metre" />
+      <property role="22P1Ek" value="4zqoYUyQ7z4/metric_negative" />
       <ref role="Rn5ok" node="6EvkZrNLE8G" resolve="luminance" />
       <node concept="CIsGf" id="6q45UTzs14t" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs14u" role="CIi4h">
@@ -5235,6 +5312,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="lm÷W" />
       <property role="1o$tow" value="lumen per watt" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrNLUp$" resolve="luminous efficacy" />
       <node concept="CIsGf" id="6q45UTzs14z" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs14$" role="CIi4h">
@@ -5399,6 +5477,7 @@
     <node concept="_ixoA" id="6EvkZrNYPKw" role="_iOnB" />
     <node concept="CIrOH" id="3xM68GMih14" role="_iOnB">
       <property role="TrG5h" value="°C" />
+      <property role="1o$tow" value="degree celsius" />
       <ref role="Rn5ok" node="3xM68GMigWm" resolve="thermodynamic temperature" />
     </node>
     <node concept="_ixoA" id="6EvkZrNRLve" role="_iOnB" />
@@ -5406,6 +5485,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="J÷K" />
       <property role="1o$tow" value="joule per kelvin (heat capacity)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrNXdcc" resolve="heat capacity" />
       <node concept="CIsGf" id="6q45UTzs14B" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs14C" role="CIi4h">
@@ -5422,6 +5502,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="J÷K" />
       <property role="1o$tow" value="joule per kelvin (entropy)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="70JbBCbx7Tf" resolve="entropy" />
       <node concept="CIsGf" id="70JbBCbCqDS" role="4gtQf">
         <node concept="2Wclh2" id="70JbBCbCqDT" role="CIi4h">
@@ -5438,6 +5519,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="J÷(K⋅kg)" />
       <property role="1o$tow" value="joule per kilogram kelvin (specific heat capacity)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrNXuk1" resolve="specific heat capacity" />
       <node concept="CIsGf" id="6q45UTzs14F" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs14G" role="CIi4h">
@@ -5459,6 +5541,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="J÷(K⋅kg)" />
       <property role="1o$tow" value="joule per kilogram kelvin (specific entropy)" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="70JbBCbJJ1m" resolve="specific entropy" />
       <node concept="CIsGf" id="70JbBCbOELf" role="4gtQf">
         <node concept="2Wclh2" id="70JbBCbOELg" role="CIi4h">
@@ -5480,6 +5563,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="W÷(m⋅K)" />
       <property role="1o$tow" value="watt per metre kelvin" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrNZpHy" resolve="thermal conductivity" />
       <node concept="CIsGf" id="6q45UTzs14L" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs14M" role="CIi4h">
@@ -5501,6 +5585,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="K÷W" />
       <property role="1o$tow" value="kelvin per watt" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrNXJB4" resolve="thermal resistance" />
       <node concept="CIsGf" id="6q45UTzs14R" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs14S" role="CIi4h">
@@ -5533,6 +5618,7 @@
       <property role="1xMkt3" value="true" />
       <property role="TrG5h" value="K÷m" />
       <property role="1o$tow" value="kelvin per metre" />
+      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
       <ref role="Rn5ok" node="6EvkZrNYivh" resolve="temperature gradient" />
       <node concept="CIsGf" id="6q45UTzs14Z" role="4gtQf">
         <node concept="2Wclh2" id="6q45UTzs150" role="CIi4h">
@@ -5814,13 +5900,13 @@
     <node concept="CIrOH" id="14aBVbN55En" role="_iOnB">
       <property role="TrG5h" value="byte" />
       <property role="1o$tow" value="byte" />
-      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
+      <property role="22P1Ek" value="4zqoYUyQ7z3/metric_positive" />
       <ref role="Rn5ok" node="7F14or$gcr1" resolve="digital information" />
     </node>
     <node concept="CIrOH" id="14aBVbN55Ep" role="_iOnB">
       <property role="TrG5h" value="bit" />
       <property role="1o$tow" value="bit" />
-      <property role="22P1Ek" value="2hbaSyABMZN/metric" />
+      <property role="22P1Ek" value="4zqoYUyQ7z3/metric_positive" />
       <ref role="Rn5ok" node="7F14or$gcr1" resolve="digital information" />
     </node>
     <node concept="_ixoA" id="2liNWkVV20T" role="_iOnB" />

--- a/code/languages/org.iets3.opensource/solutions/test.org.iets3.analysis.base/test.org.iets3.analysis.base.msd
+++ b/code/languages/org.iets3.opensource/solutions/test.org.iets3.analysis.base/test.org.iets3.analysis.base.msd
@@ -16,9 +16,56 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)</dependency>
   </dependencies>
-  <languageVersions />
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="5" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
   <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)" version="0" />
+    <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
+    <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
+    <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
+    <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />
+    <module reference="b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)" version="0" />
+    <module reference="848ef45d-e560-4e35-853c-f35a64cc135c(de.itemis.mps.editor.celllayout.runtime)" version="0" />
+    <module reference="24c96a96-b7a1-4f30-82da-0f8e279a2661(de.itemis.mps.editor.celllayout.styles)" version="0" />
+    <module reference="cce85e64-7b37-4ad5-b0e6-9d18324cdfb3(de.itemis.mps.selection.runtime)" version="0" />
+    <module reference="dc038ceb-b7ea-4fea-ac12-55f7400e97ba(de.slisson.mps.editor.multiline.runtime)" version="0" />
+    <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
+    <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
+    <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
+    <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
+    <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
+    <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
+    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="1" />
+    <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
     <module reference="40a81503-9f0e-4cd0-8e0c-4ac462de08b8(test.org.iets3.analysis.base)" version="0" />
+    <module reference="5a0fae25-8093-498f-81fe-3b264864819a(test.org.iets3.analysis.base.solvable)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.coverage@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.coverage@tests.mps
@@ -308,7 +308,7 @@
           </node>
         </node>
         <node concept="1amXfx" id="620LAS5PQG6" role="1am$gN">
-          <ref role="1amXd5" to="hm2y:2ufoZQIKHqp" resolve="SimpleExpressionValueInspector" />
+          <ref role="1amXd5" to="hm2y:2ufoZQIKHqp" resolve="SimpleValueInspector" />
           <node concept="1z9TsT" id="620LAS5PQGZ" role="lGtFl">
             <node concept="OjmMv" id="620LAS5PQH0" role="1w35rA">
               <node concept="19SGf9" id="620LAS5PQH1" role="OjmMu">
@@ -3666,7 +3666,7 @@
           <ref role="1amXd5" to="yv47:6JZACDWOa9c" resolve="ReferenceableFlag" />
         </node>
         <node concept="1amXfx" id="1yEri41yK3C" role="1am$gN">
-          <ref role="1amXd5" to="hm2y:2ufoZQIKHqp" resolve="SimpleExpressionValueInspector" />
+          <ref role="1amXd5" to="hm2y:2ufoZQIKHqp" resolve="SimpleValueInspector" />
           <node concept="1z9TsT" id="1yEri41yKgy" role="lGtFl">
             <node concept="OjmMv" id="1yEri41yKgz" role="1w35rA">
               <node concept="19SGf9" id="1yEri41yKg$" role="OjmMu">

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.phyunits@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.phyunits@tests.mps
@@ -9607,6 +9607,35 @@
           </node>
         </node>
         <node concept="_ixoA" id="7F14or$fHlD" role="_iOnC" />
+        <node concept="2zPypq" id="2xkb_2HNX$X" role="_iOnC">
+          <property role="TrG5h" value="bitMixing" />
+          <node concept="1YnStw" id="2xkb_2HO4WC" role="2zPyp_">
+            <node concept="CIsGf" id="2xkb_2HO4WB" role="2c7tTI">
+              <node concept="CIsvn" id="2xkb_2HO4WA" role="CIi4h">
+                <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="bit" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="2xkb_2HO3ZQ" role="1YnStB">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="7CXmI" id="2xkb_2HVCle" role="lGtFl">
+              <node concept="1TM$A" id="2xkb_2HVDU1" role="7EUXB">
+                <node concept="2PYRI3" id="2xkb_2HVDU2" role="3lydEf">
+                  <ref role="39XzEq" to="x0pf:6qDtanU0Ksh" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2c7tTJ" id="2xkb_2HO2bB" role="2zM23F">
+            <node concept="CIsGf" id="2xkb_2HO35y" role="2c7tTI">
+              <node concept="CIsvn" id="2xkb_2HO35x" role="CIi4h">
+                <ref role="CIi3I" to="8ps7:14aBVbN55Ep" resolve="bit" />
+              </node>
+            </node>
+            <node concept="mLuIC" id="2xkb_2HO1hU" role="2c7tTw" />
+          </node>
+        </node>
+        <node concept="_ixoA" id="2xkb_2HNSNf" role="_iOnC" />
         <node concept="CIrOH" id="7F14or$fHoz" role="_iOnC">
           <property role="TrG5h" value="mUnit" />
           <property role="22P1Ek" value="2hbaSyABMZN/metric" />
@@ -9786,6 +9815,12 @@
         <node concept="_ixoA" id="7CCjMgEywLU" role="_iOnC" />
         <node concept="3GEVxB" id="EsE2hyiAIe" role="3i6evy">
           <ref role="3GEb4d" to="8ps7:3xM68GMigWg" resolve="SIBaseUnits" />
+        </node>
+        <node concept="3GEVxB" id="2xkb_2HNTIj" role="3i6evy">
+          <ref role="3GEb4d" to="8ps7:ZkGd2yKlmo" resolve="UnitsOfInformationIEC" />
+        </node>
+        <node concept="3GEVxB" id="2xkb_2HNVBI" role="3i6evy">
+          <ref role="3GEb4d" to="8ps7:ZkGd2yKlml" resolve="UnitsOfInformationMetric" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.phyunits@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.phyunits@tests.mps
@@ -5512,7 +5512,7 @@
               <node concept="CIsGf" id="3wrpJuuAO$Z" role="2c7tTI">
                 <node concept="CIsvn" id="3wrpJuuAO$Y" role="CIi4h">
                   <property role="1xG2w7" value="k" />
-                  <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                  <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
                 </node>
               </node>
               <node concept="30bXRB" id="3wrpJuuALzR" role="1YnStB">
@@ -5545,7 +5545,7 @@
             <node concept="CIsGf" id="3wrpJuuC0NM" role="2c7tTI">
               <node concept="CIsvn" id="3wrpJuuC2f4" role="CIi4h">
                 <property role="1xG2w7" value="k" />
-                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
               </node>
             </node>
           </node>
@@ -7810,14 +7810,14 @@
           <node concept="3EXbTZ" id="2Yx91N$vVTp" role="1QScD9">
             <node concept="CIsvn" id="3rpYUh$WJ81" role="2qyG0l">
               <property role="1xG2w7" value="" />
-              <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+              <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
             </node>
           </node>
           <node concept="1YnStw" id="2Yx91N$vRZ2" role="30czhm">
             <node concept="CIsGf" id="2Yx91N$vRZ1" role="2c7tTI">
               <node concept="CIsvn" id="6DczoUSytLG" role="CIi4h">
                 <property role="1xG2w7" value="Ki" />
-                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="2Yx91N$tX9J" role="1YnStB">
@@ -7835,14 +7835,14 @@
           <node concept="3EXbTZ" id="3rpYUh$WKxn" role="1QScD9">
             <node concept="CIsvn" id="3rpYUh$WKxo" role="2qyG0l">
               <property role="1xG2w7" value="" />
-              <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+              <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
             </node>
           </node>
           <node concept="1YnStw" id="3rpYUh$WKxp" role="30czhm">
             <node concept="CIsGf" id="3rpYUh$WKxq" role="2c7tTI">
               <node concept="CIsvn" id="6DczoUSyAPo" role="CIi4h">
                 <property role="1xG2w7" value="Mi" />
-                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="3rpYUh$WKxs" role="1YnStB">
@@ -7860,14 +7860,14 @@
           <node concept="3EXbTZ" id="3rpYUh$WLMc" role="1QScD9">
             <node concept="CIsvn" id="3rpYUh$WLMd" role="2qyG0l">
               <property role="1xG2w7" value="" />
-              <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+              <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
             </node>
           </node>
           <node concept="1YnStw" id="3rpYUh$WLMe" role="30czhm">
             <node concept="CIsGf" id="3rpYUh$WLMf" role="2c7tTI">
               <node concept="CIsvn" id="6DczoUSyJL7" role="CIi4h">
                 <property role="1xG2w7" value="Gi" />
-                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="3rpYUh$WLMh" role="1YnStB">
@@ -7885,14 +7885,14 @@
           <node concept="3EXbTZ" id="3rpYUh$WNa1" role="1QScD9">
             <node concept="CIsvn" id="3rpYUh$WNa2" role="2qyG0l">
               <property role="1xG2w7" value="" />
-              <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+              <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
             </node>
           </node>
           <node concept="1YnStw" id="3rpYUh$WNa3" role="30czhm">
             <node concept="CIsGf" id="3rpYUh$WNa4" role="2c7tTI">
               <node concept="CIsvn" id="6DczoUSySI$" role="CIi4h">
                 <property role="1xG2w7" value="Ti" />
-                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="3rpYUh$WNa6" role="1YnStB">
@@ -7910,14 +7910,14 @@
           <node concept="3EXbTZ" id="3rpYUh$X5Ue" role="1QScD9">
             <node concept="CIsvn" id="3rpYUh$X5Uf" role="2qyG0l">
               <property role="1xG2w7" value="" />
-              <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+              <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
             </node>
           </node>
           <node concept="1YnStw" id="3rpYUh$X5Ug" role="30czhm">
             <node concept="CIsGf" id="3rpYUh$X5Uh" role="2c7tTI">
               <node concept="CIsvn" id="6DczoUSz1xH" role="CIi4h">
                 <property role="1xG2w7" value="Pi" />
-                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="3rpYUh$X5Uj" role="1YnStB">
@@ -7935,14 +7935,14 @@
           <node concept="3EXbTZ" id="3rpYUh$X7zT" role="1QScD9">
             <node concept="CIsvn" id="3rpYUh$X7zU" role="2qyG0l">
               <property role="1xG2w7" value="" />
-              <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+              <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
             </node>
           </node>
           <node concept="1YnStw" id="3rpYUh$X7zV" role="30czhm">
             <node concept="CIsGf" id="3rpYUh$X7zW" role="2c7tTI">
               <node concept="CIsvn" id="6DczoUSzaw_" role="CIi4h">
                 <property role="1xG2w7" value="Ei" />
-                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="3rpYUh$X7zY" role="1YnStB">
@@ -7960,14 +7960,14 @@
           <node concept="3EXbTZ" id="3rpYUh$X9kJ" role="1QScD9">
             <node concept="CIsvn" id="3rpYUh$X9kK" role="2qyG0l">
               <property role="1xG2w7" value="" />
-              <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+              <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
             </node>
           </node>
           <node concept="1YnStw" id="3rpYUh$X9kL" role="30czhm">
             <node concept="CIsGf" id="3rpYUh$X9kM" role="2c7tTI">
               <node concept="CIsvn" id="6DczoUSzjsl" role="CIi4h">
                 <property role="1xG2w7" value="Zi" />
-                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="3rpYUh$X9kO" role="1YnStB">
@@ -7985,14 +7985,14 @@
           <node concept="3EXbTZ" id="3rpYUh$Xbax" role="1QScD9">
             <node concept="CIsvn" id="3rpYUh$Xbay" role="2qyG0l">
               <property role="1xG2w7" value="" />
-              <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+              <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
             </node>
           </node>
           <node concept="1YnStw" id="3rpYUh$Xbaz" role="30czhm">
             <node concept="CIsGf" id="3rpYUh$Xba$" role="2c7tTI">
               <node concept="CIsvn" id="6DczoUSzsaF" role="CIi4h">
                 <property role="1xG2w7" value="Yi" />
-                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="3rpYUh$XbaA" role="1YnStB">
@@ -8013,14 +8013,14 @@
         <node concept="1QScDb" id="14aBVbN6aKg" role="_fkuY">
           <node concept="3EXbTZ" id="14aBVbN6aKh" role="1QScD9">
             <node concept="CIsvn" id="14aBVbN7CqV" role="2qyG0l">
-              <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+              <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
             </node>
           </node>
           <node concept="1YnStw" id="14aBVbN6aKj" role="30czhm">
             <node concept="CIsGf" id="14aBVbN6aKk" role="2c7tTI">
               <node concept="CIsvn" id="14aBVbNgEy2" role="CIi4h">
                 <property role="1xG2w7" value="k" />
-                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="14aBVbN6aKm" role="1YnStB">
@@ -8039,7 +8039,7 @@
             <node concept="CIsGf" id="14aBVbN6aKu" role="2c7tTI">
               <node concept="CIsvn" id="14aBVbNiZoi" role="CIi4h">
                 <property role="1xG2w7" value="M" />
-                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="14aBVbN6aKw" role="1YnStB">
@@ -8048,7 +8048,7 @@
           </node>
           <node concept="3EXbTZ" id="14aBVbNiIb2" role="1QScD9">
             <node concept="CIsvn" id="14aBVbNiLD0" role="2qyG0l">
-              <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+              <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
             </node>
           </node>
         </node>
@@ -8061,14 +8061,14 @@
         <node concept="1QScDb" id="14aBVbN6aK$" role="_fkuY">
           <node concept="3EXbTZ" id="14aBVbN6aK_" role="1QScD9">
             <node concept="CIsvn" id="14aBVbN7JjF" role="2qyG0l">
-              <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+              <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
             </node>
           </node>
           <node concept="1YnStw" id="14aBVbN6aKB" role="30czhm">
             <node concept="CIsGf" id="14aBVbN6aKC" role="2c7tTI">
               <node concept="CIsvn" id="14aBVbNci2P" role="CIi4h">
                 <property role="1xG2w7" value="G" />
-                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="14aBVbN6aKE" role="1YnStB">
@@ -8085,14 +8085,14 @@
         <node concept="1QScDb" id="14aBVbN6aKI" role="_fkuY">
           <node concept="3EXbTZ" id="14aBVbN6aKJ" role="1QScD9">
             <node concept="CIsvn" id="14aBVbN7MKC" role="2qyG0l">
-              <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+              <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
             </node>
           </node>
           <node concept="1YnStw" id="14aBVbN6aKL" role="30czhm">
             <node concept="CIsGf" id="14aBVbN6aKM" role="2c7tTI">
               <node concept="CIsvn" id="14aBVbNckZB" role="CIi4h">
                 <property role="1xG2w7" value="T" />
-                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="14aBVbN6aKO" role="1YnStB">
@@ -8109,14 +8109,14 @@
         <node concept="1QScDb" id="14aBVbN6aKS" role="_fkuY">
           <node concept="3EXbTZ" id="14aBVbN6aKT" role="1QScD9">
             <node concept="CIsvn" id="14aBVbN7PYm" role="2qyG0l">
-              <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+              <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
             </node>
           </node>
           <node concept="1YnStw" id="14aBVbN6aKV" role="30czhm">
             <node concept="CIsGf" id="14aBVbN6aKW" role="2c7tTI">
               <node concept="CIsvn" id="14aBVbNco7u" role="CIi4h">
                 <property role="1xG2w7" value="P" />
-                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="14aBVbN6aKY" role="1YnStB">
@@ -8133,14 +8133,14 @@
         <node concept="1QScDb" id="14aBVbN6aL2" role="_fkuY">
           <node concept="3EXbTZ" id="14aBVbN6aL3" role="1QScD9">
             <node concept="CIsvn" id="14aBVbN7T5T" role="2qyG0l">
-              <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+              <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
             </node>
           </node>
           <node concept="1YnStw" id="14aBVbN6aL5" role="30czhm">
             <node concept="CIsGf" id="14aBVbN6aL6" role="2c7tTI">
               <node concept="CIsvn" id="14aBVbNgNWE" role="CIi4h">
                 <property role="1xG2w7" value="E" />
-                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="14aBVbN6aL8" role="1YnStB">
@@ -8157,14 +8157,14 @@
         <node concept="1QScDb" id="14aBVbN6aLc" role="_fkuY">
           <node concept="3EXbTZ" id="14aBVbN6aLd" role="1QScD9">
             <node concept="CIsvn" id="14aBVbN7W7h" role="2qyG0l">
-              <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+              <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
             </node>
           </node>
           <node concept="1YnStw" id="14aBVbN6aLf" role="30czhm">
             <node concept="CIsGf" id="14aBVbN6aLg" role="2c7tTI">
               <node concept="CIsvn" id="14aBVbNgVZv" role="CIi4h">
                 <property role="1xG2w7" value="Z" />
-                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="14aBVbN6aLi" role="1YnStB">
@@ -8181,14 +8181,14 @@
         <node concept="1QScDb" id="14aBVbN6aLm" role="_fkuY">
           <node concept="3EXbTZ" id="14aBVbN6aLn" role="1QScD9">
             <node concept="CIsvn" id="14aBVbN7Z2u" role="2qyG0l">
-              <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+              <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
             </node>
           </node>
           <node concept="1YnStw" id="14aBVbN6aLp" role="30czhm">
             <node concept="CIsGf" id="14aBVbN6aLq" role="2c7tTI">
               <node concept="CIsvn" id="14aBVbNgZbq" role="CIi4h">
                 <property role="1xG2w7" value="Y" />
-                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="14aBVbN6aLs" role="1YnStB">
@@ -8209,14 +8209,14 @@
         <node concept="1QScDb" id="FMy9mep0hR" role="_fkuY">
           <node concept="3EXbTZ" id="FMy9mep0hS" role="1QScD9">
             <node concept="CIsvn" id="1eut2uSWQD3" role="2qyG0l">
-              <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+              <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
             </node>
           </node>
           <node concept="1YnStw" id="FMy9mep0hU" role="30czhm">
             <node concept="CIsGf" id="FMy9mep0hV" role="2c7tTI">
               <node concept="CIsvn" id="1eut2uSWKZ$" role="CIi4h">
                 <property role="1xG2w7" value="K" />
-                <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+                <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="FMy9mep0hX" role="1YnStB">
@@ -8235,7 +8235,7 @@
             <node concept="CIsGf" id="FMy9mep0i3" role="2c7tTI">
               <node concept="CIsvn" id="1eut2uSXqwe" role="CIi4h">
                 <property role="1xG2w7" value="M" />
-                <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+                <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="FMy9mep0i5" role="1YnStB">
@@ -8244,7 +8244,7 @@
           </node>
           <node concept="3EXbTZ" id="FMy9mep0i6" role="1QScD9">
             <node concept="CIsvn" id="1eut2uSXDmi" role="2qyG0l">
-              <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+              <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
             </node>
           </node>
         </node>
@@ -8257,14 +8257,14 @@
         <node concept="1QScDb" id="FMy9mep0ib" role="_fkuY">
           <node concept="3EXbTZ" id="FMy9mep0ic" role="1QScD9">
             <node concept="CIsvn" id="1eut2uSYc7r" role="2qyG0l">
-              <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+              <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
             </node>
           </node>
           <node concept="1YnStw" id="FMy9mep0ie" role="30czhm">
             <node concept="CIsGf" id="FMy9mep0if" role="2c7tTI">
               <node concept="CIsvn" id="1eut2uSXNlt" role="CIi4h">
                 <property role="1xG2w7" value="G" />
-                <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+                <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="FMy9mep0ih" role="1YnStB">
@@ -8281,14 +8281,14 @@
         <node concept="1QScDb" id="FMy9mep0il" role="_fkuY">
           <node concept="3EXbTZ" id="FMy9mep0im" role="1QScD9">
             <node concept="CIsvn" id="1eut2uSYm6S" role="2qyG0l">
-              <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+              <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
             </node>
           </node>
           <node concept="1YnStw" id="FMy9mep0io" role="30czhm">
             <node concept="CIsGf" id="FMy9mep0ip" role="2c7tTI">
               <node concept="CIsvn" id="1eut2uSYha_" role="CIi4h">
                 <property role="1xG2w7" value="T" />
-                <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+                <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="FMy9mep0ir" role="1YnStB">
@@ -8337,14 +8337,14 @@
           <node concept="3EXbTZ" id="3rpYUh$ZLpz" role="1QScD9">
             <node concept="CIsvn" id="6DczoUSzQH9" role="2qyG0l">
               <property role="1xG2w7" value="Gi" />
-              <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="b" />
+              <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="bit" />
             </node>
           </node>
           <node concept="1YnStw" id="3rpYUh$ZHjz" role="30czhm">
             <node concept="CIsGf" id="3rpYUh$ZHjy" role="2c7tTI">
               <node concept="CIsvn" id="6DczoUSz$Qs" role="CIi4h">
                 <property role="1xG2w7" value="Ki" />
-                <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="b" />
+                <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="bit" />
               </node>
             </node>
             <node concept="30bXRB" id="3rpYUh$ZFdk" role="1YnStB">
@@ -8361,14 +8361,14 @@
         <node concept="1QScDb" id="3rpYUh_0hUp" role="_fkuY">
           <node concept="3EXbTZ" id="3rpYUh_0hUq" role="1QScD9">
             <node concept="CIsvn" id="3rpYUh_0kek" role="2qyG0l">
-              <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="b" />
+              <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="bit" />
             </node>
           </node>
           <node concept="1YnStw" id="3rpYUh_0hUs" role="30czhm">
             <node concept="CIsGf" id="3rpYUh_0hUt" role="2c7tTI">
               <node concept="CIsvn" id="6DczoUSzHJD" role="CIi4h">
                 <property role="1xG2w7" value="Ki" />
-                <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="b" />
+                <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="bit" />
               </node>
             </node>
             <node concept="30bXRB" id="3rpYUh_0hUv" role="1YnStB">
@@ -8385,13 +8385,13 @@
         <node concept="1QScDb" id="14aBVbN3Hxd" role="_fkuY">
           <node concept="3EXbTZ" id="14aBVbN3K5y" role="1QScD9">
             <node concept="CIsvn" id="2liNWkWZWo2" role="2qyG0l">
-              <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="b" />
+              <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="bit" />
             </node>
           </node>
           <node concept="1YnStw" id="14aBVbN3EXr" role="30czhm">
             <node concept="CIsGf" id="14aBVbN3EXq" role="2c7tTI">
               <node concept="CIsvn" id="2liNWkWZRVn" role="CIi4h">
-                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="14aBVbN3Cm9" role="1YnStB">
@@ -10952,7 +10952,7 @@
                     <ref role="3AHY9a" to="8ps7:3NjH4t$iNK$" resolve="d" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblN" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:14aBVbN55En" resolve="B" />
+                    <ref role="3AHY9a" to="8ps7:14aBVbN55En" resolve="byte" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JblO" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrLfJso" resolve="kg÷m²" />
@@ -10991,7 +10991,7 @@
                     <ref role="3AHY9a" to="8ps7:6EvkZrLhVh6" resolve="kg÷s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbm0" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:14aBVbN55Ep" resolve="b" />
+                    <ref role="3AHY9a" to="8ps7:14aBVbN55Ep" resolve="bit" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbm1" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3xM68GMigWv" resolve="K" />
@@ -11078,7 +11078,7 @@
                     <ref role="3AHY9a" to="8ps7:3xM68GMigZy" resolve="C" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmt" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:FMy9mdSdEf" resolve="B" />
+                    <ref role="3AHY9a" to="8ps7:FMy9mdSdEf" resolve="byte" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmu" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:70JbBCa75ni" resolve="W÷m²" />
@@ -11090,7 +11090,7 @@
                     <ref role="3AHY9a" to="8ps7:70JbBC9V$B4" resolve="N÷m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmx" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:7F14or$gczd" resolve="B" />
+                    <ref role="3AHY9a" to="8ps7:7F14or$gczd" resolve="byte" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbmy" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:1a2DxsCM1DB" resolve="ton" />
@@ -11249,7 +11249,7 @@
                     <ref role="3AHY9a" to="8ps7:6EvkZrMyT$w" resolve="mol÷kg" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbnm" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:FMy9mdSdEg" resolve="b" />
+                    <ref role="3AHY9a" to="8ps7:FMy9mdSdEg" resolve="bit" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbnn" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3xM68GMigWx" resolve="cd" />
@@ -11291,7 +11291,7 @@
                     <ref role="3AHY9a" to="8ps7:70JbBC5NCZ5" resolve="J" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbn$" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:2Yx91N$tLAX" resolve="b" />
+                    <ref role="3AHY9a" to="8ps7:2Yx91N$tLAX" resolve="bit" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2Jbn_" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3NjH4t$iNIu" resolve="min" />
@@ -11447,7 +11447,7 @@
                     <ref role="3AHY9a" to="8ps7:3NjH4t$iNK$" resolve="d" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$S" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:14aBVbN55En" resolve="B" />
+                    <ref role="3AHY9a" to="8ps7:14aBVbN55En" resolve="byte" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI$T" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:6EvkZrLfJso" resolve="kg÷m²" />
@@ -11486,7 +11486,7 @@
                     <ref role="3AHY9a" to="8ps7:6EvkZrLhVh6" resolve="kg÷s" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_5" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:14aBVbN55Ep" resolve="b" />
+                    <ref role="3AHY9a" to="8ps7:14aBVbN55Ep" resolve="bit" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_6" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3xM68GMigWv" resolve="K" />
@@ -11573,7 +11573,7 @@
                     <ref role="3AHY9a" to="8ps7:3xM68GMigZy" resolve="C" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_y" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:FMy9mdSdEf" resolve="B" />
+                    <ref role="3AHY9a" to="8ps7:FMy9mdSdEf" resolve="byte" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_z" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:70JbBCa75ni" resolve="W÷m²" />
@@ -11585,7 +11585,7 @@
                     <ref role="3AHY9a" to="8ps7:70JbBC9V$B4" resolve="N÷m" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_A" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:7F14or$gczd" resolve="B" />
+                    <ref role="3AHY9a" to="8ps7:7F14or$gczd" resolve="byte" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JI_B" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:1a2DxsCM1DB" resolve="ton" />
@@ -11744,7 +11744,7 @@
                     <ref role="3AHY9a" to="8ps7:6EvkZrMyT$w" resolve="mol÷kg" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAr" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:FMy9mdSdEg" resolve="b" />
+                    <ref role="3AHY9a" to="8ps7:FMy9mdSdEg" resolve="bit" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAs" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3xM68GMigWx" resolve="cd" />
@@ -11786,7 +11786,7 @@
                     <ref role="3AHY9a" to="8ps7:70JbBC5NCZ5" resolve="J" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAD" role="3KTr4d">
-                    <ref role="3AHY9a" to="8ps7:2Yx91N$tLAX" resolve="b" />
+                    <ref role="3AHY9a" to="8ps7:2Yx91N$tLAX" resolve="bit" />
                   </node>
                   <node concept="3KTrbX" id="1eut2v2JIAE" role="3KTr4d">
                     <ref role="3AHY9a" to="8ps7:3NjH4t$iNIu" resolve="min" />
@@ -12655,7 +12655,7 @@
           <node concept="1YnStw" id="1NEOJAW1vES" role="2zPyp_">
             <node concept="CIsGf" id="1NEOJAW1vER" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAW38oR" role="CIi4h">
-                <ref role="CIi3I" to="8ps7:14aBVbN55Ep" resolve="b" />
+                <ref role="CIi3I" to="8ps7:14aBVbN55Ep" resolve="bit" />
               </node>
             </node>
             <node concept="30bXRB" id="1NEOJAW1fUU" role="1YnStB">
@@ -12665,7 +12665,7 @@
           <node concept="2c7tTJ" id="1NEOJAW0k3w" role="2zM23F">
             <node concept="CIsGf" id="1NEOJAW0z_z" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAW0Mnk" role="CIi4h">
-                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
               </node>
             </node>
             <node concept="mLuIC" id="1NEOJAVZQxp" role="2c7tTw">
@@ -12680,7 +12680,7 @@
           <node concept="1YnStw" id="1NEOJAW2cmi" role="2zPyp_">
             <node concept="CIsGf" id="1NEOJAW2cmj" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAW2EoH" role="CIi4h">
-                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="1NEOJAW2cml" role="1YnStB">
@@ -12690,7 +12690,7 @@
           <node concept="2c7tTJ" id="1NEOJAW2cmm" role="2zM23F">
             <node concept="CIsGf" id="1NEOJAW2cmn" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAW2Tq0" role="CIi4h">
-                <ref role="CIi3I" to="8ps7:14aBVbN55Ep" resolve="b" />
+                <ref role="CIi3I" to="8ps7:14aBVbN55Ep" resolve="bit" />
               </node>
             </node>
             <node concept="mLuIC" id="1NEOJAW2cmp" role="2c7tTw">
@@ -12706,7 +12706,7 @@
           <node concept="1YnStw" id="1NEOJAW3BPW" role="2zPyp_">
             <node concept="CIsGf" id="1NEOJAW3BPX" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAW51F5" role="CIi4h">
-                <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="b" />
+                <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="bit" />
               </node>
             </node>
             <node concept="30bXRB" id="1NEOJAW3BPZ" role="1YnStB">
@@ -12716,7 +12716,7 @@
           <node concept="2c7tTJ" id="1NEOJAW3BQ0" role="2zM23F">
             <node concept="CIsGf" id="1NEOJAW3BQ1" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAW4MwP" role="CIi4h">
-                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
               </node>
             </node>
             <node concept="mLuIC" id="1NEOJAW3BQ3" role="2c7tTw">
@@ -12731,7 +12731,7 @@
           <node concept="1YnStw" id="1NEOJAW3BQ6" role="2zPyp_">
             <node concept="CIsGf" id="1NEOJAW3BQ7" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAW5JlW" role="CIi4h">
-                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="1NEOJAW3BQ9" role="1YnStB">
@@ -12741,7 +12741,7 @@
           <node concept="2c7tTJ" id="1NEOJAW3BQa" role="2zM23F">
             <node concept="CIsGf" id="1NEOJAW3BQb" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAW5gN4" role="CIi4h">
-                <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="b" />
+                <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="bit" />
               </node>
             </node>
             <node concept="mLuIC" id="1NEOJAW3BQd" role="2c7tTw">
@@ -12757,7 +12757,7 @@
           <node concept="1YnStw" id="1NEOJAW5vXt" role="2zPyp_">
             <node concept="CIsGf" id="1NEOJAW5vXu" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAW7rAA" role="CIi4h">
-                <ref role="CIi3I" to="8ps7:FMy9mdSdEg" resolve="b" />
+                <ref role="CIi3I" to="8ps7:FMy9mdSdEg" resolve="bit" />
               </node>
             </node>
             <node concept="30bXRB" id="1NEOJAW5vXw" role="1YnStB">
@@ -12767,7 +12767,7 @@
           <node concept="2c7tTJ" id="1NEOJAW5vXx" role="2zM23F">
             <node concept="CIsGf" id="1NEOJAW5vXy" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAW6WQq" role="CIi4h">
-                <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+                <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
               </node>
             </node>
             <node concept="mLuIC" id="1NEOJAW5vX$" role="2c7tTw">
@@ -12782,7 +12782,7 @@
           <node concept="1YnStw" id="1NEOJAW5vXB" role="2zPyp_">
             <node concept="CIsGf" id="1NEOJAW5vXC" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAW7EWq" role="CIi4h">
-                <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+                <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="1NEOJAW5vXE" role="1YnStB">
@@ -12792,7 +12792,7 @@
           <node concept="2c7tTJ" id="1NEOJAW5vXF" role="2zM23F">
             <node concept="CIsGf" id="1NEOJAW5vXG" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAW7cev" role="CIi4h">
-                <ref role="CIi3I" to="8ps7:FMy9mdSdEg" resolve="b" />
+                <ref role="CIi3I" to="8ps7:FMy9mdSdEg" resolve="bit" />
               </node>
             </node>
             <node concept="mLuIC" id="1NEOJAW5vXI" role="2c7tTw">
@@ -12913,7 +12913,7 @@
             <node concept="CIsGf" id="1NEOJAW8oUh" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAWkvDl" role="CIi4h">
                 <property role="1xG2w7" value="k" />
-                <ref role="CIi3I" to="8ps7:14aBVbN55Ep" resolve="b" />
+                <ref role="CIi3I" to="8ps7:14aBVbN55Ep" resolve="bit" />
               </node>
             </node>
             <node concept="30bXRB" id="1NEOJAW8oUj" role="1YnStB">
@@ -12923,7 +12923,7 @@
           <node concept="2c7tTJ" id="1NEOJAW8oUk" role="2zM23F">
             <node concept="CIsGf" id="1NEOJAW8oUl" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAWhZw7" role="CIi4h">
-                <ref role="CIi3I" to="8ps7:14aBVbN55Ep" resolve="b" />
+                <ref role="CIi3I" to="8ps7:14aBVbN55Ep" resolve="bit" />
               </node>
             </node>
             <node concept="30bXLL" id="1NEOJAWAVc7" role="2c7tTw" />
@@ -12935,7 +12935,7 @@
             <node concept="CIsGf" id="1NEOJAW8oUr" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAWkJ$9" role="CIi4h">
                 <property role="1xG2w7" value="k" />
-                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="1NEOJAW8oUt" role="1YnStB">
@@ -12945,7 +12945,7 @@
           <node concept="2c7tTJ" id="1NEOJAW8oUu" role="2zM23F">
             <node concept="CIsGf" id="1NEOJAW8oUv" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAWiveh" role="CIi4h">
-                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
               </node>
             </node>
             <node concept="30bXLL" id="1NEOJAWBLqm" role="2c7tTw" />
@@ -12957,7 +12957,7 @@
             <node concept="CIsGf" id="1NEOJAW8oUA" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAWGoBO" role="CIi4h">
                 <property role="1xG2w7" value="Ki" />
-                <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="b" />
+                <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="bit" />
               </node>
             </node>
             <node concept="30bXRB" id="1NEOJAW8oUC" role="1YnStB">
@@ -12967,7 +12967,7 @@
           <node concept="2c7tTJ" id="1NEOJAW8oUD" role="2zM23F">
             <node concept="CIsGf" id="1NEOJAW8oUE" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAWjfGP" role="CIi4h">
-                <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="b" />
+                <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="bit" />
               </node>
             </node>
             <node concept="30bXLL" id="1NEOJAWC4lg" role="2c7tTw" />
@@ -12979,7 +12979,7 @@
             <node concept="CIsGf" id="1NEOJAW8oUK" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAWGFEL" role="CIi4h">
                 <property role="1xG2w7" value="Ki" />
-                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="1NEOJAW8oUM" role="1YnStB">
@@ -12989,7 +12989,7 @@
           <node concept="2c7tTJ" id="1NEOJAW8oUN" role="2zM23F">
             <node concept="CIsGf" id="1NEOJAW8oUO" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAWjvEa" role="CIi4h">
-                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
               </node>
             </node>
             <node concept="30bXLL" id="1NEOJAWCCP3" role="2c7tTw" />
@@ -13001,7 +13001,7 @@
             <node concept="CIsGf" id="1NEOJAW8oUV" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAWHgk5" role="CIi4h">
                 <property role="1xG2w7" value="K" />
-                <ref role="CIi3I" to="8ps7:FMy9mdSdEg" resolve="b" />
+                <ref role="CIi3I" to="8ps7:FMy9mdSdEg" resolve="bit" />
               </node>
             </node>
             <node concept="30bXRB" id="1NEOJAW8oUX" role="1YnStB">
@@ -13012,7 +13012,7 @@
             <node concept="CIsGf" id="1NEOJAW8oUZ" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAWHQwF" role="CIi4h">
                 <property role="1xG2w7" value="" />
-                <ref role="CIi3I" to="8ps7:FMy9mdSdEg" resolve="b" />
+                <ref role="CIi3I" to="8ps7:FMy9mdSdEg" resolve="bit" />
               </node>
             </node>
             <node concept="30bXLL" id="1NEOJAXcKko" role="2c7tTw" />
@@ -13024,7 +13024,7 @@
             <node concept="CIsGf" id="1NEOJAW8oV5" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAWHy$5" role="CIi4h">
                 <property role="1xG2w7" value="K" />
-                <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+                <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
               </node>
             </node>
             <node concept="30bXRB" id="1NEOJAW8oV7" role="1YnStB">
@@ -13035,7 +13035,7 @@
             <node concept="CIsGf" id="1NEOJAW8oV9" role="2c7tTI">
               <node concept="CIsvn" id="1NEOJAWI9uL" role="CIi4h">
                 <property role="1xG2w7" value="" />
-                <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+                <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
               </node>
             </node>
             <node concept="30bXLL" id="1NEOJAXd2wd" role="2c7tTw" />
@@ -14468,14 +14468,14 @@
               <node concept="3EXbTZ" id="57Dr2jFef2D" role="1QScD9">
                 <node concept="CIsvn" id="57Dr2jFef2E" role="2qyG0l">
                   <property role="1xG2w7" value="" />
-                  <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                  <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
                 </node>
               </node>
               <node concept="1YnStw" id="57Dr2jFef2F" role="30czhm">
                 <node concept="CIsGf" id="57Dr2jFef2G" role="2c7tTI">
                   <node concept="CIsvn" id="57Dr2jFef2H" role="CIi4h">
                     <property role="1xG2w7" value="Ki" />
-                    <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                    <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
                   </node>
                 </node>
                 <node concept="30bXRB" id="57Dr2jFef2I" role="1YnStB">
@@ -14494,7 +14494,7 @@
                     <node concept="CIsGf" id="57Dr2jFF3pw" role="2c7tTI">
                       <node concept="CIsvn" id="57Dr2jFF3px" role="CIi4h">
                         <property role="1xG2w7" value="" />
-                        <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                        <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
                       </node>
                     </node>
                   </node>
@@ -14511,14 +14511,14 @@
               <node concept="3EXbTZ" id="57Dr2jFef3J" role="1QScD9">
                 <node concept="CIsvn" id="57Dr2jFef3K" role="2qyG0l">
                   <property role="1xG2w7" value="" />
-                  <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                  <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
                 </node>
               </node>
               <node concept="1YnStw" id="57Dr2jFef3L" role="30czhm">
                 <node concept="CIsGf" id="57Dr2jFef3M" role="2c7tTI">
                   <node concept="CIsvn" id="57Dr2jFef3N" role="CIi4h">
                     <property role="1xG2w7" value="Yi" />
-                    <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                    <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
                   </node>
                 </node>
                 <node concept="30bXRB" id="57Dr2jFef3O" role="1YnStB">
@@ -14537,7 +14537,7 @@
                     <node concept="CIsGf" id="I2wguftFDV" role="2c7tTI">
                       <node concept="CIsvn" id="I2wguftFDW" role="CIi4h">
                         <property role="1xG2w7" value="" />
-                        <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                        <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
                       </node>
                     </node>
                   </node>
@@ -14557,14 +14557,14 @@
             <node concept="1QScDb" id="57Dr2jFef3U" role="_fkuY">
               <node concept="3EXbTZ" id="57Dr2jFef3V" role="1QScD9">
                 <node concept="CIsvn" id="57Dr2jFef3W" role="2qyG0l">
-                  <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                  <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
                 </node>
               </node>
               <node concept="1YnStw" id="57Dr2jFef3X" role="30czhm">
                 <node concept="CIsGf" id="57Dr2jFef3Y" role="2c7tTI">
                   <node concept="CIsvn" id="57Dr2jFef3Z" role="CIi4h">
                     <property role="1xG2w7" value="k" />
-                    <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                    <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
                   </node>
                 </node>
                 <node concept="30bXRB" id="57Dr2jFef40" role="1YnStB">
@@ -14583,7 +14583,7 @@
                     <node concept="CIsGf" id="124bbdDGWYO" role="2c7tTI">
                       <node concept="CIsvn" id="124bbdDGWYP" role="CIi4h">
                         <property role="1xG2w7" value="" />
-                        <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                        <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
                       </node>
                     </node>
                   </node>
@@ -14600,14 +14600,14 @@
               <node concept="3EXbTZ" id="57Dr2jFrGQE" role="1QScD9">
                 <node concept="CIsvn" id="57Dr2jFrSWV" role="2qyG0l">
                   <property role="1xG2w7" value="k" />
-                  <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                  <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
                 </node>
               </node>
               <node concept="1YnStw" id="57Dr2jFrGQG" role="30czhm">
                 <node concept="CIsGf" id="57Dr2jFrGQH" role="2c7tTI">
                   <node concept="CIsvn" id="57Dr2jFrGQI" role="CIi4h">
                     <property role="1xG2w7" value="" />
-                    <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                    <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
                   </node>
                 </node>
                 <node concept="30bXRB" id="57Dr2jFrGQJ" role="1YnStB">
@@ -14626,7 +14626,7 @@
                     <node concept="CIsGf" id="124bbdDH99O" role="2c7tTI">
                       <node concept="CIsvn" id="124bbdDH99P" role="CIi4h">
                         <property role="1xG2w7" value="k" />
-                        <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                        <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
                       </node>
                     </node>
                   </node>
@@ -14642,14 +14642,14 @@
             <node concept="1QScDb" id="57Dr2jFef50" role="_fkuY">
               <node concept="3EXbTZ" id="57Dr2jFef51" role="1QScD9">
                 <node concept="CIsvn" id="57Dr2jFef52" role="2qyG0l">
-                  <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                  <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
                 </node>
               </node>
               <node concept="1YnStw" id="57Dr2jFef53" role="30czhm">
                 <node concept="CIsGf" id="57Dr2jFef54" role="2c7tTI">
                   <node concept="CIsvn" id="57Dr2jFef55" role="CIi4h">
                     <property role="1xG2w7" value="Y" />
-                    <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                    <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
                   </node>
                 </node>
                 <node concept="30bXRB" id="57Dr2jFef56" role="1YnStB">
@@ -14668,7 +14668,7 @@
                     <node concept="CIsGf" id="I2wguhhEtg" role="2c7tTI">
                       <node concept="CIsvn" id="I2wguhhEth" role="CIi4h">
                         <property role="1xG2w7" value="" />
-                        <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="B" />
+                        <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
                       </node>
                     </node>
                   </node>
@@ -14688,14 +14688,14 @@
             <node concept="1QScDb" id="57Dr2jFef5c" role="_fkuY">
               <node concept="3EXbTZ" id="57Dr2jFef5d" role="1QScD9">
                 <node concept="CIsvn" id="57Dr2jFef5e" role="2qyG0l">
-                  <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+                  <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
                 </node>
               </node>
               <node concept="1YnStw" id="57Dr2jFef5f" role="30czhm">
                 <node concept="CIsGf" id="57Dr2jFef5g" role="2c7tTI">
                   <node concept="CIsvn" id="57Dr2jFef5h" role="CIi4h">
                     <property role="1xG2w7" value="K" />
-                    <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+                    <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
                   </node>
                 </node>
                 <node concept="30bXRB" id="57Dr2jFef5i" role="1YnStB">
@@ -14714,7 +14714,7 @@
                     <node concept="CIsGf" id="124bbdDHvyO" role="2c7tTI">
                       <node concept="CIsvn" id="124bbdDHvyP" role="CIi4h">
                         <property role="1xG2w7" value="" />
-                        <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+                        <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
                       </node>
                     </node>
                   </node>
@@ -14731,13 +14731,13 @@
               <node concept="3EXbTZ" id="57Dr2jFtJFR" role="1QScD9">
                 <node concept="CIsvn" id="57Dr2jFtVyi" role="2qyG0l">
                   <property role="1xG2w7" value="K" />
-                  <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+                  <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
                 </node>
               </node>
               <node concept="1YnStw" id="57Dr2jFtJFT" role="30czhm">
                 <node concept="CIsGf" id="57Dr2jFtJFU" role="2c7tTI">
                   <node concept="CIsvn" id="57Dr2jFu70B" role="CIi4h">
-                    <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+                    <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
                   </node>
                 </node>
                 <node concept="30bXRB" id="57Dr2jFtJFW" role="1YnStB">
@@ -14756,7 +14756,7 @@
                     <node concept="CIsGf" id="124bbdDHFO2" role="2c7tTI">
                       <node concept="CIsvn" id="124bbdDHFO3" role="CIi4h">
                         <property role="1xG2w7" value="K" />
-                        <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+                        <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
                       </node>
                     </node>
                   </node>
@@ -14772,14 +14772,14 @@
             <node concept="1QScDb" id="57Dr2jFef5E" role="_fkuY">
               <node concept="3EXbTZ" id="57Dr2jFef5F" role="1QScD9">
                 <node concept="CIsvn" id="57Dr2jFef5G" role="2qyG0l">
-                  <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+                  <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
                 </node>
               </node>
               <node concept="1YnStw" id="57Dr2jFef5H" role="30czhm">
                 <node concept="CIsGf" id="57Dr2jFef5I" role="2c7tTI">
                   <node concept="CIsvn" id="57Dr2jFef5J" role="CIi4h">
                     <property role="1xG2w7" value="T" />
-                    <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+                    <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
                   </node>
                 </node>
                 <node concept="30bXRB" id="57Dr2jFef5K" role="1YnStB">
@@ -14798,7 +14798,7 @@
                     <node concept="CIsGf" id="124bbdDHQZY" role="2c7tTI">
                       <node concept="CIsvn" id="124bbdDHQZZ" role="CIi4h">
                         <property role="1xG2w7" value="" />
-                        <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="B" />
+                        <ref role="CIi3I" to="8ps7:FMy9mdSdEf" resolve="byte" />
                       </node>
                     </node>
                   </node>
@@ -14864,14 +14864,14 @@
               <node concept="3EXbTZ" id="57Dr2jFef63" role="1QScD9">
                 <node concept="CIsvn" id="57Dr2jFef64" role="2qyG0l">
                   <property role="1xG2w7" value="Gi" />
-                  <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="b" />
+                  <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="bit" />
                 </node>
               </node>
               <node concept="1YnStw" id="57Dr2jFef65" role="30czhm">
                 <node concept="CIsGf" id="57Dr2jFef66" role="2c7tTI">
                   <node concept="CIsvn" id="57Dr2jFef67" role="CIi4h">
                     <property role="1xG2w7" value="Ki" />
-                    <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="b" />
+                    <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="bit" />
                   </node>
                 </node>
                 <node concept="30bXRB" id="57Dr2jFef68" role="1YnStB">
@@ -14890,7 +14890,7 @@
                     <node concept="CIsGf" id="124bbdDIqbV" role="2c7tTI">
                       <node concept="CIsvn" id="124bbdDIqbW" role="CIi4h">
                         <property role="1xG2w7" value="Gi" />
-                        <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="b" />
+                        <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="bit" />
                       </node>
                     </node>
                   </node>
@@ -14906,14 +14906,14 @@
             <node concept="1QScDb" id="57Dr2jFef6c" role="_fkuY">
               <node concept="3EXbTZ" id="57Dr2jFef6d" role="1QScD9">
                 <node concept="CIsvn" id="57Dr2jFef6e" role="2qyG0l">
-                  <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="b" />
+                  <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="bit" />
                 </node>
               </node>
               <node concept="1YnStw" id="57Dr2jFef6f" role="30czhm">
                 <node concept="CIsGf" id="57Dr2jFef6g" role="2c7tTI">
                   <node concept="CIsvn" id="57Dr2jFef6h" role="CIi4h">
                     <property role="1xG2w7" value="Ki" />
-                    <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="b" />
+                    <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="bit" />
                   </node>
                 </node>
                 <node concept="30bXRB" id="57Dr2jFef6i" role="1YnStB">
@@ -14932,7 +14932,7 @@
                     <node concept="CIsGf" id="124bbdDI_yt" role="2c7tTI">
                       <node concept="CIsvn" id="124bbdDI_yu" role="CIi4h">
                         <property role="1xG2w7" value="" />
-                        <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="b" />
+                        <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="bit" />
                       </node>
                     </node>
                   </node>
@@ -14948,13 +14948,13 @@
             <node concept="1QScDb" id="57Dr2jFef6m" role="_fkuY">
               <node concept="3EXbTZ" id="57Dr2jFef6n" role="1QScD9">
                 <node concept="CIsvn" id="57Dr2jFef6o" role="2qyG0l">
-                  <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="b" />
+                  <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="bit" />
                 </node>
               </node>
               <node concept="1YnStw" id="57Dr2jFef6p" role="30czhm">
                 <node concept="CIsGf" id="57Dr2jFef6q" role="2c7tTI">
                   <node concept="CIsvn" id="57Dr2jFef6r" role="CIi4h">
-                    <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="B" />
+                    <ref role="CIi3I" to="8ps7:7F14or$gczd" resolve="byte" />
                   </node>
                 </node>
                 <node concept="30bXRB" id="57Dr2jFef6s" role="1YnStB">
@@ -14976,7 +14976,7 @@
                     <node concept="CIsGf" id="124bbdDIKTS" role="2c7tTI">
                       <node concept="CIsvn" id="124bbdDIKTT" role="CIi4h">
                         <property role="1xG2w7" value="" />
-                        <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="b" />
+                        <ref role="CIi3I" to="8ps7:2Yx91N$tLAX" resolve="bit" />
                       </node>
                     </node>
                   </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.phyunits@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.phyunits@tests.mps
@@ -5133,6 +5133,9 @@
         <node concept="3GEVxB" id="3wrpJuuALAm" role="3i6evy">
           <ref role="3GEb4d" to="8ps7:3xM68GMigWy" resolve="SIDerivedUnits" />
         </node>
+        <node concept="3GEVxB" id="xExe$xkHsR" role="3i6evy">
+          <ref role="3GEb4d" to="8ps7:ZkGd2yKlml" resolve="UnitsOfInformationMetric" />
+        </node>
         <node concept="2zPypq" id="76ZhK6XZhug" role="_iOnC">
           <property role="TrG5h" value="a" />
           <node concept="30dDZf" id="5XaocLWH3Zw" role="2zPyp_">
@@ -7550,7 +7553,7 @@
   <node concept="_iOnU" id="69HsIy5Gyat">
     <property role="1XBH2A" value="true" />
     <property role="TrG5h" value="UnitScaledTest" />
-    <ref role="2HwdWd" to="8ps7:3xM68GMigWy" resolve="SIDerivedUnits" />
+    <ref role="2HwdWd" to="8ps7:xExe$xoFsp" resolve="UnitsOfInformation" />
     <node concept="TRoc0" id="3wrpJuuk0j9" role="_iOnB">
       <property role="2yp$z_" value="true" />
       <property role="2yEn8j" value="0" />
@@ -10842,7 +10845,7 @@
       <node concept="_iOnV" id="42$mjgfjmPA" role="1qenE9">
         <property role="TrG5h" value="MyLibrary" />
         <node concept="3GEVxB" id="42$mjgfjn1p" role="3i6evy">
-          <ref role="3GEb4d" to="8ps7:3xM68GMigWy" resolve="SIDerivedUnits" />
+          <ref role="3GEb4d" to="8ps7:xExe$xoFsp" resolve="UnitsOfInformation" />
         </node>
         <node concept="2zPypq" id="42$mjgfjn7j" role="_iOnC">
           <property role="TrG5h" value="allReferences" />
@@ -12045,6 +12048,9 @@
         <node concept="3GEVxB" id="1NEOJAVgxQk" role="3i6evy">
           <ref role="3GEb4d" node="1NEOJAVfc5u" resolve="ImperialUnits" />
         </node>
+        <node concept="3GEVxB" id="xExe$xp6Rb" role="3i6evy">
+          <ref role="3GEb4d" to="8ps7:xExe$xoFsp" resolve="UnitsOfInformation" />
+        </node>
         <node concept="CIrOH" id="kS03ZnkM4V" role="_iOnC">
           <property role="TrG5h" value="mi" />
           <property role="1o$tow" value="mile" />
@@ -12809,6 +12815,9 @@
         <property role="TrG5h" value="QuantityPrefixComparable" />
         <node concept="3GEVxB" id="1NEOJAV_EBe" role="3i6evy">
           <ref role="3GEb4d" node="1NEOJAVfc5u" resolve="ImperialUnits" />
+        </node>
+        <node concept="3GEVxB" id="xExe$xqT6O" role="3i6evy">
+          <ref role="3GEb4d" to="8ps7:xExe$xoFsp" resolve="UnitsOfInformation" />
         </node>
         <node concept="2zPypq" id="1NEOJAV_EBh" role="_iOnC">
           <property role="TrG5h" value="milliMeter2Meter" />
@@ -13857,7 +13866,7 @@
       <node concept="_iOnU" id="57Dr2jFef0Y" role="1qenE9">
         <property role="1XBH2A" value="true" />
         <property role="TrG5h" value="UnitScaledTest" />
-        <ref role="2HwdWd" to="8ps7:3xM68GMigWy" resolve="SIDerivedUnits" />
+        <ref role="2HwdWd" to="8ps7:xExe$xoFsp" resolve="UnitsOfInformation" />
         <node concept="TRoc0" id="57Dr2jFef0Z" role="_iOnB">
           <property role="2yp$z_" value="true" />
           <property role="2yEn8j" value="0" />


### PR DESCRIPTION
- The physical units B and b were renamed to byte and bit to avoid confusion.
- Breaking change: The units of digital information were split into 3 different libraries: `UnitsOfInformationIEC`, `UnitsOfInformationJEDEC`, `UnitsOfInformationMetric`. They are still considered part of the derived units. If you want to use them, you therefore have to include them in your scope method.
- Physical units now also support metric scaling for only the positive and negative prefixes.
- I also noticed that many derived units can also have metric prefixes. The information for the last and this item are AI checked, so we have to trust the information that we got.
-  Scaling can also be overwritten for units by overwritten `IUnitLangConfig#getOverwrittenScaling` for the extension point `PhysUnitLangConfig`.