### PR TITLE
Remove TestInfo nodes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,6 +197,7 @@ task resolveDependencies(dependsOn: ['downloadJbr', resolveMps, resolveLanguageL
 def defaultScriptArgs = [
         'mps.home'                          : resolveMps.destinationDir,
         'iets3.github.opensource.home'      : rootDir,
+        'mps.test.project.path'             : "${rootDir}/code/languages/org.iets3.opensource",
         'build.dir'                         : buildDir,
         'mps.generator.skipUnmodifiedModels': incrementalBuild,
         'version'                           : version

--- a/code/languages/org.iets3.opensource/.mps/.gitignore
+++ b/code/languages/org.iets3.opensource/.mps/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/code/languages/org.iets3.opensource/.mps/vcs.xml
+++ b/code/languages/org.iets3.opensource/.mps/vcs.xml
@@ -11,6 +11,6 @@
     </option>
   </component>
   <component name="VcsDirectoryMappings">
-    <mapping directory="$iets3.github.opensource.home$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/../../.." vcs="Git" />
   </component>
 </project>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/generator/template/main@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/generator/template/main@generator.mps
@@ -18,10 +18,10 @@
     <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
     <import index="rbkg" ref="63b449db-0918-4a4a-a891-2c430ab133e4/java:org.junit.jupiter.api.extension(org.junit.junit5/)" />
     <import index="yqm7" ref="63b449db-0918-4a4a-a891-2c430ab133e4/java:org.junit.jupiter.api(org.junit.junit5/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="tp5o" ref="r:00000000-0000-4000-0000-011c89590380(jetbrains.mps.lang.test.behavior)" />
+    <import index="tp5g" ref="r:00000000-0000-4000-0000-011c89590388(jetbrains.mps.lang.test.structure)" />
     <import index="av4b" ref="r:ba7faab6-2b80-43d5-8b95-0c440665312c(org.iets3.core.expr.tests.structure)" implicit="true" />
-    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
-    <import index="tp5g" ref="r:00000000-0000-4000-0000-011c89590388(jetbrains.mps.lang.test.structure)" implicit="true" />
-    <import index="tp5o" ref="r:00000000-0000-4000-0000-011c89590380(jetbrains.mps.lang.test.behavior)" implicit="true" />
     <import index="tpe5" ref="r:00000000-0000-4000-0000-011c895902d1(jetbrains.mps.baseLanguage.unitTest.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -91,9 +91,7 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
-        <property id="1068580123138" name="value" index="3clFbU" />
-      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
@@ -278,79 +276,69 @@
       <node concept="2ShNRf" id="4dqLDEZ0gCn" role="33vP2m">
         <node concept="1pGfFk" id="4dqLDEZ0gzP" role="2ShVmc">
           <ref role="37wK5l" to="tp6m:4dqLDEYYHvm" resolve="TestParametersCacheExtension" />
-          <node concept="2ShNRf" id="5iphLhCeqoV" role="37wK5m">
-            <node concept="1pGfFk" id="5iphLhCeqoW" role="2ShVmc">
-              <ref role="37wK5l" to="tp6m:5LbRjS1nRFZ" resolve="TestParametersCache" />
-              <node concept="3VsKOn" id="5iphLhCeqoX" role="37wK5m">
-                <ref role="3VsUkX" node="21ieoTcCJQ7" resolve="MPSTestCase" />
-              </node>
-              <node concept="Xl_RD" id="1thG8hDHxlT" role="37wK5m">
-                <property role="Xl_RC" value="project path" />
-                <node concept="17Uvod" id="1thG8hDHxlU" role="lGtFl">
-                  <property role="2qtEX9" value="value" />
-                  <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                  <node concept="3zFVjK" id="1thG8hDHxlV" role="3zH0cK">
-                    <node concept="3clFbS" id="1thG8hDHxlW" role="2VODD2">
-                      <node concept="3clFbF" id="1thG8hDHxlX" role="3cqZAp">
-                        <node concept="2YIFZM" id="1thG8hDHxlY" role="3clFbG">
-                          <ref role="1Pybhc" to="tgi8:L0xQjiTXbn" resolve="TestsUtil" />
-                          <ref role="37wK5l" to="tgi8:L0xQjiTXbx" resolve="getProjectPath" />
-                          <node concept="2OqwBi" id="1thG8hDHxlZ" role="37wK5m">
-                            <node concept="30H73N" id="1thG8hDHxm0" role="2Oq$k0" />
-                            <node concept="I4A8Y" id="1thG8hDHxm1" role="2OqNvi" />
-                          </node>
-                        </node>
+          <node concept="2OqwBi" id="5U2b9J9Dre3" role="37wK5m">
+            <node concept="2OqwBi" id="5U2b9J9Do3$" role="2Oq$k0">
+              <node concept="2OqwBi" id="5U2b9J9Dmo1" role="2Oq$k0">
+                <node concept="2OqwBi" id="5U2b9J9DkKQ" role="2Oq$k0">
+                  <node concept="2ShNRf" id="5U2b9J9DiYk" role="2Oq$k0">
+                    <node concept="1pGfFk" id="5U2b9J9DkqL" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" to="tp6m:6US8dKoOF6n" />
+                      <node concept="3VsKOn" id="5U2b9J9Dk_M" role="37wK5m">
+                        <ref role="3VsUkX" node="21ieoTcCJQ7" resolve="MPSTestCase" />
                       </node>
                     </node>
                   </node>
-                </node>
-              </node>
-              <node concept="Xl_RD" id="1thG8hDHxm2" role="37wK5m">
-                <property role="Xl_RC" value="model.fq.name" />
-                <node concept="17Uvod" id="1thG8hDHxm3" role="lGtFl">
-                  <property role="2qtEX9" value="value" />
-                  <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                  <node concept="3zFVjK" id="1thG8hDHxm4" role="3zH0cK">
-                    <node concept="3clFbS" id="1thG8hDHxm5" role="2VODD2">
-                      <node concept="3clFbF" id="1thG8hDHxm6" role="3cqZAp">
-                        <node concept="2OqwBi" id="1thG8hDHxm7" role="3clFbG">
-                          <node concept="2OqwBi" id="1thG8hDHxm8" role="2Oq$k0">
-                            <node concept="liA8E" id="1thG8hDHxm9" role="2OqNvi">
-                              <ref role="37wK5l" to="mhbf:~SModel.getReference()" resolve="getReference" />
-                            </node>
-                            <node concept="2JrnkZ" id="1thG8hDHxma" role="2Oq$k0">
-                              <node concept="2OqwBi" id="1thG8hDHxmb" role="2JrQYb">
-                                <node concept="1iwH7S" id="1thG8hDHxmc" role="2Oq$k0" />
-                                <node concept="1st3f0" id="1thG8hDHxmd" role="2OqNvi" />
+                  <node concept="liA8E" id="5U2b9J9DkWK" role="2OqNvi">
+                    <ref role="37wK5l" to="tp6m:6US8dKoOtkl" resolve="projectPath" />
+                    <node concept="Xl_RD" id="5U2b9J9Dl0T" role="37wK5m">
+                      <property role="Xl_RC" value="" />
+                      <node concept="17Uvod" id="5U2b9J9Dl__" role="lGtFl">
+                        <property role="2qtEX9" value="value" />
+                        <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                        <node concept="3zFVjK" id="5U2b9J9Dl_A" role="3zH0cK">
+                          <node concept="3clFbS" id="5U2b9J9Dl_B" role="2VODD2">
+                            <node concept="3clFbF" id="5U2b9J9DlRp" role="3cqZAp">
+                              <node concept="2YIFZM" id="5U2b9J9DlRq" role="3clFbG">
+                                <ref role="1Pybhc" to="tgi8:L0xQjiTXbn" resolve="TestsUtil" />
+                                <ref role="37wK5l" to="tgi8:L0xQjiTXbx" resolve="getProjectPath" />
+                                <node concept="2OqwBi" id="5U2b9J9DlRr" role="37wK5m">
+                                  <node concept="30H73N" id="5U2b9J9DlRs" role="2Oq$k0" />
+                                  <node concept="I4A8Y" id="5U2b9J9DlRt" role="2OqNvi" />
+                                </node>
                               </node>
                             </node>
                           </node>
-                          <node concept="liA8E" id="1thG8hDHxme" role="2OqNvi">
-                            <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                          </node>
                         </node>
                       </node>
                     </node>
                   </node>
                 </node>
-              </node>
-              <node concept="3clFbT" id="1thG8hDHxmf" role="37wK5m">
-                <property role="3clFbU" value="false" />
-                <node concept="17Uvod" id="1thG8hDHxmg" role="lGtFl">
-                  <property role="2qtEX9" value="value" />
-                  <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123137/1068580123138" />
-                  <node concept="3zFVjK" id="1thG8hDHxmh" role="3zH0cK">
-                    <node concept="3clFbS" id="1thG8hDHxmi" role="2VODD2">
-                      <node concept="3clFbF" id="1thG8hDHxmj" role="3cqZAp">
-                        <node concept="2OqwBi" id="1thG8hDHxmk" role="3clFbG">
-                          <node concept="35c_gC" id="1thG8hDHxml" role="2Oq$k0">
-                            <ref role="35c_gD" to="tp5g:4qWC2JVrBca" resolve="TestInfo" />
-                          </node>
-                          <node concept="2qgKlT" id="1thG8hDHxmm" role="2OqNvi">
-                            <ref role="37wK5l" to="tp5o:ThWTaQhG7P" resolve="reOpenProject" />
-                            <node concept="2OqwBi" id="1thG8hDHxmn" role="37wK5m">
-                              <node concept="30H73N" id="1thG8hDHxmo" role="2Oq$k0" />
-                              <node concept="I4A8Y" id="1thG8hDHxmp" role="2OqNvi" />
+                <node concept="liA8E" id="5U2b9J9DmBL" role="2OqNvi">
+                  <ref role="37wK5l" to="tp6m:6US8dKoOs$1" resolve="modelRef" />
+                  <node concept="Xl_RD" id="5U2b9J9DmK$" role="37wK5m">
+                    <property role="Xl_RC" value="model.fq.name" />
+                    <node concept="17Uvod" id="5U2b9J9DnjE" role="lGtFl">
+                      <property role="2qtEX9" value="value" />
+                      <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
+                      <node concept="3zFVjK" id="5U2b9J9DnjF" role="3zH0cK">
+                        <node concept="3clFbS" id="5U2b9J9DnjG" role="2VODD2">
+                          <node concept="3clFbF" id="5U2b9J9DnrB" role="3cqZAp">
+                            <node concept="2OqwBi" id="5U2b9J9DnrC" role="3clFbG">
+                              <node concept="2OqwBi" id="5U2b9J9DnrD" role="2Oq$k0">
+                                <node concept="liA8E" id="5U2b9J9DnrE" role="2OqNvi">
+                                  <ref role="37wK5l" to="mhbf:~SModel.getReference()" resolve="getReference" />
+                                </node>
+                                <node concept="2JrnkZ" id="5U2b9J9DnrF" role="2Oq$k0">
+                                  <node concept="2OqwBi" id="5U2b9J9DnrG" role="2JrQYb">
+                                    <node concept="1iwH7S" id="5U2b9J9DnrH" role="2Oq$k0" />
+                                    <node concept="1st3f0" id="5U2b9J9DnrI" role="2OqNvi" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="5U2b9J9DnrJ" role="2OqNvi">
+                                <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -359,6 +347,36 @@
                   </node>
                 </node>
               </node>
+              <node concept="liA8E" id="5U2b9J9Doop" role="2OqNvi">
+                <ref role="37wK5l" to="tp6m:6US8dKoOtLM" resolve="reopenProject" />
+                <node concept="3clFbT" id="5U2b9J9DoRR" role="37wK5m">
+                  <node concept="17Uvod" id="5U2b9J9Dpml" role="lGtFl">
+                    <property role="2qtEX9" value="value" />
+                    <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123137/1068580123138" />
+                    <node concept="3zFVjK" id="5U2b9J9Dpmm" role="3zH0cK">
+                      <node concept="3clFbS" id="5U2b9J9Dpmn" role="2VODD2">
+                        <node concept="3clFbF" id="5U2b9J9DpG1" role="3cqZAp">
+                          <node concept="2OqwBi" id="5U2b9J9DpG2" role="3clFbG">
+                            <node concept="35c_gC" id="5U2b9J9DpG3" role="2Oq$k0">
+                              <ref role="35c_gD" to="tp5g:4qWC2JVrBca" resolve="TestInfo" />
+                            </node>
+                            <node concept="2qgKlT" id="5U2b9J9DpG4" role="2OqNvi">
+                              <ref role="37wK5l" to="tp5o:ThWTaQhG7P" resolve="reOpenProject" />
+                              <node concept="2OqwBi" id="5U2b9J9DpG5" role="37wK5m">
+                                <node concept="30H73N" id="5U2b9J9DpG6" role="2Oq$k0" />
+                                <node concept="I4A8Y" id="5U2b9J9DpG7" role="2OqNvi" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="liA8E" id="5U2b9J9DsoS" role="2OqNvi">
+              <ref role="37wK5l" to="tp6m:6US8dKoNyEp" resolve="build" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/generator/template/main@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/generator/template/main@generator.mps
@@ -91,7 +91,9 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
@@ -118,6 +120,7 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
@@ -140,6 +143,10 @@
         <child id="1219952894531" name="dropRootRule" index="aQYdv" />
         <child id="1167514678247" name="rootMappingRule" index="3lj3bC" />
       </concept>
+      <concept id="1177093525992" name="jetbrains.mps.lang.generator.structure.InlineTemplate_RuleConsequence" flags="lg" index="gft3U">
+        <child id="1177093586806" name="templateNode" index="gfFT$" />
+      </concept>
+      <concept id="5015072279636592410" name="jetbrains.mps.lang.generator.structure.VarMacro_ValueQuery" flags="in" index="2jfdEK" />
       <concept id="1112730859144" name="jetbrains.mps.lang.generator.structure.TemplateSwitch" flags="ig" index="jVnub">
         <child id="1168558750579" name="defaultConsequence" index="jxRDz" />
         <child id="1167340453568" name="reductionMappingRule" index="3aUrZf" />
@@ -167,6 +174,15 @@
       <concept id="1167514355419" name="jetbrains.mps.lang.generator.structure.Root_MappingRule" flags="lg" index="3lhOvk">
         <reference id="1167514355421" name="template" index="3lhOvi" />
       </concept>
+      <concept id="1048903277989260815" name="jetbrains.mps.lang.generator.structure.TemplateArgumentVarRefExpression2" flags="ng" index="1mL9RQ">
+        <reference id="1048903277989260816" name="vardecl" index="1mL9RD" />
+      </concept>
+      <concept id="1048903277984099206" name="jetbrains.mps.lang.generator.structure.VarDeclaration" flags="ng" index="1ps_xZ">
+        <child id="1048903277984099210" name="value" index="1ps_xN" />
+      </concept>
+      <concept id="1048903277984099198" name="jetbrains.mps.lang.generator.structure.VarMacro2" flags="lg" index="1ps_y7">
+        <child id="1048903277984099213" name="variables" index="1ps_xO" />
+      </concept>
       <concept id="982871510068000147" name="jetbrains.mps.lang.generator.structure.TemplateSwitchMacro" flags="lg" index="1sPUBX" />
       <concept id="1167756080639" name="jetbrains.mps.lang.generator.structure.PropertyMacro_GetPropertyValue" flags="in" index="3zFVjK" />
       <concept id="1167770111131" name="jetbrains.mps.lang.generator.structure.ReferenceMacro_GetReferent" flags="in" index="3$xsQk" />
@@ -176,6 +192,7 @@
         <child id="8900764248744213871" name="contentNode" index="1Koe22" />
       </concept>
       <concept id="1118773211870" name="jetbrains.mps.lang.generator.structure.IfMacro" flags="ln" index="1W57fq">
+        <child id="1194989344771" name="alternativeConsequence" index="UU_$l" />
         <child id="1167945861827" name="conditionFunction" index="3IZSJc" />
       </concept>
       <concept id="1118786554307" name="jetbrains.mps.lang.generator.structure.LoopMacro" flags="ln" index="1WS0z7">
@@ -266,77 +283,88 @@
   <node concept="312cEu" id="21ieoTcCJQ7">
     <property role="TrG5h" value="MPSTestCase" />
     <node concept="2tJIrI" id="36bouteoEbE" role="jymVt" />
-    <node concept="Wx3nA" id="4dqLDEZ0eMU" role="jymVt">
+    <node concept="Wx3nA" id="5Vv2MCkyVed" role="jymVt">
       <property role="3TUv4t" value="true" />
       <property role="TrG5h" value="ourParametersCacheExtension" />
-      <node concept="3Tm6S6" id="4dqLDEZ0eMW" role="1B3o_S" />
-      <node concept="3uibUv" id="4dqLDEZ0gjZ" role="1tU5fm">
+      <node concept="3Tm6S6" id="5Vv2MCkyVee" role="1B3o_S" />
+      <node concept="3uibUv" id="5Vv2MCkyVef" role="1tU5fm">
         <ref role="3uigEE" to="tp6m:4dqLDEYYwgD" resolve="TestParametersCacheExtension" />
       </node>
-      <node concept="2ShNRf" id="4dqLDEZ0gCn" role="33vP2m">
-        <node concept="1pGfFk" id="4dqLDEZ0gzP" role="2ShVmc">
-          <ref role="37wK5l" to="tp6m:4dqLDEYYHvm" resolve="TestParametersCacheExtension" />
-          <node concept="2OqwBi" id="5U2b9J9Dre3" role="37wK5m">
-            <node concept="2OqwBi" id="5U2b9J9Do3$" role="2Oq$k0">
-              <node concept="2OqwBi" id="5U2b9J9Dmo1" role="2Oq$k0">
-                <node concept="2OqwBi" id="5U2b9J9DkKQ" role="2Oq$k0">
-                  <node concept="2ShNRf" id="5U2b9J9DiYk" role="2Oq$k0">
-                    <node concept="1pGfFk" id="5U2b9J9DkqL" role="2ShVmc">
-                      <property role="373rjd" value="true" />
+      <node concept="2ShNRf" id="5Vv2MCkyVeg" role="33vP2m">
+        <node concept="1pGfFk" id="5Vv2MCkyVeh" role="2ShVmc">
+          <ref role="37wK5l" to="tp6m:4dqLDEYYHvm" />
+          <node concept="2OqwBi" id="6US8dKoUjLt" role="37wK5m">
+            <node concept="2OqwBi" id="6US8dKoUiaJ" role="2Oq$k0">
+              <node concept="2OqwBi" id="6US8dKoUhnW" role="2Oq$k0">
+                <node concept="2OqwBi" id="6US8dKoUgEq" role="2Oq$k0">
+                  <node concept="2ShNRf" id="6US8dKoUfqM" role="2Oq$k0">
+                    <node concept="1pGfFk" id="6US8dKoUflU" role="2ShVmc">
                       <ref role="37wK5l" to="tp6m:6US8dKoOF6n" />
-                      <node concept="3VsKOn" id="5U2b9J9Dk_M" role="37wK5m">
+                      <node concept="3VsKOn" id="4dqLDEZ0kE$" role="37wK5m">
                         <ref role="3VsUkX" node="21ieoTcCJQ7" resolve="MPSTestCase" />
                       </node>
                     </node>
                   </node>
-                  <node concept="liA8E" id="5U2b9J9DkWK" role="2OqNvi">
+                  <node concept="liA8E" id="6US8dKoUh1q" role="2OqNvi">
                     <ref role="37wK5l" to="tp6m:6US8dKoOtkl" resolve="projectPath" />
-                    <node concept="Xl_RD" id="5U2b9J9Dl0T" role="37wK5m">
-                      <property role="Xl_RC" value="" />
-                      <node concept="17Uvod" id="5U2b9J9Dl__" role="lGtFl">
+                    <node concept="Xl_RD" id="4dqLDEZ0kE_" role="37wK5m">
+                      <property role="Xl_RC" value="project path" />
+                      <node concept="17Uvod" id="4dqLDEZ0kEA" role="lGtFl">
                         <property role="2qtEX9" value="value" />
                         <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                        <node concept="3zFVjK" id="5U2b9J9Dl_A" role="3zH0cK">
-                          <node concept="3clFbS" id="5U2b9J9Dl_B" role="2VODD2">
-                            <node concept="3clFbF" id="5U2b9J9DlRp" role="3cqZAp">
-                              <node concept="2YIFZM" id="5U2b9J9DlRq" role="3clFbG">
-                                <ref role="1Pybhc" to="tgi8:L0xQjiTXbn" resolve="TestsUtil" />
-                                <ref role="37wK5l" to="tgi8:L0xQjiTXbx" resolve="getProjectPath" />
-                                <node concept="2OqwBi" id="5U2b9J9DlRr" role="37wK5m">
-                                  <node concept="30H73N" id="5U2b9J9DlRs" role="2Oq$k0" />
-                                  <node concept="I4A8Y" id="5U2b9J9DlRt" role="2OqNvi" />
-                                </node>
+                        <node concept="3zFVjK" id="4dqLDEZ0kEB" role="3zH0cK">
+                          <node concept="3clFbS" id="4dqLDEZ0kEC" role="2VODD2">
+                            <node concept="3clFbF" id="6US8dKoXsXx" role="3cqZAp">
+                              <node concept="1mL9RQ" id="6US8dKoXsXw" role="3clFbG">
+                                <ref role="1mL9RD" node="6US8dKoXryG" resolve="projectPath" />
                               </node>
                             </node>
                           </node>
                         </node>
                       </node>
+                      <node concept="1W57fq" id="6US8dKoXts_" role="lGtFl">
+                        <node concept="3IZrLx" id="6US8dKoXtsA" role="3IZSJc">
+                          <node concept="3clFbS" id="6US8dKoXtsB" role="2VODD2">
+                            <node concept="3clFbF" id="6US8dKoXtU_" role="3cqZAp">
+                              <node concept="3y3z36" id="6US8dKoXvEz" role="3clFbG">
+                                <node concept="10Nm6u" id="6US8dKoXwHK" role="3uHU7w" />
+                                <node concept="1mL9RQ" id="6US8dKoXtU$" role="3uHU7B">
+                                  <ref role="1mL9RD" node="6US8dKoXryG" resolve="projectPath" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="gft3U" id="6US8dKoXwSA" role="UU_$l">
+                          <node concept="10Nm6u" id="6US8dKoXx0g" role="gfFT$" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
-                <node concept="liA8E" id="5U2b9J9DmBL" role="2OqNvi">
+                <node concept="liA8E" id="6US8dKoUh_J" role="2OqNvi">
                   <ref role="37wK5l" to="tp6m:6US8dKoOs$1" resolve="modelRef" />
-                  <node concept="Xl_RD" id="5U2b9J9DmK$" role="37wK5m">
+                  <node concept="Xl_RD" id="4dqLDEZ0kEI" role="37wK5m">
                     <property role="Xl_RC" value="model.fq.name" />
-                    <node concept="17Uvod" id="5U2b9J9DnjE" role="lGtFl">
+                    <node concept="17Uvod" id="4dqLDEZ0kEJ" role="lGtFl">
                       <property role="2qtEX9" value="value" />
                       <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1070475926800/1070475926801" />
-                      <node concept="3zFVjK" id="5U2b9J9DnjF" role="3zH0cK">
-                        <node concept="3clFbS" id="5U2b9J9DnjG" role="2VODD2">
-                          <node concept="3clFbF" id="5U2b9J9DnrB" role="3cqZAp">
-                            <node concept="2OqwBi" id="5U2b9J9DnrC" role="3clFbG">
-                              <node concept="2OqwBi" id="5U2b9J9DnrD" role="2Oq$k0">
-                                <node concept="liA8E" id="5U2b9J9DnrE" role="2OqNvi">
+                      <node concept="3zFVjK" id="4dqLDEZ0kEK" role="3zH0cK">
+                        <node concept="3clFbS" id="4dqLDEZ0kEL" role="2VODD2">
+                          <node concept="3clFbF" id="4dqLDEZ0kEM" role="3cqZAp">
+                            <node concept="2OqwBi" id="4dqLDEZ0kEN" role="3clFbG">
+                              <node concept="2OqwBi" id="4dqLDEZ0kEO" role="2Oq$k0">
+                                <node concept="liA8E" id="4dqLDEZ0kEP" role="2OqNvi">
                                   <ref role="37wK5l" to="mhbf:~SModel.getReference()" resolve="getReference" />
                                 </node>
-                                <node concept="2JrnkZ" id="5U2b9J9DnrF" role="2Oq$k0">
-                                  <node concept="2OqwBi" id="5U2b9J9DnrG" role="2JrQYb">
-                                    <node concept="1iwH7S" id="5U2b9J9DnrH" role="2Oq$k0" />
-                                    <node concept="1st3f0" id="5U2b9J9DnrI" role="2OqNvi" />
+                                <node concept="2JrnkZ" id="4dqLDEZ0kEQ" role="2Oq$k0">
+                                  <node concept="2OqwBi" id="4dqLDEZ0kER" role="2JrQYb">
+                                    <node concept="1iwH7S" id="4dqLDEZ0kES" role="2Oq$k0" />
+                                    <node concept="1st3f0" id="4dqLDEZ0kET" role="2OqNvi" />
                                   </node>
                                 </node>
                               </node>
-                              <node concept="liA8E" id="5U2b9J9DnrJ" role="2OqNvi">
+                              <node concept="liA8E" id="4dqLDEZ0kEU" role="2OqNvi">
                                 <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
                               </node>
                             </node>
@@ -347,26 +375,63 @@
                   </node>
                 </node>
               </node>
-              <node concept="liA8E" id="5U2b9J9Doop" role="2OqNvi">
+              <node concept="liA8E" id="6US8dKoUiHU" role="2OqNvi">
                 <ref role="37wK5l" to="tp6m:6US8dKoOtLM" resolve="reopenProject" />
-                <node concept="3clFbT" id="5U2b9J9DoRR" role="37wK5m">
-                  <node concept="17Uvod" id="5U2b9J9Dpml" role="lGtFl">
+                <node concept="3clFbT" id="4dqLDEZ0kEV" role="37wK5m">
+                  <property role="3clFbU" value="false" />
+                  <node concept="17Uvod" id="4dqLDEZ0kEW" role="lGtFl">
                     <property role="2qtEX9" value="value" />
                     <property role="P4ACc" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123137/1068580123138" />
-                    <node concept="3zFVjK" id="5U2b9J9Dpmm" role="3zH0cK">
-                      <node concept="3clFbS" id="5U2b9J9Dpmn" role="2VODD2">
-                        <node concept="3clFbF" id="5U2b9J9DpG1" role="3cqZAp">
-                          <node concept="2OqwBi" id="5U2b9J9DpG2" role="3clFbG">
-                            <node concept="35c_gC" id="5U2b9J9DpG3" role="2Oq$k0">
+                    <node concept="3zFVjK" id="4dqLDEZ0kEX" role="3zH0cK">
+                      <node concept="3clFbS" id="4dqLDEZ0kEY" role="2VODD2">
+                        <node concept="3clFbF" id="4dqLDEZ0kEZ" role="3cqZAp">
+                          <node concept="2OqwBi" id="4dqLDEZ0kF0" role="3clFbG">
+                            <node concept="35c_gC" id="4dqLDEZ0kF1" role="2Oq$k0">
                               <ref role="35c_gD" to="tp5g:4qWC2JVrBca" resolve="TestInfo" />
                             </node>
-                            <node concept="2qgKlT" id="5U2b9J9DpG4" role="2OqNvi">
+                            <node concept="2qgKlT" id="4dqLDEZ0kF2" role="2OqNvi">
                               <ref role="37wK5l" to="tp5o:ThWTaQhG7P" resolve="reOpenProject" />
-                              <node concept="2OqwBi" id="5U2b9J9DpG5" role="37wK5m">
-                                <node concept="30H73N" id="5U2b9J9DpG6" role="2Oq$k0" />
-                                <node concept="I4A8Y" id="5U2b9J9DpG7" role="2OqNvi" />
+                              <node concept="2OqwBi" id="4dqLDEZ0kF3" role="37wK5m">
+                                <node concept="30H73N" id="4dqLDEZ0kF4" role="2Oq$k0" />
+                                <node concept="I4A8Y" id="4dqLDEZ0kF5" role="2OqNvi" />
                               </node>
                             </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="1W57fq" id="6US8dKoX_wY" role="lGtFl">
+                    <node concept="3IZrLx" id="6US8dKoX_wZ" role="3IZSJc">
+                      <node concept="3clFbS" id="6US8dKoX_x0" role="2VODD2">
+                        <node concept="3clFbF" id="6US8dKoX_x1" role="3cqZAp">
+                          <node concept="3y3z36" id="6US8dKoX_x2" role="3clFbG">
+                            <node concept="10Nm6u" id="6US8dKoX_x3" role="3uHU7w" />
+                            <node concept="1mL9RQ" id="6US8dKoX_x4" role="3uHU7B">
+                              <ref role="1mL9RD" node="6US8dKoXryG" resolve="projectPath" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gft3U" id="6US8dKoX_x5" role="UU_$l">
+                      <node concept="10Nm6u" id="6US8dKoX_x6" role="gfFT$" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1ps_y7" id="6US8dKoXryF" role="lGtFl">
+                <node concept="1ps_xZ" id="6US8dKoXryG" role="1ps_xO">
+                  <property role="TrG5h" value="projectPath" />
+                  <node concept="2jfdEK" id="6US8dKoXryH" role="1ps_xN">
+                    <node concept="3clFbS" id="6US8dKoXryI" role="2VODD2">
+                      <node concept="3clFbF" id="6US8dKoXsaY" role="3cqZAp">
+                        <node concept="2YIFZM" id="6US8dKoXsaZ" role="3clFbG">
+                          <ref role="37wK5l" to="tgi8:L0xQjiTXbx" resolve="getProjectPath" />
+                          <ref role="1Pybhc" to="tgi8:L0xQjiTXbn" resolve="TestsUtil" />
+                          <node concept="2OqwBi" id="6US8dKoXsb0" role="37wK5m">
+                            <node concept="30H73N" id="6US8dKoXsb1" role="2Oq$k0" />
+                            <node concept="I4A8Y" id="6US8dKoXsb2" role="2OqNvi" />
                           </node>
                         </node>
                       </node>
@@ -375,13 +440,13 @@
                 </node>
               </node>
             </node>
-            <node concept="liA8E" id="5U2b9J9DsoS" role="2OqNvi">
+            <node concept="liA8E" id="6US8dKoUkrn" role="2OqNvi">
               <ref role="37wK5l" to="tp6m:6US8dKoNyEp" resolve="build" />
             </node>
           </node>
         </node>
       </node>
-      <node concept="2AHcQZ" id="4dqLDEZ0lE$" role="2AJF6D">
+      <node concept="2AHcQZ" id="5Vv2MCkyVei" role="2AJF6D">
         <ref role="2AI5Lk" to="rbkg:~RegisterExtension" resolve="RegisterExtension" />
       </node>
     </node>
@@ -394,7 +459,7 @@
           <ref role="37wK5l" to="tp6m:5LbRjS1pM4D" resolve="BaseTransformationTest" />
           <node concept="2OqwBi" id="4dqLDEZ0ng6" role="37wK5m">
             <node concept="10M0yZ" id="7zD2yq84n12" role="2Oq$k0">
-              <ref role="3cqZAo" node="4dqLDEZ0eMU" resolve="ourParametersCacheExtension" />
+              <ref role="3cqZAo" node="5Vv2MCkyVed" resolve="ourParametersCacheExtension" />
               <ref role="1PxDUh" node="21ieoTcCJQ7" resolve="MPSTestCase" />
             </node>
             <node concept="liA8E" id="4dqLDEZ0nBp" role="2OqNvi">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/generator/template/org.iets3.core.expr.tests.generator.template.util.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/generator/template/org.iets3.core.expr.tests.generator.template.util.mps
@@ -9,8 +9,10 @@
     <import index="tpe5" ref="r:00000000-0000-4000-0000-011c895902d1(jetbrains.mps.baseLanguage.unitTest.behavior)" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="wwqx" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.logging(MPS.Core/)" />
-    <import index="tp5o" ref="r:00000000-0000-4000-0000-011c89590380(jetbrains.mps.lang.test.behavior)" implicit="true" />
-    <import index="tp5g" ref="r:00000000-0000-4000-0000-011c89590388(jetbrains.mps.lang.test.structure)" implicit="true" />
+    <import index="tp5o" ref="r:00000000-0000-4000-0000-011c89590380(jetbrains.mps.lang.test.behavior)" />
+    <import index="3fh5" ref="r:3d2b27a7-4374-41aa-af31-19e1e430d9f5(jetbrains.mps.lang.test.generator.template.util)" />
+    <import index="tp5g" ref="r:00000000-0000-4000-0000-011c89590388(jetbrains.mps.lang.test.structure)" />
+    <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="av4b" ref="r:ba7faab6-2b80-43d5-8b95-0c440665312c(org.iets3.core.expr.tests.structure)" implicit="true" />
     <import index="xk6s" ref="r:7961970e-5737-42e2-b144-9bef3ad8d077(org.iets3.core.expr.tests.behavior)" implicit="true" />
@@ -137,68 +139,72 @@
       <node concept="17QB3L" id="L0xQjiTXb_" role="3clF45" />
       <node concept="3Tm1VV" id="L0xQjiTXbz" role="1B3o_S" />
       <node concept="3clFbS" id="L0xQjiTXb$" role="3clF47">
-        <node concept="3cpWs8" id="L0xQjiTXbD" role="3cqZAp">
-          <node concept="3cpWsn" id="L0xQjiTXbE" role="3cpWs9">
+        <node concept="3cpWs8" id="7v5ch11Erzp" role="3cqZAp">
+          <node concept="3cpWsn" id="7v5ch11Erzq" role="3cpWs9">
             <property role="TrG5h" value="projectPath" />
-            <node concept="17QB3L" id="L0xQjiTXbF" role="1tU5fm" />
-            <node concept="2OqwBi" id="L_Hr3kEs0z" role="33vP2m">
-              <node concept="2qgKlT" id="L_Hr3kEs0$" role="2OqNvi">
+            <node concept="17QB3L" id="7v5ch11Erzr" role="1tU5fm" />
+            <node concept="2OqwBi" id="7v5ch11Erzs" role="33vP2m">
+              <node concept="2qgKlT" id="7v5ch11Erzt" role="2OqNvi">
                 <ref role="37wK5l" to="tp5o:4qWC2JVrBcn" resolve="getProjectPath" />
-                <node concept="37vLTw" id="L_Hr3kEs0_" role="37wK5m">
+                <node concept="37vLTw" id="7v5ch11E_N0" role="37wK5m">
                   <ref role="3cqZAo" node="L0xQjiTXck" resolve="model" />
                 </node>
               </node>
-              <node concept="35c_gC" id="7aH5t2gC7wp" role="2Oq$k0">
+              <node concept="35c_gC" id="7v5ch11Erzv" role="2Oq$k0">
                 <ref role="35c_gD" to="tp5g:4qWC2JVrBca" resolve="TestInfo" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbJ" id="L0xQjiTXbK" role="3cqZAp">
-          <node concept="3clFbS" id="L0xQjiTXbL" role="3clFbx">
-            <node concept="3cpWs6" id="L0xQjiTXbM" role="3cqZAp">
-              <node concept="37vLTw" id="3GM_nagT$TT" role="3cqZAk">
-                <ref role="3cqZAo" node="L0xQjiTXbE" resolve="projectPath" />
-              </node>
+        <node concept="3clFbJ" id="7v5ch11Erzw" role="3cqZAp">
+          <node concept="3y3z36" id="6US8dKoWnI5" role="3clFbw">
+            <node concept="37vLTw" id="7v5ch11ErzA" role="3uHU7B">
+              <ref role="3cqZAo" node="7v5ch11Erzq" resolve="projectPath" />
             </node>
+            <node concept="10Nm6u" id="7v5ch11Erz_" role="3uHU7w" />
           </node>
-          <node concept="3y3z36" id="L0xQjiTXbO" role="3clFbw">
-            <node concept="10Nm6u" id="L0xQjiTXbP" role="3uHU7w" />
-            <node concept="37vLTw" id="3GM_nagTvuJ" role="3uHU7B">
-              <ref role="3cqZAo" node="L0xQjiTXbE" resolve="projectPath" />
+          <node concept="3clFbS" id="7v5ch11Erzx" role="3clFbx">
+            <node concept="3cpWs6" id="7v5ch11Erzy" role="3cqZAp">
+              <node concept="2YIFZM" id="2$lGPJtm42B" role="3cqZAk">
+                <ref role="37wK5l" to="18ew:~NameUtil.escapeString(java.lang.String)" resolve="escapeString" />
+                <ref role="1Pybhc" to="18ew:~NameUtil" resolve="NameUtil" />
+                <node concept="37vLTw" id="2$lGPJtm4ks" role="37wK5m">
+                  <ref role="3cqZAo" node="7v5ch11Erzq" resolve="projectPath" />
+                </node>
+              </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="4z0AnX5BR$y" role="3cqZAp">
-          <node concept="2OqwBi" id="4z0AnX5BRTQ" role="3clFbG">
-            <node concept="2YIFZM" id="4z0AnX5BRBS" role="2Oq$k0">
-              <ref role="37wK5l" to="wwqx:~Logger.getLogger(java.lang.Class)" resolve="getLogger" />
+        <node concept="3clFbF" id="7v5ch11ErzB" role="3cqZAp">
+          <node concept="2OqwBi" id="7v5ch11ErzC" role="3clFbG">
+            <node concept="2YIFZM" id="7v5ch11ErzD" role="2Oq$k0">
               <ref role="1Pybhc" to="wwqx:~Logger" resolve="Logger" />
-              <node concept="3VsKOn" id="4z0AnX5BRJf" role="37wK5m">
+              <ref role="37wK5l" to="wwqx:~Logger.getLogger(java.lang.Class)" resolve="getLogger" />
+              <node concept="3VsKOn" id="7v5ch11ErzE" role="37wK5m">
                 <ref role="3VsUkX" node="L0xQjiTXbn" resolve="TestsUtil" />
               </node>
             </node>
-            <node concept="liA8E" id="4z0AnX5BS4F" role="2OqNvi">
-              <ref role="37wK5l" to="wwqx:~Logger.error(java.lang.String)" resolve="error" />
-              <node concept="2YIFZM" id="7aH5t2gCcho" role="37wK5m">
+            <node concept="liA8E" id="7v5ch11ErzF" role="2OqNvi">
+              <ref role="37wK5l" to="wwqx:~Logger.info(java.lang.String)" resolve="info" />
+              <node concept="2YIFZM" id="7v5ch11ErzG" role="37wK5m">
                 <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
                 <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
-                <node concept="Xl_RD" id="7aH5t2gCcjz" role="37wK5m">
-                  <property role="Xl_RC" value="Model %s (from %s) doesn't specify TestInfo and relies on deprecated way to locate an active project, please FIX!" />
+                <node concept="Xl_RD" id="7v5ch11ErzH" role="37wK5m">
+                  <property role="Xl_RC" value="Model %s (from %s) doesn't specify project path in TestInfo. Use -Dmps.test.project.path to specify project path." />
                 </node>
-                <node concept="2OqwBi" id="7aH5t2gCdVe" role="37wK5m">
-                  <node concept="37vLTw" id="7aH5t2gCdRn" role="2Oq$k0">
+                <node concept="2OqwBi" id="7v5ch11ErzI" role="37wK5m">
+                  <node concept="37vLTw" id="7v5ch11ErzJ" role="2Oq$k0">
                     <ref role="3cqZAo" node="L0xQjiTXck" resolve="model" />
                   </node>
-                  <node concept="LkI2h" id="7aH5t2gCdYx" role="2OqNvi" />
+                  <node concept="LkI2h" id="7v5ch11ErzK" role="2OqNvi" />
                 </node>
-                <node concept="2OqwBi" id="7aH5t2gCecB" role="37wK5m">
-                  <node concept="2JrnkZ" id="7aH5t2gCe99" role="2Oq$k0">
-                    <node concept="37vLTw" id="7aH5t2gCe52" role="2JrQYb">
+                <node concept="2OqwBi" id="7v5ch11ErzL" role="37wK5m">
+                  <node concept="2JrnkZ" id="7v5ch11ErzM" role="2Oq$k0">
+                    <node concept="37vLTw" id="7v5ch11ErzN" role="2JrQYb">
                       <ref role="3cqZAo" node="L0xQjiTXck" resolve="model" />
                     </node>
                   </node>
-                  <node concept="liA8E" id="7aH5t2gCei6" role="2OqNvi">
+                  <node concept="liA8E" id="7v5ch11ErzO" role="2OqNvi">
                     <ref role="37wK5l" to="mhbf:~SModel.getSource()" resolve="getSource" />
                   </node>
                 </node>
@@ -206,10 +212,8 @@
             </node>
           </node>
         </node>
-        <node concept="3cpWs6" id="L0xQjiTXci" role="3cqZAp">
-          <node concept="Xl_RD" id="L0xQjiTXcj" role="3cqZAk">
-            <property role="Xl_RC" value="" />
-          </node>
+        <node concept="3cpWs6" id="7v5ch11ErzP" role="3cqZAp">
+          <node concept="10Nm6u" id="6US8dKoWnBg" role="3cqZAk" />
         </node>
       </node>
       <node concept="37vLTG" id="L0xQjiTXck" role="3clF46">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.opensource.build.gentests/generator/template/org.iets3.opensource.build.gentests.generator.main@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.opensource.build.gentests/generator/template/org.iets3.opensource.build.gentests.generator.main@generator.mps
@@ -2390,6 +2390,22 @@
                     </node>
                   </node>
                 </node>
+                <node concept="2pNNFK" id="3pajOvjI3r" role="3o6s8t">
+                  <property role="2pNNFO" value="sysproperty" />
+                  <property role="qg3DV" value="true" />
+                  <node concept="2pNUuL" id="3pajOvjJqf" role="2pNNFR">
+                    <property role="2pNUuO" value="key" />
+                    <node concept="2pMdtt" id="3pajOvjJqg" role="2pMdts">
+                      <property role="2pMdty" value="mps.test.project.path" />
+                    </node>
+                  </node>
+                  <node concept="2pNUuL" id="3pajOvjJr2" role="2pNNFR">
+                    <property role="2pNUuO" value="value" />
+                    <node concept="2pMdtt" id="3pajOvjJr3" role="2pMdts">
+                      <property role="2pMdty" value="${basedir}" />
+                    </node>
+                  </node>
+                </node>
                 <node concept="3o6iSG" id="4mAIL6pn14P" role="3o6s8t" />
                 <node concept="2pNNFK" id="16twgkTaVbz" role="3o6s8t">
                   <property role="qg3DV" value="true" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -30,6 +30,7 @@
       <concept id="6593674873639474400" name="jetbrains.mps.build.mps.tests.structure.BuildMps_TestModules_Options" flags="ng" index="24cAiW">
         <child id="1688667350638517006" name="compressArgs" index="XX84c" />
         <child id="3609768169816292377" name="jvmArgs" index="1psgkv" />
+        <child id="7978162869575635130" name="projectPath" index="1RZ71A" />
       </concept>
       <concept id="4005526075820600484" name="jetbrains.mps.build.mps.tests.structure.BuildModuleTestsPlugin" flags="ng" index="1gjT0q" />
     </language>
@@ -14109,6 +14110,9 @@
           <node concept="3Mxwew" id="1DM13Xaw8ZX" role="3MwsjC">
             <property role="3MwjfP" value="-Xss2048k -Xmx2048m" />
           </node>
+        </node>
+        <node concept="398BVA" id="71RLIEFHzg5" role="1RZ71A">
+          <ref role="398BVh" node="OJuIQp$deE" resolve="iets3.lang.opensource" />
         </node>
       </node>
       <node concept="22LTRM" id="OJuIQp_hdf" role="22LTRK">

--- a/code/languages/org.iets3.opensource/solutions/playground/models/m1.mps
+++ b/code/languages/org.iets3.opensource/solutions/playground/models/m1.mps
@@ -6,11 +6,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="7554398283340640412" name="org.iets3.core.expr.collections.structure.MapOp" flags="ng" index="3iw6QE" />
       <concept id="7554398283340020764" name="org.iets3.core.expr.collections.structure.OneArgCollectionOp" flags="ng" index="3iAY4E">
@@ -1714,9 +1709,6 @@
     <node concept="_ixoA" id="3yVmeSjL7oI" role="_iOnB" />
     <node concept="_ixoA" id="3yVmeSjL7oJ" role="_iOnB" />
     <node concept="_ixoA" id="3yVmeSjL7oK" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/solutions/playground/models/playground.priorisationInCC.mps
+++ b/code/languages/org.iets3.opensource/solutions/playground/models/playground.priorisationInCC.mps
@@ -6,11 +6,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
       <concept id="7089558164905593724" name="org.iets3.core.expr.base.structure.IOptionallyTyped" flags="ngI" index="2zM23E">
         <child id="7089558164905593725" name="type" index="2zM23F" />
@@ -64,9 +59,6 @@
       </concept>
     </language>
   </registry>
-  <node concept="2XOHcx" id="jqB9UczCLJ">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
-  </node>
   <node concept="_iOnU" id="jqB9UczD_y">
     <property role="TrG5h" value="TryOutPriorisation" />
     <node concept="5mgZ8" id="6wzrxL3eVQr" role="_iOnB">

--- a/code/languages/org.iets3.opensource/solutions/playground/models/sheets.mps
+++ b/code/languages/org.iets3.opensource/solutions/playground/models/sheets.mps
@@ -7,11 +7,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="5585772046594451299" name="org.iets3.core.expr.collections.structure.SumOp" flags="ng" index="2$5g5R" />
       <concept id="8872269265515619803" name="org.iets3.core.expr.collections.structure.AnyOp" flags="ng" index="2Tz0gS" />
@@ -3985,9 +3980,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/solutions/playground/models/wgld.mps
+++ b/code/languages/org.iets3.opensource/solutions/playground/models/wgld.mps
@@ -7,11 +7,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="5585772046594451299" name="org.iets3.core.expr.collections.structure.SumOp" flags="ng" index="2$5g5R" />
     </language>
@@ -327,9 +322,6 @@
     </node>
     <node concept="_ixoA" id="JV9IWPRy82" role="_iOnB" />
     <node concept="_ixoA" id="JV9IWPRy84" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="JV9IWPRy8W">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="_iOnU" id="JV9IWPRyTJ">
     <property role="1XBH2A" value="true" />

--- a/code/languages/org.iets3.opensource/solutions/test.ex.core.expr.genjava/models/messages@tests.mps
+++ b/code/languages/org.iets3.opensource/solutions/test.ex.core.expr.genjava/models/messages@tests.mps
@@ -12,11 +12,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base">
       <concept id="7831630342157089621" name="org.iets3.core.base.structure.IDetectNeedToRunManually" flags="ngI" index="0Rz4o">
         <property id="7831630342157089649" name="__hash" index="0Rz4W" />
@@ -1101,9 +1096,6 @@
       <property role="TrG5h" value="money" />
       <node concept="mLuIC" id="1CNpG_h8F11" role="1WbbD4" />
     </node>
-  </node>
-  <node concept="2XOHcx" id="3vxfdxbrceL">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/solutions/test.iets3.core.assessment/models/test/iets3/core/tracequery/tracequery@tests.mps
+++ b/code/languages/org.iets3.opensource/solutions/test.iets3.core.assessment/models/test/iets3/core/tracequery/tracequery@tests.mps
@@ -25,9 +25,6 @@
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1216993439383" name="methods" index="1qtyYc" />
@@ -252,9 +249,6 @@
       </concept>
     </language>
   </registry>
-  <node concept="2XOHcx" id="1HLccB8ALk3">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
-  </node>
   <node concept="1lH9Xt" id="1HLccB8ALxI">
     <property role="TrG5h" value="GenericTraceHelperTests" />
     <property role="3DII0k" value="2hh8MJdVwqX/command" />

--- a/code/languages/org.iets3.opensource/solutions/test.org.iets3.analysis.base/models/test.org.iets3.analysis.base.async@tests.mps
+++ b/code/languages/org.iets3.opensource/solutions/test.org.iets3.analysis.base/models/test.org.iets3.analysis.base.async@tests.mps
@@ -24,9 +24,6 @@
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1225467090849" name="jetbrains.mps.lang.test.structure.ProjectExpression" flags="nn" index="1jxXqW" />
       <concept id="1225469856668" name="jetbrains.mps.lang.test.structure.ModelExpression" flags="nn" index="1jGwE1" />
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
@@ -912,9 +909,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="1lH9Xt" id="7Ne8N_$sCzc">
     <property role="3DII0k" value="2hh8MJdVwqT/none" />

--- a/code/languages/org.iets3.opensource/solutions/test.org.iets3.core.comments/models/tests@tests.mps
+++ b/code/languages/org.iets3.opensource/solutions/test.org.iets3.core.comments/models/tests@tests.mps
@@ -25,9 +25,6 @@
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
       </concept>
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
         <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
       </concept>
@@ -222,9 +219,6 @@
         <node concept="1i1AuW" id="5kwEgmAh7pZ" role="1i1AA4" />
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="LiM7Y" id="5kwEgmAi6Ll">
     <property role="TrG5h" value="CommentsOnSubstructure" />

--- a/code/languages/org.iets3.opensource/solutions/test.ts.components.core/models/tests@tests.mps
+++ b/code/languages/org.iets3.opensource/solutions/test.ts.components.core/models/tests@tests.mps
@@ -32,9 +32,6 @@
         <reference id="8333855927540250453" name="declaration" index="39XzEq" />
       </concept>
       <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -240,9 +237,6 @@
       </concept>
     </language>
   </registry>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
-  </node>
   <node concept="1lH9Xt" id="58cNi02eX0u">
     <property role="TrG5h" value="ConceptSpecificAndContextTypeSpecificAttributes" />
     <property role="3DII0k" value="2hh8MJdVwqX/command" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/algebraic@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/algebraic@tests.mps
@@ -13,11 +13,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="2156530943179783739" name="org.iets3.core.expr.collections.structure.ListWithOp" flags="ng" index="2iGZtc" />
       <concept id="8694548031077039769" name="org.iets3.core.expr.collections.structure.ElementTypeConstraintSingle" flags="ng" index="ygwf7">
@@ -5177,9 +5172,6 @@
     <node concept="_ixoA" id="28$LOSBVN_n" role="_iOnB" />
     <node concept="_ixoA" id="28$LOSBM6Lz" role="_iOnB" />
     <node concept="_ixoA" id="28$LOSBM6MX" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/dataflow@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/dataflow@tests.mps
@@ -13,11 +13,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
       <concept id="7971844778466793051" name="org.iets3.core.expr.base.structure.AltOption" flags="ng" index="2fGnzd">
         <child id="7971844778466793072" name="then" index="2fGnzA" />
@@ -4744,9 +4739,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="_iOnU" id="4qjJWfVq$ZE">
     <property role="TrG5h" value="BasicBlocks" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/datetime@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/datetime@tests.mps
@@ -13,11 +13,6 @@
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
   </imports>
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="8694548031077039769" name="org.iets3.core.expr.collections.structure.ElementTypeConstraintSingle" flags="ng" index="ygwf7">
         <child id="8694548031077039770" name="typeConstraint" index="ygwf4" />
@@ -6943,9 +6938,6 @@
     </node>
     <node concept="_ixoA" id="4V0FBnKJi0T" role="_iOnB" />
     <node concept="_ixoA" id="j5CxBK7y2D" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="3pwaUo" id="3MHhZL0CVjV">
     <property role="TrG5h" value="InterpreterCoverage" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/math@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/math@tests.mps
@@ -24,9 +24,6 @@
         <reference id="8333855927540250453" name="declaration" index="39XzEq" />
       </concept>
       <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -233,9 +230,6 @@
       </concept>
     </language>
   </registry>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
-  </node>
   <node concept="_iOnU" id="1yW0h04Clb1">
     <property role="TrG5h" value="math" />
     <property role="1XBH2A" value="true" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/messages@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/messages@tests.mps
@@ -16,9 +16,6 @@
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
       <concept id="2325284917965760583" name="jetbrains.mps.lang.test.structure.BeforeTestsMethod" flags="ig" index="0EjCn" />
       <concept id="2325284917965760584" name="jetbrains.mps.lang.test.structure.AfterTestsMethod" flags="ig" index="0EjCo" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="2325284917965993569" name="beforeTests" index="0EEgL" />
@@ -1024,9 +1021,6 @@
     <node concept="_ixoA" id="4AahbtVkebP" role="_iOnB" />
     <node concept="_ixoA" id="4AahbtVkefb" role="_iOnB" />
     <node concept="_ixoA" id="4AahbtVbkzw" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="3vxfdxbrceL">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="1WOfUn" id="3vxfdxbret3">
     <property role="TrG5h" value="Messages" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/mutable@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/mutable@tests.mps
@@ -95,11 +95,6 @@
         <reference id="24388123200566265" name="param" index="1GjhsB" />
       </concept>
     </language>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util">
       <concept id="4214990435115877128" name="org.iets3.core.expr.util.structure.DecTab" flags="ng" index="UJIhK">
         <child id="4214990435115877193" name="contents" index="UJIgL" />
@@ -2429,9 +2424,6 @@
     </node>
     <node concept="_ixoA" id="4IV0h48dZXj" role="_iOnB" />
     <node concept="_ixoA" id="4IV0h48e00O" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="_iOnU" id="35BERWyOOpU">
     <property role="TrG5h" value="mutable_globals" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/operatorgroup@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/operatorgroup@tests.mps
@@ -10,11 +10,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
       <concept id="5338017450510309031" name="org.iets3.core.expr.base.structure.AndTag" flags="ng" index="2s_agL" />
       <concept id="5338017450510303355" name="org.iets3.core.expr.base.structure.OperatorGroup" flags="ng" index="2s_bbH">
@@ -76,9 +71,6 @@
       </concept>
     </language>
   </registry>
-  <node concept="2XOHcx" id="6WstIz8wNvC">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
-  </node>
   <node concept="_iOnU" id="6WstIz8wNvD">
     <property role="TrG5h" value="logicalgroups" />
     <property role="1XBH2A" value="true" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/statemachines@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/statemachines@tests.mps
@@ -56,9 +56,6 @@
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
       </concept>
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -143,9 +140,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="agNjvG6VA8">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="LiM7Y" id="agNjvGi1OB">
     <property role="TrG5h" value="SquashEntryActionsIntention_minimalExample" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/temporal@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/temporal@tests.mps
@@ -18,11 +18,6 @@
     <import index="8rdi" ref="r:f17e1021-3869-4fe5-b3c7-0b2a9149a478(org.iets3.core.expr.temporal.runtime)" />
   </imports>
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="8694548031077039769" name="org.iets3.core.expr.collections.structure.ElementTypeConstraintSingle" flags="ng" index="ygwf7">
         <child id="8694548031077039770" name="typeConstraint" index="ygwf4" />
@@ -502,9 +497,6 @@
       <concept id="7554398283340826520" name="org.iets3.core.expr.lambda.structure.ShortLambdaItExpression" flags="ng" index="3izPEI" />
     </language>
   </registry>
-  <node concept="2XOHcx" id="7aRvJQEr9o9">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
-  </node>
   <node concept="_iOnU" id="7aRvJQErc4N">
     <property role="1XBH2A" value="true" />
     <property role="TrG5h" value="TemporalTests" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.alt@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.alt@tests.mps
@@ -9,11 +9,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base">
       <concept id="7831630342157089621" name="org.iets3.core.base.structure.IDetectNeedToRunManually" flags="ngI" index="0Rz4o">
         <property id="7831630342157089649" name="__hash" index="0Rz4W" />
@@ -914,9 +909,6 @@
     </node>
     <node concept="_ixoA" id="4qTaF_E4NxV" role="_iOnB" />
     <node concept="_ixoA" id="38v7GtLshzg" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.applicationExamples@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.applicationExamples@tests.mps
@@ -11,11 +11,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
       <concept id="7971844778466793051" name="org.iets3.core.expr.base.structure.AltOption" flags="ng" index="2fGnzd">
         <child id="7971844778466793072" name="then" index="2fGnzA" />
@@ -576,9 +571,6 @@
     </node>
     <node concept="_ixoA" id="5ElkanPON4a" role="_iOnB" />
     <node concept="_ixoA" id="5ElkanPON8m" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.base@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.base@tests.mps
@@ -11,11 +11,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base">
       <concept id="7831630342157089621" name="org.iets3.core.base.structure.IDetectNeedToRunManually" flags="ngI" index="0Rz4o">
         <property id="7831630342157089649" name="__hash" index="0Rz4W" />
@@ -259,13 +254,13 @@
       <property role="TrG5h" value="base" />
       <node concept="_fkuZ" id="38v7GtLqRlT" role="_fkp5">
         <node concept="_fku$" id="38v7GtLqRlU" role="_fkur" />
-        <node concept="30bXRB" id="38v7GtLqRlV" role="_fkuS">
-          <property role="30bXRw" value="5" />
-        </node>
         <node concept="30bsCy" id="38v7GtLqRlW" role="_fkuY">
           <node concept="30bXRB" id="3oWFox9iSLd" role="30bsDf">
             <property role="30bXRw" value="5" />
           </node>
+        </node>
+        <node concept="30bXRB" id="38v7GtLqRlV" role="_fkuS">
+          <property role="30bXRw" value="5" />
         </node>
       </node>
       <node concept="_fkuZ" id="38v7GtLqRlY" role="_fkp5">
@@ -2252,9 +2247,6 @@
         <node concept="mLuIC" id="3$XzGmIYA0K" role="3ix9CU" />
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.collections@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.collections@tests.mps
@@ -14,11 +14,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="527291771330968213" name="org.iets3.core.expr.collections.structure.ISetOneArgOp" flags="ngI" index="24uAI7">
         <child id="527291771330969242" name="arg" index="24uAY8" />
@@ -20757,9 +20752,6 @@
     <node concept="_ixoA" id="2ufoZQJ2tm0" role="_iOnB" />
     <node concept="_ixoA" id="2ufoZQIV1H2" role="_iOnB" />
     <node concept="_ixoA" id="1$1rueeqtL1" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="_iOnU" id="2YQA$NZ_Q7Y">
     <property role="1XBH2A" value="true" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.contracts@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.contracts@tests.mps
@@ -11,11 +11,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="6095949300270588116" name="org.iets3.core.expr.collections.structure.IsNotEmptyOp" flags="ng" index="nW$_3" />
       <concept id="8694548031077039769" name="org.iets3.core.expr.collections.structure.ElementTypeConstraintSingle" flags="ng" index="ygwf7">
@@ -3681,9 +3676,6 @@
       <node concept="3dYjL0" id="4J64Kqd70t" role="_fkp5" />
     </node>
     <node concept="_ixoA" id="4qTaF_EipkA" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.datatable@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.datatable@tests.mps
@@ -12,11 +12,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base">
       <concept id="7831630342157089621" name="org.iets3.core.base.structure.IDetectNeedToRunManually" flags="ngI" index="0Rz4o">
         <property id="7831630342157089649" name="__hash" index="0Rz4W" />
@@ -124,9 +119,6 @@
       <concept id="231307155597471414" name="org.iets3.core.expr.data.structure.DataColDef" flags="ng" index="3CkmCn" />
     </language>
   </registry>
-  <node concept="2XOHcx" id="cPLa7FqXwt">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
-  </node>
   <node concept="_iOnU" id="cPLa7FqXIK">
     <property role="1XBH2A" value="true" />
     <property role="TrG5h" value="DataTable" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.datatablegen@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.datatablegen@tests.mps
@@ -11,11 +11,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
       <concept id="2390066428848651932" name="org.iets3.core.expr.base.structure.BangOp" flags="ng" index="wdKpt" />
       <concept id="7071042522334260296" name="org.iets3.core.expr.base.structure.ITyped" flags="ngI" index="2_iKZX">
@@ -102,9 +97,6 @@
       <concept id="231307155597471414" name="org.iets3.core.expr.data.structure.DataColDef" flags="ng" index="3CkmCn" />
     </language>
   </registry>
-  <node concept="2XOHcx" id="6wzrxL2ZwEE">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
-  </node>
   <node concept="_iOnU" id="28$LOSAPZOM">
     <property role="TrG5h" value="TestsForDataTableGenerator" />
     <property role="1XBH2A" value="true" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.dectabs@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.dectabs@tests.mps
@@ -10,11 +10,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util">
       <concept id="2346756181072973168" name="org.iets3.core.expr.util.structure.SingleValueRS" flags="ng" index="3RXsw">
         <child id="2346756181072973169" name="bound" index="3RXsx" />
@@ -3239,9 +3234,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.enums@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.enums@tests.mps
@@ -10,11 +10,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="8694548031077039769" name="org.iets3.core.expr.collections.structure.ElementTypeConstraintSingle" flags="ng" index="ygwf7">
         <child id="8694548031077039770" name="typeConstraint" index="ygwf4" />
@@ -708,9 +703,6 @@
     <node concept="_ixoA" id="c36CPsxzDq" role="_iOnB" />
     <node concept="_ixoA" id="5WNmJ7EzoQ0" role="_iOnB" />
     <node concept="_ixoA" id="5WNmJ7EzoRu" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="_iOnU" id="2Alk1ztJIs8">
     <property role="1XBH2A" value="true" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.error@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.error@tests.mps
@@ -9,11 +9,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base">
       <concept id="7831630342157089621" name="org.iets3.core.base.structure.IDetectNeedToRunManually" flags="ngI" index="0Rz4o">
         <property id="7831630342157089649" name="__hash" index="0Rz4W" />
@@ -1152,9 +1147,6 @@
     <node concept="_ixoA" id="3kdFyLXuHzF" role="_iOnB" />
     <node concept="_ixoA" id="3kdFyLXuHDm" role="_iOnB" />
     <node concept="_ixoA" id="7ZoBx3xvi$M" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.functions@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.functions@tests.mps
@@ -9,11 +9,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="2156530943179783739" name="org.iets3.core.expr.collections.structure.ListWithOp" flags="ng" index="2iGZtc" />
       <concept id="362871314062739301" name="org.iets3.core.expr.collections.structure.ListWithAllOp" flags="ng" index="2oUEFG" />
@@ -1389,9 +1384,6 @@
     </node>
     <node concept="_ixoA" id="7b6J31DljTa" role="_iOnB" />
     <node concept="_ixoA" id="7b6J31Doom$" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="_iOnU" id="Cqs5T9JiZ8">
     <property role="1XBH2A" value="true" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.ignoredTests@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.ignoredTests@tests.mps
@@ -11,11 +11,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="d441fba0-f46b-43cd-b723-dad7b65da615" name="org.iets3.core.expr.tests">
       <concept id="8219602584783477664" name="org.iets3.core.expr.tests.structure.AbstractTestItem" flags="ng" index="mXNUw">
         <property id="4770332828445654111" name="isIgnored" index="2xO9KL" />
@@ -45,9 +40,6 @@
       </concept>
     </language>
   </registry>
-  <node concept="2XOHcx" id="48NC6VzWiYe">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
-  </node>
   <node concept="_iOnU" id="48NC6VzWjct">
     <property role="TrG5h" value="ignoredTests" />
     <property role="1XBH2A" value="true" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.lambda@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.lambda@tests.mps
@@ -9,11 +9,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="5585772046594451299" name="org.iets3.core.expr.collections.structure.SumOp" flags="ng" index="2$5g5R" />
       <concept id="7554398283340640412" name="org.iets3.core.expr.collections.structure.MapOp" flags="ng" index="3iw6QE" />
@@ -1537,9 +1532,6 @@
       <node concept="mLuIC" id="1ufrWYcQ8oW" role="2zM23F" />
     </node>
     <node concept="_ixoA" id="6HHp2WmWx5x" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.lookuptable@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.lookuptable@tests.mps
@@ -9,11 +9,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
       <concept id="5115872837156802409" name="org.iets3.core.expr.base.structure.UnaryExpression" flags="ng" index="30czhk">
         <child id="5115872837156802411" name="expr" index="30czhm" />
@@ -127,9 +122,6 @@
       <node concept="3dYjL0" id="1tbxNVtG3xF" role="_fkp5" />
       <node concept="3dYjL0" id="1tbxNVtG3xQ" role="_fkp5" />
     </node>
-  </node>
-  <node concept="2XOHcx" id="cPLa7FqXwt">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.nix@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.nix@tests.mps
@@ -11,11 +11,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base">
       <concept id="7831630342157089621" name="org.iets3.core.base.structure.IDetectNeedToRunManually" flags="ngI" index="0Rz4o">
         <property id="7831630342157089649" name="__hash" index="0Rz4W" />
@@ -149,9 +144,6 @@
       </concept>
     </language>
   </registry>
-  <node concept="2XOHcx" id="3nVyIts6iiH">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
-  </node>
   <node concept="_iOnU" id="3nVyIts6iiI">
     <property role="TrG5h" value="nix" />
     <property role="1XBH2A" value="true" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.numbers@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.numbers@tests.mps
@@ -10,11 +10,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
       <concept id="8219602584757553931" name="org.iets3.core.expr.base.structure.CheckTypeConstraintsExpr" flags="ng" index="hiESb">
         <child id="8219602584757553932" name="expr" index="hiESc" />
@@ -2233,9 +2228,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.options@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.options@tests.mps
@@ -11,11 +11,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="8694548031077039769" name="org.iets3.core.expr.collections.structure.ElementTypeConstraintSingle" flags="ng" index="ygwf7">
         <child id="8694548031077039770" name="typeConstraint" index="ygwf4" />
@@ -4929,9 +4924,6 @@
     </node>
     <node concept="_ixoA" id="2q1ydqQ0FPG" role="_iOnB" />
     <node concept="_ixoA" id="6HHp2WmWPRl" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="_iOnU" id="2YQA$NZANNg">
     <property role="1XBH2A" value="true" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.query@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.query@tests.mps
@@ -11,11 +11,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="1330041117646892901" name="org.iets3.core.expr.collections.structure.CollectionSizeSpec" flags="ng" index="2gteSW">
         <property id="1330041117646892912" name="max" index="2gteSD" />
@@ -177,9 +172,6 @@
       <concept id="7554398283340826520" name="org.iets3.core.expr.lambda.structure.ShortLambdaItExpression" flags="ng" index="3izPEI" />
     </language>
   </registry>
-  <node concept="2XOHcx" id="5QDPRL$oCuX">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
-  </node>
   <node concept="_iOnU" id="5QDPRL$oCCj">
     <property role="1XBH2A" value="true" />
     <property role="TrG5h" value="helloQuery" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.records@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.records@tests.mps
@@ -11,11 +11,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="6095949300270588116" name="org.iets3.core.expr.collections.structure.IsNotEmptyOp" flags="ng" index="nW$_3" />
       <concept id="8694548031077039769" name="org.iets3.core.expr.collections.structure.ElementTypeConstraintSingle" flags="ng" index="ygwf7">
@@ -1830,9 +1825,6 @@
       <node concept="3dYjL0" id="7k6A8WftUml" role="_fkp5" />
     </node>
     <node concept="_ixoA" id="4ptnK4jeq01" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="_iOnU" id="7cphKbLeYOb">
     <property role="TrG5h" value="projection" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.strings@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.strings@tests.mps
@@ -10,11 +10,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
       <concept id="606861080870797309" name="org.iets3.core.expr.base.structure.IfElseSection" flags="ng" index="pf3Wd">
         <child id="606861080870797310" name="expr" index="pf3We" />
@@ -1099,9 +1094,6 @@
         <node concept="30bdrP" id="60Qa1k_HyQQ" role="_fkuS" />
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.stringvalidation@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.stringvalidation@tests.mps
@@ -15,11 +15,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="8694548031077039769" name="org.iets3.core.expr.collections.structure.ElementTypeConstraintSingle" flags="ng" index="ygwf7">
         <child id="8694548031077039770" name="typeConstraint" index="ygwf4" />
@@ -3338,9 +3333,6 @@
     </node>
     <node concept="_ixoA" id="6Sp$RJ7bBHK" role="_iOnB" />
     <node concept="_ixoA" id="6Sp$RJ7bBZ1" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tests@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tests@tests.mps
@@ -9,11 +9,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
       <concept id="7971844778466793051" name="org.iets3.core.expr.base.structure.AltOption" flags="ng" index="2fGnzd">
         <child id="7971844778466793072" name="then" index="2fGnzA" />
@@ -401,9 +396,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tolerance@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tolerance@tests.mps
@@ -9,11 +9,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base">
       <concept id="7831630342157089621" name="org.iets3.core.base.structure.IDetectNeedToRunManually" flags="ngI" index="0Rz4o">
         <property id="7831630342157089649" name="__hash" index="0Rz4W" />
@@ -618,9 +613,6 @@
         <node concept="2vmpnb" id="4399ITSFeqO" role="_fkuS" />
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tuples@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.tuples@tests.mps
@@ -9,11 +9,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="1330041117646892901" name="org.iets3.core.expr.collections.structure.CollectionSizeSpec" flags="ng" index="2gteSW">
         <property id="1330041117646892912" name="max" index="2gteSD" />
@@ -835,9 +830,6 @@
       </node>
     </node>
     <node concept="_ixoA" id="41vYFO3dyVh" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.typedefs@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.typedefs@tests.mps
@@ -9,11 +9,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="8694548031077039769" name="org.iets3.core.expr.collections.structure.ElementTypeConstraintSingle" flags="ng" index="ygwf7">
         <child id="8694548031077039770" name="typeConstraint" index="ygwf4" />
@@ -890,9 +885,6 @@
     <node concept="_ixoA" id="252QIDyqyDN" role="_iOnB" />
     <node concept="_ixoA" id="252QIDypUtt" role="_iOnB" />
     <node concept="_ixoA" id="252QIDypUuj" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/todo@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/todo@tests.mps
@@ -18,11 +18,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util">
       <concept id="2346756181087515423" name="org.iets3.core.expr.util.structure.DecTree" flags="ng" index="4Ji_f">
         <child id="2346756181087516195" name="root" index="4JiLN" />
@@ -3763,9 +3758,6 @@
     <node concept="_ixoA" id="5sTgzMChE_D" role="_iOnB" />
     <node concept="_ixoA" id="5iD_kvlNO9n" role="_iOnB" />
     <node concept="_ixoA" id="5iD_kvlNObe" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="_iOnU" id="1URbfFFNt7E">
     <property role="TrG5h" value="dectre" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/utils@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/utils@tests.mps
@@ -10,11 +10,6 @@
   </languages>
   <imports />
   <registry>
-    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
-    </language>
     <language id="8bb1251e-eae5-47ab-9843-33adfae8edaa" name="org.iets3.core.expr.util">
       <concept id="2346756181072973168" name="org.iets3.core.expr.util.structure.SingleValueRS" flags="ng" index="3RXsw">
         <child id="2346756181072973169" name="bound" index="3RXsx" />
@@ -1572,9 +1567,6 @@
     </node>
     <node concept="_ixoA" id="38udS81r9gd" role="_iOnB" />
     <node concept="_ixoA" id="38udS81r9nE" role="_iOnB" />
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="_iOnU" id="6OunYCfiz1J">
     <property role="TrG5h" value="utils_dectab_ranges" />

--- a/code/languages/org.iets3.opensource/tests/test.node.expr.os/models/test.node.expr.os.base@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.node.expr.os/models/test.node.expr.os.base@tests.mps
@@ -20,9 +20,6 @@
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1216993439383" name="methods" index="1qtyYc" />
@@ -279,9 +276,6 @@
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
     </language>
   </registry>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
-  </node>
   <node concept="1lH9Xt" id="7YuIrXyB1Kn">
     <property role="3DII0k" value="2hh8MJdVwqX/command" />
     <property role="TrG5h" value="TestDefaultCoverageAnalyzer" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os.comma/models/test.ts.expr.os.comma.m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os.comma/models/test.ts.expr.os.comma.m1@tests.mps
@@ -28,9 +28,6 @@
       <concept id="1215607067978" name="jetbrains.mps.lang.test.structure.CheckNodeForErrorMessagesOperation" flags="ng" index="7OXhh">
         <property id="3743352646565420194" name="includeSelf" index="GvXf4" />
       </concept>
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="2325284917965993569" name="beforeTests" index="0EEgL" />
@@ -5661,9 +5658,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="1lH9Xt" id="1t_lOkRegEA">
     <property role="TrG5h" value="commaRealTests" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.IValidNamedConcept@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.IValidNamedConcept@tests.mps
@@ -42,9 +42,6 @@
       <concept id="7691029917083872157" name="jetbrains.mps.lang.test.structure.IRuleReference" flags="ngI" index="2u4UPC">
         <reference id="8333855927540250453" name="declaration" index="39XzEq" />
       </concept>
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="8333855927540283103" name="jetbrains.mps.lang.test.structure.NodeConstraintsErrorCheckOperation" flags="ng" index="39XrGg">
         <child id="8333855927548182241" name="errorRef" index="39rjcI" />
       </concept>
@@ -1683,9 +1680,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="6OMpQn6WPOR">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.LeastCommonSuperType@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.LeastCommonSuperType@tests.mps
@@ -15,9 +15,9 @@
   </languages>
   <imports>
     <import index="ku0a" ref="r:1881124b-7ac4-4b0f-a7dd-12953ac3263b(org.iets3.core.expr.typetags.units.si.units)" />
+    <import index="eddd" ref="r:76654092-7126-4d48-8113-566c63e58f87(test.ts.expr.os.nix.structure)" />
     <import index="9mim" ref="r:5bf19129-2710-45a6-906e-9ee2d0977853(org.iets3.core.expr.simpleTypes.plugin)" />
     <import index="u78q" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.typesystem.inference(MPS.Core/)" />
-    <import index="eddd" ref="r:76654092-7126-4d48-8113-566c63e58f87(test.ts.expr.os.nix.structure)" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
     <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" />
     <import index="700h" ref="r:61b1de80-490d-4fee-8e95-b956503290e9(org.iets3.core.expr.collections.structure)" implicit="true" />
@@ -37,9 +37,6 @@
       <concept id="1211979288880" name="jetbrains.mps.lang.test.structure.AssertMatch" flags="nn" index="JA50E">
         <child id="1211979305365" name="before" index="JA92f" />
         <child id="1211979322383" name="after" index="JAdkl" />
-      </concept>
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
       </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
@@ -3105,9 +3102,6 @@
       </node>
     </node>
   </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
-  </node>
   <node concept="1lH9Xt" id="7iQqdOBdOo$">
     <property role="TrG5h" value="LeastCommonSuperTypesWithUnits" />
     <property role="3DII0k" value="2hh8MJdVwqX/command" />
@@ -4746,6 +4740,32 @@
       </node>
     </node>
   </node>
+  <node concept="312cEu" id="2fy$Fh$r6Ga">
+    <property role="TrG5h" value="TestSimpleTypesPrimitiveTypeMapper" />
+    <node concept="3clFb_" id="2fy$Fh$rkB$" role="jymVt">
+      <property role="TrG5h" value="removeStringTypeWithConstraint" />
+      <node concept="3clFbS" id="2fy$Fh$rkBA" role="3clF47">
+        <node concept="3clFbF" id="2fy$Fh$rlbi" role="3cqZAp">
+          <node concept="3nyPlj" id="2fy$Fh$rlbg" role="3clFbG">
+            <ref role="37wK5l" to="9mim:2fy$Fh$rd4_" resolve="removeStringTypeWithConstraint" />
+            <node concept="37vLTw" id="2fy$Fh$rlGl" role="37wK5m">
+              <ref role="3cqZAo" node="2fy$Fh$rkBG" resolve="resultTypes" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2I9FWS" id="2fy$Fh$rkBF" role="3clF45" />
+      <node concept="37vLTG" id="2fy$Fh$rkBG" role="3clF46">
+        <property role="TrG5h" value="resultTypes" />
+        <node concept="2I9FWS" id="2fy$Fh$rkBH" role="1tU5fm" />
+      </node>
+      <node concept="3Tmbuc" id="2fy$Fh$rlPc" role="1B3o_S" />
+    </node>
+    <node concept="3Tm1VV" id="2fy$Fh$r6Gb" role="1B3o_S" />
+    <node concept="3uibUv" id="2fy$Fh$r6Hg" role="1zkMxy">
+      <ref role="3uigEE" to="9mim:3p6$WoErNuK" resolve="SimpleTypesPrimitiveTypeMapper" />
+    </node>
+  </node>
   <node concept="1lH9Xt" id="4IUq0ZMxZMr">
     <property role="3DII0k" value="2hh8MJdVwqX/command" />
     <property role="TrG5h" value="SupertypeComputer" />
@@ -5442,32 +5462,6 @@
           </node>
         </node>
       </node>
-    </node>
-  </node>
-  <node concept="312cEu" id="2fy$Fh$r6Ga">
-    <property role="TrG5h" value="TestSimpleTypesPrimitiveTypeMapper" />
-    <node concept="3clFb_" id="2fy$Fh$rkB$" role="jymVt">
-      <property role="TrG5h" value="removeStringTypeWithConstraint" />
-      <node concept="3clFbS" id="2fy$Fh$rkBA" role="3clF47">
-        <node concept="3clFbF" id="2fy$Fh$rlbi" role="3cqZAp">
-          <node concept="3nyPlj" id="2fy$Fh$rlbg" role="3clFbG">
-            <ref role="37wK5l" to="9mim:2fy$Fh$rd4_" resolve="removeStringTypeWithConstraint" />
-            <node concept="37vLTw" id="2fy$Fh$rlGl" role="37wK5m">
-              <ref role="3cqZAo" node="2fy$Fh$rkBG" resolve="resultTypes" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2I9FWS" id="2fy$Fh$rkBF" role="3clF45" />
-      <node concept="37vLTG" id="2fy$Fh$rkBG" role="3clF46">
-        <property role="TrG5h" value="resultTypes" />
-        <node concept="2I9FWS" id="2fy$Fh$rkBH" role="1tU5fm" />
-      </node>
-      <node concept="3Tmbuc" id="2fy$Fh$rlPc" role="1B3o_S" />
-    </node>
-    <node concept="3Tm1VV" id="2fy$Fh$r6Gb" role="1B3o_S" />
-    <node concept="3uibUv" id="2fy$Fh$r6Hg" role="1zkMxy">
-      <ref role="3uigEE" to="9mim:3p6$WoErNuK" resolve="SimpleTypesPrimitiveTypeMapper" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.base@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.base@tests.mps
@@ -27,9 +27,6 @@
         <reference id="8333855927540250453" name="declaration" index="39XzEq" />
       </concept>
       <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -260,9 +257,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="6powCZkaIEt">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="1lH9Xt" id="59R2joRHWCX">
     <property role="3DII0k" value="2hh8MJdVwqX/command" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.bindingtimes@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.bindingtimes@tests.mps
@@ -24,9 +24,6 @@
         <reference id="8333855927540250453" name="declaration" index="39XzEq" />
       </concept>
       <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -365,9 +362,6 @@
         <node concept="_ixoA" id="2ahKK8r1NA8" role="_iOnB" />
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="39Wr1SsNbgB">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="1lH9Xt" id="1CvMCa_pvyR">
     <property role="TrG5h" value="CycleDetection" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.phyunits@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.phyunits@tests.mps
@@ -78,9 +78,6 @@
       <concept id="4649457259824807647" name="jetbrains.mps.lang.test.structure.TypesystemEquationReference" flags="ng" index="MGsTx" />
       <concept id="4531408400486526326" name="jetbrains.mps.lang.test.structure.WarningStatementReference" flags="ng" index="2PQEqo" />
       <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1225469856668" name="jetbrains.mps.lang.test.structure.ModelExpression" flags="nn" index="1jGwE1" />
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
@@ -1104,9 +1101,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="1HLccB8ALk3">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="1lH9Xt" id="1fzaMYHrHpe">
     <property role="TrG5h" value="ExpressionsPart2" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.records@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.records@tests.mps
@@ -22,9 +22,6 @@
       <concept id="1215607067978" name="jetbrains.mps.lang.test.structure.CheckNodeForErrorMessagesOperation" flags="ng" index="7OXhh">
         <property id="3743352646565420194" name="includeSelf" index="GvXf4" />
       </concept>
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1216993439383" name="methods" index="1qtyYc" />
@@ -385,9 +382,6 @@
         <node concept="_ixoA" id="5FFsEXIecoe" role="_iOnB" />
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="1lH9Xt" id="4Ab6HDmqyCz">
     <property role="TrG5h" value="RecordValueTest" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.temporal@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.temporal@tests.mps
@@ -34,9 +34,6 @@
       </concept>
       <concept id="4531408400486526326" name="jetbrains.mps.lang.test.structure.WarningStatementReference" flags="ng" index="2PQEqo" />
       <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -616,9 +613,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -80,9 +80,6 @@
       <concept id="4649457259824807647" name="jetbrains.mps.lang.test.structure.TypesystemEquationReference" flags="ng" index="MGsTx" />
       <concept id="4531408400486526326" name="jetbrains.mps.lang.test.structure.WarningStatementReference" flags="ng" index="2PQEqo" />
       <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="8333855927540283103" name="jetbrains.mps.lang.test.structure.NodeConstraintsErrorCheckOperation" flags="ng" index="39XrGg">
         <child id="8333855927548182241" name="errorRef" index="39rjcI" />
       </concept>
@@ -3731,9 +3728,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="1lH9Xt" id="TuTPrvFMnN">
     <property role="TrG5h" value="alt" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/typetags@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/typetags@tests.mps
@@ -29,9 +29,6 @@
       </concept>
       <concept id="428590876651279930" name="jetbrains.mps.lang.test.structure.NodeTypeSystemErrorCheckOperation" flags="ng" index="2DdRWr" />
       <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -170,9 +167,6 @@
       </concept>
     </language>
   </registry>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
-  </node>
   <node concept="1lH9Xt" id="x_aN5M7h83">
     <property role="TrG5h" value="classificationOnly" />
     <property role="3DII0k" value="2hh8MJdVwqX/command" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/unitsonly@tests.mps
@@ -58,9 +58,6 @@
       </concept>
       <concept id="428590876651279930" name="jetbrains.mps.lang.test.structure.NodeTypeSystemErrorCheckOperation" flags="ng" index="2DdRWr" />
       <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="2325284917965993569" name="beforeTests" index="0EEgL" />
@@ -5923,9 +5920,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="4rZeNQ6M9GV">
-    <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
   </node>
   <node concept="_iOnV" id="2JXkwhJfMDf">
     <property role="TrG5h" value="UnitsAndConversions" />


### PR DESCRIPTION
`TestInfo` nodes are not necessary anymore since the project path is set in the build script directly.