### PR TITLE
physunits: allow mixing quantities with different prefixes through IUnitLangConfig#implicitConversionIsEnabledAt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 - Hexadecimal attributes are now better visible in the diff view.
 - Negative decimal values are now correctly converted to hexadecimal values.
 
-### Changes
+### Changed
 
 - It is now possible to customize where hex values are enabled. With PrimitiveTypeMapper#filterHexadecimalSupportingNodes you can now enable/disable them for specific nodes.
+
+### Added
+
+- If two quantities are compatible but implicit conversions are not enabled, this check can now be disabled through setting `IUnitLangConfig#allowMixingUnitPrefixesWithoutConversions` to true for the `PhysUnitLangConfig` extension point.
 
 ## October 2024
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
@@ -596,10 +596,7 @@
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
-      <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7">
-        <property id="8575328350543493365" name="message" index="huDt6" />
-        <property id="2423417345669755629" name="filter" index="1eyWvh" />
-      </concept>
+      <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7" />
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
       <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
@@ -4874,6 +4871,52 @@
           </node>
         </node>
         <node concept="3clFbH" id="2Ux6GHgYavD" role="3cqZAp" />
+        <node concept="3SKdUt" id="5zjZVcti4Mr" role="3cqZAp">
+          <node concept="1PaTwC" id="5zjZVcti4Ms" role="1aUNEU">
+            <node concept="3oM_SD" id="5zjZVcti5E1" role="1PaTwD">
+              <property role="3oM_SC" value="deprecated" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVcti5E2" role="1PaTwD">
+              <property role="3oM_SC" value="getInstance" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVcti5E3" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVcti5E4" role="1PaTwD">
+              <property role="3oM_SC" value="necessary" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVcti5E5" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVcti5E6" role="1PaTwD">
+              <property role="3oM_SC" value="ensure" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVcti5E7" role="1PaTwD">
+              <property role="3oM_SC" value="compatibility" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVcti5E8" role="1PaTwD">
+              <property role="3oM_SC" value="with" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVcti5E9" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVcti5Ea" role="1PaTwD">
+              <property role="3oM_SC" value="command-line" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVcti5Eb" role="1PaTwD">
+              <property role="3oM_SC" value="generator" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVcti5Ec" role="1PaTwD">
+              <property role="3oM_SC" value="execution" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVcti5Ed" role="1PaTwD">
+              <property role="3oM_SC" value="(MpsEnvironment)" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVcti5DZ" role="1PaTwD">
+              <property role="3oM_SC" value="" />
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="4wvzrd4Fadu" role="3cqZAp">
           <node concept="3cpWsn" id="4wvzrd4Fadv" role="3cpWs9">
             <property role="TrG5h" value="repository" />
@@ -7769,10 +7812,8 @@
           </node>
         </node>
       </node>
-      <node concept="_YKpA" id="4jkbLB63Lsl" role="3clF45">
-        <node concept="3Tqbb2" id="4jkbLB63LOI" role="_ZDj9">
-          <ref role="ehGHo" to="i3ya:7athFveEYHG" resolve="UnitExpression" />
-        </node>
+      <node concept="2I9FWS" id="5zjZVctrBox" role="3clF45">
+        <ref role="2I9WkF" to="i3ya:7athFveEYHG" resolve="UnitExpression" />
       </node>
     </node>
     <node concept="2tJIrI" id="4jkbLB61hJe" role="jymVt" />
@@ -9167,16 +9208,17 @@
                 <ref role="3Tt5mk" to="i3ya:7eOyx9r3qG3" resolve="specification" />
               </node>
             </node>
-            <node concept="1rXfSq" id="7dduDjLgU0m" role="37vLTx">
-              <ref role="37wK5l" node="7dduDjL8xAO" resolve="createUnitMultiplication" />
-              <node concept="37vLTw" id="7dduDjLgXlK" role="37wK5m">
-                <ref role="3cqZAo" node="6q$NxWeYcv3" resolve="unitRefs" />
+            <node concept="1PxgMI" id="5zjZVcts1pc" role="37vLTx">
+              <node concept="chp4Y" id="5zjZVcts6$v" role="3oSUPX">
+                <ref role="cht4Q" to="i3ya:7athFveEYHG" resolve="UnitExpression" />
+              </node>
+              <node concept="1rXfSq" id="7dduDjLgU0m" role="1m5AlR">
+                <ref role="37wK5l" node="7dduDjL8xAO" resolve="createUnitMultiplication" />
+                <node concept="37vLTw" id="7dduDjLgXlK" role="37wK5m">
+                  <ref role="3cqZAo" node="6q$NxWeYcv3" resolve="unitRefs" />
+                </node>
               </node>
             </node>
-          </node>
-          <node concept="15s5l7" id="4esM_INBtf_" role="lGtFl">
-            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;" />
-            <property role="huDt6" value="all typesystem messages" />
           </node>
         </node>
         <node concept="3cpWs6" id="6q$NxWeYcvl" role="3cqZAp">
@@ -9274,10 +9316,8 @@
       </node>
       <node concept="37vLTG" id="7dduDjL8_GQ" role="3clF46">
         <property role="TrG5h" value="unitExprs" />
-        <node concept="_YKpA" id="7dduDjL8_GO" role="1tU5fm">
-          <node concept="3Tqbb2" id="7dduDjL8EGs" role="_ZDj9">
-            <ref role="ehGHo" to="i3ya:45a4DYZTq2h" resolve="IGroupLike" />
-          </node>
+        <node concept="2I9FWS" id="5zjZVctruRz" role="1tU5fm">
+          <ref role="2I9WkF" to="i3ya:45a4DYZTq2h" resolve="IGroupLike" />
         </node>
       </node>
     </node>
@@ -9397,10 +9437,8 @@
         </node>
       </node>
       <node concept="3Tm1VV" id="28ZCOKTZGej" role="1B3o_S" />
-      <node concept="_YKpA" id="28ZCOKTZNQp" role="3clF45">
-        <node concept="3Tqbb2" id="28ZCOKTZQDS" role="_ZDj9">
-          <ref role="ehGHo" to="i3ya:7athFveEYHG" resolve="UnitExpression" />
-        </node>
+      <node concept="2I9FWS" id="5zjZVctrGVS" role="3clF45">
+        <ref role="2I9WkF" to="i3ya:7athFveEYHG" resolve="UnitExpression" />
       </node>
       <node concept="37vLTG" id="28ZCOKTZV_K" role="3clF46">
         <property role="TrG5h" value="expr" />
@@ -9693,6 +9731,61 @@
             </node>
           </node>
         </node>
+        <node concept="3SKdUt" id="5zjZVctiMcU" role="3cqZAp">
+          <node concept="1PaTwC" id="5zjZVctiMcV" role="1aUNEU">
+            <node concept="3oM_SD" id="5zjZVctiRZp" role="1PaTwD">
+              <property role="3oM_SC" value="deprecated" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVctiRZq" role="1PaTwD">
+              <property role="3oM_SC" value="getInstance" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVctiRZr" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVctiRZs" role="1PaTwD">
+              <property role="3oM_SC" value="necessary" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVctiRZt" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVctiRZu" role="1PaTwD">
+              <property role="3oM_SC" value="ensure" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVctiRZv" role="1PaTwD">
+              <property role="3oM_SC" value="compatibility" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVctiRZw" role="1PaTwD">
+              <property role="3oM_SC" value="with" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVctiRZx" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVctiRZy" role="1PaTwD">
+              <property role="3oM_SC" value="command-line" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVctiRZz" role="1PaTwD">
+              <property role="3oM_SC" value="generator" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVctiRZ$" role="1PaTwD">
+              <property role="3oM_SC" value="execution" />
+            </node>
+            <node concept="3oM_SD" id="5zjZVctiRZ_" role="1PaTwD">
+              <property role="3oM_SC" value="(MpsEnvironment)" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5zjZVctioiE" role="3cqZAp">
+          <node concept="3cpWsn" id="5zjZVctioiF" role="3cpWs9">
+            <property role="TrG5h" value="classLoaderManager" />
+            <node concept="3uibUv" id="5zjZVctiaXu" role="1tU5fm">
+              <ref role="3uigEE" to="3qmy:~ClassLoaderManager" resolve="ClassLoaderManager" />
+            </node>
+            <node concept="2YIFZM" id="5zjZVctioiG" role="33vP2m">
+              <ref role="37wK5l" to="3qmy:~ClassLoaderManager.getInstance()" resolve="getInstance" />
+              <ref role="1Pybhc" to="3qmy:~ClassLoaderManager" resolve="ClassLoaderManager" />
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="4P6r3pewrDc" role="3cqZAp">
           <node concept="3cpWsn" id="4P6r3pewrDd" role="3cpWs9">
             <property role="TrG5h" value="typeChecking" />
@@ -9712,9 +9805,8 @@
                     <ref role="37wK5l" to="u78q:~TypeChecker.getTypeCheckerHelper()" resolve="getTypeCheckerHelper" />
                   </node>
                 </node>
-                <node concept="2YIFZM" id="6sSKyiUq00K" role="37wK5m">
-                  <ref role="37wK5l" to="3qmy:~ClassLoaderManager.getInstance()" resolve="getInstance" />
-                  <ref role="1Pybhc" to="3qmy:~ClassLoaderManager" resolve="ClassLoaderManager" />
+                <node concept="37vLTw" id="5zjZVctioiH" role="37wK5m">
+                  <ref role="3cqZAo" node="5zjZVctioiF" resolve="instance" />
                 </node>
               </node>
             </node>
@@ -10776,6 +10868,61 @@
         </node>
         <node concept="3clFbJ" id="3_TFq$0_vSL" role="3cqZAp">
           <node concept="3clFbS" id="3_TFq$0_vSM" role="3clFbx">
+            <node concept="3SKdUt" id="5zjZVcthEyb" role="3cqZAp">
+              <node concept="1PaTwC" id="5zjZVcthEyc" role="1aUNEU">
+                <node concept="3oM_SD" id="5zjZVcti1HI" role="1PaTwD">
+                  <property role="3oM_SC" value="deprecated" />
+                </node>
+                <node concept="3oM_SD" id="5zjZVcthPJv" role="1PaTwD">
+                  <property role="3oM_SC" value="getInstance" />
+                </node>
+                <node concept="3oM_SD" id="5zjZVcthPLS" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="5zjZVcthPOh" role="1PaTwD">
+                  <property role="3oM_SC" value="necessary" />
+                </node>
+                <node concept="3oM_SD" id="5zjZVcthPOi" role="1PaTwD">
+                  <property role="3oM_SC" value="to" />
+                </node>
+                <node concept="3oM_SD" id="5zjZVcthPPv" role="1PaTwD">
+                  <property role="3oM_SC" value="ensure" />
+                </node>
+                <node concept="3oM_SD" id="5zjZVcthPQG" role="1PaTwD">
+                  <property role="3oM_SC" value="compatibility" />
+                </node>
+                <node concept="3oM_SD" id="5zjZVcthPRT" role="1PaTwD">
+                  <property role="3oM_SC" value="with" />
+                </node>
+                <node concept="3oM_SD" id="5zjZVcthPRU" role="1PaTwD">
+                  <property role="3oM_SC" value="the" />
+                </node>
+                <node concept="3oM_SD" id="5zjZVcthQ7s" role="1PaTwD">
+                  <property role="3oM_SC" value="command-line" />
+                </node>
+                <node concept="3oM_SD" id="5zjZVcthPWH" role="1PaTwD">
+                  <property role="3oM_SC" value="generator" />
+                </node>
+                <node concept="3oM_SD" id="5zjZVcthPXU" role="1PaTwD">
+                  <property role="3oM_SC" value="execution" />
+                </node>
+                <node concept="3oM_SD" id="5zjZVcthPXV" role="1PaTwD">
+                  <property role="3oM_SC" value="(MpsEnvironment)" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="5zjZVcthJ9j" role="3cqZAp">
+              <node concept="3cpWsn" id="5zjZVcthJ9k" role="3cpWs9">
+                <property role="TrG5h" value="classLoaderManager" />
+                <node concept="3uibUv" id="5zjZVcthFgf" role="1tU5fm">
+                  <ref role="3uigEE" to="3qmy:~ClassLoaderManager" resolve="ClassLoaderManager" />
+                </node>
+                <node concept="2YIFZM" id="5zjZVcthJ9l" role="33vP2m">
+                  <ref role="37wK5l" to="3qmy:~ClassLoaderManager.getInstance()" resolve="getInstance" />
+                  <ref role="1Pybhc" to="3qmy:~ClassLoaderManager" resolve="ClassLoaderManager" />
+                </node>
+              </node>
+            </node>
             <node concept="3cpWs8" id="5pqsPq42MOm" role="3cqZAp">
               <node concept="3cpWsn" id="5pqsPq42MOn" role="3cpWs9">
                 <property role="TrG5h" value="typeChecking" />
@@ -10795,9 +10942,8 @@
                         <ref role="37wK5l" to="u78q:~TypeChecker.getTypeCheckerHelper()" resolve="getTypeCheckerHelper" />
                       </node>
                     </node>
-                    <node concept="2YIFZM" id="6sSKyiUpdcc" role="37wK5m">
-                      <ref role="37wK5l" to="3qmy:~ClassLoaderManager.getInstance()" resolve="getInstance" />
-                      <ref role="1Pybhc" to="3qmy:~ClassLoaderManager" resolve="ClassLoaderManager" />
+                    <node concept="37vLTw" id="5zjZVcthJ9m" role="37wK5m">
+                      <ref role="3cqZAo" node="5zjZVcthJ9k" resolve="instance" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
@@ -9676,6 +9676,22 @@
     <node concept="2YIFZL" id="5X7HQPSGcOs" role="jymVt">
       <property role="TrG5h" value="createConversionSpecifierForPrefixedUnitReferences" />
       <node concept="3clFbS" id="5X7HQPSGcOv" role="3clF47">
+        <node concept="3cpWs8" id="2UCp54UXT_G" role="3cqZAp">
+          <node concept="3cpWsn" id="2UCp54UXT_H" role="3cpWs9">
+            <property role="TrG5h" value="expression" />
+            <node concept="3Tqbb2" id="2UCp54UXG55" role="1tU5fm">
+              <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+            </node>
+            <node concept="2OqwBi" id="2UCp54UXT_I" role="33vP2m">
+              <node concept="37vLTw" id="2UCp54UXT_J" role="2Oq$k0">
+                <ref role="3cqZAo" node="5X7HQPSGCgW" resolve="convertUnit" />
+              </node>
+              <node concept="2qgKlT" id="2UCp54UXT_K" role="2OqNvi">
+                <ref role="37wK5l" node="7SygLIkQnGn" resolve="getExpression" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="4P6r3pewrDc" role="3cqZAp">
           <node concept="3cpWsn" id="4P6r3pewrDd" role="3cpWs9">
             <property role="TrG5h" value="typeChecking" />
@@ -9686,13 +9702,8 @@
               <node concept="1pGfFk" id="4P6r3pewrDg" role="2ShVmc">
                 <property role="373rjd" value="true" />
                 <ref role="37wK5l" to="evo:~IncrementalTypecheckingContext.&lt;init&gt;(org.jetbrains.mps.openapi.model.SNode,jetbrains.mps.typesystem.inference.TypeCheckerHelper,jetbrains.mps.classloading.ClassLoaderManager)" resolve="IncrementalTypecheckingContext" />
-                <node concept="2OqwBi" id="4P6r3pewtH5" role="37wK5m">
-                  <node concept="37vLTw" id="4P6r3pewtH6" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5X7HQPSGCgW" resolve="convertUnit" />
-                  </node>
-                  <node concept="2qgKlT" id="4P6r3pewtH7" role="2OqNvi">
-                    <ref role="37wK5l" node="7SygLIkQnGn" resolve="getExpression" />
-                  </node>
+                <node concept="37vLTw" id="2UCp54UXT_L" role="37wK5m">
+                  <ref role="3cqZAo" node="2UCp54UXT_H" resolve="expression" />
                 </node>
                 <node concept="2OqwBi" id="4P6r3pewrDk" role="37wK5m">
                   <node concept="2QUAEa" id="4P6r3pewrDl" role="2Oq$k0" />
@@ -9714,8 +9725,11 @@
               <ref role="3cqZAo" node="4P6r3pewrDd" resolve="typeChecking" />
             </node>
             <node concept="liA8E" id="4P6r3pewrDw" role="2OqNvi">
-              <ref role="37wK5l" to="u78q:~TypeCheckingContext.checkRoot(boolean)" resolve="checkRoot" />
-              <node concept="3clFbT" id="4P6r3pewrDx" role="37wK5m" />
+              <ref role="37wK5l" to="u78q:~TypeCheckingContext.checkIfNotChecked(org.jetbrains.mps.openapi.model.SNode,boolean)" resolve="checkIfNotChecked" />
+              <node concept="37vLTw" id="2UCp54UY6uD" role="37wK5m">
+                <ref role="3cqZAo" node="2UCp54UXT_H" resolve="expression" />
+              </node>
+              <node concept="3clFbT" id="2UCp54UYdBY" role="37wK5m" />
             </node>
           </node>
         </node>
@@ -9729,13 +9743,8 @@
               </node>
               <node concept="liA8E" id="4P6r3pewrDB" role="2OqNvi">
                 <ref role="37wK5l" to="u78q:~TypeCheckingContext.typeOf(org.jetbrains.mps.openapi.model.SNode)" resolve="typeOf" />
-                <node concept="2OqwBi" id="4P6r3pewuaR" role="37wK5m">
-                  <node concept="37vLTw" id="4P6r3pewuaS" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5X7HQPSGCgW" resolve="convertUnit" />
-                  </node>
-                  <node concept="2qgKlT" id="4P6r3pewuaT" role="2OqNvi">
-                    <ref role="37wK5l" node="7SygLIkQnGn" resolve="getExpression" />
-                  </node>
+                <node concept="37vLTw" id="2UCp54UXT_M" role="37wK5m">
+                  <ref role="3cqZAo" node="2UCp54UXT_H" resolve="expression" />
                 </node>
               </node>
             </node>
@@ -10750,7 +10759,20 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="5X7HQPSCcpp" role="3cqZAp" />
+        <node concept="3cpWs8" id="2UCp54UW3Fx" role="3cqZAp">
+          <node concept="3cpWsn" id="2UCp54UW3Fy" role="3cpWs9">
+            <property role="TrG5h" value="expression" />
+            <node concept="3Tqbb2" id="2UCp54UW32n" role="1tU5fm">
+              <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
+            </node>
+            <node concept="2OqwBi" id="2UCp54UW3Fz" role="33vP2m">
+              <node concept="13iPFW" id="2UCp54UW3F$" role="2Oq$k0" />
+              <node concept="2qgKlT" id="2UCp54UW3F_" role="2OqNvi">
+                <ref role="37wK5l" node="7SygLIkQnGn" resolve="getExpression" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbJ" id="3_TFq$0_vSL" role="3cqZAp">
           <node concept="3clFbS" id="3_TFq$0_vSM" role="3clFbx">
             <node concept="3cpWs8" id="5pqsPq42MOm" role="3cqZAp">
@@ -10763,11 +10785,8 @@
                   <node concept="1pGfFk" id="5pqsPq4jsma" role="2ShVmc">
                     <property role="373rjd" value="true" />
                     <ref role="37wK5l" to="evo:~IncrementalTypecheckingContext.&lt;init&gt;(org.jetbrains.mps.openapi.model.SNode,jetbrains.mps.typesystem.inference.TypeCheckerHelper,jetbrains.mps.classloading.ClassLoaderManager)" resolve="IncrementalTypecheckingContext" />
-                    <node concept="2OqwBi" id="5pqsPq4m$Ct" role="37wK5m">
-                      <node concept="13iPFW" id="5pqsPq4m$Cu" role="2Oq$k0" />
-                      <node concept="2qgKlT" id="5pqsPq4m$Cv" role="2OqNvi">
-                        <ref role="37wK5l" node="7SygLIkQnGn" resolve="getExpression" />
-                      </node>
+                    <node concept="37vLTw" id="2UCp54UW3FA" role="37wK5m">
+                      <ref role="3cqZAo" node="2UCp54UW3Fy" resolve="expression" />
                     </node>
                     <node concept="2OqwBi" id="5pqsPq4jvSq" role="37wK5m">
                       <node concept="2QUAEa" id="5pqsPq4jvDn" role="2Oq$k0" />
@@ -10789,8 +10808,11 @@
                   <ref role="3cqZAo" node="5pqsPq42MOn" resolve="typeChecking" />
                 </node>
                 <node concept="liA8E" id="5pqsPq4t7Z4" role="2OqNvi">
-                  <ref role="37wK5l" to="u78q:~TypeCheckingContext.checkRoot(boolean)" resolve="checkRoot" />
-                  <node concept="3clFbT" id="5pqsPq4t9oT" role="37wK5m" />
+                  <ref role="37wK5l" to="u78q:~TypeCheckingContext.checkIfNotChecked(org.jetbrains.mps.openapi.model.SNode,boolean)" resolve="checkIfNotChecked" />
+                  <node concept="37vLTw" id="2UCp54UW8Hx" role="37wK5m">
+                    <ref role="3cqZAo" node="2UCp54UW3Fy" resolve="expression" />
+                  </node>
+                  <node concept="3clFbT" id="2UCp54UWbnN" role="37wK5m" />
                 </node>
               </node>
             </node>
@@ -10804,11 +10826,8 @@
                   </node>
                   <node concept="liA8E" id="5pqsPq4my1P" role="2OqNvi">
                     <ref role="37wK5l" to="u78q:~TypeCheckingContext.typeOf(org.jetbrains.mps.openapi.model.SNode)" resolve="typeOf" />
-                    <node concept="2OqwBi" id="5X7HQPSJuZk" role="37wK5m">
-                      <node concept="13iPFW" id="5X7HQPSJuZl" role="2Oq$k0" />
-                      <node concept="2qgKlT" id="5X7HQPSJuZm" role="2OqNvi">
-                        <ref role="37wK5l" node="7SygLIkQnGn" resolve="getExpression" />
-                      </node>
+                    <node concept="37vLTw" id="2UCp54UW3FC" role="37wK5m">
+                      <ref role="3cqZAo" node="2UCp54UW3Fy" resolve="expression" />
                     </node>
                   </node>
                 </node>
@@ -11353,10 +11372,10 @@
               </node>
             </node>
             <node concept="3y3z36" id="3_TFq$0_wG$" role="3uHU7B">
-              <node concept="BsUDl" id="7SygLIkQp_g" role="3uHU7B">
-                <ref role="37wK5l" node="7SygLIkQnGn" resolve="getExpression" />
-              </node>
               <node concept="10Nm6u" id="3_TFq$0_wHn" role="3uHU7w" />
+              <node concept="37vLTw" id="2UCp54UW6iD" role="3uHU7B">
+                <ref role="3cqZAo" node="2UCp54UW3Fy" resolve="expression" />
+              </node>
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
@@ -9806,6 +9806,114 @@
             </node>
           </node>
           <node concept="3clFbS" id="5X7HQPSGrDF" role="Jncv_">
+            <node concept="3cpWs8" id="6u5vaA8jyrb" role="3cqZAp">
+              <node concept="3cpWsn" id="6u5vaA8jyrc" role="3cpWs9">
+                <property role="TrG5h" value="sourceUnitMapCopy" />
+                <node concept="3rvAFt" id="6u5vaA8jtox" role="1tU5fm">
+                  <node concept="3uibUv" id="6u5vaA8jtoB" role="3rvSg0">
+                    <ref role="3uigEE" to="xfg9:5dSoB2LMRlC" resolve="Fraction" />
+                  </node>
+                  <node concept="3uibUv" id="6u5vaA8jtoA" role="3rvQeY">
+                    <ref role="3uigEE" node="6O1cltdz00u" resolve="NamedKeyWrapper" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6u5vaA8oQUJ" role="33vP2m">
+                  <node concept="3rGOSV" id="6u5vaA8oW9V" role="2ShVmc">
+                    <node concept="3uibUv" id="6u5vaA8p5$5" role="3rHrn6">
+                      <ref role="3uigEE" node="6O1cltdz00u" resolve="NamedKeyWrapper" />
+                    </node>
+                    <node concept="3uibUv" id="6u5vaA8pe5T" role="3rHtpV">
+                      <ref role="3uigEE" to="xfg9:5dSoB2LMRlC" resolve="Fraction" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2Gpval" id="6u5vaA8pxg5" role="3cqZAp">
+              <node concept="2GrKxI" id="6u5vaA8pxg7" role="2Gsz3X">
+                <property role="TrG5h" value="entry" />
+              </node>
+              <node concept="37vLTw" id="6u5vaA8pMKr" role="2GsD0m">
+                <ref role="3cqZAo" node="5X7HQPSHvT8" resolve="sourceUnitMap" />
+              </node>
+              <node concept="3clFbS" id="6u5vaA8pxgb" role="2LFqv$">
+                <node concept="3clFbF" id="6u5vaA8q0gR" role="3cqZAp">
+                  <node concept="37vLTI" id="6u5vaA8qDaR" role="3clFbG">
+                    <node concept="2OqwBi" id="6u5vaA8qGcZ" role="37vLTx">
+                      <node concept="2GrUjf" id="6u5vaA8qENH" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="6u5vaA8pxg7" resolve="entry" />
+                      </node>
+                      <node concept="3AV6Ez" id="6u5vaA8qOqc" role="2OqNvi" />
+                    </node>
+                    <node concept="3EllGN" id="6u5vaA8q908" role="37vLTJ">
+                      <node concept="2OqwBi" id="6u5vaA8qqMP" role="3ElVtu">
+                        <node concept="2GrUjf" id="6u5vaA8qpzf" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="6u5vaA8pxg7" resolve="entry" />
+                        </node>
+                        <node concept="3AY5_j" id="6u5vaA8qyZf" role="2OqNvi" />
+                      </node>
+                      <node concept="37vLTw" id="6u5vaA8q0gQ" role="3ElQJh">
+                        <ref role="3cqZAo" node="6u5vaA8jyrc" resolve="sourceUnitMapCopy" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="6u5vaA8qWbE" role="3cqZAp">
+              <node concept="3cpWsn" id="6u5vaA8qWbF" role="3cpWs9">
+                <property role="TrG5h" value="targetUnitMapCopy" />
+                <node concept="3rvAFt" id="6u5vaA8qWbG" role="1tU5fm">
+                  <node concept="3uibUv" id="6u5vaA8qWbH" role="3rvSg0">
+                    <ref role="3uigEE" to="xfg9:5dSoB2LMRlC" resolve="Fraction" />
+                  </node>
+                  <node concept="3uibUv" id="6u5vaA8qWbI" role="3rvQeY">
+                    <ref role="3uigEE" node="6O1cltdz00u" resolve="NamedKeyWrapper" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="6u5vaA8qWbJ" role="33vP2m">
+                  <node concept="3rGOSV" id="6u5vaA8qWbK" role="2ShVmc">
+                    <node concept="3uibUv" id="6u5vaA8qWbL" role="3rHrn6">
+                      <ref role="3uigEE" node="6O1cltdz00u" resolve="NamedKeyWrapper" />
+                    </node>
+                    <node concept="3uibUv" id="6u5vaA8qWbM" role="3rHtpV">
+                      <ref role="3uigEE" to="xfg9:5dSoB2LMRlC" resolve="Fraction" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2Gpval" id="6u5vaA8qWbN" role="3cqZAp">
+              <node concept="2GrKxI" id="6u5vaA8qWbO" role="2Gsz3X">
+                <property role="TrG5h" value="entry" />
+              </node>
+              <node concept="37vLTw" id="6u5vaA8qWbP" role="2GsD0m">
+                <ref role="3cqZAo" node="5X7HQPSHJpu" resolve="targetUnitMap" />
+              </node>
+              <node concept="3clFbS" id="6u5vaA8qWbQ" role="2LFqv$">
+                <node concept="3clFbF" id="6u5vaA8qWbR" role="3cqZAp">
+                  <node concept="37vLTI" id="6u5vaA8qWbS" role="3clFbG">
+                    <node concept="2OqwBi" id="6u5vaA8qWbT" role="37vLTx">
+                      <node concept="2GrUjf" id="6u5vaA8qWbU" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="6u5vaA8qWbO" resolve="entry" />
+                      </node>
+                      <node concept="3AV6Ez" id="6u5vaA8qWbV" role="2OqNvi" />
+                    </node>
+                    <node concept="3EllGN" id="6u5vaA8qWbW" role="37vLTJ">
+                      <node concept="2OqwBi" id="6u5vaA8qWbX" role="3ElVtu">
+                        <node concept="2GrUjf" id="6u5vaA8qWbY" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="6u5vaA8qWbO" resolve="entry" />
+                        </node>
+                        <node concept="3AY5_j" id="6u5vaA8qWbZ" role="2OqNvi" />
+                      </node>
+                      <node concept="37vLTw" id="6u5vaA8qWc0" role="3ElQJh">
+                        <ref role="3cqZAo" node="6u5vaA8qWbF" resolve="sourceUnitMapCopy" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
             <node concept="2Gpval" id="3oHM6lDP5Mz" role="3cqZAp">
               <node concept="2GrKxI" id="3oHM6lDP5M_" role="2Gsz3X">
                 <property role="TrG5h" value="sourceUnitMapping" />
@@ -9831,7 +9939,7 @@
                     <node concept="3clFbF" id="2FchHsQdGlR" role="3cqZAp">
                       <node concept="2OqwBi" id="2FchHsQdHwk" role="3clFbG">
                         <node concept="37vLTw" id="2FchHsQdGlP" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5X7HQPSHvT8" resolve="sourceUnitMap" />
+                          <ref role="3cqZAo" node="6u5vaA8jyrc" resolve="sourceUnitMapCopy" />
                         </node>
                         <node concept="kI3uX" id="2FchHsQdIMa" role="2OqNvi">
                           <node concept="2OqwBi" id="2FchHsQdPgl" role="kIiFs">
@@ -9867,7 +9975,7 @@
                             </node>
                           </node>
                           <node concept="37vLTw" id="2FchHsQdV$3" role="3ElQJh">
-                            <ref role="3cqZAo" node="5X7HQPSHvT8" resolve="sourceUnitMap" />
+                            <ref role="3cqZAo" node="6u5vaA8jyrc" resolve="sourceUnitMapCopy" />
                           </node>
                         </node>
                       </node>
@@ -9905,7 +10013,7 @@
                     <node concept="3clFbF" id="2FchHsQf2d0" role="3cqZAp">
                       <node concept="2OqwBi" id="2FchHsQf2d1" role="3clFbG">
                         <node concept="37vLTw" id="2FchHsQf2d2" role="2Oq$k0">
-                          <ref role="3cqZAo" node="5X7HQPSHJpu" resolve="targetUnitMap" />
+                          <ref role="3cqZAo" node="6u5vaA8qWbF" resolve="targetUnitMapCopy" />
                         </node>
                         <node concept="kI3uX" id="2FchHsQf2d3" role="2OqNvi">
                           <node concept="2OqwBi" id="2FchHsQf2d4" role="kIiFs">
@@ -9941,7 +10049,7 @@
                             </node>
                           </node>
                           <node concept="37vLTw" id="2FchHsQf2di" role="3ElQJh">
-                            <ref role="3cqZAo" node="5X7HQPSHJpu" resolve="targetUnitMap" />
+                            <ref role="3cqZAo" node="6u5vaA8qWbF" resolve="targetUnitMapCopy" />
                           </node>
                         </node>
                       </node>
@@ -10322,10 +10430,10 @@
                   <ref role="37wK5l" node="4jkbLB5XZz4" resolve="matchingMappings" />
                   <ref role="1Pybhc" node="4jkbLB5RJZL" resolve="UnitConversionUtil" />
                   <node concept="37vLTw" id="5X7HQPSGrFc" role="37wK5m">
-                    <ref role="3cqZAo" node="5X7HQPSHvT8" resolve="sourceUnitMap" />
+                    <ref role="3cqZAo" node="6u5vaA8jyrc" resolve="sourceUnitMapCopy" />
                   </node>
                   <node concept="37vLTw" id="5X7HQPSGrFd" role="37wK5m">
-                    <ref role="3cqZAo" node="5X7HQPSHJpu" resolve="targetUnitMap" />
+                    <ref role="3cqZAo" node="6u5vaA8qWbF" resolve="targetUnitMapCopy" />
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
@@ -596,7 +596,10 @@
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
-      <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7" />
+      <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7">
+        <property id="8575328350543493365" name="message" index="huDt6" />
+        <property id="2423417345669755629" name="filter" index="1eyWvh" />
+      </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
       <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
@@ -7626,7 +7629,7 @@
             <node concept="2ShNRf" id="4jkbLB63NMM" role="33vP2m">
               <node concept="Tc6Ow" id="4jkbLB63NMA" role="2ShVmc">
                 <node concept="3Tqbb2" id="4jkbLB63NMB" role="HW$YZ">
-                  <ref role="ehGHo" to="i3ya:7eOyx9r3kR5" resolve="UnitReference" />
+                  <ref role="ehGHo" to="i3ya:7athFveEYHG" resolve="UnitExpression" />
                 </node>
               </node>
             </node>
@@ -9164,18 +9167,16 @@
                 <ref role="3Tt5mk" to="i3ya:7eOyx9r3qG3" resolve="specification" />
               </node>
             </node>
-            <node concept="1PxgMI" id="YaFIdpOyRE" role="37vLTx">
-              <property role="1BlNFB" value="true" />
-              <node concept="chp4Y" id="YaFIdpOBIc" role="3oSUPX">
-                <ref role="cht4Q" to="i3ya:7athFveEYHG" resolve="UnitExpression" />
-              </node>
-              <node concept="1rXfSq" id="7dduDjLgU0m" role="1m5AlR">
-                <ref role="37wK5l" node="7dduDjL8xAO" resolve="createUnitMultiplication" />
-                <node concept="37vLTw" id="7dduDjLgXlK" role="37wK5m">
-                  <ref role="3cqZAo" node="6q$NxWeYcv3" resolve="unitRefs" />
-                </node>
+            <node concept="1rXfSq" id="7dduDjLgU0m" role="37vLTx">
+              <ref role="37wK5l" node="7dduDjL8xAO" resolve="createUnitMultiplication" />
+              <node concept="37vLTw" id="7dduDjLgXlK" role="37wK5m">
+                <ref role="3cqZAo" node="6q$NxWeYcv3" resolve="unitRefs" />
               </node>
             </node>
+          </node>
+          <node concept="15s5l7" id="4esM_INBtf_" role="lGtFl">
+            <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;" />
+            <property role="huDt6" value="all typesystem messages" />
           </node>
         </node>
         <node concept="3cpWs6" id="6q$NxWeYcvl" role="3cqZAp">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
@@ -352,9 +352,6 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
-      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
-        <reference id="1116615189566" name="classifier" index="3VsUkX" />
-      </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="1200397529627" name="jetbrains.mps.baseLanguage.structure.CharConstant" flags="nn" index="1Xhbcc">
         <property id="1200397540847" name="charConstant" index="1XhdNS" />
@@ -4880,22 +4877,9 @@
             <node concept="3uibUv" id="4wvzrd4Fadw" role="1tU5fm">
               <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
             </node>
-            <node concept="2OqwBi" id="4wvzrd4Fdye" role="33vP2m">
-              <node concept="2OqwBi" id="4wvzrd4Fcgl" role="2Oq$k0">
-                <node concept="2YIFZM" id="4wvzrd4FbSN" role="2Oq$k0">
-                  <ref role="37wK5l" to="3a50:~MPSCoreComponents.getInstance()" resolve="getInstance" />
-                  <ref role="1Pybhc" to="3a50:~MPSCoreComponents" resolve="MPSCoreComponents" />
-                </node>
-                <node concept="liA8E" id="4wvzrd4Fd3P" role="2OqNvi">
-                  <ref role="37wK5l" to="3a50:~MPSCoreComponents.getPlatform()" resolve="getPlatform" />
-                </node>
-              </node>
-              <node concept="liA8E" id="4wvzrd4Fe1R" role="2OqNvi">
-                <ref role="37wK5l" to="wyuk:~ComponentHost.findComponent(java.lang.Class)" resolve="findComponent" />
-                <node concept="3VsKOn" id="4wvzrd4Fj$z" role="37wK5m">
-                  <ref role="3VsUkX" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
-                </node>
-              </node>
+            <node concept="2YIFZM" id="6sSKyiUpltu" role="33vP2m">
+              <ref role="37wK5l" to="w1kc:~MPSModuleRepository.getInstance()" resolve="getInstance" />
+              <ref role="1Pybhc" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
             </node>
           </node>
         </node>
@@ -9716,22 +9700,9 @@
                     <ref role="37wK5l" to="u78q:~TypeChecker.getTypeCheckerHelper()" resolve="getTypeCheckerHelper" />
                   </node>
                 </node>
-                <node concept="2OqwBi" id="4P6r3pewrDn" role="37wK5m">
-                  <node concept="2OqwBi" id="4P6r3pewrDo" role="2Oq$k0">
-                    <node concept="2YIFZM" id="4P6r3pewrDp" role="2Oq$k0">
-                      <ref role="37wK5l" to="3a50:~MPSCoreComponents.getInstance()" resolve="getInstance" />
-                      <ref role="1Pybhc" to="3a50:~MPSCoreComponents" resolve="MPSCoreComponents" />
-                    </node>
-                    <node concept="liA8E" id="4P6r3pewrDq" role="2OqNvi">
-                      <ref role="37wK5l" to="3a50:~MPSCoreComponents.getPlatform()" resolve="getPlatform" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="4P6r3pewrDr" role="2OqNvi">
-                    <ref role="37wK5l" to="wyuk:~ComponentHost.findComponent(java.lang.Class)" resolve="findComponent" />
-                    <node concept="3VsKOn" id="4P6r3pewrDs" role="37wK5m">
-                      <ref role="3VsUkX" to="3qmy:~ClassLoaderManager" resolve="ClassLoaderManager" />
-                    </node>
-                  </node>
+                <node concept="2YIFZM" id="6sSKyiUq00K" role="37wK5m">
+                  <ref role="37wK5l" to="3qmy:~ClassLoaderManager.getInstance()" resolve="getInstance" />
+                  <ref role="1Pybhc" to="3qmy:~ClassLoaderManager" resolve="ClassLoaderManager" />
                 </node>
               </node>
             </node>
@@ -10804,22 +10775,9 @@
                         <ref role="37wK5l" to="u78q:~TypeChecker.getTypeCheckerHelper()" resolve="getTypeCheckerHelper" />
                       </node>
                     </node>
-                    <node concept="2OqwBi" id="5pqsPq4vJod" role="37wK5m">
-                      <node concept="2OqwBi" id="5pqsPq4vJoe" role="2Oq$k0">
-                        <node concept="2YIFZM" id="5pqsPq4vJof" role="2Oq$k0">
-                          <ref role="37wK5l" to="3a50:~MPSCoreComponents.getInstance()" resolve="getInstance" />
-                          <ref role="1Pybhc" to="3a50:~MPSCoreComponents" resolve="MPSCoreComponents" />
-                        </node>
-                        <node concept="liA8E" id="5pqsPq4vJog" role="2OqNvi">
-                          <ref role="37wK5l" to="3a50:~MPSCoreComponents.getPlatform()" resolve="getPlatform" />
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="5pqsPq4vJoh" role="2OqNvi">
-                        <ref role="37wK5l" to="wyuk:~ComponentHost.findComponent(java.lang.Class)" resolve="findComponent" />
-                        <node concept="3VsKOn" id="5pqsPq4vJoi" role="37wK5m">
-                          <ref role="3VsUkX" to="3qmy:~ClassLoaderManager" resolve="ClassLoaderManager" />
-                        </node>
-                      </node>
+                    <node concept="2YIFZM" id="6sSKyiUpdcc" role="37wK5m">
+                      <ref role="37wK5l" to="3qmy:~ClassLoaderManager.getInstance()" resolve="getInstance" />
+                      <ref role="1Pybhc" to="3qmy:~ClassLoaderManager" resolve="ClassLoaderManager" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
@@ -28623,41 +28623,62 @@
             <ref role="3cqZAo" node="6O1cltdz00w" resolve="key" />
           </node>
           <node concept="3clFbS" id="3GYKef6ahjW" role="Jncv_">
-            <node concept="3clFbF" id="3GYKef6d$Ks" role="3cqZAp">
-              <node concept="37vLTI" id="3GYKef6dATL" role="3clFbG">
-                <node concept="37vLTw" id="3GYKef6d$Kq" role="37vLTJ">
-                  <ref role="3cqZAo" node="3GYKef6dzo3" resolve="hash" />
+            <node concept="3cpWs8" id="4tOoIrpGlPO" role="3cqZAp">
+              <node concept="3cpWsn" id="4tOoIrpGlPP" role="3cpWs9">
+                <property role="TrG5h" value="referencedNode" />
+                <node concept="3Tqbb2" id="4tOoIrpGlKK" role="1tU5fm">
+                  <ref role="ehGHo" to="tpck:h0TrEE$" resolve="INamedConcept" />
                 </node>
-                <node concept="3cpWs3" id="3GYKef6dEqB" role="37vLTx">
-                  <node concept="17qRlL" id="3GYKef6dCsS" role="3uHU7B">
-                    <node concept="3cmrfG" id="3GYKef6dC0x" role="3uHU7B">
-                      <property role="3cmrfH" value="31" />
-                    </node>
-                    <node concept="37vLTw" id="3GYKef6dD4B" role="3uHU7w">
-                      <ref role="3cqZAo" node="3GYKef6dzo3" resolve="hash" />
-                    </node>
+                <node concept="2OqwBi" id="4tOoIrpGlPQ" role="33vP2m">
+                  <node concept="Jnkvi" id="4tOoIrpGlPR" role="2Oq$k0">
+                    <ref role="1M0zk5" node="3GYKef6ahjX" resolve="reference" />
                   </node>
-                  <node concept="2OqwBi" id="3GYKef6dFR3" role="3uHU7w">
-                    <node concept="2JrnkZ" id="3GYKef6asxP" role="2Oq$k0">
-                      <node concept="2OqwBi" id="3GYKef6aqZr" role="2JrQYb">
-                        <node concept="Jnkvi" id="3GYKef6aq_E" role="2Oq$k0">
-                          <ref role="1M0zk5" node="3GYKef6ahjX" resolve="reference" />
-                        </node>
-                        <node concept="2qgKlT" id="3GYKef6aseR" role="2OqNvi">
-                          <ref role="37wK5l" node="6q45UTyu4YY" resolve="getReferencedNode" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="3GYKef6dGcb" role="2OqNvi">
-                      <ref role="37wK5l" to="wyt6:~Object.hashCode()" resolve="hashCode" />
-                    </node>
+                  <node concept="2qgKlT" id="4tOoIrpGlPS" role="2OqNvi">
+                    <ref role="37wK5l" node="6q45UTyu4YY" resolve="getReferencedNode" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="3cpWs6" id="3GYKef6dGze" role="3cqZAp">
-              <node concept="37vLTw" id="3GYKef6dHjI" role="3cqZAk">
-                <ref role="3cqZAo" node="3GYKef6dzo3" resolve="hash" />
+            <node concept="3clFbJ" id="4tOoIrpGmD8" role="3cqZAp">
+              <node concept="3clFbS" id="4tOoIrpGmDa" role="3clFbx">
+                <node concept="3clFbF" id="3GYKef6d$Ks" role="3cqZAp">
+                  <node concept="37vLTI" id="3GYKef6dATL" role="3clFbG">
+                    <node concept="37vLTw" id="3GYKef6d$Kq" role="37vLTJ">
+                      <ref role="3cqZAo" node="3GYKef6dzo3" resolve="hash" />
+                    </node>
+                    <node concept="3cpWs3" id="3GYKef6dEqB" role="37vLTx">
+                      <node concept="17qRlL" id="3GYKef6dCsS" role="3uHU7B">
+                        <node concept="3cmrfG" id="3GYKef6dC0x" role="3uHU7B">
+                          <property role="3cmrfH" value="31" />
+                        </node>
+                        <node concept="37vLTw" id="3GYKef6dD4B" role="3uHU7w">
+                          <ref role="3cqZAo" node="3GYKef6dzo3" resolve="hash" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="3GYKef6dFR3" role="3uHU7w">
+                        <node concept="2JrnkZ" id="3GYKef6asxP" role="2Oq$k0">
+                          <node concept="37vLTw" id="4tOoIrpGlPT" role="2JrQYb">
+                            <ref role="3cqZAo" node="4tOoIrpGlPP" resolve="referencedNode" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="3GYKef6dGcb" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~Object.hashCode()" resolve="hashCode" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="3GYKef6dGze" role="3cqZAp">
+                  <node concept="37vLTw" id="3GYKef6dHjI" role="3cqZAk">
+                    <ref role="3cqZAo" node="3GYKef6dzo3" resolve="hash" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4tOoIrpGoeV" role="3clFbw">
+                <node concept="37vLTw" id="4tOoIrpGn1T" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4tOoIrpGlPP" resolve="referencedNode" />
+                </node>
+                <node concept="3x8VRR" id="4tOoIrpGoFF" role="2OqNvi" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
@@ -13118,23 +13118,6 @@
         </node>
       </node>
     </node>
-    <node concept="13i0hz" id="41vYFO2MP_s" role="13h7CS">
-      <property role="TrG5h" value="createDefaultVarExpr" />
-      <ref role="13i0hy" to="pbu6:60Qa1k_nI2O" resolve="createDefaultVarExpr" />
-      <node concept="3Tm1VV" id="41vYFO2MP_t" role="1B3o_S" />
-      <node concept="3clFbS" id="41vYFO2MP_w" role="3clF47">
-        <node concept="3clFbF" id="41vYFO2MPAp" role="3cqZAp">
-          <node concept="2pJPEk" id="41vYFO2MPAn" role="3clFbG">
-            <node concept="2pJPED" id="41vYFO2MPAo" role="2pJPEn">
-              <ref role="2pJxaS" to="i3ya:45a4DYZtiVD" resolve="QuantityEmptyType" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tqbb2" id="41vYFO2MP_x" role="3clF45">
-        <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
-      </node>
-    </node>
   </node>
   <node concept="13h7C7" id="45a4DZ02V_e">
     <property role="3GE5qa" value="group.typesystem" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.plugin.mps
@@ -46,7 +46,7 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
-      <concept id="2323553266850475941" name="jetbrains.mps.baseLanguage.structure.IHasModifiers" flags="ng" index="2frcj7">
+      <concept id="2323553266850475941" name="jetbrains.mps.baseLanguage.structure.IHasModifiers" flags="ngI" index="2frcj7">
         <child id="2323553266850475953" name="modifiers" index="2frcjj" />
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
@@ -55,7 +55,7 @@
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
-      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
       <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
@@ -108,7 +108,7 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
-      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -160,7 +160,7 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -177,7 +177,7 @@
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1144226303539" name="jetbrains.mps.baseLanguage.structure.ForeachStatement" flags="nn" index="1DcWWT">
@@ -363,7 +363,7 @@
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
@@ -1048,6 +1048,19 @@
       </node>
     </node>
     <node concept="2tJIrI" id="HeBpG0vQy" role="jymVt" />
+    <node concept="3clFb_" id="77DmBXAD1A5" role="jymVt">
+      <property role="TrG5h" value="allowMixingCompatibleQuantitiesWithoutConversions" />
+      <node concept="3clFbS" id="77DmBXAD1A8" role="3clF47">
+        <node concept="3clFbF" id="77DmBXAD2la" role="3cqZAp">
+          <node concept="3clFbT" id="77DmBXAD2l9" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="77DmBXAD1A9" role="1B3o_S" />
+      <node concept="10P_77" id="77DmBXAD16M" role="3clF45" />
+      <node concept="2JFqV2" id="77DmBXAD1VJ" role="2frcjj" />
+    </node>
+    <node concept="2tJIrI" id="77DmBXAD1ms" role="jymVt" />
+    <node concept="2tJIrI" id="77DmBXAD1rE" role="jymVt" />
     <node concept="3clFb_" id="HeBpG0y2X" role="jymVt">
       <property role="TrG5h" value="getExponentComparator" />
       <node concept="3clFbS" id="HeBpG0y30" role="3clF47" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.plugin.mps
@@ -1058,6 +1058,23 @@
       <node concept="3Tm1VV" id="77DmBXAD1A9" role="1B3o_S" />
       <node concept="10P_77" id="77DmBXAD16M" role="3clF45" />
       <node concept="2JFqV2" id="77DmBXAD1VJ" role="2frcjj" />
+      <node concept="P$JXv" id="5zjZVctiSA$" role="lGtFl">
+        <node concept="TZ5HA" id="5zjZVctiSA_" role="TZ5H$">
+          <node concept="1dT_AC" id="5zjZVctiSAA" role="1dT_Ay">
+            <property role="1dT_AB" value="Allows compatible unit specifications (e.g. different prefix than expected) without implicit conversions being enabled." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="5zjZVctiTT4" role="TZ5H$">
+          <node concept="1dT_AC" id="5zjZVctiTT5" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="5zjZVctiTYG" role="TZ5H$">
+          <node concept="1dT_AC" id="5zjZVctiTYH" role="1dT_Ay">
+            <property role="1dT_AB" value="Introduced to support the new, stricter unit compatibility check without forcing activation of the implicit conversions." />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="77DmBXAD1ms" role="jymVt" />
     <node concept="2tJIrI" id="77DmBXAD1rE" role="jymVt" />
@@ -1075,11 +1092,6 @@
         <node concept="TZ5HA" id="HeBpG2jhY" role="TZ5H$">
           <node concept="1dT_AC" id="HeBpG2jhZ" role="1dT_Ay">
             <property role="1dT_AB" value="Returns the comparator used to order exponents in group-like expressions e.g. quantity and unit specification expression." />
-          </node>
-        </node>
-        <node concept="TZ5HA" id="HeBpG2jsq" role="TZ5H$">
-          <node concept="1dT_AC" id="HeBpG2jsr" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.structure.mps
@@ -590,9 +590,6 @@
     <node concept="PrWs8" id="45a4DYZTszf" role="PzmwI">
       <ref role="PrY4T" node="45a4DYZTq2h" resolve="IGroupLike" />
     </node>
-    <node concept="PrWs8" id="41vYFO2MPjy" role="PzmwI">
-      <ref role="PrY4T" to="hm2y:60Qa1k_nI2f" resolve="ITypeSupportsDefaultValue" />
-    </node>
   </node>
   <node concept="1TIwiD" id="45a4DYZrKZa">
     <property role="EcuMT" value="4704593238062731210" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.typesystem.mps
@@ -12852,8 +12852,19 @@
               </node>
             </node>
           </node>
-          <node concept="1Wc70l" id="O$qsZ6vizh" role="3clFbw">
-            <node concept="2OqwBi" id="6qDtanTTjMB" role="3uHU7B">
+          <node concept="1Wc70l" id="1ccGBAwDzrJ" role="3clFbw">
+            <node concept="3fqX7Q" id="O$qsZ6vjiD" role="3uHU7B">
+              <node concept="2OqwBi" id="O$qsZ6vjiE" role="3fr31v">
+                <node concept="2YIFZM" id="O$qsZ6vjiF" role="2Oq$k0">
+                  <ref role="37wK5l" to="65nr:4qv99IrBnzk" resolve="getConfig" />
+                  <ref role="1Pybhc" to="65nr:4qv99IrBkzE" resolve="PhysUnitLangConfigHelper" />
+                </node>
+                <node concept="liA8E" id="O$qsZ6vjiG" role="2OqNvi">
+                  <ref role="37wK5l" to="65nr:77DmBXAD1A5" resolve="allowMixingCompatibleQuantitiesWithoutConversions" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6qDtanTTjMB" role="3uHU7w">
               <node concept="2OqwBi" id="6qDtanTTjMC" role="2Oq$k0">
                 <node concept="37vLTw" id="6qDtanTTjMD" role="2Oq$k0">
                   <ref role="3cqZAo" node="6qDtanTTjM8" resolve="convertToTarget" />
@@ -12876,17 +12887,6 @@
                 </node>
               </node>
               <node concept="1v1jN8" id="6qDtanTTjML" role="2OqNvi" />
-            </node>
-            <node concept="3fqX7Q" id="O$qsZ6vjiD" role="3uHU7w">
-              <node concept="2OqwBi" id="O$qsZ6vjiE" role="3fr31v">
-                <node concept="2YIFZM" id="O$qsZ6vjiF" role="2Oq$k0">
-                  <ref role="37wK5l" to="65nr:4qv99IrBnzk" resolve="getConfig" />
-                  <ref role="1Pybhc" to="65nr:4qv99IrBkzE" resolve="PhysUnitLangConfigHelper" />
-                </node>
-                <node concept="liA8E" id="O$qsZ6vjiG" role="2OqNvi">
-                  <ref role="37wK5l" to="65nr:77DmBXAD1A5" resolve="allowMixingUnitPrefixesWithoutConversions" />
-                </node>
-              </node>
             </node>
           </node>
           <node concept="3eNFk2" id="6qDtanTTjMM" role="3eNLev">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.typesystem.mps
@@ -259,9 +259,6 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
-      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
-        <reference id="1116615189566" name="classifier" index="3VsUkX" />
-      </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="363746191845183785" name="jetbrains.mps.baseLanguage.structure.LoopLabelReference" flags="ng" index="3Wmhwi">
         <reference id="363746191845183786" name="loopLabel" index="3Wmhwh" />
@@ -11733,22 +11730,9 @@
                 <node concept="3uibUv" id="7CCjMgEJCyb" role="1tU5fm">
                   <ref role="3uigEE" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
                 </node>
-                <node concept="2OqwBi" id="7CCjMgEJCXV" role="33vP2m">
-                  <node concept="2OqwBi" id="7CCjMgEJCXW" role="2Oq$k0">
-                    <node concept="2YIFZM" id="7CCjMgEJCXX" role="2Oq$k0">
-                      <ref role="37wK5l" to="3a50:~MPSCoreComponents.getInstance()" resolve="getInstance" />
-                      <ref role="1Pybhc" to="3a50:~MPSCoreComponents" resolve="MPSCoreComponents" />
-                    </node>
-                    <node concept="liA8E" id="7CCjMgEJCXY" role="2OqNvi">
-                      <ref role="37wK5l" to="3a50:~MPSCoreComponents.getPlatform()" resolve="getPlatform" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="7CCjMgEJCXZ" role="2OqNvi">
-                    <ref role="37wK5l" to="wyuk:~ComponentHost.findComponent(java.lang.Class)" resolve="findComponent" />
-                    <node concept="3VsKOn" id="7CCjMgEJCY0" role="37wK5m">
-                      <ref role="3VsUkX" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
-                    </node>
-                  </node>
+                <node concept="2YIFZM" id="6sSKyiUqbQ9" role="33vP2m">
+                  <ref role="37wK5l" to="w1kc:~MPSModuleRepository.getInstance()" resolve="getInstance" />
+                  <ref role="1Pybhc" to="w1kc:~MPSModuleRepository" resolve="MPSModuleRepository" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.typesystem.mps
@@ -81,7 +81,7 @@
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
-      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
@@ -129,7 +129,7 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
-      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
@@ -194,7 +194,7 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -221,7 +221,7 @@
       <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4">
         <child id="9056323058805176516" name="loopLabelReference" index="2mV7Oi" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
@@ -554,7 +554,7 @@
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
       <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7">
@@ -12868,39 +12868,65 @@
               </node>
             </node>
           </node>
-          <node concept="2OqwBi" id="6qDtanTTjMB" role="3clFbw">
-            <node concept="2OqwBi" id="6qDtanTTjMC" role="2Oq$k0">
-              <node concept="37vLTw" id="6qDtanTTjMD" role="2Oq$k0">
-                <ref role="3cqZAo" node="6qDtanTTjM8" resolve="convertToTarget" />
-              </node>
-              <node concept="2qgKlT" id="6qDtanTTjME" role="2OqNvi">
-                <ref role="37wK5l" to="rppw:3_TFq$0_vSx" resolve="getApplicableConversionSpecifiers" />
-                <node concept="2OqwBi" id="6qDtanTTjMF" role="37wK5m">
-                  <node concept="37vLTw" id="6qDtanTTptm" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6qDtanTTo2U" resolve="expr" />
-                  </node>
-                  <node concept="2Xjw5R" id="6qDtanTTjMH" role="2OqNvi">
-                    <node concept="1xMEDy" id="6qDtanTTjMI" role="1xVPHs">
-                      <node concept="chp4Y" id="6qDtanTTjMJ" role="ri$Ld">
-                        <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
-                      </node>
+          <node concept="1Wc70l" id="O$qsZ6vizh" role="3clFbw">
+            <node concept="2OqwBi" id="6qDtanTTjMB" role="3uHU7B">
+              <node concept="2OqwBi" id="6qDtanTTjMC" role="2Oq$k0">
+                <node concept="37vLTw" id="6qDtanTTjMD" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6qDtanTTjM8" resolve="convertToTarget" />
+                </node>
+                <node concept="2qgKlT" id="6qDtanTTjME" role="2OqNvi">
+                  <ref role="37wK5l" to="rppw:3_TFq$0_vSx" resolve="getApplicableConversionSpecifiers" />
+                  <node concept="2OqwBi" id="6qDtanTTjMF" role="37wK5m">
+                    <node concept="37vLTw" id="6qDtanTTptm" role="2Oq$k0">
+                      <ref role="3cqZAo" node="6qDtanTTo2U" resolve="expr" />
                     </node>
-                    <node concept="1xIGOp" id="6qDtanTTjMK" role="1xVPHs" />
+                    <node concept="2Xjw5R" id="6qDtanTTjMH" role="2OqNvi">
+                      <node concept="1xMEDy" id="6qDtanTTjMI" role="1xVPHs">
+                        <node concept="chp4Y" id="6qDtanTTjMJ" role="ri$Ld">
+                          <ref role="cht4Q" to="vs0r:6clJcrJXo2z" resolve="IVisibleElementProvider" />
+                        </node>
+                      </node>
+                      <node concept="1xIGOp" id="6qDtanTTjMK" role="1xVPHs" />
+                    </node>
                   </node>
                 </node>
               </node>
+              <node concept="1v1jN8" id="6qDtanTTjML" role="2OqNvi" />
             </node>
-            <node concept="1v1jN8" id="6qDtanTTjML" role="2OqNvi" />
-          </node>
-          <node concept="3eNFk2" id="6qDtanTTjMM" role="3eNLev">
-            <node concept="3fqX7Q" id="6qDtanTTjMN" role="3eO9$A">
-              <node concept="2OqwBi" id="6qDtanTTjMO" role="3fr31v">
-                <node concept="2YIFZM" id="6qDtanTTjMP" role="2Oq$k0">
+            <node concept="3fqX7Q" id="O$qsZ6vjiD" role="3uHU7w">
+              <node concept="2OqwBi" id="O$qsZ6vjiE" role="3fr31v">
+                <node concept="2YIFZM" id="O$qsZ6vjiF" role="2Oq$k0">
                   <ref role="37wK5l" to="65nr:4qv99IrBnzk" resolve="getConfig" />
                   <ref role="1Pybhc" to="65nr:4qv99IrBkzE" resolve="PhysUnitLangConfigHelper" />
                 </node>
-                <node concept="liA8E" id="6qDtanTTjMQ" role="2OqNvi">
-                  <ref role="37wK5l" to="65nr:3wrpJuqrQh9" resolve="implicitConversionIsEnabled" />
+                <node concept="liA8E" id="O$qsZ6vjiG" role="2OqNvi">
+                  <ref role="37wK5l" to="65nr:77DmBXAD1A5" resolve="allowMixingUnitPrefixesWithoutConversions" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3eNFk2" id="6qDtanTTjMM" role="3eNLev">
+            <node concept="1Wc70l" id="77DmBXADDB4" role="3eO9$A">
+              <node concept="3fqX7Q" id="6qDtanTTjMN" role="3uHU7B">
+                <node concept="2OqwBi" id="6qDtanTTjMO" role="3fr31v">
+                  <node concept="2YIFZM" id="6qDtanTTjMP" role="2Oq$k0">
+                    <ref role="37wK5l" to="65nr:4qv99IrBnzk" resolve="getConfig" />
+                    <ref role="1Pybhc" to="65nr:4qv99IrBkzE" resolve="PhysUnitLangConfigHelper" />
+                  </node>
+                  <node concept="liA8E" id="6qDtanTTjMQ" role="2OqNvi">
+                    <ref role="37wK5l" to="65nr:3wrpJuqrQh9" resolve="implicitConversionIsEnabled" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3fqX7Q" id="77DmBXADIaK" role="3uHU7w">
+                <node concept="2OqwBi" id="77DmBXADIaM" role="3fr31v">
+                  <node concept="2YIFZM" id="77DmBXADIaN" role="2Oq$k0">
+                    <ref role="37wK5l" to="65nr:4qv99IrBnzk" resolve="getConfig" />
+                    <ref role="1Pybhc" to="65nr:4qv99IrBkzE" resolve="PhysUnitLangConfigHelper" />
+                  </node>
+                  <node concept="liA8E" id="77DmBXADIaO" role="2OqNvi">
+                    <ref role="37wK5l" to="65nr:77DmBXAD1A5" resolve="allowMixingUnitPrefixesWithoutConversions" />
+                  </node>
                 </node>
               </node>
             </node>


### PR DESCRIPTION
This workaround is necessary for cases where projects can't switch to implicit conversions.