### PR TITLE
Improve line wrapping by using more indent layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## December 2024
+
+### Changed
+
+- The line wrapping ability of some concepts was improved.
+
 ## November 2024
 
 ### Fixed

--- a/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/editor.mps
@@ -20,7 +20,6 @@
       <concept id="1140524381322" name="jetbrains.mps.lang.editor.structure.CellModel_ListWithRole" flags="ng" index="2czfm3">
         <child id="1140524464360" name="cellLayout" index="2czzBx" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
@@ -202,7 +201,7 @@
               <property role="VOm3f" value="true" />
             </node>
           </node>
-          <node concept="2iRfu4" id="2GQBRFCFw0_" role="2iSdaV" />
+          <node concept="l2Vlx" id="1ASK_Hec6P6" role="2iSdaV" />
           <node concept="pkWqt" id="2ZalWa8IziB" role="pqm2j">
             <node concept="3clFbS" id="2ZalWa8IziC" role="2VODD2">
               <node concept="3clFbF" id="2ZalWa8IzpN" role="3cqZAp">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
@@ -961,7 +961,9 @@
         <node concept="VPM3Z" id="1WAg9TyWDHh" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="3XFhqQ" id="1WAg9Tz0qPM" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwdyU5g" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="1WAg9TyWDHj" role="3EZMnx">
           <property role="3F0ifm" value="EXPR:" />
         </node>
@@ -985,31 +987,28 @@
         </node>
         <node concept="l2Vlx" id="1ASK_HedI_i" role="2iSdaV" />
       </node>
-      <node concept="2iRkQZ" id="siw10FmIs1" role="2iSdaV" />
-      <node concept="3EZMnI" id="siw10FmJ56" role="3EZMnx">
-        <node concept="3XFhqQ" id="siw10FmJb$" role="3EZMnx" />
-        <node concept="3EZMnI" id="siw10Fjg2E" role="3EZMnx">
-          <node concept="PMmxH" id="6Zesk0dph8" role="3EZMnx">
-            <ref role="PMmxG" node="6Zesk0deRP" resolve="componentAttributesSection" />
-          </node>
-          <node concept="2iRkQZ" id="siw10Fjg2F" role="2iSdaV" />
-          <node concept="3F2HdR" id="6LfBX8Yi4qc" role="3EZMnx">
-            <ref role="1NtTu8" to="w9y2:6LfBX8Yi4ps" resolve="contents" />
-            <node concept="2iRkQZ" id="siw10Fp9kb" role="2czzBx" />
-            <node concept="3F0ifn" id="6LfBX8Yi4tf" role="2czzBI">
-              <property role="3F0ifm" value="" />
-              <node concept="VPxyj" id="6LfBX8Yi4u8" role="3F10Kt">
-                <property role="VOm3f" value="true" />
-              </node>
+      <node concept="l2Vlx" id="2tlTgwfDMoB" role="2iSdaV" />
+      <node concept="3EZMnI" id="siw10Fjg2E" role="3EZMnx">
+        <node concept="PMmxH" id="6Zesk0dph8" role="3EZMnx">
+          <ref role="PMmxG" node="6Zesk0deRP" resolve="componentAttributesSection" />
+        </node>
+        <node concept="l2Vlx" id="2tlTgwebpqF" role="2iSdaV" />
+        <node concept="3F2HdR" id="6LfBX8Yi4qc" role="3EZMnx">
+          <ref role="1NtTu8" to="w9y2:6LfBX8Yi4ps" resolve="contents" />
+          <node concept="2iRkQZ" id="siw10Fp9kb" role="2czzBx" />
+          <node concept="3F0ifn" id="6LfBX8Yi4tf" role="2czzBI">
+            <property role="3F0ifm" value="" />
+            <node concept="VPxyj" id="6LfBX8Yi4u8" role="3F10Kt">
+              <property role="VOm3f" value="true" />
             </node>
-            <node concept="4$FPG" id="6LfBX8Yi4vL" role="4_6I_">
-              <node concept="3clFbS" id="6LfBX8Yi4vM" role="2VODD2">
-                <node concept="3clFbF" id="6LfBX8Yi4wf" role="3cqZAp">
-                  <node concept="2ShNRf" id="6LfBX8Yi4wd" role="3clFbG">
-                    <node concept="3zrR0B" id="6LfBX8Yi4A$" role="2ShVmc">
-                      <node concept="3Tqbb2" id="6LfBX8Yi4AA" role="3zrR0E">
-                        <ref role="ehGHo" to="w9y2:6LfBX8Yi4ug" resolve="EmptyComponentContent" />
-                      </node>
+          </node>
+          <node concept="4$FPG" id="6LfBX8Yi4vL" role="4_6I_">
+            <node concept="3clFbS" id="6LfBX8Yi4vM" role="2VODD2">
+              <node concept="3clFbF" id="6LfBX8Yi4wf" role="3cqZAp">
+                <node concept="2ShNRf" id="6LfBX8Yi4wd" role="3clFbG">
+                  <node concept="3zrR0B" id="6LfBX8Yi4A$" role="2ShVmc">
+                    <node concept="3Tqbb2" id="6LfBX8Yi4AA" role="3zrR0E">
+                      <ref role="ehGHo" to="w9y2:6LfBX8Yi4ug" resolve="EmptyComponentContent" />
                     </node>
                   </node>
                 </node>
@@ -1017,7 +1016,12 @@
             </node>
           </node>
         </node>
-        <node concept="l2Vlx" id="1ASK_HedI_j" role="2iSdaV" />
+        <node concept="lj46D" id="2tlTgwebpqH" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pj6Ft" id="2tlTgwebpqJ" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
       </node>
       <node concept="3F0ifn" id="6LfBX8Yi4pk" role="3EZMnx">
         <property role="3F0ifm" value="}" />
@@ -1101,6 +1105,9 @@
           <property role="3F0ifm" value="{...}" />
         </node>
         <node concept="l2Vlx" id="1ASK_HedI_k" role="2iSdaV" />
+      </node>
+      <node concept="pj6Ft" id="2tlTgwfDMoD" role="3F10Kt">
+        <property role="VOm3f" value="true" />
       </node>
     </node>
     <node concept="3EZMnI" id="1MFobPsu0Bt" role="6VMZX">
@@ -7731,9 +7738,12 @@
         <node concept="PMmxH" id="6cDi3KAInMq" role="3EZMnx">
           <ref role="PMmxG" node="3xTZ$YBv7mN" resolve="ComponentInstanceBase_Diagram_Footer" />
         </node>
-        <node concept="2iRkQZ" id="siw10FuWOP" role="2iSdaV" />
+        <node concept="l2Vlx" id="2tlTgwfDDLV" role="2iSdaV" />
         <node concept="VPM3Z" id="siw10FuWOQ" role="3F10Kt">
           <property role="VOm3f" value="false" />
+        </node>
+        <node concept="pj6Ft" id="2tlTgwfDHFt" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
       </node>
       <node concept="230Hcy" id="siw10FuXzh" role="3DrZTU">
@@ -10670,7 +10680,7 @@
     <property role="3GE5qa" value="behavior.simple" />
     <ref role="1XX52x" to="w9y2:2Q7cX_iyKnT" resolve="SimpleBehavior" />
     <node concept="3EZMnI" id="2Q7cX_iyKq6" role="2wV5jI">
-      <node concept="2iRkQZ" id="2Q7cX_iyKq7" role="2iSdaV" />
+      <node concept="l2Vlx" id="2tlTgwfDNN0" role="2iSdaV" />
       <node concept="3EZMnI" id="2Q7cX_iyKpK" role="3EZMnx">
         <node concept="1kIj98" id="2Q7cX_iyKtY" role="3EZMnx">
           <node concept="3F1sOY" id="2Q7cX_iyKtQ" role="1kIj9b">
@@ -10691,38 +10701,40 @@
         </node>
         <node concept="l2Vlx" id="1ASK_HedI__" role="2iSdaV" />
       </node>
-      <node concept="3EZMnI" id="2Q7cX_iyKqF" role="3EZMnx">
-        <node concept="VPM3Z" id="2Q7cX_iyKqH" role="3F10Kt">
-          <property role="VOm3f" value="false" />
-        </node>
-        <node concept="3XFhqQ" id="2Q7cX_iyKqW" role="3EZMnx" />
-        <node concept="3F2HdR" id="2Q7cX_iyKr2" role="3EZMnx">
-          <ref role="1NtTu8" to="w9y2:2Q7cX_iyKnZ" resolve="actions" />
-          <node concept="2iRkQZ" id="2Q7cX_iyKrb" role="2czzBx" />
-          <node concept="4$FPG" id="2Q7cX_iyKu6" role="4_6I_">
-            <node concept="3clFbS" id="2Q7cX_iyKu7" role="2VODD2">
-              <node concept="3clFbF" id="2Q7cX_iyKux" role="3cqZAp">
-                <node concept="2ShNRf" id="2Q7cX_iyKuv" role="3clFbG">
-                  <node concept="3zrR0B" id="2Q7cX_iyKHj" role="2ShVmc">
-                    <node concept="3Tqbb2" id="2Q7cX_iyKHl" role="3zrR0E">
-                      <ref role="ehGHo" to="w9y2:2Q7cX_iyKre" resolve="EmptyAction" />
-                    </node>
+      <node concept="3F2HdR" id="2Q7cX_iyKr2" role="3EZMnx">
+        <ref role="1NtTu8" to="w9y2:2Q7cX_iyKnZ" resolve="actions" />
+        <node concept="l2Vlx" id="2tlTgwdLpH4" role="2czzBx" />
+        <node concept="4$FPG" id="2Q7cX_iyKu6" role="4_6I_">
+          <node concept="3clFbS" id="2Q7cX_iyKu7" role="2VODD2">
+            <node concept="3clFbF" id="2Q7cX_iyKux" role="3cqZAp">
+              <node concept="2ShNRf" id="2Q7cX_iyKuv" role="3clFbG">
+                <node concept="3zrR0B" id="2Q7cX_iyKHj" role="2ShVmc">
+                  <node concept="3Tqbb2" id="2Q7cX_iyKHl" role="3zrR0E">
+                    <ref role="ehGHo" to="w9y2:2Q7cX_iyKre" resolve="EmptyAction" />
                   </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="3F0ifn" id="426GYJ1y2hP" role="2czzBI">
-            <property role="3F0ifm" value="" />
-            <node concept="VPxyj" id="426GYJ1y6vm" role="3F10Kt">
-              <property role="VOm3f" value="true" />
-            </node>
+        </node>
+        <node concept="3F0ifn" id="426GYJ1y2hP" role="2czzBI">
+          <property role="3F0ifm" value="" />
+          <node concept="VPxyj" id="426GYJ1y6vm" role="3F10Kt">
+            <property role="VOm3f" value="true" />
           </node>
         </node>
-        <node concept="l2Vlx" id="2Q7cX_iyKqK" role="2iSdaV" />
+        <node concept="lj46D" id="2tlTgwdLpJx" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pj6Ft" id="2tlTgwdNTsG" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
       </node>
       <node concept="3F0ifn" id="2Q7cX_iyKqr" role="3EZMnx">
         <property role="3F0ifm" value="}" />
+      </node>
+      <node concept="pj6Ft" id="2tlTgwfDNN2" role="3F10Kt">
+        <property role="VOm3f" value="true" />
       </node>
     </node>
   </node>
@@ -13209,7 +13221,6 @@
         </node>
       </node>
       <node concept="3EZMnI" id="1YJV4bMuZgr" role="1QoVPY">
-        <node concept="3XFhqQ" id="1YJV4bMuZgs" role="3EZMnx" />
         <node concept="1QoScp" id="1YJV4bMuZgt" role="3EZMnx">
           <property role="1QpmdY" value="true" />
           <node concept="pkWqt" id="1YJV4bMuZgu" role="3e4ffs">
@@ -13302,7 +13313,9 @@
         <node concept="37jFXN" id="1YJV4bMuZh4" role="3F10Kt">
           <property role="37lx6p" value="hZ7kQ4a/CENTER" />
         </node>
-        <node concept="3XFhqQ" id="1YJV4bMuZhd" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwdyWj1" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="l2Vlx" id="1ASK_HedI_K" role="2iSdaV" />
       </node>
     </node>
@@ -13382,7 +13395,6 @@
         </node>
       </node>
       <node concept="3EZMnI" id="1VnwbRVGx5e" role="1QoVPY">
-        <node concept="3XFhqQ" id="1VnwbRVGx5f" role="3EZMnx" />
         <node concept="1iCGBv" id="1VnwbRVG_7D" role="3EZMnx">
           <ref role="1NtTu8" to="w9y2:77HYM7HnhfL" resolve="component" />
           <node concept="1sVBvm" id="1VnwbRVG_7F" role="1sWHZn">
@@ -13413,7 +13425,9 @@
         <node concept="37jFXN" id="1VnwbRVGx5R" role="3F10Kt">
           <property role="37lx6p" value="hZ7kQ4a/CENTER" />
         </node>
-        <node concept="3XFhqQ" id="1VnwbRVGx5S" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwdyYte" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="l2Vlx" id="1ASK_HedI_M" role="2iSdaV" />
       </node>
     </node>
@@ -13552,7 +13566,9 @@
         <node concept="VPM3Z" id="77HYM7Hoq83" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="3XFhqQ" id="77HYM7Hoq84" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwdyXbv" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="77HYM7Hoq85" role="3EZMnx">
           <property role="3F0ifm" value="EXPR:" />
         </node>
@@ -13576,31 +13592,28 @@
         </node>
         <node concept="l2Vlx" id="1ASK_HedI_P" role="2iSdaV" />
       </node>
-      <node concept="2iRkQZ" id="77HYM7Hoq8g" role="2iSdaV" />
-      <node concept="3EZMnI" id="77HYM7Hoq8h" role="3EZMnx">
-        <node concept="3XFhqQ" id="77HYM7Hoq8j" role="3EZMnx" />
-        <node concept="3EZMnI" id="77HYM7Hoq8k" role="3EZMnx">
-          <node concept="PMmxH" id="77HYM7Hoq8l" role="3EZMnx">
-            <ref role="PMmxG" node="6Zesk0deRP" resolve="componentAttributesSection" />
-          </node>
-          <node concept="2iRkQZ" id="77HYM7Hoq8m" role="2iSdaV" />
-          <node concept="3F2HdR" id="77HYM7Hoq8n" role="3EZMnx">
-            <ref role="1NtTu8" to="w9y2:6LfBX8Yi4ps" resolve="contents" />
-            <node concept="2iRkQZ" id="77HYM7Hoq8o" role="2czzBx" />
-            <node concept="3F0ifn" id="77HYM7Hoq8p" role="2czzBI">
-              <property role="3F0ifm" value="" />
-              <node concept="VPxyj" id="77HYM7Hoq8q" role="3F10Kt">
-                <property role="VOm3f" value="true" />
-              </node>
+      <node concept="l2Vlx" id="2tlTgwfDN40" role="2iSdaV" />
+      <node concept="3EZMnI" id="77HYM7Hoq8k" role="3EZMnx">
+        <node concept="PMmxH" id="77HYM7Hoq8l" role="3EZMnx">
+          <ref role="PMmxG" node="6Zesk0deRP" resolve="componentAttributesSection" />
+        </node>
+        <node concept="l2Vlx" id="2tlTgwdY73V" role="2iSdaV" />
+        <node concept="3F2HdR" id="77HYM7Hoq8n" role="3EZMnx">
+          <ref role="1NtTu8" to="w9y2:6LfBX8Yi4ps" resolve="contents" />
+          <node concept="2iRkQZ" id="77HYM7Hoq8o" role="2czzBx" />
+          <node concept="3F0ifn" id="77HYM7Hoq8p" role="2czzBI">
+            <property role="3F0ifm" value="" />
+            <node concept="VPxyj" id="77HYM7Hoq8q" role="3F10Kt">
+              <property role="VOm3f" value="true" />
             </node>
-            <node concept="4$FPG" id="77HYM7Hoq8r" role="4_6I_">
-              <node concept="3clFbS" id="77HYM7Hoq8s" role="2VODD2">
-                <node concept="3clFbF" id="77HYM7Hoq8t" role="3cqZAp">
-                  <node concept="2ShNRf" id="77HYM7Hoq8u" role="3clFbG">
-                    <node concept="3zrR0B" id="77HYM7Hoq8v" role="2ShVmc">
-                      <node concept="3Tqbb2" id="77HYM7Hoq8w" role="3zrR0E">
-                        <ref role="ehGHo" to="w9y2:6LfBX8Yi4ug" resolve="EmptyComponentContent" />
-                      </node>
+          </node>
+          <node concept="4$FPG" id="77HYM7Hoq8r" role="4_6I_">
+            <node concept="3clFbS" id="77HYM7Hoq8s" role="2VODD2">
+              <node concept="3clFbF" id="77HYM7Hoq8t" role="3cqZAp">
+                <node concept="2ShNRf" id="77HYM7Hoq8u" role="3clFbG">
+                  <node concept="3zrR0B" id="77HYM7Hoq8v" role="2ShVmc">
+                    <node concept="3Tqbb2" id="77HYM7Hoq8w" role="3zrR0E">
+                      <ref role="ehGHo" to="w9y2:6LfBX8Yi4ug" resolve="EmptyComponentContent" />
                     </node>
                   </node>
                 </node>
@@ -13608,7 +13621,12 @@
             </node>
           </node>
         </node>
-        <node concept="l2Vlx" id="1ASK_HedI_Q" role="2iSdaV" />
+        <node concept="lj46D" id="2tlTgwdY73X" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pj6Ft" id="2tlTgwdY73Z" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
       </node>
       <node concept="3F0ifn" id="77HYM7Hoq8x" role="3EZMnx">
         <property role="3F0ifm" value="}" />
@@ -13647,6 +13665,9 @@
           <property role="3F0ifm" value="{...}" />
         </node>
         <node concept="l2Vlx" id="1ASK_HedI_R" role="2iSdaV" />
+      </node>
+      <node concept="pj6Ft" id="2tlTgwfDN42" role="3F10Kt">
+        <property role="VOm3f" value="true" />
       </node>
     </node>
     <node concept="3EZMnI" id="77HYM7HoqS1" role="6VMZX">
@@ -13804,7 +13825,6 @@
         </node>
       </node>
       <node concept="3EZMnI" id="1YJV4bMuZsd" role="1QoVPY">
-        <node concept="3XFhqQ" id="1YJV4bMuZse" role="3EZMnx" />
         <node concept="s8t4o" id="1YJV4bMuZsq" role="3EZMnx">
           <property role="28Zw97" value="true" />
           <ref role="28F8cf" to="w9y2:6LfBX8Yi4o1" resolve="Component" />
@@ -13848,7 +13868,9 @@
         <node concept="37jFXN" id="1YJV4bMuZsQ" role="3F10Kt">
           <property role="37lx6p" value="hZ7kQ4a/CENTER" />
         </node>
-        <node concept="3XFhqQ" id="1YJV4bMuZsR" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwdyKDD" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="l2Vlx" id="1ASK_HedI_U" role="2iSdaV" />
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
@@ -236,7 +236,6 @@
       </concept>
       <concept id="1176717841777" name="jetbrains.mps.lang.editor.structure.QueryFunction_ModelAccess_Getter" flags="in" index="3TQlhw" />
       <concept id="1176749715029" name="jetbrains.mps.lang.editor.structure.QueryFunction_CellProvider" flags="in" index="3VJUX4" />
-      <concept id="1198256887712" name="jetbrains.mps.lang.editor.structure.CellModel_Indent" flags="ng" index="3XFhqQ" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
@@ -524,6 +523,7 @@
       <concept id="4682418030828844315" name="de.itemis.mps.editor.celllayout.structure.HorizontalLineColorStyle" flags="lg" index="2T_bXS" />
       <concept id="4682418030828844314" name="de.itemis.mps.editor.celllayout.structure.HorzontalLineWidthStyle" flags="lg" index="2T_bXT" />
       <concept id="4682418030828725523" name="de.itemis.mps.editor.celllayout.structure.HorizontalLineCell" flags="ng" index="2T_mXK" />
+      <concept id="2728748097294412051" name="de.itemis.mps.editor.celllayout.structure.PushXStyle" flags="lg" index="3T7XNW" />
       <concept id="2728748097294192922" name="de.itemis.mps.editor.celllayout.structure.IntegerStyle" flags="lg" index="3To2jP">
         <property id="1221209241505" name="value" index="1lJzqX" />
       </concept>
@@ -1356,14 +1356,13 @@
             </node>
           </node>
         </node>
-        <node concept="3XFhqQ" id="7nsgDAXznVR" role="3EZMnx" />
-        <node concept="3XFhqQ" id="7nsgDAXznWo" role="3EZMnx" />
-        <node concept="3XFhqQ" id="7nsgDAXznWT" role="3EZMnx" />
-        <node concept="3XFhqQ" id="7nsgDAXznXr" role="3EZMnx" />
-        <node concept="3XFhqQ" id="7nsgDAXznXY" role="3EZMnx" />
-        <node concept="3XFhqQ" id="7nsgDAX$QF1" role="3EZMnx" />
-        <node concept="3XFhqQ" id="7nsgDAX$QFF" role="3EZMnx" />
-        <node concept="3XFhqQ" id="7nsgDAX$QGm" role="3EZMnx" />
+        <node concept="3F0ifn" id="2tlTgwelJbu" role="3EZMnx">
+          <property role="3F0ifm" value="" />
+          <node concept="VPM3Z" id="2tlTgwelJfS" role="3F10Kt" />
+          <node concept="3T7XNW" id="2tlTgwegFXM" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
         <node concept="3EZMnI" id="7nsgDAX$QE7" role="3EZMnx">
           <node concept="3F0ifn" id="7nsgDAX$QEW" role="3EZMnx">
             <property role="3F0ifm" value="imports" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.core/models/editor.mps
@@ -808,7 +808,6 @@
     <node concept="3EZMnI" id="6LfBX8Yi4ow" role="2wV5jI">
       <property role="S$Qs1" value="true" />
       <node concept="3EZMnI" id="siw10FmIv1" role="3EZMnx">
-        <node concept="2iRfu4" id="siw10FmIv2" role="2iSdaV" />
         <node concept="1kHk_G" id="5kXA14mWgcV" role="3EZMnx">
           <ref role="1NtTu8" to="w9y2:5kXA14mWc_G" resolve="public" />
           <ref role="1k5W1q" node="7Dcax7Ah0s0" resolve="componentsKeyword" />
@@ -859,7 +858,6 @@
         <node concept="1v6uyg" id="uuJ7IpZty5" role="3EZMnx">
           <property role="2oejA6" value="true" />
           <node concept="3EZMnI" id="7Atos1y0YVe" role="wsdo6">
-            <node concept="2iRfu4" id="7Atos1y0YVf" role="2iSdaV" />
             <node concept="gc7cB" id="7Atos1y0YVg" role="3EZMnx">
               <node concept="3VJUX4" id="7Atos1y0YVh" role="3YsKMw">
                 <node concept="3clFbS" id="7Atos1y0YVi" role="2VODD2">
@@ -919,6 +917,7 @@
                 </node>
               </node>
             </node>
+            <node concept="l2Vlx" id="1ASK_HedI_h" role="2iSdaV" />
           </node>
           <node concept="3F0A7n" id="6LfBX8Yi4oY" role="1j7Clw">
             <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
@@ -956,6 +955,7 @@
         <node concept="3F0ifn" id="6LfBX8Yi4p8" role="3EZMnx">
           <property role="3F0ifm" value="{" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI_g" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="1WAg9TyWDHf" role="3EZMnx">
         <node concept="VPM3Z" id="1WAg9TyWDHh" role="3F10Kt">
@@ -968,7 +968,6 @@
         <node concept="3F1sOY" id="1WAg9TyWDR1" role="3EZMnx">
           <ref role="1NtTu8" to="w9y2:1WAg9TyWDtQ" resolve="expttest" />
         </node>
-        <node concept="2iRfu4" id="1WAg9TyWDHk" role="2iSdaV" />
         <node concept="pkWqt" id="1WAg9Tz0p$b" role="pqm2j">
           <node concept="3clFbS" id="1WAg9Tz0p$c" role="2VODD2">
             <node concept="3clFbF" id="1WAg9Tz0pGw" role="3cqZAp">
@@ -984,10 +983,10 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI_i" role="2iSdaV" />
       </node>
       <node concept="2iRkQZ" id="siw10FmIs1" role="2iSdaV" />
       <node concept="3EZMnI" id="siw10FmJ56" role="3EZMnx">
-        <node concept="2iRfu4" id="siw10FmJ57" role="2iSdaV" />
         <node concept="3XFhqQ" id="siw10FmJb$" role="3EZMnx" />
         <node concept="3EZMnI" id="siw10Fjg2E" role="3EZMnx">
           <node concept="PMmxH" id="6Zesk0dph8" role="3EZMnx">
@@ -1018,12 +1017,12 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI_j" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="6LfBX8Yi4pk" role="3EZMnx">
         <property role="3F0ifm" value="}" />
       </node>
       <node concept="3EZMnI" id="siw10FrZ_w" role="AHCbl">
-        <node concept="2iRfu4" id="siw10FrZ_x" role="2iSdaV" />
         <node concept="3F0ifn" id="7wKyBbUVI_L" role="3EZMnx">
           <property role="3F0ifm" value="public" />
           <ref role="1k5W1q" node="7Dcax7Ah0s0" resolve="componentsKeyword" />
@@ -1101,6 +1100,7 @@
         <node concept="3F0ifn" id="siw10FrZ_L" role="3EZMnx">
           <property role="3F0ifm" value="{...}" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI_k" role="2iSdaV" />
       </node>
     </node>
     <node concept="3EZMnI" id="1MFobPsu0Bt" role="6VMZX">
@@ -1123,7 +1123,6 @@
         </node>
       </node>
       <node concept="3EZMnI" id="7Atos1xXKfM" role="3EZMnx">
-        <node concept="2iRfu4" id="7Atos1xXKfO" role="2iSdaV" />
         <node concept="gc7cB" id="7Atos1xXKfP" role="3EZMnx">
           <node concept="3VJUX4" id="7Atos1xXKfQ" role="3YsKMw">
             <node concept="3clFbS" id="7Atos1xXKfR" role="2VODD2">
@@ -1183,6 +1182,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI_l" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -1217,7 +1217,6 @@
     <ref role="1XX52x" to="w9y2:6LfBX8Yivee" resolve="ComponentsChunk" />
     <node concept="3EZMnI" id="4tXyFaWwywa" role="2wV5jI">
       <node concept="3EZMnI" id="7nsgDAXznLJ" role="3EZMnx">
-        <node concept="2iRfu4" id="7nsgDAXznLK" role="2iSdaV" />
         <node concept="3EZMnI" id="4tXyFaWwywk" role="3EZMnx">
           <node concept="gc7cB" id="4SjtGYzwku9" role="3EZMnx">
             <node concept="3VJUX4" id="4SjtGYzwkub" role="3YsKMw">
@@ -1359,7 +1358,6 @@
         <node concept="3XFhqQ" id="7nsgDAX$QFF" role="3EZMnx" />
         <node concept="3XFhqQ" id="7nsgDAX$QGm" role="3EZMnx" />
         <node concept="3EZMnI" id="7nsgDAX$QE7" role="3EZMnx">
-          <node concept="2iRfu4" id="7nsgDAX$QE8" role="2iSdaV" />
           <node concept="3F0ifn" id="7nsgDAX$QEW" role="3EZMnx">
             <property role="3F0ifm" value="imports" />
           </node>
@@ -1367,7 +1365,9 @@
             <ref role="1NtTu8" to="w9y2:7nsgDAXznlY" resolve="imports" />
             <node concept="2iRkQZ" id="7nsgDAXznZJ" role="2czzBx" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedI_n" role="2iSdaV" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI_m" role="2iSdaV" />
       </node>
       <node concept="2iRkQZ" id="4tXyFaWwywd" role="2iSdaV" />
       <node concept="2T_mXK" id="7DfYVnpe9Vf" role="3EZMnx">
@@ -1569,7 +1569,6 @@
     <property role="3GE5qa" value="components" />
     <ref role="1XX52x" to="w9y2:6LfBX8YiQvG" resolve="EnrichesClause" />
     <node concept="3EZMnI" id="6LfBX8YiQwj" role="2wV5jI">
-      <node concept="2iRfu4" id="6LfBX8YiQwk" role="2iSdaV" />
       <node concept="3F0ifn" id="6LfBX8YiQwg" role="3EZMnx">
         <property role="3F0ifm" value="enriches" />
       </node>
@@ -1578,6 +1577,7 @@
         <ref role="1NtTu8" to="w9y2:6LfBX8YiQvO" resolve="fragments" />
         <node concept="2iRfu4" id="6LfBX8YiQwu" role="2czzBx" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI_o" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6LfBX8Yj9oh">
@@ -1591,7 +1591,7 @@
     <property role="3GE5qa" value="components.substructure" />
     <ref role="1XX52x" to="w9y2:6LfBX8YlosD" resolve="ComponentInstance" />
     <node concept="3EZMnI" id="6LfBX8Ylotb" role="2wV5jI">
-      <node concept="2iRfu4" id="6LfBX8Ylotc" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedDDj" role="2iSdaV" />
       <node concept="3F0ifn" id="6LfBX8Ylot8" role="3EZMnx">
         <property role="3F0ifm" value="instance" />
         <ref role="1k5W1q" node="7Dcax7Ah0s0" resolve="componentsKeyword" />
@@ -1702,7 +1702,7 @@
     <property role="3GE5qa" value="components.substructure" />
     <ref role="1XX52x" to="w9y2:7Zvsa54vnWq" resolve="AssemblyConnector" />
     <node concept="3EZMnI" id="7Zvsa54vwrw" role="2wV5jI">
-      <node concept="2iRfu4" id="7Zvsa54vwrx" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedBCQ" role="2iSdaV" />
       <node concept="3F0ifn" id="7Zvsa54vwrt" role="3EZMnx">
         <property role="3F0ifm" value="connect" />
         <ref role="1k5W1q" node="7Dcax7Ah0s0" resolve="componentsKeyword" />
@@ -1984,7 +1984,6 @@
         </node>
       </node>
       <node concept="3EZMnI" id="x8tpS_VvJy" role="3EZMnx">
-        <node concept="2iRfu4" id="x8tpS_VvJz" role="2iSdaV" />
         <node concept="2T_mXK" id="7DfYVnpe8BD" role="3EZMnx">
           <node concept="2T_bXS" id="7DfYVnpe8BE" role="3F10Kt">
             <property role="Vb096" value="fLJRk5_/gray" />
@@ -2007,6 +2006,7 @@
             <property role="1lJzqX" value="2" />
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI_p" role="2iSdaV" />
       </node>
       <node concept="gc7cB" id="x8tpS_VvJq" role="3EZMnx">
         <node concept="3VJUX4" id="x8tpS_VvJr" role="3YsKMw">
@@ -3858,7 +3858,6 @@
                       <property role="VOm3f" value="false" />
                     </node>
                     <node concept="3EZMnI" id="2worSEgN_Nh" role="3EZMnx">
-                      <node concept="2iRfu4" id="2worSEgN_Ni" role="2iSdaV" />
                       <node concept="3F0A7n" id="2worSEgN_Nj" role="3EZMnx">
                         <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
                         <node concept="Vb9p2" id="2worSEgN_Nk" role="3F10Kt">
@@ -3871,6 +3870,7 @@
                           <property role="VOm3f" value="false" />
                         </node>
                       </node>
+                      <node concept="l2Vlx" id="1ASK_HedI_s" role="2iSdaV" />
                     </node>
                     <node concept="G$OnD" id="2worSEgN_NM" role="3EZMnx">
                       <node concept="2xQOud" id="2worSEgN_NN" role="G$OdO">
@@ -3914,9 +3914,8 @@
                         <property role="37lx6p" value="hZ7kOz9/RIGHT" />
                       </node>
                     </node>
-                    <node concept="2iRfu4" id="2worSEgN_tv" role="2iSdaV" />
+                    <node concept="l2Vlx" id="1ASK_HedI_r" role="2iSdaV" />
                   </node>
-                  <node concept="2iRfu4" id="j0Hi33XyM7" role="2iSdaV" />
                   <node concept="pkWqt" id="5tAZxwRcuIi" role="pqm2j">
                     <node concept="3clFbS" id="5tAZxwRcuIj" role="2VODD2">
                       <node concept="3clFbF" id="5tAZxwRb0tc" role="3cqZAp">
@@ -3947,6 +3946,7 @@
                       </node>
                     </node>
                   </node>
+                  <node concept="l2Vlx" id="1ASK_HedI_q" role="2iSdaV" />
                 </node>
                 <node concept="3EZMnI" id="5tAZxwRctQ2" role="3EZMnx">
                   <node concept="3EZMnI" id="2worSEgNAFp" role="3EZMnx">
@@ -3996,7 +3996,6 @@
                       </node>
                     </node>
                     <node concept="3EZMnI" id="2worSEgNB0_" role="3EZMnx">
-                      <node concept="2iRfu4" id="2worSEgNB0A" role="2iSdaV" />
                       <node concept="3F0ifn" id="2worSEgNB0B" role="3EZMnx">
                         <property role="3F0ifm" value=" " />
                         <node concept="VPM3Z" id="2worSEgNB0C" role="3F10Kt">
@@ -4009,10 +4008,10 @@
                           <property role="Vbekb" value="g1_k_vY/BOLD" />
                         </node>
                       </node>
+                      <node concept="l2Vlx" id="1ASK_HedI_v" role="2iSdaV" />
                     </node>
-                    <node concept="2iRfu4" id="2worSEgNAFu" role="2iSdaV" />
+                    <node concept="l2Vlx" id="1ASK_HedI_u" role="2iSdaV" />
                   </node>
-                  <node concept="2iRfu4" id="5tAZxwRctRp" role="2iSdaV" />
                   <node concept="pkWqt" id="5tAZxwRcwc$" role="pqm2j">
                     <node concept="3clFbS" id="5tAZxwRcwc_" role="2VODD2">
                       <node concept="3clFbF" id="5tAZxwRctQK" role="3cqZAp">
@@ -4043,6 +4042,7 @@
                       </node>
                     </node>
                   </node>
+                  <node concept="l2Vlx" id="1ASK_HedI_t" role="2iSdaV" />
                 </node>
                 <node concept="3EZMnI" id="5tAZxwRcu6e" role="3EZMnx">
                   <node concept="3EZMnI" id="2worSEgNBTn" role="3EZMnx">
@@ -4050,13 +4050,13 @@
                       <property role="VOm3f" value="false" />
                     </node>
                     <node concept="3EZMnI" id="2worSEgNCfa" role="3EZMnx">
-                      <node concept="2iRfu4" id="2worSEgNCfb" role="2iSdaV" />
                       <node concept="3F0A7n" id="2worSEgNCfc" role="3EZMnx">
                         <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
                         <node concept="Vb9p2" id="2worSEgNCfd" role="3F10Kt">
                           <property role="Vbekb" value="g1_k_vY/BOLD" />
                         </node>
                       </node>
+                      <node concept="l2Vlx" id="1ASK_HedI_x" role="2iSdaV" />
                     </node>
                     <node concept="G$OnD" id="2worSEgNCt5" role="3EZMnx">
                       <node concept="2xQOud" id="2worSEgNCt6" role="G$OdO">
@@ -4102,7 +4102,6 @@
                     </node>
                     <node concept="2iRkQZ" id="2worSEgNBTs" role="2iSdaV" />
                   </node>
-                  <node concept="2iRfu4" id="5tAZxwRcu7_" role="2iSdaV" />
                   <node concept="pkWqt" id="5tAZxwRcu7a" role="pqm2j">
                     <node concept="3clFbS" id="5tAZxwRcu7b" role="2VODD2">
                       <node concept="3clFbF" id="5tAZxwRcu7c" role="3cqZAp">
@@ -4133,6 +4132,7 @@
                       </node>
                     </node>
                   </node>
+                  <node concept="l2Vlx" id="1ASK_HedI_w" role="2iSdaV" />
                 </node>
                 <node concept="3EZMnI" id="5tAZxwRcubI" role="3EZMnx">
                   <node concept="3EZMnI" id="2worSEgNDxB" role="3EZMnx">
@@ -4182,17 +4182,16 @@
                       <property role="VOm3f" value="false" />
                     </node>
                     <node concept="3EZMnI" id="2worSEgNDQJ" role="3EZMnx">
-                      <node concept="2iRfu4" id="2worSEgNDQK" role="2iSdaV" />
                       <node concept="3F0A7n" id="2worSEgNDQL" role="3EZMnx">
                         <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
                         <node concept="Vb9p2" id="2worSEgNDQM" role="3F10Kt">
                           <property role="Vbekb" value="g1_k_vY/BOLD" />
                         </node>
                       </node>
+                      <node concept="l2Vlx" id="1ASK_HedI_z" role="2iSdaV" />
                     </node>
                     <node concept="2iRkQZ" id="2worSEgNDxG" role="2iSdaV" />
                   </node>
-                  <node concept="2iRfu4" id="5tAZxwRcud5" role="2iSdaV" />
                   <node concept="pkWqt" id="5tAZxwRcucU" role="pqm2j">
                     <node concept="3clFbS" id="5tAZxwRcucV" role="2VODD2">
                       <node concept="3clFbF" id="5tAZxwRcucW" role="3cqZAp">
@@ -4223,6 +4222,7 @@
                       </node>
                     </node>
                   </node>
+                  <node concept="l2Vlx" id="1ASK_HedI_y" role="2iSdaV" />
                 </node>
               </node>
             </node>
@@ -8603,7 +8603,7 @@
       <node concept="3F1sOY" id="siw10GrK04" role="3EZMnx">
         <ref role="1NtTu8" to="w9y2:4UgzZxsF_xC" resolve="value" />
       </node>
-      <node concept="2iRfu4" id="siw10GrK1R" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedI_$" role="2iSdaV" />
     </node>
     <node concept="2aJ2om" id="siw10GrK1P" role="CpUAK">
       <ref role="2$4xQ3" node="siw10FuTec" resolve="wiringDiagram" />
@@ -10672,7 +10672,6 @@
     <node concept="3EZMnI" id="2Q7cX_iyKq6" role="2wV5jI">
       <node concept="2iRkQZ" id="2Q7cX_iyKq7" role="2iSdaV" />
       <node concept="3EZMnI" id="2Q7cX_iyKpK" role="3EZMnx">
-        <node concept="2iRfu4" id="2Q7cX_iyKr8" role="2iSdaV" />
         <node concept="1kIj98" id="2Q7cX_iyKtY" role="3EZMnx">
           <node concept="3F1sOY" id="2Q7cX_iyKtQ" role="1kIj9b">
             <ref role="1NtTu8" to="w9y2:2Q7cX_iyKtq" resolve="trigger" />
@@ -10690,6 +10689,7 @@
         <node concept="3F0ifn" id="2Q7cX_iyKq1" role="3EZMnx">
           <property role="3F0ifm" value="{" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI__" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="2Q7cX_iyKqF" role="3EZMnx">
         <node concept="VPM3Z" id="2Q7cX_iyKqH" role="3F10Kt">
@@ -10943,10 +10943,10 @@
           <node concept="3F1sOY" id="7kdj6EM27fu" role="3EZMnx">
             <ref role="1NtTu8" to="w9y2:7kdj6EM27d6" resolve="init" />
           </node>
-          <node concept="2iRfu4" id="7kdj6EM27fi" role="2iSdaV" />
           <node concept="VPM3Z" id="7kdj6EM27fj" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedI_B" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgkZNn" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgkZNo" role="2VODD2">
@@ -10958,7 +10958,7 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="7kdj6EM27eC" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedI_A" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="435Eqf9ebv_">
@@ -11847,7 +11847,6 @@
     <property role="3GE5qa" value="expr.portselection" />
     <ref role="1XX52x" to="w9y2:1WAg9TzeH4s" resolve="PortsTarget" />
     <node concept="3EZMnI" id="1WAg9Tzu5Nw" role="2wV5jI">
-      <node concept="2iRfu4" id="1WAg9Tzu5Nx" role="2iSdaV" />
       <node concept="PMmxH" id="1WAg9TzeH5n" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
       </node>
@@ -11871,13 +11870,13 @@
               <property role="VOm3f" value="true" />
             </node>
           </node>
-          <node concept="2iRfu4" id="1WAg9Tzu5NN" role="2iSdaV" />
           <node concept="11L4FC" id="1WAg9Tzu5RW" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
           <node concept="VPM3Z" id="1WAg9Tzu5NO" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedI_D" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgkZFA" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgkZFB" role="2VODD2">
@@ -11889,6 +11888,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI_C" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="1WAg9TzeHd6">
@@ -11924,7 +11924,7 @@
     <property role="3GE5qa" value="expr.instanceselection" />
     <ref role="1XX52x" to="w9y2:1WAg9Tzy1MA" resolve="AbstractInstancesTarget" />
     <node concept="3EZMnI" id="1WAg9Tzy29Q" role="2wV5jI">
-      <node concept="2iRfu4" id="1WAg9Tzy29R" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedAUv" role="2iSdaV" />
       <node concept="PMmxH" id="1WAg9Tz$GMn" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
       </node>
@@ -11952,7 +11952,7 @@
     <property role="3GE5qa" value="expr.portselection" />
     <ref role="1XX52x" to="w9y2:1WAg9TzjsPq" resolve="AllPortsTarget" />
     <node concept="3EZMnI" id="1WAg9Tzu5SV" role="2wV5jI">
-      <node concept="2iRfu4" id="1WAg9Tzu5SW" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedB0U" role="2iSdaV" />
       <node concept="3F0ifn" id="1WAg9TzjsQ4" role="3EZMnx">
         <property role="3F0ifm" value="allports" />
       </node>
@@ -11976,7 +11976,7 @@
               <property role="VOm3f" value="true" />
             </node>
           </node>
-          <node concept="2iRfu4" id="1WAg9Tzu5Tc" role="2iSdaV" />
+          <node concept="l2Vlx" id="1ASK_HedB0W" role="2iSdaV" />
           <node concept="11L4FC" id="1WAg9Tzu5Td" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
@@ -12013,7 +12013,6 @@
     <property role="3GE5qa" value="expr.portselection" />
     <ref role="1XX52x" to="w9y2:1WAg9Tzrz6d" resolve="PortTypeSpecificPortType" />
     <node concept="3EZMnI" id="1WAg9Tzrz6J" role="2wV5jI">
-      <node concept="2iRfu4" id="1WAg9Tzrz6K" role="2iSdaV" />
       <node concept="3F0ifn" id="1WAg9Tzrz6G" role="3EZMnx">
         <property role="3F0ifm" value="port&lt;" />
         <ref role="1k5W1q" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
@@ -12035,6 +12034,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI_E" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="x8tpS_Roxp">
@@ -12085,7 +12085,7 @@
         </node>
       </node>
       <node concept="3EZMnI" id="x8tpS_Vr2k" role="3EZMnx">
-        <node concept="2iRfu4" id="x8tpS_Vr2l" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedE7i" role="2iSdaV" />
         <node concept="2T_mXK" id="7DfYVnpb1bq" role="3EZMnx">
           <node concept="2T_bXS" id="7DfYVnpb1ke" role="3F10Kt">
             <property role="Vb096" value="fLJRk5_/gray" />
@@ -12132,7 +12132,7 @@
         <node concept="2iRkQZ" id="x8tpSAOL_x" role="2iSdaV" />
         <node concept="3EZMnI" id="x8tpSAONaW" role="3EZMnx">
           <node concept="3EZMnI" id="x8tpSAONDo" role="3EZMnx">
-            <node concept="2iRfu4" id="x8tpSAONDp" role="2iSdaV" />
+            <node concept="l2Vlx" id="1ASK_HedE7k" role="2iSdaV" />
             <node concept="2T_mXK" id="7DfYVnpe6Zu" role="3EZMnx">
               <node concept="2T_bXS" id="7DfYVnpe6Zv" role="3F10Kt">
                 <property role="Vb096" value="hEZAO13/white" />
@@ -12188,7 +12188,7 @@
           </node>
           <node concept="3EZMnI" id="x8tpSARW4U" role="3EZMnx">
             <node concept="3EZMnI" id="x8tpSARW4V" role="3EZMnx">
-              <node concept="2iRfu4" id="x8tpSARW4W" role="2iSdaV" />
+              <node concept="l2Vlx" id="1ASK_HedE7o" role="2iSdaV" />
               <node concept="2T_mXK" id="7DfYVnpe7Lc" role="3EZMnx">
                 <node concept="2T_bXS" id="7DfYVnpe7Ld" role="3F10Kt">
                   <property role="Vb096" value="hEZAO13/white" />
@@ -12240,7 +12240,7 @@
           </node>
           <node concept="3EZMnI" id="x8tpSARW5r" role="3EZMnx">
             <node concept="3EZMnI" id="x8tpSARW5s" role="3EZMnx">
-              <node concept="2iRfu4" id="x8tpSARW5t" role="2iSdaV" />
+              <node concept="l2Vlx" id="1ASK_HedE7q" role="2iSdaV" />
               <node concept="2T_mXK" id="7DfYVnpe7WH" role="3EZMnx">
                 <node concept="2T_bXS" id="7DfYVnpe7WI" role="3F10Kt">
                   <property role="Vb096" value="hEZAO13/white" />
@@ -12290,7 +12290,7 @@
               </node>
             </node>
           </node>
-          <node concept="2iRfu4" id="x8tpSARW5W" role="2iSdaV" />
+          <node concept="l2Vlx" id="1ASK_HedE7m" role="2iSdaV" />
         </node>
         <node concept="1HlG4h" id="x8tpS_Rrx2" role="AHCbl">
           <ref role="1k5W1q" node="7Dcax7Ah0s0" resolve="componentsKeyword" />
@@ -12781,7 +12781,6 @@
         </node>
       </node>
       <node concept="3EZMnI" id="6Zesk0deSc" role="3EZMnx">
-        <node concept="2iRfu4" id="6Zesk0deSd" role="2iSdaV" />
         <node concept="2T_mXK" id="7DfYVnpkjKr" role="3EZMnx">
           <node concept="2T_bXS" id="7DfYVnpkjKs" role="3F10Kt">
             <property role="Vb096" value="fLJRk5_/gray" />
@@ -12804,6 +12803,7 @@
             <property role="1lJzqX" value="2" />
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI_F" role="2iSdaV" />
       </node>
       <node concept="gc7cB" id="6Zesk0deSw" role="3EZMnx">
         <node concept="3VJUX4" id="6Zesk0deSx" role="3YsKMw">
@@ -12863,7 +12863,6 @@
         <node concept="VPM3Z" id="1UsX3PC54Tk" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="2iRfu4" id="1UsX3PC54Tn" role="2iSdaV" />
         <node concept="2T_mXK" id="7DfYVnpkjN5" role="3EZMnx">
           <node concept="2T_bXS" id="7DfYVnpkjN6" role="3F10Kt">
             <property role="Vb096" value="fLJRk5_/gray" />
@@ -12943,6 +12942,7 @@
             <property role="1lJzqX" value="2" />
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI_G" role="2iSdaV" />
       </node>
       <node concept="2T_mXK" id="7DfYVnpkjB8" role="3EZMnx">
         <node concept="2T_bXS" id="7DfYVnpkjB9" role="3F10Kt">
@@ -13079,7 +13079,6 @@
     <property role="3GE5qa" value="components.substructure" />
     <ref role="1XX52x" to="w9y2:77HYM7HnhfK" resolve="InlineComponentInstance" />
     <node concept="3EZMnI" id="77HYM7H$GrX" role="2wV5jI">
-      <node concept="2iRfu4" id="77HYM7H$GrY" role="2iSdaV" />
       <node concept="3F1sOY" id="77HYM7HooHl" role="3EZMnx">
         <ref role="1NtTu8" to="w9y2:77HYM7HnhfL" resolve="component" />
         <ref role="1ERwB7" node="hhc7obSiWn" resolve="approveDelete" />
@@ -13095,6 +13094,7 @@
       <node concept="VLuvy" id="5gz2b$9WDz7" role="3F10Kt">
         <property role="Vb096" value="fLJRk5_/gray" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI_H" role="2iSdaV" />
     </node>
   </node>
   <node concept="PKFIW" id="7ojHaJ3O9Xp">
@@ -13114,7 +13114,6 @@
           <node concept="37jFXN" id="7Atos1xGvva" role="3F10Kt">
             <property role="37lx6p" value="hZ7kQ4a/CENTER" />
           </node>
-          <node concept="2iRfu4" id="7Atos1xGvjb" role="2iSdaV" />
           <node concept="gc7cB" id="1MFobPsx4tI" role="3EZMnx">
             <node concept="3VJUX4" id="1MFobPsx4tK" role="3YsKMw">
               <node concept="3clFbS" id="1MFobPsx4tM" role="2VODD2">
@@ -13159,12 +13158,12 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedI_I" role="2iSdaV" />
         </node>
         <node concept="3EZMnI" id="7Atos1xJ4Lo" role="3EZMnx">
           <node concept="37jFXN" id="7Atos1xJ4Lp" role="3F10Kt">
             <property role="37lx6p" value="hZ7kQ4a/CENTER" />
           </node>
-          <node concept="2iRfu4" id="7Atos1xJ4Lq" role="2iSdaV" />
           <node concept="3EZMnI" id="7Atos1xJ4LL" role="3EZMnx">
             <node concept="l2Vlx" id="7Atos1xJ4LM" role="2iSdaV" />
             <node concept="3F0ifn" id="7Atos1xJ4LN" role="3EZMnx">
@@ -13190,6 +13189,7 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedI_J" role="2iSdaV" />
         </node>
         <node concept="2iRkQZ" id="1YJV4bMuZdB" role="2iSdaV" />
       </node>
@@ -13274,7 +13274,6 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="1YJV4bMuZgR" role="2iSdaV" />
         <node concept="3EZMnI" id="1YJV4bMuZgS" role="3EZMnx">
           <node concept="l2Vlx" id="1YJV4bMuZgT" role="2iSdaV" />
           <node concept="3F0ifn" id="1YJV4bMuZgU" role="3EZMnx">
@@ -13304,6 +13303,7 @@
           <property role="37lx6p" value="hZ7kQ4a/CENTER" />
         </node>
         <node concept="3XFhqQ" id="1YJV4bMuZhd" role="3EZMnx" />
+        <node concept="l2Vlx" id="1ASK_HedI_K" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -13320,7 +13320,6 @@
         <node concept="37jFXN" id="1VnwbRVGx4u" role="3F10Kt">
           <property role="37lx6p" value="hZ7kQ4a/CENTER" />
         </node>
-        <node concept="2iRfu4" id="1VnwbRVGx4v" role="2iSdaV" />
         <node concept="gc7cB" id="1VnwbRVGx4w" role="3EZMnx">
           <node concept="3VJUX4" id="1VnwbRVGx4x" role="3YsKMw">
             <node concept="3clFbS" id="1VnwbRVGx4y" role="2VODD2">
@@ -13365,6 +13364,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI_L" role="2iSdaV" />
       </node>
       <node concept="pkWqt" id="1VnwbRVGx56" role="3e4ffs">
         <node concept="3clFbS" id="1VnwbRVGx57" role="2VODD2">
@@ -13410,11 +13410,11 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="1VnwbRVGx5E" role="2iSdaV" />
         <node concept="37jFXN" id="1VnwbRVGx5R" role="3F10Kt">
           <property role="37lx6p" value="hZ7kQ4a/CENTER" />
         </node>
         <node concept="3XFhqQ" id="1VnwbRVGx5S" role="3EZMnx" />
+        <node concept="l2Vlx" id="1ASK_HedI_M" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -13440,7 +13440,6 @@
     <node concept="3EZMnI" id="77HYM7Hoq7d" role="2wV5jI">
       <property role="S$Qs1" value="true" />
       <node concept="3EZMnI" id="77HYM7Hoq7e" role="3EZMnx">
-        <node concept="2iRfu4" id="77HYM7Hoq7f" role="2iSdaV" />
         <node concept="3F0ifn" id="77HYM7Hoq7j" role="3EZMnx">
           <property role="3F0ifm" value="inline instance" />
           <ref role="1k5W1q" node="7Dcax7Ah0s0" resolve="componentsKeyword" />
@@ -13479,7 +13478,6 @@
         <node concept="1v6uyg" id="uuJ7IpZty7" role="3EZMnx">
           <property role="2oejA6" value="true" />
           <node concept="3EZMnI" id="77HYM7Hoq7o" role="wsdo6">
-            <node concept="2iRfu4" id="77HYM7Hoq7p" role="2iSdaV" />
             <node concept="gc7cB" id="77HYM7Hoq7q" role="3EZMnx">
               <node concept="3VJUX4" id="77HYM7Hoq7r" role="3YsKMw">
                 <node concept="3clFbS" id="77HYM7Hoq7s" role="2VODD2">
@@ -13539,6 +13537,7 @@
                 </node>
               </node>
             </node>
+            <node concept="l2Vlx" id="1ASK_HedI_O" role="2iSdaV" />
           </node>
           <node concept="3F0A7n" id="77HYM7Hoq7n" role="1j7Clw">
             <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
@@ -13547,6 +13546,7 @@
         <node concept="3F0ifn" id="77HYM7Hoq81" role="3EZMnx">
           <property role="3F0ifm" value="{" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI_N" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="77HYM7Hoq82" role="3EZMnx">
         <node concept="VPM3Z" id="77HYM7Hoq83" role="3F10Kt">
@@ -13559,7 +13559,6 @@
         <node concept="3F1sOY" id="77HYM7Hoq86" role="3EZMnx">
           <ref role="1NtTu8" to="w9y2:1WAg9TyWDtQ" resolve="expttest" />
         </node>
-        <node concept="2iRfu4" id="77HYM7Hoq87" role="2iSdaV" />
         <node concept="pkWqt" id="77HYM7Hoq88" role="pqm2j">
           <node concept="3clFbS" id="77HYM7Hoq89" role="2VODD2">
             <node concept="3clFbF" id="77HYM7Hoq8a" role="3cqZAp">
@@ -13575,10 +13574,10 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI_P" role="2iSdaV" />
       </node>
       <node concept="2iRkQZ" id="77HYM7Hoq8g" role="2iSdaV" />
       <node concept="3EZMnI" id="77HYM7Hoq8h" role="3EZMnx">
-        <node concept="2iRfu4" id="77HYM7Hoq8i" role="2iSdaV" />
         <node concept="3XFhqQ" id="77HYM7Hoq8j" role="3EZMnx" />
         <node concept="3EZMnI" id="77HYM7Hoq8k" role="3EZMnx">
           <node concept="PMmxH" id="77HYM7Hoq8l" role="3EZMnx">
@@ -13609,12 +13608,12 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI_Q" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="77HYM7Hoq8x" role="3EZMnx">
         <property role="3F0ifm" value="}" />
       </node>
       <node concept="3EZMnI" id="77HYM7Hoq8y" role="AHCbl">
-        <node concept="2iRfu4" id="77HYM7Hoq8z" role="2iSdaV" />
         <node concept="3F0ifn" id="77HYM7Hoq8G" role="3EZMnx">
           <property role="3F0ifm" value="inline instance" />
           <ref role="1k5W1q" node="7Dcax7Ah0s0" resolve="componentsKeyword" />
@@ -13647,6 +13646,7 @@
         <node concept="3F0ifn" id="77HYM7Hoq8Z" role="3EZMnx">
           <property role="3F0ifm" value="{...}" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI_R" role="2iSdaV" />
       </node>
     </node>
     <node concept="3EZMnI" id="77HYM7HoqS1" role="6VMZX">
@@ -13669,7 +13669,6 @@
         </node>
       </node>
       <node concept="3EZMnI" id="77HYM7HoqSa" role="3EZMnx">
-        <node concept="2iRfu4" id="77HYM7HoqSb" role="2iSdaV" />
         <node concept="gc7cB" id="77HYM7HoqSc" role="3EZMnx">
           <node concept="3VJUX4" id="77HYM7HoqSd" role="3YsKMw">
             <node concept="3clFbS" id="77HYM7HoqSe" role="2VODD2">
@@ -13729,6 +13728,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI_S" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -13742,7 +13742,6 @@
         <node concept="37jFXN" id="1YJV4bMuZrt" role="3F10Kt">
           <property role="37lx6p" value="hZ7kQ4a/CENTER" />
         </node>
-        <node concept="2iRfu4" id="1YJV4bMuZru" role="2iSdaV" />
         <node concept="gc7cB" id="1YJV4bMuZrv" role="3EZMnx">
           <node concept="3VJUX4" id="1YJV4bMuZrw" role="3YsKMw">
             <node concept="3clFbS" id="1YJV4bMuZrx" role="2VODD2">
@@ -13787,6 +13786,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI_T" role="2iSdaV" />
       </node>
       <node concept="pkWqt" id="1YJV4bMuZs5" role="3e4ffs">
         <node concept="3clFbS" id="1YJV4bMuZs6" role="2VODD2">
@@ -13845,11 +13845,11 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="1YJV4bMuZsD" role="2iSdaV" />
         <node concept="37jFXN" id="1YJV4bMuZsQ" role="3F10Kt">
           <property role="37lx6p" value="hZ7kQ4a/CENTER" />
         </node>
         <node concept="3XFhqQ" id="1YJV4bMuZsR" role="3EZMnx" />
+        <node concept="l2Vlx" id="1ASK_HedI_U" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -13877,7 +13877,7 @@
       <node concept="3F1sOY" id="5aaqidNQeT0" role="3EZMnx">
         <ref role="1NtTu8" to="w9y2:4kCIAUZDpkP" resolve="value" />
       </node>
-      <node concept="2iRfu4" id="4kCIAUZDmJu" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedI_V" role="2iSdaV" />
     </node>
   </node>
   <node concept="1h_SRR" id="hhc7obSiWn">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.req/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.req/models/editor.mps
@@ -24,8 +24,8 @@
       <concept id="1078308402140" name="jetbrains.mps.lang.editor.structure.CellModel_Custom" flags="sg" stub="8104358048506730068" index="gc7cB">
         <child id="1176795024817" name="cellProvider" index="3YsKMw" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
@@ -159,7 +159,7 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="cJpacq5XBF" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIzs" role="2iSdaV" />
       </node>
       <node concept="gc7cB" id="cJpacq6vPB" role="3EZMnx">
         <node concept="3VJUX4" id="cJpacq6vPC" role="3YsKMw">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.assessment/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.assessment/models/editor.mps
@@ -20,6 +20,7 @@
         <child id="1140524464360" name="cellLayout" index="2czzBx" />
       </concept>
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
@@ -273,7 +274,7 @@
         <ref role="1NtTu8" to="330h:5ZLQMNq2g6M" resolve="traceTargets" />
         <node concept="2iRfu4" id="5ZLQMNq2kcu" role="2czzBx" />
       </node>
-      <node concept="2iRfu4" id="5ZLQMNq2iky" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedI_5" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5ZLQMNq2l6u">
@@ -330,7 +331,7 @@
       <node concept="3F1sOY" id="5ZLQMNq2laq" role="3EZMnx">
         <ref role="1NtTu8" to="330h:5ZLQMNq2hPN" resolve="scope" />
       </node>
-      <node concept="2iRfu4" id="5ZLQMNq2l6z" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedI_6" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="1lUgLJUk$sf">
@@ -397,14 +398,13 @@
       <node concept="3F1sOY" id="378sigX35nl" role="3EZMnx">
         <ref role="1NtTu8" to="330h:378sigX35lr" resolve="scope" />
       </node>
-      <node concept="2iRfu4" id="378sigX35m4" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedI_7" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="378sigX4OUJ">
     <property role="3GE5qa" value="result" />
     <ref role="1XX52x" to="330h:378sigX3YpU" resolve="UntracedResult" />
     <node concept="3EZMnI" id="378sigX4OV4" role="2wV5jI">
-      <node concept="2iRfu4" id="378sigX4OV7" role="2iSdaV" />
       <node concept="1iCGBv" id="6_Ift$_CY$T" role="3EZMnx">
         <ref role="1NtTu8" to="330h:378sigX3YpV" resolve="element" />
         <node concept="1sVBvm" id="6_Ift$_CY$U" role="1sWHZn">
@@ -445,6 +445,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI_8" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.attributes/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.attributes/models/editor.mps
@@ -45,7 +45,6 @@
       <concept id="1078308402140" name="jetbrains.mps.lang.editor.structure.CellModel_Custom" flags="sg" stub="8104358048506730068" index="gc7cB">
         <child id="1176795024817" name="cellProvider" index="3YsKMw" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
@@ -632,7 +631,6 @@
                   </node>
                 </node>
               </node>
-              <node concept="2iRfu4" id="3Nl4besgRzm" role="2iSdaV" />
               <node concept="VPM3Z" id="3Nl4besgRzn" role="3F10Kt">
                 <property role="VOm3f" value="false" />
               </node>
@@ -642,6 +640,7 @@
               <node concept="3F1sOY" id="3Nl4besgRzp" role="3EZMnx">
                 <ref role="1NtTu8" to="138:1HqphBIBJyQ" resolve="value" />
               </node>
+              <node concept="l2Vlx" id="1ASK_HedIzf" role="2iSdaV" />
             </node>
           </node>
           <node concept="pkWqt" id="3Nl4besgRzq" role="1p_IA6">
@@ -674,14 +673,13 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="1HqphBIQDHN" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIze" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="1HqphBIZ3zL">
     <property role="3GE5qa" value="attributes" />
     <ref role="1XX52x" to="138:1HqphBIxQFX" resolve="IValueAttribute" />
     <node concept="3EZMnI" id="1HqphBIQDqs" role="2wV5jI">
-      <node concept="2iRfu4" id="1HqphBIQDqt" role="2iSdaV" />
       <node concept="1HlG4h" id="1HqphBIQDc5" role="3EZMnx">
         <node concept="1HfYo3" id="1HqphBIQDc7" role="1HlULh">
           <node concept="3TQlhw" id="1HqphBIQDc9" role="1Hhtcw">
@@ -710,6 +708,7 @@
       <node concept="3F1sOY" id="1HqphBIQDAI" role="3EZMnx">
         <ref role="1NtTu8" to="138:1HqphBIBJyQ" resolve="value" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzg" role="2iSdaV" />
     </node>
   </node>
   <node concept="PKFIW" id="4um6WxnZYeG">
@@ -911,7 +910,6 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="165w3u_zeWp" role="2iSdaV" />
       <node concept="pkWqt" id="5yaPPfdA2S5" role="pqm2j">
         <node concept="3clFbS" id="5yaPPfdA2S6" role="2VODD2">
           <node concept="3clFbF" id="5yaPPfdA4p1" role="3cqZAp">
@@ -924,6 +922,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzh" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="43MQ47XI4aS">
@@ -939,7 +938,7 @@
       <node concept="3F1sOY" id="43MQ47XI4cO" role="3EZMnx">
         <ref role="1NtTu8" to="138:43MQ47XHSpR" resolve="value" />
       </node>
-      <node concept="2iRfu4" id="43MQ47XI4b2" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIzi" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4fgA7QrG5MD">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/models/editor.mps
@@ -42,6 +42,7 @@
       </concept>
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
@@ -314,7 +315,6 @@
   <node concept="24kQdi" id="5a_u3OyMtus">
     <ref role="1XX52x" to="v0r8:5a_u3OyMtco" resolve="AlgebraicDeclaration" />
     <node concept="3EZMnI" id="5a_u3OyMtvq" role="2wV5jI">
-      <node concept="2iRfu4" id="5a_u3OyMtvr" role="2iSdaV" />
       <node concept="3F0ifn" id="5a_u3OyMtuu" role="3EZMnx">
         <property role="3F0ifm" value="algebraic" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -333,6 +333,7 @@
           <property role="3F0ifm" value="{...}" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsk" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5a_u3OyMtwp">
@@ -340,7 +341,6 @@
     <node concept="3EZMnI" id="5a_u3OzNQ$I" role="2wV5jI">
       <node concept="2iRkQZ" id="5a_u3OzNQ$J" role="2iSdaV" />
       <node concept="3EZMnI" id="5a_u3OyMtwu" role="3EZMnx">
-        <node concept="2iRfu4" id="5a_u3OyMtwv" role="2iSdaV" />
         <node concept="3F0ifn" id="5a_u3OyMtwr" role="3EZMnx">
           <property role="3F0ifm" value="|" />
         </node>
@@ -360,7 +360,6 @@
           <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
         </node>
         <node concept="3EZMnI" id="5a_u3OzNmXx" role="3EZMnx">
-          <node concept="2iRfu4" id="5a_u3OzNmXy" role="2iSdaV" />
           <node concept="3F0ifn" id="5a_u3OyMtwJ" role="3EZMnx">
             <property role="3F0ifm" value="(" />
             <node concept="11LMrY" id="5a_u3OyMtwZ" role="3F10Kt">
@@ -398,7 +397,9 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIsm" role="2iSdaV" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIsl" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="5a_u3OzNR0r" role="3EZMnx">
         <node concept="VPM3Z" id="5a_u3OzNR0t" role="3F10Kt">
@@ -413,7 +414,6 @@
             <property role="3F0ifm" value="{...}" />
           </node>
         </node>
-        <node concept="2iRfu4" id="5a_u3OzNR0w" role="2iSdaV" />
         <node concept="pkWqt" id="5a_u3OzNRqL" role="pqm2j">
           <node concept="3clFbS" id="5a_u3OzNRqM" role="2VODD2">
             <node concept="3clFbF" id="5a_u3OzNRxX" role="3cqZAp">
@@ -429,12 +429,12 @@
         <node concept="3F0ifn" id="7aipPVpSbkA" role="AHCbl">
           <property role="3F0ifm" value="{...}" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIsn" role="2iSdaV" />
       </node>
     </node>
     <node concept="3EZMnI" id="7aipPVq6gB6" role="6VMZX">
       <node concept="2iRkQZ" id="7aipPVq6gB7" role="2iSdaV" />
       <node concept="3EZMnI" id="7aipPVq1RLg" role="3EZMnx">
-        <node concept="2iRfu4" id="7aipPVq1RLh" role="2iSdaV" />
         <node concept="3F0ifn" id="7aipPVq1RLm" role="3EZMnx">
           <property role="3F0ifm" value="symbolic name:" />
         </node>
@@ -442,9 +442,9 @@
           <property role="1O74Pk" value="true" />
           <ref role="1NtTu8" to="v0r8:7aipPVq1Rrh" resolve="symbolicName" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIso" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="7aipPVq6gNG" role="3EZMnx">
-        <node concept="2iRfu4" id="7aipPVq6gNH" role="2iSdaV" />
         <node concept="3F0ifn" id="7aipPVq6gNI" role="3EZMnx">
           <property role="3F0ifm" value="no symbol:    " />
         </node>
@@ -452,9 +452,9 @@
           <property role="1O74Pk" value="true" />
           <ref role="1NtTu8" to="v0r8:7aipPVq6grL" resolve="noSymbol" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIsp" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="7aipPVqatUQ" role="3EZMnx">
-        <node concept="2iRfu4" id="7aipPVqatUR" role="2iSdaV" />
         <node concept="3F0ifn" id="7aipPVqatUS" role="3EZMnx">
           <property role="3F0ifm" value="infix:        " />
         </node>
@@ -462,6 +462,7 @@
           <property role="1O74Pk" value="true" />
           <ref role="1NtTu8" to="v0r8:7aipPVqatax" resolve="infix" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIsq" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -494,7 +495,6 @@
     <node concept="3EZMnI" id="5a_u3Ozad_3" role="2wV5jI">
       <node concept="2iRkQZ" id="5a_u3Ozad_4" role="2iSdaV" />
       <node concept="3EZMnI" id="5a_u3Oz7hIn" role="3EZMnx">
-        <node concept="2iRfu4" id="5a_u3Oz7hIo" role="2iSdaV" />
         <node concept="1kIj98" id="5a_u3Oz7hIp" role="3EZMnx">
           <node concept="3F1sOY" id="5a_u3Oz7hIq" role="1kIj9b">
             <ref role="1NtTu8" to="v0r8:5a_u3OyMSQm" resolve="type" />
@@ -567,6 +567,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIsr" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="28$LOSBsDin" role="3EZMnx">
         <node concept="2iRkQZ" id="28$LOSBsGOk" role="2iSdaV" />
@@ -585,7 +586,6 @@
           </node>
         </node>
         <node concept="3EZMnI" id="28$LOSBsHij" role="3EZMnx">
-          <node concept="2iRfu4" id="28$LOSBsHik" role="2iSdaV" />
           <node concept="3XFhqQ" id="28$LOSBsI7r" role="3EZMnx" />
           <node concept="3F2HdR" id="28$LOSBsDiO" role="3EZMnx">
             <ref role="1NtTu8" to="v0r8:5a_u3OyMSNE" resolve="args" />
@@ -597,6 +597,7 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIss" role="2iSdaV" />
         </node>
         <node concept="pkWqt" id="28$LOSBsDjM" role="pqm2j">
           <node concept="3clFbS" id="28$LOSBsDjN" role="2VODD2">
@@ -626,7 +627,6 @@
       <node concept="3EZMnI" id="7aipPVpTAJ1" role="3EZMnx">
         <node concept="2iRkQZ" id="7aipPVpTAJ2" role="2iSdaV" />
         <node concept="3EZMnI" id="7aipPVpTAJ3" role="3EZMnx">
-          <node concept="2iRfu4" id="7aipPVpTAJ4" role="2iSdaV" />
           <node concept="1kIj98" id="7aipPVpTAJ5" role="3EZMnx">
             <node concept="3F1sOY" id="7aipPVpTAJ6" role="1kIj9b">
               <ref role="1NtTu8" to="v0r8:5a_u3OyMSQm" resolve="type" />
@@ -729,6 +729,7 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIst" role="2iSdaV" />
         </node>
         <node concept="3EZMnI" id="7aipPVpTAJD" role="3EZMnx">
           <node concept="VPM3Z" id="7aipPVpTAJE" role="3F10Kt">
@@ -812,7 +813,6 @@
               </node>
             </node>
           </node>
-          <node concept="2iRfu4" id="7aipPVpTAK7" role="2iSdaV" />
           <node concept="pkWqt" id="7aipPVpTAK8" role="pqm2j">
             <node concept="3clFbS" id="7aipPVpTAK9" role="2VODD2">
               <node concept="3clFbJ" id="7aipPVpTAKa" role="3cqZAp">
@@ -862,6 +862,7 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIsu" role="2iSdaV" />
         </node>
         <node concept="pkWqt" id="7aipPVpTSYf" role="pqm2j">
           <node concept="3clFbS" id="7aipPVpTSYg" role="2VODD2">
@@ -922,7 +923,7 @@
             <property role="VOm3f" value="true" />
           </node>
         </node>
-        <node concept="2iRfu4" id="54HsVvNUXeE" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIsv" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -931,7 +932,6 @@
     <node concept="3EZMnI" id="5a_u3OySkaB" role="2wV5jI">
       <node concept="2iRkQZ" id="5a_u3OySkaC" role="2iSdaV" />
       <node concept="3EZMnI" id="5a_u3OySk7X" role="3EZMnx">
-        <node concept="2iRfu4" id="5a_u3OySk7Y" role="2iSdaV" />
         <node concept="3F0ifn" id="5a_u3OySk7U" role="3EZMnx">
           <property role="3F0ifm" value="match" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -954,9 +954,9 @@
             <property role="VOm3f" value="true" />
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIsw" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="5a_u3OySkbb" role="3EZMnx">
-        <node concept="2iRfu4" id="5a_u3OySkbc" role="2iSdaV" />
         <node concept="gc7cB" id="5a_u3OzouqX" role="3EZMnx">
           <node concept="3VJUX4" id="5a_u3OzouqZ" role="3YsKMw">
             <node concept="3clFbS" id="5a_u3Ozour1" role="2VODD2">
@@ -992,6 +992,7 @@
             <property role="3F0ifm" value="{...}" />
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIsx" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -1047,7 +1048,7 @@
       <node concept="3F1sOY" id="5a_u3OySk9q" role="3EZMnx">
         <ref role="1NtTu8" to="v0r8:5a_u3OySk8u" resolve="result" />
       </node>
-      <node concept="2iRfu4" id="5a_u3OySk98" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIsy" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5a_u3OySC0q">
@@ -1065,7 +1066,6 @@
   <node concept="24kQdi" id="5a_u3OyUzmJ">
     <ref role="1XX52x" to="v0r8:5a_u3OyUzm8" resolve="NameAnnotation" />
     <node concept="3EZMnI" id="5a_u3OyUzmX" role="2wV5jI">
-      <node concept="2iRfu4" id="5a_u3OyUzmY" role="2iSdaV" />
       <node concept="2SsqMj" id="5a_u3OyUzmU" role="3EZMnx" />
       <node concept="3F0ifn" id="5a_u3OyUzn6" role="3EZMnx">
         <property role="3F0ifm" value="@" />
@@ -1091,6 +1091,7 @@
           <property role="Vb096" value="fLwANPs/magenta" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsz" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5a_u3OyVzc4">
@@ -1114,7 +1115,6 @@
   <node concept="24kQdi" id="5a_u3OyYLf7">
     <ref role="1XX52x" to="v0r8:5a_u3OyYLey" resolve="NameExpr" />
     <node concept="3EZMnI" id="5a_u3OyYLfi" role="2wV5jI">
-      <node concept="2iRfu4" id="5a_u3OyYLfj" role="2iSdaV" />
       <node concept="3F0ifn" id="5a_u3OyYLff" role="3EZMnx">
         <property role="3F0ifm" value="@" />
         <node concept="Vb9p2" id="5a_u3OyYLf$" role="3F10Kt">
@@ -1136,6 +1136,7 @@
           <property role="Vb096" value="fLwANPs/magenta" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIs$" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5a_u3Oz3q2I">
@@ -1159,7 +1160,6 @@
   <node concept="24kQdi" id="5a_u3Oz5b3O">
     <ref role="1XX52x" to="v0r8:5a_u3Oz5b39" resolve="CaseCondition" />
     <node concept="3EZMnI" id="5a_u3Oz5bbt" role="2wV5jI">
-      <node concept="2iRfu4" id="5a_u3Oz5bbu" role="2iSdaV" />
       <node concept="3F0ifn" id="5a_u3Oz5bbq" role="3EZMnx">
         <property role="3F0ifm" value="if" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -1167,6 +1167,7 @@
       <node concept="3F1sOY" id="5a_u3Oz5bbA" role="3EZMnx">
         <ref role="1NtTu8" to="v0r8:5a_u3Oz5b3p" resolve="cond" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIs_" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5a_u3OzlhaU">
@@ -1180,7 +1181,6 @@
     <property role="3GE5qa" value="traverse" />
     <ref role="1XX52x" to="v0r8:5a_u3Ozlh9S" resolve="TraverseExpr" />
     <node concept="3EZMnI" id="5a_u3Ozlhc3" role="2wV5jI">
-      <node concept="2iRfu4" id="5a_u3Ozlhc4" role="2iSdaV" />
       <node concept="3F0ifn" id="5a_u3OzlhbZ" role="3EZMnx">
         <property role="3F0ifm" value="traverse" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -1224,6 +1224,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsA" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5a_u3OzRCT9">
@@ -1391,7 +1392,6 @@
     <property role="3GE5qa" value="quote" />
     <ref role="1XX52x" to="v0r8:28$LOSAcnmu" resolve="QuoteExpression" />
     <node concept="3EZMnI" id="28$LOSAcnn5" role="2wV5jI">
-      <node concept="2iRfu4" id="28$LOSAcnn6" role="2iSdaV" />
       <node concept="3F0ifn" id="28$LOSAcnn1" role="3EZMnx">
         <property role="3F0ifm" value="quote" />
       </node>
@@ -1413,13 +1413,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsB" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="28$LOSAcnoC">
     <property role="3GE5qa" value="quote" />
     <ref role="1XX52x" to="v0r8:28$LOSAcnob" resolve="QuotedTermType" />
     <node concept="3EZMnI" id="28$LOSAflsy" role="2wV5jI">
-      <node concept="2iRfu4" id="28$LOSAflsz" role="2iSdaV" />
       <node concept="3F0ifn" id="28$LOSAcnoE" role="3EZMnx">
         <property role="3F0ifm" value="quoted" />
         <ref role="1k5W1q" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
@@ -1447,13 +1447,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsC" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="28$LOSAeeDq">
     <property role="3GE5qa" value="quote" />
     <ref role="1XX52x" to="v0r8:28$LOSAeeCX" resolve="UnquoteExpression" />
     <node concept="3EZMnI" id="28$LOSAeeDs" role="2wV5jI">
-      <node concept="2iRfu4" id="28$LOSAeeDt" role="2iSdaV" />
       <node concept="3F0ifn" id="28$LOSAeeDu" role="3EZMnx">
         <property role="3F0ifm" value="unquote" />
       </node>
@@ -1475,13 +1475,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsD" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="28$LOSAJ7F_">
     <property role="3GE5qa" value="dot" />
     <ref role="1XX52x" to="v0r8:28$LOSAJ7nc" resolve="ReplaceWith" />
     <node concept="3EZMnI" id="28$LOSAJ7FF" role="2wV5jI">
-      <node concept="2iRfu4" id="28$LOSAJ7FG" role="2iSdaV" />
       <node concept="3F0ifn" id="28$LOSAJ7FB" role="3EZMnx">
         <property role="3F0ifm" value="replaceWith" />
       </node>
@@ -1503,6 +1503,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsE" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="28$LOSAMChr">
@@ -1530,7 +1531,6 @@
     <property role="3GE5qa" value="dot" />
     <ref role="1XX52x" to="v0r8:28$LOSBqa1k" resolve="Ancestor" />
     <node concept="3EZMnI" id="28$LOSBqa1L" role="2wV5jI">
-      <node concept="2iRfu4" id="28$LOSBqa1M" role="2iSdaV" />
       <node concept="3F0ifn" id="28$LOSBqa23" role="3EZMnx">
         <property role="3F0ifm" value="ancestor" />
       </node>
@@ -1552,12 +1552,12 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsF" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="28$LOSBCuhf">
     <ref role="1XX52x" to="v0r8:28$LOSBCtT$" resolve="AlgebraicConstructorArg" />
     <node concept="3EZMnI" id="28$LOSBF$UT" role="2wV5jI">
-      <node concept="2iRfu4" id="28$LOSBF$UU" role="2iSdaV" />
       <node concept="1kIj98" id="28$LOSBCuhk" role="3EZMnx">
         <node concept="3F1sOY" id="28$LOSBCuhq" role="1kIj9b">
           <ref role="1NtTu8" to="hm2y:7D7uZV2iYAD" resolve="type" />
@@ -1595,6 +1595,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsG" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="28$LOSBF$hw">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/models/editor.mps
@@ -252,6 +252,9 @@
       <concept id="8877288515760224194" name="com.mbeddr.mpsutil.treenotation.structure.SimpleInsertFunction" flags="ig" index="1XI84t" />
       <concept id="8877288515760224565" name="com.mbeddr.mpsutil.treenotation.structure.Parameter_index" flags="ng" index="1XI8ZE" />
     </language>
+    <language id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout">
+      <concept id="9000758320091481718" name="de.itemis.mps.editor.celllayout.structure.GridLayoutFlattenStyle" flags="lg" index="1QQdxR" />
+    </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
       <concept id="1176544042499" name="jetbrains.mps.lang.typesystem.structure.Node_TypeOperation" flags="nn" index="3JvlWi" />
     </language>
@@ -999,6 +1002,9 @@
   <node concept="24kQdi" id="5a_u3OySk8U">
     <ref role="1XX52x" to="v0r8:5a_u3OySk8l" resolve="MatchCase" />
     <node concept="3EZMnI" id="5a_u3OySk95" role="2wV5jI">
+      <node concept="1QQdxR" id="2tlTgwes_Ls" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
       <node concept="3F1sOY" id="5a_u3OySk9c" role="3EZMnx">
         <ref role="1NtTu8" to="v0r8:5a_u3OySk8s" resolve="pattern" />
       </node>
@@ -1048,7 +1054,7 @@
       <node concept="3F1sOY" id="5a_u3OySk9q" role="3EZMnx">
         <ref role="1NtTu8" to="v0r8:5a_u3OySk8u" resolve="result" />
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIsy" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwet$IZ" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5a_u3OySC0q">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/models/editor.mps
@@ -43,8 +43,11 @@
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
+      <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
+      <concept id="1237375020029" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineChildrenStyleClassItem" flags="ln" index="pj6Ft" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
+      <concept id="1237385578942" name="jetbrains.mps.lang.editor.structure.IndentLayoutOnNewLineStyleClassItem" flags="ln" index="pVoyu" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
@@ -102,7 +105,6 @@
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <child id="1106270802874" name="cellLayout" index="2iSdaV" />
-        <child id="7723470090030138869" name="foldedCellModel" index="AHCbl" />
         <child id="1073389446424" name="childCellModel" index="3EZMnx" />
       </concept>
       <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn">
@@ -115,7 +117,6 @@
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
       <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
       <concept id="1176749715029" name="jetbrains.mps.lang.editor.structure.QueryFunction_CellProvider" flags="in" index="3VJUX4" />
-      <concept id="1198256887712" name="jetbrains.mps.lang.editor.structure.CellModel_Indent" flags="ng" index="3XFhqQ" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
@@ -342,7 +343,7 @@
   <node concept="24kQdi" id="5a_u3OyMtwp">
     <ref role="1XX52x" to="v0r8:5a_u3OyMttW" resolve="AlgebraicConstructor" />
     <node concept="3EZMnI" id="5a_u3OzNQ$I" role="2wV5jI">
-      <node concept="2iRkQZ" id="5a_u3OzNQ$J" role="2iSdaV" />
+      <node concept="l2Vlx" id="2tlTgwfDRha" role="2iSdaV" />
       <node concept="3EZMnI" id="5a_u3OyMtwu" role="3EZMnx">
         <node concept="3F0ifn" id="5a_u3OyMtwr" role="3EZMnx">
           <property role="3F0ifm" value="|" />
@@ -404,21 +405,21 @@
         </node>
         <node concept="l2Vlx" id="1ASK_HedIsl" role="2iSdaV" />
       </node>
-      <node concept="3EZMnI" id="5a_u3OzNR0r" role="3EZMnx">
-        <node concept="VPM3Z" id="5a_u3OzNR0t" role="3F10Kt">
-          <property role="VOm3f" value="false" />
+      <node concept="3F2HdR" id="5a_u3OzNRqC" role="3EZMnx">
+        <property role="S$F3r" value="true" />
+        <ref role="1NtTu8" to="v0r8:5a_u3OzNl11" resolve="constructors" />
+        <node concept="l2Vlx" id="2tlTgweofJ_" role="2czzBx" />
+        <node concept="3F0ifn" id="7aipPVpSSf6" role="3EmGlc">
+          <property role="3F0ifm" value="{...}" />
         </node>
-        <node concept="3XFhqQ" id="5a_u3OzNRdU" role="3EZMnx" />
-        <node concept="3F2HdR" id="5a_u3OzNRqC" role="3EZMnx">
-          <property role="S$F3r" value="true" />
-          <ref role="1NtTu8" to="v0r8:5a_u3OzNl11" resolve="constructors" />
-          <node concept="2iRkQZ" id="5a_u3OzOBs3" role="2czzBx" />
-          <node concept="3F0ifn" id="7aipPVpSSf6" role="3EmGlc">
-            <property role="3F0ifm" value="{...}" />
-          </node>
+        <node concept="lj46D" id="2tlTgweofJz" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
-        <node concept="pkWqt" id="5a_u3OzNRqL" role="pqm2j">
-          <node concept="3clFbS" id="5a_u3OzNRqM" role="2VODD2">
+        <node concept="pj6Ft" id="2tlTgweofJC" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pkWqt" id="2tlTgwfDR69" role="pqm2j">
+          <node concept="3clFbS" id="2tlTgwfDR6a" role="2VODD2">
             <node concept="3clFbF" id="5a_u3OzNRxX" role="3cqZAp">
               <node concept="2OqwBi" id="5a_u3OzNRKw" role="3clFbG">
                 <node concept="pncrf" id="5a_u3OzNRxW" role="2Oq$k0" />
@@ -429,10 +430,9 @@
             </node>
           </node>
         </node>
-        <node concept="3F0ifn" id="7aipPVpSbkA" role="AHCbl">
-          <property role="3F0ifm" value="{...}" />
-        </node>
-        <node concept="l2Vlx" id="1ASK_HedIsn" role="2iSdaV" />
+      </node>
+      <node concept="pj6Ft" id="2tlTgwfDRhR" role="3F10Kt">
+        <property role="VOm3f" value="true" />
       </node>
     </node>
     <node concept="3EZMnI" id="7aipPVq6gB6" role="6VMZX">
@@ -573,7 +573,7 @@
         <node concept="l2Vlx" id="1ASK_HedIsr" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="28$LOSBsDin" role="3EZMnx">
-        <node concept="2iRkQZ" id="28$LOSBsGOk" role="2iSdaV" />
+        <node concept="l2Vlx" id="2tlTgwfDRkH" role="2iSdaV" />
         <node concept="1kIj98" id="28$LOSBsDip" role="3EZMnx">
           <node concept="3F1sOY" id="28$LOSBsDiq" role="1kIj9b">
             <ref role="1NtTu8" to="v0r8:5a_u3OyMSQm" resolve="type" />
@@ -588,19 +588,21 @@
             </node>
           </node>
         </node>
-        <node concept="3EZMnI" id="28$LOSBsHij" role="3EZMnx">
-          <node concept="3XFhqQ" id="28$LOSBsI7r" role="3EZMnx" />
-          <node concept="3F2HdR" id="28$LOSBsDiO" role="3EZMnx">
-            <ref role="1NtTu8" to="v0r8:5a_u3OyMSNE" resolve="args" />
-            <node concept="2iRkQZ" id="28$LOSBsIt0" role="2czzBx" />
-            <node concept="3F0ifn" id="28$LOSBsDiQ" role="2czzBI">
-              <property role="3F0ifm" value="" />
-              <node concept="VPxyj" id="28$LOSBsDiR" role="3F10Kt">
-                <property role="VOm3f" value="true" />
-              </node>
+        <node concept="3F2HdR" id="28$LOSBsDiO" role="3EZMnx">
+          <ref role="1NtTu8" to="v0r8:5a_u3OyMSNE" resolve="args" />
+          <node concept="lj46D" id="2tlTgwdEjJY" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="pVoyu" id="2tlTgwfDRu9" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="2iRkQZ" id="28$LOSBsIt0" role="2czzBx" />
+          <node concept="3F0ifn" id="28$LOSBsDiQ" role="2czzBI">
+            <property role="3F0ifm" value="" />
+            <node concept="VPxyj" id="28$LOSBsDiR" role="3F10Kt">
+              <property role="VOm3f" value="true" />
             </node>
           </node>
-          <node concept="l2Vlx" id="1ASK_HedIss" role="2iSdaV" />
         </node>
         <node concept="pkWqt" id="28$LOSBsDjM" role="pqm2j">
           <node concept="3clFbS" id="28$LOSBsDjN" role="2VODD2">
@@ -1046,11 +1048,9 @@
           </node>
         </node>
       </node>
-      <node concept="3XFhqQ" id="5a_u3OySk9$" role="3EZMnx" />
       <node concept="3F0ifn" id="5a_u3OySk9i" role="3EZMnx">
         <property role="3F0ifm" value="=&gt;" />
       </node>
-      <node concept="3XFhqQ" id="5a_u3OySk9K" role="3EZMnx" />
       <node concept="3F1sOY" id="5a_u3OySk9q" role="3EZMnx">
         <ref role="1NtTu8" to="v0r8:5a_u3OySk8u" resolve="result" />
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -28913,7 +28913,7 @@
                       </node>
                       <node concept="2OqwBi" id="4YiHwWVM3cm" role="3uHU7w">
                         <node concept="37vLTw" id="4gPFP6uBVkM" role="2Oq$k0">
-                          <ref role="3cqZAo" node="4gPFP6uBVkI" resolve="integer" />
+                          <ref role="3cqZAo" node="4gPFP6uBVkI" resolve="integerValue" />
                         </node>
                         <node concept="liA8E" id="4YiHwWVM3cq" role="2OqNvi">
                           <ref role="37wK5l" to="xlxw:~BigInteger.toString(int)" resolve="toString" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
@@ -840,7 +840,6 @@
           <ref role="1NtTu8" to="hm2y:4rZeNQ6MpKm" resolve="left" />
         </node>
         <node concept="3EZMnI" id="15gN1OJ6ZFv" role="3EZMnx">
-          <node concept="2iRfu4" id="15gN1OJ6ZFw" role="2iSdaV" />
           <node concept="1Lj6DL" id="15gN1OJ0by9" role="3EZMnx">
             <node concept="1Lj6DC" id="15gN1OJ0byb" role="1Lj8FM">
               <node concept="3clFbS" id="15gN1OJ0byd" role="2VODD2">
@@ -859,6 +858,7 @@
           <node concept="pVoyu" id="7LAhY5FckSE" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIyg" role="2iSdaV" />
         </node>
         <node concept="1QQdxR" id="15gN1OKA3t3" role="3F10Kt">
           <property role="VOm3f" value="true" />
@@ -1094,7 +1094,6 @@
         </node>
       </node>
       <node concept="3EZMnI" id="_kNv2Q_SyU" role="1QoS34">
-        <node concept="2iRfu4" id="_kNv2Q_SyV" role="2iSdaV" />
         <node concept="gc7cB" id="3ijo1YRL7z7" role="3EZMnx">
           <node concept="3VJUX4" id="3ijo1YRL7z9" role="3YsKMw">
             <node concept="3clFbS" id="3ijo1YRL7zb" role="2VODD2">
@@ -1348,6 +1347,7 @@
             <property role="VOm3f" value="false" />
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIyh" role="2iSdaV" />
       </node>
       <node concept="gc7cB" id="3ijo1YSEoeq" role="1QoVPY">
         <node concept="3VJUX4" id="3ijo1YSEoer" role="3YsKMw">
@@ -1766,7 +1766,6 @@
       <node concept="3EZMnI" id="71dSyJVppr5" role="3EZMnx">
         <ref role="1ERwB7" node="71dSyJVpVG$" resolve="deleteInspector" />
         <ref role="1k5W1q" to="itrz:6zaFu4oRqi5" resolve="iets3Smaller" />
-        <node concept="2iRfu4" id="71dSyJVppr6" role="2iSdaV" />
         <node concept="3F0ifn" id="71dSyJVpprk" role="3EZMnx">
           <property role="3F0ifm" value="-&gt;" />
         </node>
@@ -1776,6 +1775,7 @@
             <property role="VOm3f" value="true" />
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIyi" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -1799,7 +1799,6 @@
   <node concept="24kQdi" id="71dSyJVqZSD">
     <ref role="1XX52x" to="hm2y:71dSyJVqZSe" resolve="TracerExpression" />
     <node concept="3EZMnI" id="71dSyJVr0aR" role="2wV5jI">
-      <node concept="2iRfu4" id="71dSyJVr0aS" role="2iSdaV" />
       <node concept="3F0ifn" id="71dSyJVr0b0" role="3EZMnx">
         <property role="3F0ifm" value="[" />
         <node concept="VechU" id="71dSyJVtLwB" role="3F10Kt">
@@ -1866,9 +1865,9 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIyj" role="2iSdaV" />
     </node>
     <node concept="3EZMnI" id="71dSyJVtsWW" role="6VMZX">
-      <node concept="2iRfu4" id="71dSyJVtsWX" role="2iSdaV" />
       <node concept="3F0ifn" id="71dSyJVtsWY" role="3EZMnx">
         <property role="3F0ifm" value="[" />
         <node concept="11LMrY" id="71dSyJVtsWZ" role="3F10Kt">
@@ -1923,13 +1922,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIyk" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="2rOWEwsEjcF">
     <property role="3GE5qa" value="option" />
     <ref role="1XX52x" to="hm2y:2rOWEwsEjcg" resolve="OptionType" />
     <node concept="3EZMnI" id="2rOWEwsEjcK" role="2wV5jI">
-      <node concept="2iRfu4" id="2rOWEwsEjcL" role="2iSdaV" />
       <node concept="PMmxH" id="2rOWEwsEjit" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
         <ref role="1k5W1q" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
@@ -1959,6 +1958,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIyl" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="2rOWEwsEjiY">
@@ -2007,10 +2007,10 @@
           <node concept="3F1sOY" id="5ye9uPrilLJ" role="3EZMnx">
             <ref role="1NtTu8" to="4kwy:cJpacq40jC" resolve="optionalName" />
           </node>
-          <node concept="2iRfu4" id="5ye9uPrilLz" role="2iSdaV" />
           <node concept="VPM3Z" id="5ye9uPrilL$" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIym" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgmO61" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgmO62" role="2VODD2">
@@ -2036,7 +2036,6 @@
       </node>
       <node concept="_tjkj" id="7fOaqhhVEPB" role="3EZMnx">
         <node concept="3EZMnI" id="7fOaqhhVEUK" role="_tjki">
-          <node concept="2iRfu4" id="7fOaqhhVEUL" role="2iSdaV" />
           <node concept="3F0ifn" id="7fOaqhhVEPI" role="3EZMnx">
             <property role="3F0ifm" value="&lt;" />
             <node concept="11L4FC" id="7fOaqhhVESn" role="3F10Kt">
@@ -2058,6 +2057,7 @@
           <node concept="11L4FC" id="7fOaqhhWP5O" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIyn" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqkbz" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqkb$" role="2VODD2">
@@ -2302,7 +2302,6 @@
     <property role="3GE5qa" value="error.types" />
     <ref role="1XX52x" to="hm2y:5BNZGjBtUbJ" resolve="AttemptType" />
     <node concept="3EZMnI" id="1Ez$z58DYWN" role="2wV5jI">
-      <node concept="2iRfu4" id="1Ez$z58DYWO" role="2iSdaV" />
       <node concept="3F0ifn" id="1Ez$z58DYWJ" role="3EZMnx">
         <property role="3F0ifm" value="attempt" />
         <ref role="1k5W1q" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
@@ -2329,7 +2328,6 @@
           <node concept="11L4FC" id="1WAg9TyMWQN" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
-          <node concept="2iRfu4" id="4iVHBBByoVp" role="2iSdaV" />
           <node concept="3F0ifn" id="34FVxARjT7q" role="3EZMnx">
             <property role="3F0ifm" value="|" />
             <node concept="11L4FC" id="34FVxARk$Fc" role="3F10Kt">
@@ -2344,6 +2342,7 @@
             <ref role="1NtTu8" to="hm2y:12WRc28Xz6l" resolve="errorLiterals" />
             <node concept="2iRfu4" id="12WRc28Xzs7" role="2czzBx" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIyp" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgl0sU" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgl0sV" role="2VODD2">
@@ -2361,6 +2360,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIyo" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="1Ez$z58Hu8c">
@@ -2391,13 +2391,13 @@
               <property role="VOm3f" value="true" />
             </node>
           </node>
-          <node concept="2iRfu4" id="1Ez$z58Hu8O" role="2iSdaV" />
           <node concept="VPM3Z" id="1Ez$z58Hu8P" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
           <node concept="11L4FC" id="7JKsSwYyQXa" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIyr" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgl0Dq" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgl0Dr" role="2VODD2">
@@ -2409,14 +2409,13 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="1Ez$z58Hu8h" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIyq" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="1Ez$z58L7EK">
     <property role="3GE5qa" value="error.types" />
     <ref role="1XX52x" to="hm2y:1Ez$z58L7Ek" resolve="SuccessType" />
     <node concept="3EZMnI" id="1Ez$z58L7EQ" role="2wV5jI">
-      <node concept="2iRfu4" id="1Ez$z58L7ER" role="2iSdaV" />
       <node concept="3F0ifn" id="1Ez$z58L7EM" role="3EZMnx">
         <property role="3F0ifm" value="success" />
         <ref role="1k5W1q" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
@@ -2445,6 +2444,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIys" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="1Ez$z58L7JA">
@@ -2486,7 +2486,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="2iRfu4" id="1Ez$z58L7Kd" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIyt" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5BNZGjBvVhu">
@@ -2495,7 +2495,6 @@
     <node concept="3EZMnI" id="5BNZGjBvVhG" role="2wV5jI">
       <node concept="2iRkQZ" id="5OzSgxdVjaL" role="2iSdaV" />
       <node concept="3EZMnI" id="5BNZGjBvVhA" role="3EZMnx">
-        <node concept="2iRfu4" id="5BNZGjBvVhB" role="2iSdaV" />
         <node concept="3F0ifn" id="5BNZGjBvVhz" role="3EZMnx">
           <property role="3F0ifm" value="try" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -2518,7 +2517,6 @@
         </node>
         <node concept="_tjkj" id="69zaTr1XunJ" role="3EZMnx">
           <node concept="3EZMnI" id="69zaTr1Xuo7" role="_tjki">
-            <node concept="2iRfu4" id="69zaTr1Xuo8" role="2iSdaV" />
             <node concept="3F0ifn" id="3kzwyUOm9SN" role="3EZMnx">
               <property role="3F0ifm" value="as" />
               <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -2526,6 +2524,7 @@
             <node concept="3F1sOY" id="69zaTr1XunS" role="3EZMnx">
               <ref role="1NtTu8" to="4kwy:cJpacq40jC" resolve="optionalName" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIyv" role="2iSdaV" />
           </node>
           <node concept="uPpia" id="1ZlHRbgqokZ" role="1djCvC">
             <node concept="3clFbS" id="1ZlHRbgqol0" role="2VODD2">
@@ -2540,6 +2539,7 @@
         <node concept="3F1sOY" id="5BNZGjBxorV" role="3EZMnx">
           <ref role="1NtTu8" to="hm2y:5BNZGjBxo8e" resolve="successClause" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIyu" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="69zaTr1V8re" role="3EZMnx">
         <node concept="VPM3Z" id="69zaTr1V8rg" role="3F10Kt">
@@ -2550,7 +2550,6 @@
           <ref role="1NtTu8" to="hm2y:69zaTr1V8r3" resolve="errorClauses" />
           <node concept="2EHx9g" id="69zaTr1V8rG" role="2czzBx" />
         </node>
-        <node concept="2iRfu4" id="69zaTr1V8rj" role="2iSdaV" />
         <node concept="pkWqt" id="69zaTr1WcV3" role="pqm2j">
           <node concept="3clFbS" id="69zaTr1WcV4" role="2VODD2">
             <node concept="3clFbF" id="69zaTr1WcW9" role="3cqZAp">
@@ -2566,6 +2565,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIyw" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -2579,7 +2579,7 @@
       <node concept="3F1sOY" id="5BNZGjBxo8a" role="3EZMnx">
         <ref role="1NtTu8" to="hm2y:5BNZGjBxo70" resolve="expr" />
       </node>
-      <node concept="2iRfu4" id="5BNZGjBxo80" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIyx" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="69zaTr1POf9">
@@ -2611,7 +2611,6 @@
     <property role="3GE5qa" value="error" />
     <ref role="1XX52x" to="hm2y:69zaTr1V8fb" resolve="TryErrorClause" />
     <node concept="3EZMnI" id="69zaTr1V8fK" role="2wV5jI">
-      <node concept="2iRfu4" id="69zaTr1V8fL" role="2iSdaV" />
       <node concept="3F0ifn" id="69zaTr1V8fF" role="3EZMnx">
         <property role="3F0ifm" value="error" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -2636,13 +2635,13 @@
               <property role="VOm3f" value="true" />
             </node>
           </node>
-          <node concept="2iRfu4" id="69zaTr1Z62n" role="2iSdaV" />
           <node concept="VPM3Z" id="69zaTr1Z62o" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
           <node concept="11L4FC" id="7fOaqhhY_w_" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIyz" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqo4m" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqo4n" role="2VODD2">
@@ -2660,6 +2659,7 @@
       <node concept="3F1sOY" id="69zaTr1V8fT" role="3EZMnx">
         <ref role="1NtTu8" to="hm2y:69zaTr1V8fI" resolve="expr" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIyy" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="69zaTr1Yk3L">
@@ -2741,7 +2741,6 @@
       <node concept="3F1sOY" id="2NHHcg2$Pj6" role="3EZMnx">
         <ref role="1NtTu8" to="hm2y:252QIDzztQk" resolve="expr" />
       </node>
-      <node concept="2iRfu4" id="2NHHcg2$Pj7" role="2iSdaV" />
       <node concept="3F0ifn" id="2NHHcg2$Pj8" role="3EZMnx">
         <property role="3F0ifm" value=")" />
         <node concept="11L4FC" id="2NHHcg2$Pj9" role="3F10Kt">
@@ -2751,13 +2750,13 @@
       <node concept="VPM3Z" id="46cplYwLY$f" role="3F10Kt">
         <property role="VOm3f" value="true" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIy$" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="KaZMgy4Im0">
     <property role="3GE5qa" value="contract" />
     <ref role="1XX52x" to="hm2y:KaZMgy4Ilx" resolve="Contract" />
     <node concept="3EZMnI" id="KaZMgy4Im6" role="2wV5jI">
-      <node concept="2iRfu4" id="KaZMgy4Im7" role="2iSdaV" />
       <node concept="3F0ifn" id="KaZMgy4Im2" role="3EZMnx">
         <property role="3F0ifm" value="where" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -2796,6 +2795,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIy_" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="KaZMgy4J$f">
@@ -3011,7 +3011,6 @@
     <property role="3GE5qa" value="targets" />
     <ref role="1XX52x" to="hm2y:2U5Q01UkDMQ" resolve="OneOfTarget" />
     <node concept="3EZMnI" id="2U5Q01UkDNw" role="2wV5jI">
-      <node concept="2iRfu4" id="2U5Q01UkDNx" role="2iSdaV" />
       <node concept="PMmxH" id="12bsjhgd0e2" role="3EZMnx">
         <ref role="PMmxG" node="12bsjhgd0dR" resolve="OpAlias" />
       </node>
@@ -3041,6 +3040,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIyA" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="1WCh2thoP3E">
@@ -3253,7 +3253,6 @@
     <property role="3GE5qa" value="tuples" />
     <ref role="1XX52x" to="hm2y:S$tO8ocniU" resolve="TupleType" />
     <node concept="3EZMnI" id="S$tO8ocnjq" role="2wV5jI">
-      <node concept="2iRfu4" id="S$tO8ocnjr" role="2iSdaV" />
       <node concept="1HlG4h" id="1DSLxNDLLIH" role="3EZMnx">
         <node concept="11LMrY" id="1DSLxNDLTwD" role="3F10Kt">
           <property role="VOm3f" value="true" />
@@ -3312,13 +3311,13 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIyB" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="S$tO8ocnpP">
     <property role="3GE5qa" value="tuples" />
     <ref role="1XX52x" to="hm2y:S$tO8ocnpq" resolve="TupleValue" />
     <node concept="3EZMnI" id="S$tO8ocnpU" role="2wV5jI">
-      <node concept="2iRfu4" id="S$tO8ocnpV" role="2iSdaV" />
       <node concept="1HlG4h" id="1DSLxNDLYAF" role="3EZMnx">
         <node concept="11LMrY" id="1DSLxNDLZhB" role="3F10Kt">
           <property role="VOm3f" value="true" />
@@ -3372,13 +3371,13 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIyC" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="2ck7OjOLg5z">
     <property role="3GE5qa" value="tuples" />
     <ref role="1XX52x" to="hm2y:2ck7OjOLg5a" resolve="TupleAccessExpr" />
     <node concept="3EZMnI" id="2ck7OjOLh9Z" role="2wV5jI">
-      <node concept="2iRfu4" id="2ck7OjOLha0" role="2iSdaV" />
       <node concept="1kIj98" id="2ck7OjOLha7" role="3EZMnx">
         <node concept="3F1sOY" id="2ck7OjOLh9P" role="1kIj9b">
           <ref role="1NtTu8" to="hm2y:2ck7OjOLg5_" resolve="tuple" />
@@ -3421,6 +3420,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIyD" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6UxFDrx4dr$">
@@ -3498,7 +3498,6 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="6UxFDrx4drV" role="2iSdaV" />
       <node concept="gc7cB" id="6cw1FA3OVWd" role="3EZMnx">
         <node concept="3VJUX4" id="6cw1FA3OVWf" role="3YsKMw">
           <node concept="3clFbS" id="6cw1FA3OVWh" role="2VODD2">
@@ -3517,6 +3516,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIyE" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6UxFDrx4dqb">
@@ -3535,7 +3535,7 @@
       <node concept="3F1sOY" id="6UxFDrx4dr5" role="3EZMnx">
         <ref role="1NtTu8" to="hm2y:6UxFDrx4dpK" resolve="then" />
       </node>
-      <node concept="2iRfu4" id="6UxFDrx4dqN" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIyF" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3kzwyUOs0Fy">
@@ -3562,7 +3562,6 @@
     <property role="3GE5qa" value="validity" />
     <ref role="1XX52x" to="hm2y:78hTg1zmOGb" resolve="CheckTypeConstraintsExpr" />
     <node concept="3EZMnI" id="78hTg1zmOGL" role="2wV5jI">
-      <node concept="2iRfu4" id="78hTg1zmOGM" role="2iSdaV" />
       <node concept="3F0ifn" id="78hTg1zmOGI" role="3EZMnx">
         <property role="3F0ifm" value="check" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -3623,6 +3622,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIyG" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="78hTg1zmOHV">
@@ -3696,7 +3696,7 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="5ElkanPUlAt" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIyH" role="2iSdaV" />
     </node>
   </node>
   <node concept="V5hpn" id="5ElkanQdZcU">
@@ -4150,12 +4150,11 @@
         </node>
       </node>
       <node concept="3EZMnI" id="7RUjcsXhRks" role="1QoVPY">
-        <node concept="2iRfu4" id="7RUjcsXhRkt" role="2iSdaV" />
         <node concept="35HoNQ" id="7MlD5Pw_wTX" role="3EZMnx" />
         <node concept="Rtstu" id="7RUjcsXhRk_" role="3EZMnx" />
+        <node concept="l2Vlx" id="1ASK_HedIyI" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="2udM7u9g_io" role="1QoS34">
-        <node concept="2iRfu4" id="2udM7u9g_ip" role="2iSdaV" />
         <node concept="gc7cB" id="1WlYLwX1UJ4" role="3EZMnx">
           <node concept="3VJUX4" id="1WlYLwX1UJ6" role="3YsKMw">
             <node concept="3clFbS" id="1WlYLwX1UJ8" role="2VODD2">
@@ -4576,6 +4575,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIyJ" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -4592,7 +4592,6 @@
     <property role="3GE5qa" value="ref" />
     <ref role="1XX52x" to="hm2y:6JZACDWIfNW" resolve="ReferenceType" />
     <node concept="3EZMnI" id="6JZACDWIfOQ" role="2wV5jI">
-      <node concept="2iRfu4" id="6JZACDWIfOR" role="2iSdaV" />
       <node concept="3F0ifn" id="6JZACDWIfON" role="3EZMnx">
         <property role="3F0ifm" value="ref" />
         <ref role="1k5W1q" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
@@ -4620,6 +4619,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIyK" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6JZACDWLX9H">
@@ -4640,7 +4640,6 @@
     <property role="3GE5qa" value="join" />
     <ref role="1XX52x" to="hm2y:7VuYlCQZ3ll" resolve="JoinType" />
     <node concept="3EZMnI" id="7VuYlCQZ3lQ" role="2wV5jI">
-      <node concept="2iRfu4" id="7VuYlCQZ3lR" role="2iSdaV" />
       <node concept="3F0ifn" id="7VuYlCQZ3lN" role="3EZMnx">
         <property role="3F0ifm" value="join" />
         <ref role="1k5W1q" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
@@ -4676,6 +4675,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIyL" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4hW8Ne0bR5G">
@@ -4698,7 +4698,6 @@
         </node>
       </node>
       <node concept="3EZMnI" id="7RXj7bkMqQm" role="3EZMnx">
-        <node concept="2iRfu4" id="7RXj7bkMqQn" role="2iSdaV" />
         <node concept="3F0ifn" id="7RXj7bkMqQo" role="3EZMnx">
           <property role="3F0ifm" value="[" />
           <ref role="1ERwB7" node="4yQfyMjn6w1" resolve="deleteReveal" />
@@ -4743,6 +4742,7 @@
             <property role="1iTho6" value="FCDADA" />
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIyM" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -4998,7 +4998,6 @@
   <node concept="24kQdi" id="60Qa1k_nMTB">
     <ref role="1XX52x" to="hm2y:60Qa1k_nMSK" resolve="DefaultValueExpression" />
     <node concept="3EZMnI" id="60Qa1k_nMTG" role="2wV5jI">
-      <node concept="2iRfu4" id="60Qa1k_nMTH" role="2iSdaV" />
       <node concept="3F0ifn" id="60Qa1k_nMTD" role="3EZMnx">
         <property role="3F0ifm" value="default" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -5021,6 +5020,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIyN" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4fgA7QrKStn">
@@ -5033,7 +5033,6 @@
   <node concept="24kQdi" id="mQGcCvPufp">
     <ref role="1XX52x" to="hm2y:mQGcCvPueU" resolve="FailExpr" />
     <node concept="3EZMnI" id="mQGcCvPuf$" role="2wV5jI">
-      <node concept="2iRfu4" id="mQGcCvPuf_" role="2iSdaV" />
       <node concept="3F0ifn" id="mQGcCvPufx" role="3EZMnx">
         <property role="3F0ifm" value="fail" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -5062,7 +5061,7 @@
               <property role="VOm3f" value="true" />
             </node>
           </node>
-          <node concept="2iRfu4" id="6jT4GDw7eSP" role="2iSdaV" />
+          <node concept="l2Vlx" id="1ASK_HedIyP" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgl0YL" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgl0YM" role="2VODD2">
@@ -5097,10 +5096,10 @@
           <node concept="3F1sOY" id="4CksDrlwXpP" role="3EZMnx">
             <ref role="1NtTu8" to="hm2y:4CksDrlwXox" resolve="contextExpression" />
           </node>
-          <node concept="2iRfu4" id="4CksDrlwXpy" role="2iSdaV" />
           <node concept="VPM3Z" id="4CksDrlwXpz" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIyQ" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgl147" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgl148" role="2VODD2">
@@ -5118,6 +5117,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIyO" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="xG0f0hk40M">
@@ -5130,7 +5130,7 @@
       <node concept="3F1sOY" id="xG0f0hk411" role="3EZMnx">
         <ref role="1NtTu8" to="hm2y:xG0f0hk3ZY" resolve="expr" />
       </node>
-      <node concept="2iRfu4" id="xG0f0hk73x" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIyR" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="79jc6YzaH5U">
@@ -5186,7 +5186,6 @@
         <node concept="2iRkQZ" id="6a3SqxOuf2N" role="2iSdaV" />
         <node concept="3EZMnI" id="3ToB$MLMJAs" role="3EZMnx">
           <ref role="1ERwB7" node="2ufoZQIP11$" resolve="deleteValueInspector" />
-          <node concept="2iRfu4" id="3ToB$MLMJAt" role="2iSdaV" />
           <node concept="gc7cB" id="3ToB$MLMJAu" role="3EZMnx">
             <node concept="3VJUX4" id="3ToB$MLMJAv" role="3YsKMw">
               <node concept="3clFbS" id="3ToB$MLMJAw" role="2VODD2">
@@ -5272,6 +5271,7 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIyS" role="2iSdaV" />
         </node>
         <node concept="2T_mXK" id="6a3SqxOuxVD" role="3EZMnx">
           <node concept="2T_bXT" id="6a3SqxO$ZPl" role="3F10Kt">
@@ -5289,10 +5289,8 @@
       </node>
       <node concept="3EZMnI" id="6a3SqxOu7vo" role="1QoVPY">
         <node concept="2SsqMj" id="6a3SqxOu7vp" role="3EZMnx" />
-        <node concept="2iRfu4" id="6a3SqxOu7ww" role="2iSdaV" />
         <node concept="3EZMnI" id="3ToB$MLsrug" role="3EZMnx">
           <ref role="1ERwB7" node="2ufoZQIP11$" resolve="deleteValueInspector" />
-          <node concept="2iRfu4" id="3ToB$MLsruh" role="2iSdaV" />
           <node concept="gc7cB" id="3boFcNpzAqg" role="3EZMnx">
             <node concept="3VJUX4" id="3boFcNpzAqh" role="3YsKMw">
               <node concept="3clFbS" id="3boFcNpzAqi" role="2VODD2">
@@ -5407,31 +5405,32 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIyU" role="2iSdaV" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIyT" role="2iSdaV" />
       </node>
     </node>
     <node concept="3EZMnI" id="6a3SqxOwJ1y" role="6VMZX">
       <node concept="2iRkQZ" id="6a3SqxOwJ1z" role="2iSdaV" />
       <node concept="3EZMnI" id="6a3SqxOqyGM" role="3EZMnx">
-        <node concept="2iRfu4" id="6a3SqxOqyGN" role="2iSdaV" />
         <node concept="3F0ifn" id="6a3SqxOqziO" role="3EZMnx">
           <property role="3F0ifm" value="store only last value:" />
         </node>
         <node concept="3F0A7n" id="6a3SqxOqziW" role="3EZMnx">
           <ref role="1NtTu8" to="hm2y:6a3SqxOqxli" resolve="onlyLast" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIyV" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="6a3SqxOwK6A" role="3EZMnx">
-        <node concept="2iRfu4" id="6a3SqxOwK6B" role="2iSdaV" />
         <node concept="3F0ifn" id="6a3SqxOwK6C" role="3EZMnx">
           <property role="3F0ifm" value="show on top:          " />
         </node>
         <node concept="3F0A7n" id="6a3SqxOwK6D" role="3EZMnx">
           <ref role="1NtTu8" to="hm2y:6a3SqxOtOxB" resolve="showOnTop" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIyW" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="1Hyq9Gjg5YJ" role="3EZMnx">
-        <node concept="2iRfu4" id="1Hyq9Gjg5YK" role="2iSdaV" />
         <node concept="3F0ifn" id="1Hyq9Gjg5YL" role="3EZMnx">
           <property role="3F0ifm" value="show on console:      " />
         </node>
@@ -5445,6 +5444,7 @@
           <property role="1O74Pk" value="true" />
           <ref role="1NtTu8" to="hm2y:1Hyq9GjK0Mo" resolve="optionalLabel" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIyX" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -5535,14 +5535,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="2iRfu4" id="5bEkIpehgVA" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIyY" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="1RwPUjzgk0Z">
     <property role="3GE5qa" value="numeric.number.limit" />
     <ref role="1XX52x" to="hm2y:1RwPUjzgk0y" resolve="AbstractMinMaxExpression" />
     <node concept="3EZMnI" id="1RwPUjzgk14" role="2wV5jI">
-      <node concept="2iRfu4" id="1RwPUjzgk15" role="2iSdaV" />
       <node concept="PMmxH" id="1RwPUjzgk11" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
       </node>
@@ -5572,6 +5571,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIyZ" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4AahbtURxh7">
@@ -5601,7 +5601,6 @@
     <property role="3GE5qa" value="messages" />
     <ref role="1XX52x" to="hm2y:4AahbtVAEwi" resolve="InlineMessage" />
     <node concept="3EZMnI" id="4AahbtVAEwN" role="2wV5jI">
-      <node concept="2iRfu4" id="4AahbtVAEwO" role="2iSdaV" />
       <node concept="3F0ifn" id="4AahbtVAEwK" role="3EZMnx">
         <property role="3F0ifm" value="message" />
       </node>
@@ -5623,6 +5622,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIz0" role="2iSdaV" />
     </node>
   </node>
   <node concept="3INDKC" id="_kNv2QMdmd">
@@ -5879,7 +5879,6 @@
     <property role="3GE5qa" value="group" />
     <ref role="1XX52x" to="hm2y:4CksDrmwc1V" resolve="OperatorGroup" />
     <node concept="3EZMnI" id="4CksDrmwcd_" role="2wV5jI">
-      <node concept="2iRfu4" id="4CksDrmwcdA" role="2iSdaV" />
       <node concept="PMmxH" id="6WstIz8zy8p" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -5963,9 +5962,9 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIz1" role="2iSdaV" />
     </node>
     <node concept="3EZMnI" id="4CksDrmxhVM" role="6VMZX">
-      <node concept="2iRfu4" id="4CksDrmxhVN" role="2iSdaV" />
       <node concept="3F0ifn" id="4CksDrmxisM" role="3EZMnx">
         <property role="3F0ifm" value="reduced:" />
       </node>
@@ -5990,6 +5989,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIz2" role="2iSdaV" />
     </node>
   </node>
   <node concept="2ABfQD" id="1vo80pjxwh">
@@ -6168,7 +6168,7 @@
             <property role="VOm3f" value="true" />
           </node>
         </node>
-        <node concept="2iRfu4" id="24Fec4173UX" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIz3" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -6190,13 +6190,13 @@
     <property role="3GE5qa" value="convenientBoolean" />
     <ref role="1XX52x" to="hm2y:7khFtBHnQPW" resolve="ConvenientValueCond" />
     <node concept="3EZMnI" id="7khFtBHnQQt" role="2wV5jI">
-      <node concept="2iRfu4" id="7khFtBHnQQu" role="2iSdaV" />
       <node concept="3F0ifn" id="7khFtBHnQQq" role="3EZMnx">
         <property role="3F0ifm" value="if" />
       </node>
       <node concept="3F1sOY" id="7khFtBHnQQA" role="3EZMnx">
         <ref role="1NtTu8" to="hm2y:7khFtBHnQPX" resolve="expr" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIz4" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7khFtBHrBD7">
@@ -6896,7 +6896,6 @@
     <property role="3GE5qa" value="nix" />
     <ref role="1XX52x" to="hm2y:3nVyItrZBN9" resolve="EmptyValue" />
     <node concept="3EZMnI" id="3nVyItrZBNG" role="2wV5jI">
-      <node concept="2iRfu4" id="3nVyItrZBNH" role="2iSdaV" />
       <node concept="3F0ifn" id="3nVyItrZBND" role="3EZMnx">
         <property role="3F0ifm" value="empty" />
         <node concept="3CIbrd" id="1kEzTWVBIaM" role="3F10Kt">
@@ -6923,7 +6922,7 @@
               <property role="VOm3f" value="true" />
             </node>
           </node>
-          <node concept="2iRfu4" id="3tcv7J0yv9D" role="2iSdaV" />
+          <node concept="l2Vlx" id="1ASK_HedIz6" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgl0yg" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgl0yh" role="2VODD2">
@@ -6935,6 +6934,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIz5" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3nVyItrZka1">
@@ -7614,7 +7614,6 @@
     <property role="3GE5qa" value="tuples" />
     <ref role="1XX52x" to="hm2y:25rRV02ooIM" resolve="NCopiesOp" />
     <node concept="3EZMnI" id="25rRV02oBq3" role="2wV5jI">
-      <node concept="2iRfu4" id="25rRV02oBq4" role="2iSdaV" />
       <node concept="PMmxH" id="25rRV02oA23" role="3EZMnx">
         <ref role="PMmxG" node="12bsjhgd0dR" resolve="OpAlias" />
       </node>
@@ -7636,6 +7635,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIz7" role="2iSdaV" />
     </node>
   </node>
   <node concept="22mcaB" id="1DSLxNDQ1bz">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
@@ -3516,7 +3516,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIyE" role="2iSdaV" />
+      <node concept="2iRfu4" id="1OEjBB5BzwQ" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6UxFDrx4dqb">
@@ -5962,7 +5962,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIz1" role="2iSdaV" />
+      <node concept="2iRfu4" id="1OEjBB5E03X" role="2iSdaV" />
     </node>
     <node concept="3EZMnI" id="4CksDrmxhVM" role="6VMZX">
       <node concept="3F0ifn" id="4CksDrmxisM" role="3EZMnx">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
@@ -832,7 +832,7 @@
               <ref role="1NtTu8" to="hm2y:4rZeNQ6MpKo" resolve="right" />
             </node>
           </node>
-          <node concept="l2Vlx" id="4rZeNQ6MpLs" role="2iSdaV" />
+          <node concept="l2Vlx" id="2tlTgwgCWJi" role="2iSdaV" />
         </node>
       </node>
       <node concept="3EZMnI" id="15gN1OJ0aX9" role="1QoS34">
@@ -858,12 +858,12 @@
           <node concept="pVoyu" id="7LAhY5FckSE" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
-          <node concept="l2Vlx" id="1ASK_HedIyg" role="2iSdaV" />
+          <node concept="l2Vlx" id="2tlTgwgANVY" role="2iSdaV" />
         </node>
         <node concept="1QQdxR" id="15gN1OKA3t3" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
-        <node concept="l2Vlx" id="7LAhY5FckNA" role="2iSdaV" />
+        <node concept="l2Vlx" id="2tlTgwg$BoM" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -2852,7 +2852,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="37V13JRkqaW" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwfR2Vf" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="KaZMgy8$Iz">
@@ -2899,7 +2899,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="37V13JRkqaS" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwfR39U" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="KaZMgy8$Jl">
@@ -2946,7 +2946,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="37V13JRkqaO" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwfR3gW" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="KaZMgylLmN">
@@ -2970,7 +2970,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="3xthw2gJs7n" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwfR32S" role="2iSdaV" />
       <node concept="1kIj98" id="KaZMgylLmV" role="3EZMnx">
         <node concept="3F1sOY" id="KaZMgylLn3" role="1kIj9b">
           <ref role="1NtTu8" to="hm2y:KaZMgy4Ilu" resolve="expr" />
@@ -2987,7 +2987,7 @@
       </node>
       <node concept="_tjkj" id="68JOYCcXU8W" role="3EZMnx">
         <node concept="3EZMnI" id="68JOYCcXU94" role="_tjki">
-          <node concept="l2Vlx" id="3xthw2gJs7g" role="2iSdaV" />
+          <node concept="2iRfu4" id="2tlTgwfURpj" role="2iSdaV" />
           <node concept="3F0ifn" id="68JOYCcXU9b" role="3EZMnx">
             <property role="3F0ifm" value=":" />
           </node>
@@ -3458,7 +3458,6 @@
       <node concept="3F2HdR" id="6UxFDrx4ds5" role="3EZMnx">
         <property role="S$F3r" value="true" />
         <ref role="1NtTu8" to="hm2y:6UxFDrx4dra" resolve="alternatives" />
-        <node concept="2EHx9g" id="6UxFDrx4dsb" role="2czzBx" />
         <node concept="3F0ifn" id="6UxFDrx4dse" role="2czzBI">
           <property role="3F0ifm" value="" />
           <node concept="VPxyj" id="6UxFDrx4dt4" role="3F10Kt">
@@ -3497,6 +3496,7 @@
             </node>
           </node>
         </node>
+        <node concept="2EHx9g" id="6UxFDrx4dsb" role="2czzBx" />
       </node>
       <node concept="gc7cB" id="6cw1FA3OVWd" role="3EZMnx">
         <node concept="3VJUX4" id="6cw1FA3OVWf" role="3YsKMw">
@@ -3535,7 +3535,7 @@
       <node concept="3F1sOY" id="6UxFDrx4dr5" role="3EZMnx">
         <ref role="1NtTu8" to="hm2y:6UxFDrx4dpK" resolve="then" />
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIyF" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwfOTQz" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3kzwyUOs0Fy">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/editor.mps
@@ -110,6 +110,7 @@
       <concept id="784421273959492578" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_IncludeMenu" flags="ng" index="mvV$s">
         <child id="6718020819487784677" name="menuReference" index="A14EM" />
       </concept>
+      <concept id="1237375020029" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineChildrenStyleClassItem" flags="ln" index="pj6Ft" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1237385578942" name="jetbrains.mps.lang.editor.structure.IndentLayoutOnNewLineStyleClassItem" flags="ln" index="pVoyu" />
@@ -349,7 +350,6 @@
       <concept id="1950447826681509042" name="jetbrains.mps.lang.editor.structure.ApplyStyleClass" flags="lg" index="3Xmtl4">
         <child id="1950447826683828796" name="target" index="3XvnJa" />
       </concept>
-      <concept id="1198256887712" name="jetbrains.mps.lang.editor.structure.CellModel_Indent" flags="ng" index="3XFhqQ" />
       <concept id="8428109087107030357" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_ReferenceScope" flags="ng" index="3XHNnq">
         <reference id="8428109087107339113" name="reference" index="3XGfJA" />
         <child id="4307758654694904293" name="matchingTextFunction" index="1WZ6D9" />
@@ -749,7 +749,6 @@
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
-      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
       <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
       <concept id="1178894719932" name="jetbrains.mps.baseLanguage.collections.structure.DistinctOperation" flags="nn" index="1VAtEI" />
     </language>
@@ -2493,7 +2492,7 @@
     <property role="3GE5qa" value="error" />
     <ref role="1XX52x" to="hm2y:5BNZGjBvVgC" resolve="TryExpression" />
     <node concept="3EZMnI" id="5BNZGjBvVhG" role="2wV5jI">
-      <node concept="2iRkQZ" id="5OzSgxdVjaL" role="2iSdaV" />
+      <node concept="l2Vlx" id="2tlTgwfER6c" role="2iSdaV" />
       <node concept="3EZMnI" id="5BNZGjBvVhA" role="3EZMnx">
         <node concept="3F0ifn" id="5BNZGjBvVhz" role="3EZMnx">
           <property role="3F0ifm" value="try" />
@@ -2541,31 +2540,18 @@
         </node>
         <node concept="l2Vlx" id="1ASK_HedIyu" role="2iSdaV" />
       </node>
-      <node concept="3EZMnI" id="69zaTr1V8re" role="3EZMnx">
-        <node concept="VPM3Z" id="69zaTr1V8rg" role="3F10Kt">
-          <property role="VOm3f" value="false" />
+      <node concept="3F2HdR" id="69zaTr1V8rz" role="3EZMnx">
+        <ref role="1NtTu8" to="hm2y:69zaTr1V8r3" resolve="errorClauses" />
+        <node concept="l2Vlx" id="2tlTgwfkTfD" role="2czzBx" />
+        <node concept="lj46D" id="2tlTgwfkTfG" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
-        <node concept="3XFhqQ" id="69zaTr1V8rt" role="3EZMnx" />
-        <node concept="3F2HdR" id="69zaTr1V8rz" role="3EZMnx">
-          <ref role="1NtTu8" to="hm2y:69zaTr1V8r3" resolve="errorClauses" />
-          <node concept="2EHx9g" id="69zaTr1V8rG" role="2czzBx" />
+        <node concept="pj6Ft" id="2tlTgwfkTfI" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
-        <node concept="pkWqt" id="69zaTr1WcV3" role="pqm2j">
-          <node concept="3clFbS" id="69zaTr1WcV4" role="2VODD2">
-            <node concept="3clFbF" id="69zaTr1WcW9" role="3cqZAp">
-              <node concept="2OqwBi" id="69zaTr1WdxU" role="3clFbG">
-                <node concept="2OqwBi" id="69zaTr1WcYK" role="2Oq$k0">
-                  <node concept="pncrf" id="69zaTr1WcW8" role="2Oq$k0" />
-                  <node concept="3Tsc0h" id="69zaTr1Wd4v" role="2OqNvi">
-                    <ref role="3TtcxE" to="hm2y:69zaTr1V8r3" resolve="errorClauses" />
-                  </node>
-                </node>
-                <node concept="3GX2aA" id="69zaTr1Wf61" role="2OqNvi" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="l2Vlx" id="1ASK_HedIyw" role="2iSdaV" />
+      </node>
+      <node concept="pj6Ft" id="2tlTgwfER6e" role="3F10Kt">
+        <property role="VOm3f" value="true" />
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/models/editor.mps
@@ -46,7 +46,6 @@
         <child id="1140524464359" name="emptyCellModel" index="2czzBI" />
         <child id="1233141163694" name="separatorStyle" index="sWeuL" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="6089045305654894366" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Default" flags="ng" index="2kknPJ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="784421273959492578" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_IncludeMenu" flags="ng" index="mvV$s">
@@ -332,7 +331,6 @@
     <property role="3GE5qa" value="collection" />
     <ref role="1XX52x" to="700h:6zmBjqUily5" resolve="CollectionType" />
     <node concept="3EZMnI" id="6zmBjqUilHG" role="2wV5jI">
-      <node concept="2iRfu4" id="6js_s$ijRY5" role="2iSdaV" />
       <node concept="3F0ifn" id="6zmBjqUilHD" role="3EZMnx">
         <property role="3F0ifm" value="collection" />
         <ref role="1k5W1q" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
@@ -389,6 +387,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIt7" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6zmBjqUintD">
@@ -404,7 +403,6 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="6js_s$ijRWK" role="2iSdaV" />
       <node concept="3F0ifn" id="6zmBjqUjGnF" role="3EZMnx">
         <property role="3F0ifm" value="&lt;" />
         <node concept="11L4FC" id="6zmBjqUjGoB" role="3F10Kt">
@@ -449,6 +447,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIt8" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6zmBjqUinVM">
@@ -516,7 +515,6 @@
       </node>
     </node>
     <node concept="3EZMnI" id="4399ITQA59t" role="6VMZX">
-      <node concept="2iRfu4" id="4399ITQA59u" role="2iSdaV" />
       <node concept="3F0ifn" id="4399ITQA59x" role="3EZMnx">
         <property role="3F0ifm" value="number of elements:" />
       </node>
@@ -545,6 +543,7 @@
         </node>
         <node concept="VPM3Z" id="4399ITQAliF" role="3F10Kt" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIt9" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6zmBjqUiwL4">
@@ -598,7 +597,6 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="6js_s$ijRY9" role="2iSdaV" />
       <node concept="3F0ifn" id="6DR5zXWAe8k" role="3EZMnx">
         <property role="3F0ifm" value="&lt;" />
         <node concept="11L4FC" id="6DR5zXWAe8l" role="3F10Kt">
@@ -617,6 +615,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIta" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7GwCuf2WbAB">
@@ -679,7 +678,6 @@
       </node>
     </node>
     <node concept="3EZMnI" id="4399ITQAotv" role="6VMZX">
-      <node concept="2iRfu4" id="4399ITQAotw" role="2iSdaV" />
       <node concept="3F0ifn" id="4399ITQAotx" role="3EZMnx">
         <property role="3F0ifm" value="number of elements:" />
       </node>
@@ -708,6 +706,7 @@
         </node>
         <node concept="VPM3Z" id="4399ITQAotI" role="3F10Kt" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItb" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="54HsVvNUXe_">
@@ -785,7 +784,7 @@
             <property role="VOm3f" value="true" />
           </node>
         </node>
-        <node concept="2iRfu4" id="54HsVvNUXeE" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedItc" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -829,7 +828,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="2iRfu4" id="7kYh9WszdCp" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedItd" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7kYh9WszdI7">
@@ -909,14 +908,13 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="7kYh9WszdIc" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIte" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7kYh9Wszg2K">
     <property role="3GE5qa" value="map" />
     <ref role="1XX52x" to="700h:7kYh9WszdHC" resolve="MapLiteral" />
     <node concept="3EZMnI" id="7kYh9Wszg2P" role="2wV5jI">
-      <node concept="2iRfu4" id="NE1gl597Mv" role="2iSdaV" />
       <node concept="3F0ifn" id="7kYh9Wszg2M" role="3EZMnx">
         <property role="3F0ifm" value="map" />
       </node>
@@ -969,9 +967,9 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItf" role="2iSdaV" />
     </node>
     <node concept="3EZMnI" id="4399ITQAm3v" role="6VMZX">
-      <node concept="2iRfu4" id="4399ITQAm3w" role="2iSdaV" />
       <node concept="3F0ifn" id="4399ITQAm3x" role="3EZMnx">
         <property role="3F0ifm" value="number of elements:" />
       </node>
@@ -1000,13 +998,13 @@
         </node>
         <node concept="VPM3Z" id="4399ITQAm3I" role="3F10Kt" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItg" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7kYh9Ws$z$k">
     <property role="3GE5qa" value="map" />
     <ref role="1XX52x" to="700h:6IBT1wT$hPp" resolve="IMapOneArgOp" />
     <node concept="3EZMnI" id="7kYh9Ws$z$o" role="2wV5jI">
-      <node concept="2iRfu4" id="7kYh9Ws$z$p" role="2iSdaV" />
       <node concept="PMmxH" id="4l_LUjie3iJ" role="3EZMnx">
         <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
@@ -1028,6 +1026,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIth" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4Q4DxjDbyqy">
@@ -1121,13 +1120,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="2iRfu4" id="7yDflTqUNIZ" role="2iSdaV" />
       <node concept="11L4FC" id="7yDflTqY$U8" role="3F10Kt">
         <property role="VOm3f" value="true" />
       </node>
       <node concept="11LMrY" id="7yDflTqY$XL" role="3F10Kt">
         <property role="VOm3f" value="true" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIti" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7yDflTqZBMc">
@@ -1160,13 +1159,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="2iRfu4" id="7yDflTqZBMm" role="2iSdaV" />
       <node concept="11L4FC" id="7yDflTqZBMn" role="3F10Kt">
         <property role="VOm3f" value="true" />
       </node>
       <node concept="11LMrY" id="7yDflTqZBMo" role="3F10Kt">
         <property role="VOm3f" value="true" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItj" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3tudP_A1$vE">
@@ -1513,7 +1512,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="2iRfu4" id="3tudP_AOMNM" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedItk" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4bUWUHViFI">
@@ -1584,7 +1583,6 @@
     <property role="3GE5qa" value="set" />
     <ref role="1XX52x" to="700h:thkha3aNEl" resolve="ISetOneArgOp" />
     <node concept="3EZMnI" id="thkha3aNE$" role="2wV5jI">
-      <node concept="2iRfu4" id="thkha3aNE_" role="2iSdaV" />
       <node concept="PMmxH" id="4l_LUjie3j5" role="3EZMnx">
         <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
@@ -1606,6 +1604,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItl" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6IBT1wUeIoQ">
@@ -1619,7 +1618,6 @@
     <property role="3GE5qa" value="list" />
     <ref role="1XX52x" to="700h:LrvgQhjFyf" resolve="ListInsertOp" />
     <node concept="3EZMnI" id="LrvgQhkLIP" role="2wV5jI">
-      <node concept="2iRfu4" id="LrvgQhkLIQ" role="2iSdaV" />
       <node concept="PMmxH" id="4l_LUjie3im" role="3EZMnx">
         <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
@@ -1650,13 +1648,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItm" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="twWOnQMHuR">
     <property role="3GE5qa" value="list" />
     <ref role="1XX52x" to="700h:twWOnQMGuT" resolve="ListPickOp" />
     <node concept="3EZMnI" id="twWOnQMH$E" role="2wV5jI">
-      <node concept="2iRfu4" id="twWOnQMH$F" role="2iSdaV" />
       <node concept="PMmxH" id="twWOnQMIuy" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
       </node>
@@ -1678,6 +1676,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItn" role="2iSdaV" />
     </node>
   </node>
   <node concept="3ICUPy" id="6f7f4BmhEmW">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/models/org.iets3.core.expr.data.editor.mps
@@ -38,7 +38,6 @@
         <child id="1140524464360" name="cellLayout" index="2czzBx" />
         <child id="1140524464359" name="emptyCellModel" index="2czzBI" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
@@ -420,8 +419,8 @@
       <node concept="3F1sOY" id="cPLa7Fqq09" role="3EZMnx">
         <ref role="1NtTu8" to="e9k1:cPLa7Fpe9f" resolve="value" />
       </node>
-      <node concept="2iRfu4" id="cPLa7FpdRx" role="2iSdaV" />
       <node concept="VPM3Z" id="5yPljRXI5DO" role="3F10Kt" />
+      <node concept="l2Vlx" id="1ASK_HedIwG" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="cPLa7Fpj5k">
@@ -429,7 +428,6 @@
     <node concept="3EZMnI" id="cPLa7FpjvB" role="2wV5jI">
       <node concept="2iRkQZ" id="cPLa7FpjvC" role="2iSdaV" />
       <node concept="3EZMnI" id="cPLa7Fpje4" role="3EZMnx">
-        <node concept="2iRfu4" id="cPLa7Fpje5" role="2iSdaV" />
         <node concept="3F0ifn" id="cPLa7Fpj8f" role="3EZMnx">
           <property role="3F0ifm" value="data" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -457,10 +455,10 @@
             <node concept="3F0ifn" id="7F9023_LY$s" role="3EZMnx">
               <property role="3F0ifm" value="with default:" />
             </node>
-            <node concept="2iRfu4" id="7F9023_LY$t" role="2iSdaV" />
             <node concept="3F1sOY" id="7F9023_OOmA" role="3EZMnx">
               <ref role="1NtTu8" to="e9k1:7F9023_OEld" resolve="defaultLookupColumn" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIwI" role="2iSdaV" />
           </node>
           <node concept="uPpia" id="1ZlHRbgqrpG" role="1djCvC">
             <node concept="3clFbS" id="1ZlHRbgqrpH" role="2VODD2">
@@ -472,6 +470,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIwH" role="2iSdaV" />
       </node>
       <node concept="3ZSo5i" id="5yPljRXLZR8" role="3EZMnx">
         <node concept="3VJUX4" id="5yPljRXM4pb" role="3ZZHOD">
@@ -769,13 +768,13 @@
         <node concept="2reCLy" id="5hullqu1JxI" role="2reCL6">
           <node concept="3EZMnI" id="8XWEteq8eD" role="2reSmM">
             <ref role="1k5W1q" node="5BtJuGRt7EY" resolve="DataTableRowHeader" />
-            <node concept="2iRfu4" id="8XWEteq8eE" role="2iSdaV" />
             <node concept="3F0A7n" id="4v5hZncKAmQ" role="3EZMnx">
               <property role="1O74Pk" value="true" />
               <property role="39s7Ar" value="true" />
               <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
               <ref role="1k5W1q" to="itrz:ub9nkyQsN2" resolve="iets3Identifier" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIwJ" role="2iSdaV" />
           </node>
           <node concept="1g0IQG" id="5BtJuGRtY05" role="1geGt4" />
         </node>
@@ -1046,7 +1045,7 @@
       <node concept="3F1sOY" id="cPLa7FqmyJ" role="3EZMnx">
         <ref role="1NtTu8" to="hm2y:7D7uZV2iYAD" resolve="type" />
       </node>
-      <node concept="2iRfu4" id="cPLa7FqmpM" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIwK" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="cPLa7Fs1I7">
@@ -1199,7 +1198,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="2iRfu4" id="stdmzxm7Yv" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIwL" role="2iSdaV" />
     </node>
   </node>
   <node concept="PKFIW" id="6dXnuBU76js">
@@ -1271,7 +1270,6 @@
       </node>
     </node>
     <node concept="3EZMnI" id="7rdMSLlhFCc" role="6VMZX">
-      <node concept="2iRfu4" id="7rdMSLlhFCd" role="2iSdaV" />
       <node concept="3F0ifn" id="7rdMSLlhFKZ" role="3EZMnx">
         <property role="3F0ifm" value="reduced:" />
       </node>
@@ -1311,6 +1309,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwM" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7F9023_OqBq">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.dataflow/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.dataflow/models/editor.mps
@@ -436,14 +436,12 @@
   <node concept="24kQdi" id="4YhD5cZsmK0">
     <ref role="1XX52x" to="gx5r:4YhD5cZsmA4" resolve="ExprBlock" />
     <node concept="3EZMnI" id="2vkvJYSN66c" role="2wV5jI">
-      <node concept="2iRfu4" id="2vkvJYSN66d" role="2iSdaV" />
       <node concept="3F0ifn" id="2vkvJYSN66e" role="3EZMnx">
         <property role="3F0ifm" value="block" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
       </node>
       <node concept="_tjkj" id="2vkvJYSN6eZ" role="3EZMnx">
         <node concept="3EZMnI" id="2vkvJYSN6bF" role="_tjki">
-          <node concept="2iRfu4" id="2vkvJYSN6bG" role="2iSdaV" />
           <node concept="3F0ifn" id="2vkvJYSN6ae" role="3EZMnx">
             <property role="3F0ifm" value="[" />
             <node concept="11L4FC" id="2vkvJYSN6aP" role="3F10Kt">
@@ -476,6 +474,7 @@
           <node concept="11L4FC" id="2vkvJYSP_QX" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIxd" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqAX4" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqAX5" role="2VODD2">
@@ -513,7 +512,6 @@
               <property role="Vb096" value="fLJRk5_/gray" />
             </node>
           </node>
-          <node concept="2iRfu4" id="2vkvJYSN66m" role="2iSdaV" />
           <node concept="11L4FC" id="2vkvJYSN66n" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
@@ -532,6 +530,7 @@
               <property role="Vb096" value="fLJRk5_/gray" />
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIxe" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqB3E" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqB3F" role="2VODD2">
@@ -585,6 +584,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIxc" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4YhD5cZsmNv">
@@ -604,7 +604,6 @@
     <property role="3GE5qa" value="ports" />
     <ref role="1XX52x" to="gx5r:3_milxHH5Cj" resolve="OutportValue" />
     <node concept="3EZMnI" id="3_milxHH5Dk" role="2wV5jI">
-      <node concept="2iRfu4" id="3_milxHH5Dl" role="2iSdaV" />
       <node concept="1iCGBv" id="2vkvJYSY$3h" role="3EZMnx">
         <ref role="1NtTu8" to="gx5r:2vkvJYSYprW" resolve="outport" />
         <node concept="1sVBvm" id="2vkvJYSY$3j" role="1sWHZn">
@@ -620,6 +619,7 @@
       <node concept="3F1sOY" id="3_milxHH5D_" role="3EZMnx">
         <ref role="1NtTu8" to="gx5r:3_milxHH5Cy" resolve="value" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIxf" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3_milxHHT1V">
@@ -634,7 +634,6 @@
         </node>
         <node concept="_tjkj" id="2vkvJYSPA7e" role="3EZMnx">
           <node concept="3EZMnI" id="2vkvJYSPA7f" role="_tjki">
-            <node concept="2iRfu4" id="2vkvJYSPA7g" role="2iSdaV" />
             <node concept="3F0ifn" id="2vkvJYSPA7h" role="3EZMnx">
               <property role="3F0ifm" value="[" />
               <node concept="11L4FC" id="2vkvJYSPA7i" role="3F10Kt">
@@ -667,6 +666,7 @@
             <node concept="11L4FC" id="2vkvJYSPA7r" role="3F10Kt">
               <property role="VOm3f" value="true" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIxg" role="2iSdaV" />
           </node>
           <node concept="uPpia" id="1ZlHRbgqsKJ" role="1djCvC">
             <node concept="3clFbS" id="1ZlHRbgqsKK" role="2VODD2">
@@ -752,13 +752,13 @@
                 <property role="Vb096" value="fLJRk5_/gray" />
               </node>
             </node>
-            <node concept="2iRfu4" id="2vkvJYSN65B" role="2iSdaV" />
             <node concept="11L4FC" id="2vkvJYSN65C" role="3F10Kt">
               <property role="VOm3f" value="true" />
             </node>
             <node concept="VPM3Z" id="2vkvJYSN65D" role="3F10Kt">
               <property role="VOm3f" value="false" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIxh" role="2iSdaV" />
           </node>
           <node concept="uPpia" id="1ZlHRbgqsMa" role="1djCvC">
             <node concept="3clFbS" id="1ZlHRbgqsMb" role="2VODD2">
@@ -869,7 +869,6 @@
             </node>
             <node concept="238au4" id="3_milxHJX5M" role="23bJyd">
               <node concept="3EZMnI" id="5Q9FzcI4uTm" role="2wV5jI">
-                <node concept="2iRfu4" id="5Q9FzcI4uTn" role="2iSdaV" />
                 <node concept="3F0ifn" id="5Q9FzcI4uTQ" role="3EZMnx">
                   <property role="3F0ifm" value=" " />
                   <node concept="VPM3Z" id="5Q9FzcI4uTR" role="3F10Kt">
@@ -891,6 +890,7 @@
                     <property role="VOm3f" value="false" />
                   </node>
                 </node>
+                <node concept="l2Vlx" id="1ASK_HedIxi" role="2iSdaV" />
               </node>
             </node>
             <node concept="3clFbT" id="3_milxHJXbe" role="SH2gk">
@@ -927,7 +927,6 @@
             </node>
             <node concept="238au4" id="3_milxHJXlN" role="23bJyd">
               <node concept="3EZMnI" id="5Q9FzcI4uUs" role="2wV5jI">
-                <node concept="2iRfu4" id="5Q9FzcI4uUt" role="2iSdaV" />
                 <node concept="3F0ifn" id="5Q9FzcI4uUu" role="3EZMnx">
                   <property role="3F0ifm" value=" " />
                   <node concept="VPM3Z" id="5Q9FzcI4uUv" role="3F10Kt">
@@ -949,6 +948,7 @@
                     <property role="VOm3f" value="false" />
                   </node>
                 </node>
+                <node concept="l2Vlx" id="1ASK_HedIxj" role="2iSdaV" />
               </node>
             </node>
             <node concept="3clFbT" id="3_milxHJXlT" role="SH2gk">
@@ -1757,7 +1757,6 @@
             </node>
           </node>
           <node concept="3EZMnI" id="3_milxHMeL6" role="1QoS34">
-            <node concept="2iRfu4" id="3_milxHMeL7" role="2iSdaV" />
             <node concept="3F0ifn" id="3_milxHMeXr" role="3EZMnx">
               <property role="3F0ifm" value=" " />
               <node concept="VPM3Z" id="3_milxHMeXz" role="3F10Kt">
@@ -1812,9 +1811,9 @@
             <node concept="37jFXN" id="2vkvJYSTyIM" role="3F10Kt">
               <property role="37lx6p" value="hZ7kQ4a/CENTER" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIxk" role="2iSdaV" />
           </node>
           <node concept="3EZMnI" id="5I_8B5ujnbv" role="1QoVPY">
-            <node concept="2iRfu4" id="5I_8B5ujnbw" role="2iSdaV" />
             <node concept="3F0ifn" id="5I_8B5ujlk0" role="3EZMnx">
               <property role="3F0ifm" value=" " />
               <node concept="VPM3Z" id="5I_8B5ujlk1" role="3F10Kt">
@@ -1842,6 +1841,7 @@
                 <property role="VOm3f" value="false" />
               </node>
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIxl" role="2iSdaV" />
           </node>
         </node>
         <node concept="3EZMnI" id="2vkvJYSQKra" role="3EZMnx">
@@ -3449,7 +3449,6 @@
     <property role="3GE5qa" value="ports" />
     <ref role="1XX52x" to="gx5r:4YhD5cZsmAw" resolve="InPort" />
     <node concept="3EZMnI" id="2vkvJYSMVlp" role="2wV5jI">
-      <node concept="2iRfu4" id="2vkvJYSMVlq" role="2iSdaV" />
       <node concept="1kIj98" id="2vkvJYSMVlr" role="3EZMnx">
         <property role="3g2DhO" value="true" />
         <node concept="3F0A7n" id="2vkvJYSMVls" role="1kIj9b">
@@ -3479,13 +3478,13 @@
           <node concept="3F1sOY" id="2vkvJYSMVly" role="3EZMnx">
             <ref role="1NtTu8" to="gx5r:4YhD5cZsmAx" resolve="type" />
           </node>
-          <node concept="2iRfu4" id="2vkvJYSMVlz" role="2iSdaV" />
           <node concept="VPM3Z" id="2vkvJYSMVl$" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
           <node concept="11L4FC" id="2vkvJYSMVl_" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIxn" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqB55" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqB56" role="2VODD2">
@@ -3497,13 +3496,13 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIxm" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="2vkvJYSMVmc">
     <property role="3GE5qa" value="ports" />
     <ref role="1XX52x" to="gx5r:4YhD5cZsmGJ" resolve="OutPort" />
     <node concept="3EZMnI" id="2vkvJYSMVmG" role="2wV5jI">
-      <node concept="2iRfu4" id="2vkvJYSMVmH" role="2iSdaV" />
       <node concept="1kIj98" id="2vkvJYSMVmI" role="3EZMnx">
         <property role="3g2DhO" value="true" />
         <node concept="3F0A7n" id="2vkvJYSMVmJ" role="1kIj9b">
@@ -3536,13 +3535,13 @@
           <node concept="3F1sOY" id="2vkvJYSMVmP" role="3EZMnx">
             <ref role="1NtTu8" to="gx5r:4YhD5cZsmAx" resolve="type" />
           </node>
-          <node concept="2iRfu4" id="2vkvJYSMVmQ" role="2iSdaV" />
           <node concept="VPM3Z" id="2vkvJYSMVmR" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
           <node concept="11L4FC" id="2vkvJYSMVmS" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIxp" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqBca" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqBcb" role="2VODD2">
@@ -3562,10 +3561,10 @@
           <node concept="3F1sOY" id="2vkvJYT218f" role="3EZMnx">
             <ref role="1NtTu8" to="gx5r:2vkvJYT213x" resolve="value" />
           </node>
-          <node concept="2iRfu4" id="2vkvJYT217Z" role="2iSdaV" />
           <node concept="VPM3Z" id="2vkvJYT2180" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIxq" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqBiv" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqBiw" role="2VODD2">
@@ -3577,12 +3576,12 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIxo" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="2vkvJYSMVnX">
     <ref role="1XX52x" to="gx5r:5Q9FzcI8h1p" resolve="BlockParameter" />
     <node concept="3EZMnI" id="49WTic8fvNp" role="2wV5jI">
-      <node concept="2iRfu4" id="49WTic8fvNq" role="2iSdaV" />
       <node concept="1kIj98" id="6HHp2WmZ0Ki" role="3EZMnx">
         <property role="3g2DhO" value="true" />
         <node concept="3F0A7n" id="49WTic8fvN_" role="1kIj9b">
@@ -3612,13 +3611,13 @@
           <node concept="3F1sOY" id="6HHp2WmOBkT" role="3EZMnx">
             <ref role="1NtTu8" to="gx5r:2vkvJYT8fls" resolve="type" />
           </node>
-          <node concept="2iRfu4" id="5WJNTMTyRb8" role="2iSdaV" />
           <node concept="VPM3Z" id="5WJNTMTyRb9" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
           <node concept="11L4FC" id="5WJNTMTzYOB" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIxs" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqrrN" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqrrO" role="2VODD2">
@@ -3630,6 +3629,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIxr" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="2vkvJYSMWK1">
@@ -3647,7 +3647,6 @@
   <node concept="24kQdi" id="2vkvJYSQEwB">
     <ref role="1XX52x" to="gx5r:2vkvJYSQEv$" resolve="ParamValue" />
     <node concept="3EZMnI" id="2vkvJYSQExs" role="2wV5jI">
-      <node concept="2iRfu4" id="2vkvJYSQExt" role="2iSdaV" />
       <node concept="1iCGBv" id="2vkvJYSQExd" role="3EZMnx">
         <ref role="1NtTu8" to="gx5r:2vkvJYSQEwb" resolve="param" />
         <node concept="1sVBvm" id="2vkvJYSQExf" role="1sWHZn">
@@ -3663,12 +3662,12 @@
       <node concept="3F1sOY" id="2vkvJYSQExR" role="3EZMnx">
         <ref role="1NtTu8" to="gx5r:2vkvJYSQEw9" resolve="value" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIxt" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="2vkvJYT6dI1">
     <ref role="1XX52x" to="gx5r:2vkvJYT6dDU" resolve="BlockCallExpr" />
     <node concept="3EZMnI" id="2vkvJYT6dNH" role="2wV5jI">
-      <node concept="2iRfu4" id="2vkvJYT6dNI" role="2iSdaV" />
       <node concept="1iCGBv" id="2vkvJYT6dLB" role="3EZMnx">
         <ref role="1NtTu8" to="gx5r:2vkvJYT6dHv" resolve="block" />
         <node concept="1sVBvm" id="2vkvJYT6dLD" role="1sWHZn">
@@ -3711,7 +3710,6 @@
             <property role="VOm3f" value="true" />
           </node>
         </node>
-        <node concept="2iRfu4" id="2DnmbxUz1KL" role="2iSdaV" />
         <node concept="pkWqt" id="2DnmbxUz1KM" role="pqm2j">
           <node concept="3clFbS" id="2DnmbxUz1KN" role="2VODD2">
             <node concept="3clFbF" id="2DnmbxUz1SX" role="3cqZAp">
@@ -3732,6 +3730,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIxv" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="2vkvJYT6dMf" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -3759,6 +3758,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIxu" role="2iSdaV" />
     </node>
   </node>
   <node concept="PKFIW" id="6dXnuBU76ju">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.dataflow/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.dataflow/models/editor.mps
@@ -3541,7 +3541,7 @@
           <node concept="11L4FC" id="2vkvJYSMVmS" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
-          <node concept="l2Vlx" id="1ASK_HedIxp" role="2iSdaV" />
+          <node concept="2iRfu4" id="2tlTgwfU1lP" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqBca" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqBcb" role="2VODD2">
@@ -3564,7 +3564,7 @@
           <node concept="VPM3Z" id="2vkvJYT2180" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
-          <node concept="l2Vlx" id="1ASK_HedIxq" role="2iSdaV" />
+          <node concept="2iRfu4" id="2tlTgwfU1lR" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqBiv" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqBiw" role="2VODD2">
@@ -3576,7 +3576,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIxo" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwfTb$z" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="2vkvJYSMVnX">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.datetime/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.datetime/models/editor.mps
@@ -25,6 +25,7 @@
         <child id="1140524464359" name="emptyCellModel" index="2czzBI" />
       </concept>
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
@@ -176,14 +177,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="2iRfu4" id="3nGzaxURa4P" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIy0" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3nGzaxUXsgI">
     <property role="3GE5qa" value="range.literals" />
     <ref role="1XX52x" to="mi3w:3nGzaxUXsgj" resolve="YearRangeLiteral" />
     <node concept="3EZMnI" id="3nGzaxUXsgM" role="2wV5jI">
-      <node concept="2iRfu4" id="3nGzaxUXsgN" role="2iSdaV" />
       <node concept="3F0ifn" id="3nGzaxUXsgK" role="3EZMnx">
         <property role="3F0ifm" value="year[" />
         <node concept="11LMrY" id="3nGzaxUXsgU" role="3F10Kt">
@@ -199,6 +199,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIy1" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3nGzaxUXXmA">
@@ -212,7 +213,6 @@
     <property role="3GE5qa" value="range.literals" />
     <ref role="1XX52x" to="mi3w:1Mp62pP0lMQ" resolve="MonthRangeLiteral" />
     <node concept="3EZMnI" id="1Mp62pP0lNt" role="2wV5jI">
-      <node concept="2iRfu4" id="1Mp62pP0lNu" role="2iSdaV" />
       <node concept="3F0ifn" id="1Mp62pP0lNv" role="3EZMnx">
         <property role="3F0ifm" value="month[" />
         <node concept="11LMrY" id="1Mp62pP0lNw" role="3F10Kt">
@@ -240,9 +240,9 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIy2" role="2iSdaV" />
     </node>
     <node concept="3EZMnI" id="8iseid1w9q" role="6VMZX">
-      <node concept="2iRfu4" id="8iseid1w9r" role="2iSdaV" />
       <node concept="3F0ifn" id="8iseid1w9D" role="3EZMnx">
         <property role="3F0ifm" value="old expressions" />
       </node>
@@ -255,6 +255,7 @@
       <node concept="3F1sOY" id="1Mp62pP0lO2" role="3EZMnx">
         <ref role="1NtTu8" to="mi3w:1Mp62pP0lMW" resolve="month" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIy3" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7aRvJQE5gM3">
@@ -303,7 +304,6 @@
     <property role="3GE5qa" value="date" />
     <ref role="1XX52x" to="mi3w:7khFtBHlNKe" resolve="MakeDate" />
     <node concept="3EZMnI" id="7khFtBHlNKQ" role="2wV5jI">
-      <node concept="2iRfu4" id="7khFtBHlNKR" role="2iSdaV" />
       <node concept="PMmxH" id="4MwjAOTSmU5" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
       </node>
@@ -333,13 +333,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIy4" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7khFtBHyEke">
     <property role="3GE5qa" value="range.rel" />
     <ref role="1XX52x" to="mi3w:7khFtBHyEjM" resolve="AbstractRangeRelOp" />
     <node concept="3EZMnI" id="7khFtBHyEki" role="2wV5jI">
-      <node concept="2iRfu4" id="7khFtBHyEkj" role="2iSdaV" />
       <node concept="PMmxH" id="7khFtBHyEkg" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
       </node>
@@ -361,13 +361,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIy5" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7khFtBH_CY0">
     <property role="3GE5qa" value="date.op" />
     <ref role="1XX52x" to="mi3w:7khFtBH_CX$" resolve="UntilOp" />
     <node concept="3EZMnI" id="7khFtBH_CY5" role="2wV5jI">
-      <node concept="2iRfu4" id="7khFtBH_CY6" role="2iSdaV" />
       <node concept="3F0ifn" id="7khFtBH_CY2" role="3EZMnx">
         <property role="3F0ifm" value="until" />
       </node>
@@ -389,6 +389,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIy6" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7khFtBHCk9N">
@@ -444,7 +445,7 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="7RGJ_88mSBB" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIy7" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -452,7 +453,6 @@
     <property role="3GE5qa" value="range.rel" />
     <ref role="1XX52x" to="mi3w:4O9rw8aD7_O" resolve="IntersectRangeOp" />
     <node concept="3EZMnI" id="4O9rw8aD8cV" role="2wV5jI">
-      <node concept="2iRfu4" id="4O9rw8aD8cW" role="2iSdaV" />
       <node concept="PMmxH" id="4O9rw8aD8cX" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
       </node>
@@ -474,6 +474,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIy8" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4O9rw8aDx0n">
@@ -494,7 +495,6 @@
     <property role="3GE5qa" value="date.earlylate" />
     <ref role="1XX52x" to="mi3w:1RwPUjzgk0y" resolve="AbstractEarliestLastestExpression" />
     <node concept="3EZMnI" id="1RwPUjzgk14" role="2wV5jI">
-      <node concept="2iRfu4" id="1RwPUjzgk15" role="2iSdaV" />
       <node concept="PMmxH" id="1RwPUjzgk11" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
       </node>
@@ -524,6 +524,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIy9" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="41xkdV7Z9Bu">
@@ -564,7 +565,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="2iRfu4" id="5LVdhDvvxTE" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIya" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5LVdhDvvyFk">
@@ -598,7 +599,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="2iRfu4" id="5LVdhDvvyFt" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIyb" role="2iSdaV" />
     </node>
   </node>
   <node concept="PKFIW" id="6dXnuBU76jw">
@@ -664,14 +665,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="2iRfu4" id="3HiHZey9pe8" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIyc" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3HiHZeyanBy">
     <property role="3GE5qa" value="time" />
     <ref role="1XX52x" to="mi3w:3HiHZey9lU5" resolve="MakeTime" />
     <node concept="3EZMnI" id="3HiHZeyanOW" role="2wV5jI">
-      <node concept="2iRfu4" id="3HiHZeyanOX" role="2iSdaV" />
       <node concept="PMmxH" id="3HiHZeyanOY" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
       </node>
@@ -719,13 +719,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIyd" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3HiHZeyb5u1">
     <property role="3GE5qa" value="time" />
     <ref role="1XX52x" to="mi3w:3HiHZeyb5sw" resolve="HourRangeLiteral" />
     <node concept="3EZMnI" id="3HiHZeyb5u3" role="2wV5jI">
-      <node concept="2iRfu4" id="3HiHZeyb5u4" role="2iSdaV" />
       <node concept="3F0ifn" id="3HiHZeyb5u5" role="3EZMnx">
         <property role="3F0ifm" value="hour[" />
         <node concept="11LMrY" id="3HiHZeyb5u6" role="3F10Kt">
@@ -741,6 +741,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIye" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3HiHZeycpLW">
@@ -788,7 +789,7 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="3HiHZeyhTtx" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIyf" role="2iSdaV" />
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.doc/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.doc/models/editor.mps
@@ -40,8 +40,8 @@
       <concept id="1078308402140" name="jetbrains.mps.lang.editor.structure.CellModel_Custom" flags="sg" stub="8104358048506730068" index="gc7cB">
         <child id="1176795024817" name="cellProvider" index="3YsKMw" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
@@ -260,7 +260,6 @@
       <property role="S$Qs1" value="true" />
       <node concept="2iRkQZ" id="1sudaVNnKrb" role="2iSdaV" />
       <node concept="3EZMnI" id="1sudaVNnKqP" role="3EZMnx">
-        <node concept="2iRfu4" id="1sudaVNnKqQ" role="2iSdaV" />
         <node concept="3F0ifn" id="1sudaVNnKpR" role="3EZMnx">
           <property role="3F0ifm" value="frame" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -268,18 +267,18 @@
         <node concept="3F0A7n" id="1sudaVNnKr4" role="3EZMnx">
           <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIxF" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="1sudaVNq55w" role="3EZMnx">
-        <node concept="2iRfu4" id="1sudaVNq55x" role="2iSdaV" />
         <node concept="3F1sOY" id="1sudaVNqppQ" role="3EZMnx">
           <ref role="1NtTu8" to="34lm:1sudaVNqppI" resolve="content" />
           <node concept="VPXOz" id="1sudaVNqppW" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIxG" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="2c2AzQcDZA5" role="AHCbl">
-        <node concept="2iRfu4" id="2c2AzQcDZA6" role="2iSdaV" />
         <node concept="3F0ifn" id="2c2AzQcDZA7" role="3EZMnx">
           <property role="3F0ifm" value="frame" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -290,12 +289,12 @@
         <node concept="3F0ifn" id="2c2AzQcDZAh" role="3EZMnx">
           <property role="3F0ifm" value="{...}" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIxH" role="2iSdaV" />
       </node>
     </node>
     <node concept="3EZMnI" id="1sudaVNr7dm" role="6VMZX">
       <node concept="2iRkQZ" id="1sudaVNr7dn" role="2iSdaV" />
       <node concept="3EZMnI" id="1sudaVNr5Vl" role="3EZMnx">
-        <node concept="2iRfu4" id="1sudaVNr5Vm" role="2iSdaV" />
         <node concept="3F0ifn" id="1sudaVNr5Vr" role="3EZMnx">
           <property role="3F0ifm" value="screenshot path" />
         </node>
@@ -315,9 +314,9 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIxI" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="2c2AzQc_OGm" role="3EZMnx">
-        <node concept="2iRfu4" id="2c2AzQc_OGn" role="2iSdaV" />
         <node concept="3F0ifn" id="2c2AzQc_OGo" role="3EZMnx">
           <property role="3F0ifm" value="local path     " />
         </node>
@@ -358,9 +357,9 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIxJ" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="2c2AzQcEfkh" role="3EZMnx">
-        <node concept="2iRfu4" id="2c2AzQcEfki" role="2iSdaV" />
         <node concept="3F0ifn" id="2c2AzQcEfkj" role="3EZMnx">
           <property role="3F0ifm" value="URL            " />
         </node>
@@ -379,6 +378,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIxK" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="2c2AzQcEjiA" role="3EZMnx">
         <node concept="VPM3Z" id="2c2AzQcEjF6" role="3F10Kt">
@@ -386,7 +386,6 @@
         </node>
       </node>
       <node concept="3EZMnI" id="2c2AzQcE1DQ" role="3EZMnx">
-        <node concept="2iRfu4" id="2c2AzQcE1DR" role="2iSdaV" />
         <node concept="3F0ifn" id="2c2AzQcE1DS" role="3EZMnx">
           <property role="3F0ifm" value="include        " />
         </node>
@@ -406,9 +405,9 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIxL" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="5AlTalNZfNM" role="3EZMnx">
-        <node concept="2iRfu4" id="5AlTalNZfNN" role="2iSdaV" />
         <node concept="3F0ifn" id="5AlTalNZfNO" role="3EZMnx">
           <property role="3F0ifm" value="               " />
         </node>
@@ -500,6 +499,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIxM" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="4vZ65iJZOmu" role="3EZMnx">
         <node concept="VPM3Z" id="4vZ65iJZOmv" role="3F10Kt">
@@ -507,7 +507,6 @@
         </node>
       </node>
       <node concept="3EZMnI" id="4vZ65iJZRq4" role="3EZMnx">
-        <node concept="2iRfu4" id="4vZ65iJZRq5" role="2iSdaV" />
         <node concept="3F0ifn" id="4vZ65iJZRq6" role="3EZMnx">
           <property role="3F0ifm" value="use as bookmark" />
         </node>
@@ -529,9 +528,9 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIxN" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="4vZ65iK015v" role="3EZMnx">
-        <node concept="2iRfu4" id="4vZ65iK015w" role="2iSdaV" />
         <node concept="3F0ifn" id="4vZ65iK015x" role="3EZMnx">
           <property role="3F0ifm" value="bookmark path  " />
         </node>
@@ -540,6 +539,7 @@
           <property role="1O74Pk" value="true" />
           <ref role="1NtTu8" to="34lm:4vZ65iK00Og" resolve="bookmarkPath" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIxO" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -581,14 +581,13 @@
           <property role="3F0ifm" value="screenshot-path" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
         </node>
-        <node concept="2iRfu4" id="1sudaVNqvmk" role="2iSdaV" />
         <node concept="3F1sOY" id="1JOtRcapYu$" role="3EZMnx">
           <ref role="1NtTu8" to="34lm:1JOtRcapYu0" resolve="path" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIxP" role="2iSdaV" />
       </node>
     </node>
     <node concept="3EZMnI" id="1JOtRcaq9rg" role="6VMZX">
-      <node concept="2iRfu4" id="1JOtRcaq9rh" role="2iSdaV" />
       <node concept="3F0ifn" id="1JOtRcaq9rm" role="3EZMnx">
         <property role="3F0ifm" value="absolute path:" />
       </node>
@@ -613,6 +612,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIxQ" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="2c2AzQcFDEH">
@@ -654,13 +654,12 @@
       <node concept="3F1sOY" id="2c2AzQcFROa" role="3EZMnx">
         <ref role="1NtTu8" to="34lm:2c2AzQcFPou" resolve="frame2" />
       </node>
-      <node concept="2iRfu4" id="2c2AzQcFPoq" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIxR" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="NE1gl52$xU">
     <ref role="1XX52x" to="34lm:NE1gl52$xw" resolve="DotDotDot" />
     <node concept="3EZMnI" id="NE1gl52E0l" role="2wV5jI">
-      <node concept="2iRfu4" id="NE1gl52E0m" role="2iSdaV" />
       <node concept="3F0ifn" id="NE1gl52$xW" role="3EZMnx">
         <property role="3F0ifm" value="..." />
       </node>
@@ -674,7 +673,6 @@
         <node concept="3F0ifn" id="NE1gl52E0J" role="3EZMnx">
           <property role="3F0ifm" value="..." />
         </node>
-        <node concept="2iRfu4" id="NE1gl52E0z" role="2iSdaV" />
         <node concept="pkWqt" id="NE1gl52E0N" role="pqm2j">
           <node concept="3clFbS" id="NE1gl52E0O" role="2VODD2">
             <node concept="3clFbF" id="NE1gl52EGg" role="3cqZAp">
@@ -690,27 +688,29 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIxT" role="2iSdaV" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIxS" role="2iSdaV" />
     </node>
     <node concept="3EZMnI" id="NE1gl52Gxr" role="6VMZX">
       <node concept="2iRkQZ" id="NE1gl52Gxs" role="2iSdaV" />
       <node concept="3EZMnI" id="NE1gl52$KX" role="3EZMnx">
-        <node concept="2iRfu4" id="NE1gl52$KY" role="2iSdaV" />
         <node concept="3F0ifn" id="NE1gl52$KV" role="3EZMnx">
           <property role="3F0ifm" value="type:" />
         </node>
         <node concept="3F1sOY" id="NE1gl52$L6" role="3EZMnx">
           <ref role="1NtTu8" to="34lm:NE1gl52$KT" resolve="type" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIxU" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="NE1gl52GEX" role="3EZMnx">
-        <node concept="2iRfu4" id="NE1gl52GEY" role="2iSdaV" />
         <node concept="3F0ifn" id="NE1gl52GEZ" role="3EZMnx">
           <property role="3F0ifm" value="text:" />
         </node>
         <node concept="3F0A7n" id="NE1gl52GFd" role="3EZMnx">
           <ref role="1NtTu8" to="34lm:NE1gl52E0j" resolve="text" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIxV" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -735,7 +735,6 @@
     <ref role="1XX52x" to="34lm:4vZ65iKiy7Y" resolve="BookmarkAnnotation" />
     <node concept="3EZMnI" id="4vZ65iKiy8z" role="2wV5jI">
       <node concept="3EZMnI" id="4vZ65iKiy8L" role="3EZMnx">
-        <node concept="2iRfu4" id="4vZ65iKiy8M" role="2iSdaV" />
         <node concept="3F0ifn" id="4vZ65iKiy8H" role="3EZMnx">
           <property role="3F0ifm" value="@bookmark" />
           <ref role="1ERwB7" node="4vZ65iKq6xG" resolve="deleteAnnotation" />
@@ -749,6 +748,7 @@
             <property role="Vb096" value="fLJRk5_/gray" />
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIxW" role="2iSdaV" />
       </node>
       <node concept="2iRkQZ" id="4vZ65iKiy8A" role="2iSdaV" />
       <node concept="2SsqMj" id="4vZ65iKiy9h" role="3EZMnx" />
@@ -757,7 +757,6 @@
   <node concept="24kQdi" id="4vZ65iK7gAZ">
     <ref role="1XX52x" to="34lm:4vZ65iK7gAp" resolve="Bookmark" />
     <node concept="3EZMnI" id="4vZ65iK7gBb" role="2wV5jI">
-      <node concept="2iRfu4" id="4vZ65iK7gBc" role="2iSdaV" />
       <node concept="3F0ifn" id="4vZ65iK7gB7" role="3EZMnx">
         <property role="3F0ifm" value="bookmark" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -773,10 +772,10 @@
           <node concept="3F1sOY" id="4vZ65iKhYA1" role="3EZMnx">
             <ref role="1NtTu8" to="34lm:4vZ65iKhY_V" resolve="redirect" />
           </node>
-          <node concept="2iRfu4" id="4vZ65iKhhAp" role="2iSdaV" />
           <node concept="VPM3Z" id="4vZ65iKhhAq" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIxY" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqBq4" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqBq5" role="2VODD2">
@@ -788,6 +787,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIxX" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4vZ65iKjGtY">
@@ -821,7 +821,6 @@
     <node concept="3EZMnI" id="5OzSgxea3Dq" role="2wV5jI">
       <node concept="2iRkQZ" id="5OzSgxea3Dr" role="2iSdaV" />
       <node concept="3EZMnI" id="5OzSgxea3DB" role="3EZMnx">
-        <node concept="2iRfu4" id="5OzSgxea3DC" role="2iSdaV" />
         <node concept="3F0ifn" id="5OzSgxea3Dm" role="3EZMnx">
           <property role="3F0ifm" value="example-solution:" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -835,6 +834,7 @@
         <node concept="VPXOz" id="6DUidk48gGg" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIxZ" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="5OzSgxea3Kq" role="3EZMnx">
         <node concept="VPM3Z" id="5OzSgxea3Ks" role="3F10Kt">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.stateMachineExample/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.stateMachineExample/models/editor.mps
@@ -18,8 +18,9 @@
         <child id="1140524464360" name="cellLayout" index="2czzBx" />
       </concept>
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
-      <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
+      <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
+      <concept id="1237375020029" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineChildrenStyleClassItem" flags="ln" index="pj6Ft" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
@@ -51,7 +52,6 @@
       </concept>
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
       <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
-      <concept id="1198256887712" name="jetbrains.mps.lang.editor.structure.CellModel_Indent" flags="ng" index="3XFhqQ" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
@@ -108,19 +108,15 @@
       <node concept="3F0ifn" id="4NM7IHyCGif" role="3EZMnx">
         <property role="3F0ifm" value="Events" />
       </node>
-      <node concept="3EZMnI" id="4NM7IHyCGiy" role="3EZMnx">
-        <node concept="VPM3Z" id="4NM7IHyCGi$" role="3F10Kt">
-          <property role="VOm3f" value="false" />
+      <node concept="3F2HdR" id="4NM7IHyCGiU" role="3EZMnx">
+        <ref role="1NtTu8" to="44fz:4NM7IHyCGfE" resolve="events" />
+        <node concept="l2Vlx" id="2tlTgwdHNkl" role="2czzBx" />
+        <node concept="lj46D" id="2tlTgwdHuwM" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
-        <node concept="3XFhqQ" id="4NM7IHyCGiO" role="3EZMnx" />
-        <node concept="3F2HdR" id="4NM7IHyCGiU" role="3EZMnx">
-          <ref role="1NtTu8" to="44fz:4NM7IHyCGfE" resolve="events" />
-          <node concept="2iRkQZ" id="4NM7IHyCGiX" role="2czzBx" />
-          <node concept="VPM3Z" id="4NM7IHyCGiY" role="3F10Kt">
-            <property role="VOm3f" value="false" />
-          </node>
+        <node concept="pj6Ft" id="2tlTgwdI7Qz" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
-        <node concept="l2Vlx" id="1ASK_HedIxx" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="4NM7IHyCGj3" role="3EZMnx" />
       <node concept="3F0ifn" id="4NM7IHyCGjk" role="3EZMnx" />
@@ -147,21 +143,20 @@
       <node concept="3F0ifn" id="4NM7IHyCGls" role="3EZMnx">
         <property role="3F0ifm" value="States" />
       </node>
-      <node concept="3EZMnI" id="4NM7IHyCGml" role="3EZMnx">
-        <node concept="VPM3Z" id="4NM7IHyCGmm" role="3F10Kt">
-          <property role="VOm3f" value="false" />
+      <node concept="3F2HdR" id="4NM7IHyCGmo" role="3EZMnx">
+        <ref role="1NtTu8" to="44fz:4NM7IHyCGfG" resolve="states" />
+        <node concept="l2Vlx" id="2tlTgwfn5wB" role="2czzBx" />
+        <node concept="lj46D" id="2tlTgwfn5wD" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
-        <node concept="3XFhqQ" id="4NM7IHyCGmn" role="3EZMnx" />
-        <node concept="3F2HdR" id="4NM7IHyCGmo" role="3EZMnx">
-          <ref role="1NtTu8" to="44fz:4NM7IHyCGfG" resolve="states" />
-          <node concept="2iRkQZ" id="4NM7IHyCGmp" role="2czzBx" />
-          <node concept="VPM3Z" id="4NM7IHyCGmq" role="3F10Kt">
-            <property role="VOm3f" value="false" />
-          </node>
+        <node concept="pj6Ft" id="2tlTgwfn5wF" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
-        <node concept="l2Vlx" id="1ASK_HedIxz" role="2iSdaV" />
       </node>
-      <node concept="2iRkQZ" id="4NM7IHyCGhy" role="2iSdaV" />
+      <node concept="l2Vlx" id="2tlTgwfnq3d" role="2iSdaV" />
+      <node concept="pj6Ft" id="2tlTgwfnq3f" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
     </node>
   </node>
   <node concept="24kQdi" id="4NM7IHyCGnD">
@@ -206,21 +201,20 @@
       <node concept="3F0A7n" id="4NM7IHyCRbd" role="3EZMnx">
         <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
       </node>
-      <node concept="3EZMnI" id="4NM7IHyCRbw" role="3EZMnx">
-        <node concept="VPM3Z" id="4NM7IHyCRby" role="3F10Kt">
-          <property role="VOm3f" value="false" />
+      <node concept="3F2HdR" id="4NM7IHyCRbL" role="3EZMnx">
+        <ref role="1NtTu8" to="44fz:4NM7IHyCGfN" resolve="transitions" />
+        <node concept="l2Vlx" id="2tlTgwfn5wH" role="2czzBx" />
+        <node concept="lj46D" id="2tlTgwfn5wJ" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
-        <node concept="3XFhqQ" id="4NM7IHyCRbF" role="3EZMnx" />
-        <node concept="3F2HdR" id="4NM7IHyCRbL" role="3EZMnx">
-          <ref role="1NtTu8" to="44fz:4NM7IHyCGfN" resolve="transitions" />
-          <node concept="2iRkQZ" id="4NM7IHyCRbO" role="2czzBx" />
-          <node concept="VPM3Z" id="4NM7IHyCRbP" role="3F10Kt">
-            <property role="VOm3f" value="false" />
-          </node>
+        <node concept="pj6Ft" id="2tlTgwfn5wL" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
-        <node concept="l2Vlx" id="1ASK_HedIxA" role="2iSdaV" />
       </node>
-      <node concept="2iRkQZ" id="4NM7IHyCRb6" role="2iSdaV" />
+      <node concept="l2Vlx" id="2tlTgwfnIsl" role="2iSdaV" />
+      <node concept="pj6Ft" id="2tlTgwfnIsn" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
     </node>
   </node>
   <node concept="24kQdi" id="4NM7IHyCRci">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.stateMachineExample/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.stateMachineExample/models/editor.mps
@@ -19,6 +19,7 @@
       </concept>
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
@@ -100,7 +101,7 @@
         <node concept="3F0A7n" id="4NM7IHyCGhQ" role="3EZMnx">
           <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
         </node>
-        <node concept="2iRfu4" id="4NM7IHyCGhI" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIxw" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="4NM7IHyCGi0" role="3EZMnx" />
       <node concept="3F0ifn" id="4NM7IHyCGi7" role="3EZMnx" />
@@ -119,7 +120,7 @@
             <property role="VOm3f" value="false" />
           </node>
         </node>
-        <node concept="2iRfu4" id="4NM7IHyCGiB" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIxx" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="4NM7IHyCGj3" role="3EZMnx" />
       <node concept="3F0ifn" id="4NM7IHyCGjk" role="3EZMnx" />
@@ -139,7 +140,7 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="4NM7IHyCGjY" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIxy" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="4NM7IHyCGkB" role="3EZMnx" />
       <node concept="3F0ifn" id="4NM7IHyCGl1" role="3EZMnx" />
@@ -158,7 +159,7 @@
             <property role="VOm3f" value="false" />
           </node>
         </node>
-        <node concept="2iRfu4" id="4NM7IHyCGmr" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIxz" role="2iSdaV" />
       </node>
       <node concept="2iRkQZ" id="4NM7IHyCGhy" role="2iSdaV" />
     </node>
@@ -181,10 +182,10 @@
           <node concept="3F0ifn" id="4NM7IHyCGot" role="3EZMnx">
             <property role="3F0ifm" value=")" />
           </node>
-          <node concept="2iRfu4" id="4NM7IHyCGo6" role="2iSdaV" />
           <node concept="VPM3Z" id="4NM7IHyCGo7" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIx_" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqBDG" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqBDH" role="2VODD2">
@@ -196,7 +197,7 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="4NM7IHyCGnI" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIx$" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4NM7IHyCRb1">
@@ -217,7 +218,7 @@
             <property role="VOm3f" value="false" />
           </node>
         </node>
-        <node concept="2iRfu4" id="4NM7IHyCRb_" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIxA" role="2iSdaV" />
       </node>
       <node concept="2iRkQZ" id="4NM7IHyCRb6" role="2iSdaV" />
     </node>
@@ -245,7 +246,7 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="4NM7IHyCRcn" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIxB" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4NM7IHyCRcY">
@@ -260,7 +261,7 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="4NM7IHyCRd3" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIxC" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4NM7IHyCRd$">
@@ -293,13 +294,12 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="4NM7IHyCRdD" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIxD" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4NM7IHyCRf3">
     <ref role="1XX52x" to="44fz:4NM7IHyCGeH" resolve="Transition" />
     <node concept="3EZMnI" id="4NM7IHyCRf5" role="2wV5jI">
-      <node concept="2iRfu4" id="4NM7IHyCRf8" role="2iSdaV" />
       <node concept="3F1sOY" id="4NM7IHyCRfG" role="3EZMnx">
         <ref role="1NtTu8" to="44fz:4NM7IHyCGfR" resolve="event" />
       </node>
@@ -315,6 +315,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIxE" role="2iSdaV" />
     </node>
   </node>
   <node concept="PKFIW" id="6dXnuBU76j$">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.util/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.util/models/editor.mps
@@ -17,7 +17,6 @@
         <child id="1140524464360" name="cellLayout" index="2czzBx" />
         <child id="1233141163694" name="separatorStyle" index="sWeuL" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1233148810477" name="jetbrains.mps.lang.editor.structure.InlineStyleDeclaration" flags="ng" index="tppnM" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
@@ -104,7 +103,6 @@
   <node concept="24kQdi" id="2FeCPocbJ5d">
     <ref role="1XX52x" to="5pht:2FeCPocbIIQ" resolve="KFMaybeNot" />
     <node concept="3EZMnI" id="2FeCPocbJ8s" role="2wV5jI">
-      <node concept="2iRfu4" id="2FeCPocbJ8t" role="2iSdaV" />
       <node concept="3F0ifn" id="2FeCPocbJ8n" role="3EZMnx">
         <property role="3F0ifm" value="maybenot(" />
       </node>
@@ -123,6 +121,7 @@
       <node concept="3F0ifn" id="2FeCPocbJlL" role="3EZMnx">
         <property role="3F0ifm" value=")" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIt3" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/editor.mps
@@ -362,7 +362,6 @@
     <property role="3GE5qa" value="function" />
     <ref role="1XX52x" to="zzzn:6zmBjqUjGYQ" resolve="FunctionType" />
     <node concept="3EZMnI" id="6zmBjqUjGZp" role="2wV5jI">
-      <node concept="2iRfu4" id="6zmBjqUjGZq" role="2iSdaV" />
       <node concept="3F0ifn" id="6zmBjqUjGZm" role="3EZMnx">
         <property role="3F0ifm" value="(" />
         <node concept="11LMrY" id="6zmBjqUjH25" role="3F10Kt">
@@ -411,6 +410,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIx2" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6zmBjqUkwFS">
@@ -447,13 +447,13 @@
           <node concept="3F1sOY" id="6zmBjqUkwGb" role="3EZMnx">
             <ref role="1NtTu8" to="zzzn:6zmBjqUkwsc" resolve="type" />
           </node>
-          <node concept="2iRfu4" id="5WJNTMTzFsq" role="2iSdaV" />
           <node concept="VPM3Z" id="5WJNTMTzFsr" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
           <node concept="11L4FC" id="5WJNTMT$Elm" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIx3" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqBUF" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqBUG" role="2VODD2">
@@ -564,7 +564,6 @@
     <property role="3GE5qa" value="function" />
     <ref role="1XX52x" to="zzzn:6zmBjqUln66" resolve="ExecOp" />
     <node concept="3EZMnI" id="6zmBjqUltls" role="2wV5jI">
-      <node concept="2iRfu4" id="6zmBjqUltlt" role="2iSdaV" />
       <node concept="3F0ifn" id="6zmBjqUln6J" role="3EZMnx">
         <property role="3F0ifm" value="exec(" />
         <node concept="11LMrY" id="6zmBjqUltnn" role="3F10Kt">
@@ -611,6 +610,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIx4" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6zmBjqUm7Nh">
@@ -694,7 +694,6 @@
     <property role="3GE5qa" value="function" />
     <ref role="1XX52x" to="zzzn:49WTic8eSD1" resolve="FunctionArgument" />
     <node concept="3EZMnI" id="49WTic8fvNp" role="2wV5jI">
-      <node concept="2iRfu4" id="49WTic8fvNq" role="2iSdaV" />
       <node concept="1kIj98" id="6HHp2WmZ0Ki" role="3EZMnx">
         <property role="3g2DhO" value="true" />
         <node concept="3F0A7n" id="49WTic8fvN_" role="1kIj9b">
@@ -724,13 +723,13 @@
           <node concept="3F1sOY" id="6HHp2WmOBkT" role="3EZMnx">
             <ref role="1NtTu8" to="zzzn:6zmBjqUkwsc" resolve="type" />
           </node>
-          <node concept="2iRfu4" id="5WJNTMTyRb8" role="2iSdaV" />
           <node concept="VPM3Z" id="5WJNTMTyRb9" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
           <node concept="11L4FC" id="5WJNTMTzYOB" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIx6" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqBGi" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqBGj" role="2VODD2">
@@ -742,6 +741,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIx5" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="49WTic8fSj$">
@@ -903,10 +903,10 @@
           <node concept="3F1sOY" id="69zaTr1ELcl" role="3EZMnx">
             <ref role="1NtTu8" to="hm2y:69zaTr1EKHX" resolve="type" />
           </node>
-          <node concept="2iRfu4" id="69zaTr1ELc9" role="2iSdaV" />
           <node concept="VPM3Z" id="69zaTr1ELca" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIx7" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqCxR" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqCxS" role="2VODD2">
@@ -966,7 +966,6 @@
     <property role="3GE5qa" value="function" />
     <ref role="1XX52x" to="zzzn:2rOWEwsAzV1" resolve="BindOp" />
     <node concept="3EZMnI" id="2rOWEwsAzVw" role="2wV5jI">
-      <node concept="2iRfu4" id="2rOWEwsAzVx" role="2iSdaV" />
       <node concept="3F0ifn" id="2rOWEwsAzVy" role="3EZMnx">
         <property role="3F0ifm" value="bind(" />
         <node concept="11LMrY" id="2rOWEwsAzVz" role="3F10Kt">
@@ -990,6 +989,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIx8" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="22hm_0zJHVr">
@@ -1001,7 +1001,6 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="2iRfu4" id="22hm_0zJHVM" role="2iSdaV" />
       <node concept="1HlG4h" id="22hm_0zJYsD" role="3EZMnx">
         <node concept="1HfYo3" id="22hm_0zJYsF" role="1HlULh">
           <node concept="3TQlhw" id="22hm_0zJYsH" role="1Hhtcw">
@@ -1029,6 +1028,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIx9" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="KaZMgy7sWC">
@@ -1169,7 +1169,6 @@
   <node concept="24kQdi" id="79jc6YzNL57">
     <ref role="1XX52x" to="zzzn:79jc6YzNL4y" resolve="AssertExpr" />
     <node concept="3EZMnI" id="79jc6YzNL5l" role="2wV5jI">
-      <node concept="2iRfu4" id="79jc6YzNL5m" role="2iSdaV" />
       <node concept="3F0ifn" id="79jc6YzNL5i" role="3EZMnx">
         <property role="3F0ifm" value="assert" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -1192,6 +1191,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIxa" role="2iSdaV" />
     </node>
   </node>
   <node concept="V5hpn" id="4qVjx3jYYFJ">
@@ -1673,10 +1673,10 @@
           <node concept="3F1sOY" id="1VmWkC0z5TU" role="3EZMnx">
             <ref role="1NtTu8" to="hm2y:69zaTr1EKHX" resolve="type" />
           </node>
-          <node concept="2iRfu4" id="1VmWkC0z5TV" role="2iSdaV" />
           <node concept="VPM3Z" id="1VmWkC0z5TW" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIxb" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqC30" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqC31" role="2VODD2">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lookup/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lookup/models/editor.mps
@@ -26,7 +26,7 @@
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
@@ -332,7 +332,6 @@
   <node concept="24kQdi" id="55lPkJGG4At">
     <ref role="1XX52x" to="8qwc:55lPkJGFLaQ" resolve="LookupTable" />
     <node concept="3EZMnI" id="55lPkJGG4A_" role="2wV5jI">
-      <node concept="2iRfu4" id="55lPkJGG4AA" role="2iSdaV" />
       <node concept="3F0ifn" id="55lPkJGG4Av" role="3EZMnx">
         <property role="3F0ifm" value="lookup" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -348,10 +347,10 @@
           <node concept="3F1sOY" id="55lPkJGQ49f" role="3EZMnx">
             <ref role="1NtTu8" to="8qwc:55lPkJGFLUc" resolve="resultType" />
           </node>
-          <node concept="2iRfu4" id="55lPkJGQ48$" role="2iSdaV" />
           <node concept="VPM3Z" id="55lPkJGQ48_" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIz9" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqFgb" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqFgc" role="2VODD2">
@@ -1215,32 +1214,32 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIz8" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="55lPkJGKum3">
     <ref role="1XX52x" to="8qwc:55lPkJGIN9r" resolve="LookupTableCell" />
     <node concept="3EZMnI" id="5yPljRXS8$E" role="2wV5jI">
-      <node concept="2iRfu4" id="5yPljRXS8$F" role="2iSdaV" />
       <node concept="3F1sOY" id="55lPkJGKuoZ" role="3EZMnx">
         <ref role="1NtTu8" to="8qwc:55lPkJGINbe" resolve="val" />
       </node>
       <node concept="VPM3Z" id="5yPljRXS8$K" role="3F10Kt" />
+      <node concept="l2Vlx" id="1ASK_HedIza" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="55lPkJGLBaK">
     <ref role="1XX52x" to="8qwc:55lPkJGLB68" resolve="LookupTableHeader" />
     <node concept="3EZMnI" id="5yPljRXSpWD" role="2wV5jI">
-      <node concept="2iRfu4" id="5yPljRXSpWE" role="2iSdaV" />
       <node concept="3F1sOY" id="55lPkJGLBcQ" role="3EZMnx">
         <ref role="1NtTu8" to="8qwc:55lPkJGLB8d" resolve="val" />
       </node>
       <node concept="VPM3Z" id="5yPljRXSpWJ" role="3F10Kt" />
+      <node concept="l2Vlx" id="1ASK_HedIzb" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="55lPkJGZxnZ">
     <ref role="1XX52x" to="8qwc:55lPkJGZwPb" resolve="LookupTableType" />
     <node concept="3EZMnI" id="55lPkJGZxp9" role="2wV5jI">
-      <node concept="2iRfu4" id="55lPkJGZxpa" role="2iSdaV" />
       <node concept="3F0ifn" id="55lPkJGZxp3" role="3EZMnx">
         <property role="3F0ifm" value="lookup" />
         <ref role="1k5W1q" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
@@ -1280,12 +1279,12 @@
       <node concept="3F1sOY" id="55lPkJGZxum" role="3EZMnx">
         <ref role="1NtTu8" to="8qwc:55lPkJGZxnp" resolve="resType" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzc" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="55lPkJH1N1s">
     <ref role="1XX52x" to="8qwc:55lPkJH1wUe" resolve="LookupTarget" />
     <node concept="3EZMnI" id="55lPkJH1N_Y" role="2wV5jI">
-      <node concept="2iRfu4" id="55lPkJH1N_Z" role="2iSdaV" />
       <node concept="3F0ifn" id="55lPkJH1N_S" role="3EZMnx">
         <property role="3F0ifm" value="lookup" />
       </node>
@@ -1319,6 +1318,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzd" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="55lPkJH2uuL">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/editor.mps
@@ -32,7 +32,7 @@
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
       <concept id="1597643335227097138" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_TransformationMenu_node" flags="ng" index="7Obwk" />
       <concept id="6516520003787916624" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_Condition" flags="ig" index="27VH4U" />
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
@@ -475,7 +475,6 @@
     <ref role="1XX52x" to="1qv1:4iu6t1eB654" resolve="PowerExpression" />
     <node concept="jtDJS" id="4r1mNB_o5YQ" role="2wV5jI">
       <node concept="3EZMnI" id="3SqLunIqL1_" role="jn6J4">
-        <node concept="2iRfu4" id="3SqLunIqL1A" role="2iSdaV" />
         <node concept="3F0ifn" id="3SqLunIqL1U" role="3EZMnx">
           <property role="3F0ifm" value="(" />
           <ref role="1k5W1q" to="itrz:3_9S6lia_no" resolve="iets3PassiveText" />
@@ -520,6 +519,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIwA" role="2iSdaV" />
       </node>
       <node concept="3F1sOY" id="4r1mNB_o5ZL" role="jn6J3">
         <ref role="1NtTu8" to="1qv1:4r1mNB_o5WJ" resolve="exponent" />
@@ -536,7 +536,6 @@
         <ref role="1NtTu8" to="1qv1:PWcNB4VG$Z" resolve="upper" />
       </node>
       <node concept="3EZMnI" id="7sJd_4s1tks" role="1B_Wnt">
-        <node concept="2iRfu4" id="7sJd_4s1tkt" role="2iSdaV" />
         <node concept="3F0A7n" id="7sJd_4s1tku" role="3EZMnx">
           <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
         </node>
@@ -555,6 +554,7 @@
         <node concept="3F1sOY" id="7sJd_4s1tkw" role="3EZMnx">
           <ref role="1NtTu8" to="1qv1:PWcNB4W2v_" resolve="lower" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIwB" role="2iSdaV" />
       </node>
       <node concept="3F1sOY" id="7sJd_4s1tkO" role="1B_Wn3">
         <ref role="1NtTu8" to="1qv1:PWcNB4VG_6" resolve="body" />
@@ -795,7 +795,6 @@
         <ref role="1NtTu8" to="1qv1:PWcNB4VG$Z" resolve="upper" />
       </node>
       <node concept="3EZMnI" id="PWcNB4W7de" role="1B_Wnt">
-        <node concept="2iRfu4" id="PWcNB4W7df" role="2iSdaV" />
         <node concept="3F0A7n" id="PWcNB4W7dm" role="3EZMnx">
           <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
         </node>
@@ -814,6 +813,7 @@
         <node concept="3F1sOY" id="PWcNB4W7dN" role="3EZMnx">
           <ref role="1NtTu8" to="1qv1:PWcNB4W2v_" resolve="lower" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIwC" role="2iSdaV" />
       </node>
       <node concept="1GO0HI" id="7sJd_4s10PM" role="1FbL03">
         <node concept="3clFbS" id="7sJd_4s10PN" role="2VODD2">
@@ -912,7 +912,6 @@
     <property role="3GE5qa" value="rat" />
     <ref role="1XX52x" to="1qv1:5mz5Tt_jL63" resolve="ToDecimalTarget" />
     <node concept="3EZMnI" id="5mz5Tt_jL6A" role="2wV5jI">
-      <node concept="2iRfu4" id="5mz5Tt_jL6B" role="2iSdaV" />
       <node concept="PMmxH" id="1VqmZU7jneu" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
       </node>
@@ -934,6 +933,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwD" role="2iSdaV" />
     </node>
   </node>
   <node concept="3INDKC" id="5mz5Tt_l9Nq">
@@ -1033,7 +1033,6 @@
     <property role="3GE5qa" value="rat" />
     <ref role="1XX52x" to="1qv1:5mz5Tt_ip39" resolve="RatExpr" />
     <node concept="3EZMnI" id="5mz5Tt_ip3C" role="2wV5jI">
-      <node concept="2iRfu4" id="5mz5Tt_ip3D" role="2iSdaV" />
       <node concept="3F0ifn" id="5mz5Tt_ip3_" role="3EZMnx">
         <property role="3F0ifm" value="rat" />
       </node>
@@ -1055,6 +1054,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwE" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="M7eZQBbq6V">
@@ -1088,7 +1088,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="2iRfu4" id="M7eZQBbq7c" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIwF" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3iWt5efOyI5">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
@@ -43,6 +43,8 @@
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
+      <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
+      <concept id="1237375020029" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineChildrenStyleClassItem" flags="ln" index="pj6Ft" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
@@ -128,7 +130,6 @@
       </concept>
       <concept id="1176717841777" name="jetbrains.mps.lang.editor.structure.QueryFunction_ModelAccess_Getter" flags="in" index="3TQlhw" />
       <concept id="1176749715029" name="jetbrains.mps.lang.editor.structure.QueryFunction_CellProvider" flags="in" index="3VJUX4" />
-      <concept id="1198256887712" name="jetbrains.mps.lang.editor.structure.CellModel_Indent" flags="ng" index="3XFhqQ" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
@@ -611,7 +612,7 @@
   <node concept="24kQdi" id="3vxfdxbcDNx">
     <ref role="1XX52x" to="kelk:3vxfdxbcs9r" resolve="Group" />
     <node concept="3EZMnI" id="3vxfdxbcDNW" role="2wV5jI">
-      <node concept="2iRkQZ" id="3vxfdxbcDNX" role="2iSdaV" />
+      <node concept="l2Vlx" id="2tlTgwfH2b0" role="2iSdaV" />
       <node concept="3EZMnI" id="3vxfdxbcDNB" role="3EZMnx">
         <node concept="PMmxH" id="VFjlN5$ZY5" role="3EZMnx">
           <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
@@ -625,35 +626,40 @@
         </node>
         <node concept="l2Vlx" id="1ASK_HedIsa" role="2iSdaV" />
       </node>
-      <node concept="3EZMnI" id="3vxfdxbcDOD" role="3EZMnx">
-        <node concept="3XFhqQ" id="3vxfdxbcDOt" role="3EZMnx" />
-        <node concept="3F2HdR" id="3vxfdxbcDP0" role="3EZMnx">
-          <ref role="1NtTu8" to="kelk:3vxfdxbcs9Q" resolve="contents" />
-          <node concept="2iRkQZ" id="3vxfdxbcDP9" role="2czzBx" />
-          <node concept="3F0ifn" id="3vxfdxbcDPd" role="2czzBI">
-            <property role="3F0ifm" value="" />
-            <node concept="VPxyj" id="3vxfdxbcDPg" role="3F10Kt">
-              <property role="VOm3f" value="true" />
-            </node>
+      <node concept="3F2HdR" id="3vxfdxbcDP0" role="3EZMnx">
+        <ref role="1NtTu8" to="kelk:3vxfdxbcs9Q" resolve="contents" />
+        <node concept="l2Vlx" id="2tlTgwfo2ZN" role="2czzBx" />
+        <node concept="3F0ifn" id="3vxfdxbcDPd" role="2czzBI">
+          <property role="3F0ifm" value="" />
+          <node concept="VPxyj" id="3vxfdxbcDPg" role="3F10Kt">
+            <property role="VOm3f" value="true" />
           </node>
-          <node concept="4$FPG" id="3vxfdxbd3cm" role="4_6I_">
-            <node concept="3clFbS" id="3vxfdxbd3cn" role="2VODD2">
-              <node concept="3clFbF" id="3vxfdxbd3co" role="3cqZAp">
-                <node concept="2ShNRf" id="3vxfdxbd3cp" role="3clFbG">
-                  <node concept="3zrR0B" id="3vxfdxbd3cq" role="2ShVmc">
-                    <node concept="3Tqbb2" id="3vxfdxbd3cr" role="3zrR0E">
-                      <ref role="ehGHo" to="kelk:3vxfdxbcS_H" resolve="EmptyMessageContent" />
-                    </node>
+        </node>
+        <node concept="4$FPG" id="3vxfdxbd3cm" role="4_6I_">
+          <node concept="3clFbS" id="3vxfdxbd3cn" role="2VODD2">
+            <node concept="3clFbF" id="3vxfdxbd3co" role="3cqZAp">
+              <node concept="2ShNRf" id="3vxfdxbd3cp" role="3clFbG">
+                <node concept="3zrR0B" id="3vxfdxbd3cq" role="2ShVmc">
+                  <node concept="3Tqbb2" id="3vxfdxbd3cr" role="3zrR0E">
+                    <ref role="ehGHo" to="kelk:3vxfdxbcS_H" resolve="EmptyMessageContent" />
                   </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="l2Vlx" id="1ASK_HedIsb" role="2iSdaV" />
+        <node concept="lj46D" id="2tlTgwfo2ZP" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pj6Ft" id="2tlTgwfo2ZR" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
       </node>
       <node concept="3F0ifn" id="3vxfdxbcDPy" role="3EZMnx">
         <property role="3F0ifm" value="}" />
+      </node>
+      <node concept="pj6Ft" id="2tlTgwfH2b2" role="3F10Kt">
+        <property role="VOm3f" value="true" />
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
@@ -1062,7 +1062,7 @@
       <node concept="3F1sOY" id="3vxfdxblP5h" role="3EZMnx">
         <ref role="1NtTu8" to="kelk:3vxfdxblP40" resolve="expr" />
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIsj" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwfX06j" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3vxfdxbnLbW">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/editor.mps
@@ -42,6 +42,7 @@
       </concept>
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
@@ -270,7 +271,6 @@
     <node concept="3EZMnI" id="ub9nkyK63c" role="2wV5jI">
       <node concept="2iRkQZ" id="ub9nkyK63d" role="2iSdaV" />
       <node concept="3EZMnI" id="ub9nkyK62L" role="3EZMnx">
-        <node concept="2iRfu4" id="ub9nkyK62M" role="2iSdaV" />
         <node concept="3F0ifn" id="ub9nkyK62I" role="3EZMnx">
           <property role="3F0ifm" value="messages" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -379,6 +379,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIs7" role="2iSdaV" />
       </node>
       <node concept="gc7cB" id="4tXyFaWwywB" role="3EZMnx">
         <node concept="3VJUX4" id="4tXyFaWwywD" role="3YsKMw">
@@ -510,7 +511,6 @@
   <node concept="24kQdi" id="3vxfdxbcBqS">
     <ref role="1XX52x" to="kelk:3vxfdxbcBqr" resolve="MessageDefinition" />
     <node concept="3EZMnI" id="3vxfdxbcBqY" role="2wV5jI">
-      <node concept="2iRfu4" id="3vxfdxbcBqZ" role="2iSdaV" />
       <node concept="1kIj98" id="3vxfdxbcFFR" role="3EZMnx">
         <property role="3g2DhO" value="true" />
         <node concept="3F0A7n" id="3vxfdxbcBtZ" role="1kIj9b">
@@ -587,7 +587,7 @@
               <property role="VOm3f" value="true" />
             </node>
           </node>
-          <node concept="2iRfu4" id="3vxfdxbdUmg" role="2iSdaV" />
+          <node concept="l2Vlx" id="1ASK_HedIs9" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqG5q" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqG5r" role="2VODD2">
@@ -605,6 +605,7 @@
       <node concept="3F1sOY" id="3vxfdxbdM8O" role="3EZMnx">
         <ref role="1NtTu8" to="kelk:3vxfdxbdM7Q" resolve="text" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIs8" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3vxfdxbcDNx">
@@ -612,7 +613,6 @@
     <node concept="3EZMnI" id="3vxfdxbcDNW" role="2wV5jI">
       <node concept="2iRkQZ" id="3vxfdxbcDNX" role="2iSdaV" />
       <node concept="3EZMnI" id="3vxfdxbcDNB" role="3EZMnx">
-        <node concept="2iRfu4" id="3vxfdxbcDNC" role="2iSdaV" />
         <node concept="PMmxH" id="VFjlN5$ZY5" role="3EZMnx">
           <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -623,9 +623,9 @@
         <node concept="3F0ifn" id="3vxfdxbcDPq" role="3EZMnx">
           <property role="3F0ifm" value="{" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIsa" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="3vxfdxbcDOD" role="3EZMnx">
-        <node concept="2iRfu4" id="3vxfdxbcDOE" role="2iSdaV" />
         <node concept="3XFhqQ" id="3vxfdxbcDOt" role="3EZMnx" />
         <node concept="3F2HdR" id="3vxfdxbcDP0" role="3EZMnx">
           <ref role="1NtTu8" to="kelk:3vxfdxbcs9Q" resolve="contents" />
@@ -650,6 +650,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIsb" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="3vxfdxbcDPy" role="3EZMnx">
         <property role="3F0ifm" value="}" />
@@ -754,7 +755,6 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="3vxfdxbjbRV" role="2iSdaV" />
       <node concept="3EZMnI" id="3vxfdxbjc$D" role="3EZMnx">
         <node concept="11L4FC" id="5ZJ96SJCpeP" role="3F10Kt">
           <property role="VOm3f" value="true" />
@@ -788,7 +788,6 @@
             <property role="VOm3f" value="true" />
           </node>
         </node>
-        <node concept="2iRfu4" id="3vxfdxbjc$I" role="2iSdaV" />
         <node concept="pkWqt" id="3vxfdxbjetK" role="pqm2j">
           <node concept="3clFbS" id="3vxfdxbjetL" role="2VODD2">
             <node concept="3clFbF" id="3vxfdxbjeSW" role="3cqZAp">
@@ -820,7 +819,9 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIsd" role="2iSdaV" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsc" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3vxfdxbd$wF">
@@ -839,7 +840,6 @@
   <node concept="24kQdi" id="3vxfdxbdUl$">
     <ref role="1XX52x" to="kelk:3vxfdxbdUeD" resolve="MessageArg" />
     <node concept="3EZMnI" id="49WTic8fvNp" role="2wV5jI">
-      <node concept="2iRfu4" id="49WTic8fvNq" role="2iSdaV" />
       <node concept="1kIj98" id="6HHp2WmZ0Ki" role="3EZMnx">
         <property role="3g2DhO" value="true" />
         <node concept="3F0A7n" id="49WTic8fvN_" role="1kIj9b">
@@ -869,13 +869,13 @@
           <node concept="3F1sOY" id="6HHp2WmOBkT" role="3EZMnx">
             <ref role="1NtTu8" to="kelk:3vxfdxbdUeH" resolve="type" />
           </node>
-          <node concept="2iRfu4" id="5WJNTMTyRb8" role="2iSdaV" />
           <node concept="VPM3Z" id="5WJNTMTyRb9" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
           <node concept="11L4FC" id="5WJNTMTzYOB" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIsf" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqFnJ" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqFnK" role="2VODD2">
@@ -887,6 +887,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIse" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3vxfdxbeBfk">
@@ -919,7 +920,6 @@
   <node concept="24kQdi" id="3vxfdxbi6Be">
     <ref role="1XX52x" to="kelk:3vxfdxbi6AO" resolve="NamespaceType" />
     <node concept="3EZMnI" id="3vxfdxbi77$" role="2wV5jI">
-      <node concept="2iRfu4" id="3vxfdxbi77_" role="2iSdaV" />
       <node concept="3F0ifn" id="3vxfdxbi6Bg" role="3EZMnx">
         <property role="3F0ifm" value="namespace" />
         <ref role="1k5W1q" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
@@ -953,6 +953,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsg" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3vxfdxbiEYc">
@@ -972,7 +973,6 @@
     <property role="3GE5qa" value="kind" />
     <ref role="1XX52x" to="kelk:3vxfdxbkQiy" resolve="ErrorKind" />
     <node concept="3EZMnI" id="5ZJ96SJAc3x" role="2wV5jI">
-      <node concept="2iRfu4" id="5ZJ96SJAc3y" role="2iSdaV" />
       <node concept="3F0ifn" id="3vxfdxbkQiY" role="3EZMnx">
         <property role="3F0ifm" value="error[" />
         <node concept="VechU" id="3vxfdxbkQj5" role="3F10Kt">
@@ -997,13 +997,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsh" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3vxfdxbkQjz">
     <property role="3GE5qa" value="kind" />
     <ref role="1XX52x" to="kelk:3vxfdxbkQj9" resolve="WarningKind" />
     <node concept="3EZMnI" id="7OtDX6qjWPQ" role="2wV5jI">
-      <node concept="2iRfu4" id="7OtDX6qjWPR" role="2iSdaV" />
       <node concept="3F0ifn" id="3vxfdxbkQj_" role="3EZMnx">
         <property role="3F0ifm" value="warning[" />
         <node concept="VechU" id="3vxfdxbkQjD" role="3F10Kt">
@@ -1035,12 +1035,12 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsi" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3vxfdxblP4u">
     <ref role="1XX52x" to="kelk:3vxfdxblP3W" resolve="TypeCoercion" />
     <node concept="3EZMnI" id="3vxfdxblP4$" role="2wV5jI">
-      <node concept="2iRfu4" id="3vxfdxblP4_" role="2iSdaV" />
       <node concept="3F0ifn" id="3vxfdxbongJ" role="3EZMnx">
         <property role="3F0ifm" value="coerce" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -1062,6 +1062,7 @@
       <node concept="3F1sOY" id="3vxfdxblP5h" role="3EZMnx">
         <ref role="1NtTu8" to="kelk:3vxfdxblP40" resolve="expr" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsj" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3vxfdxbnLbW">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.mutable/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.mutable/models/editor.mps
@@ -414,7 +414,6 @@
     <property role="3GE5qa" value="box" />
     <ref role="1XX52x" to="8lgj:3GdqffBKoAm" resolve="BoxType" />
     <node concept="3EZMnI" id="3GdqffBKoBI" role="2wV5jI">
-      <node concept="2iRfu4" id="3GdqffBKoBJ" role="2iSdaV" />
       <node concept="3F0ifn" id="3GdqffBKoAO" role="3EZMnx">
         <property role="3F0ifm" value="box" />
         <ref role="1k5W1q" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
@@ -442,13 +441,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItO" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3GdqffBOVwX">
     <property role="3GE5qa" value="box" />
     <ref role="1XX52x" to="8lgj:3GdqffBOVwu" resolve="BoxExpression" />
     <node concept="3EZMnI" id="3GdqffBOVx5" role="2wV5jI">
-      <node concept="2iRfu4" id="3GdqffBOVx6" role="2iSdaV" />
       <node concept="3F0ifn" id="3GdqffBOVx2" role="3EZMnx">
         <property role="3F0ifm" value="box" />
       </node>
@@ -470,6 +469,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItP" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3GdqffBPke5">
@@ -483,7 +483,6 @@
     <property role="3GE5qa" value="box" />
     <ref role="1XX52x" to="8lgj:3GdqffBQYFy" resolve="BoxUpdateTarget" />
     <node concept="3EZMnI" id="3GdqffBQYG9" role="2wV5jI">
-      <node concept="2iRfu4" id="3GdqffBQYGa" role="2iSdaV" />
       <node concept="3F0ifn" id="3GdqffBQYG6" role="3EZMnx">
         <property role="3F0ifm" value="update" />
       </node>
@@ -543,6 +542,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItQ" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3GdqffC6Llz">
@@ -793,7 +793,6 @@
       </node>
       <node concept="_tjkj" id="4IV0h47K4KR" role="3EZMnx">
         <node concept="3EZMnI" id="4IV0h47hCZj" role="_tjki">
-          <node concept="2iRfu4" id="4IV0h47hCZk" role="2iSdaV" />
           <node concept="3F0ifn" id="4IV0h47hCZg" role="3EZMnx">
             <property role="3F0ifm" value="[" />
             <node concept="11LMrY" id="4IV0h47hCZJ" role="3F10Kt">
@@ -829,6 +828,7 @@
           <node concept="11LMrY" id="4IV0h47j1Ef" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedItR" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqHp$" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqHp_" role="2VODD2">
@@ -955,7 +955,6 @@
     <property role="3GE5qa" value="interactor" />
     <ref role="1XX52x" to="8lgj:Z4fkwz6NL_" resolve="InteractorValueTarget" />
     <node concept="3EZMnI" id="4IV0h47K6fy" role="2wV5jI">
-      <node concept="2iRfu4" id="4IV0h47K6fz" role="2iSdaV" />
       <node concept="3F0A7n" id="Z4fkwz6NM2" role="3EZMnx">
         <ref role="1k5W1q" to="itrz:ub9nkyQsN2" resolve="iets3Identifier" />
         <ref role="1NtTu8" to="8lgj:Z4fkwz6NLA" resolve="value" />
@@ -1122,7 +1121,6 @@
       </node>
       <node concept="_tjkj" id="4IV0h47K7fH" role="3EZMnx">
         <node concept="3EZMnI" id="4IV0h47K7fI" role="_tjki">
-          <node concept="2iRfu4" id="4IV0h47K7fJ" role="2iSdaV" />
           <node concept="3F0ifn" id="4IV0h47K7fK" role="3EZMnx">
             <property role="3F0ifm" value="[" />
             <node concept="11LMrY" id="4IV0h47K7fL" role="3F10Kt">
@@ -1158,6 +1156,7 @@
           <node concept="11LMrY" id="4IV0h47K7fV" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedItT" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqIFd" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqIFe" role="2VODD2">
@@ -1169,13 +1168,13 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItS" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7bd8pkl7uFU">
     <property role="3GE5qa" value="interactor.interact" />
     <ref role="1XX52x" to="8lgj:7bd8pkl7uF5" resolve="LiveExpression" />
     <node concept="3EZMnI" id="7bd8pkl7uFZ" role="2wV5jI">
-      <node concept="2iRfu4" id="7bd8pkl7uG0" role="2iSdaV" />
       <node concept="3F0ifn" id="7bd8pkl7uFW" role="3EZMnx">
         <property role="3F0ifm" value="live" />
         <node concept="11LMrY" id="7bd8pkl7uGn" role="3F10Kt">
@@ -1200,13 +1199,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItU" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7bd8pkl7uYU">
     <property role="3GE5qa" value="interactor.interact" />
     <ref role="1XX52x" to="8lgj:7bd8pkl7uY3" resolve="LiveType" />
     <node concept="3EZMnI" id="7bd8pkl7uYZ" role="2wV5jI">
-      <node concept="2iRfu4" id="7bd8pkl7uZ0" role="2iSdaV" />
       <node concept="3F0ifn" id="7bd8pkl7uYW" role="3EZMnx">
         <property role="3F0ifm" value="live" />
         <ref role="1k5W1q" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
@@ -1234,6 +1233,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItV" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3iESbJsCqXu">
@@ -1321,7 +1321,6 @@
     <property role="3GE5qa" value="clock" />
     <ref role="1XX52x" to="8lgj:3iESbJsEYoW" resolve="ArtificialClockExpr" />
     <node concept="3EZMnI" id="5kGo$yLAk$P" role="2wV5jI">
-      <node concept="2iRfu4" id="5kGo$yLAk$Q" role="2iSdaV" />
       <node concept="3F0ifn" id="3iESbJsEYpo" role="3EZMnx">
         <property role="3F0ifm" value="artificialclock" />
       </node>
@@ -1343,6 +1342,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItW" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3iESbJsEYtR">
@@ -1371,7 +1371,6 @@
     <property role="3GE5qa" value="clock" />
     <ref role="1XX52x" to="8lgj:3iESbJsIl$2" resolve="AdvanceByTarget" />
     <node concept="3EZMnI" id="3iESbJsIl$W" role="2wV5jI">
-      <node concept="2iRfu4" id="3iESbJsIl$X" role="2iSdaV" />
       <node concept="3F0ifn" id="3iESbJsIl$T" role="3EZMnx">
         <property role="3F0ifm" value="advance" />
       </node>
@@ -1393,6 +1392,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItX" role="2iSdaV" />
     </node>
   </node>
   <node concept="2$ogZn" id="1yW0h03EWZv">
@@ -1842,7 +1842,6 @@
     <property role="TrG5h" value="interceptors" />
     <ref role="1XX52x" to="8lgj:4IV0h47dfWs" resolve="IInterceptorContainer" />
     <node concept="3EZMnI" id="4IV0h47dgTX" role="2wV5jI">
-      <node concept="2iRfu4" id="4IV0h47dgTY" role="2iSdaV" />
       <node concept="3F0ifn" id="4IV0h47dgTU" role="3EZMnx">
         <property role="3F0ifm" value="[" />
         <node concept="11LMrY" id="4IV0h47dgUn" role="3F10Kt">
@@ -1881,6 +1880,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItY" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4IV0h47f8_x">
@@ -1908,7 +1908,6 @@
     <property role="3GE5qa" value="interactor.intercept" />
     <ref role="1XX52x" to="8lgj:4IV0h47hCXy" resolve="ContextArgValue" />
     <node concept="3EZMnI" id="4IV0h47hCY6" role="2wV5jI">
-      <node concept="2iRfu4" id="4IV0h47hCY7" role="2iSdaV" />
       <node concept="1kIj98" id="4IV0h47hCYB" role="3EZMnx">
         <property role="3g2DhO" value="true" />
         <node concept="3F1sOY" id="4IV0h47hCY3" role="1kIj9b">
@@ -1922,6 +1921,7 @@
       <node concept="3F1sOY" id="4IV0h47hCYn" role="3EZMnx">
         <ref role="1NtTu8" to="8lgj:4IV0h47hCX_" resolve="value" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItZ" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4IV0h47GcwS">
@@ -1980,7 +1980,6 @@
     <property role="3GE5qa" value="interactor.intercept.interceptors" />
     <ref role="1XX52x" to="8lgj:4IV0h47QL2E" resolve="RateLimitInterceptor" />
     <node concept="3EZMnI" id="4IV0h47QL3A" role="2wV5jI">
-      <node concept="2iRfu4" id="4IV0h47QL3B" role="2iSdaV" />
       <node concept="3F0ifn" id="4IV0h47QL3z" role="3EZMnx">
         <property role="3F0ifm" value="rate" />
       </node>
@@ -2031,13 +2030,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIu0" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="31BLocd1pVD">
     <property role="3GE5qa" value="box" />
     <ref role="1XX52x" to="8lgj:31BLocd1pRE" resolve="UpdateCurrencyCheck" />
     <node concept="3EZMnI" id="31BLocd1pVJ" role="2wV5jI">
-      <node concept="2iRfu4" id="31BLocd1pVK" role="2iSdaV" />
       <node concept="3F0ifn" id="31BLocd1pWZ" role="3EZMnx">
         <property role="3F0ifm" value="from" />
       </node>
@@ -2059,6 +2058,7 @@
       <node concept="3F0ifn" id="31BLocd1R0l" role="3EZMnx">
         <property role="3F0ifm" value="to" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIu1" role="2iSdaV" />
     </node>
   </node>
   <node concept="3ICUPy" id="5mZZgpxcanv">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.natlang/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.natlang/models/editor.mps
@@ -37,11 +37,11 @@
       <concept id="1078308402140" name="jetbrains.mps.lang.editor.structure.CellModel_Custom" flags="sg" stub="8104358048506730068" index="gc7cB">
         <child id="1176795024817" name="cellProvider" index="3YsKMw" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="6089045305654894367" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Named" flags="ng" index="2kknPI">
         <reference id="6089045305654944382" name="menu" index="2kkw0f" />
       </concept>
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
@@ -341,7 +341,6 @@
     <node concept="3EZMnI" id="1u1U5lETWNb" role="2wV5jI">
       <node concept="2iRkQZ" id="1u1U5lETWNc" role="2iSdaV" />
       <node concept="3EZMnI" id="1u1U5lETVlY" role="3EZMnx">
-        <node concept="2iRfu4" id="1u1U5lETVlZ" role="2iSdaV" />
         <node concept="3F0ifn" id="1u1U5lETVlV" role="3EZMnx">
           <property role="3F0ifm" value="@syntax{" />
           <ref role="1ERwB7" node="7fOaqhi0grK" resolve="syntax" />
@@ -383,6 +382,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIzo" role="2iSdaV" />
       </node>
       <node concept="2SsqMj" id="1u1U5lETWNw" role="3EZMnx" />
     </node>
@@ -390,7 +390,6 @@
   <node concept="24kQdi" id="1u1U5lEW8jl">
     <ref role="1XX52x" to="1xa4:1u1U5lEW8iD" resolve="NatLangFunctionArgRef" />
     <node concept="3EZMnI" id="1u1U5lEW8jD" role="2wV5jI">
-      <node concept="2iRfu4" id="1u1U5lEW8jE" role="2iSdaV" />
       <node concept="3F0ifn" id="1u1U5lEW8jA" role="3EZMnx">
         <property role="3F0ifm" value="@[" />
         <node concept="11LMrY" id="1u1U5lEW8nu" role="3F10Kt">
@@ -474,6 +473,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzp" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5Q45tqZrW7D">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.process/models/org.iets3.core.expr.process.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.process/models/org.iets3.core.expr.process.editor.mps
@@ -141,7 +141,6 @@
   <node concept="24kQdi" id="7WFhXJlPaRe">
     <ref role="1XX52x" to="7y2b:7WFhXJlPaQK" resolve="Party" />
     <node concept="3EZMnI" id="7WFhXJlPaSb" role="2wV5jI">
-      <node concept="2iRfu4" id="7WFhXJlPaSc" role="2iSdaV" />
       <node concept="3F0ifn" id="7WFhXJlPaSh" role="3EZMnx">
         <property role="3F0ifm" value="@" />
         <node concept="11LMrY" id="7WFhXJlPaSA" role="3F10Kt">
@@ -157,6 +156,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzD" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7WFhXJlQmB_">
@@ -216,7 +216,6 @@
                   <property role="1lJzqX" value="6" />
                 </node>
               </node>
-              <node concept="2iRfu4" id="7WFhXJlQobp" role="2iSdaV" />
               <node concept="3F0ifn" id="7WFhXJlPaTu" role="3EZMnx">
                 <property role="3F0ifm" value="multi-party-decision" />
               </node>
@@ -232,6 +231,7 @@
                   <property role="1lJzqX" value="6" />
                 </node>
               </node>
+              <node concept="l2Vlx" id="1ASK_HedIzE" role="2iSdaV" />
             </node>
           </node>
           <node concept="3j0QqT" id="3wXkdMVr3XA" role="3EZMnx">
@@ -328,7 +328,7 @@
                     <property role="1lJzqX" value="6" />
                   </node>
                 </node>
-                <node concept="2iRfu4" id="7WFhXJlPaTJ" role="2iSdaV" />
+                <node concept="l2Vlx" id="1ASK_HedIzF" role="2iSdaV" />
               </node>
               <node concept="3EZMnI" id="VApoyDEMHu" role="3EZMnx">
                 <node concept="3F0ifn" id="VApoyDEMHQ" role="3EZMnx">
@@ -346,7 +346,6 @@
                 <node concept="3F0ifn" id="VApoyDEMHy" role="3EZMnx">
                   <property role="3F0ifm" value="dynamic?" />
                 </node>
-                <node concept="2iRfu4" id="VApoyDEMHz" role="2iSdaV" />
                 <node concept="27S6Sx" id="VApoyDEMJK" role="3EZMnx">
                   <ref role="1NtTu8" to="7y2b:VApoyDEJo7" resolve="dynamicParties" />
                 </node>
@@ -366,7 +365,6 @@
                   <node concept="3F0ifn" id="3H4W4dhqZHi" role="3EZMnx">
                     <property role="3F0ifm" value="sealable?" />
                   </node>
-                  <node concept="2iRfu4" id="3H4W4dhqZHj" role="2iSdaV" />
                   <node concept="27S6Sx" id="3H4W4dhqZHk" role="3EZMnx">
                     <ref role="1NtTu8" to="7y2b:3H4W4dhr03S" resolve="sealable" />
                   </node>
@@ -382,7 +380,9 @@
                       </node>
                     </node>
                   </node>
+                  <node concept="l2Vlx" id="1ASK_HedIzH" role="2iSdaV" />
                 </node>
+                <node concept="l2Vlx" id="1ASK_HedIzG" role="2iSdaV" />
               </node>
             </node>
           </node>
@@ -448,10 +448,10 @@
                   <node concept="3F0ifn" id="Z4fkwzdXgr" role="3EZMnx">
                     <property role="3F0ifm" value="procedure:" />
                   </node>
-                  <node concept="2iRfu4" id="Z4fkwzdXgw" role="2iSdaV" />
                   <node concept="3F1sOY" id="33mFrumMoXU" role="3EZMnx">
                     <ref role="1NtTu8" to="7y2b:33mFrumMoXi" resolve="procedure" />
                   </node>
+                  <node concept="l2Vlx" id="1ASK_HedIzJ" role="2iSdaV" />
                 </node>
                 <node concept="3EZMnI" id="3wXkdMVktj2" role="3EZMnx">
                   <node concept="VPM3Z" id="3wXkdMVktj3" role="3F10Kt">
@@ -460,11 +460,11 @@
                   <node concept="3F0ifn" id="3wXkdMVktj5" role="3EZMnx">
                     <property role="3F0ifm" value="turnout:  " />
                   </node>
-                  <node concept="2iRfu4" id="3wXkdMVktj6" role="2iSdaV" />
                   <node concept="3F1sOY" id="3wXkdMVktj7" role="3EZMnx">
                     <property role="1$x2rV" value="&lt;none&gt;" />
                     <ref role="1NtTu8" to="7y2b:3wXkdMVkc9Y" resolve="turnout" />
                   </node>
+                  <node concept="l2Vlx" id="1ASK_HedIzK" role="2iSdaV" />
                 </node>
                 <node concept="2iRkQZ" id="3wXkdMVqjQ8" role="2iSdaV" />
               </node>
@@ -482,11 +482,11 @@
                   <node concept="3F0ifn" id="4voDClGzHun" role="3EZMnx">
                     <property role="3F0ifm" value="time limit:" />
                   </node>
-                  <node concept="2iRfu4" id="4voDClGzHuo" role="2iSdaV" />
                   <node concept="3F1sOY" id="4voDClGzHup" role="3EZMnx">
                     <property role="1$x2rV" value="&lt;none&gt;" />
                     <ref role="1NtTu8" to="7y2b:4voDClGzENw" resolve="timeLimit" />
                   </node>
+                  <node concept="l2Vlx" id="1ASK_HedIzL" role="2iSdaV" />
                 </node>
                 <node concept="3EZMnI" id="33mFrumMoXl" role="3EZMnx">
                   <node concept="VPM3Z" id="33mFrumMoXm" role="3F10Kt">
@@ -498,7 +498,7 @@
                   <node concept="27S6Sx" id="33mFrumMoXp" role="3EZMnx">
                     <ref role="1NtTu8" to="7y2b:Z4fkwzdXgm" resolve="revoke" />
                   </node>
-                  <node concept="2iRfu4" id="33mFrumMoXq" role="2iSdaV" />
+                  <node concept="l2Vlx" id="1ASK_HedIzM" role="2iSdaV" />
                 </node>
               </node>
               <node concept="3F0ifn" id="3wXkdMVr7M_" role="3EZMnx">
@@ -510,7 +510,7 @@
                   <property role="1lJzqX" value="6" />
                 </node>
               </node>
-              <node concept="2iRfu4" id="3wXkdMVqjPw" role="2iSdaV" />
+              <node concept="l2Vlx" id="1ASK_HedIzI" role="2iSdaV" />
             </node>
           </node>
           <node concept="2iRkQZ" id="3wXkdMVq6Pg" role="2iSdaV" />
@@ -583,7 +583,6 @@
   <node concept="24kQdi" id="Z4fkwzeKWZ">
     <ref role="1XX52x" to="7y2b:Z4fkwzeKWz" resolve="PartyLiteral" />
     <node concept="3EZMnI" id="Z4fkwzeKX4" role="2wV5jI">
-      <node concept="2iRfu4" id="Z4fkwzeKX5" role="2iSdaV" />
       <node concept="3F0ifn" id="Z4fkwzeKX1" role="3EZMnx">
         <property role="3F0ifm" value="@[" />
         <node concept="11LMrY" id="Z4fkwzeKXh" role="3F10Kt">
@@ -599,6 +598,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzN" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="33mFrum$lDj">
@@ -633,13 +633,13 @@
     <property role="3GE5qa" value="procedure" />
     <ref role="1XX52x" to="7y2b:3iESbJshtqt" resolve="CustomDecProc" />
     <node concept="3EZMnI" id="3iESbJshIPc" role="2wV5jI">
-      <node concept="2iRfu4" id="3iESbJshIPd" role="2iSdaV" />
       <node concept="3F0ifn" id="3iESbJshIP9" role="3EZMnx">
         <property role="3F0ifm" value="custom" />
       </node>
       <node concept="3F1sOY" id="3iESbJshIPt" role="3EZMnx">
         <ref role="1NtTu8" to="s7zn:5cK3QOc9w5h" resolve="function" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzO" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3wXkdMVlu$v">
@@ -668,7 +668,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="2iRfu4" id="4IV0h47Eajg" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIzP" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4IV0h47EqmS">
@@ -689,7 +689,6 @@
     <property role="3GE5qa" value="interceptor" />
     <ref role="1XX52x" to="7y2b:4IV0h48lf7t" resolve="TakeTurnsInterceptor" />
     <node concept="3EZMnI" id="4IV0h48lf8E" role="2wV5jI">
-      <node concept="2iRfu4" id="4IV0h48lf8F" role="2iSdaV" />
       <node concept="3F0ifn" id="4IV0h48lf8G" role="3EZMnx">
         <property role="3F0ifm" value="takeTurns" />
       </node>
@@ -752,7 +751,6 @@
             <property role="Vbekb" value="g1_k_vY/BOLD" />
           </node>
         </node>
-        <node concept="2iRfu4" id="31HpwbvYAFc" role="2iSdaV" />
         <node concept="pkWqt" id="31HpwbvYAGv" role="pqm2j">
           <node concept="3clFbS" id="31HpwbvYAGw" role="2VODD2">
             <node concept="3clFbF" id="31HpwbvYEXD" role="3cqZAp">
@@ -765,6 +763,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIzR" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="4IV0h48lf8P" role="3EZMnx">
         <property role="3F0ifm" value=")" />
@@ -772,6 +771,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzQ" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5hiN5Pkqrsk">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.query/models/org.iets3.core.expr.query.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.query/models/org.iets3.core.expr.query.editor.mps
@@ -20,7 +20,7 @@
       <concept id="1078308402140" name="jetbrains.mps.lang.editor.structure.CellModel_Custom" flags="sg" stub="8104358048506730068" index="gc7cB">
         <child id="1176795024817" name="cellProvider" index="3YsKMw" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
@@ -99,7 +99,6 @@
   <node concept="24kQdi" id="5QDPRL$oihD">
     <ref role="1XX52x" to="ysgh:5QDPRL$ohHz" resolve="QueryExpr" />
     <node concept="3EZMnI" id="5QDPRL$oimO" role="2wV5jI">
-      <node concept="2iRfu4" id="5QDPRL$oimP" role="2iSdaV" />
       <node concept="3F0ifn" id="5QDPRL$oike" role="3EZMnx">
         <property role="3F0ifm" value="query" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -129,7 +128,6 @@
         </node>
         <node concept="2EHx9g" id="5QDPRL$pj27" role="2iSdaV" />
         <node concept="3EZMnI" id="5QDPRL$qtE9" role="3EZMnx">
-          <node concept="2iRfu4" id="5QDPRL$qtEa" role="2iSdaV" />
           <node concept="3F0ifn" id="5QDPRL$qtGV" role="3EZMnx">
             <property role="3F0ifm" value="from     " />
             <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -137,9 +135,9 @@
           <node concept="3F1sOY" id="5QDPRL$pANN" role="3EZMnx">
             <ref role="1NtTu8" to="ysgh:5QDPRL$oi4v" resolve="source" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIsI" role="2iSdaV" />
         </node>
         <node concept="3EZMnI" id="5QDPRL$qtM9" role="3EZMnx">
-          <node concept="2iRfu4" id="5QDPRL$qtMa" role="2iSdaV" />
           <node concept="3F0ifn" id="5QDPRL$qtP0" role="3EZMnx">
             <property role="3F0ifm" value="filter   " />
             <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -162,9 +160,9 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIsJ" role="2iSdaV" />
         </node>
         <node concept="3EZMnI" id="5QDPRL$qtZp" role="3EZMnx">
-          <node concept="2iRfu4" id="5QDPRL$qtZq" role="2iSdaV" />
           <node concept="3F0ifn" id="5QDPRL$qtZI" role="3EZMnx">
             <property role="3F0ifm" value="transform" />
             <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -187,9 +185,9 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIsK" role="2iSdaV" />
         </node>
         <node concept="3EZMnI" id="5QDPRL$x5GP" role="3EZMnx">
-          <node concept="2iRfu4" id="5QDPRL$x5GQ" role="2iSdaV" />
           <node concept="3F0ifn" id="5QDPRL$x5GR" role="3EZMnx">
             <property role="3F0ifm" value="group    " />
             <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -212,6 +210,7 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIsL" role="2iSdaV" />
         </node>
       </node>
       <node concept="gc7cB" id="5QDPRL$sBH2" role="3EZMnx">
@@ -232,33 +231,34 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsH" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5QDPRL$oUJj">
     <ref role="1XX52x" to="ysgh:5QDPRL$oUsO" resolve="QueryFilter" />
     <node concept="3EZMnI" id="5QDPRL$oUOv" role="2wV5jI">
-      <node concept="2iRfu4" id="5QDPRL$oUOw" role="2iSdaV" />
       <node concept="3F1sOY" id="5QDPRL$oUTP" role="3EZMnx">
         <ref role="1NtTu8" to="s7zn:5cK3QOc9w5h" resolve="function" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsM" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5QDPRL$pxh_">
     <ref role="1XX52x" to="ysgh:5QDPRL$pwTW" resolve="QuerySource" />
     <node concept="3EZMnI" id="5QDPRL$qt3f" role="2wV5jI">
-      <node concept="2iRfu4" id="5QDPRL$qt3g" role="2iSdaV" />
       <node concept="3F1sOY" id="5QDPRL$pxse" role="3EZMnx">
         <ref role="1NtTu8" to="ysgh:5QDPRL$px4h" resolve="expr" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsN" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5QDPRL$qihI">
     <ref role="1XX52x" to="ysgh:5QDPRL$qhvL" resolve="QueryTransform" />
     <node concept="3EZMnI" id="5QDPRL$qikl" role="2wV5jI">
-      <node concept="2iRfu4" id="5QDPRL$qikm" role="2iSdaV" />
       <node concept="3F1sOY" id="5QDPRL$qiko" role="3EZMnx">
         <ref role="1NtTu8" to="s7zn:5cK3QOc9w5h" resolve="function" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsO" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5QDPRL$x4ta">
@@ -266,7 +266,6 @@
     <node concept="3EZMnI" id="5QDPRL$xyvI" role="2wV5jI">
       <node concept="2EHx9g" id="5QDPRL$yTCU" role="2iSdaV" />
       <node concept="3EZMnI" id="5QDPRL$x4w4" role="3EZMnx">
-        <node concept="2iRfu4" id="5QDPRL$x4w5" role="2iSdaV" />
         <node concept="3F0ifn" id="5QDPRL$x4za" role="3EZMnx">
           <property role="3F0ifm" value="by   " />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -277,6 +276,7 @@
         <node concept="1QQdxR" id="5QDPRL$yXsZ" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIsP" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="5QDPRL$xy_Z" role="3EZMnx">
         <node concept="VPM3Z" id="5QDPRL$xyA1" role="3F10Kt" />
@@ -287,10 +287,10 @@
           <property role="3F0ifm" value="build" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
         </node>
-        <node concept="2iRfu4" id="5QDPRL$xyA4" role="2iSdaV" />
         <node concept="3F1sOY" id="5QDPRL$xz5V" role="3EZMnx">
           <ref role="1NtTu8" to="ysgh:5QDPRL$xyOH" resolve="build" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIsQ" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -306,7 +306,7 @@
       <node concept="3F1sOY" id="5QDPRL$y6fm" role="3EZMnx">
         <ref role="1NtTu8" to="s7zn:5cK3QOc9w5h" resolve="function" />
       </node>
-      <node concept="2iRfu4" id="5QDPRL$y6cg" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIsR" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.query/models/org.iets3.core.expr.query.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.query/models/org.iets3.core.expr.query.editor.mps
@@ -20,6 +20,7 @@
       <concept id="1078308402140" name="jetbrains.mps.lang.editor.structure.CellModel_Custom" flags="sg" stub="8104358048506730068" index="gc7cB">
         <child id="1176795024817" name="cellProvider" index="3YsKMw" />
       </concept>
+      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
@@ -231,7 +232,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIsH" role="2iSdaV" />
+      <node concept="2iRfu4" id="1OEjBB5GrGS" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5QDPRL$oUJj">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/editor.mps
@@ -69,6 +69,7 @@
       <concept id="6089045305654894367" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Named" flags="ng" index="2kknPI">
         <reference id="6089045305654944382" name="menu" index="2kkw0f" />
       </concept>
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
@@ -594,7 +595,6 @@
   <node concept="24kQdi" id="14RJwd1gc25">
     <ref role="1XX52x" to="wtll:14RJwd1g889" resolve="DefaultEntry" />
     <node concept="3EZMnI" id="4nY0kF8kHPk" role="2wV5jI">
-      <node concept="2iRfu4" id="4nY0kF8kHPl" role="2iSdaV" />
       <node concept="3j0QqT" id="5U8d23QobMD" role="3EZMnx">
         <node concept="Veino" id="5U8d23QsP3$" role="3F10Kt">
           <node concept="3ZlJ5R" id="5U8d23QsP3G" role="VblUZ">
@@ -769,7 +769,6 @@
             </node>
           </node>
           <node concept="3EZMnI" id="4nY0kF8k75H" role="1j7Clw">
-            <node concept="2iRfu4" id="4nY0kF8k75I" role="2iSdaV" />
             <node concept="1HlG4h" id="4nY0kF8k75J" role="3EZMnx">
               <node concept="1HfYo3" id="4nY0kF8k75K" role="1HlULh">
                 <node concept="3TQlhw" id="4nY0kF8k75L" role="1Hhtcw">
@@ -815,7 +814,6 @@
             </node>
             <node concept="_tjkj" id="4nY0kF8k764" role="3EZMnx">
               <node concept="3EZMnI" id="4nY0kF8k765" role="_tjki">
-                <node concept="2iRfu4" id="4nY0kF8k766" role="2iSdaV" />
                 <node concept="3F0ifn" id="4nY0kF8k767" role="3EZMnx">
                   <property role="3F0ifm" value="," />
                   <node concept="11L4FC" id="4nY0kF8k768" role="3F10Kt">
@@ -828,6 +826,7 @@
                 <node concept="11L4FC" id="4nY0kF8k76a" role="3F10Kt">
                   <property role="VOm3f" value="true" />
                 </node>
+                <node concept="l2Vlx" id="1ASK_HedIvg" role="2iSdaV" />
               </node>
               <node concept="uPpia" id="1ZlHRbgqLax" role="1djCvC">
                 <node concept="3clFbS" id="1ZlHRbgqLay" role="2VODD2">
@@ -885,6 +884,7 @@
             <node concept="2R9Tw8" id="4nY0kF8mz4R" role="3F10Kt">
               <property role="VOm3f" value="true" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIvf" role="2iSdaV" />
           </node>
         </node>
       </node>
@@ -989,7 +989,6 @@
           <property role="3vr1H$" value="true" />
           <property role="3vD9g8" value="true" />
           <node concept="3EZMnI" id="3a2FJuC5bUB" role="3v87hO">
-            <node concept="2iRfu4" id="3a2FJuC5bUC" role="2iSdaV" />
             <node concept="3XFhqQ" id="3a2FJuC5crx" role="3EZMnx" />
             <node concept="gc7cB" id="59T8kEoBBAZ" role="3EZMnx">
               <node concept="3VJUX4" id="59T8kEoBBB1" role="3YsKMw">
@@ -1646,9 +1645,9 @@
                 <property role="VOm3f" value="false" />
               </node>
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIvh" role="2iSdaV" />
           </node>
           <node concept="3EZMnI" id="4nY0kF8tRZ4" role="3v1y6z">
-            <node concept="2iRfu4" id="4nY0kF8tRZ5" role="2iSdaV" />
             <node concept="3F1sOY" id="4nY0kF8k76t" role="3EZMnx">
               <ref role="1NtTu8" to="wtll:14RJwd1g88t" resolve="expression" />
               <node concept="xShMh" id="4nY0kF8rzPb" role="3F10Kt">
@@ -1685,7 +1684,6 @@
               </node>
             </node>
             <node concept="3EZMnI" id="4nY0kF8k76H" role="3EZMnx">
-              <node concept="2iRfu4" id="4nY0kF8k76I" role="2iSdaV" />
               <node concept="3XFhqQ" id="4nY0kF8k76J" role="3EZMnx" />
               <node concept="3F0ifn" id="4nY0kF8k76K" role="3EZMnx">
                 <property role="3F0ifm" value=":" />
@@ -1879,6 +1877,7 @@
                   </node>
                 </node>
               </node>
+              <node concept="l2Vlx" id="1ASK_HedIvj" role="2iSdaV" />
             </node>
             <node concept="VPM3Z" id="4nY0kF8vTiP" role="3F10Kt">
               <property role="VOm3f" value="false" />
@@ -1897,9 +1896,11 @@
                 </node>
               </node>
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIvi" role="2iSdaV" />
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIve" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="2HpFPvT65UC">
@@ -1907,7 +1908,6 @@
     <node concept="3EZMnI" id="2HpFPvT65UE" role="2wV5jI">
       <node concept="2iRkQZ" id="2HpFPvT65UF" role="2iSdaV" />
       <node concept="3EZMnI" id="2HpFPvT65UN" role="3EZMnx">
-        <node concept="2iRfu4" id="2HpFPvT65UO" role="2iSdaV" />
         <node concept="3F0ifn" id="2HpFPvT65UK" role="3EZMnx">
           <property role="3F0ifm" value="repl" />
         </node>
@@ -1986,7 +1986,6 @@
               </node>
             </node>
           </node>
-          <node concept="2iRfu4" id="3FexrMiPNZj" role="2iSdaV" />
           <node concept="pkWqt" id="4b4fYXfomT1" role="pqm2j">
             <node concept="3clFbS" id="4b4fYXfomT2" role="2VODD2">
               <node concept="3clFbF" id="4b4fYXfont3" role="3cqZAp">
@@ -2002,7 +2001,9 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIvl" role="2iSdaV" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIvk" role="2iSdaV" />
       </node>
       <node concept="2T_mXK" id="6LVVWmzDMIv" role="3EZMnx">
         <node concept="2T_bXT" id="6LVVWmzDNDL" role="3F10Kt">
@@ -2013,29 +2014,28 @@
         </node>
       </node>
       <node concept="3EZMnI" id="69FYpZqxMQd" role="3EZMnx">
-        <node concept="2iRfu4" id="69FYpZqxMQe" role="2iSdaV" />
         <node concept="3EZMnI" id="4nY0kF8rhEq" role="3EZMnx">
-          <node concept="2iRfu4" id="4nY0kF8rhEr" role="2iSdaV" />
           <node concept="3F0ifn" id="4nY0kF8ryRw" role="3EZMnx">
             <property role="3F0ifm" value="downstream updates" />
           </node>
           <node concept="27S6Sx" id="4nY0kF8rzD1" role="3EZMnx">
             <ref role="1NtTu8" to="wtll:4nY0kF8rhEo" resolve="updateDownstream" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIvn" role="2iSdaV" />
         </node>
         <node concept="3XFhqQ" id="6LVVWmzDmxU" role="3EZMnx" />
         <node concept="3EZMnI" id="6LVVWmzDh7Q" role="3EZMnx">
-          <node concept="2iRfu4" id="6LVVWmzDh7R" role="2iSdaV" />
           <node concept="3F0ifn" id="6LVVWmzDh7S" role="3EZMnx">
             <property role="3F0ifm" value="show diffs" />
           </node>
           <node concept="27S6Sx" id="6LVVWmzDh7T" role="3EZMnx">
             <ref role="1NtTu8" to="wtll:6LVVWmzDh7N" resolve="showDiffs" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIvo" role="2iSdaV" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIvm" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="6LVVWmzE0Lt" role="3EZMnx">
-        <node concept="2iRfu4" id="6LVVWmzE0Lu" role="2iSdaV" />
         <node concept="3gTLQM" id="6LVVWmzE0Lv" role="3EZMnx">
           <node concept="3Fmcul" id="6LVVWmzE0Lw" role="3FoqZy">
             <node concept="3clFbS" id="6LVVWmzE0Lx" role="2VODD2">
@@ -2354,6 +2354,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIvp" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="4tXyFaWwBfP" role="3EZMnx">
         <node concept="VPM3Z" id="4tXyFaWwBiM" role="3F10Kt">
@@ -2588,7 +2589,6 @@
             <property role="Vb096" value="fLwANPu/blue" />
           </node>
         </node>
-        <node concept="2iRfu4" id="2HpFPvT9Hg4" role="2iSdaV" />
         <node concept="1iCGBv" id="2HpFPvT9Hge" role="3EZMnx">
           <ref role="1NtTu8" to="wtll:2HpFPvT9Hfy" resolve="entry" />
           <node concept="1sVBvm" id="2HpFPvT9Hgg" role="1sWHZn">
@@ -2638,6 +2638,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIvq" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -2662,7 +2663,6 @@
     <node concept="3EZMnI" id="5xEoEMrtKze" role="2wV5jI">
       <node concept="2iRkQZ" id="5xEoEMrtKzf" role="2iSdaV" />
       <node concept="3EZMnI" id="5xEoEMrtOJO" role="3EZMnx">
-        <node concept="2iRfu4" id="5xEoEMrtOJP" role="2iSdaV" />
         <node concept="3F0ifn" id="5xEoEMrGLvO" role="3EZMnx">
           <property role="3F0ifm" value="sheet" />
         </node>
@@ -2697,9 +2697,9 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIvr" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="3_Nra3E1ktF" role="3EZMnx">
-        <node concept="2iRfu4" id="3_Nra3E1ktG" role="2iSdaV" />
         <node concept="3EZMnI" id="7HzLUeHu6ly" role="3EZMnx">
           <node concept="VPM3Z" id="7HzLUeHu6l$" role="3F10Kt">
             <property role="VOm3f" value="false" />
@@ -2725,7 +2725,6 @@
               <property role="VOm3f" value="true" />
             </node>
           </node>
-          <node concept="2iRfu4" id="7HzLUeHu6lB" role="2iSdaV" />
           <node concept="pkWqt" id="7HzLUeHu754" role="pqm2j">
             <node concept="3clFbS" id="7HzLUeHu755" role="2VODD2">
               <node concept="3clFbF" id="7HzLUeHu7cf" role="3cqZAp">
@@ -2741,6 +2740,7 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIvt" role="2iSdaV" />
         </node>
         <node concept="3EZMnI" id="5avmkTFF3Yv" role="3EZMnx">
           <property role="S$Qs1" value="true" />
@@ -3481,10 +3481,10 @@
             <property role="3F0ifm" value="{...}" />
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIvs" role="2iSdaV" />
       </node>
     </node>
     <node concept="3EZMnI" id="2c2AzQdd_v$" role="6VMZX">
-      <node concept="2iRfu4" id="2c2AzQdd_v_" role="2iSdaV" />
       <node concept="3F0ifn" id="2c2AzQdd_vA" role="3EZMnx">
         <property role="3F0ifm" value="sheet" />
       </node>
@@ -3506,6 +3506,7 @@
         <ref role="1NtTu8" to="wtll:5xEoEMrutTn" resolve="booleansAreChecks" />
       </node>
       <node concept="3XFhqQ" id="2c2AzQdd_vI" role="3EZMnx" />
+      <node concept="l2Vlx" id="1ASK_HedIvu" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5xEoEMrmwhO">
@@ -4244,7 +4245,6 @@
           <property role="VOm3f" value="false" />
         </node>
         <node concept="3EZMnI" id="5xEoEMr$1Pz" role="3EZMnx">
-          <node concept="2iRfu4" id="5xEoEMr$1P$" role="2iSdaV" />
           <node concept="3F1sOY" id="5xEoEMrsh5c" role="3EZMnx">
             <ref role="1NtTu8" to="wtll:5xEoEMrsgwl" resolve="label" />
             <node concept="pkWqt" id="5xEoEMr$1r4" role="pqm2j">
@@ -4284,7 +4284,6 @@
                 </node>
               </node>
             </node>
-            <node concept="2iRfu4" id="5xEoEMr$2xw" role="2iSdaV" />
             <node concept="pkWqt" id="5xEoEMr$Nlq" role="pqm2j">
               <node concept="3clFbS" id="5xEoEMr$Nlr" role="2VODD2">
                 <node concept="3clFbF" id="5xEoEMr$O1H" role="3cqZAp">
@@ -4306,7 +4305,9 @@
                 <property role="VOm3f" value="true" />
               </node>
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIvw" role="2iSdaV" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIvv" role="2iSdaV" />
         </node>
         <node concept="gc7cB" id="5xEoEMrtvxp" role="3EZMnx">
           <node concept="3VJUX4" id="5xEoEMrtvxr" role="3YsKMw">
@@ -4561,7 +4562,6 @@
           </node>
         </node>
         <node concept="3EZMnI" id="5avmkTFfg8W" role="1QoS34">
-          <node concept="2iRfu4" id="5avmkTFfg8X" role="2iSdaV" />
           <node concept="1v6uyg" id="uuJ7IpZtyd" role="3EZMnx">
             <property role="2oejA6" value="true" />
             <node concept="s8t4o" id="3_Nra3DXpqD" role="wsdo6">
@@ -4610,7 +4610,6 @@
             </node>
           </node>
           <node concept="3EZMnI" id="7HzLUeHsQ$p" role="3EZMnx">
-            <node concept="2iRfu4" id="7HzLUeHsQ$q" role="2iSdaV" />
             <node concept="3F0ifn" id="48DDwlwV29l" role="3EZMnx">
               <property role="3F0ifm" value="R|" />
               <node concept="Veino" id="48DDwlwV3Jy" role="3F10Kt">
@@ -4642,13 +4641,13 @@
                 </node>
               </node>
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIvy" role="2iSdaV" />
           </node>
           <node concept="1v6uyg" id="uuJ7IpZtye" role="3EZMnx">
             <property role="2oejA6" value="true" />
             <node concept="3EZMnI" id="5avmkTFwxw9" role="wsdo6">
               <node concept="2iRkQZ" id="5avmkTFwxwa" role="2iSdaV" />
               <node concept="3EZMnI" id="5avmkTFwxSV" role="3EZMnx">
-                <node concept="2iRfu4" id="5avmkTFwxSW" role="2iSdaV" />
                 <node concept="3F0ifn" id="5avmkTFwyio" role="3EZMnx">
                   <property role="3F0ifm" value="type: " />
                 </node>
@@ -4676,9 +4675,9 @@
                     </node>
                   </node>
                 </node>
+                <node concept="l2Vlx" id="1ASK_HedIvz" role="2iSdaV" />
               </node>
               <node concept="3EZMnI" id="5avmkTFwB_m" role="3EZMnx">
-                <node concept="2iRfu4" id="5avmkTFwB_n" role="2iSdaV" />
                 <node concept="3F0ifn" id="5avmkTFwB_o" role="3EZMnx">
                   <property role="3F0ifm" value="value:" />
                 </node>
@@ -4732,6 +4731,7 @@
                     </node>
                   </node>
                 </node>
+                <node concept="l2Vlx" id="1ASK_HedIv$" role="2iSdaV" />
               </node>
               <node concept="pkWqt" id="5avmkTFxlsU" role="pqm2j">
                 <node concept="3clFbS" id="5avmkTFxlsV" role="2VODD2">
@@ -4772,13 +4772,13 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIvx" role="2iSdaV" />
         </node>
         <node concept="1v6uyg" id="uuJ7IpZtyf" role="1QoVPY">
           <property role="2oejA6" value="true" />
           <node concept="3EZMnI" id="5avmkTFxQi1" role="wsdo6">
             <node concept="2iRkQZ" id="5avmkTFxQi2" role="2iSdaV" />
             <node concept="3EZMnI" id="5avmkTFxQi3" role="3EZMnx">
-              <node concept="2iRfu4" id="5avmkTFxQi4" role="2iSdaV" />
               <node concept="3F0ifn" id="5avmkTFxQi5" role="3EZMnx">
                 <property role="3F0ifm" value="type: " />
               </node>
@@ -4806,6 +4806,7 @@
                   </node>
                 </node>
               </node>
+              <node concept="l2Vlx" id="1ASK_HedIv_" role="2iSdaV" />
             </node>
             <node concept="pkWqt" id="5avmkTFxQii" role="pqm2j">
               <node concept="3clFbS" id="5avmkTFxQij" role="2VODD2">
@@ -4823,7 +4824,6 @@
               </node>
             </node>
             <node concept="3EZMnI" id="5avmkTFHRxQ" role="3EZMnx">
-              <node concept="2iRfu4" id="5avmkTFHRxR" role="2iSdaV" />
               <node concept="3F0ifn" id="5avmkTFHRxS" role="3EZMnx">
                 <property role="3F0ifm" value="expr: " />
               </node>
@@ -4858,6 +4858,7 @@
                   </node>
                 </node>
               </node>
+              <node concept="l2Vlx" id="1ASK_HedIvA" role="2iSdaV" />
             </node>
           </node>
           <node concept="3EZMnI" id="5avmkTFxQiq" role="1j7Clw">
@@ -5267,7 +5268,7 @@
                 </node>
               </node>
             </node>
-            <node concept="2iRfu4" id="5avmkTFxQir" role="2iSdaV" />
+            <node concept="l2Vlx" id="1ASK_HedIvB" role="2iSdaV" />
           </node>
         </node>
       </node>
@@ -5299,16 +5300,15 @@
           <node concept="3EZMnI" id="7HzLUeHpCtZ" role="3v87hO">
             <node concept="2iRkQZ" id="7HzLUeHpCu0" role="2iSdaV" />
             <node concept="3EZMnI" id="7HzLUeHpCu1" role="3EZMnx">
-              <node concept="2iRfu4" id="7HzLUeHpCu2" role="2iSdaV" />
               <node concept="3F0ifn" id="7HzLUeHpCu3" role="3EZMnx">
                 <property role="3F0ifm" value="result:     " />
               </node>
               <node concept="27S6Sx" id="7HzLUeHpCu4" role="3EZMnx">
                 <ref role="1NtTu8" to="wtll:48DDwlwUXpx" resolve="result" />
               </node>
+              <node concept="l2Vlx" id="1ASK_HedIvC" role="2iSdaV" />
             </node>
             <node concept="3EZMnI" id="7HzLUeHpCu5" role="3EZMnx">
-              <node concept="2iRfu4" id="7HzLUeHpCu6" role="2iSdaV" />
               <node concept="3F0ifn" id="7HzLUeHpCu7" role="3EZMnx">
                 <property role="3F0ifm" value="locked:     " />
               </node>
@@ -5338,9 +5338,9 @@
                   </node>
                 </node>
               </node>
+              <node concept="l2Vlx" id="1ASK_HedIvD" role="2iSdaV" />
             </node>
             <node concept="3EZMnI" id="7HzLUeHw_ly" role="3EZMnx">
-              <node concept="2iRfu4" id="7HzLUeHw_lz" role="2iSdaV" />
               <node concept="3F0ifn" id="7HzLUeHw_l$" role="3EZMnx">
                 <property role="3F0ifm" value="template:   " />
               </node>
@@ -5368,15 +5368,16 @@
                   </node>
                 </node>
               </node>
+              <node concept="l2Vlx" id="1ASK_HedIvE" role="2iSdaV" />
             </node>
             <node concept="3EZMnI" id="1mFXz_FVM7z" role="3EZMnx">
-              <node concept="2iRfu4" id="1mFXz_FVM7$" role="2iSdaV" />
               <node concept="3F0ifn" id="1mFXz_FVM7_" role="3EZMnx">
                 <property role="3F0ifm" value="internal:   " />
               </node>
               <node concept="27S6Sx" id="1mFXz_FVM7A" role="3EZMnx">
                 <ref role="1NtTu8" to="wtll:1mFXz_FVM7k" resolve="internal" />
               </node>
+              <node concept="l2Vlx" id="1ASK_HedIvF" role="2iSdaV" />
             </node>
             <node concept="3EZMnI" id="7HzLUeHpCu9" role="3EZMnx">
               <node concept="VPM3Z" id="7HzLUeHpCua" role="3F10Kt">
@@ -5385,13 +5386,12 @@
               <node concept="3F0ifn" id="7HzLUeHpCub" role="3EZMnx">
                 <property role="3F0ifm" value="constraint: " />
               </node>
-              <node concept="2iRfu4" id="7HzLUeHpCuc" role="2iSdaV" />
               <node concept="3F1sOY" id="7HzLUeHpCud" role="3EZMnx">
                 <ref role="1NtTu8" to="wtll:3_Nra3DTfmI" resolve="constraint" />
               </node>
+              <node concept="l2Vlx" id="1ASK_HedIvG" role="2iSdaV" />
             </node>
             <node concept="3EZMnI" id="7HzLUeHpCue" role="3EZMnx">
-              <node concept="2iRfu4" id="7HzLUeHpCuf" role="2iSdaV" />
               <node concept="3F0ifn" id="7HzLUeHpCug" role="3EZMnx">
                 <property role="3F0ifm" value="styles:     " />
               </node>
@@ -5399,6 +5399,7 @@
                 <ref role="1NtTu8" to="wtll:5avmkTFQoVb" resolve="styles" />
                 <node concept="2iRkQZ" id="7HzLUeHpCyU" role="2czzBx" />
               </node>
+              <node concept="l2Vlx" id="1ASK_HedIvH" role="2iSdaV" />
             </node>
           </node>
           <node concept="3F0ifn" id="7HzLUeHrclS" role="3v1y6z">
@@ -5434,7 +5435,6 @@
     <node concept="3EZMnI" id="5avmkTFQq98" role="6VMZX">
       <node concept="2iRkQZ" id="5avmkTFQq99" role="2iSdaV" />
       <node concept="3EZMnI" id="7HzLUeH$fsQ" role="3EZMnx">
-        <node concept="2iRfu4" id="7HzLUeH$fsR" role="2iSdaV" />
         <node concept="3F0ifn" id="7HzLUeH$fsS" role="3EZMnx">
           <property role="3F0ifm" value="expression: " />
         </node>
@@ -5462,6 +5462,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIvI" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="1mFXz_FUPDp" role="3EZMnx">
         <property role="3F0ifm" value="------------------------------------------------------" />
@@ -5488,16 +5489,15 @@
         </node>
       </node>
       <node concept="3EZMnI" id="1mFXz_FUMtE" role="3EZMnx">
-        <node concept="2iRfu4" id="1mFXz_FUMtF" role="2iSdaV" />
         <node concept="3F0ifn" id="1mFXz_FUMtG" role="3EZMnx">
           <property role="3F0ifm" value="result:     " />
         </node>
         <node concept="27S6Sx" id="1mFXz_FUMtH" role="3EZMnx">
           <ref role="1NtTu8" to="wtll:48DDwlwUXpx" resolve="result" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIvJ" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="7HzLUeH$fsU" role="3EZMnx">
-        <node concept="2iRfu4" id="7HzLUeH$fsV" role="2iSdaV" />
         <node concept="3F0ifn" id="7HzLUeH$fsW" role="3EZMnx">
           <property role="3F0ifm" value="locked:     " />
         </node>
@@ -5527,9 +5527,9 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIvK" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="7HzLUeH$ft9" role="3EZMnx">
-        <node concept="2iRfu4" id="7HzLUeH$fta" role="2iSdaV" />
         <node concept="3F0ifn" id="7HzLUeH$ftb" role="3EZMnx">
           <property role="3F0ifm" value="template:   " />
         </node>
@@ -5557,15 +5557,16 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIvL" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="1mFXz_FWLiL" role="3EZMnx">
-        <node concept="2iRfu4" id="1mFXz_FWLiM" role="2iSdaV" />
         <node concept="3F0ifn" id="1mFXz_FWLiN" role="3EZMnx">
           <property role="3F0ifm" value="internal:   " />
         </node>
         <node concept="27S6Sx" id="1mFXz_FWLiO" role="3EZMnx">
           <ref role="1NtTu8" to="wtll:1mFXz_FVM7k" resolve="internal" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIvM" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="7HzLUeH$ftn" role="3EZMnx">
         <node concept="VPM3Z" id="7HzLUeH$fto" role="3F10Kt">
@@ -5574,13 +5575,12 @@
         <node concept="3F0ifn" id="7HzLUeH$ftp" role="3EZMnx">
           <property role="3F0ifm" value="constraint: " />
         </node>
-        <node concept="2iRfu4" id="7HzLUeH$ftq" role="2iSdaV" />
         <node concept="3F1sOY" id="7HzLUeH$ftr" role="3EZMnx">
           <ref role="1NtTu8" to="wtll:3_Nra3DTfmI" resolve="constraint" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIvN" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="7HzLUeH$fts" role="3EZMnx">
-        <node concept="2iRfu4" id="7HzLUeH$ftt" role="2iSdaV" />
         <node concept="3F0ifn" id="7HzLUeH$ftu" role="3EZMnx">
           <property role="3F0ifm" value="styles:     " />
         </node>
@@ -5588,6 +5588,7 @@
           <ref role="1NtTu8" to="wtll:5avmkTFQoVb" resolve="styles" />
           <node concept="2iRkQZ" id="7HzLUeH$ftw" role="2czzBx" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIvO" role="2iSdaV" />
       </node>
       <node concept="pkWqt" id="7HzLUeHpGiB" role="pqm2j">
         <node concept="3clFbS" id="7HzLUeHpGiC" role="2VODD2">
@@ -5617,7 +5618,6 @@
     <property role="3GE5qa" value="sheet.ref" />
     <ref role="1XX52x" to="wtll:5xEoEMrqNzj" resolve="CoordCellRef" />
     <node concept="3EZMnI" id="5xEoEMrFDD9" role="2wV5jI">
-      <node concept="2iRfu4" id="5xEoEMrFDDa" role="2iSdaV" />
       <node concept="3F0ifn" id="5xEoEMrqNzJ" role="3EZMnx">
         <property role="3F0ifm" value="$" />
         <node concept="11L4FC" id="3pIANU$W0tA" role="3F10Kt">
@@ -5667,7 +5667,6 @@
           </node>
         </node>
         <node concept="3EZMnI" id="3pIANU$VZUl" role="_tjki">
-          <node concept="2iRfu4" id="3pIANU$VZUo" role="2iSdaV" />
           <node concept="VPM3Z" id="3pIANU$VZUp" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
@@ -5686,6 +5685,7 @@
               <property role="VOm3f" value="true" />
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIvQ" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqJid" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqJie" role="2VODD2">
@@ -5794,6 +5794,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIvP" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5xEoEMrsCHM">
@@ -5803,7 +5804,6 @@
       <node concept="VQ3r3" id="5xEoEMrt3tG" role="3F10Kt">
         <property role="2USNnj" value="gtbM8PH/underlined" />
       </node>
-      <node concept="2iRfu4" id="5xEoEMrsCI8" role="2iSdaV" />
       <node concept="3F0A7n" id="5xEoEMrsCI3" role="3EZMnx">
         <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
         <node concept="Vb9p2" id="5xEoEMrsQ0l" role="3F10Kt">
@@ -5816,6 +5816,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIvR" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5xEoEMrvqJB">
@@ -5884,7 +5885,6 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="5xEoEMrFs8u" role="2iSdaV" />
       <node concept="1iCGBv" id="5xEoEMrvqJD" role="3EZMnx">
         <ref role="1NtTu8" to="wtll:5xEoEMrvqJb" resolve="label" />
         <node concept="1sVBvm" id="5xEoEMrvqJF" role="1sWHZn">
@@ -5912,13 +5912,13 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIvS" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5xEoEMrzSmX">
     <property role="3GE5qa" value="sheet" />
     <ref role="1XX52x" to="wtll:5xEoEMrzSmg" resolve="CellArg" />
     <node concept="3EZMnI" id="5xEoEMrzSnb" role="2wV5jI">
-      <node concept="2iRfu4" id="5xEoEMrzSnc" role="2iSdaV" />
       <node concept="1kIj98" id="5xEoEMrzSmZ" role="3EZMnx">
         <node concept="3F0A7n" id="5xEoEMrzSn7" role="1kIj9b">
           <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
@@ -5944,13 +5944,13 @@
           <node concept="3F1sOY" id="5xEoEMrzSo2" role="3EZMnx">
             <ref role="1NtTu8" to="wtll:5xEoEMrzSmx" resolve="type" />
           </node>
-          <node concept="2iRfu4" id="5xEoEMrzSnJ" role="2iSdaV" />
           <node concept="11L4FC" id="5xEoEMrC5g6" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
           <node concept="VPM3Z" id="5xEoEMrzSnK" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIvU" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqIMM" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqIMN" role="2VODD2">
@@ -5962,6 +5962,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIvT" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5xEoEMrAqEw">
@@ -6008,16 +6009,14 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="2iRfu4" id="5xEoEMrFs7q" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIvV" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5avmkTFGp6V">
     <property role="3GE5qa" value="sheet" />
     <ref role="1XX52x" to="wtll:5avmkTFFvOK" resolve="SheetTestItem" />
     <node concept="3EZMnI" id="5avmkTFIuGQ" role="2wV5jI">
-      <node concept="2iRfu4" id="5avmkTFPEmq" role="2iSdaV" />
       <node concept="3EZMnI" id="5avmkTFIuGZ" role="3EZMnx">
-        <node concept="2iRfu4" id="5avmkTFIuH0" role="2iSdaV" />
         <node concept="3F0ifn" id="5avmkTFIuGW" role="3EZMnx">
           <property role="3F0ifm" value="new sheet will be" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -6051,6 +6050,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIvX" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="5avmkTFPiCw" role="3EZMnx">
         <property role="3F0ifm" value="sheet" />
@@ -6089,6 +6089,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIvW" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5avmkTFQoUP">
@@ -6098,10 +6099,10 @@
       <node concept="PMmxH" id="5avmkTFQoUY" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
       </node>
-      <node concept="2iRfu4" id="5avmkTFQoUU" role="2iSdaV" />
       <node concept="3F0A7n" id="5avmkTFQoV3" role="3EZMnx">
         <ref role="1NtTu8" to="wtll:5avmkTFQoU1" resolve="width" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIvY" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5avmkTFTZQZ">
@@ -6117,16 +6118,14 @@
       <node concept="3F0A7n" id="5avmkTFTZRe" role="3EZMnx">
         <ref role="1NtTu8" to="wtll:5avmkTFTZQ$" resolve="text" />
       </node>
-      <node concept="2iRfu4" id="5avmkTFTZR4" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIvZ" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="48DDwlwTbR6">
     <property role="3GE5qa" value="sheet" />
     <ref role="1XX52x" to="wtll:48DDwlwTb_l" resolve="SheetEmbedExpr" />
     <node concept="3EZMnI" id="48DDwlwTbRb" role="2wV5jI">
-      <node concept="2iRfu4" id="48DDwlwTbRc" role="2iSdaV" />
       <node concept="3EZMnI" id="48DDwlwTbRd" role="3EZMnx">
-        <node concept="2iRfu4" id="48DDwlwTbRe" role="2iSdaV" />
         <node concept="3F0ifn" id="48DDwlwTbRf" role="3EZMnx">
           <property role="3F0ifm" value="new sheet" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -6177,6 +6176,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIw1" role="2iSdaV" />
       </node>
       <node concept="3F1sOY" id="48DDwlwTbR_" role="3EZMnx">
         <ref role="1NtTu8" to="wtll:48DDwlwTbQF" resolve="sheet" />
@@ -6199,6 +6199,7 @@
       <node concept="VPM3Z" id="48DDwlx2eTe" role="3F10Kt">
         <property role="VOm3f" value="true" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIw0" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3_Nra3DTaTu">
@@ -6206,7 +6207,6 @@
     <ref role="1XX52x" to="wtll:3_Nra3DTaSZ" resolve="CellConstraint" />
     <node concept="3EZMnI" id="3_Nra3DTaTw" role="2wV5jI">
       <node concept="3EZMnI" id="3_Nra3DTaTL" role="3EZMnx">
-        <node concept="2iRfu4" id="3_Nra3DTaTM" role="2iSdaV" />
         <node concept="3F0ifn" id="3_Nra3DTaTB" role="3EZMnx">
           <property role="3F0ifm" value="type:" />
         </node>
@@ -6224,6 +6224,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIw2" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="3_Nra3DTaU5" role="3EZMnx">
         <node concept="VPM3Z" id="3_Nra3DTaU7" role="3F10Kt">
@@ -6232,10 +6233,10 @@
         <node concept="3F0ifn" id="3_Nra3DTaU9" role="3EZMnx">
           <property role="3F0ifm" value="where" />
         </node>
-        <node concept="2iRfu4" id="3_Nra3DTaUa" role="2iSdaV" />
         <node concept="3F1sOY" id="3_Nra3DTaUq" role="3EZMnx">
           <ref role="1NtTu8" to="wtll:3_Nra3DTaT2" resolve="constraint" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIw3" role="2iSdaV" />
       </node>
       <node concept="2iRkQZ" id="3_Nra3DTaTz" role="2iSdaV" />
     </node>
@@ -6251,7 +6252,6 @@
     <property role="3GE5qa" value="sheet" />
     <ref role="1XX52x" to="wtll:3_Nra3E2xkf" resolve="SheetType" />
     <node concept="3EZMnI" id="3_Nra3E2xkQ" role="2wV5jI">
-      <node concept="2iRfu4" id="3_Nra3E2xkR" role="2iSdaV" />
       <node concept="3F0ifn" id="3_Nra3E2xkN" role="3EZMnx">
         <property role="3F0ifm" value="sheet" />
         <ref role="1k5W1q" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
@@ -6285,6 +6285,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIw4" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3_Nra3E2xml">
@@ -6293,7 +6294,6 @@
     <node concept="3EZMnI" id="3pIANU_69r7" role="2wV5jI">
       <node concept="2iRkQZ" id="3pIANU_69r8" role="2iSdaV" />
       <node concept="3EZMnI" id="3_Nra3E2xmt" role="3EZMnx">
-        <node concept="2iRfu4" id="3_Nra3E2xmu" role="2iSdaV" />
         <node concept="1kHk_G" id="3pIANU_03oi" role="3EZMnx">
           <ref role="1NtTu8" to="wtll:3pIANU_03o9" resolve="template" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -6328,9 +6328,9 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIw5" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="3pIANU_69rw" role="3EZMnx">
-        <node concept="2iRfu4" id="3pIANU_69rx" role="2iSdaV" />
         <node concept="3XFhqQ" id="3pIANU_69rM" role="3EZMnx" />
         <node concept="3F1sOY" id="3_Nra3E2xmI" role="3EZMnx">
           <ref role="1NtTu8" to="wtll:3_Nra3E2xlU" resolve="sheet" />
@@ -6349,9 +6349,9 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIw6" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="2c2AzQdaZkT" role="3EZMnx">
-        <node concept="2iRfu4" id="2c2AzQdaZkU" role="2iSdaV" />
         <node concept="3F1sOY" id="2c2AzQdaZkW" role="3EZMnx">
           <ref role="1NtTu8" to="wtll:3_Nra3E2xlU" resolve="sheet" />
         </node>
@@ -6367,6 +6367,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIw7" role="2iSdaV" />
       </node>
     </node>
     <node concept="3EZMnI" id="2c2AzQdaZXM" role="6VMZX">
@@ -6381,10 +6382,9 @@
         <node concept="27S6Sx" id="2c2AzQdb0uO" role="3EZMnx">
           <ref role="1NtTu8" to="wtll:2c2AzQdaWRH" resolve="hideTitle" />
         </node>
-        <node concept="2iRfu4" id="2c2AzQdb0ku" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIw8" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="2c2AzQdaWRK" role="3EZMnx">
-        <node concept="2iRfu4" id="2c2AzQdaWRL" role="2iSdaV" />
         <node concept="1kHk_G" id="2c2AzQdaWRM" role="3EZMnx">
           <ref role="1NtTu8" to="wtll:3pIANU_03o9" resolve="template" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -6417,6 +6417,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIw9" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -6431,7 +6432,6 @@
     <property role="3GE5qa" value="sheet" />
     <ref role="1XX52x" to="wtll:7HzLUeHESCI" resolve="QuoteExpr" />
     <node concept="3EZMnI" id="7HzLUeHESGl" role="2wV5jI">
-      <node concept="2iRfu4" id="7HzLUeHESGm" role="2iSdaV" />
       <node concept="3F0ifn" id="7HzLUeHESGi" role="3EZMnx">
         <property role="3F0ifm" value="quote" />
       </node>
@@ -6453,6 +6453,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwa" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3pIANU$T$6y">
@@ -6482,7 +6483,6 @@
     <property role="3GE5qa" value="sheet.range" />
     <ref role="1XX52x" to="wtll:4YhD5cZkcH6" resolve="AbstractRangeExpr" />
     <node concept="3EZMnI" id="5avmkTFl_v1" role="2wV5jI">
-      <node concept="2iRfu4" id="5avmkTFl_v2" role="2iSdaV" />
       <node concept="PMmxH" id="4YhD5cZkdRs" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
       </node>
@@ -6516,13 +6516,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwb" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4YhD5cZo8KS">
     <property role="3GE5qa" value="sheet.range" />
     <ref role="1XX52x" to="wtll:4YhD5cZo8Ks" resolve="MakeRecordExpr" />
     <node concept="3EZMnI" id="4YhD5cZo8KX" role="2wV5jI">
-      <node concept="2iRfu4" id="4YhD5cZo8KY" role="2iSdaV" />
       <node concept="3F0ifn" id="4YhD5cZo8KU" role="3EZMnx">
         <property role="3F0ifm" value="makeRecord" />
       </node>
@@ -6577,6 +6577,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwc" role="2iSdaV" />
     </node>
   </node>
   <node concept="3ICUPy" id="2HpFPvTbk0c">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/editor.mps
@@ -70,6 +70,8 @@
         <reference id="6089045305654944382" name="menu" index="2kkw0f" />
       </concept>
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
+      <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
+      <concept id="1237375020029" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineChildrenStyleClassItem" flags="ln" index="pj6Ft" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
@@ -209,7 +211,6 @@
       <concept id="1176749715029" name="jetbrains.mps.lang.editor.structure.QueryFunction_CellProvider" flags="in" index="3VJUX4" />
       <concept id="4307758654696938365" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_RefPresentation" flags="ig" index="1WAQ3h" />
       <concept id="4307758654696952957" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_ReferencedNode" flags="ng" index="1WAUZh" />
-      <concept id="1198256887712" name="jetbrains.mps.lang.editor.structure.CellModel_Indent" flags="ng" index="3XFhqQ" />
       <concept id="8428109087107030357" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_ReferenceScope" flags="ng" index="3XHNnq">
         <reference id="8428109087107339113" name="reference" index="3XGfJA" />
         <child id="4307758654694904293" name="matchingTextFunction" index="1WZ6D9" />
@@ -989,7 +990,6 @@
           <property role="3vr1H$" value="true" />
           <property role="3vD9g8" value="true" />
           <node concept="3EZMnI" id="3a2FJuC5bUB" role="3v87hO">
-            <node concept="3XFhqQ" id="3a2FJuC5crx" role="3EZMnx" />
             <node concept="gc7cB" id="59T8kEoBBAZ" role="3EZMnx">
               <node concept="3VJUX4" id="59T8kEoBBB1" role="3YsKMw">
                 <node concept="3clFbS" id="59T8kEoBBB3" role="2VODD2">
@@ -1548,7 +1548,6 @@
                 </node>
               </node>
             </node>
-            <node concept="3XFhqQ" id="69FYpZqtfvx" role="3EZMnx" />
             <node concept="1HlG4h" id="69FYpZqt9FM" role="3EZMnx">
               <node concept="1HfYo3" id="69FYpZqt9FN" role="1HlULh">
                 <node concept="3TQlhw" id="69FYpZqt9FO" role="1Hhtcw">
@@ -1684,7 +1683,6 @@
               </node>
             </node>
             <node concept="3EZMnI" id="4nY0kF8k76H" role="3EZMnx">
-              <node concept="3XFhqQ" id="4nY0kF8k76J" role="3EZMnx" />
               <node concept="3F0ifn" id="4nY0kF8k76K" role="3EZMnx">
                 <property role="3F0ifm" value=":" />
                 <node concept="xShMh" id="4nY0kF8k76L" role="3F10Kt">
@@ -2023,7 +2021,6 @@
           </node>
           <node concept="l2Vlx" id="1ASK_HedIvn" role="2iSdaV" />
         </node>
-        <node concept="3XFhqQ" id="6LVVWmzDmxU" role="3EZMnx" />
         <node concept="3EZMnI" id="6LVVWmzDh7Q" role="3EZMnx">
           <node concept="3F0ifn" id="6LVVWmzDh7S" role="3EZMnx">
             <property role="3F0ifm" value="show diffs" />
@@ -2090,7 +2087,6 @@
             </node>
           </node>
         </node>
-        <node concept="3XFhqQ" id="6LVVWmzE0LR" role="3EZMnx" />
         <node concept="3gTLQM" id="6LVVWmzE0LS" role="3EZMnx">
           <node concept="3Fmcul" id="6LVVWmzE0LT" role="3FoqZy">
             <node concept="3clFbS" id="6LVVWmzE0LU" role="2VODD2">
@@ -2148,7 +2144,6 @@
             </node>
           </node>
         </node>
-        <node concept="3XFhqQ" id="6LVVWmzE0Mi" role="3EZMnx" />
         <node concept="3gTLQM" id="6LVVWmzE0Mj" role="3EZMnx">
           <node concept="3Fmcul" id="6LVVWmzE0Mk" role="3FoqZy">
             <node concept="3clFbS" id="6LVVWmzE0Ml" role="2VODD2">
@@ -2286,7 +2281,6 @@
             </node>
           </node>
         </node>
-        <node concept="3XFhqQ" id="6LVVWmzE0Ne" role="3EZMnx" />
         <node concept="3gTLQM" id="6LVVWmzE0Nf" role="3EZMnx">
           <node concept="3Fmcul" id="6LVVWmzE0Ng" role="3FoqZy">
             <node concept="3clFbS" id="6LVVWmzE0Nh" role="2VODD2">
@@ -2669,21 +2663,18 @@
         <node concept="3F0A7n" id="5xEoEMrGLwh" role="3EZMnx">
           <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
         </node>
-        <node concept="3XFhqQ" id="5xEoEMrGLwM" role="3EZMnx" />
         <node concept="3F0ifn" id="5xEoEMrtOsd" role="3EZMnx">
           <property role="3F0ifm" value="show values" />
         </node>
         <node concept="27S6Sx" id="5avmkTFCRs3" role="3EZMnx">
           <ref role="1NtTu8" to="wtll:5avmkTFfeqZ" resolve="showValues" />
         </node>
-        <node concept="3XFhqQ" id="5avmkTFDAu2" role="3EZMnx" />
         <node concept="3F0ifn" id="5avmkTFDAvC" role="3EZMnx">
           <property role="3F0ifm" value="booleans are checks:" />
         </node>
         <node concept="27S6Sx" id="5avmkTFgLLn" role="3EZMnx">
           <ref role="1NtTu8" to="wtll:5xEoEMrutTn" resolve="booleansAreChecks" />
         </node>
-        <node concept="3XFhqQ" id="5xEoEMrutQL" role="3EZMnx" />
         <node concept="pkWqt" id="5avmkTFGMSb" role="pqm2j">
           <node concept="3clFbS" id="5avmkTFGMSc" role="2VODD2">
             <node concept="3clFbF" id="5avmkTFGNPi" role="3cqZAp">
@@ -3491,21 +3482,18 @@
       <node concept="3F0A7n" id="2c2AzQdd_vB" role="3EZMnx">
         <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
       </node>
-      <node concept="3XFhqQ" id="2c2AzQdd_vC" role="3EZMnx" />
       <node concept="3F0ifn" id="2c2AzQdd_vD" role="3EZMnx">
         <property role="3F0ifm" value="show values" />
       </node>
       <node concept="27S6Sx" id="2c2AzQdd_vE" role="3EZMnx">
         <ref role="1NtTu8" to="wtll:5avmkTFfeqZ" resolve="showValues" />
       </node>
-      <node concept="3XFhqQ" id="2c2AzQdd_vF" role="3EZMnx" />
       <node concept="3F0ifn" id="2c2AzQdd_vG" role="3EZMnx">
         <property role="3F0ifm" value="booleans are checks:" />
       </node>
       <node concept="27S6Sx" id="2c2AzQdd_vH" role="3EZMnx">
         <ref role="1NtTu8" to="wtll:5xEoEMrutTn" resolve="booleansAreChecks" />
       </node>
-      <node concept="3XFhqQ" id="2c2AzQdd_vI" role="3EZMnx" />
       <node concept="l2Vlx" id="1ASK_HedIvu" role="2iSdaV" />
     </node>
   </node>
@@ -6292,7 +6280,7 @@
     <property role="3GE5qa" value="sheet" />
     <ref role="1XX52x" to="wtll:3_Nra3E2xlO" resolve="TopLevelSheet" />
     <node concept="3EZMnI" id="3pIANU_69r7" role="2wV5jI">
-      <node concept="2iRkQZ" id="3pIANU_69r8" role="2iSdaV" />
+      <node concept="l2Vlx" id="2tlTgwfrshQ" role="2iSdaV" />
       <node concept="3EZMnI" id="3_Nra3E2xmt" role="3EZMnx">
         <node concept="1kHk_G" id="3pIANU_03oi" role="3EZMnx">
           <ref role="1NtTu8" to="wtll:3pIANU_03o9" resolve="template" />
@@ -6331,7 +6319,6 @@
         <node concept="l2Vlx" id="1ASK_HedIw5" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="3pIANU_69rw" role="3EZMnx">
-        <node concept="3XFhqQ" id="3pIANU_69rM" role="3EZMnx" />
         <node concept="3F1sOY" id="3_Nra3E2xmI" role="3EZMnx">
           <ref role="1NtTu8" to="wtll:3_Nra3E2xlU" resolve="sheet" />
         </node>
@@ -6350,6 +6337,9 @@
           </node>
         </node>
         <node concept="l2Vlx" id="1ASK_HedIw6" role="2iSdaV" />
+        <node concept="lj46D" id="2tlTgwfrshO" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
       </node>
       <node concept="3EZMnI" id="2c2AzQdaZkT" role="3EZMnx">
         <node concept="3F1sOY" id="2c2AzQdaZkW" role="3EZMnx">
@@ -6368,6 +6358,9 @@
           </node>
         </node>
         <node concept="l2Vlx" id="1ASK_HedIw7" role="2iSdaV" />
+      </node>
+      <node concept="pj6Ft" id="2tlTgwfrshT" role="3F10Kt">
+        <property role="VOm3f" value="true" />
       </node>
     </node>
     <node concept="3EZMnI" id="2c2AzQdaZXM" role="6VMZX">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/editor.mps
@@ -6050,7 +6050,7 @@
             </node>
           </node>
         </node>
-        <node concept="l2Vlx" id="1ASK_HedIvX" role="2iSdaV" />
+        <node concept="2iRfu4" id="2tlTgwg1IIv" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="5avmkTFPiCw" role="3EZMnx">
         <property role="3F0ifm" value="sheet" />
@@ -6089,7 +6089,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIvW" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwg1IIs" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5avmkTFQoUP">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes.tests/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes.tests/models/editor.mps
@@ -11,7 +11,7 @@
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
@@ -34,7 +34,6 @@
   <node concept="24kQdi" id="1bwJEEfG$Fd">
     <ref role="1XX52x" to="q6b8:1bwJEEfGu9F" resolve="RandomVectorProducer" />
     <node concept="3EZMnI" id="1bwJEEfG$Gr" role="2wV5jI">
-      <node concept="2iRfu4" id="1bwJEEfG$Gs" role="2iSdaV" />
       <node concept="3F0ifn" id="1bwJEEfG$Gn" role="3EZMnx">
         <property role="3F0ifm" value="random" />
       </node>
@@ -47,15 +46,16 @@
       <node concept="3F0A7n" id="4o7_AWgGUm5" role="3EZMnx">
         <ref role="1NtTu8" to="q6b8:4o7_AWgGUlO" resolve="onlyInteresing" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzq" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="u9itSZOLZW">
     <ref role="1XX52x" to="q6b8:u9itSZOLXL" resolve="EqClassProducer" />
     <node concept="3EZMnI" id="u9itSZOM07" role="2wV5jI">
-      <node concept="2iRfu4" id="u9itSZOM08" role="2iSdaV" />
       <node concept="3F0ifn" id="u9itSZOM09" role="3EZMnx">
         <property role="3F0ifm" value="eqclass" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzr" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/editor.mps
@@ -183,7 +183,6 @@
       <concept id="1950447826686048995" name="jetbrains.mps.lang.editor.structure.UnapplyStyle" flags="lg" index="3XB9Gl">
         <child id="1950447826686049051" name="target" index="3XB9FH" />
       </concept>
-      <concept id="1198256887712" name="jetbrains.mps.lang.editor.structure.CellModel_Indent" flags="ng" index="3XFhqQ" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
@@ -1455,7 +1454,6 @@
       <node concept="3F1sOY" id="4eVSC65NNBo" role="3EZMnx">
         <ref role="1NtTu8" to="5qo5:4eVSC65JA4Q" resolve="expr" />
       </node>
-      <node concept="3XFhqQ" id="4eVSC65NPCu" role="3EZMnx" />
       <node concept="1HlG4h" id="4eVSC65NNCC" role="3EZMnx">
         <node concept="1HfYo3" id="4eVSC65NNCE" role="1HlULh">
           <node concept="3TQlhw" id="4eVSC65NNCG" role="1Hhtcw">
@@ -1480,7 +1478,6 @@
         <property role="39s7Ar" value="true" />
         <ref role="1NtTu8" to="5qo5:4eVSC65JA4S" resolve="lower" />
       </node>
-      <node concept="3XFhqQ" id="4eVSC65NPAV" role="3EZMnx" />
       <node concept="1HlG4h" id="4eVSC65NPiG" role="3EZMnx">
         <node concept="1HfYo3" id="4eVSC65NPiH" role="1HlULh">
           <node concept="3TQlhw" id="4eVSC65NPiI" role="1Hhtcw">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/editor.mps
@@ -47,7 +47,6 @@
         <property id="1226504838901" name="measure" index="2hoDZC" />
       </concept>
       <concept id="1597643335227097138" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_TransformationMenu_node" flags="ng" index="7Obwk" />
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="6089045305654894366" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Default" flags="ng" index="2kknPJ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="784421273959492578" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_IncludeMenu" flags="ng" index="mvV$s">
@@ -599,7 +598,7 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="53_W9lll903" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIsT" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -642,10 +641,10 @@
             <property role="VOm3f" value="true" />
           </node>
         </node>
-        <node concept="2iRfu4" id="77bOUKddjb1" role="2iSdaV" />
         <node concept="34QqEe" id="77bOUKddf4x" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIsU" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -653,7 +652,6 @@
     <property role="3GE5qa" value="numeric.number" />
     <ref role="1XX52x" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
     <node concept="3EZMnI" id="78hTg1$P0Vp" role="2wV5jI">
-      <node concept="2iRfu4" id="2M9Ik4CULYv" role="2iSdaV" />
       <node concept="3F0ifn" id="78hTg1$P0Vl" role="3EZMnx">
         <property role="3F0ifm" value="number" />
         <ref role="1k5W1q" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
@@ -721,6 +719,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsV" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="19PglA20rbP">
@@ -862,7 +861,6 @@
     <property role="3GE5qa" value="numeric.number" />
     <ref role="1XX52x" to="5qo5:19PglA20qX_" resolve="NumberRangeSpec" />
     <node concept="3EZMnI" id="19PglA20r05" role="2wV5jI">
-      <node concept="2iRfu4" id="5i1yF0wqXGJ" role="2iSdaV" />
       <node concept="1HlG4h" id="2MMBR00YETl" role="3EZMnx">
         <node concept="1HfYo3" id="2MMBR00YETp" role="1HlULh">
           <node concept="3TQlhw" id="2MMBR00YETt" role="1Hhtcw">
@@ -1204,6 +1202,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsW" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7DTWJ$8kg4G">
@@ -1324,7 +1323,6 @@
     <property role="3GE5qa" value="string" />
     <ref role="1XX52x" to="5qo5:IMhG9rs$rK" resolve="StringContainsTarget" />
     <node concept="3EZMnI" id="IMhG9rs$sp" role="2wV5jI">
-      <node concept="2iRfu4" id="IMhG9rs$sq" role="2iSdaV" />
       <node concept="3F0ifn" id="IMhG9rs$sl" role="3EZMnx">
         <property role="3F0ifm" value="contains" />
       </node>
@@ -1346,13 +1344,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsX" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7cphKbL6ihA">
     <property role="3GE5qa" value="string.interpol" />
     <ref role="1XX52x" to="5qo5:7cphKbL6iha" resolve="StringInterpolationExpr" />
     <node concept="3EZMnI" id="7cphKbL6ihC" role="2wV5jI">
-      <node concept="2iRfu4" id="7cphKbL6ihD" role="2iSdaV" />
       <node concept="3F0ifn" id="7cphKbL6ihI" role="3EZMnx">
         <property role="3F0ifm" value="'''" />
         <node concept="11LMrY" id="7cphKbL9IhK" role="3F10Kt">
@@ -1373,13 +1371,13 @@
           <ref role="1wgcnl" to="itrz:4rZeNQ6OYRX" resolve="IETS3String" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsY" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7cphKbL6izY">
     <property role="3GE5qa" value="string.interpol" />
     <ref role="1XX52x" to="5qo5:7cphKbL6izy" resolve="InterpolExprWord" />
     <node concept="3EZMnI" id="7cphKbL6i$3" role="2wV5jI">
-      <node concept="2iRfu4" id="7cphKbL6i$4" role="2iSdaV" />
       <node concept="3F0ifn" id="7cphKbL6i$0" role="3EZMnx">
         <property role="3F0ifm" value="$(" />
         <node concept="11LMrY" id="7cphKbL6i$p" role="3F10Kt">
@@ -1406,13 +1404,13 @@
           <ref role="1wgcnl" to="itrz:4rZeNQ6OYRX" resolve="IETS3String" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsZ" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="56r2aFONcW7">
     <property role="3GE5qa" value="string" />
     <ref role="1XX52x" to="5qo5:56r2aFONcVD" resolve="StringStartsWithTarget" />
     <node concept="3EZMnI" id="56r2aFONcWc" role="2wV5jI">
-      <node concept="2iRfu4" id="56r2aFONcWd" role="2iSdaV" />
       <node concept="3F0ifn" id="56r2aFONcWe" role="3EZMnx">
         <property role="3F0ifm" value="startsWith" />
       </node>
@@ -1434,6 +1432,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIt0" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4eVSC65JA5o">
@@ -1579,7 +1578,7 @@
         <node concept="3F1sOY" id="4399ITS_f2o" role="3EZMnx">
           <ref role="1NtTu8" to="5qo5:4399ITS_elI" resolve="tolerance" />
         </node>
-        <node concept="2iRfu4" id="4399ITS_eQf" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIt1" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -1587,7 +1586,6 @@
     <property role="3GE5qa" value="string" />
     <ref role="1XX52x" to="5qo5:5bvGQanjMKN" resolve="StringEndsWithTarget" />
     <node concept="3EZMnI" id="5bvGQanjMKS" role="2wV5jI">
-      <node concept="2iRfu4" id="5bvGQanjMKT" role="2iSdaV" />
       <node concept="3F0ifn" id="5bvGQanjMKU" role="3EZMnx">
         <property role="3F0ifm" value="endsWith" />
       </node>
@@ -1609,6 +1607,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIt2" role="2iSdaV" />
     </node>
   </node>
   <node concept="3ICUPy" id="72b39kzfT$m">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/editor.mps
@@ -13,6 +13,7 @@
     <use id="654422bf-e75f-44dc-936d-188890a746ce" name="de.slisson.mps.reflection" version="0" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <use id="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" name="com.mbeddr.mpsutil.editor.querylist" version="0" />
+    <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
   </languages>
   <imports>
     <import index="itrz" ref="r:80fb0853-eb3b-4e84-aebd-cc7fdb011d97(org.iets3.core.base.editor)" />
@@ -47,6 +48,7 @@
         <property id="1226504838901" name="measure" index="2hoDZC" />
       </concept>
       <concept id="1597643335227097138" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_TransformationMenu_node" flags="ng" index="7Obwk" />
+      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="6089045305654894366" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Default" flags="ng" index="2kknPJ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="784421273959492578" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_IncludeMenu" flags="ng" index="mvV$s">
@@ -627,9 +629,6 @@
           <ref role="1NtTu8" to="5qo5:4rZeNQ6OYRb" resolve="value" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6OYRX" resolve="IETS3String" />
           <node concept="bYqrx" id="1cHKpSpdbs5" role="2lD6_D" />
-          <node concept="34QqEe" id="77bOUKdd3oj" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
         </node>
         <node concept="3F0ifn" id="5jmmCdx$f6s" role="3EZMnx">
           <property role="3F0ifm" value="&quot;" />
@@ -641,10 +640,7 @@
             <property role="VOm3f" value="true" />
           </node>
         </node>
-        <node concept="34QqEe" id="77bOUKddf4x" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-        <node concept="l2Vlx" id="1ASK_HedIsU" role="2iSdaV" />
+        <node concept="2iRfu4" id="4_VVT2YyEm1" role="2iSdaV" />
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/org.iets3.core.expr.simpleTypes.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/org.iets3.core.expr.simpleTypes.mpl
@@ -32,6 +32,7 @@
     <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="2" />
     <language slang="l:b4f35ed8-45af-4efa-abe4-00ac26956e69:com.mbeddr.mpsutil.grammarcells.runtimelang" version="0" />
     <language slang="l:b92f861d-0184-446d-b88b-6dcf0e070241:com.mbeddr.mpsutil.intentions" version="0" />
+    <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
     <language slang="l:654422bf-e75f-44dc-936d-188890a746ce:de.slisson.mps.reflection" version="0" />
     <language slang="l:52733268-be24-4f5f-ab84-a73b7c0c03b0:de.slisson.mps.richtext.customcell" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.statemachines/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.statemachines/models/editor.mps
@@ -606,10 +606,10 @@
             <property role="Vbekb" value="g1_k_vY/BOLD" />
           </node>
         </node>
-        <node concept="2iRfu4" id="4J6AqiINm71" role="2iSdaV" />
         <node concept="3F0ifn" id="4J6AqiINmPH" role="3EZMnx">
           <property role="3F0ifm" value="{..}" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIu9" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -618,7 +618,6 @@
     <ref role="1XX52x" to="19m5:7$TgoCYa5Nt" resolve="TriggeredTransition" />
     <node concept="3EZMnI" id="k9boAueuKd" role="6VMZX">
       <node concept="3EZMnI" id="k9boAu1Yjs" role="3EZMnx">
-        <node concept="2iRfu4" id="k9boAu1Yjt" role="2iSdaV" />
         <node concept="3F0ifn" id="k9boAuexnG" role="3EZMnx">
           <property role="3F0ifm" value="Common Container:" />
         </node>
@@ -689,9 +688,9 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIua" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="k9boAu1ZEz" role="3EZMnx">
-        <node concept="2iRfu4" id="k9boAu1ZE$" role="2iSdaV" />
         <node concept="3F0ifn" id="k9boAuezzw" role="3EZMnx">
           <property role="3F0ifm" value="Leaving States:  " />
         </node>
@@ -787,9 +786,9 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIub" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="k9boAu6WKG" role="3EZMnx">
-        <node concept="2iRfu4" id="k9boAu6WKH" role="2iSdaV" />
         <node concept="3F0ifn" id="k9boAueAoH" role="3EZMnx">
           <property role="3F0ifm" value="Entering States: " />
         </node>
@@ -895,6 +894,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIuc" role="2iSdaV" />
       </node>
       <node concept="2iRkQZ" id="k9boAueuKe" role="2iSdaV" />
     </node>
@@ -967,7 +967,6 @@
               <property role="VOm3f" value="true" />
             </node>
           </node>
-          <node concept="2iRfu4" id="5kGo$yL17Qa" role="2iSdaV" />
           <node concept="pkWqt" id="5kGo$yL2E8a" role="pqm2j">
             <node concept="3clFbS" id="5kGo$yL2E8b" role="2VODD2">
               <node concept="3clFbJ" id="4IV0h47UjQl" role="3cqZAp">
@@ -1013,6 +1012,7 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIud" role="2iSdaV" />
         </node>
         <node concept="_tjkj" id="7$TgoCYa5WH" role="3EZMnx">
           <node concept="3EZMnI" id="7$TgoCYa5WW" role="_tjki">
@@ -1177,7 +1177,6 @@
     <property role="3GE5qa" value="machine" />
     <ref role="1XX52x" to="19m5:7$TgoCYaty$" resolve="StartExpr" />
     <node concept="3EZMnI" id="7$TgoCYatz7" role="2wV5jI">
-      <node concept="2iRfu4" id="7$TgoCYatz8" role="2iSdaV" />
       <node concept="3F0ifn" id="7$TgoCYatz4" role="3EZMnx">
         <property role="3F0ifm" value="start" />
       </node>
@@ -1261,6 +1260,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIue" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7$TgoCYaFGV">
@@ -1443,7 +1443,6 @@
     <property role="3GE5qa" value="machine" />
     <ref role="1XX52x" to="19m5:aPhVmWQWVH" resolve="EventArg" />
     <node concept="3EZMnI" id="49WTic8fvNp" role="2wV5jI">
-      <node concept="2iRfu4" id="49WTic8fvNq" role="2iSdaV" />
       <node concept="1kIj98" id="6HHp2WmZ0Ki" role="3EZMnx">
         <property role="3g2DhO" value="true" />
         <node concept="3F0A7n" id="49WTic8fvN_" role="1kIj9b">
@@ -1464,13 +1463,13 @@
           <node concept="3F1sOY" id="6HHp2WmOBkT" role="3EZMnx">
             <ref role="1NtTu8" to="zzzn:6zmBjqUkwsc" resolve="type" />
           </node>
-          <node concept="2iRfu4" id="5WJNTMTyRb8" role="2iSdaV" />
           <node concept="VPM3Z" id="5WJNTMTyRb9" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
           <node concept="11L4FC" id="5WJNTMTzYOB" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIug" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqLXq" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqLXr" role="2VODD2">
@@ -1482,6 +1481,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIuf" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="aPhVmWRzRx">
@@ -1539,13 +1539,13 @@
           <node concept="3F1sOY" id="aPhVmWWeTB" role="3EZMnx">
             <ref role="1NtTu8" to="hm2y:7D7uZV2iYAD" resolve="type" />
           </node>
-          <node concept="2iRfu4" id="aPhVmWWeTC" role="2iSdaV" />
           <node concept="VPM3Z" id="aPhVmWWeTD" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
           <node concept="11L4FC" id="aPhVmWWeTE" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIui" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqMfS" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqMfT" role="2VODD2">
@@ -1557,13 +1557,13 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="aPhVmWWekD" role="2iSdaV" />
       <node concept="3F0ifn" id="aPhVmWWeU9" role="3EZMnx">
         <property role="3F0ifm" value="=" />
       </node>
       <node concept="3F1sOY" id="aPhVmWWeUX" role="3EZMnx">
         <ref role="1NtTu8" to="19m5:aPhVmWWek9" resolve="init" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIuh" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="aPhVmWXzKE">
@@ -1596,7 +1596,6 @@
     <property role="3GE5qa" value="operations" />
     <ref role="1XX52x" to="19m5:33mFrumBT5e" resolve="IsInStateTarget" />
     <node concept="3EZMnI" id="33mFrumBT5V" role="2wV5jI">
-      <node concept="2iRfu4" id="33mFrumBT5W" role="2iSdaV" />
       <node concept="3F0ifn" id="33mFrumBT5S" role="3EZMnx">
         <property role="3F0ifm" value="isInState(" />
         <node concept="11LMrY" id="33mFrumBT6s" role="3F10Kt">
@@ -1618,6 +1617,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIuj" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="33mFrumGujG">
@@ -1637,7 +1637,6 @@
     <property role="3GE5qa" value="machine.param" />
     <ref role="1XX52x" to="19m5:1mDdTG5A7m" resolve="Parameter" />
     <node concept="3EZMnI" id="1mDdTG5A8c" role="2wV5jI">
-      <node concept="2iRfu4" id="1mDdTG5A8d" role="2iSdaV" />
       <node concept="1kIj98" id="1mDdTG5A80" role="3EZMnx">
         <node concept="3F0A7n" id="1mDdTG5A89" role="1kIj9b">
           <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
@@ -1652,6 +1651,7 @@
       <node concept="3F1sOY" id="1mDdTG5A8y" role="3EZMnx">
         <ref role="1NtTu8" to="zzzn:6zmBjqUkwsc" resolve="type" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIuk" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="1mDdTG6Vgk">
@@ -1834,13 +1834,13 @@
           <property role="Vbekb" value="g1_k_vY/BOLD" />
         </node>
       </node>
-      <node concept="2iRfu4" id="4J6AqiIShkV" role="2iSdaV" />
       <node concept="3F0ifn" id="4J6AqiIShkW" role="3EZMnx">
         <property role="3F0ifm" value="=" />
       </node>
       <node concept="3F1sOY" id="4J6AqiIShlN" role="3EZMnx">
         <ref role="1NtTu8" to="19m5:4J6AqiIShk1" resolve="expr" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIul" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4J6AqiIUTAn">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/models/org.iets3.core.expr.stringvalidation.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/models/org.iets3.core.expr.stringvalidation.editor.mps
@@ -30,6 +30,7 @@
         <child id="1176795024817" name="cellProvider" index="3YsKMw" />
       </concept>
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
@@ -119,7 +120,6 @@
   <node concept="24kQdi" id="4lCUG7Orjh$">
     <ref role="1XX52x" to="3r88:4lCUG7OqbH2" resolve="ValidateStringExpr" />
     <node concept="3EZMnI" id="2LaXqmXxyBp" role="2wV5jI">
-      <node concept="2iRfu4" id="2LaXqmXxyBr" role="2iSdaV" />
       <node concept="3F0ifn" id="4lCUG7OrjhA" role="3EZMnx">
         <property role="3F0ifm" value="validate" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -202,13 +202,13 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwN" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4lCUG7OsQvR">
     <property role="3GE5qa" value="matches" />
     <ref role="1XX52x" to="3r88:4lCUG7OsQvq" resolve="SpecificSequenceElementaryMatch" />
     <node concept="3EZMnI" id="4lCUG7OsQvY" role="2wV5jI">
-      <node concept="2iRfu4" id="4lCUG7OsQvZ" role="2iSdaV" />
       <node concept="PMmxH" id="4lCUG7OsQvW" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -232,13 +232,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwO" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4lCUG7OsQx7">
     <property role="3GE5qa" value="matches" />
     <ref role="1XX52x" to="3r88:4lCUG7OsQwC" resolve="NamedElementaryMatchDecl" />
     <node concept="3EZMnI" id="4lCUG7OsQxc" role="2wV5jI">
-      <node concept="2iRfu4" id="4lCUG7OsQxd" role="2iSdaV" />
       <node concept="3F0ifn" id="4lCUG7OsQx9" role="3EZMnx">
         <property role="3F0ifm" value="match" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -252,6 +252,7 @@
       <node concept="3F1sOY" id="4lCUG7OsQxB" role="3EZMnx">
         <ref role="1NtTu8" to="3r88:4lCUG7OsQwF" resolve="match" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwP" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4lCUG7OsQ_w">
@@ -279,7 +280,6 @@
       <node concept="3F1sOY" id="4lCUG7Ot7Qx" role="3EZMnx">
         <ref role="1NtTu8" to="3r88:4lCUG7Ot7PP" resolve="match" />
       </node>
-      <node concept="2iRfu4" id="2LaXqmXzFss" role="2iSdaV" />
       <node concept="gc7cB" id="2LaXqmXzdoA" role="3EZMnx">
         <node concept="3VJUX4" id="2LaXqmXzdoB" role="3YsKMw">
           <node concept="3clFbS" id="2LaXqmXzdoC" role="2VODD2">
@@ -323,6 +323,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwQ" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4lCUG7OtenI">
@@ -344,7 +345,6 @@
     <property role="3GE5qa" value="check.occurence" />
     <ref role="1XX52x" to="3r88:4lCUG7OtrYr" resolve="AtPositionCheck" />
     <node concept="3EZMnI" id="4lCUG7OtrZ2" role="2wV5jI">
-      <node concept="2iRfu4" id="4lCUG7OtrZ3" role="2iSdaV" />
       <node concept="3F1sOY" id="4lCUG7OtrZZ" role="3EZMnx">
         <ref role="1NtTu8" to="3r88:4lCUG7OtrZL" resolve="kind" />
       </node>
@@ -355,6 +355,7 @@
       <node concept="3F1sOY" id="6KviS2Kv9sl" role="3EZMnx">
         <ref role="1NtTu8" to="3r88:6KviS2Ku$hC" resolve="pos" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwR" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4lCUG7OtrZ$">
@@ -377,7 +378,6 @@
     <property role="3GE5qa" value="check.occurence" />
     <ref role="1XX52x" to="3r88:6KviS2JcA9O" resolve="CannotRepeatCheck" />
     <node concept="3EZMnI" id="6KviS2JcUFI" role="2wV5jI">
-      <node concept="2iRfu4" id="6KviS2JcUFJ" role="2iSdaV" />
       <node concept="3F1sOY" id="6KviS2JcUFR" role="3EZMnx">
         <ref role="1NtTu8" to="3r88:4lCUG7OtrZL" resolve="kind" />
       </node>
@@ -385,6 +385,7 @@
         <property role="3F0ifm" value="not repeat" />
         <ref role="1k5W1q" to="itrz:5E2dhwjbsH2" resolve="notEditableIets3Keyword" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwS" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6KviS2JdW9Y">
@@ -399,7 +400,6 @@
     <property role="3GE5qa" value="check.pos" />
     <ref role="1XX52x" to="3r88:6KviS2Ku$9Y" resolve="PositionIndicatorIndex" />
     <node concept="3EZMnI" id="6KviS2Ku$aw" role="2wV5jI">
-      <node concept="2iRfu4" id="6KviS2Ku$ax" role="2iSdaV" />
       <node concept="3F0ifn" id="6KviS2Ku$at" role="3EZMnx">
         <property role="3F0ifm" value="index" />
         <ref role="1k5W1q" to="itrz:5E2dhwjbsH2" resolve="notEditableIets3Keyword" />
@@ -407,6 +407,7 @@
       <node concept="3F0A7n" id="6KviS2Ku$aD" role="3EZMnx">
         <ref role="1NtTu8" to="3r88:6KviS2Ku$9Z" resolve="value" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwT" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6KviS2KvaIH">
@@ -434,7 +435,6 @@
     <property role="3GE5qa" value="clauses.positionbased" />
     <ref role="1XX52x" to="3r88:6KviS2KxsKA" resolve="PositionBasedValidationClause" />
     <node concept="3EZMnI" id="6KviS2KxRPI" role="2wV5jI">
-      <node concept="2iRfu4" id="6KviS2KxRPJ" role="2iSdaV" />
       <node concept="3F0ifn" id="6KviS2KyoXc" role="3EZMnx">
         <property role="3F0ifm" value="at position" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -452,6 +452,7 @@
       <node concept="3F1sOY" id="6KviS2KyOjL" role="3EZMnx">
         <ref role="1NtTu8" to="3r88:6KviS2KyOjv" resolve="match" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwU" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6KviS2Kz2Qd">
@@ -474,7 +475,6 @@
     <property role="3GE5qa" value="matches" />
     <ref role="1XX52x" to="3r88:6KviS2KztF5" resolve="OneOfMatch" />
     <node concept="3EZMnI" id="6KviS2KztFB" role="2wV5jI">
-      <node concept="2iRfu4" id="6KviS2KztFC" role="2iSdaV" />
       <node concept="PMmxH" id="6_uiIQ$E_PF" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -499,13 +499,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwV" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6KviS2KA7yC">
     <property role="3GE5qa" value="matches" />
     <ref role="1XX52x" to="3r88:6KviS2KA7ya" resolve="SequenceMatcher" />
     <node concept="3EZMnI" id="6KviS2KA7yE" role="2wV5jI">
-      <node concept="2iRfu4" id="6KviS2KA7yF" role="2iSdaV" />
       <node concept="PMmxH" id="6KviS2KA7yQ" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -534,13 +534,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwW" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="2LaXqmXpudB">
     <property role="3GE5qa" value="matches" />
     <ref role="1XX52x" to="3r88:2LaXqmXpuda" resolve="AllSameCharMatcher" />
     <node concept="3EZMnI" id="2LaXqmXpudI" role="2wV5jI">
-      <node concept="2iRfu4" id="2LaXqmXpudJ" role="2iSdaV" />
       <node concept="PMmxH" id="2LaXqmXpudG" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -563,13 +563,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwX" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="2LaXqmX$cks">
     <property role="3GE5qa" value="clauses.positionbased" />
     <ref role="1XX52x" to="3r88:2LaXqmX$cjT" resolve="RangeBasedValidationClause" />
     <node concept="3EZMnI" id="2LaXqmX$cku" role="2wV5jI">
-      <node concept="2iRfu4" id="2LaXqmX$ckv" role="2iSdaV" />
       <node concept="3F0ifn" id="2LaXqmX$ckw" role="3EZMnx">
         <property role="3F0ifm" value="range" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -593,13 +593,13 @@
       <node concept="3F1sOY" id="2LaXqmX$ck$" role="3EZMnx">
         <ref role="1NtTu8" to="3r88:2LaXqmX$cjW" resolve="match" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwY" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="2LaXqmXAhLf">
     <property role="3GE5qa" value="check.occurence" />
     <ref role="1XX52x" to="3r88:2LaXqmXAgwW" resolve="PredecessorCheck" />
     <node concept="3EZMnI" id="2LaXqmXAhLj" role="2wV5jI">
-      <node concept="2iRfu4" id="2LaXqmXAhLk" role="2iSdaV" />
       <node concept="PMmxH" id="2LaXqmXAhLh" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -614,13 +614,13 @@
       <node concept="3F1sOY" id="2LaXqmXAhL$" role="3EZMnx">
         <ref role="1NtTu8" to="3r88:2LaXqmXAhKL" resolve="match" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwZ" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3dTPcTTdvOB">
     <property role="3GE5qa" value="check.occurence" />
     <ref role="1XX52x" to="3r88:3dTPcTTdvOa" resolve="MaxCountCheck" />
     <node concept="3EZMnI" id="3dTPcTTdvOG" role="2wV5jI">
-      <node concept="2iRfu4" id="3dTPcTTdvOH" role="2iSdaV" />
       <node concept="3F1sOY" id="3dTPcTTdvPL" role="3EZMnx">
         <ref role="1NtTu8" to="3r88:4lCUG7OtrZL" resolve="kind" />
       </node>
@@ -639,6 +639,7 @@
         <property role="3F0ifm" value="times" />
         <ref role="1k5W1q" to="itrz:5E2dhwjbsH2" resolve="notEditableIets3Keyword" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIx0" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3dTPcTTfMOp">
@@ -672,7 +673,6 @@
     <property role="3GE5qa" value="check.occurence" />
     <ref role="1XX52x" to="3r88:4xzR2e_wXqB" resolve="SuccessorCheck" />
     <node concept="3EZMnI" id="4xzR2e_wXr5" role="2wV5jI">
-      <node concept="2iRfu4" id="4xzR2e_wXr6" role="2iSdaV" />
       <node concept="PMmxH" id="4xzR2e_wXr7" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -687,6 +687,7 @@
       <node concept="3F1sOY" id="4xzR2e_wXra" role="3EZMnx">
         <ref role="1NtTu8" to="3r88:4xzR2e_wXqC" resolve="match" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIx1" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/models/org.iets3.core.expr.stringvalidation.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/models/org.iets3.core.expr.stringvalidation.editor.mps
@@ -202,7 +202,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIwN" role="2iSdaV" />
+      <node concept="2iRfu4" id="1OEjBB5KJEL" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4lCUG7OsQvR">
@@ -323,7 +323,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIwQ" role="2iSdaV" />
+      <node concept="2iRfu4" id="1OEjBB5Gwok" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4lCUG7OtenI">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/models/org.iets3.core.expr.stringvalidation.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/models/org.iets3.core.expr.stringvalidation.editor.mps
@@ -355,7 +355,7 @@
       <node concept="3F1sOY" id="6KviS2Kv9sl" role="3EZMnx">
         <ref role="1NtTu8" to="3r88:6KviS2Ku$hC" resolve="pos" />
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIwR" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwfXRmL" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4lCUG7OtrZ$">
@@ -385,7 +385,7 @@
         <property role="3F0ifm" value="not repeat" />
         <ref role="1k5W1q" to="itrz:5E2dhwjbsH2" resolve="notEditableIets3Keyword" />
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIwS" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwfXRmN" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6KviS2JdW9Y">
@@ -452,7 +452,7 @@
       <node concept="3F1sOY" id="6KviS2KyOjL" role="3EZMnx">
         <ref role="1NtTu8" to="3r88:6KviS2KyOjv" resolve="match" />
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIwU" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwfY9B8" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6KviS2Kz2Qd">
@@ -593,7 +593,7 @@
       <node concept="3F1sOY" id="2LaXqmX$ck$" role="3EZMnx">
         <ref role="1NtTu8" to="3r88:2LaXqmX$cjW" resolve="match" />
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIwY" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwfY9Ba" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="2LaXqmXAhLf">
@@ -614,7 +614,7 @@
       <node concept="3F1sOY" id="2LaXqmXAhL$" role="3EZMnx">
         <ref role="1NtTu8" to="3r88:2LaXqmXAhKL" resolve="match" />
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIwZ" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwfXRmR" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3dTPcTTdvOB">
@@ -639,7 +639,7 @@
         <property role="3F0ifm" value="times" />
         <ref role="1k5W1q" to="itrz:5E2dhwjbsH2" resolve="notEditableIets3Keyword" />
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIx0" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwfXRmP" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3dTPcTTfMOp">
@@ -687,7 +687,7 @@
       <node concept="3F1sOY" id="4xzR2e_wXra" role="3EZMnx">
         <ref role="1NtTu8" to="3r88:4xzR2e_wXqC" resolve="match" />
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIx1" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwfXRmT" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/editor.mps
@@ -194,7 +194,6 @@
   <node concept="24kQdi" id="50smQ1V8i9n">
     <ref role="1XX52x" to="l462:50smQ1V8i89" resolve="TemporalType" />
     <node concept="3EZMnI" id="50smQ1V8izM" role="2wV5jI">
-      <node concept="2iRfu4" id="50smQ1V8izN" role="2iSdaV" />
       <node concept="3F0ifn" id="3wXkdMVKDGG" role="3EZMnx">
         <property role="3F0ifm" value="TT" />
         <ref role="1k5W1q" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
@@ -222,12 +221,12 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzt" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="50smQ1V8QEK">
     <ref role="1XX52x" to="l462:50smQ1V8QEh" resolve="Slice" />
     <node concept="3EZMnI" id="50smQ1V8QEM" role="2wV5jI">
-      <node concept="2iRfu4" id="50smQ1V8QEP" role="2iSdaV" />
       <node concept="1kIj98" id="50smQ1V8QF9" role="3EZMnx">
         <node concept="3F1sOY" id="50smQ1V8QEW" role="1kIj9b">
           <ref role="1NtTu8" to="l462:50smQ1V8QEi" resolve="pointInTime" />
@@ -243,6 +242,7 @@
         <property role="1cu_pB" value="hQNNVxO/attractsRecursively" />
         <ref role="1NtTu8" to="l462:50smQ1V8QEk" resolve="value" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzu" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="50smQ1V8QG1">
@@ -275,7 +275,7 @@
               <property role="VOm3f" value="true" />
             </node>
           </node>
-          <node concept="2iRfu4" id="7yDflTqUNIZ" role="2iSdaV" />
+          <node concept="l2Vlx" id="1ASK_HedIzw" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="7UPMhn0TeXM" role="1djCvC">
           <node concept="3clFbS" id="7UPMhn0TeXN" role="2VODD2">
@@ -303,7 +303,7 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="50smQ1V8QG9" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIzv" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="50smQ1VcyCu">
@@ -321,7 +321,6 @@
   <node concept="24kQdi" id="50smQ1VexWh">
     <ref role="1XX52x" to="l462:50smQ1VexVM" resolve="ValueAtOp" />
     <node concept="3EZMnI" id="50smQ1VexWp" role="2wV5jI">
-      <node concept="2iRfu4" id="50smQ1VexWq" role="2iSdaV" />
       <node concept="PMmxH" id="12bsjhgbOoz" role="3EZMnx">
         <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
@@ -398,6 +397,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzx" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3nGzaxUt$0I">
@@ -540,7 +540,6 @@
     <property role="3GE5qa" value="reslice" />
     <ref role="1XX52x" to="l462:3nGzaxUt$2z" resolve="AfterOp" />
     <node concept="3EZMnI" id="12bsjhg8w8f" role="2wV5jI">
-      <node concept="2iRfu4" id="12bsjhg8w8g" role="2iSdaV" />
       <node concept="PMmxH" id="12bsjhgc$I8" role="3EZMnx">
         <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
@@ -617,13 +616,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzy" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3nGzaxUyXFD">
     <property role="3GE5qa" value="reslice" />
     <ref role="1XX52x" to="l462:3nGzaxUyXFe" resolve="BeforeOp" />
     <node concept="3EZMnI" id="12bsjhg8wq8" role="2wV5jI">
-      <node concept="2iRfu4" id="12bsjhg8wq9" role="2iSdaV" />
       <node concept="PMmxH" id="12bsjhgc$X7" role="3EZMnx">
         <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
@@ -700,13 +699,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzz" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3nGzaxUzMEp">
     <property role="3GE5qa" value="reslice" />
     <ref role="1XX52x" to="l462:3nGzaxUzMDV" resolve="BetweenOp" />
     <node concept="3EZMnI" id="3nGzaxUzMEr" role="2wV5jI">
-      <node concept="2iRfu4" id="3nGzaxUzMEs" role="2iSdaV" />
       <node concept="PMmxH" id="12bsjhgc_43" role="3EZMnx">
         <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
@@ -789,12 +788,12 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIz$" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4voqclTxddz">
     <ref role="1XX52x" to="l462:4voqclTxdd4" resolve="AlwaysExpression" />
     <node concept="3EZMnI" id="4voqclTxddF" role="2wV5jI">
-      <node concept="2iRfu4" id="4voqclTxddG" role="2iSdaV" />
       <node concept="3F0ifn" id="4voqclTxddC" role="3EZMnx">
         <property role="3F0ifm" value="always" />
       </node>
@@ -816,6 +815,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIz_" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="1Mp62pP0G9p">
@@ -968,7 +968,6 @@
   <node concept="24kQdi" id="7aRvJQF6gkO">
     <ref role="1XX52x" to="l462:7aRvJQF6gko" resolve="FullOverlapExpr" />
     <node concept="3EZMnI" id="7aRvJQF6gkT" role="2wV5jI">
-      <node concept="2iRfu4" id="7aRvJQF6gkU" role="2iSdaV" />
       <node concept="PMmxH" id="7aRvJQF7G4k" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
       </node>
@@ -998,12 +997,12 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzA" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3rApyZ4E9WG">
     <ref role="1XX52x" to="l462:3rApyZ4E9Wd" resolve="DefaultSliceValueExpr" />
     <node concept="3EZMnI" id="3rApyZ4E9Yh" role="2wV5jI">
-      <node concept="2iRfu4" id="3rApyZ4E9Yi" role="2iSdaV" />
       <node concept="3F0ifn" id="3rApyZ4E9WI" role="3EZMnx">
         <property role="3F0ifm" value="with-default-value" />
       </node>
@@ -1031,6 +1030,7 @@
       <node concept="3F1sOY" id="3rApyZ4E9ZD" role="3EZMnx">
         <ref role="1NtTu8" to="l462:3rApyZ4E9Wg" resolve="body" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzB" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6C2wkq7f3Kq">
@@ -1069,7 +1069,6 @@
   <node concept="24kQdi" id="6C2wkq7iPtu">
     <ref role="1XX52x" to="l462:6C2wkq7iPsz" resolve="WithSliceOp" />
     <node concept="3EZMnI" id="6C2wkq7iPtA" role="2wV5jI">
-      <node concept="2iRfu4" id="6C2wkq7iPtB" role="2iSdaV" />
       <node concept="PMmxH" id="12bsjhgcAys" role="3EZMnx">
         <ref role="PMmxG" to="buwp:12bsjhgd0dR" resolve="OpAlias" />
       </node>
@@ -1091,6 +1090,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzC" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6C2wkq7lrzD">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/editor.mps
@@ -242,7 +242,7 @@
         <property role="1cu_pB" value="hQNNVxO/attractsRecursively" />
         <ref role="1NtTu8" to="l462:50smQ1V8QEk" resolve="value" />
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIzu" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwfYrFS" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="50smQ1V8QG1">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.testExecution/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.testExecution/models/editor.mps
@@ -13,8 +13,8 @@
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
@@ -55,22 +55,22 @@
     <node concept="3EZMnI" id="3SkjTN1LTw6" role="2wV5jI">
       <node concept="2iRkQZ" id="3SkjTN1LTw7" role="2iSdaV" />
       <node concept="3EZMnI" id="3SkjTN1LTwc" role="3EZMnx">
-        <node concept="2iRfu4" id="3SkjTN1LTwd" role="2iSdaV" />
         <node concept="3F0ifn" id="3SkjTN1LTw3" role="3EZMnx">
           <property role="3F0ifm" value="Test Execution Preferences: " />
         </node>
         <node concept="3F0A7n" id="3SkjTN1LTwp" role="3EZMnx">
           <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIum" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="3SkjTN1LTwJ" role="3EZMnx">
-        <node concept="2iRfu4" id="3SkjTN1LTwK" role="2iSdaV" />
         <node concept="3F0ifn" id="3SkjTN1LTwD" role="3EZMnx">
           <property role="3F0ifm" value="Execution Mode: " />
         </node>
         <node concept="3F1sOY" id="3SkjTN1LTwW" role="3EZMnx">
           <ref role="1NtTu8" to="6yn5:3SkjTN1LTtQ" resolve="executionMode" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIun" role="2iSdaV" />
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
@@ -83,6 +83,7 @@
       <concept id="1078308402140" name="jetbrains.mps.lang.editor.structure.CellModel_Custom" flags="sg" stub="8104358048506730068" index="gc7cB">
         <child id="1176795024817" name="cellProvider" index="3YsKMw" />
       </concept>
+      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
@@ -814,7 +815,7 @@
             <node concept="3F0ifn" id="6HHp2WmRFwc" role="3EZMnx">
               <property role="3F0ifm" value="=" />
             </node>
-            <node concept="l2Vlx" id="1ASK_HedIzY" role="2iSdaV" />
+            <node concept="2iRfu4" id="2tlTgwg2B2_" role="2iSdaV" />
           </node>
           <node concept="ZYGn8" id="6HHp2WmRFwg" role="ZWbT9">
             <node concept="3clFbS" id="6HHp2WmRFwh" role="2VODD2">
@@ -851,7 +852,7 @@
             </node>
           </node>
         </node>
-        <node concept="l2Vlx" id="1ASK_HedIzX" role="2iSdaV" />
+        <node concept="2iRfu4" id="2tlTgwg2B2z" role="2iSdaV" />
       </node>
       <node concept="3F1sOY" id="7aipPVpIgC4" role="3EZMnx">
         <ref role="1NtTu8" to="av4b:ub9nkyHAbb" resolve="actual" />
@@ -992,7 +993,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIzW" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwg2B2t" role="2iSdaV" />
     </node>
     <node concept="PMmxH" id="5Pgo_ASgPtA" role="6VMZX">
       <ref role="PMmxG" node="5Pgo_ASgPrj" resolve="StackTrace_EditorComponent" />
@@ -1886,7 +1887,7 @@
               <property role="1lJzqX" value="-1" />
             </node>
           </node>
-          <node concept="l2Vlx" id="1ASK_HedI$8" role="2iSdaV" />
+          <node concept="2iRfu4" id="2tlTgwg2Cly" role="2iSdaV" />
         </node>
         <node concept="ZYGn8" id="5bElvpN2tht" role="ZWbT9">
           <node concept="3clFbS" id="5bElvpN2thu" role="2VODD2">
@@ -1907,7 +1908,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedI$7" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwg2Cls" role="2iSdaV" />
     </node>
     <node concept="PMmxH" id="6UrZmTWpShN" role="6VMZX">
       <ref role="PMmxG" node="5Pgo_ASgPrj" resolve="StackTrace_EditorComponent" />
@@ -2660,7 +2661,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedI$v" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwf$MCI" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="RaqQlV9tmb">
@@ -2680,7 +2681,7 @@
           <ref role="1NtTu8" to="av4b:RaqQlV9tlI" resolve="valueStats" />
           <node concept="2EHx9g" id="RaqQlV9tn_" role="2czzBx" />
         </node>
-        <node concept="l2Vlx" id="1ASK_HedI$w" role="2iSdaV" />
+        <node concept="2iRfu4" id="2tlTgwfyT0N" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -2808,7 +2809,7 @@
               </node>
             </node>
           </node>
-          <node concept="l2Vlx" id="1ASK_HedI$y" role="2iSdaV" />
+          <node concept="2iRfu4" id="2tlTgwg2D3T" role="2iSdaV" />
         </node>
         <node concept="ZYGn8" id="4e_7uAt7pbT" role="ZWbT9">
           <node concept="3clFbS" id="4e_7uAt7pbU" role="2VODD2">
@@ -2829,7 +2830,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedI$x" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwg2D3N" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="CrzyxmEdPh">
@@ -3255,7 +3256,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedI$A" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwg2_Mv" role="2iSdaV" />
     </node>
   </node>
   <node concept="PKFIW" id="1bwJEEeTsOh">
@@ -4729,7 +4730,7 @@
       <node concept="3F1sOY" id="3BFGe1EJa6l" role="3EZMnx">
         <ref role="1NtTu8" to="av4b:3BFGe1EJa5G" resolve="vectors" />
       </node>
-      <node concept="l2Vlx" id="1ASK_HedI$G" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwg2ElO" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3BFGe1EJa6M">
@@ -5098,7 +5099,7 @@
             </node>
           </node>
         </node>
-        <node concept="l2Vlx" id="1ASK_HedI$N" role="2iSdaV" />
+        <node concept="2iRfu4" id="2tlTgwg2E0b" role="2iSdaV" />
       </node>
       <node concept="3F1sOY" id="ub9nkyHAco" role="3EZMnx">
         <ref role="1NtTu8" to="av4b:7aipPVpH1LP" resolve="actual" />
@@ -5311,7 +5312,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedI$M" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwg2DZp" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5Pgo_AS3PSR">
@@ -5326,7 +5327,7 @@
             <node concept="3F0ifn" id="5Pgo_ASpfTb" role="3EZMnx">
               <property role="3F0ifm" value="=" />
             </node>
-            <node concept="l2Vlx" id="1ASK_HedI$Q" role="2iSdaV" />
+            <node concept="2iRfu4" id="2tlTgwg2BJN" role="2iSdaV" />
           </node>
           <node concept="ZYGn8" id="5Pgo_ASpfTc" role="ZWbT9">
             <node concept="3clFbS" id="5Pgo_ASpfTd" role="2VODD2">
@@ -5363,7 +5364,7 @@
             </node>
           </node>
         </node>
-        <node concept="l2Vlx" id="1ASK_HedI$P" role="2iSdaV" />
+        <node concept="2iRfu4" id="2tlTgwg2BJL" role="2iSdaV" />
       </node>
       <node concept="3F1sOY" id="5Pgo_AS3Q2g" role="3EZMnx">
         <ref role="1NtTu8" to="av4b:5Pgo_AS3PT3" resolve="value" />
@@ -5501,7 +5502,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedI$O" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwg2BJF" role="2iSdaV" />
     </node>
     <node concept="PMmxH" id="5Pgo_ASjauE" role="6VMZX">
       <ref role="PMmxG" node="5Pgo_ASgPrj" resolve="StackTrace_EditorComponent" />
@@ -6980,7 +6981,7 @@
             <property role="VOm3f" value="true" />
           </node>
         </node>
-        <node concept="l2Vlx" id="1ASK_HedI_1" role="2iSdaV" />
+        <node concept="2iRfu4" id="2tlTgwg43Ol" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="1vo80p0QHM" role="3EZMnx">
         <property role="3F0ifm" value="complete?" />
@@ -6988,7 +6989,7 @@
       <node concept="27S6Sx" id="1vo80oWF6m" role="3EZMnx">
         <ref role="1NtTu8" to="av4b:1vo80oWF62" resolve="completeSubtree" />
       </node>
-      <node concept="l2Vlx" id="1ASK_HedI_0" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwg43Oi" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7khFtBHvbuH">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
@@ -444,6 +444,7 @@
       <concept id="4682418030828844314" name="de.itemis.mps.editor.celllayout.structure.HorzontalLineWidthStyle" flags="lg" index="2T_bXT" />
       <concept id="4682418030828725523" name="de.itemis.mps.editor.celllayout.structure.HorizontalLineCell" flags="ng" index="2T_mXK" />
       <concept id="9000758320091481718" name="de.itemis.mps.editor.celllayout.structure.GridLayoutFlattenStyle" flags="lg" index="1QQdxR" />
+      <concept id="2728748097294684357" name="de.itemis.mps.editor.celllayout.structure.OverflowXStyle" flags="lg" index="3T6UkE" />
       <concept id="2728748097294192922" name="de.itemis.mps.editor.celllayout.structure.IntegerStyle" flags="lg" index="3To2jP">
         <property id="1221209241505" name="value" index="1lJzqX" />
       </concept>
@@ -4542,6 +4543,9 @@
               </node>
             </node>
           </node>
+        </node>
+        <node concept="3T6UkE" id="4_VVT2YkLMp" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
@@ -87,6 +87,7 @@
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
+      <concept id="1237375020029" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineChildrenStyleClassItem" flags="ln" index="pj6Ft" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
@@ -1184,8 +1185,6 @@
         <node concept="PMmxH" id="6vTsh3ZZGrE" role="3EZMnx">
           <ref role="PMmxG" node="6vTsh3ZZ$b7" resolve="testStatus" />
         </node>
-        <node concept="3XFhqQ" id="7D7uZV2GpGb" role="3EZMnx" />
-        <node concept="3XFhqQ" id="7D7uZV2GpGi" role="3EZMnx" />
         <node concept="3EZMnI" id="6HHp2WmWVic" role="3EZMnx">
           <node concept="2iRkQZ" id="6HHp2WmWVid" role="2iSdaV" />
           <node concept="3EZMnI" id="7m_MLaK8Fm2" role="3EZMnx">
@@ -2208,7 +2207,7 @@
     <ref role="1XX52x" to="av4b:4XlPKep95_T" resolve="AbstractCoverageQuery" />
     <node concept="3EZMnI" id="3_DFadN86Is" role="2wV5jI">
       <property role="S$Qs1" value="true" />
-      <node concept="2iRkQZ" id="3_DFadN86It" role="2iSdaV" />
+      <node concept="l2Vlx" id="2tlTgwfsP18" role="2iSdaV" />
       <node concept="3EZMnI" id="3_DFadNfZSf" role="3EZMnx">
         <node concept="PMmxH" id="3_DFadMGHMY" role="3EZMnx">
           <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
@@ -2225,7 +2224,9 @@
         <node concept="VPM3Z" id="3_DFadN86IH" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="3XFhqQ" id="3_DFadN86IV" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwfsP15" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="3_DFadNcBWf" role="3EZMnx">
           <property role="3F0ifm" value="problems only:" />
         </node>
@@ -2238,7 +2239,9 @@
         <node concept="VPM3Z" id="18$bUx5D_rk" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="3XFhqQ" id="18$bUx5D_rl" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwfsP1e" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="18$bUx5D_rm" role="3EZMnx">
           <property role="3F0ifm" value="languages:" />
         </node>
@@ -2282,7 +2285,9 @@
         <node concept="VPM3Z" id="3_DFadNcBWq" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="3XFhqQ" id="3_DFadNcBWr" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwfsP1f" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="3_DFadNcBWs" role="3EZMnx">
           <property role="3F0ifm" value="ignore:   " />
         </node>
@@ -2331,6 +2336,9 @@
         </node>
         <node concept="l2Vlx" id="1ASK_HedI$g" role="2iSdaV" />
       </node>
+      <node concept="pj6Ft" id="2tlTgwfsP1b" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
     </node>
   </node>
   <node concept="24kQdi" id="3MHhZL0ts27">
@@ -2338,7 +2346,7 @@
     <ref role="1XX52x" to="av4b:4XlPKepaaha" resolve="StructuralCoverageAssQuery" />
     <node concept="3EZMnI" id="3MHhZL0ts29" role="2wV5jI">
       <property role="S$Qs1" value="true" />
-      <node concept="2iRkQZ" id="3MHhZL0ts2a" role="2iSdaV" />
+      <node concept="l2Vlx" id="2tlTgwfuLN6" role="2iSdaV" />
       <node concept="3EZMnI" id="3MHhZL0ts2b" role="3EZMnx">
         <node concept="PMmxH" id="3MHhZL0ts2d" role="3EZMnx">
           <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
@@ -2355,7 +2363,9 @@
         <node concept="VPM3Z" id="3MHhZL0ts3g" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="3XFhqQ" id="3MHhZL0ts3h" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwfuLNA" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="3MHhZL0ts3i" role="3EZMnx">
           <property role="3F0ifm" value="limits:             " />
         </node>
@@ -2419,7 +2429,9 @@
         <node concept="VPM3Z" id="3MHhZL0$oIJ" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="3XFhqQ" id="3MHhZL0$oIK" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwfuLNC" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="3MHhZL0$oIL" role="3EZMnx">
           <property role="3F0ifm" value="show limit errors:  " />
         </node>
@@ -2432,7 +2444,9 @@
         <node concept="VPM3Z" id="4e_7uAsvP5d" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="3XFhqQ" id="4e_7uAsvP5e" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwfuLNE" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="4e_7uAsvP5f" role="3EZMnx">
           <property role="3F0ifm" value="look outside suites:" />
         </node>
@@ -2445,7 +2459,9 @@
         <node concept="VPM3Z" id="5s_NuasYe_R" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="3XFhqQ" id="5s_NuasYe_S" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwfuLNL" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="5s_NuasYe_T" role="3EZMnx">
           <property role="3F0ifm" value="track properties:   " />
         </node>
@@ -2458,7 +2474,9 @@
         <node concept="VPM3Z" id="CrzyxmE7H9" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="3XFhqQ" id="CrzyxmE7Ha" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwfuLNT" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="CrzyxmE7Hb" role="3EZMnx">
           <property role="3F0ifm" value="nodes filter:       " />
         </node>
@@ -2478,7 +2496,9 @@
         <node concept="VPM3Z" id="3MHhZL0ts2n" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="3XFhqQ" id="3MHhZL0ts2o" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwfuLNU" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="3MHhZL0ts2p" role="3EZMnx">
           <property role="3F0ifm" value="languages:          " />
         </node>
@@ -2492,7 +2512,9 @@
         <node concept="VPM3Z" id="3MHhZL0ts2u" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="3XFhqQ" id="3MHhZL0ts2v" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwfuLNV" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="3MHhZL0ts2w" role="3EZMnx">
           <property role="3F0ifm" value="ignore:             " />
         </node>
@@ -2510,6 +2532,9 @@
           <property role="3F0ifm" value="{...}" />
         </node>
         <node concept="l2Vlx" id="1ASK_HedI$t" role="2iSdaV" />
+      </node>
+      <node concept="pj6Ft" id="2tlTgwfuLNm" role="3F10Kt">
+        <property role="VOm3f" value="true" />
       </node>
     </node>
   </node>
@@ -2668,7 +2693,6 @@
     <property role="3GE5qa" value="assessment.interpreter" />
     <ref role="1XX52x" to="av4b:RaqQlV9tkj" resolve="InterpreterValueSummary" />
     <node concept="3EZMnI" id="RaqQlV9tms" role="2wV5jI">
-      <node concept="2iRkQZ" id="RaqQlV9tmt" role="2iSdaV" />
       <node concept="3F0ifn" id="RaqQlV9tmA" role="3EZMnx">
         <property role="3F0ifm" value="value ranges" />
       </node>
@@ -2683,6 +2707,7 @@
         </node>
         <node concept="2iRfu4" id="2tlTgwfyT0N" role="2iSdaV" />
       </node>
+      <node concept="2iRkQZ" id="RaqQlV9tmt" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3tudP__5TLy">
@@ -4744,7 +4769,7 @@
     <property role="3GE5qa" value="mutator" />
     <ref role="1XX52x" to="av4b:3_xsRJ4oOr7" resolve="MutationEngine" />
     <node concept="3EZMnI" id="1qjbRymSXnn" role="2wV5jI">
-      <node concept="2iRkQZ" id="1qjbRymSXno" role="2iSdaV" />
+      <node concept="l2Vlx" id="2tlTgwfuKLP" role="2iSdaV" />
       <node concept="3EZMnI" id="7WSgHRL8$yA" role="3EZMnx">
         <node concept="2iRkQZ" id="7WSgHRL8$yB" role="2iSdaV" />
         <node concept="3EZMnI" id="7WSgHRL8$oF" role="3EZMnx">
@@ -4766,17 +4791,11 @@
           <node concept="l2Vlx" id="1ASK_HedI$I" role="2iSdaV" />
         </node>
       </node>
-      <node concept="3EZMnI" id="1qjbRymSXnD" role="3EZMnx">
-        <node concept="VPM3Z" id="1qjbRymSXnF" role="3F10Kt">
-          <property role="VOm3f" value="false" />
-        </node>
-        <node concept="3XFhqQ" id="1qjbRymSXnR" role="3EZMnx" />
-        <node concept="3F2HdR" id="1qjbRymSXnZ" role="3EZMnx">
-          <ref role="1NtTu8" to="av4b:1qjbRymSXnX" resolve="logs" />
-          <node concept="2iRkQZ" id="1qjbRymSXo5" role="2czzBx" />
-        </node>
-        <node concept="pkWqt" id="1qjbRymUCui" role="pqm2j">
-          <node concept="3clFbS" id="1qjbRymUCuj" role="2VODD2">
+      <node concept="3F2HdR" id="1qjbRymSXnZ" role="3EZMnx">
+        <ref role="1NtTu8" to="av4b:1qjbRymSXnX" resolve="logs" />
+        <node concept="l2Vlx" id="2tlTgwfw5fc" role="2czzBx" />
+        <node concept="pkWqt" id="2tlTgwfw5fe" role="pqm2j">
+          <node concept="3clFbS" id="2tlTgwfw5ff" role="2VODD2">
             <node concept="3clFbF" id="1qjbRymUC_y" role="3cqZAp">
               <node concept="2OqwBi" id="1qjbRymUEOK" role="3clFbG">
                 <node concept="2OqwBi" id="1qjbRymUCLH" role="2Oq$k0">
@@ -4790,7 +4809,15 @@
             </node>
           </node>
         </node>
-        <node concept="l2Vlx" id="1ASK_HedI$J" role="2iSdaV" />
+        <node concept="lj46D" id="2tlTgwfw5wa" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pj6Ft" id="2tlTgwfw5xx" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="pj6Ft" id="2tlTgwfuKLR" role="3F10Kt">
+        <property role="VOm3f" value="true" />
       </node>
     </node>
   </node>
@@ -5556,7 +5583,7 @@
     <property role="3GE5qa" value="" />
     <ref role="1XX52x" to="4kwy:3R3AIvuMXwK" resolve="ICanStoreCheckResult" />
     <node concept="3EZMnI" id="5Pgo_ASgPrk" role="2wV5jI">
-      <node concept="2iRkQZ" id="5Pgo_ASgPrl" role="2iSdaV" />
+      <node concept="l2Vlx" id="2tlTgwfuLBE" role="2iSdaV" />
       <node concept="3EZMnI" id="5Pgo_ASgPrm" role="3EZMnx">
         <node concept="3F0ifn" id="5Pgo_ASgPro" role="3EZMnx">
           <property role="3F0ifm" value="Constraint Failed:" />
@@ -5639,7 +5666,6 @@
         <node concept="l2Vlx" id="1ASK_HedI$R" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="5Pgo_ASgPrR" role="3EZMnx">
-        <node concept="3XFhqQ" id="5Pgo_ASgPrT" role="3EZMnx" />
         <node concept="3F0ifn" id="5Pgo_ASgPrU" role="3EZMnx">
           <property role="3F0ifm" value="at" />
         </node>
@@ -5811,6 +5837,9 @@
           <node concept="2iRkQZ" id="5Pgo_ASgPt8" role="2czzBy" />
         </node>
         <node concept="l2Vlx" id="1ASK_HedI$S" role="2iSdaV" />
+        <node concept="lj46D" id="2tlTgwfuLKx" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
       </node>
       <node concept="pkWqt" id="5Pgo_ASgPt9" role="pqm2j">
         <node concept="3clFbS" id="5Pgo_ASgPta" role="2VODD2">
@@ -5879,6 +5908,9 @@
             </node>
           </node>
         </node>
+      </node>
+      <node concept="pj6Ft" id="2tlTgwfuLEV" role="3F10Kt">
+        <property role="VOm3f" value="true" />
       </node>
     </node>
   </node>
@@ -6667,7 +6699,7 @@
     <ref role="1XX52x" to="av4b:5IKJrJHPvF0" resolve="TestCoverageAssQuery" />
     <node concept="3EZMnI" id="1vo80oMm0t" role="2wV5jI">
       <property role="S$Qs1" value="true" />
-      <node concept="2iRkQZ" id="1vo80oMm0u" role="2iSdaV" />
+      <node concept="l2Vlx" id="2tlTgwfuMox" role="2iSdaV" />
       <node concept="3EZMnI" id="1vo80oMm0v" role="3EZMnx">
         <node concept="PMmxH" id="1vo80oMm0x" role="3EZMnx">
           <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
@@ -6682,7 +6714,9 @@
       </node>
       <node concept="3EZMnI" id="1gw9pCYhxSf" role="3EZMnx">
         <node concept="VPM3Z" id="1gw9pCYhxSh" role="3F10Kt" />
-        <node concept="3XFhqQ" id="1gw9pCYhybU" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwfuMpq" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="1gw9pCYhyc3" role="3EZMnx">
           <property role="3F0ifm" value="effective models:" />
           <ref role="1k5W1q" to="itrz:3_9S6lia_no" resolve="iets3PassiveText" />
@@ -6821,7 +6855,9 @@
         <node concept="VPM3Z" id="1vo80oMm0_" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="3XFhqQ" id="1vo80oMm0A" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwfuMpH" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="1vo80oMm0B" role="3EZMnx">
           <property role="3F0ifm" value="problems only:" />
         </node>
@@ -6834,7 +6870,9 @@
         <node concept="VPM3Z" id="1vo80oMm0F" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="3XFhqQ" id="1vo80oMm0G" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwfuMpJ" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="1vo80oMm0H" role="3EZMnx">
           <property role="3F0ifm" value="measure for:" />
         </node>
@@ -6878,7 +6916,9 @@
         <node concept="VPM3Z" id="3TIaSh_20yw" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
-        <node concept="3XFhqQ" id="3TIaSh_20yx" role="3EZMnx" />
+        <node concept="lj46D" id="2tlTgwfuMpK" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
         <node concept="3F0ifn" id="3TIaSh_20yy" role="3EZMnx">
           <property role="3F0ifm" value="ignore:     " />
         </node>
@@ -6926,6 +6966,9 @@
           <property role="3F0ifm" value="{...}" />
         </node>
         <node concept="l2Vlx" id="1ASK_HedI$Z" role="2iSdaV" />
+      </node>
+      <node concept="pj6Ft" id="2tlTgwfuMoP" role="3F10Kt">
+        <property role="VOm3f" value="true" />
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
@@ -83,9 +83,9 @@
       <concept id="1078308402140" name="jetbrains.mps.lang.editor.structure.CellModel_Custom" flags="sg" stub="8104358048506730068" index="gc7cB">
         <child id="1176795024817" name="cellProvider" index="3YsKMw" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
+      <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
@@ -671,7 +671,6 @@
       <property role="S$Qs1" value="true" />
       <node concept="2iRkQZ" id="ub9nkyHAdA" role="2iSdaV" />
       <node concept="3EZMnI" id="ub9nkyHAdf" role="3EZMnx">
-        <node concept="2iRfu4" id="ub9nkyHAdg" role="2iSdaV" />
         <node concept="3F0ifn" id="ub9nkyHAdc" role="3EZMnx">
           <property role="3F0ifm" value="test case" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -692,10 +691,10 @@
               <property role="3F0ifm" value="setup" />
               <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
             </node>
-            <node concept="2iRfu4" id="1cd9HYWxD68" role="2iSdaV" />
             <node concept="3F1sOY" id="1cd9HYWxDuX" role="3EZMnx">
               <ref role="1NtTu8" to="av4b:1cd9HYWxxA0" resolve="setup" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIzT" role="2iSdaV" />
           </node>
           <node concept="uPpia" id="1ZlHRbgqU80" role="1djCvC">
             <node concept="3clFbS" id="1ZlHRbgqU81" role="2VODD2">
@@ -725,6 +724,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIzS" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="1cd9HYWzYup" role="3EZMnx">
         <property role="3F0ifm" value="{" />
@@ -745,8 +745,6 @@
         </node>
       </node>
       <node concept="3EZMnI" id="ub9nkyHAed" role="3EZMnx">
-        <node concept="2iRfu4" id="ub9nkyHAee" role="2iSdaV" />
-        <node concept="3XFhqQ" id="ub9nkyHAev" role="3EZMnx" />
         <node concept="3F2HdR" id="ub9nkyHAe2" role="3EZMnx">
           <ref role="1NtTu8" to="av4b:ub9nkyHAcK" resolve="items" />
           <node concept="2EHx9g" id="ub9nkyHAe$" role="2czzBx" />
@@ -763,13 +761,16 @@
               </node>
             </node>
           </node>
+          <node concept="lj46D" id="1ASK_HeJipS" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIzU" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="ub9nkyHAdN" role="3EZMnx">
         <property role="3F0ifm" value="}" />
       </node>
       <node concept="3EZMnI" id="3KzlhPzXwmd" role="AHCbl">
-        <node concept="2iRfu4" id="3KzlhPzXwme" role="2iSdaV" />
         <node concept="3F0ifn" id="3KzlhPzXwmf" role="3EZMnx">
           <property role="3F0ifm" value="test case" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -783,6 +784,7 @@
         <node concept="3F0ifn" id="3KzlhPzXwmh" role="3EZMnx">
           <property role="3F0ifm" value="{...}" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIzV" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -802,17 +804,16 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="7aipPVpIgBV" role="2iSdaV" />
       <node concept="3EZMnI" id="7aipPVpIgBW" role="3EZMnx">
         <node concept="_tjkj" id="6HHp2WmRF2$" role="3EZMnx">
           <node concept="3EZMnI" id="6HHp2WmRFw3" role="_tjki">
-            <node concept="2iRfu4" id="6HHp2WmRFw4" role="2iSdaV" />
             <node concept="3F1sOY" id="6HHp2WmRFbS" role="3EZMnx">
               <ref role="1NtTu8" to="4kwy:cJpacq40jC" resolve="optionalName" />
             </node>
             <node concept="3F0ifn" id="6HHp2WmRFwc" role="3EZMnx">
               <property role="3F0ifm" value="=" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIzY" role="2iSdaV" />
           </node>
           <node concept="ZYGn8" id="6HHp2WmRFwg" role="ZWbT9">
             <node concept="3clFbS" id="6HHp2WmRFwh" role="2VODD2">
@@ -833,7 +834,6 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="7aipPVpIgBX" role="2iSdaV" />
         <node concept="PMmxH" id="7aipPVpIgBY" role="3EZMnx">
           <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -850,6 +850,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIzX" role="2iSdaV" />
       </node>
       <node concept="3F1sOY" id="7aipPVpIgC4" role="3EZMnx">
         <ref role="1NtTu8" to="av4b:ub9nkyHAbb" resolve="actual" />
@@ -990,6 +991,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIzW" role="2iSdaV" />
     </node>
     <node concept="PMmxH" id="5Pgo_ASgPtA" role="6VMZX">
       <ref role="PMmxG" node="5Pgo_ASgPrj" resolve="StackTrace_EditorComponent" />
@@ -1048,7 +1050,6 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="ub9nkyK62M" role="2iSdaV" />
         <node concept="3F0ifn" id="ub9nkyK62I" role="3EZMnx">
           <property role="3F0ifm" value="test suite" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -1186,25 +1187,24 @@
         <node concept="3EZMnI" id="6HHp2WmWVic" role="3EZMnx">
           <node concept="2iRkQZ" id="6HHp2WmWVid" role="2iSdaV" />
           <node concept="3EZMnI" id="7m_MLaK8Fm2" role="3EZMnx">
-            <node concept="2iRfu4" id="7m_MLaK8Fm3" role="2iSdaV" />
             <node concept="3F0ifn" id="7m_MLaK8Fm4" role="3EZMnx">
               <property role="3F0ifm" value="show types:             " />
             </node>
             <node concept="3F0A7n" id="7m_MLaK8Fm5" role="3EZMnx">
               <ref role="1NtTu8" to="av4b:7m_MLaK8FlX" resolve="showTypes" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedI$0" role="2iSdaV" />
           </node>
           <node concept="3EZMnI" id="6HHp2WmWVoa" role="3EZMnx">
-            <node concept="2iRfu4" id="6HHp2WmWVob" role="2iSdaV" />
             <node concept="3F0ifn" id="6HHp2WmWVoc" role="3EZMnx">
               <property role="3F0ifm" value="only local declarations:" />
             </node>
             <node concept="3F0A7n" id="6HHp2WmWVod" role="3EZMnx">
               <ref role="1NtTu8" to="av4b:6HHp2WmWVi9" resolve="referenceOnlyLocalStuff" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedI$1" role="2iSdaV" />
           </node>
           <node concept="3EZMnI" id="1KPsfaLHyY0" role="3EZMnx">
-            <node concept="2iRfu4" id="1KPsfaLHyY1" role="2iSdaV" />
             <node concept="3F0ifn" id="1KPsfaLHyY2" role="3EZMnx">
               <property role="3F0ifm" value="inherit scope from:     " />
             </node>
@@ -1214,8 +1214,10 @@
                 <node concept="3SHvHV" id="1KPsfaLHzLA" role="2wV5jI" />
               </node>
             </node>
+            <node concept="l2Vlx" id="1ASK_HedI$2" role="2iSdaV" />
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIzZ" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="7OzZ9xIaL37" role="3EZMnx">
         <node concept="VPxyj" id="7OzZ9xIcFj1" role="3F10Kt">
@@ -1613,7 +1615,6 @@
     <property role="3GE5qa" value="" />
     <ref role="1XX52x" to="av4b:ub9nkyHAba" resolve="AssertTestItem" />
     <node concept="3EZMnI" id="6HHp2WmZdRC" role="2wV5jI">
-      <node concept="2iRfu4" id="6HHp2WmZdRD" role="2iSdaV" />
       <node concept="3EZMnI" id="6HHp2WmZdRE" role="3EZMnx">
         <node concept="_tjkj" id="6HHp2WmZdRF" role="3EZMnx">
           <node concept="3EZMnI" id="6HHp2WmZdRG" role="_tjki">
@@ -1629,7 +1630,6 @@
                 </node>
               </node>
             </node>
-            <node concept="2iRfu4" id="6HHp2WmZdRH" role="2iSdaV" />
             <node concept="3F0ifn" id="6HHp2Wn5zNt" role="3EZMnx">
               <property role="3F0ifm" value="val" />
               <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -1640,6 +1640,7 @@
             <node concept="3F0ifn" id="6HHp2WmZdRJ" role="3EZMnx">
               <property role="3F0ifm" value="=" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedI$5" role="2iSdaV" />
           </node>
           <node concept="ZYGn8" id="6HHp2WmZdRK" role="ZWbT9">
             <node concept="3clFbS" id="6HHp2WmZdRL" role="2VODD2">
@@ -1660,7 +1661,6 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="6HHp2WmZdRO" role="2iSdaV" />
         <node concept="3tD6jV" id="6HHp2Wn5dNr" role="3F10Kt">
           <ref role="3tD7wE" to="z0fb:7ND7w4acsmT" resolve="_grid-layout-flatten" />
           <node concept="3sjG9q" id="6HHp2Wn5dNt" role="3tD6jU">
@@ -1673,6 +1673,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$4" role="2iSdaV" />
       </node>
       <node concept="3F1sOY" id="6HHp2WmZdRV" role="3EZMnx">
         <ref role="1NtTu8" to="av4b:ub9nkyHAbb" resolve="actual" />
@@ -1762,6 +1763,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI$3" role="2iSdaV" />
     </node>
     <node concept="2aJ2om" id="6HHp2WmZe4J" role="CpUAK">
       <ref role="2$4xQ3" node="6HHp2WmZdFE" resolve="demoMode" />
@@ -1771,7 +1773,6 @@
     <property role="3GE5qa" value="" />
     <ref role="1XX52x" to="av4b:4kV9Ob9XpO0" resolve="RealEqualsTestOp" />
     <node concept="3EZMnI" id="4kV9Ob9YBZq" role="2wV5jI">
-      <node concept="2iRfu4" id="4kV9Ob9YBZr" role="2iSdaV" />
       <node concept="3F0ifn" id="4kV9Ob9YBZn" role="3EZMnx">
         <property role="3F0ifm" value="real-equals[" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -1788,12 +1789,12 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI$6" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="78hTg1$TLIS">
     <ref role="1XX52x" to="av4b:78hTg1$THIv" resolve="ConstraintFailedTestItem" />
     <node concept="3EZMnI" id="78hTg1$TLIY" role="2wV5jI">
-      <node concept="2iRfu4" id="78hTg1_1BHP" role="2iSdaV" />
       <node concept="3F0ifn" id="78hTg1$TLIU" role="3EZMnx">
         <property role="3F0ifm" value="confail" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -1874,7 +1875,6 @@
           <node concept="1QQdxR" id="6oH$76vefBd" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
-          <node concept="2iRfu4" id="5bElvpNdesi" role="2iSdaV" />
           <node concept="3F0ifn" id="5bElvpN19iq" role="3EZMnx">
             <property role="3F0ifm" value="with error" />
             <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -1885,6 +1885,7 @@
               <property role="1lJzqX" value="-1" />
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedI$8" role="2iSdaV" />
         </node>
         <node concept="ZYGn8" id="5bElvpN2tht" role="ZWbT9">
           <node concept="3clFbS" id="5bElvpN2thu" role="2VODD2">
@@ -1905,6 +1906,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI$7" role="2iSdaV" />
     </node>
     <node concept="PMmxH" id="6UrZmTWpShN" role="6VMZX">
       <ref role="PMmxG" node="5Pgo_ASgPrj" resolve="StackTrace_EditorComponent" />
@@ -1951,7 +1953,6 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="16N5YaaOTXW" role="2iSdaV" />
       <node concept="3F0A7n" id="3_DFadMGIih" role="3EZMnx">
         <ref role="1NtTu8" to="av4b:3_DFadMGIe1" resolve="comment" />
         <node concept="VechU" id="18$bUx5w6h_" role="3F10Kt">
@@ -2039,13 +2040,13 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI$9" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3_DFadN838J">
     <property role="3GE5qa" value="assessment" />
     <ref role="1XX52x" to="av4b:3_DFadN835W" resolve="LanguageRef" />
     <node concept="3EZMnI" id="3_DFadN86Jj" role="2wV5jI">
-      <node concept="2iRfu4" id="3_DFadN86Jk" role="2iSdaV" />
       <node concept="3F0ifn" id="3_DFadN87_j" role="3EZMnx">
         <property role="3F0ifm" value="language/" />
         <node concept="11LMrY" id="3_DFadN87NJ" role="3F10Kt">
@@ -2153,13 +2154,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI$a" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3_DFadNcC04">
     <property role="3GE5qa" value="assessment" />
     <ref role="1XX52x" to="av4b:3_DFadNcBX2" resolve="IgnoredConcept" />
     <node concept="3EZMnI" id="3_DFadNcC2H" role="2wV5jI">
-      <node concept="2iRfu4" id="3_DFadNcC2I" role="2iSdaV" />
       <node concept="3F0ifn" id="3_DFadNcC2D" role="3EZMnx">
         <property role="3F0ifm" value="concept/" />
         <node concept="11LMrY" id="3_DFadNcC7S" role="3F10Kt">
@@ -2181,6 +2182,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI$b" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="18$bUx5b58j">
@@ -2206,7 +2208,6 @@
       <property role="S$Qs1" value="true" />
       <node concept="2iRkQZ" id="3_DFadN86It" role="2iSdaV" />
       <node concept="3EZMnI" id="3_DFadNfZSf" role="3EZMnx">
-        <node concept="2iRfu4" id="3_DFadNfZSg" role="2iSdaV" />
         <node concept="PMmxH" id="3_DFadMGHMY" role="3EZMnx">
           <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
         </node>
@@ -2216,6 +2217,7 @@
         <node concept="3F1sOY" id="3_DFadNfZT7" role="3EZMnx">
           <ref role="1NtTu8" to="av4b:3_DFadNfZS8" resolve="scope" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$c" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="3_DFadN86IF" role="3EZMnx">
         <node concept="VPM3Z" id="3_DFadN86IH" role="3F10Kt">
@@ -2228,7 +2230,7 @@
         <node concept="27S6Sx" id="18$bUx5DAE9" role="3EZMnx">
           <ref role="1NtTu8" to="av4b:18$bUx5D_ps" resolve="hideOK" />
         </node>
-        <node concept="2iRfu4" id="3_DFadN86IK" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedI$d" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="18$bUx5D_rj" role="3EZMnx">
         <node concept="VPM3Z" id="18$bUx5D_rk" role="3F10Kt">
@@ -2272,7 +2274,7 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="18$bUx5D_rp" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedI$e" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="3_DFadNcBWp" role="3EZMnx">
         <node concept="VPM3Z" id="3_DFadNcBWq" role="3F10Kt">
@@ -2282,7 +2284,6 @@
         <node concept="3F0ifn" id="3_DFadNcBWs" role="3EZMnx">
           <property role="3F0ifm" value="ignore:   " />
         </node>
-        <node concept="2iRfu4" id="3_DFadNcBWv" role="2iSdaV" />
         <node concept="3F2HdR" id="3_DFadNcYys" role="3EZMnx">
           <property role="S$F3r" value="true" />
           <ref role="1NtTu8" to="av4b:3_DFadNcYyg" resolve="ignoredConcepts" />
@@ -2317,15 +2318,16 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$f" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="3_DFadNciy5" role="AHCbl">
-        <node concept="2iRfu4" id="3_DFadNciy6" role="2iSdaV" />
         <node concept="PMmxH" id="3_DFadNciy2" role="3EZMnx">
           <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
         </node>
         <node concept="3F0ifn" id="3_DFadNciyk" role="3EZMnx">
           <property role="3F0ifm" value="{...}" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$g" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -2336,7 +2338,6 @@
       <property role="S$Qs1" value="true" />
       <node concept="2iRkQZ" id="3MHhZL0ts2a" role="2iSdaV" />
       <node concept="3EZMnI" id="3MHhZL0ts2b" role="3EZMnx">
-        <node concept="2iRfu4" id="3MHhZL0ts2c" role="2iSdaV" />
         <node concept="PMmxH" id="3MHhZL0ts2d" role="3EZMnx">
           <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
         </node>
@@ -2346,6 +2347,7 @@
         <node concept="3F1sOY" id="3MHhZL0ts2f" role="3EZMnx">
           <ref role="1NtTu8" to="av4b:3_DFadNfZS8" resolve="scope" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$h" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="3MHhZL0ts3f" role="3EZMnx">
         <node concept="VPM3Z" id="3MHhZL0ts3g" role="3F10Kt">
@@ -2355,7 +2357,6 @@
         <node concept="3F0ifn" id="3MHhZL0ts3i" role="3EZMnx">
           <property role="3F0ifm" value="limits:             " />
         </node>
-        <node concept="2iRfu4" id="3MHhZL0ts3k" role="2iSdaV" />
         <node concept="3EZMnI" id="3MHhZL0ts4q" role="3EZMnx">
           <node concept="VPM3Z" id="3MHhZL0ts4s" role="3F10Kt">
             <property role="VOm3f" value="false" />
@@ -2367,10 +2368,10 @@
             <node concept="3F0ifn" id="3MHhZL0ts5t" role="3EZMnx">
               <property role="3F0ifm" value="min N    = " />
             </node>
-            <node concept="2iRfu4" id="3MHhZL0ts5u" role="2iSdaV" />
             <node concept="3F0A7n" id="3MHhZL0ts5Q" role="3EZMnx">
               <ref role="1NtTu8" to="av4b:3MHhZL0ts1h" resolve="minTestCount" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedI$j" role="2iSdaV" />
           </node>
           <node concept="3EZMnI" id="3MHhZL0ts5U" role="3EZMnx">
             <node concept="VPM3Z" id="3MHhZL0ts5V" role="3F10Kt">
@@ -2379,10 +2380,10 @@
             <node concept="3F0ifn" id="3MHhZL0ts5W" role="3EZMnx">
               <property role="3F0ifm" value="min V    = " />
             </node>
-            <node concept="2iRfu4" id="3MHhZL0ts5X" role="2iSdaV" />
             <node concept="3F0A7n" id="3MHhZL0ts5Y" role="3EZMnx">
               <ref role="1NtTu8" to="av4b:3MHhZL0ts1w" resolve="minTestVolume" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedI$k" role="2iSdaV" />
           </node>
           <node concept="3EZMnI" id="3MHhZL0ts69" role="3EZMnx">
             <node concept="VPM3Z" id="3MHhZL0ts6a" role="3F10Kt">
@@ -2391,10 +2392,10 @@
             <node concept="3F0ifn" id="3MHhZL0ts6b" role="3EZMnx">
               <property role="3F0ifm" value="max MinH = " />
             </node>
-            <node concept="2iRfu4" id="3MHhZL0ts6c" role="2iSdaV" />
             <node concept="3F0A7n" id="3MHhZL0ts6d" role="3EZMnx">
               <ref role="1NtTu8" to="av4b:3MHhZL0ts1z" resolve="maximalMinHetero" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedI$l" role="2iSdaV" />
           </node>
           <node concept="3EZMnI" id="3MHhZL0ts6t" role="3EZMnx">
             <node concept="VPM3Z" id="3MHhZL0ts6u" role="3F10Kt">
@@ -2403,13 +2404,14 @@
             <node concept="3F0ifn" id="3MHhZL0ts6v" role="3EZMnx">
               <property role="3F0ifm" value="min MaxH = " />
             </node>
-            <node concept="2iRfu4" id="3MHhZL0ts6w" role="2iSdaV" />
             <node concept="3F0A7n" id="3MHhZL0ts6x" role="3EZMnx">
               <ref role="1NtTu8" to="av4b:3MHhZL0ts1B" resolve="minimumMaxHetero" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedI$m" role="2iSdaV" />
           </node>
           <node concept="2iRkQZ" id="3MHhZL0ts4v" role="2iSdaV" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$i" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="3MHhZL0$oII" role="3EZMnx">
         <node concept="VPM3Z" id="3MHhZL0$oIJ" role="3F10Kt">
@@ -2422,7 +2424,7 @@
         <node concept="27S6Sx" id="3MHhZL0$oIM" role="3EZMnx">
           <ref role="1NtTu8" to="av4b:3MHhZL0$oIw" resolve="highlightErrors" />
         </node>
-        <node concept="2iRfu4" id="3MHhZL0$oIN" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedI$n" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="4e_7uAsvP5c" role="3EZMnx">
         <node concept="VPM3Z" id="4e_7uAsvP5d" role="3F10Kt">
@@ -2435,7 +2437,7 @@
         <node concept="27S6Sx" id="4e_7uAsvP5g" role="3EZMnx">
           <ref role="1NtTu8" to="av4b:4e_7uAsvP4Z" resolve="lookOutsideTestSuites" />
         </node>
-        <node concept="2iRfu4" id="4e_7uAsvP5h" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedI$o" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="5s_NuasYe_Q" role="3EZMnx">
         <node concept="VPM3Z" id="5s_NuasYe_R" role="3F10Kt">
@@ -2448,7 +2450,7 @@
         <node concept="27S6Sx" id="5s_NuasYe_U" role="3EZMnx">
           <ref role="1NtTu8" to="av4b:5s_NuasW9F6" resolve="trackProperties" />
         </node>
-        <node concept="2iRfu4" id="5s_NuasYe_V" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedI$p" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="CrzyxmE7H8" role="3EZMnx">
         <node concept="VPM3Z" id="CrzyxmE7H9" role="3F10Kt">
@@ -2468,7 +2470,7 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="CrzyxmE7Hd" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedI$q" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="3MHhZL0ts2m" role="3EZMnx">
         <node concept="VPM3Z" id="3MHhZL0ts2n" role="3F10Kt">
@@ -2482,7 +2484,7 @@
           <ref role="1NtTu8" to="av4b:3_DFadN86Ip" resolve="languages" />
           <node concept="2iRkQZ" id="3MHhZL0ts2r" role="2czzBx" />
         </node>
-        <node concept="2iRfu4" id="3MHhZL0ts2s" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedI$r" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="3MHhZL0ts2t" role="3EZMnx">
         <node concept="VPM3Z" id="3MHhZL0ts2u" role="3F10Kt">
@@ -2492,20 +2494,20 @@
         <node concept="3F0ifn" id="3MHhZL0ts2w" role="3EZMnx">
           <property role="3F0ifm" value="ignore:             " />
         </node>
-        <node concept="2iRfu4" id="3MHhZL0ts2x" role="2iSdaV" />
         <node concept="3F2HdR" id="3MHhZL0ts2y" role="3EZMnx">
           <ref role="1NtTu8" to="av4b:3_DFadNcYyg" resolve="ignoredConcepts" />
           <node concept="2iRkQZ" id="3MHhZL0ts2z" role="2czzBx" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$s" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="3MHhZL0ts2$" role="AHCbl">
-        <node concept="2iRfu4" id="3MHhZL0ts2_" role="2iSdaV" />
         <node concept="PMmxH" id="3MHhZL0ts2A" role="3EZMnx">
           <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
         </node>
         <node concept="3F0ifn" id="3MHhZL0ts2B" role="3EZMnx">
           <property role="3F0ifm" value="{...}" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$t" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -2525,7 +2527,6 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="4n6gQwSWK4T" role="2iSdaV" />
       <node concept="3F0A7n" id="3MHhZL0ul2h" role="3EZMnx">
         <ref role="1NtTu8" to="av4b:3MHhZL0ul1k" resolve="comment" />
         <node concept="VechU" id="3MHhZL0ul2i" role="3F10Kt">
@@ -2613,13 +2614,13 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI$u" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="RaqQlV9tkP">
     <property role="3GE5qa" value="assessment.interpreter" />
     <ref role="1XX52x" to="av4b:RaqQlV9tkk" resolve="InterpreterValueStat" />
     <node concept="3EZMnI" id="RaqQlV9tl4" role="2wV5jI">
-      <node concept="2iRfu4" id="RaqQlV9tl5" role="2iSdaV" />
       <node concept="3F0A7n" id="RaqQlV9tl1" role="3EZMnx">
         <ref role="1NtTu8" to="av4b:RaqQlV9tkl" resolve="label" />
       </node>
@@ -2658,6 +2659,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI$v" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="RaqQlV9tmb">
@@ -2673,11 +2675,11 @@
           <property role="VOm3f" value="false" />
         </node>
         <node concept="3XFhqQ" id="RaqQlV9tnj" role="3EZMnx" />
-        <node concept="2iRfu4" id="RaqQlV9tn7" role="2iSdaV" />
         <node concept="3F2HdR" id="RaqQlV9tnv" role="3EZMnx">
           <ref role="1NtTu8" to="av4b:RaqQlV9tlI" resolve="valueStats" />
           <node concept="2EHx9g" id="RaqQlV9tn_" role="2czzBx" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$w" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -2697,7 +2699,6 @@
   <node concept="24kQdi" id="4e_7uAt7p2u">
     <ref role="1XX52x" to="av4b:4e_7uAt7oTg" resolve="InvalidValueTestItem" />
     <node concept="3EZMnI" id="4e_7uAt7pba" role="2wV5jI">
-      <node concept="2iRfu4" id="4e_7uAt7pbb" role="2iSdaV" />
       <node concept="3F0ifn" id="4e_7uAt7pbc" role="3EZMnx">
         <property role="3F0ifm" value="inval" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -2775,7 +2776,6 @@
       </node>
       <node concept="_tjkj" id="4e_7uAt7pbE" role="3EZMnx">
         <node concept="3EZMnI" id="4e_7uAt7pbF" role="_tjki">
-          <node concept="2iRfu4" id="4e_7uAt7pbG" role="2iSdaV" />
           <node concept="3F0ifn" id="4e_7uAt7pbH" role="3EZMnx">
             <property role="3F0ifm" value="with error" />
             <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -2807,6 +2807,7 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedI$y" role="2iSdaV" />
         </node>
         <node concept="ZYGn8" id="4e_7uAt7pbT" role="ZWbT9">
           <node concept="3clFbS" id="4e_7uAt7pbU" role="2VODD2">
@@ -2827,6 +2828,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI$x" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="CrzyxmEdPh">
@@ -2859,7 +2861,6 @@
       <node concept="1QQdxR" id="6L$vAtzT5lu" role="3F10Kt">
         <property role="VOm3f" value="true" />
       </node>
-      <node concept="2iRfu4" id="3ZQ1PLQkkd9" role="2iSdaV" />
       <node concept="1iCGBv" id="5IKJrJHQlOA" role="3EZMnx">
         <ref role="1NtTu8" to="av4b:hJB5MUc" resolve="coveredNode" />
         <node concept="1sVBvm" id="5IKJrJHQlP0" role="1sWHZn">
@@ -3061,13 +3062,13 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI$z" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="1$1rueeDiOr">
     <property role="3GE5qa" value="opt" />
     <ref role="1XX52x" to="av4b:1$1rueeDiNV" resolve="OptExpression" />
     <node concept="3EZMnI" id="1$1rueeDiOw" role="2wV5jI">
-      <node concept="2iRfu4" id="1$1rueeDiOx" role="2iSdaV" />
       <node concept="3F0ifn" id="1$1rueeDiOt" role="3EZMnx">
         <property role="3F0ifm" value="some&lt;" />
         <node concept="11LMrY" id="1$1rueeDiSl" role="3F10Kt">
@@ -3083,13 +3084,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI$$" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="1$1rueeG25O">
     <property role="3GE5qa" value="opt" />
     <ref role="1XX52x" to="av4b:1$1rueeG254" resolve="NoneExpr" />
     <node concept="3EZMnI" id="1$1rueeG25Q" role="2wV5jI">
-      <node concept="2iRfu4" id="1$1rueeG25R" role="2iSdaV" />
       <node concept="3F0ifn" id="1$1rueeG25S" role="3EZMnx">
         <property role="3F0ifm" value="none&lt;" />
         <node concept="11LMrY" id="1$1rueeG25U" role="3F10Kt">
@@ -3105,6 +3106,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI$_" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3kdFyLYhwNR">
@@ -3123,7 +3125,6 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="3kdFyLYhwOe" role="2iSdaV" />
       <node concept="3F0ifn" id="713ZPaW16M_" role="3EZMnx">
         <property role="3F0ifm" value="assert-opt" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -3253,6 +3254,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI$A" role="2iSdaV" />
     </node>
   </node>
   <node concept="PKFIW" id="1bwJEEeTsOh">
@@ -3263,13 +3265,13 @@
       <property role="S$Qs1" value="false" />
       <node concept="2iRkQZ" id="1bwJEEfE056" role="2iSdaV" />
       <node concept="3EZMnI" id="1bwJEEfE3rX" role="3EZMnx">
-        <node concept="2iRfu4" id="1bwJEEfE3rY" role="2iSdaV" />
         <node concept="3F0ifn" id="1bwJEEfE1PL" role="3EZMnx">
           <property role="3F0ifm" value="producer:" />
         </node>
         <node concept="3F1sOY" id="1bwJEEfE52C" role="3EZMnx">
           <ref role="1NtTu8" to="av4b:1bwJEEfE03W" resolve="producer" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$B" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="3yVmeSjNH1z" role="3EZMnx">
         <property role="S$Qs1" value="true" />
@@ -4434,13 +4436,13 @@
                                           <property role="Vb096" value="fLJRk5_/gray" />
                                         </node>
                                       </node>
-                                      <node concept="2iRfu4" id="7WrYb3e7k$h" role="2iSdaV" />
                                       <node concept="VPM3Z" id="7WrYb3e7k$i" role="3F10Kt">
                                         <property role="VOm3f" value="false" />
                                       </node>
                                       <node concept="3F1sOY" id="7WrYb3e7k$j" role="3EZMnx">
                                         <ref role="1NtTu8" to="av4b:1bwJEEfL7oM" resolve="outcome" />
                                       </node>
+                                      <node concept="l2Vlx" id="1ASK_HedI$C" role="2iSdaV" />
                                     </node>
                                   </node>
                                 </node>
@@ -4594,7 +4596,6 @@
     <node concept="3EZMnI" id="1bwJEEgrgye" role="2wV5jI">
       <node concept="2iRkQZ" id="1bwJEEgrgyf" role="2iSdaV" />
       <node concept="3EZMnI" id="1bwJEEfQxEa" role="3EZMnx">
-        <node concept="2iRfu4" id="1bwJEEfQxEb" role="2iSdaV" />
         <node concept="3F0ifn" id="1bwJEEfQxE7" role="3EZMnx">
           <property role="3F0ifm" value="function" />
         </node>
@@ -4607,18 +4608,18 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$D" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="1bwJEEgrgyu" role="3EZMnx">
-        <node concept="2iRfu4" id="1bwJEEgrgyv" role="2iSdaV" />
         <node concept="3F0ifn" id="1bwJEEgrgyN" role="3EZMnx">
           <property role="3F0ifm" value="results:" />
         </node>
         <node concept="3F0A7n" id="1bwJEEgrgyV" role="3EZMnx">
           <ref role="1NtTu8" to="av4b:1bwJEEgrgy9" resolve="checkResults" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$E" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="1qjbRymJMWS" role="3EZMnx">
-        <node concept="2iRfu4" id="1qjbRymJMWT" role="2iSdaV" />
         <node concept="3F0ifn" id="1qjbRymJMWU" role="3EZMnx">
           <property role="3F0ifm" value="mutator:" />
         </node>
@@ -4640,6 +4641,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$F" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -4654,7 +4656,6 @@
     <property role="3GE5qa" value="vector.testItem" />
     <ref role="1XX52x" to="av4b:3BFGe1EJa4q" resolve="VectorTestItem" />
     <node concept="3EZMnI" id="3BFGe1EJa6c" role="2wV5jI">
-      <node concept="2iRfu4" id="3BFGe1EJa6d" role="2iSdaV" />
       <node concept="3F0ifn" id="3BFGe1EJa69" role="3EZMnx">
         <property role="3F0ifm" value="vectors" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -4724,6 +4725,7 @@
       <node concept="3F1sOY" id="3BFGe1EJa6l" role="3EZMnx">
         <ref role="1NtTu8" to="av4b:3BFGe1EJa5G" resolve="vectors" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI$G" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3BFGe1EJa6M">
@@ -4741,22 +4743,22 @@
       <node concept="3EZMnI" id="7WSgHRL8$yA" role="3EZMnx">
         <node concept="2iRkQZ" id="7WSgHRL8$yB" role="2iSdaV" />
         <node concept="3EZMnI" id="7WSgHRL8$oF" role="3EZMnx">
-          <node concept="2iRfu4" id="7WSgHRL8$oG" role="2iSdaV" />
           <node concept="3F0ifn" id="7WSgHRL8$yy" role="3EZMnx">
             <property role="3F0ifm" value="# of mutations" />
           </node>
           <node concept="3F0A7n" id="1qjbRymJOHS" role="3EZMnx">
             <ref role="1NtTu8" to="av4b:3_xsRJ4W_Ua" resolve="numberOfMutations" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedI$H" role="2iSdaV" />
         </node>
         <node concept="3EZMnI" id="7WSgHRL8$z5" role="3EZMnx">
-          <node concept="2iRfu4" id="7WSgHRL8$z6" role="2iSdaV" />
           <node concept="3F0ifn" id="7WSgHRL8$yN" role="3EZMnx">
             <property role="3F0ifm" value="keep all:     " />
           </node>
           <node concept="3F0A7n" id="7WSgHRL8$zi" role="3EZMnx">
             <ref role="1NtTu8" to="av4b:7WSgHRL8$oC" resolve="keepAll" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedI$I" role="2iSdaV" />
         </node>
       </node>
       <node concept="3EZMnI" id="1qjbRymSXnD" role="3EZMnx">
@@ -4768,7 +4770,6 @@
           <ref role="1NtTu8" to="av4b:1qjbRymSXnX" resolve="logs" />
           <node concept="2iRkQZ" id="1qjbRymSXo5" role="2czzBx" />
         </node>
-        <node concept="2iRfu4" id="1qjbRymSXnI" role="2iSdaV" />
         <node concept="pkWqt" id="1qjbRymUCui" role="pqm2j">
           <node concept="3clFbS" id="1qjbRymUCuj" role="2VODD2">
             <node concept="3clFbF" id="1qjbRymUC_y" role="3cqZAp">
@@ -4784,6 +4785,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$J" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -4791,7 +4793,6 @@
     <property role="3GE5qa" value="mutator" />
     <ref role="1XX52x" to="av4b:1qjbRymN1gl" resolve="MutationLog" />
     <node concept="3EZMnI" id="1qjbRymSXn1" role="2wV5jI">
-      <node concept="2iRfu4" id="1qjbRymSXn2" role="2iSdaV" />
       <node concept="3F0ifn" id="1qjbRymN1h3" role="3EZMnx">
         <property role="3F0ifm" value="-&gt;" />
       </node>
@@ -4819,6 +4820,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI$K" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="1qjbRymQQx6">
@@ -5047,7 +5049,6 @@
       <node concept="3F1sOY" id="2NHHcg2$Pj6" role="3EZMnx">
         <ref role="1NtTu8" to="av4b:5kGo$yLJ8lv" resolve="expr" />
       </node>
-      <node concept="2iRfu4" id="2NHHcg2$Pj7" role="2iSdaV" />
       <node concept="3F0ifn" id="2NHHcg2$Pj8" role="3EZMnx">
         <property role="3F0ifm" value=")" />
         <node concept="11L4FC" id="2NHHcg2$Pj9" role="3F10Kt">
@@ -5057,6 +5058,7 @@
       <node concept="VPM3Z" id="46cplYwLY$f" role="3F10Kt">
         <property role="VOm3f" value="true" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI$L" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7aipPVpH2GM">
@@ -5075,9 +5077,7 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="ub9nkyHAcg" role="2iSdaV" />
       <node concept="3EZMnI" id="6HHp2WmTD6M" role="3EZMnx">
-        <node concept="2iRfu4" id="6HHp2WmTD6N" role="2iSdaV" />
         <node concept="PMmxH" id="14JXsMcwWyM" role="3EZMnx">
           <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -5094,6 +5094,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$N" role="2iSdaV" />
       </node>
       <node concept="3F1sOY" id="ub9nkyHAco" role="3EZMnx">
         <ref role="1NtTu8" to="av4b:7aipPVpH1LP" resolve="actual" />
@@ -5306,6 +5307,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI$M" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5Pgo_AS3PSR">
@@ -5314,13 +5316,13 @@
       <node concept="3EZMnI" id="5Pgo_ASpfT6" role="3EZMnx">
         <node concept="_tjkj" id="5Pgo_ASpfT7" role="3EZMnx">
           <node concept="3EZMnI" id="5Pgo_ASpfT8" role="_tjki">
-            <node concept="2iRfu4" id="5Pgo_ASpfT9" role="2iSdaV" />
             <node concept="3F1sOY" id="5Pgo_ASpfTa" role="3EZMnx">
               <ref role="1NtTu8" to="4kwy:cJpacq40jC" resolve="optionalName" />
             </node>
             <node concept="3F0ifn" id="5Pgo_ASpfTb" role="3EZMnx">
               <property role="3F0ifm" value="=" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedI$Q" role="2iSdaV" />
           </node>
           <node concept="ZYGn8" id="5Pgo_ASpfTc" role="ZWbT9">
             <node concept="3clFbS" id="5Pgo_ASpfTd" role="2VODD2">
@@ -5341,7 +5343,6 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="5Pgo_ASpfTg" role="2iSdaV" />
         <node concept="PMmxH" id="5Pgo_ASpfTh" role="3EZMnx">
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
           <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
@@ -5358,6 +5359,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$P" role="2iSdaV" />
       </node>
       <node concept="3F1sOY" id="5Pgo_AS3Q2g" role="3EZMnx">
         <ref role="1NtTu8" to="av4b:5Pgo_AS3PT3" resolve="value" />
@@ -5427,7 +5429,6 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="5Pgo_ASpb7$" role="2iSdaV" />
       <node concept="3tD6jV" id="5Pgo_ASpbXo" role="3F10Kt">
         <ref role="3tD7wE" to="z0fb:7ND7w4acsmT" resolve="_grid-layout-flatten" />
         <node concept="3sjG9q" id="5Pgo_ASpbXp" role="3tD6jU">
@@ -5496,6 +5497,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI$O" role="2iSdaV" />
     </node>
     <node concept="PMmxH" id="5Pgo_ASjauE" role="6VMZX">
       <ref role="PMmxG" node="5Pgo_ASgPrj" resolve="StackTrace_EditorComponent" />
@@ -5551,7 +5553,6 @@
     <node concept="3EZMnI" id="5Pgo_ASgPrk" role="2wV5jI">
       <node concept="2iRkQZ" id="5Pgo_ASgPrl" role="2iSdaV" />
       <node concept="3EZMnI" id="5Pgo_ASgPrm" role="3EZMnx">
-        <node concept="2iRfu4" id="5Pgo_ASgPrn" role="2iSdaV" />
         <node concept="3F0ifn" id="5Pgo_ASgPro" role="3EZMnx">
           <property role="3F0ifm" value="Constraint Failed:" />
         </node>
@@ -5630,9 +5631,9 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$R" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="5Pgo_ASgPrR" role="3EZMnx">
-        <node concept="2iRfu4" id="5Pgo_ASgPrS" role="2iSdaV" />
         <node concept="3XFhqQ" id="5Pgo_ASgPrT" role="3EZMnx" />
         <node concept="3F0ifn" id="5Pgo_ASgPrU" role="3EZMnx">
           <property role="3F0ifm" value="at" />
@@ -5804,6 +5805,7 @@
           </node>
           <node concept="2iRkQZ" id="5Pgo_ASgPt8" role="2czzBy" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$S" role="2iSdaV" />
       </node>
       <node concept="pkWqt" id="5Pgo_ASgPt9" role="pqm2j">
         <node concept="3clFbS" id="5Pgo_ASgPta" role="2VODD2">
@@ -6652,7 +6654,7 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="3boFcNpzAqc" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedI$T" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="1vo80oMm0r">
@@ -6662,7 +6664,6 @@
       <property role="S$Qs1" value="true" />
       <node concept="2iRkQZ" id="1vo80oMm0u" role="2iSdaV" />
       <node concept="3EZMnI" id="1vo80oMm0v" role="3EZMnx">
-        <node concept="2iRfu4" id="1vo80oMm0w" role="2iSdaV" />
         <node concept="PMmxH" id="1vo80oMm0x" role="3EZMnx">
           <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
         </node>
@@ -6672,6 +6673,7 @@
         <node concept="3F1sOY" id="1vo80oMm0z" role="3EZMnx">
           <ref role="1NtTu8" to="av4b:3_DFadNfZS8" resolve="scope" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$U" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="1gw9pCYhxSf" role="3EZMnx">
         <node concept="VPM3Z" id="1gw9pCYhxSh" role="3F10Kt" />
@@ -6680,7 +6682,6 @@
           <property role="3F0ifm" value="effective models:" />
           <ref role="1k5W1q" to="itrz:3_9S6lia_no" resolve="iets3PassiveText" />
         </node>
-        <node concept="2iRfu4" id="1gw9pCYhxSk" role="2iSdaV" />
         <node concept="gc7cB" id="1gw9pCYhyrI" role="3EZMnx">
           <ref role="1k5W1q" to="itrz:3_9S6lia_no" resolve="iets3PassiveText" />
           <node concept="3VJUX4" id="1gw9pCYhyrJ" role="3YsKMw">
@@ -6809,6 +6810,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$V" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="1vo80oMm0$" role="3EZMnx">
         <node concept="VPM3Z" id="1vo80oMm0_" role="3F10Kt">
@@ -6821,7 +6823,7 @@
         <node concept="27S6Sx" id="1vo80oMm0C" role="3EZMnx">
           <ref role="1NtTu8" to="av4b:18$bUx5D_ps" resolve="hideOK" />
         </node>
-        <node concept="2iRfu4" id="1vo80oMm0D" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedI$W" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="1vo80oMm0E" role="3EZMnx">
         <node concept="VPM3Z" id="1vo80oMm0F" role="3F10Kt">
@@ -6865,7 +6867,7 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="1vo80oMm0Y" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedI$X" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="3TIaSh_20yv" role="3EZMnx">
         <node concept="VPM3Z" id="3TIaSh_20yw" role="3F10Kt">
@@ -6875,7 +6877,6 @@
         <node concept="3F0ifn" id="3TIaSh_20yy" role="3EZMnx">
           <property role="3F0ifm" value="ignore:     " />
         </node>
-        <node concept="2iRfu4" id="3TIaSh_20yz" role="2iSdaV" />
         <node concept="3F2HdR" id="3TIaSh_20y$" role="3EZMnx">
           <property role="S$F3r" value="true" />
           <ref role="1NtTu8" to="av4b:3_DFadNcYyg" resolve="ignoredConcepts" />
@@ -6910,15 +6911,16 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$Y" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="1vo80oMm1k" role="AHCbl">
-        <node concept="2iRfu4" id="1vo80oMm1l" role="2iSdaV" />
         <node concept="PMmxH" id="1vo80oMm1m" role="3EZMnx">
           <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
         </node>
         <node concept="3F0ifn" id="1vo80oMm1n" role="3EZMnx">
           <property role="3F0ifm" value="{...}" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI$Z" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -6949,7 +6951,6 @@
     <property role="3GE5qa" value="assessment.models" />
     <ref role="1XX52x" to="av4b:1vo80oMkMQ" resolve="MeasureCoverageFor" />
     <node concept="3EZMnI" id="1vo80oMkNl" role="2wV5jI">
-      <node concept="2iRfu4" id="1vo80oMkNm" role="2iSdaV" />
       <node concept="3EZMnI" id="1vo80oY4fj" role="3EZMnx">
         <node concept="VPM3Z" id="1vo80oY4fl" role="3F10Kt">
           <property role="VOm3f" value="false" />
@@ -6975,7 +6976,7 @@
             <property role="VOm3f" value="true" />
           </node>
         </node>
-        <node concept="2iRfu4" id="1vo80oY4fo" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedI_1" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="1vo80p0QHM" role="3EZMnx">
         <property role="3F0ifm" value="complete?" />
@@ -6983,12 +6984,12 @@
       <node concept="27S6Sx" id="1vo80oWF6m" role="3EZMnx">
         <ref role="1NtTu8" to="av4b:1vo80oWF62" resolve="completeSubtree" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI_0" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7khFtBHvbuH">
     <ref role="1XX52x" to="av4b:7khFtBHvbuh" resolve="EvalAnythingExpr" />
     <node concept="3EZMnI" id="7khFtBHvbuM" role="2wV5jI">
-      <node concept="2iRfu4" id="7khFtBHvbuN" role="2iSdaV" />
       <node concept="3F0ifn" id="7khFtBHvbuJ" role="3EZMnx">
         <property role="3F0ifm" value="evalanything" />
         <ref role="1k5W1q" to="itrz:3R2njxnikay" resolve="iets3GreyText" />
@@ -7007,6 +7008,7 @@
         <property role="3F0ifm" value="]" />
         <ref role="1k5W1q" to="itrz:3R2njxnikay" resolve="iets3GreyText" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI_2" role="2iSdaV" />
     </node>
   </node>
   <node concept="PKFIW" id="48NC6VzSWwz">
@@ -7023,7 +7025,6 @@
           <property role="Vb096" value="fLwANPn/red" />
         </node>
       </node>
-      <node concept="2iRfu4" id="48NC6VzSWXm" role="2iSdaV" />
       <node concept="pkWqt" id="48NC6VzWphj" role="pqm2j">
         <node concept="3clFbS" id="48NC6VzWphk" role="2VODD2">
           <node concept="3clFbF" id="48NC6VzWpo9" role="3cqZAp">
@@ -7036,6 +7037,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI_3" role="2iSdaV" />
     </node>
   </node>
   <node concept="PKFIW" id="6vTsh3ZZ$b7">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -600,6 +600,7 @@
       <concept id="4682418030828844315" name="de.itemis.mps.editor.celllayout.structure.HorizontalLineColorStyle" flags="lg" index="2T_bXS" />
       <concept id="4682418030828844314" name="de.itemis.mps.editor.celllayout.structure.HorzontalLineWidthStyle" flags="lg" index="2T_bXT" />
       <concept id="4682418030828725523" name="de.itemis.mps.editor.celllayout.structure.HorizontalLineCell" flags="ng" index="2T_mXK" />
+      <concept id="2728748097294412051" name="de.itemis.mps.editor.celllayout.structure.PushXStyle" flags="lg" index="3T7XNW" />
       <concept id="2728748097294192922" name="de.itemis.mps.editor.celllayout.structure.IntegerStyle" flags="lg" index="3To2jP">
         <property id="1221209241505" name="value" index="1lJzqX" />
       </concept>
@@ -3078,8 +3079,13 @@
             </node>
           </node>
         </node>
-        <node concept="3XFhqQ" id="5VEHrQcW_$E" role="3EZMnx" />
-        <node concept="3XFhqQ" id="5VEHrQcW__u" role="3EZMnx" />
+        <node concept="3F0ifn" id="2tlTgwfAI5X" role="3EZMnx">
+          <property role="3F0ifm" value="" />
+          <node concept="VPM3Z" id="2tlTgwelJfS" role="3F10Kt" />
+          <node concept="3T7XNW" id="2tlTgwegFXM" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
         <node concept="3EZMnI" id="5VEHrQcYPrQ" role="3EZMnx">
           <node concept="VPM3Z" id="5VEHrQcYPrS" role="3F10Kt">
             <property role="VOm3f" value="false" />
@@ -3103,8 +3109,6 @@
           </node>
           <node concept="2iRkQZ" id="5VEHrQcYPrV" role="2iSdaV" />
         </node>
-        <node concept="3XFhqQ" id="5VEHrQcW_Af" role="3EZMnx" />
-        <node concept="3XFhqQ" id="5VEHrQcW_B2" role="3EZMnx" />
         <node concept="3F0ifn" id="5VEHrQcW_CQ" role="3EZMnx">
           <property role="3F0ifm" value="imports:" />
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -1658,7 +1658,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIuM" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwg5mYT" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7D7uZV2iYB6">
@@ -2871,7 +2871,7 @@
         </node>
         <node concept="l2Vlx" id="1ASK_HedIuT" role="2iSdaV" />
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIuS" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwg5lJz" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3Y6fbK1h_zj">
@@ -3393,7 +3393,7 @@
       <node concept="VPXOz" id="4ptnK4jbr0W" role="3F10Kt">
         <property role="VOm3f" value="true" />
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIv0" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwg5kld" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4ptnK4jbr1n">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/editor.mps
@@ -865,13 +865,13 @@
             <node concept="3F1sOY" id="69zaTr1GaWH" role="3EZMnx">
               <ref role="1NtTu8" to="hm2y:69zaTr1EKHX" resolve="type" />
             </node>
-            <node concept="2iRfu4" id="69zaTr1GaWx" role="2iSdaV" />
             <node concept="VPM3Z" id="69zaTr1GaWy" role="3F10Kt">
               <property role="VOm3f" value="false" />
             </node>
             <node concept="11L4FC" id="2KGel$SqWxl" role="3F10Kt">
               <property role="VOm3f" value="true" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIuD" role="2iSdaV" />
           </node>
           <node concept="uPpia" id="1ZlHRbgqWuB" role="1djCvC">
             <node concept="3clFbS" id="1ZlHRbgqWuC" role="2VODD2">
@@ -1114,7 +1114,6 @@
     <property role="3GE5qa" value="function" />
     <ref role="1XX52x" to="yv47:49WTic8hwXW" resolve="FunRef" />
     <node concept="3EZMnI" id="49WTic8hwYs" role="2wV5jI">
-      <node concept="2iRfu4" id="49WTic8hwYt" role="2iSdaV" />
       <node concept="3F0ifn" id="49WTic8hwYp" role="3EZMnx">
         <property role="3F0ifm" value=":" />
         <node concept="11LMrY" id="49WTic8hwZD" role="3F10Kt">
@@ -1130,6 +1129,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIuE" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="2uR5X5a$35O">
@@ -1255,13 +1255,13 @@
           <node concept="3F1sOY" id="69zaTr1HgT4" role="3EZMnx">
             <ref role="1NtTu8" to="hm2y:69zaTr1EKHX" resolve="type" />
           </node>
-          <node concept="2iRfu4" id="69zaTr1HgSS" role="2iSdaV" />
           <node concept="VPM3Z" id="69zaTr1HgST" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
           <node concept="11L4FC" id="5WJNTMT_1q1" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIuG" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqUxB" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqUxC" role="2VODD2">
@@ -1279,12 +1279,12 @@
       <node concept="3F1sOY" id="69zaTr1HgTI" role="3EZMnx">
         <ref role="1NtTu8" to="yv47:69zaTr1HgRN" resolve="value" />
       </node>
-      <node concept="2iRfu4" id="69zaTr1HgSr" role="2iSdaV" />
       <node concept="18a60v" id="_kNv2QrIUx" role="3EZMnx">
         <node concept="VPM3Z" id="_kNv2QrIUz" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIuF" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="ub9nkyGD9H">
@@ -1416,7 +1416,7 @@
         <node concept="3F0ifn" id="11foXHHQY7$" role="3EZMnx">
           <property role="3F0ifm" value="{" />
         </node>
-        <node concept="2iRfu4" id="11foXHHQXIs" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIuH" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="11foXHHQZJY" role="3EZMnx">
         <node concept="VPM3Z" id="11foXHHQZK0" role="3F10Kt">
@@ -1462,7 +1462,7 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="11foXHHQZK3" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIuI" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="11foXHHQYxy" role="3EZMnx">
         <node concept="VPM3Z" id="11foXHHQYx$" role="3F10Kt">
@@ -1495,7 +1495,6 @@
           </node>
         </node>
         <node concept="3EZMnI" id="3sWKo0DYLzM" role="3EZMnx">
-          <node concept="2iRfu4" id="3sWKo0DYLzN" role="2iSdaV" />
           <node concept="3F0ifn" id="3sWKo0DYLW2" role="3EZMnx">
             <property role="3F0ifm" value="with comparison order" />
             <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -1520,6 +1519,7 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIuK" role="2iSdaV" />
         </node>
         <node concept="_tjkj" id="11foXHHQYya" role="3EZMnx">
           <node concept="3F1sOY" id="11foXHHQYyb" role="_tjki">
@@ -1544,7 +1544,7 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="11foXHHQYxB" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIuJ" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="11foXHHQZ9r" role="AHCbl">
         <node concept="_tjkj" id="11foXHHQZ9s" role="3EZMnx">
@@ -1592,10 +1592,10 @@
         <node concept="3F0ifn" id="11foXHHQZ9w" role="3EZMnx">
           <property role="3F0ifm" value="{..}" />
         </node>
-        <node concept="2iRfu4" id="11foXHHQZ9x" role="2iSdaV" />
         <node concept="VPM3Z" id="11foXHHQZ9y" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIuL" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -1603,7 +1603,6 @@
     <property role="3GE5qa" value="record" />
     <ref role="1XX52x" to="yv47:7D7uZV2dYyT" resolve="RecordMember" />
     <node concept="3EZMnI" id="7D7uZV2e2L0" role="2wV5jI">
-      <node concept="2iRfu4" id="7D7uZV2e2L1" role="2iSdaV" />
       <node concept="1kIj98" id="7D7uZV2fCYT" role="3EZMnx">
         <node concept="3F0A7n" id="7D7uZV2e2KX" role="1kIj9b">
           <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
@@ -1659,6 +1658,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIuM" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7D7uZV2iYB6">
@@ -2091,7 +2091,6 @@
     <property role="3GE5qa" value="typedef" />
     <ref role="1XX52x" to="yv47:6HHp2WngtTC" resolve="Typedef" />
     <node concept="3EZMnI" id="6HHp2WngtUa" role="2wV5jI">
-      <node concept="2iRfu4" id="6HHp2WngtUb" role="2iSdaV" />
       <node concept="3F0ifn" id="6HHp2WngtU7" role="3EZMnx">
         <property role="3F0ifm" value="type" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -2153,6 +2152,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIuN" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6HHp2WngtVL">
@@ -2247,10 +2247,10 @@
           <node concept="3F1sOY" id="15mJ3JeHQ$X" role="3EZMnx">
             <ref role="1NtTu8" to="yv47:15mJ3JeHQzT" resolve="newValue" />
           </node>
-          <node concept="2iRfu4" id="15mJ3JeHQ_L" role="2iSdaV" />
           <node concept="VPM3Z" id="15mJ3JeHQ_M" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIuP" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="1ZlHRbgqWAX" role="1djCvC">
           <node concept="3clFbS" id="1ZlHRbgqWAY" role="2VODD2">
@@ -2262,7 +2262,7 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="15mJ3JeHQ$p" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIuO" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="15mJ3JeHR3J">
@@ -2428,8 +2428,8 @@
           <node concept="3F1sOY" id="wlV$3lAU9q" role="3EZMnx">
             <ref role="1NtTu8" to="yv47:6PMVc5H_jOd" resolve="order" />
           </node>
-          <node concept="2iRfu4" id="6ww1tcsEGEj" role="2iSdaV" />
           <node concept="VPM3Z" id="6ww1tcsEGEk" role="3F10Kt" />
+          <node concept="l2Vlx" id="1ASK_HedIuQ" role="2iSdaV" />
         </node>
       </node>
       <node concept="3F0ifn" id="365yA_NB4Ey" role="3EZMnx">
@@ -2696,13 +2696,13 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="3YhAT14Yx9m" role="2iSdaV" />
         <node concept="VPM3Z" id="3YhAT14Yx9n" role="3F10Kt">
           <property role="VOm3f" value="false" />
         </node>
         <node concept="3F0ifn" id="3YhAT14YyFY" role="3EZMnx">
           <property role="3F0ifm" value="{..}" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIuR" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -2813,7 +2813,6 @@
     <property role="3GE5qa" value="enum" />
     <ref role="1XX52x" to="yv47:67Y8mp$DMVh" resolve="EnumLiteral" />
     <node concept="3EZMnI" id="2S5yK$QHtFr" role="2wV5jI">
-      <node concept="2iRfu4" id="2S5yK$QHtFs" role="2iSdaV" />
       <node concept="1kIj98" id="3WWvqarUTDw" role="3EZMnx">
         <node concept="3F0A7n" id="3WWvqarUTDx" role="1kIj9b">
           <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
@@ -2844,7 +2843,6 @@
         </node>
       </node>
       <node concept="3EZMnI" id="3WWvqarUTDu" role="3EZMnx">
-        <node concept="2iRfu4" id="3WWvqarUTTe" role="2iSdaV" />
         <node concept="3F0ifn" id="3WWvqarUTD_" role="3EZMnx">
           <property role="3F0ifm" value="-&gt;" />
         </node>
@@ -2871,7 +2869,9 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIuT" role="2iSdaV" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIuS" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="3Y6fbK1h_zj">
@@ -2949,7 +2949,6 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="ub9nkyK62M" role="2iSdaV" />
         <node concept="3F0ifn" id="ub9nkyK62I" role="3EZMnx">
           <property role="3F0ifm" value="library" />
           <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -3119,6 +3118,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIuU" role="2iSdaV" />
       </node>
       <node concept="gc7cB" id="4tXyFaWwywB" role="3EZMnx">
         <node concept="3VJUX4" id="4tXyFaWwywD" role="3YsKMw">
@@ -3175,7 +3175,6 @@
     <property role="3GE5qa" value="record" />
     <ref role="1XX52x" to="yv47:6JZACDWOa9c" resolve="ReferenceableFlag" />
     <node concept="3EZMnI" id="6JZACDWRoq3" role="2wV5jI">
-      <node concept="2iRfu4" id="6JZACDWRoq4" role="2iSdaV" />
       <node concept="3F0ifn" id="6JZACDWOa9C" role="3EZMnx">
         <property role="3F0ifm" value="referenceable" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -3204,13 +3203,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIuV" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7cphKbKnKSa">
     <property role="3GE5qa" value="record.group" />
     <ref role="1XX52x" to="yv47:7cphKbKnKRF" resolve="GroupType" />
     <node concept="3EZMnI" id="7cphKbKnKSc" role="2wV5jI">
-      <node concept="2iRfu4" id="7cphKbKnKSd" role="2iSdaV" />
       <node concept="3F0ifn" id="7cphKbKnKSi" role="3EZMnx">
         <property role="3F0ifm" value="group" />
         <ref role="1k5W1q" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
@@ -3247,6 +3246,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIuW" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7cphKbKssKm">
@@ -3267,7 +3267,6 @@
     <property role="3GE5qa" value="record.project" />
     <ref role="1XX52x" to="yv47:7cphKbLawNf" resolve="InlineRecordType" />
     <node concept="3EZMnI" id="7cphKbLhAKV" role="2wV5jI">
-      <node concept="2iRfu4" id="7cphKbLhAKW" role="2iSdaV" />
       <node concept="3F0ifn" id="7cphKbLawOi" role="3EZMnx">
         <property role="3F0ifm" value="record" />
         <ref role="1k5W1q" to="itrz:7D7uZV2g_XJ" resolve="iets3Type" />
@@ -3297,13 +3296,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIuX" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7cphKbLawP9">
     <property role="3GE5qa" value="record.project" />
     <ref role="1XX52x" to="yv47:7cphKbLawOC" resolve="ProjectMember" />
     <node concept="3EZMnI" id="7cphKbLawPk" role="2wV5jI">
-      <node concept="2iRfu4" id="7cphKbLawPl" role="2iSdaV" />
       <node concept="1kIj98" id="7cphKbLf0BF" role="3EZMnx">
         <property role="3g2DhO" value="true" />
         <node concept="3F0A7n" id="7cphKbLawPh" role="1kIj9b">
@@ -3316,13 +3315,13 @@
       <node concept="3F1sOY" id="7cphKbLawP_" role="3EZMnx">
         <ref role="1NtTu8" to="yv47:7cphKbLawOI" resolve="expr" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIuY" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7cphKbLawQ5">
     <property role="3GE5qa" value="record.project" />
     <ref role="1XX52x" to="yv47:7cphKbLawO$" resolve="ProjectOp" />
     <node concept="3EZMnI" id="7cphKbLawQd" role="2wV5jI">
-      <node concept="2iRfu4" id="7cphKbLawQe" role="2iSdaV" />
       <node concept="3F0ifn" id="7cphKbLawQa" role="3EZMnx">
         <property role="3F0ifm" value="project" />
       </node>
@@ -3352,6 +3351,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIuZ" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7cphKbLg8AO">
@@ -3390,10 +3390,10 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="2iRfu4" id="4ptnK4jbr0y" role="2iSdaV" />
       <node concept="VPXOz" id="4ptnK4jbr0W" role="3F10Kt">
         <property role="VOm3f" value="true" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIv0" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4ptnK4jbr1n">
@@ -3425,10 +3425,9 @@
             <property role="VOm3f" value="true" />
           </node>
         </node>
-        <node concept="2iRfu4" id="4ptnK4jbr8m" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIv1" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="7FXEnEy69oF" role="3v87hO">
-        <node concept="2iRfu4" id="7FXEnEy69oG" role="2iSdaV" />
         <node concept="3F2HdR" id="4ptnK4jbr8v" role="3EZMnx">
           <ref role="1NtTu8" to="yv47:4ptnK4jbqZD" resolve="elements" />
           <node concept="2EHx9g" id="4ptnK4jbr8y" role="2czzBx" />
@@ -3513,6 +3512,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIv2" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -4215,7 +4215,6 @@
       </node>
     </node>
     <node concept="3EZMnI" id="7rdMSLlhFCc" role="6VMZX">
-      <node concept="2iRfu4" id="7rdMSLlhFCd" role="2iSdaV" />
       <node concept="3F0ifn" id="7rdMSLlhFKZ" role="3EZMnx">
         <property role="3F0ifm" value="reduced:" />
       </node>
@@ -4240,6 +4239,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIv3" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6WstIz8MKZE">
@@ -4265,7 +4265,6 @@
     <property role="3GE5qa" value="enum" />
     <ref role="1XX52x" to="yv47:4zsmO3KtfVR" resolve="QualifierRef" />
     <node concept="3EZMnI" id="4zsmO3KtfWP" role="2wV5jI">
-      <node concept="2iRfu4" id="4zsmO3KtfWQ" role="2iSdaV" />
       <node concept="1kIj98" id="4zsmO3KzJas" role="3EZMnx">
         <node concept="1iCGBv" id="4zsmO3KtfWn" role="1kIj9b">
           <ref role="1NtTu8" to="yv47:4zsmO3KtfVS" resolve="enum" />
@@ -4307,13 +4306,13 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIv4" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="2zwra1$Qiir">
     <property role="3GE5qa" value="enum" />
     <ref role="1XX52x" to="yv47:2zwra1$QhrC" resolve="AllLitList" />
     <node concept="3EZMnI" id="2zwra1$QitW" role="2wV5jI">
-      <node concept="2iRfu4" id="2zwra1$QitX" role="2iSdaV" />
       <node concept="3F0ifn" id="2zwra1$Qilk" role="3EZMnx">
         <property role="3F0ifm" value="literals" />
       </node>
@@ -4335,6 +4334,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIv5" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="c36CPsxPxs">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tracing/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tracing/models/editor.mps
@@ -49,7 +49,6 @@
       <concept id="6822301196700715228" name="jetbrains.mps.lang.editor.structure.ConceptEditorHintDeclarationReference" flags="ig" index="2aJ2om">
         <reference id="5944657839026714445" name="hint" index="2$4xQ3" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
@@ -420,11 +419,11 @@
       <node concept="3EZMnI" id="5U8d23QoQx9" role="1QoS34">
         <node concept="3j0QqT" id="5U8d23QobMD" role="3EZMnx">
           <node concept="3EZMnI" id="7cNsFS_gJuD" role="3j0Cwz">
-            <node concept="2iRfu4" id="7cNsFS_gJuE" role="2iSdaV" />
             <node concept="Rtstu" id="7cNsFS_gJuF" role="3EZMnx" />
             <node concept="2R9Tw8" id="7cNsFS_gJuG" role="3F10Kt">
               <property role="VOm3f" value="true" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIzj" role="2iSdaV" />
           </node>
           <node concept="Veino" id="5U8d23QsP3$" role="3F10Kt">
             <node concept="3ZlJ5R" id="5U8d23QsP3G" role="VblUZ">
@@ -626,13 +625,12 @@
       </node>
       <node concept="3EZMnI" id="5U8d23Qpo3F" role="1QoVPY">
         <node concept="3EZMnI" id="5U8d23Qpo3H" role="3EZMnx">
-          <node concept="2iRfu4" id="5U8d23Qpo3I" role="2iSdaV" />
           <node concept="Rtstu" id="5U8d23Qpo3J" role="3EZMnx" />
           <node concept="2R9Tw8" id="5U8d23Qpo3K" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIzl" role="2iSdaV" />
         </node>
-        <node concept="2iRfu4" id="5U8d23Qppl6" role="2iSdaV" />
         <node concept="2R9Tw8" id="5U8d23Qpo42" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
@@ -787,6 +785,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIzk" role="2iSdaV" />
       </node>
     </node>
     <node concept="Rtstu" id="1OitGwf5Zbs" role="6VMZX" />
@@ -899,11 +898,11 @@
       </node>
       <node concept="3EZMnI" id="2CFPPn7pH8D" role="1QoS34">
         <node concept="3EZMnI" id="2CFPPn7pH8E" role="3EZMnx">
-          <node concept="2iRfu4" id="2CFPPn7pH8F" role="2iSdaV" />
           <node concept="Rtstu" id="2CFPPn7pH8G" role="3EZMnx" />
           <node concept="2R9Tw8" id="2CFPPn7pH8H" role="3F10Kt">
             <property role="VOm3f" value="true" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIzm" role="2iSdaV" />
         </node>
         <node concept="2T_mXK" id="2CFPPn7pH8I" role="3EZMnx">
           <node concept="2T_bXS" id="2CFPPn7pH8J" role="3F10Kt">
@@ -1066,7 +1065,7 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="2CFPPn7pH9N" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIzn" role="2iSdaV" />
       </node>
     </node>
     <node concept="2aJ2om" id="2CFPPn7pIcN" role="CpUAK">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.bindingtime/models/org.iets3.core.expr.typetags.bindingtime.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.bindingtime/models/org.iets3.core.expr.typetags.bindingtime.editor.mps
@@ -21,7 +21,7 @@
       </concept>
       <concept id="2000375450116423800" name="jetbrains.mps.lang.editor.structure.SubstituteMenu" flags="ng" index="22mcaB" />
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
@@ -132,7 +132,6 @@
   <node concept="24kQdi" id="2tub4U54K1C">
     <ref role="1XX52x" to="n0mj:2tub4U54J$L" resolve="BTDeclaration" />
     <node concept="3EZMnI" id="2tub4U558n4" role="2wV5jI">
-      <node concept="2iRfu4" id="2tub4U558n5" role="2iSdaV" />
       <node concept="1kHk_G" id="2tub4U558nn" role="3EZMnx">
         <property role="ZjSer" value="initial" />
         <ref role="1NtTu8" to="n0mj:2tub4U558ns" resolve="initial" />
@@ -145,17 +144,16 @@
       </node>
       <node concept="_tjkj" id="13eh33rv6Ys" role="3EZMnx">
         <node concept="3EZMnI" id="13eh33rvixT" role="_tjki">
-          <node concept="2iRfu4" id="13eh33rvixU" role="2iSdaV" />
           <node concept="3F0ifn" id="13eh33rviy2" role="3EZMnx">
             <property role="3F0ifm" value=":" />
           </node>
           <node concept="3F1sOY" id="1YvM8qoU5iM" role="3EZMnx">
             <ref role="1NtTu8" to="n0mj:1YvM8qoU5bg" resolve="group" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedI_a" role="2iSdaV" />
         </node>
       </node>
       <node concept="3EZMnI" id="1SyV1pw9flw" role="3EZMnx">
-        <node concept="2iRfu4" id="1SyV1pw9flx" role="2iSdaV" />
         <node concept="3F0ifn" id="1YvM8qoUBqA" role="3EZMnx">
           <property role="3F0ifm" value="after:" />
         </node>
@@ -176,7 +174,9 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI_b" role="2iSdaV" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI_9" role="2iSdaV" />
     </node>
   </node>
   <node concept="PKFIW" id="2tub4U558nu">
@@ -255,7 +255,6 @@
   <node concept="24kQdi" id="13eh33ruPOk">
     <ref role="1XX52x" to="n0mj:13eh33ruPNR" resolve="BTGroup" />
     <node concept="3EZMnI" id="13eh33ruPOm" role="2wV5jI">
-      <node concept="2iRfu4" id="13eh33ruPOn" role="2iSdaV" />
       <node concept="1kHk_G" id="5XGFpL9THzr" role="3EZMnx">
         <property role="ZjSer" value="initial" />
         <ref role="1NtTu8" to="n0mj:5XGFpL9THzj" resolve="initial" />
@@ -267,7 +266,6 @@
         <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
       </node>
       <node concept="3EZMnI" id="5XGFpL9UL7x" role="3EZMnx">
-        <node concept="2iRfu4" id="5XGFpL9UL7y" role="2iSdaV" />
         <node concept="3F0ifn" id="5XGFpL9UL7E" role="3EZMnx">
           <property role="3F0ifm" value="after:" />
         </node>
@@ -288,7 +286,9 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedI_d" role="2iSdaV" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI_c" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="1YvM8qoUtPr">
@@ -318,7 +318,6 @@
   <node concept="24kQdi" id="2ahKK8qLgk_">
     <ref role="1XX52x" to="n0mj:1YvM8qoUB$9" resolve="BTDeclarationRef" />
     <node concept="3EZMnI" id="2ahKK8qLgkB" role="2wV5jI">
-      <node concept="2iRfu4" id="2ahKK8qLgkC" role="2iSdaV" />
       <node concept="1iCGBv" id="2ahKK8qLgkH" role="3EZMnx">
         <ref role="1NtTu8" to="n0mj:1YvM8qoUB$a" resolve="stage" />
         <node concept="1sVBvm" id="2ahKK8qLgkJ" role="1sWHZn">
@@ -328,6 +327,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI_e" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.lib/models/org/iets3/core/expr/typetags/lib/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.lib/models/org/iets3/core/expr/typetags/lib/editor.mps
@@ -12,7 +12,6 @@
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
@@ -147,7 +146,6 @@
   <node concept="24kQdi" id="sflsE7peFn">
     <ref role="1XX52x" to="f3o0:sflsE7peCK" resolve="StorePatientData" />
     <node concept="3EZMnI" id="sflsE7peFs" role="2wV5jI">
-      <node concept="2iRfu4" id="sflsE7peFt" role="2iSdaV" />
       <node concept="3F0ifn" id="sflsE7peFp" role="3EZMnx">
         <property role="3F0ifm" value="db-store*" />
       </node>
@@ -211,6 +209,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIsS" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="sflsE7piEi">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.editor.mps
@@ -12,6 +12,7 @@
     <use id="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" name="com.mbeddr.mpsutil.editor.querylist" version="0" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <use id="b1ab8c10-c118-4755-bf2a-cebab35cf533" name="jetbrains.mps.lang.editor.tooltips" version="0" />
+    <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
     <devkit ref="2677cb18-f558-4e33-bc38-a5139cee06dc(jetbrains.mps.devkit.language-design)" />
   </languages>
   <imports>
@@ -521,6 +522,9 @@
       <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
         <child id="8182547171709752112" name="expression" index="36biLW" />
       </concept>
+    </language>
+    <language id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout">
+      <concept id="9000758320091481718" name="de.itemis.mps.editor.celllayout.structure.GridLayoutFlattenStyle" flags="lg" index="1QQdxR" />
     </language>
     <language id="120e1c9d-4e27-4478-b2af-b2c3bd3850b0" name="com.mbeddr.mpsutil.editor.querylist">
       <concept id="6202678563380238499" name="com.mbeddr.mpsutil.editor.querylist.structure.Function_GetElements" flags="ig" index="s8sZD" />
@@ -1446,7 +1450,7 @@
             </node>
           </node>
         </node>
-        <node concept="l2Vlx" id="1ASK_HedItw" role="2iSdaV" />
+        <node concept="2iRfu4" id="2tlTgwg5x0n" role="2iSdaV" />
       </node>
       <node concept="PMmxH" id="2x0M_l2ibai" role="3EZMnx">
         <ref role="PMmxG" node="2x0M_l2iaKJ" resolve="ImplicitConversionSpecifier" />
@@ -4066,7 +4070,10 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedItL" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwg5xes" role="2iSdaV" />
+      <node concept="1QQdxR" id="2tlTgwg8MP3" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
     </node>
   </node>
   <node concept="22mcaB" id="15KrVXSF0u_">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.editor.mps
@@ -674,7 +674,6 @@
   <node concept="24kQdi" id="3j3yk3gAqyD">
     <ref role="1XX52x" to="i3ya:3j3yk3gAgiT" resolve="FractionalExponent" />
     <node concept="3EZMnI" id="29E2s0GMudK" role="2wV5jI">
-      <node concept="2iRfu4" id="29E2s0GMudL" role="2iSdaV" />
       <node concept="3F1sOY" id="3j3yk3gAqzu" role="3EZMnx">
         <ref role="1NtTu8" to="i3ya:3j3yk3gAnBu" resolve="fraction" />
         <node concept="3tD6jV" id="29E2s0GLFg4" role="3F10Kt">
@@ -690,6 +689,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIto" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7eOyx9r3lrf">
@@ -803,7 +803,6 @@
       </node>
       <node concept="3EZMnI" id="7yw1DU9hK3i" role="1j7Clw">
         <ref role="1k5W1q" node="4M31vJayoGp" resolve="UnitTag" />
-        <node concept="2iRfu4" id="7yw1DU9hK3j" role="2iSdaV" />
         <node concept="130CD5" id="7i1yFLlYnbZ" role="3EZMnx">
           <node concept="3F0A7n" id="7i1yFLkUqB7" role="130CDr">
             <ref role="1NtTu8" to="i3ya:7Bmg9OopAyq" resolve="prefix" />
@@ -941,6 +940,7 @@
             <ref role="2ZyFGn" to="i3ya:7eOyx9r3kR5" resolve="UnitReference" />
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedItp" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -948,7 +948,6 @@
     <property role="3GE5qa" value="definition.unit" />
     <ref role="1XX52x" to="i3ya:7eOyx9r3k4t" resolve="UnitSpecification" />
     <node concept="3EZMnI" id="7Bmg9OopAEY" role="2wV5jI">
-      <node concept="2iRfu4" id="7Bmg9OopAEZ" role="2iSdaV" />
       <node concept="VPM3Z" id="7i1yFLkY3Ie" role="3F10Kt" />
       <node concept="3F1sOY" id="69ocqYc1NTc" role="3EZMnx">
         <ref role="1NtTu8" to="i3ya:7eOyx9r3qG3" resolve="specification" />
@@ -956,6 +955,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItq" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7eOyx9r3k4P">
@@ -1013,7 +1013,6 @@
       </node>
       <node concept="_tjkj" id="3NjH4t$gA$D" role="3EZMnx">
         <node concept="3EZMnI" id="3NjH4t$gAFV" role="_tjki">
-          <node concept="2iRfu4" id="3NjH4t$gAFW" role="2iSdaV" />
           <node concept="3F0ifn" id="3NjH4t$gADQ" role="3EZMnx">
             <property role="3F0ifm" value="named" />
             <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -1021,6 +1020,7 @@
           <node concept="3F0A7n" id="3NjH4t$gAKW" role="3EZMnx">
             <ref role="1NtTu8" to="i3ya:3NjH4t$gA9B" resolve="unitName" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedItr" role="2iSdaV" />
         </node>
         <node concept="uPpia" id="7at3vyOjE$H" role="1djCvC">
           <node concept="3clFbS" id="7at3vyOjE$I" role="2VODD2">
@@ -1034,7 +1034,6 @@
       </node>
       <node concept="l2Vlx" id="7eOyx9r3k5H" role="2iSdaV" />
       <node concept="3EZMnI" id="7Bmg9Oo7Lqu" role="3EZMnx">
-        <node concept="2iRfu4" id="7Bmg9Oo7Lqv" role="2iSdaV" />
         <node concept="3F0ifn" id="7Bmg9Oo7MT7" role="3EZMnx">
           <property role="3F0ifm" value=":=" />
         </node>
@@ -1053,6 +1052,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIts" role="2iSdaV" />
       </node>
       <node concept="3F0ifn" id="y826GHGI1W" role="3EZMnx">
         <property role="3F0ifm" value="for" />
@@ -1105,7 +1105,6 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="7Mca05npLr2" role="2iSdaV" />
         <node concept="3F0ifn" id="7Mca05npLr3" role="3EZMnx">
           <property role="3F0ifm" value="SI base unit equivalents" />
         </node>
@@ -1134,9 +1133,9 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedItt" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="4RImAbiep55" role="3EZMnx">
-        <node concept="2iRfu4" id="4RImAbiep56" role="2iSdaV" />
         <node concept="1HlG4h" id="HeBpFZ72X" role="3EZMnx">
           <node concept="1HfYo3" id="HeBpFZ72Z" role="1HlULh">
             <node concept="3TQlhw" id="HeBpFZ731" role="1Hhtcw">
@@ -1197,6 +1196,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedItu" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -1383,7 +1383,6 @@
       <node concept="2iRkQZ" id="1wGuEUvY7Wd" role="2iSdaV" />
     </node>
     <node concept="3EZMnI" id="3wrpJuqGxRh" role="6VMZX">
-      <node concept="2iRfu4" id="3wrpJuqGxRi" role="2iSdaV" />
       <node concept="3F0ifn" id="3wrpJuqGxJ6" role="3EZMnx">
         <property role="3F0ifm" value="implicit priority:" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -1405,6 +1404,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItv" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5Q6EZP5OOQc">
@@ -1433,7 +1433,6 @@
     <node concept="3EZMnI" id="yGiRIEWR7M" role="6VMZX">
       <node concept="2EHx9g" id="y826GHGCuw" role="2iSdaV" />
       <node concept="3EZMnI" id="y826GHGCuz" role="3EZMnx">
-        <node concept="2iRfu4" id="y826GHGCu$" role="2iSdaV" />
         <node concept="3F0ifn" id="yGiRIEWR87" role="3EZMnx">
           <property role="3F0ifm" value="conversion specifier:" />
           <ref role="1k5W1q" to="r4b4:2CEi94e3iKI" resolve="PassiveText" />
@@ -1447,6 +1446,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedItw" role="2iSdaV" />
       </node>
       <node concept="PMmxH" id="2x0M_l2ibai" role="3EZMnx">
         <ref role="PMmxG" node="2x0M_l2iaKJ" resolve="ImplicitConversionSpecifier" />
@@ -1649,7 +1649,6 @@
     <property role="3GE5qa" value="definition.conversion" />
     <ref role="1XX52x" to="i3ya:7SygLIkPJP$" resolve="ConvertToTarget" />
     <node concept="3EZMnI" id="7SygLIkPQOx" role="2wV5jI">
-      <node concept="2iRfu4" id="7SygLIkPQOy" role="2iSdaV" />
       <node concept="PMmxH" id="7SygLIkPQOE" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -1672,11 +1671,11 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItx" role="2iSdaV" />
     </node>
     <node concept="3EZMnI" id="2x0M_l2ibdE" role="6VMZX">
       <node concept="2iRkQZ" id="2x0M_l2ibdF" role="2iSdaV" />
       <node concept="3EZMnI" id="2x0M_l2ibKv" role="3EZMnx">
-        <node concept="2iRfu4" id="2x0M_l2ibKw" role="2iSdaV" />
         <node concept="3F0ifn" id="2x0M_l2ibKx" role="3EZMnx">
           <property role="3F0ifm" value="conversion specifier:" />
           <ref role="1k5W1q" to="r4b4:2CEi94e3iKI" resolve="PassiveText" />
@@ -1690,6 +1689,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIty" role="2iSdaV" />
       </node>
       <node concept="PMmxH" id="2x0M_l2ibjI" role="3EZMnx">
         <ref role="PMmxG" node="2x0M_l2iaKJ" resolve="ImplicitConversionSpecifier" />
@@ -2556,7 +2556,6 @@
     <property role="3GE5qa" value="group" />
     <ref role="1XX52x" to="i3ya:1KUmgSFpwWn" resolve="Quantity" />
     <node concept="3EZMnI" id="1KUmgSFw7kf" role="2wV5jI">
-      <node concept="2iRfu4" id="1KUmgSFw7kg" role="2iSdaV" />
       <node concept="1kHk_G" id="7Bmg9Oo3Wqe" role="3EZMnx">
         <ref role="1NtTu8" to="i3ya:7Bmg9Oo3Vr1" resolve="derived" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -2606,7 +2605,6 @@
       </node>
       <node concept="_tjkj" id="4RImAbhz5OU" role="3EZMnx">
         <node concept="3EZMnI" id="4RImAbhz67P" role="_tjki">
-          <node concept="2iRfu4" id="4RImAbhz67Q" role="2iSdaV" />
           <node concept="3F0ifn" id="4GF8daWuyES" role="3EZMnx">
             <property role="3F0ifm" value="with" />
             <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -2633,10 +2631,10 @@
           <node concept="3F1sOY" id="4RImAbi57qp" role="3EZMnx">
             <ref role="1NtTu8" to="i3ya:4RImAbi2thS" resolve="dimension" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIt$" role="2iSdaV" />
         </node>
       </node>
       <node concept="3EZMnI" id="7Bmg9Oo3W_i" role="3EZMnx">
-        <node concept="2iRfu4" id="7Bmg9Oo3W_j" role="2iSdaV" />
         <node concept="3F0ifn" id="7Bmg9Oo3WDr" role="3EZMnx">
           <property role="3F0ifm" value=":=" />
         </node>
@@ -2655,11 +2653,12 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIt_" role="2iSdaV" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItz" role="2iSdaV" />
     </node>
     <node concept="3EZMnI" id="4RImAbhQ0RM" role="6VMZX">
       <node concept="3EZMnI" id="9M53mHMg4h" role="3EZMnx">
-        <node concept="2iRfu4" id="9M53mHMg4i" role="2iSdaV" />
         <node concept="3F0ifn" id="9M53mHMg4j" role="3EZMnx">
           <property role="3F0ifm" value="Symbol definition" />
         </node>
@@ -2683,10 +2682,10 @@
             <ref role="2$4xQ3" node="9M53mHJmiY" resolve="quantityReferenceAsSymbol" />
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedItA" role="2iSdaV" />
       </node>
       <node concept="2iRkQZ" id="4RImAbhQ0RN" role="2iSdaV" />
       <node concept="3EZMnI" id="4RImAbildag" role="3EZMnx">
-        <node concept="2iRfu4" id="4RImAbildah" role="2iSdaV" />
         <node concept="3F0ifn" id="4RImAbildai" role="3EZMnx">
           <property role="3F0ifm" value="SI base quantity equivalents" />
         </node>
@@ -2753,6 +2752,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedItB" role="2iSdaV" />
       </node>
       <node concept="1QoScp" id="9M53mH$Q6g" role="3EZMnx">
         <property role="1QpmdY" value="true" />
@@ -2785,7 +2785,6 @@
           </node>
         </node>
         <node concept="3EZMnI" id="4RImAbhDSJI" role="1QoS34">
-          <node concept="2iRfu4" id="4RImAbhDSJJ" role="2iSdaV" />
           <node concept="1HlG4h" id="HeBpFXdqC" role="3EZMnx">
             <node concept="1HfYo3" id="HeBpFXdqE" role="1HlULh">
               <node concept="3TQlhw" id="HeBpFXdqG" role="1Hhtcw">
@@ -2846,9 +2845,9 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedItC" role="2iSdaV" />
         </node>
         <node concept="3EZMnI" id="5noD5lk8d7w" role="1QoVPY">
-          <node concept="2iRfu4" id="5noD5lk8d7x" role="2iSdaV" />
           <node concept="1HlG4h" id="HeBpFXdFE" role="3EZMnx">
             <node concept="Vb9p2" id="1assitbaW2j" role="3F10Kt">
               <property role="Vbekb" value="g1_k_vY/BOLD" />
@@ -2878,10 +2877,10 @@
           <node concept="3F1sOY" id="4RImAbilfI2" role="3EZMnx">
             <ref role="1NtTu8" to="i3ya:4RImAbi2thS" resolve="dimension" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedItD" role="2iSdaV" />
         </node>
       </node>
       <node concept="3EZMnI" id="1eut2uU9B6y" role="3EZMnx">
-        <node concept="2iRfu4" id="1eut2uU9B6z" role="2iSdaV" />
         <node concept="3F0ifn" id="1eut2uU9ANe" role="3EZMnx">
           <property role="3F0ifm" value="Transformation properties" />
         </node>
@@ -2890,6 +2889,7 @@
           <ref role="1NtTu8" to="i3ya:1eut2uU9_A6" resolve="transformationProperties" />
           <node concept="2iRfu4" id="1eut2uU9BJN" role="2czzBx" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedItE" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -2897,11 +2897,11 @@
     <property role="3GE5qa" value="group" />
     <ref role="1XX52x" to="i3ya:7athFveyQjs" resolve="QuantitySpecification" />
     <node concept="3EZMnI" id="mfJ1vOPOcv" role="2wV5jI">
-      <node concept="2iRfu4" id="mfJ1vOPOcw" role="2iSdaV" />
       <node concept="3F1sOY" id="7athFveCzEb" role="3EZMnx">
         <ref role="1NtTu8" to="i3ya:7athFveyQy5" resolve="specification" />
       </node>
       <node concept="VPM3Z" id="mfJ1vOPOf1" role="3F10Kt" />
+      <node concept="l2Vlx" id="1ASK_HedItF" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7athFve$gLZ">
@@ -2991,7 +2991,6 @@
           </node>
         </node>
         <node concept="3EZMnI" id="7zq8U7tZXu7" role="jn6J4">
-          <node concept="2iRfu4" id="7zq8U7tZXu8" role="2iSdaV" />
           <node concept="3F0ifn" id="7zq8U7tZXu9" role="3EZMnx">
             <property role="3F0ifm" value="(" />
             <node concept="11LMrY" id="7zq8U7tZXua" role="3F10Kt">
@@ -3060,6 +3059,7 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedItG" role="2iSdaV" />
         </node>
       </node>
       <node concept="2ElW$n" id="7athFveAtG5" role="2El2Yn">
@@ -3083,7 +3083,6 @@
     <ref role="1XX52x" to="i3ya:7athFveCYSy" resolve="QuantityMultiplication" />
     <node concept="1WcQYu" id="7Bmg9Oo32Eb" role="2wV5jI">
       <node concept="3EZMnI" id="7athFveD0EN" role="1LiK7o">
-        <node concept="2iRfu4" id="7athFveD0EO" role="2iSdaV" />
         <node concept="1kIj98" id="7Bmg9Oo337d" role="3EZMnx">
           <node concept="3F1sOY" id="7athFveD0AG" role="1kIj9b">
             <ref role="1NtTu8" to="i3ya:1JynhuWn9Pn" resolve="left" />
@@ -3143,6 +3142,7 @@
             <ref role="1NtTu8" to="i3ya:1JynhuWna1Z" resolve="right" />
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedItH" role="2iSdaV" />
       </node>
       <node concept="2ElW$n" id="73cP8DpHpNs" role="2El2Yn" />
     </node>
@@ -3414,7 +3414,6 @@
     <property role="3GE5qa" value="group.typesystem" />
     <ref role="1XX52x" to="i3ya:45a4DYZrLdN" resolve="QuantityMultiplicationType" />
     <node concept="3EZMnI" id="45a4DYZOUYB" role="2wV5jI">
-      <node concept="2iRfu4" id="45a4DYZOUYC" role="2iSdaV" />
       <node concept="3F1sOY" id="45a4DYZOUVI" role="3EZMnx">
         <ref role="1NtTu8" to="i3ya:1JynhuWn50F" resolve="left" />
       </node>
@@ -3430,6 +3429,7 @@
       <node concept="3F1sOY" id="45a4DYZOVeb" role="3EZMnx">
         <ref role="1NtTu8" to="i3ya:1JynhuWn5at" resolve="right" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItI" role="2iSdaV" />
     </node>
   </node>
   <node concept="22mcaB" id="1JynhuWk3hZ">
@@ -3613,7 +3613,6 @@
     <ref role="1XX52x" to="i3ya:7i1yFLksg8d" resolve="UnitMultiplication" />
     <node concept="1WcQYu" id="7i1yFLkshmw" role="2wV5jI">
       <node concept="3EZMnI" id="7i1yFLkshmx" role="1LiK7o">
-        <node concept="2iRfu4" id="7i1yFLkshmy" role="2iSdaV" />
         <node concept="1kIj98" id="7i1yFLkshmz" role="3EZMnx">
           <node concept="3F1sOY" id="7i1yFLkshm$" role="1kIj9b">
             <ref role="1NtTu8" to="i3ya:7i1yFLksgFY" resolve="left" />
@@ -3713,6 +3712,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedItJ" role="2iSdaV" />
       </node>
       <node concept="2ElW$n" id="7i1yFLkshmC" role="2El2Yn" />
     </node>
@@ -3755,7 +3755,6 @@
           </node>
         </node>
         <node concept="3EZMnI" id="7zq8U7tXyKt" role="jn6J4">
-          <node concept="2iRfu4" id="7zq8U7tXyKu" role="2iSdaV" />
           <node concept="3F0ifn" id="7zq8U7tXyVu" role="3EZMnx">
             <property role="3F0ifm" value="(" />
             <node concept="11LMrY" id="7zq8U7tX_U6" role="3F10Kt">
@@ -3824,6 +3823,7 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedItK" role="2iSdaV" />
         </node>
         <node concept="130CD5" id="2NJGAccdz62" role="jn6J3">
           <node concept="3F1sOY" id="2NJGAccdz63" role="130CDr">
@@ -4034,7 +4034,6 @@
     <property role="TrG5h" value="ImplicitConversionSpecifier" />
     <ref role="1XX52x" to="i3ya:7SygLIkPQIU" resolve="IConvertUnit" />
     <node concept="3EZMnI" id="2x0M_l2hOtm" role="2wV5jI">
-      <node concept="2iRfu4" id="2x0M_l2hOtn" role="2iSdaV" />
       <node concept="3F0ifn" id="2x0M_l2hOD0" role="3EZMnx">
         <property role="3F0ifm" value="implicit conversion specifier:" />
         <ref role="1k5W1q" to="r4b4:2CEi94e3iKI" resolve="PassiveText" />
@@ -4067,6 +4066,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItL" role="2iSdaV" />
     </node>
   </node>
   <node concept="22mcaB" id="15KrVXSF0u_">
@@ -4467,7 +4467,6 @@
     <property role="3GE5qa" value="group.dimension" />
     <ref role="1XX52x" to="i3ya:4RImAbi2kS8" resolve="DimensionMultiplication" />
     <node concept="3EZMnI" id="4RImAbi2r1o" role="2wV5jI">
-      <node concept="2iRfu4" id="4RImAbi2r1p" role="2iSdaV" />
       <node concept="3F1sOY" id="4RImAbi2r1q" role="3EZMnx">
         <ref role="1NtTu8" to="i3ya:4RImAbi2l$9" resolve="left" />
       </node>
@@ -4483,6 +4482,7 @@
       <node concept="3F1sOY" id="4RImAbi2r1s" role="3EZMnx">
         <ref role="1NtTu8" to="i3ya:4RImAbi2mmB" resolve="right" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedItM" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4RImAbi2tAn">
@@ -4802,7 +4802,6 @@
     <property role="3GE5qa" value="definition.unit" />
     <ref role="1XX52x" to="i3ya:3V2fk_c6FtV" resolve="AllowNameShadowingAnnotation" />
     <node concept="3EZMnI" id="4vZ65iKiy8L" role="2wV5jI">
-      <node concept="2iRfu4" id="4vZ65iKiy8M" role="2iSdaV" />
       <node concept="130CD5" id="4iGVAJEbNye" role="3EZMnx">
         <node concept="3F0ifn" id="4iGVAJEbNBA" role="130CDr">
           <property role="3F0ifm" value="@allow name shadowing" />
@@ -4823,6 +4822,7 @@
         </node>
       </node>
       <node concept="2SsqMj" id="4iGVAJEe7w2" role="3EZMnx" />
+      <node concept="l2Vlx" id="1ASK_HedItN" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.typesystem.mps
@@ -12856,7 +12856,7 @@
                           <property role="Xl_RC" value="(" />
                         </node>
                         <node concept="37vLTw" id="2xkb_2HVGl4" role="3uHU7w">
-                          <ref role="3cqZAo" node="2xkb_2HVGkW" resolve="unitName" />
+                          <ref role="3cqZAo" node="2xkb_2HVGkW" resolve="subUnitName" />
                         </node>
                       </node>
                     </node>
@@ -12865,7 +12865,7 @@
               </node>
               <node concept="2OqwBi" id="2xkb_2HVHpx" role="3clFbw">
                 <node concept="37vLTw" id="2xkb_2HVGPK" role="2Oq$k0">
-                  <ref role="3cqZAo" node="2xkb_2HVGkW" resolve="subunitName" />
+                  <ref role="3cqZAo" node="2xkb_2HVGkW" resolve="subUnitName" />
                 </node>
                 <node concept="17RvpY" id="2xkb_2HVHS0" role="2OqNvi" />
               </node>
@@ -12911,7 +12911,7 @@
                           <property role="Xl_RC" value="(" />
                         </node>
                         <node concept="37vLTw" id="2xkb_2HVIqh" role="3uHU7w">
-                          <ref role="3cqZAo" node="2xkb_2HVIq9" resolve="unitName" />
+                          <ref role="3cqZAo" node="2xkb_2HVIq9" resolve="supUnitName" />
                         </node>
                       </node>
                     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/org.iets3.core.expr.typetags.physunits.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/org.iets3.core.expr.typetags.physunits.mpl
@@ -46,6 +46,7 @@
     <language slang="l:b4d28e19-7d2d-47e9-943e-3a41f97a0e52:com.mbeddr.mpsutil.plantuml.node" version="0" />
     <language slang="l:3eada220-3310-4fd3-b794-ff924add7d8a:com.mbeddr.mpsutil.smodule" version="0" />
     <language slang="l:3819ba36-98f4-49ac-b779-34f3a458c09b:com.mbeddr.mpsutil.varscope" version="0" />
+    <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
     <language slang="l:e359e0a2-368a-4c40-ae2a-e5a09f9cfd58:de.itemis.mps.editor.math.notations" version="0" />
     <language slang="l:92d2ea16-5a42-4fdf-a676-c7604efe3504:de.slisson.mps.richtext" version="0" />
     <language slang="l:52733268-be24-4f5f-ab84-a73b7c0c03b0:de.slisson.mps.richtext.customcell" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units.quantity/models/org.iets3.core.expr.typetags.units.quantity.editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units.quantity/models/org.iets3.core.expr.typetags.units.quantity.editor.mps
@@ -35,7 +35,6 @@
         <property id="1140524450557" name="separatorText" index="2czwfO" />
         <child id="1233141163694" name="separatorStyle" index="sWeuL" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="6089045305654894366" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Default" flags="ng" index="2kknPJ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="784421273959492578" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_IncludeMenu" flags="ng" index="mvV$s">
@@ -453,7 +452,6 @@
             </node>
           </node>
           <node concept="3EZMnI" id="76ZhK6Y0Pn1" role="3EZMnx">
-            <node concept="2iRfu4" id="76ZhK6Y0Pn2" role="2iSdaV" />
             <node concept="3F1sOY" id="76ZhK6Y0Pn3" role="3EZMnx">
               <property role="2ru_X1" value="true" />
               <ref role="1k5W1q" to="u5dy:4M31vJayoGp" resolve="UnitTag" />
@@ -493,6 +491,7 @@
                 </node>
               </node>
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIt4" role="2iSdaV" />
           </node>
           <node concept="l2Vlx" id="76ZhK6Y0Pm$" role="2iSdaV" />
         </node>
@@ -527,7 +526,6 @@
           </node>
         </node>
         <node concept="3EZMnI" id="3j3yk3g$lOk" role="jn6J3">
-          <node concept="2iRfu4" id="29E2s0GIWel" role="2iSdaV" />
           <node concept="3F1sOY" id="3j3yk3guLEv" role="3EZMnx">
             <property role="2ru_X1" value="true" />
             <ref role="1k5W1q" to="u5dy:4M31vJayoGp" resolve="UnitTag" />
@@ -567,6 +565,7 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIt5" role="2iSdaV" />
         </node>
         <node concept="3tD6jV" id="29E2s0GJxa5" role="3F10Kt">
           <ref role="3tD7wE" to="19h7:5BPceOKdmR0" resolve="side-tranformation-helper-cells" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/editor.mps
@@ -50,6 +50,7 @@
         <child id="1140524464359" name="emptyCellModel" index="2czzBI" />
         <child id="1233141163694" name="separatorStyle" index="sWeuL" />
       </concept>
+      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="6089045305654894367" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Named" flags="ng" index="2kknPI">
         <reference id="6089045305654944382" name="menu" index="2kkw0f" />
@@ -964,7 +965,7 @@
             </node>
           </node>
         </node>
-        <node concept="l2Vlx" id="1ASK_HedIu5" role="2iSdaV" />
+        <node concept="2iRfu4" id="2tlTgwgaOy1" role="2iSdaV" />
       </node>
     </node>
     <node concept="3EZMnI" id="3$KQaHc3BIh" role="2wV5jI">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/editor.mps
@@ -50,7 +50,6 @@
         <child id="1140524464359" name="emptyCellModel" index="2czzBI" />
         <child id="1233141163694" name="separatorStyle" index="sWeuL" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="6089045305654894367" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Named" flags="ng" index="2kknPI">
         <reference id="6089045305654944382" name="menu" index="2kkw0f" />
@@ -484,7 +483,6 @@
     <property role="3GE5qa" value="definition.exponent" />
     <ref role="1XX52x" to="b0gq:3j3yk3gAgiT" resolve="FractionalExponent" />
     <node concept="3EZMnI" id="29E2s0GMudK" role="2wV5jI">
-      <node concept="2iRfu4" id="29E2s0GMudL" role="2iSdaV" />
       <node concept="3F1sOY" id="3j3yk3gAqzu" role="3EZMnx">
         <ref role="1NtTu8" to="b0gq:3j3yk3gAnBu" resolve="fraction" />
         <node concept="3tD6jV" id="29E2s0GLFg4" role="3F10Kt">
@@ -500,6 +498,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIu2" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7eOyx9r3lrf">
@@ -544,7 +543,6 @@
             </node>
           </node>
           <node concept="3EZMnI" id="76ZhK6Y0Pn1" role="3EZMnx">
-            <node concept="2iRfu4" id="76ZhK6Y0Pn2" role="2iSdaV" />
             <node concept="3F1sOY" id="76ZhK6Y0Pn3" role="3EZMnx">
               <property role="2ru_X1" value="true" />
               <ref role="1NtTu8" to="b0gq:7eOyx9r3qFY" resolve="exponent" />
@@ -584,6 +582,7 @@
                 </node>
               </node>
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIu3" role="2iSdaV" />
           </node>
           <node concept="l2Vlx" id="76ZhK6Y0Pm$" role="2iSdaV" />
         </node>
@@ -618,7 +617,6 @@
           </node>
         </node>
         <node concept="3EZMnI" id="3j3yk3g$lOk" role="jn6J3">
-          <node concept="2iRfu4" id="29E2s0GIWel" role="2iSdaV" />
           <node concept="3F1sOY" id="3j3yk3guLEv" role="3EZMnx">
             <property role="2ru_X1" value="true" />
             <ref role="1k5W1q" node="4M31vJayoGp" resolve="UnitTag" />
@@ -658,6 +656,7 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIu4" role="2iSdaV" />
         </node>
         <node concept="3tD6jV" id="29E2s0GJxa5" role="3F10Kt">
           <ref role="3tD7wE" to="19h7:5BPceOKdmR0" resolve="side-tranformation-helper-cells" />
@@ -952,7 +951,6 @@
     <node concept="3EZMnI" id="yGiRIEWR7M" role="6VMZX">
       <node concept="2EHx9g" id="y826GHGCuw" role="2iSdaV" />
       <node concept="3EZMnI" id="y826GHGCuz" role="3EZMnx">
-        <node concept="2iRfu4" id="y826GHGCu$" role="2iSdaV" />
         <node concept="3F0ifn" id="yGiRIEWR87" role="3EZMnx">
           <property role="3F0ifm" value="conversion specifier:" />
           <ref role="1k5W1q" to="r4b4:2CEi94e3iKI" resolve="PassiveText" />
@@ -966,6 +964,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIu5" role="2iSdaV" />
       </node>
     </node>
     <node concept="3EZMnI" id="3$KQaHc3BIh" role="2wV5jI">
@@ -1309,7 +1308,6 @@
     <property role="3GE5qa" value="conversion" />
     <ref role="1XX52x" to="b0gq:7SygLIkPJP$" resolve="ConvertToTarget" />
     <node concept="3EZMnI" id="7SygLIkPQOx" role="2wV5jI">
-      <node concept="2iRfu4" id="7SygLIkPQOy" role="2iSdaV" />
       <node concept="PMmxH" id="7SygLIkPQOE" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
         <ref role="1k5W1q" to="r4b4:2CEi94dgHKA" resolve="KW" />
@@ -1342,9 +1340,9 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIu6" role="2iSdaV" />
     </node>
     <node concept="3EZMnI" id="2ECpYtcLTdi" role="6VMZX">
-      <node concept="2iRfu4" id="2ECpYtcLTdj" role="2iSdaV" />
       <node concept="3F0ifn" id="2ECpYtcLTdm" role="3EZMnx">
         <property role="3F0ifm" value="conversion specifier:" />
         <ref role="1k5W1q" to="r4b4:2CEi94e3iKI" resolve="PassiveText" />
@@ -1358,6 +1356,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIu7" role="2iSdaV" />
     </node>
   </node>
   <node concept="3ICUPy" id="cEt5uj8N0C">
@@ -2114,7 +2113,6 @@
     <property role="3GE5qa" value="definition" />
     <ref role="1XX52x" to="b0gq:1KUmgSFpwWn" resolve="Quantity" />
     <node concept="3EZMnI" id="1KUmgSFw7kf" role="2wV5jI">
-      <node concept="2iRfu4" id="1KUmgSFw7kg" role="2iSdaV" />
       <node concept="PMmxH" id="1KUmgSFw7kd" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -2122,6 +2120,7 @@
       <node concept="3F0A7n" id="1KUmgSFw7ko" role="3EZMnx">
         <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIu8" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags/models/org/iets3/core/expr/typetags/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags/models/org/iets3/core/expr/typetags/editor.mps
@@ -43,7 +43,6 @@
       <concept id="1078308402140" name="jetbrains.mps.lang.editor.structure.CellModel_Custom" flags="sg" stub="8104358048506730068" index="gc7cB">
         <child id="1176795024817" name="cellProvider" index="3YsKMw" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
@@ -743,7 +742,6 @@
   <node concept="24kQdi" id="2Ux6GHgZDR6">
     <ref role="1XX52x" to="w1hl:2Ux6GHgZDQF" resolve="TaggedExpression" />
     <node concept="3EZMnI" id="Fhq44ej0LB" role="2wV5jI">
-      <node concept="2iRfu4" id="Fhq44ej0LC" role="2iSdaV" />
       <node concept="3EZMnI" id="7eOyx9r3D2r" role="3EZMnx">
         <node concept="3F0ifn" id="3wrpJuuGygQ" role="3EZMnx">
           <property role="3F0ifm" value="[" />
@@ -932,6 +930,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIt6" role="2iSdaV" />
     </node>
   </node>
   <node concept="3INDKC" id="3cUcim$6q3Z">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/editor.mps
@@ -1708,7 +1708,7 @@
       <node concept="3F1sOY" id="22hm_0zfyNf" role="3EZMnx">
         <ref role="1NtTu8" to="kfo3:22hm_0zfyMh" resolve="value" />
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIwl" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwgaOy3" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="22hm_0$b7cV">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/editor.mps
@@ -68,6 +68,7 @@
       </concept>
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
@@ -635,7 +636,6 @@
       </node>
       <node concept="2iRkQZ" id="3DYDRw0NKrz" role="2iSdaV" />
       <node concept="3EZMnI" id="Nuz63eZb46" role="3EZMnx">
-        <node concept="2iRfu4" id="Nuz63eZb47" role="2iSdaV" />
         <node concept="3ZSo5i" id="4Cb98czSEOG" role="3EZMnx">
           <node concept="3VJUX5" id="4Cb98czSFX0" role="3ZZHOD">
             <node concept="3clFbS" id="4Cb98czSFX1" role="2VODD2">
@@ -1501,7 +1501,6 @@
               </node>
             </node>
           </node>
-          <node concept="2iRfu4" id="Nuz63eZ7pt" role="2iSdaV" />
           <node concept="3F0ifn" id="Nuz63eZ05G" role="3EZMnx">
             <property role="3F0ifm" value="⬅" />
           </node>
@@ -1523,7 +1522,9 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIwe" role="2iSdaV" />
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIwd" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="Nuz63eZuFI" role="3EZMnx">
         <node concept="2iRkQZ" id="Nuz63f5U4e" role="2iSdaV" />
@@ -1572,13 +1573,13 @@
               </node>
             </node>
           </node>
-          <node concept="2iRfu4" id="Nuz63f5Uhw" role="2iSdaV" />
           <node concept="3F0ifn" id="Nuz63f3gBq" role="3EZMnx">
             <property role="3F0ifm" value="⬆" />
           </node>
           <node concept="3F1sOY" id="Nuz63eZ_Du" role="3EZMnx">
             <ref role="1NtTu8" to="kfo3:Nuz63eZxZA" resolve="predefY" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIwf" role="2iSdaV" />
         </node>
         <node concept="pkWqt" id="Nuz63eZ_Dz" role="pqm2j">
           <node concept="3clFbS" id="Nuz63eZ_D$" role="2VODD2">
@@ -1606,7 +1607,6 @@
         <node concept="3F1sOY" id="3DYDRw0NOwI" role="3EZMnx">
           <ref role="1NtTu8" to="kfo3:3DYDRw0NJeI" resolve="default" />
         </node>
-        <node concept="2iRfu4" id="3DYDRw0NNeG" role="2iSdaV" />
         <node concept="pkWqt" id="3DYDRw0NOwO" role="pqm2j">
           <node concept="3clFbS" id="3DYDRw0NOwP" role="2VODD2">
             <node concept="3clFbF" id="3DYDRw0NOxW" role="3cqZAp">
@@ -1622,6 +1622,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIwg" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -1640,7 +1641,6 @@
     <property role="3GE5qa" value="range" />
     <ref role="1XX52x" to="kfo3:22hm_0z9Lc9" resolve="SplitExpression" />
     <node concept="3EZMnI" id="22hm_0z9LcG" role="2wV5jI">
-      <node concept="2iRfu4" id="22hm_0z9LcH" role="2iSdaV" />
       <node concept="3F0ifn" id="5aHkq2wi3KB" role="3EZMnx">
         <property role="3F0ifm" value="split" />
         <ref role="1k5W1q" to="itrz:4rZeNQ6MfR7" resolve="iets3Keyword" />
@@ -1661,13 +1661,13 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwh" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="22hm_0zjCQb">
     <property role="3GE5qa" value="range" />
     <ref role="1XX52x" to="kfo3:22hm_0zjCPK" resolve="SingleValueRS" />
     <node concept="3EZMnI" id="2DnmbxU3eJ1" role="2wV5jI">
-      <node concept="2iRfu4" id="2DnmbxU3eJ2" role="2iSdaV" />
       <node concept="3EZMnI" id="22hm_0zjCQd" role="3EZMnx">
         <node concept="PMmxH" id="22hm_0zjCQx" role="3EZMnx">
           <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
@@ -1675,21 +1675,22 @@
         <node concept="3F1sOY" id="22hm_0zjCQp" role="3EZMnx">
           <ref role="1NtTu8" to="kfo3:22hm_0zjCPL" resolve="bound" />
         </node>
-        <node concept="2iRfu4" id="22hm_0zjCQg" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIwj" role="2iSdaV" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwi" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="22hm_0$b7oX">
     <property role="3GE5qa" value="dectree" />
     <ref role="1XX52x" to="kfo3:22hm_0$b7cv" resolve="DecTree" />
     <node concept="3EZMnI" id="wW2kvIA_S9" role="2wV5jI">
-      <node concept="2iRfu4" id="wW2kvIA_Sa" role="2iSdaV" />
       <node concept="3F1sOY" id="22hm_0$b7pb" role="3EZMnx">
         <ref role="1NtTu8" to="kfo3:22hm_0$b7oz" resolve="root" />
         <node concept="2R9Tw8" id="wW2kvIqUga" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwk" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="22hm_0zfyMG">
@@ -1707,7 +1708,7 @@
       <node concept="3F1sOY" id="22hm_0zfyNf" role="3EZMnx">
         <ref role="1NtTu8" to="kfo3:22hm_0zfyMh" resolve="value" />
       </node>
-      <node concept="2iRfu4" id="22hm_0zfyML" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIwl" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="22hm_0$b7cV">
@@ -1753,7 +1754,6 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="7RxIimvsoMX" role="2iSdaV" />
         <node concept="pkWqt" id="7RxIimvsufz" role="pqm2j">
           <node concept="3clFbS" id="7RxIimvsuf$" role="2VODD2">
             <node concept="3clFbF" id="7RxIimvsut5" role="3cqZAp">
@@ -1769,6 +1769,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIwm" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="1mPSRGtNjOm" role="3EZMnx">
         <node concept="2iRkQZ" id="1mPSRGtNjOn" role="2iSdaV" />
@@ -2256,7 +2257,6 @@
     <ref role="1XX52x" to="kfo3:wW2kvIvda2" resolve="RootTreeNode" />
     <node concept="2SWKgc" id="wW2kvIvdat" role="2wV5jI">
       <node concept="3EZMnI" id="1NRU0vciZVo" role="2SWKFN">
-        <node concept="2iRfu4" id="1NRU0vciZVp" role="2iSdaV" />
         <node concept="3F0ifn" id="wW2kvIvda_" role="3EZMnx">
           <property role="3F0ifm" value="&lt;&gt;" />
         </node>
@@ -2268,10 +2268,10 @@
             <node concept="3F1sOY" id="1NRU0vcj02r" role="3EZMnx">
               <ref role="1NtTu8" to="kfo3:1NRU0vciZVm" resolve="defaultValue" />
             </node>
-            <node concept="2iRfu4" id="1NRU0vcj02f" role="2iSdaV" />
             <node concept="VPM3Z" id="1NRU0vcj02g" role="3F10Kt">
               <property role="VOm3f" value="false" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIwo" role="2iSdaV" />
           </node>
           <node concept="uPpia" id="1ZlHRbgqZ1L" role="1djCvC">
             <node concept="3clFbS" id="1ZlHRbgqZ1M" role="2VODD2">
@@ -2283,6 +2283,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIwn" role="2iSdaV" />
       </node>
       <node concept="3F2HdR" id="wW2kvIvdaz" role="2SWKFX">
         <ref role="1NtTu8" to="kfo3:22hm_0$b7pP" resolve="children" />
@@ -2384,13 +2385,13 @@
       <node concept="3F1sOY" id="1tPb0nsnb83" role="3EZMnx">
         <ref role="1NtTu8" to="kfo3:1tPb0nsnb7k" resolve="lower" />
       </node>
-      <node concept="2iRfu4" id="2DnmbxU3eIa" role="2iSdaV" />
       <node concept="3F0ifn" id="1tPb0nsnb8a" role="3EZMnx">
         <property role="3F0ifm" value=".." />
       </node>
       <node concept="3F1sOY" id="1tPb0nsnb8k" role="3EZMnx">
         <ref role="1NtTu8" to="kfo3:1tPb0nsnb7m" resolve="upper" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwp" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="8XWEte9mtS">
@@ -2400,7 +2401,6 @@
       <node concept="2reCLk" id="5hullqu1Iez" role="2r0Tv6">
         <node concept="2reCLy" id="5hullqu1JxI" role="2reCL6">
           <node concept="3EZMnI" id="8XWEteq8eD" role="2reSmM">
-            <node concept="2iRfu4" id="8XWEteq8eE" role="2iSdaV" />
             <node concept="3tD6jV" id="8XWEtergff" role="3F10Kt">
               <ref role="3tD7wE" to="reoo:5PDTdguqQmB" resolve="shade-color" />
               <node concept="3sjG9q" id="8XWEtergfg" role="3tD6jU">
@@ -2448,6 +2448,7 @@
               <property role="39s7Ar" value="true" />
               <ref role="1NtTu8" to="kfo3:4v5hZncKAeZ" resolve="optionalName" />
             </node>
+            <node concept="l2Vlx" id="1ASK_HedIwq" role="2iSdaV" />
           </node>
         </node>
         <node concept="2r731s" id="4_sn_QHlhmA" role="2reCL6">
@@ -2845,7 +2846,6 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="8XWEtdZOCw" role="2iSdaV" />
       <node concept="1kIj98" id="6OunYCf4NrW" role="3EZMnx">
         <property role="3g2DhO" value="true" />
         <node concept="3F0A7n" id="8XWEtdZOCs" role="1kIj9b">
@@ -2861,6 +2861,7 @@
       <node concept="3F1sOY" id="8XWEtdZOCK" role="3EZMnx">
         <ref role="1NtTu8" to="hm2y:7D7uZV2iYAD" resolve="type" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwr" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="8XWEtdZO$l">
@@ -3046,7 +3047,6 @@
         </node>
       </node>
       <node concept="VPM3Z" id="5yPljRXY_4B" role="3F10Kt" />
-      <node concept="2iRfu4" id="8XWEteeTxk" role="2iSdaV" />
       <node concept="3F0ifn" id="2FeCPobcYzo" role="3EZMnx">
         <property role="3F0ifm" value="[not]" />
         <ref role="1ERwB7" node="2FeCPoc7N5i" resolve="removeNegate" />
@@ -3085,6 +3085,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIws" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5GPhrsV2VsV">
@@ -3103,14 +3104,13 @@
       <node concept="3F1sOY" id="5GPhrsV2Vtx" role="3EZMnx">
         <ref role="1NtTu8" to="hm2y:7D7uZV2iYAD" resolve="type" />
       </node>
-      <node concept="2iRfu4" id="5GPhrsV2Vt0" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIwt" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7FuUjk_n1Lq">
     <property role="3GE5qa" value="multidectab.toplevel" />
     <ref role="1XX52x" to="kfo3:7FuUjk_mXBJ" resolve="TableCallExpression" />
     <node concept="3EZMnI" id="7FuUjk_n1LK" role="2wV5jI">
-      <node concept="2iRfu4" id="7FuUjk_n1LL" role="2iSdaV" />
       <node concept="1kIj98" id="7FuUjk_HwvZ" role="3EZMnx">
         <node concept="3F1sOY" id="7FuUjk_Hwwc" role="1kIj9b">
           <ref role="1NtTu8" to="kfo3:7FuUjk_Hwvt" resolve="target" />
@@ -3187,6 +3187,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIwu" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7FuUjk_n9qU">
@@ -3208,7 +3209,7 @@
       <node concept="3F1sOY" id="7FuUjk_n9rS" role="3EZMnx">
         <ref role="1NtTu8" to="kfo3:7FuUjk_mXBU" resolve="value" />
       </node>
-      <node concept="2iRfu4" id="7FuUjk_n9qZ" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIwv" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7FuUjk_Hv5w">
@@ -3265,7 +3266,7 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="2iRfu4" id="7EKPeISwidl" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIww" role="2iSdaV" />
     </node>
   </node>
   <node concept="PKFIW" id="1yFVafcIlfG">
@@ -3398,7 +3399,6 @@
           </node>
         </node>
         <node concept="3EZMnI" id="264ij5$S4n3" role="3EZMny">
-          <node concept="2iRfu4" id="264ij5$S4n4" role="2iSdaV" />
           <node concept="2rfBfz" id="7WrYb3emAZX" role="3EZMnx">
             <node concept="2reCLu" id="7WrYb3epq7$" role="2rf8GZ">
               <node concept="2reSaE" id="7WrYb3eptoX" role="2reCL6">
@@ -3920,9 +3920,10 @@
               </node>
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIwy" role="2iSdaV" />
         </node>
       </node>
-      <node concept="2iRfu4" id="2d3TE9ezQcY" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIwx" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="1yFVafcItV$">
@@ -3952,7 +3953,7 @@
           <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
           <ref role="1k5W1q" to="itrz:ub9nkyQsN2" resolve="iets3Identifier" />
         </node>
-        <node concept="2iRfu4" id="1yFVafcIur8" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIwz" role="2iSdaV" />
       </node>
       <node concept="2iRkQZ" id="1yFVafcIuqT" role="2iSdaV" />
       <node concept="PMmxH" id="1yFVafcIusk" role="3EZMnx">
@@ -3964,7 +3965,6 @@
     <property role="3GE5qa" value="multidectab.expr.result" />
     <ref role="1XX52x" to="kfo3:6OunYCeYf_9" resolve="LocalVarAssignColDef" />
     <node concept="3EZMnI" id="6OunYCf3ALi" role="2wV5jI">
-      <node concept="2iRfu4" id="6OunYCf3ALj" role="2iSdaV" />
       <node concept="3F0ifn" id="6OunYCf3ALr" role="3EZMnx">
         <property role="3F0ifm" value="-&gt;" />
       </node>
@@ -4035,6 +4035,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIw$" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6OunYCfi$px">
@@ -4098,7 +4099,6 @@
     <property role="3GE5qa" value="dectab" />
     <ref role="1XX52x" to="kfo3:3DYDRw0K4ce" resolve="DecTabContent" />
     <node concept="3EZMnI" id="4Cb98czSpgY" role="2wV5jI">
-      <node concept="2iRfu4" id="4Cb98czSpgZ" role="2iSdaV" />
       <node concept="1kIj98" id="5yPljRXW7vI" role="3EZMnx">
         <node concept="3F2HdR" id="5yPljRXW7vJ" role="1kIj9b">
           <property role="2czwfO" value="," />
@@ -4108,6 +4108,7 @@
         <node concept="VPM3Z" id="5yPljRXXdjF" role="3F10Kt" />
       </node>
       <node concept="VPM3Z" id="4Cb98czSpha" role="3F10Kt" />
+      <node concept="l2Vlx" id="1ASK_HedIw_" role="2iSdaV" />
     </node>
   </node>
   <node concept="1h_SRR" id="2FeCPoc7N5i">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.trace/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.trace/models/editor.mps
@@ -17,6 +17,7 @@
         <child id="1140524464360" name="cellLayout" index="2czzBx" />
       </concept>
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
@@ -52,7 +53,6 @@
   <node concept="24kQdi" id="1PzuxQOTQDq">
     <ref role="1XX52x" to="ci3w:1PzuxQOT$Zy" resolve="TraceAttributeValue" />
     <node concept="3EZMnI" id="1PzuxQOVQNI" role="2wV5jI">
-      <node concept="2iRfu4" id="1PzuxQOVQNJ" role="2iSdaV" />
       <node concept="3F1sOY" id="1PzuxQOVQO8" role="3EZMnx">
         <property role="1$x2rV" value="&lt;trace kind&gt;" />
         <ref role="1NtTu8" to="ci3w:1PzuxQOT_10" resolve="traceKind" />
@@ -65,6 +65,7 @@
         <ref role="1NtTu8" to="ci3w:1PzuxQOT_1a" resolve="traceTarget" />
         <node concept="2iRfu4" id="1PzuxQOVQPi" role="2czzBx" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedI_4" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="1PzuxQOVzGS">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.users/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.users/models/editor.mps
@@ -21,8 +21,8 @@
       <concept id="1078308402140" name="jetbrains.mps.lang.editor.structure.CellModel_Custom" flags="sg" stub="8104358048506730068" index="gc7cB">
         <child id="1176795024817" name="cellProvider" index="3YsKMw" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
@@ -204,13 +204,13 @@
               </node>
             </node>
           </node>
-          <node concept="2iRfu4" id="7mG7sQPAivH" role="2iSdaV" />
           <node concept="3F0ifn" id="7mG7sQPAivI" role="3EZMnx">
             <property role="3F0ifm" value="user directory" />
           </node>
           <node concept="3F0A7n" id="7mG7sQPAivJ" role="3EZMnx">
             <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
           </node>
+          <node concept="l2Vlx" id="1ASK_HedI_f" role="2iSdaV" />
         </node>
         <node concept="gc7cB" id="7mG7sQPAivK" role="3EZMnx">
           <node concept="3VJUX4" id="7mG7sQPAivL" role="3YsKMw">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.glossary/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.glossary/models/editor.mps
@@ -132,7 +132,6 @@
       <concept id="1950447826681509042" name="jetbrains.mps.lang.editor.structure.ApplyStyleClass" flags="lg" index="3Xmtl4">
         <child id="1950447826683828796" name="target" index="3XvnJa" />
       </concept>
-      <concept id="1198256887712" name="jetbrains.mps.lang.editor.structure.CellModel_Indent" flags="ng" index="3XFhqQ" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
@@ -448,7 +447,6 @@
           </node>
         </node>
       </node>
-      <node concept="3XFhqQ" id="6zaFu4oPQtv" role="3EZMnx" />
       <node concept="3EZMnI" id="6zaFu4oR3K0" role="3EZMnx">
         <node concept="2iRkQZ" id="6zaFu4oR3K1" role="2iSdaV" />
         <node concept="3EZMnI" id="6zaFu4oQXDJ" role="3EZMnx">
@@ -748,8 +746,6 @@
           </node>
         </node>
       </node>
-      <node concept="3XFhqQ" id="6zaFu4oRD5C" role="3EZMnx" />
-      <node concept="3XFhqQ" id="6zaFu4oRDjm" role="3EZMnx" />
       <node concept="3EZMnI" id="6zaFu4oRD5D" role="3EZMnx">
         <node concept="2iRkQZ" id="6zaFu4oRD5E" role="2iSdaV" />
         <node concept="3EZMnI" id="6zaFu4oRD5Q" role="3EZMnx">
@@ -935,7 +931,6 @@
           </node>
         </node>
       </node>
-      <node concept="3XFhqQ" id="6zaFu4oSBtZ" role="3EZMnx" />
       <node concept="1iCGBv" id="6zaFu4oSB5v" role="3EZMnx">
         <ref role="1NtTu8" to="tuf9:6zaFu4oSAXF" resolve="term" />
         <node concept="1sVBvm" id="6zaFu4oSB5x" role="1sWHZn">
@@ -977,11 +972,9 @@
         </node>
         <node concept="l2Vlx" id="1ASK_HedIvc" role="2iSdaV" />
       </node>
-      <node concept="3XFhqQ" id="6zaFu4oTqA2" role="3EZMnx" />
       <node concept="3F0ifn" id="6zaFu4oSBpY" role="3EZMnx">
         <property role="3F0ifm" value="|" />
       </node>
-      <node concept="3XFhqQ" id="6zaFu4oSBy0" role="3EZMnx" />
       <node concept="1HlG4h" id="6zaFu4oS_c9" role="3EZMnx">
         <node concept="1HfYo3" id="6zaFu4oS_cb" role="1HlULh">
           <node concept="3TQlhw" id="6zaFu4oS_cd" role="1Hhtcw">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.glossary/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.glossary/models/editor.mps
@@ -43,7 +43,6 @@
       <concept id="1078308402140" name="jetbrains.mps.lang.editor.structure.CellModel_Custom" flags="sg" stub="8104358048506730068" index="gc7cB">
         <child id="1176795024817" name="cellProvider" index="3YsKMw" />
       </concept>
-      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="7651593722933768974" name="jetbrains.mps.lang.editor.structure.MaxWidthStyleClassItem" flags="ln" index="nf9zX">
@@ -304,12 +303,12 @@
         <node concept="3F0A7n" id="6zaFu4oPOE3" role="3EZMnx">
           <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
         </node>
-        <node concept="2iRfu4" id="6zaFu4oPODT" role="2iSdaV" />
         <node concept="3Xmtl4" id="6zaFu4oPWRQ" role="3F10Kt">
           <node concept="1wgc9g" id="6zaFu4oPWRV" role="3XvnJa">
             <ref role="1wgcnl" to="itrz:6zaFu4oPVZQ" resolve="iets3ChunkHeader" />
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIv6" role="2iSdaV" />
       </node>
       <node concept="gc7cB" id="6zaFu4oPOEp" role="3EZMnx">
         <node concept="3VJUX4" id="6zaFu4oPOEr" role="3YsKMw">
@@ -448,7 +447,6 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="6zaFu4oPQrW" role="2iSdaV" />
       <node concept="3XFhqQ" id="6zaFu4oPQtv" role="3EZMnx" />
       <node concept="3EZMnI" id="6zaFu4oR3K0" role="3EZMnx">
         <node concept="2iRkQZ" id="6zaFu4oR3K1" role="2iSdaV" />
@@ -521,7 +519,7 @@
           <node concept="VPM3Z" id="6zaFu4oQXDL" role="3F10Kt">
             <property role="VOm3f" value="false" />
           </node>
-          <node concept="2iRfu4" id="6zaFu4oQXDO" role="2iSdaV" />
+          <node concept="l2Vlx" id="1ASK_HedIv8" role="2iSdaV" />
         </node>
         <node concept="gc7cB" id="6zaFu4oQGSj" role="3EZMnx">
           <node concept="3VJUX4" id="6zaFu4oQGSk" role="3YsKMw">
@@ -541,6 +539,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIv7" role="2iSdaV" />
     </node>
   </node>
   <node concept="V5hpn" id="6zaFu4oPQsa">
@@ -748,7 +747,6 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="6zaFu4oRD5B" role="2iSdaV" />
       <node concept="3XFhqQ" id="6zaFu4oRD5C" role="3EZMnx" />
       <node concept="3XFhqQ" id="6zaFu4oRDjm" role="3EZMnx" />
       <node concept="3EZMnI" id="6zaFu4oRD5D" role="3EZMnx">
@@ -827,6 +825,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIv9" role="2iSdaV" />
     </node>
     <node concept="2aJ2om" id="6zaFu4oRD8s" role="CpUAK">
       <ref role="2$4xQ3" to="r4b4:7xesQBpJXuT" resolve="presentationMode" />
@@ -836,7 +835,6 @@
     <property role="3GE5qa" value="attributes" />
     <ref role="1XX52x" to="tuf9:6zaFu4oS5HT" resolve="TermRefTermAttribute" />
     <node concept="3EZMnI" id="6zaFu4oS5Io" role="2wV5jI">
-      <node concept="2iRfu4" id="6zaFu4oS5Ip" role="2iSdaV" />
       <node concept="PMmxH" id="6zaFu4oS5Im" role="3EZMnx">
         <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
       </node>
@@ -854,6 +852,7 @@
           <ref role="1wgcnl" node="6zaFu4oQ9o9" resolve="termAttribute" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIva" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="6zaFu4oS_bs">
@@ -960,7 +959,6 @@
         <node concept="3F0A7n" id="lp3OKvgcPM" role="3EZMnx">
           <ref role="1NtTu8" to="tuf9:lp3OKvg8mt" resolve="foundAlias" />
         </node>
-        <node concept="2iRfu4" id="lp3OKvgcCn" role="2iSdaV" />
         <node concept="pkWqt" id="lp3OKvgcPR" role="pqm2j">
           <node concept="3clFbS" id="lp3OKvgcPS" role="2VODD2">
             <node concept="3clFbF" id="lp3OKvgcPZ" role="3cqZAp">
@@ -976,6 +974,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIvc" role="2iSdaV" />
       </node>
       <node concept="3XFhqQ" id="6zaFu4oTqA2" role="3EZMnx" />
       <node concept="3F0ifn" id="6zaFu4oSBpY" role="3EZMnx">
@@ -1136,7 +1135,7 @@
           </node>
         </node>
       </node>
-      <node concept="2iRfu4" id="6zaFu4oS_c2" role="2iSdaV" />
+      <node concept="l2Vlx" id="1ASK_HedIvb" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="lp3OKvfWZH">
@@ -1149,12 +1148,12 @@
       <node concept="3F0A7n" id="lp3OKvfWZW" role="3EZMnx">
         <ref role="1NtTu8" to="tuf9:lp3OKvfWZj" resolve="aliasText" />
       </node>
-      <node concept="2iRfu4" id="lp3OKvfWZM" role="2iSdaV" />
       <node concept="3Xmtl4" id="lp3OKvg7Wj" role="3F10Kt">
         <node concept="1wgc9g" id="lp3OKvg7Wn" role="3XvnJa">
           <ref role="1wgcnl" node="6zaFu4oQ9o9" resolve="termAttribute" />
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIvd" role="2iSdaV" />
     </node>
   </node>
   <node concept="22mcaB" id="cEt5uj8NZo">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.glossary/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.glossary/models/editor.mps
@@ -43,6 +43,7 @@
       <concept id="1078308402140" name="jetbrains.mps.lang.editor.structure.CellModel_Custom" flags="sg" stub="8104358048506730068" index="gc7cB">
         <child id="1176795024817" name="cellProvider" index="3YsKMw" />
       </concept>
+      <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="7651593722933768974" name="jetbrains.mps.lang.editor.structure.MaxWidthStyleClassItem" flags="ln" index="nf9zX">
@@ -539,7 +540,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIv7" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwgaOWK" role="2iSdaV" />
     </node>
   </node>
   <node concept="V5hpn" id="6zaFu4oPQsa">
@@ -825,7 +826,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIv9" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwgaP8J" role="2iSdaV" />
     </node>
     <node concept="2aJ2om" id="6zaFu4oRD8s" role="CpUAK">
       <ref role="2$4xQ3" to="r4b4:7xesQBpJXuT" resolve="presentationMode" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/editor.mps
@@ -1085,7 +1085,7 @@
       <node concept="3F0A7n" id="7Ip2X68Nu7$" role="3EZMnx">
         <ref role="1NtTu8" to="plfp:7Ip2X68Nu6H" resolve="value" />
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIut" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwgaQzD" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7Dcax7A9Ln4">
@@ -1859,9 +1859,9 @@
             </node>
           </node>
         </node>
-        <node concept="l2Vlx" id="1ASK_HedIu$" role="2iSdaV" />
+        <node concept="2iRfu4" id="2tlTgwgaQzH" role="2iSdaV" />
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIuz" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwgaQzF" role="2iSdaV" />
     </node>
   </node>
   <node concept="2ABfQD" id="4Etk_BWn_aw">
@@ -2401,7 +2401,7 @@
           </node>
         </node>
       </node>
-      <node concept="l2Vlx" id="1ASK_HedIuC" role="2iSdaV" />
+      <node concept="2iRfu4" id="2tlTgwgaQzB" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7IM3imbnRAF">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/editor.mps
@@ -71,6 +71,8 @@
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
+      <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
+      <concept id="1237375020029" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineChildrenStyleClassItem" flags="ln" index="pj6Ft" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
@@ -212,7 +214,6 @@
       <concept id="1950447826681509042" name="jetbrains.mps.lang.editor.structure.ApplyStyleClass" flags="lg" index="3Xmtl4">
         <child id="1950447826683828796" name="target" index="3XvnJa" />
       </concept>
-      <concept id="1198256887712" name="jetbrains.mps.lang.editor.structure.CellModel_Indent" flags="ng" index="3XFhqQ" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
@@ -631,7 +632,7 @@
         </node>
         <node concept="l2Vlx" id="1ASK_HedIuo" role="2iSdaV" />
       </node>
-      <node concept="2iRkQZ" id="4tXyFaWwpnn" role="2iSdaV" />
+      <node concept="l2Vlx" id="2tlTgwfCxRF" role="2iSdaV" />
       <node concept="gc7cB" id="7Dcax7Afl6M" role="3EZMnx">
         <node concept="3VJUX4" id="7Dcax7Afl6N" role="3YsKMw">
           <node concept="3clFbS" id="7Dcax7Afl6O" role="2VODD2">
@@ -657,40 +658,36 @@
           <property role="VOm3f" value="false" />
         </node>
       </node>
-      <node concept="3EZMnI" id="4tXyFaWwv1p" role="3EZMnx">
-        <property role="S$Qs1" value="false" />
-        <node concept="3XFhqQ" id="4tXyFaWwv39" role="3EZMnx" />
-        <node concept="3F2HdR" id="4tXyFaWwuZu" role="3EZMnx">
-          <property role="S$F3r" value="true" />
-          <ref role="1NtTu8" to="plfp:4tXyFaWxWA_" resolve="requirements" />
-          <node concept="2iRkQZ" id="4tXyFaWwuZw" role="2czzBx" />
-          <node concept="3F0ifn" id="4tXyFaWy0tn" role="2czzBI">
-            <node concept="VPxyj" id="4tXyFaWy0uj" role="3F10Kt">
-              <property role="VOm3f" value="true" />
-            </node>
+      <node concept="3F2HdR" id="4tXyFaWwuZu" role="3EZMnx">
+        <property role="S$F3r" value="true" />
+        <ref role="1NtTu8" to="plfp:4tXyFaWxWA_" resolve="requirements" />
+        <node concept="l2Vlx" id="2tlTgwfCy1Q" role="2czzBx" />
+        <node concept="3F0ifn" id="4tXyFaWy0tn" role="2czzBI">
+          <node concept="VPxyj" id="4tXyFaWy0uj" role="3F10Kt">
+            <property role="VOm3f" value="true" />
           </node>
-          <node concept="1HlG4h" id="7Dcax7Ag1IY" role="3EmGlc">
-            <node concept="1HfYo3" id="7Dcax7Ag1J0" role="1HlULh">
-              <node concept="3TQlhw" id="7Dcax7Ag1J2" role="1Hhtcw">
-                <node concept="3clFbS" id="7Dcax7Ag1J4" role="2VODD2">
-                  <node concept="3clFbF" id="7Dcax7Ag1JR" role="3cqZAp">
-                    <node concept="3cpWs3" id="7Dcax7Ag6xJ" role="3clFbG">
-                      <node concept="Xl_RD" id="7Dcax7Ag6xP" role="3uHU7w">
-                        <property role="Xl_RC" value=" requirements ...}" />
+        </node>
+        <node concept="1HlG4h" id="7Dcax7Ag1IY" role="3EmGlc">
+          <node concept="1HfYo3" id="7Dcax7Ag1J0" role="1HlULh">
+            <node concept="3TQlhw" id="7Dcax7Ag1J2" role="1Hhtcw">
+              <node concept="3clFbS" id="7Dcax7Ag1J4" role="2VODD2">
+                <node concept="3clFbF" id="7Dcax7Ag1JR" role="3cqZAp">
+                  <node concept="3cpWs3" id="7Dcax7Ag6xJ" role="3clFbG">
+                    <node concept="Xl_RD" id="7Dcax7Ag6xP" role="3uHU7w">
+                      <property role="Xl_RC" value=" requirements ...}" />
+                    </node>
+                    <node concept="3cpWs3" id="7Dcax7Ag2d3" role="3uHU7B">
+                      <node concept="Xl_RD" id="7Dcax7Ag1JQ" role="3uHU7B">
+                        <property role="Xl_RC" value="{... " />
                       </node>
-                      <node concept="3cpWs3" id="7Dcax7Ag2d3" role="3uHU7B">
-                        <node concept="Xl_RD" id="7Dcax7Ag1JQ" role="3uHU7B">
-                          <property role="Xl_RC" value="{... " />
-                        </node>
-                        <node concept="2OqwBi" id="7Dcax7Ag3h1" role="3uHU7w">
-                          <node concept="2OqwBi" id="7Dcax7Ag2_y" role="2Oq$k0">
-                            <node concept="pncrf" id="7Dcax7Ag2xV" role="2Oq$k0" />
-                            <node concept="3Tsc0h" id="7Dcax7Ag2Hb" role="2OqNvi">
-                              <ref role="3TtcxE" to="plfp:4tXyFaWxWA_" resolve="requirements" />
-                            </node>
+                      <node concept="2OqwBi" id="7Dcax7Ag3h1" role="3uHU7w">
+                        <node concept="2OqwBi" id="7Dcax7Ag2_y" role="2Oq$k0">
+                          <node concept="pncrf" id="7Dcax7Ag2xV" role="2Oq$k0" />
+                          <node concept="3Tsc0h" id="7Dcax7Ag2Hb" role="2OqNvi">
+                            <ref role="3TtcxE" to="plfp:4tXyFaWxWA_" resolve="requirements" />
                           </node>
-                          <node concept="34oBXx" id="7Dcax7Ag5oo" role="2OqNvi" />
                         </node>
+                        <node concept="34oBXx" id="7Dcax7Ag5oo" role="2OqNvi" />
                       </node>
                     </node>
                   </node>
@@ -699,7 +696,15 @@
             </node>
           </node>
         </node>
-        <node concept="l2Vlx" id="1ASK_HedIup" role="2iSdaV" />
+        <node concept="lj46D" id="2tlTgwfCy3S" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pj6Ft" id="2tlTgwfC_ax" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="pj6Ft" id="2tlTgwfCxS9" role="3F10Kt">
+        <property role="VOm3f" value="true" />
       </node>
     </node>
     <node concept="2aJ2om" id="7Dcax7AhwZc" role="CpUAK">
@@ -1299,7 +1304,7 @@
         </node>
         <node concept="l2Vlx" id="1ASK_HedIuu" role="2iSdaV" />
       </node>
-      <node concept="2iRkQZ" id="7Dcax7Ahwst" role="2iSdaV" />
+      <node concept="l2Vlx" id="2tlTgwfCumE" role="2iSdaV" />
       <node concept="3EZMnI" id="7Dcax7Ahwsu" role="3EZMnx">
         <node concept="VPM3Z" id="7Dcax7Ahwsv" role="3F10Kt">
           <property role="VOm3f" value="false" />
@@ -1592,40 +1597,36 @@
           <property role="VOm3f" value="false" />
         </node>
       </node>
-      <node concept="3EZMnI" id="7Dcax7AhwtB" role="3EZMnx">
-        <property role="S$Qs1" value="false" />
-        <node concept="3XFhqQ" id="7Dcax7AhwtD" role="3EZMnx" />
-        <node concept="3F2HdR" id="7Dcax7AhwtE" role="3EZMnx">
-          <property role="S$F3r" value="true" />
-          <ref role="1NtTu8" to="plfp:4tXyFaWxWA_" resolve="requirements" />
-          <node concept="2iRkQZ" id="7Dcax7AhwtF" role="2czzBx" />
-          <node concept="3F0ifn" id="7Dcax7AhwtG" role="2czzBI">
-            <node concept="VPxyj" id="7Dcax7AhwtH" role="3F10Kt">
-              <property role="VOm3f" value="true" />
-            </node>
+      <node concept="3F2HdR" id="7Dcax7AhwtE" role="3EZMnx">
+        <property role="S$F3r" value="true" />
+        <ref role="1NtTu8" to="plfp:4tXyFaWxWA_" resolve="requirements" />
+        <node concept="l2Vlx" id="2tlTgwfCwmf" role="2czzBx" />
+        <node concept="3F0ifn" id="7Dcax7AhwtG" role="2czzBI">
+          <node concept="VPxyj" id="7Dcax7AhwtH" role="3F10Kt">
+            <property role="VOm3f" value="true" />
           </node>
-          <node concept="1HlG4h" id="7Dcax7AhwtI" role="3EmGlc">
-            <node concept="1HfYo3" id="7Dcax7AhwtJ" role="1HlULh">
-              <node concept="3TQlhw" id="7Dcax7AhwtK" role="1Hhtcw">
-                <node concept="3clFbS" id="7Dcax7AhwtL" role="2VODD2">
-                  <node concept="3clFbF" id="7Dcax7AhwtM" role="3cqZAp">
-                    <node concept="3cpWs3" id="7Dcax7AhwtN" role="3clFbG">
-                      <node concept="Xl_RD" id="7Dcax7AhwtO" role="3uHU7w">
-                        <property role="Xl_RC" value=" requirements ...}" />
+        </node>
+        <node concept="1HlG4h" id="7Dcax7AhwtI" role="3EmGlc">
+          <node concept="1HfYo3" id="7Dcax7AhwtJ" role="1HlULh">
+            <node concept="3TQlhw" id="7Dcax7AhwtK" role="1Hhtcw">
+              <node concept="3clFbS" id="7Dcax7AhwtL" role="2VODD2">
+                <node concept="3clFbF" id="7Dcax7AhwtM" role="3cqZAp">
+                  <node concept="3cpWs3" id="7Dcax7AhwtN" role="3clFbG">
+                    <node concept="Xl_RD" id="7Dcax7AhwtO" role="3uHU7w">
+                      <property role="Xl_RC" value=" requirements ...}" />
+                    </node>
+                    <node concept="3cpWs3" id="7Dcax7AhwtP" role="3uHU7B">
+                      <node concept="Xl_RD" id="7Dcax7AhwtQ" role="3uHU7B">
+                        <property role="Xl_RC" value="{... " />
                       </node>
-                      <node concept="3cpWs3" id="7Dcax7AhwtP" role="3uHU7B">
-                        <node concept="Xl_RD" id="7Dcax7AhwtQ" role="3uHU7B">
-                          <property role="Xl_RC" value="{... " />
-                        </node>
-                        <node concept="2OqwBi" id="7Dcax7AhwtR" role="3uHU7w">
-                          <node concept="2OqwBi" id="7Dcax7AhwtS" role="2Oq$k0">
-                            <node concept="pncrf" id="7Dcax7AhwtT" role="2Oq$k0" />
-                            <node concept="3Tsc0h" id="7Dcax7AhwtU" role="2OqNvi">
-                              <ref role="3TtcxE" to="plfp:4tXyFaWxWA_" resolve="requirements" />
-                            </node>
+                      <node concept="2OqwBi" id="7Dcax7AhwtR" role="3uHU7w">
+                        <node concept="2OqwBi" id="7Dcax7AhwtS" role="2Oq$k0">
+                          <node concept="pncrf" id="7Dcax7AhwtT" role="2Oq$k0" />
+                          <node concept="3Tsc0h" id="7Dcax7AhwtU" role="2OqNvi">
+                            <ref role="3TtcxE" to="plfp:4tXyFaWxWA_" resolve="requirements" />
                           </node>
-                          <node concept="34oBXx" id="7Dcax7AhwtV" role="2OqNvi" />
                         </node>
+                        <node concept="34oBXx" id="7Dcax7AhwtV" role="2OqNvi" />
                       </node>
                     </node>
                   </node>
@@ -1634,7 +1635,15 @@
             </node>
           </node>
         </node>
-        <node concept="l2Vlx" id="1ASK_HedIux" role="2iSdaV" />
+        <node concept="lj46D" id="2tlTgwfCw_a" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pj6Ft" id="2tlTgwfC$pa" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="pj6Ft" id="2tlTgwfCwlW" role="3F10Kt">
+        <property role="VOm3f" value="true" />
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/editor.mps
@@ -573,7 +573,6 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="4tXyFaWwpnw" role="2iSdaV" />
         <node concept="1HlG4h" id="7Dcax7AhQF8" role="3EZMnx">
           <ref role="1k5W1q" to="r4b4:2$$_2GR98qM" resolve="gray" />
           <node concept="VSNWy" id="7Dcax7AhR31" role="3F10Kt">
@@ -630,6 +629,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIuo" role="2iSdaV" />
       </node>
       <node concept="2iRkQZ" id="4tXyFaWwpnn" role="2iSdaV" />
       <node concept="gc7cB" id="7Dcax7Afl6M" role="3EZMnx">
@@ -659,7 +659,6 @@
       </node>
       <node concept="3EZMnI" id="4tXyFaWwv1p" role="3EZMnx">
         <property role="S$Qs1" value="false" />
-        <node concept="2iRfu4" id="4tXyFaWwv1q" role="2iSdaV" />
         <node concept="3XFhqQ" id="4tXyFaWwv39" role="3EZMnx" />
         <node concept="3F2HdR" id="4tXyFaWwuZu" role="3EZMnx">
           <property role="S$F3r" value="true" />
@@ -700,6 +699,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIup" role="2iSdaV" />
       </node>
     </node>
     <node concept="2aJ2om" id="7Dcax7AhwZc" role="CpUAK">
@@ -788,9 +788,7 @@
       <node concept="3F0A7n" id="4tXyFaWyf5O" role="3EZMnx">
         <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
       </node>
-      <node concept="2iRfu4" id="4tXyFaWyf3E" role="2iSdaV" />
       <node concept="3EZMnI" id="7Dcax7Ah5KF" role="3EZMnx">
-        <node concept="2iRfu4" id="7Dcax7Ah5KG" role="2iSdaV" />
         <node concept="3F0ifn" id="4tXyFaWylMP" role="3EZMnx">
           <property role="3F0ifm" value="|" />
           <ref role="1k5W1q" to="r4b4:2$$_2GR98qM" resolve="gray" />
@@ -834,7 +832,9 @@
             <ref role="1wgcnl" node="7Dcax7Ah6hd" resolve="properties" />
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIur" role="2iSdaV" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIuq" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="4tXyFaWwyw8">
@@ -909,7 +909,6 @@
       </node>
       <node concept="2iRkQZ" id="4tXyFaWwywd" role="2iSdaV" />
       <node concept="3EZMnI" id="7Dcax7Ad3q1" role="3EZMnx">
-        <node concept="2iRfu4" id="7Dcax7Ad3q2" role="2iSdaV" />
         <node concept="3F0ifn" id="7Dcax7Ad3nA" role="3EZMnx">
           <property role="3F0ifm" value="config" />
         </node>
@@ -928,6 +927,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIus" role="2iSdaV" />
       </node>
       <node concept="gc7cB" id="4tXyFaWwywB" role="3EZMnx">
         <node concept="3VJUX4" id="4tXyFaWwywD" role="3YsKMw">
@@ -1079,13 +1079,13 @@
     <property role="3GE5qa" value="tag" />
     <ref role="1XX52x" to="plfp:7Ip2X68Nu6t" resolve="PriorityTag" />
     <node concept="3EZMnI" id="7Ip2X68Nu7r" role="2wV5jI">
-      <node concept="2iRfu4" id="7Ip2X68Nu7s" role="2iSdaV" />
       <node concept="3F0ifn" id="7Ip2X68Nu7o" role="3EZMnx">
         <property role="3F0ifm" value="priority" />
       </node>
       <node concept="3F0A7n" id="7Ip2X68Nu7$" role="3EZMnx">
         <ref role="1NtTu8" to="plfp:7Ip2X68Nu6H" resolve="value" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIut" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7Dcax7A9Ln4">
@@ -1297,7 +1297,7 @@
             </node>
           </node>
         </node>
-        <node concept="2iRfu4" id="7Dcax7Ahwss" role="2iSdaV" />
+        <node concept="l2Vlx" id="1ASK_HedIuu" role="2iSdaV" />
       </node>
       <node concept="2iRkQZ" id="7Dcax7Ahwst" role="2iSdaV" />
       <node concept="3EZMnI" id="7Dcax7Ahwsu" role="3EZMnx">
@@ -1386,9 +1386,7 @@
             <property role="Vbekb" value="g1_k_vY/BOLD" />
           </node>
         </node>
-        <node concept="2iRfu4" id="7Dcax7Ahwt3" role="2iSdaV" />
         <node concept="3EZMnI" id="7Dcax7Ahwt4" role="3EZMnx">
-          <node concept="2iRfu4" id="7Dcax7Ahwt5" role="2iSdaV" />
           <node concept="3F0ifn" id="7Dcax7Ahwt6" role="3EZMnx">
             <property role="3F0ifm" value="|" />
             <ref role="1k5W1q" to="r4b4:2$$_2GR98qM" resolve="gray" />
@@ -1424,6 +1422,7 @@
               <ref role="1wgcnl" node="7Dcax7Ah6hd" resolve="properties" />
             </node>
           </node>
+          <node concept="l2Vlx" id="1ASK_HedIuw" role="2iSdaV" />
         </node>
         <node concept="3F0ifn" id="7mG7sQP_BaR" role="3EZMnx">
           <property role="3F0ifm" value=" " />
@@ -1548,6 +1547,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIuv" role="2iSdaV" />
       </node>
       <node concept="gc7cB" id="7Dcax7Ahwtk" role="3EZMnx">
         <node concept="3VJUX4" id="7Dcax7Ahwtl" role="3YsKMw">
@@ -1594,7 +1594,6 @@
       </node>
       <node concept="3EZMnI" id="7Dcax7AhwtB" role="3EZMnx">
         <property role="S$Qs1" value="false" />
-        <node concept="2iRfu4" id="7Dcax7AhwtC" role="2iSdaV" />
         <node concept="3XFhqQ" id="7Dcax7AhwtD" role="3EZMnx" />
         <node concept="3F2HdR" id="7Dcax7AhwtE" role="3EZMnx">
           <property role="S$F3r" value="true" />
@@ -1635,6 +1634,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIux" role="2iSdaV" />
       </node>
     </node>
   </node>
@@ -1774,7 +1774,6 @@
     <property role="TrG5h" value="relation" />
     <ref role="1XX52x" to="plfp:5Zn2KFQSRwl" resolve="IRequirementsRelation" />
     <node concept="3EZMnI" id="5Zn2KFQSUj1" role="2wV5jI">
-      <node concept="2iRfu4" id="5Zn2KFQSUj2" role="2iSdaV" />
       <node concept="1kIj98" id="7mG7sQPs9yE" role="3EZMnx">
         <node concept="3F1sOY" id="5Zn2KFQT7hQ" role="1kIj9b">
           <ref role="1NtTu8" to="plfp:5Zn2KFQSUiY" resolve="kind" />
@@ -1791,6 +1790,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIuy" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5Zn2KFQSUiH">
@@ -1842,14 +1842,12 @@
     <property role="3GE5qa" value="tag" />
     <ref role="1XX52x" to="plfp:5Zn2KFQTtnV" resolve="RelTag" />
     <node concept="3EZMnI" id="7mG7sQPxOXU" role="2wV5jI">
-      <node concept="2iRfu4" id="7mG7sQPxOXV" role="2iSdaV" />
       <node concept="1kIj98" id="7mG7sQPxOXW" role="3EZMnx">
         <node concept="3F1sOY" id="7mG7sQPxOXX" role="1kIj9b">
           <ref role="1NtTu8" to="plfp:5Zn2KFQSUiY" resolve="kind" />
         </node>
       </node>
       <node concept="3EZMnI" id="7mG7sQPxOYf" role="3EZMnx">
-        <node concept="2iRfu4" id="7mG7sQPxOYg" role="2iSdaV" />
         <node concept="3F2HdR" id="7mG7sQPxOXY" role="3EZMnx">
           <property role="2czwfO" value="," />
           <property role="1cu_pB" value="gtguBGO/firstEditableCell" />
@@ -1861,7 +1859,9 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIu$" role="2iSdaV" />
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIuz" role="2iSdaV" />
     </node>
   </node>
   <node concept="2ABfQD" id="4Etk_BWn_aw">
@@ -1949,7 +1949,6 @@
       </node>
       <node concept="2iRkQZ" id="4Etk_BWvNJZ" role="2iSdaV" />
       <node concept="3EZMnI" id="4Etk_BWvNK0" role="3EZMnx">
-        <node concept="2iRfu4" id="4Etk_BWvNK1" role="2iSdaV" />
         <node concept="3F0ifn" id="4Etk_BWvNK2" role="3EZMnx">
           <property role="3F0ifm" value="config" />
         </node>
@@ -1968,6 +1967,7 @@
             </node>
           </node>
         </node>
+        <node concept="l2Vlx" id="1ASK_HedIu_" role="2iSdaV" />
       </node>
       <node concept="gc7cB" id="4Etk_BWvNK8" role="3EZMnx">
         <node concept="3VJUX4" id="4Etk_BWvNK9" role="3YsKMw">
@@ -2014,7 +2014,6 @@
         <node concept="2reCLk" id="3FGEpLFhVz2" role="2reCL6">
           <node concept="2reCLy" id="3FGEpLFhVz4" role="2reCL6">
             <node concept="3EZMnI" id="3FGEpLFj5_6" role="2reSmM">
-              <node concept="2iRfu4" id="3FGEpLFj5_7" role="2iSdaV" />
               <node concept="1HlG4h" id="3FGEpLFj5_s" role="3EZMnx">
                 <node concept="1HfYo3" id="3FGEpLFj5_u" role="1HlULh">
                   <node concept="3TQlhw" id="3FGEpLFj5_w" role="1Hhtcw">
@@ -2069,6 +2068,7 @@
                   <property role="Vbekb" value="g1_k_vY/BOLD" />
                 </node>
               </node>
+              <node concept="l2Vlx" id="1ASK_HedIuA" role="2iSdaV" />
             </node>
             <node concept="1A0rlU" id="3FGEpLFhW0F" role="2recC9">
               <node concept="3F0ifn" id="3FGEpLFhW0T" role="1A0rbF">
@@ -2197,7 +2197,6 @@
         <node concept="2reCLk" id="3FGEpLFjzYE" role="2reCL6">
           <node concept="2reCLy" id="3FGEpLFjzYF" role="2reCL6">
             <node concept="3EZMnI" id="3FGEpLFjzYG" role="2reSmM">
-              <node concept="2iRfu4" id="3FGEpLFjzYH" role="2iSdaV" />
               <node concept="1HlG4h" id="3FGEpLFjzYI" role="3EZMnx">
                 <node concept="1HfYo3" id="3FGEpLFjzYJ" role="1HlULh">
                   <node concept="3TQlhw" id="3FGEpLFjzYK" role="1Hhtcw">
@@ -2252,6 +2251,7 @@
                   <property role="Vbekb" value="g1_k_vY/BOLD" />
                 </node>
               </node>
+              <node concept="l2Vlx" id="1ASK_HedIuB" role="2iSdaV" />
             </node>
             <node concept="1A0rlU" id="3FGEpLFjzZ5" role="2recC9">
               <node concept="3F0ifn" id="3FGEpLFjzZ6" role="1A0rbF">
@@ -2387,7 +2387,6 @@
     <property role="3GE5qa" value="tag" />
     <ref role="1XX52x" to="plfp:7mG7sQPy9qR" resolve="CCTag" />
     <node concept="3EZMnI" id="7mG7sQPy9rv" role="2wV5jI">
-      <node concept="2iRfu4" id="7mG7sQPy9rw" role="2iSdaV" />
       <node concept="3F0ifn" id="7mG7sQPy9rr" role="3EZMnx">
         <property role="3F0ifm" value="CC" />
       </node>
@@ -2402,6 +2401,7 @@
           </node>
         </node>
       </node>
+      <node concept="l2Vlx" id="1ASK_HedIuC" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="7IM3imbnRAF">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.junit.interpreter.run.configuration/models/org.iets3.core.junit.interpreter.run.configuration.plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.junit.interpreter.run.configuration/models/org.iets3.core.junit.interpreter.run.configuration.plugin.mps
@@ -675,7 +675,7 @@
   </registry>
   <node concept="3wDVqS" id="2XSAFHXWCJG">
     <property role="TrG5h" value="JUnit Interpreter Test" />
-    <ref role="3wDP8j" node="2a_WN0NEddp" />
+    <ref role="3wDP8j" node="2a_WN0NEddp" resolve="JUnit Interpreter Test" />
     <node concept="yHkHE" id="5gyVhZ1ayde" role="yHkHi">
       <property role="TrG5h" value="getTestsToMake" />
       <node concept="_YKpA" id="5gyVhZ1aydh" role="3clF45">
@@ -689,7 +689,7 @@
             <node concept="2OqwBi" id="5gyVhZ1ayen" role="2Oq$k0">
               <node concept="2WthIp" id="5gyVhZ1ayem" role="2Oq$k0" />
               <node concept="yHkDZ" id="5gyVhZ1ayer" role="2OqNvi">
-                <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
               </node>
             </node>
             <node concept="2XshWL" id="5gyVhZ1ayew" role="2OqNvi">
@@ -717,7 +717,7 @@
             <node concept="2OqwBi" id="TtDygbXGs8" role="2Oq$k0">
               <node concept="2WthIp" id="TtDygbXGq5" role="2Oq$k0" />
               <node concept="yHkDZ" id="TtDygbXG$k" role="2OqNvi">
-                <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
               </node>
             </node>
             <node concept="2XshWL" id="TtDygbXGFW" role="2OqNvi">
@@ -929,7 +929,7 @@
               </node>
               <node concept="2OqwBi" id="3FQ5zX5utPU" role="33vP2m">
                 <node concept="yHkDH" id="3FQ5zX5utPV" role="2Oq$k0">
-                  <ref role="yHkDG" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                  <ref role="yHkDG" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                 </node>
                 <node concept="yHkDv" id="TtDygbZP53" role="2OqNvi">
                   <ref role="yHkD0" node="5gyVhZ1bmcA" />
@@ -973,14 +973,14 @@
           <node concept="3clFbF" id="5gyVhZ18840" role="3cqZAp">
             <node concept="2OqwBi" id="5gyVhZ1aybT" role="3clFbG">
               <node concept="yHkDH" id="5gyVhZ1aybG" role="2Oq$k0">
-                <ref role="yHkDG" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                <ref role="yHkDG" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
               </node>
               <node concept="yHkDv" id="5gyVhZ1ayc1" role="2OqNvi">
                 <ref role="yHkD0" node="5gyVhZ1bmcJ" />
                 <node concept="2OqwBi" id="5gyVhZ1ayc4" role="yHkDu">
                   <node concept="yHkzx" id="5gyVhZ1ayc3" role="2Oq$k0" />
                   <node concept="yHkDZ" id="29ovBt4Wsn_" role="2OqNvi">
-                    <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                    <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                   </node>
                 </node>
               </node>
@@ -993,14 +993,14 @@
           <node concept="3clFbF" id="5gyVhZ1aycq" role="3cqZAp">
             <node concept="2OqwBi" id="5gyVhZ1aycw" role="3clFbG">
               <node concept="yHkDH" id="5gyVhZ1aycr" role="2Oq$k0">
-                <ref role="yHkDG" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                <ref role="yHkDG" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
               </node>
               <node concept="yHkDv" id="5gyVhZ1aycD" role="2OqNvi">
                 <ref role="yHkD0" node="5gyVhZ1bmcQ" />
                 <node concept="2OqwBi" id="5gyVhZ1aycG" role="yHkDu">
                   <node concept="yHkzx" id="5gyVhZ1aycF" role="2Oq$k0" />
                   <node concept="yHkDZ" id="29ovBt4Wreh" role="2OqNvi">
-                    <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                    <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                   </node>
                 </node>
               </node>
@@ -1013,7 +1013,7 @@
           <node concept="3clFbF" id="5gyVhZ1ayc9" role="3cqZAp">
             <node concept="2OqwBi" id="5gyVhZ1aycf" role="3clFbG">
               <node concept="yHkDH" id="5gyVhZ1ayca" role="2Oq$k0">
-                <ref role="yHkDG" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                <ref role="yHkDG" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
               </node>
               <node concept="yHkDv" id="5gyVhZ1bqKs" role="2OqNvi">
                 <ref role="yHkD0" node="5gyVhZ1bmcX" />
@@ -1030,7 +1030,7 @@
             <node concept="yHkDI" id="qCQmZS5Ifb" role="2OqNvi" />
             <node concept="2OqwBi" id="1X8FusBafDI" role="2Oq$k0">
               <node concept="yHkDZ" id="1X8FusBafOB" role="2OqNvi">
-                <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
               </node>
               <node concept="2WthIp" id="1X8FusBaf$O" role="2Oq$k0" />
             </node>
@@ -1051,7 +1051,7 @@
     <property role="TrG5h" value="JUnit Interpreter Test" />
     <node concept="1QGGSu" id="4rA9Dd$P7z0" role="1bitO_">
       <node concept="10M0yZ" id="4rA9Dd$Pgjt" role="3xaMm5">
-        <ref role="1PxDUh" to="z2i8:~AllIcons$RunConfigurations" resolve="RunConfigurations" />
+        <ref role="1PxDUh" to="z2i8:~AllIcons$RunConfigurations" resolve="AllIcons.RunConfigurations" />
         <ref role="3cqZAo" to="z2i8:~AllIcons$RunConfigurations.Junit" resolve="Junit" />
       </node>
     </node>
@@ -1061,7 +1061,7 @@
     <property role="3gLNDv" value="myRunConfiguration" />
     <ref role="yIonz" node="2XSAFHXWCJG" resolve="JUnit Interpreter Test" />
     <node concept="yYvg6" id="5kzvuLPxk95" role="yYvgT">
-      <ref role="yYvg7" node="5kzvuLPx5KH" resolve="GenerateTestStubs" />
+      <ref role="yYvg7" node="5kzvuLPx5KH" resolve="JUnitInterpreterCheckInterpreterModelsBuildSate" />
     </node>
     <node concept="3CCWSg" id="2XSAFHXYaGR" role="35uJNn">
       <node concept="3clFbS" id="2XSAFHXYaGS" role="2VODD2">
@@ -1074,7 +1074,7 @@
             <node concept="2OqwBi" id="78pvOus40yj" role="33vP2m">
               <node concept="RBKsg" id="78pvOus40yk" role="2Oq$k0" />
               <node concept="yHkDZ" id="78pvOus40yl" role="2OqNvi">
-                <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
               </node>
             </node>
           </node>
@@ -1436,7 +1436,7 @@
               <property role="TrG5h" value="settings" />
               <node concept="2OqwBi" id="5aSLaYRWGzc" role="33vP2m">
                 <node concept="yHkDZ" id="5aSLaYRWGze" role="2OqNvi">
-                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                 </node>
                 <node concept="nyUVq" id="1T5iP2aBolS" role="2Oq$k0" />
               </node>
@@ -1488,7 +1488,7 @@
                   <ref role="3cqZAo" node="2XSAFHY5TsN" resolve="configuration" />
                 </node>
                 <node concept="yHkDZ" id="2h1wjLc2ls4" role="2OqNvi">
-                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                 </node>
               </node>
               <node concept="2XshWL" id="2h1wjLc2ls5" role="2OqNvi">
@@ -1521,7 +1521,7 @@
               <node concept="2OqwBi" id="5aSLaYRWINJ" role="33vP2m">
                 <node concept="nyUVq" id="4aK5w_lfTJw" role="2Oq$k0" />
                 <node concept="yHkDZ" id="6dw4cFkHgtD" role="2OqNvi">
-                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                 </node>
               </node>
             </node>
@@ -1681,7 +1681,7 @@
                   <ref role="3cqZAo" node="2XSAFHY66xC" resolve="configuration" />
                 </node>
                 <node concept="yHkDZ" id="5gyVhZ1ayj$" role="2OqNvi">
-                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                 </node>
               </node>
               <node concept="2XshWL" id="2h1wjLc27Cr" role="2OqNvi">
@@ -1712,7 +1712,7 @@
                     <ref role="3cqZAo" node="2XSAFHY66xC" resolve="configuration" />
                   </node>
                   <node concept="yHkDZ" id="5gyVhZ1ayjD" role="2OqNvi">
-                    <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                    <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                   </node>
                 </node>
                 <node concept="yHkDZ" id="5gyVhZ1bqMB" role="2OqNvi">
@@ -1741,7 +1741,7 @@
               <node concept="2OqwBi" id="1hFhnCnyDdp" role="33vP2m">
                 <node concept="nyUVq" id="4aK5w_lfTJQ" role="2Oq$k0" />
                 <node concept="yHkDZ" id="1hFhnCnyDdr" role="2OqNvi">
-                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                 </node>
               </node>
             </node>
@@ -1910,7 +1910,7 @@
                   <ref role="3cqZAo" node="2XSAFHY6cFy" resolve="configuration" />
                 </node>
                 <node concept="yHkDZ" id="2h1wjLc2lPA" role="2OqNvi">
-                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                 </node>
               </node>
               <node concept="2XshWL" id="2h1wjLc2lPB" role="2OqNvi">
@@ -1945,7 +1945,7 @@
                     <ref role="3cqZAo" node="2XSAFHY6cFy" resolve="configuration" />
                   </node>
                   <node concept="yHkDZ" id="5gyVhZ1ayjv" role="2OqNvi">
-                    <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                    <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                   </node>
                 </node>
                 <node concept="yHkDZ" id="5gyVhZ1bqMw" role="2OqNvi">
@@ -1978,7 +1978,7 @@
                     <ref role="3cqZAo" node="2XSAFHY6cFy" resolve="configuration" />
                   </node>
                   <node concept="yHkDZ" id="9iT$9ktij8" role="2OqNvi">
-                    <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                    <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                   </node>
                 </node>
                 <node concept="yHkDZ" id="9iT$9ktjjp" role="2OqNvi">
@@ -2295,7 +2295,7 @@
                   <ref role="3cqZAo" node="2XSAFHY6jgR" resolve="configuration" />
                 </node>
                 <node concept="yHkDZ" id="2h1wjLc2muO" role="2OqNvi">
-                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                 </node>
               </node>
               <node concept="2XshWL" id="2h1wjLc2muP" role="2OqNvi">
@@ -2322,7 +2322,7 @@
                     <ref role="3cqZAo" node="2XSAFHY6jgR" resolve="configuration" />
                   </node>
                   <node concept="yHkDZ" id="5gyVhZ1ayk2" role="2OqNvi">
-                    <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                    <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                   </node>
                 </node>
                 <node concept="yHkDZ" id="5gyVhZ1bqMN" role="2OqNvi">
@@ -2340,7 +2340,7 @@
                       <ref role="3cqZAo" node="2XSAFHY6jgR" resolve="configuration" />
                     </node>
                     <node concept="yHkDZ" id="AMTgNOhDt6" role="2OqNvi">
-                      <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                      <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                     </node>
                   </node>
                   <node concept="2XshWL" id="1_3tIz4e_OP" role="2OqNvi">
@@ -2380,7 +2380,7 @@
               <node concept="2OqwBi" id="9n1CQGenlV" role="33vP2m">
                 <node concept="nyUVq" id="9n1CQGenlW" role="2Oq$k0" />
                 <node concept="yHkDZ" id="9n1CQGenlX" role="2OqNvi">
-                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                 </node>
               </node>
             </node>
@@ -2776,7 +2776,7 @@
                   <ref role="3cqZAo" node="2XSAFHY6rp2" resolve="configuration" />
                 </node>
                 <node concept="yHkDZ" id="2h1wjLc2oFE" role="2OqNvi">
-                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                 </node>
               </node>
               <node concept="2XshWL" id="2h1wjLc2oFF" role="2OqNvi">
@@ -2803,7 +2803,7 @@
                     <ref role="3cqZAo" node="2XSAFHY6rp2" resolve="configuration" />
                   </node>
                   <node concept="yHkDZ" id="5gyVhZ1ayjS" role="2OqNvi">
-                    <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                    <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                   </node>
                 </node>
                 <node concept="yHkDZ" id="5gyVhZ1bqMJ" role="2OqNvi">
@@ -2821,7 +2821,7 @@
                       <ref role="3cqZAo" node="2XSAFHY6rp2" resolve="configuration" />
                     </node>
                     <node concept="yHkDZ" id="1_3tIz4eAdS" role="2OqNvi">
-                      <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                      <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                     </node>
                   </node>
                   <node concept="2XshWL" id="1_3tIz4eAdT" role="2OqNvi">
@@ -2861,7 +2861,7 @@
               <node concept="2OqwBi" id="9n1CQGhAra" role="33vP2m">
                 <node concept="nyUVq" id="9n1CQGhArb" role="2Oq$k0" />
                 <node concept="yHkDZ" id="9n1CQGhArc" role="2OqNvi">
-                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                 </node>
               </node>
             </node>
@@ -3213,7 +3213,7 @@
                   <ref role="3cqZAo" node="2XSAFHY6$BH" resolve="configuration" />
                 </node>
                 <node concept="yHkDZ" id="2h1wjLc2pMV" role="2OqNvi">
-                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                 </node>
               </node>
               <node concept="2XshWL" id="2h1wjLc2pMW" role="2OqNvi">
@@ -3238,7 +3238,7 @@
                     <ref role="3cqZAo" node="2XSAFHY6$BH" resolve="configuration" />
                   </node>
                   <node concept="yHkDZ" id="5gyVhZ1aykc" role="2OqNvi">
-                    <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                    <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                   </node>
                 </node>
                 <node concept="yHkDZ" id="5gyVhZ1bqMS" role="2OqNvi">
@@ -3256,7 +3256,7 @@
                       <ref role="3cqZAo" node="2XSAFHY6$BH" resolve="configuration" />
                     </node>
                     <node concept="yHkDZ" id="1_3tIz4eR$3" role="2OqNvi">
-                      <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                      <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                     </node>
                   </node>
                   <node concept="2XshWL" id="1_3tIz4eR$4" role="2OqNvi">
@@ -3325,7 +3325,7 @@
                   <ref role="3cqZAo" node="2XSAFHY6UMV" resolve="configuration" />
                 </node>
                 <node concept="yHkDZ" id="2h1wjLc2rYq" role="2OqNvi">
-                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                  <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                 </node>
               </node>
               <node concept="2XshWL" id="2h1wjLc2rYr" role="2OqNvi">
@@ -3418,7 +3418,7 @@
                     <ref role="3cqZAo" node="2XSAFHY6UMV" resolve="configuration" />
                   </node>
                   <node concept="yHkDZ" id="5gyVhZ1aykm" role="2OqNvi">
-                    <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                    <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                   </node>
                 </node>
                 <node concept="yHkDZ" id="2kwDHsIlYHW" role="2OqNvi">
@@ -3436,7 +3436,7 @@
                       <ref role="3cqZAo" node="2XSAFHY6UMV" resolve="configuration" />
                     </node>
                     <node concept="yHkDZ" id="2kwDHsIl_iY" role="2OqNvi">
-                      <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitSettings" />
+                      <ref role="yHkDY" node="5gyVhZ1ayaO" resolve="myJUnitInterpreterSettings" />
                     </node>
                   </node>
                   <node concept="2XshWL" id="1_3tIz4f_uf" role="2OqNvi">
@@ -3587,12 +3587,12 @@
         <node concept="3clFbF" id="6UkhXJgMwKw" role="3cqZAp">
           <node concept="37vLTI" id="6UkhXJgMyCm" role="3clFbG">
             <node concept="37vLTw" id="6UkhXJgMzcz" role="37vLTx">
-              <ref role="3cqZAo" node="3ZOWdXPxqTZ" resolve="wrapper" />
+              <ref role="3cqZAo" node="3ZOWdXPxqTZ" resolve="wrappers" />
             </node>
             <node concept="2OqwBi" id="6UkhXJgMx1h" role="37vLTJ">
               <node concept="Xjq3P" id="6UkhXJgMwKu" role="2Oq$k0" />
               <node concept="2OwXpG" id="6UkhXJgMxCU" role="2OqNvi">
-                <ref role="2Oxat5" node="6UkhXJgMtw9" resolve="wrapper" />
+                <ref role="2Oxat5" node="6UkhXJgMtw9" resolve="wrappers" />
               </node>
             </node>
           </node>
@@ -3671,13 +3671,13 @@
           <node concept="22lmx$" id="6UkhXJgMzuj" role="3clFbw">
             <node concept="2OqwBi" id="6UkhXJgMA31" role="3uHU7w">
               <node concept="37vLTw" id="6UkhXJgM$$d" role="2Oq$k0">
-                <ref role="3cqZAo" node="6UkhXJgMtw9" resolve="wrapper" />
+                <ref role="3cqZAo" node="6UkhXJgMtw9" resolve="wrappers" />
               </node>
               <node concept="1v1jN8" id="6UkhXJgME0f" role="2OqNvi" />
             </node>
             <node concept="3clFbC" id="3ZOWdXPzE7e" role="3uHU7B">
               <node concept="37vLTw" id="3ZOWdXPzDQ8" role="3uHU7B">
-                <ref role="3cqZAo" node="6UkhXJgMtw9" resolve="wrapper" />
+                <ref role="3cqZAo" node="6UkhXJgMtw9" resolve="wrappers" />
               </node>
               <node concept="10Nm6u" id="3ZOWdXPzF0f" role="3uHU7w" />
             </node>
@@ -3686,7 +3686,7 @@
         <node concept="3clFbF" id="6UkhXJgMII7" role="3cqZAp">
           <node concept="2OqwBi" id="6UkhXJgMJ_$" role="3clFbG">
             <node concept="37vLTw" id="6UkhXJgMII5" role="2Oq$k0">
-              <ref role="3cqZAo" node="6UkhXJgMtw9" resolve="wrapper" />
+              <ref role="3cqZAo" node="6UkhXJgMtw9" resolve="wrappers" />
             </node>
             <node concept="2es0OD" id="6UkhXJgMK_7" role="2OqNvi">
               <node concept="1bVj0M" id="6UkhXJgMK_9" role="23t8la">
@@ -3751,7 +3751,7 @@
       <node concept="3Tm1VV" id="3ZOWdXPxqjz" role="1B3o_S" />
       <node concept="3cqZAl" id="3ZOWdXPxqNX" role="3clF45" />
       <node concept="2AHcQZ" id="6UkhXJgKwug" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="2tJIrI" id="3ZOWdXP$ylz" role="jymVt" />
@@ -4439,7 +4439,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="6UkhXJgKy3o" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="2tJIrI" id="4UL3Yhl8C1x" role="jymVt" />
@@ -4502,7 +4502,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="6UkhXJgK_MP" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
   </node>
@@ -4656,7 +4656,7 @@
                                     <node concept="3clFbF" id="2MB0tF9N9eZ" role="3cqZAp">
                                       <node concept="2OqwBi" id="2MB0tF9MWRE" role="3clFbG">
                                         <node concept="37vLTw" id="2MB0tF9MWRF" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="724B1NsurcX" resolve="listOfInterpreterNodes" />
+                                          <ref role="3cqZAo" node="724B1NsurcX" resolve="changedModelsContainingAnInterpreter" />
                                         </node>
                                         <node concept="TSZUe" id="2MB0tF9MWRG" role="2OqNvi">
                                           <node concept="37vLTw" id="2MB0tF9MWRH" role="25WWJ7">
@@ -4777,7 +4777,7 @@
             <node concept="3clFbF" id="724B1NtmEIq" role="3cqZAp">
               <node concept="2YIFZM" id="724B1NtmGqB" role="3clFbG">
                 <ref role="37wK5l" to="fnpx:~Notifications$Bus.notify(com.intellij.notification.Notification)" resolve="notify" />
-                <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Bus" />
+                <ref role="1Pybhc" to="fnpx:~Notifications$Bus" resolve="Notifications.Bus" />
                 <node concept="37vLTw" id="724B1NtmI7_" role="37wK5m">
                   <ref role="3cqZAo" node="724B1NtjHq_" resolve="notification" />
                 </node>
@@ -4901,7 +4901,7 @@
               <ref role="3cqZAo" node="6UkhXJgJg$H" resolve="mpsProject" />
             </node>
             <node concept="37vLTw" id="6UkhXJgI_Eu" role="37vLTJ">
-              <ref role="3cqZAo" node="6UkhXJgIyid" resolve="myMpsProject" />
+              <ref role="3cqZAo" node="6UkhXJgIyid" resolve="myMPSProject" />
             </node>
           </node>
         </node>
@@ -4914,7 +4914,7 @@
               <node concept="ANE8D" id="6UkhXJgMdsd" role="2OqNvi" />
             </node>
             <node concept="37vLTw" id="2qFJdjDD4nz" role="37vLTJ">
-              <ref role="3cqZAo" node="2qFJdjDD4Df" resolve="myTestsContributor" />
+              <ref role="3cqZAo" node="2qFJdjDD4Df" resolve="wrapper" />
             </node>
           </node>
         </node>
@@ -4935,7 +4935,7 @@
               </node>
             </node>
             <node concept="37vLTw" id="78MxLJAHzfR" role="37vLTJ">
-              <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestRunState" />
+              <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestProcessRunState" />
             </node>
           </node>
         </node>
@@ -4959,7 +4959,7 @@
       <node concept="3clFbS" id="37RZV2uqcvT" role="3clF47">
         <node concept="3clFbF" id="37RZV2uqhYC" role="3cqZAp">
           <node concept="37vLTw" id="37RZV2uqhYB" role="3clFbG">
-            <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestRunState" />
+            <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestProcessRunState" />
           </node>
         </node>
       </node>
@@ -4981,7 +4981,7 @@
             <node concept="10P_77" id="2A5UIbg6xAA" role="1tU5fm" />
             <node concept="2OqwBi" id="5uCAHWJXzoT" role="33vP2m">
               <node concept="37vLTw" id="5uCAHWJXyEj" role="2Oq$k0">
-                <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestRunState" />
+                <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestProcessRunState" />
               </node>
               <node concept="liA8E" id="5uCAHWJX$Kh" role="2OqNvi">
                 <ref role="37wK5l" to="ic9i:1$FrpHy4ue1" resolve="advance" />
@@ -5016,7 +5016,7 @@
             <node concept="3cpWs6" id="2A5UIbg6tkG" role="3cqZAp">
               <node concept="2ShNRf" id="1fU_grlV7pz" role="3cqZAk">
                 <node concept="HV5vD" id="6eTCSRmB$nU" role="2ShVmc">
-                  <ref role="HV5vE" node="HCPmXXSuvm" resolve="EmptyProcessHandler" />
+                  <ref role="HV5vE" node="HCPmXXSuvm" resolve="JUnitInterpreterProcessRunStarter.EmptyProcessHandler" />
                 </node>
               </node>
             </node>
@@ -5417,7 +5417,7 @@
                             <node concept="1gVbGN" id="5Ti9jVZ8rGl" role="3cqZAp">
                               <node concept="2OqwBi" id="31DJKq8$PPO" role="1gVkn0">
                                 <node concept="37vLTw" id="4br3RNONujW" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestRunState" />
+                                  <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestProcessRunState" />
                                 </node>
                                 <node concept="liA8E" id="31DJKq8$Qip" role="2OqNvi">
                                   <ref role="37wK5l" to="ic9i:31DJKq8yqW4" resolve="isReady" />
@@ -5456,7 +5456,7 @@
                                 <node concept="3clFbF" id="5Ti9jVZ8rGr" role="3cqZAp">
                                   <node concept="2OqwBi" id="5Ti9jVZ8rGs" role="3clFbG">
                                     <node concept="37vLTw" id="4br3RNON$i4" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestRunState" />
+                                      <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestProcessRunState" />
                                     </node>
                                     <node concept="liA8E" id="5Ti9jVZ8rGu" role="2OqNvi">
                                       <ref role="37wK5l" to="ic9i:1$FrpHy4ue1" resolve="advance" />
@@ -5554,7 +5554,7 @@
                                     <node concept="10P_77" id="4br3RNOQ468" role="1tU5fm" />
                                     <node concept="2OqwBi" id="4br3RNOQ63y" role="33vP2m">
                                       <node concept="37vLTw" id="4br3RNOQ5nm" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestRunState" />
+                                        <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestProcessRunState" />
                                       </node>
                                       <node concept="liA8E" id="4br3RNOQ6w5" role="2OqNvi">
                                         <ref role="37wK5l" to="ic9i:1$FrpHy4ufk" resolve="isTerminating" />
@@ -5565,7 +5565,7 @@
                                 <node concept="3clFbF" id="4br3RNOPc7k" role="3cqZAp">
                                   <node concept="2OqwBi" id="4br3RNOPc7l" role="3clFbG">
                                     <node concept="37vLTw" id="4br3RNOPc7u" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestRunState" />
+                                      <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestProcessRunState" />
                                     </node>
                                     <node concept="liA8E" id="4br3RNOPc7m" role="2OqNvi">
                                       <ref role="37wK5l" to="ic9i:1$FrpHy4ue1" resolve="advance" />
@@ -5834,7 +5834,7 @@
                               <node concept="3clFbF" id="5Ti9jVZ8rHJ" role="3cqZAp">
                                 <node concept="2OqwBi" id="5Ti9jVZ8rHK" role="3clFbG">
                                   <node concept="37vLTw" id="4br3RNONKoN" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestRunState" />
+                                    <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestProcessRunState" />
                                   </node>
                                   <node concept="liA8E" id="5Ti9jVZ8rHM" role="2OqNvi">
                                     <ref role="37wK5l" to="ic9i:1$FrpHy4udR" resolve="set" />
@@ -5892,7 +5892,7 @@
         <node concept="3clFbF" id="5Ti9jVZ8rG7" role="3cqZAp">
           <node concept="2OqwBi" id="2A5UIbg6Tp3" role="3clFbG">
             <node concept="37vLTw" id="4br3RNOMSy8" role="2Oq$k0">
-              <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestRunState" />
+              <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestProcessRunState" />
             </node>
             <node concept="liA8E" id="2A5UIbg6TJK" role="2OqNvi">
               <ref role="37wK5l" to="ic9i:1$FrpHy4ue1" resolve="advance" />
@@ -5977,7 +5977,7 @@
                           <ref role="37wK5l" to="ic9i:31DJKq8yqW4" resolve="isReady" />
                         </node>
                         <node concept="37vLTw" id="4br3RNON0mv" role="2Oq$k0">
-                          <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestRunState" />
+                          <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestProcessRunState" />
                         </node>
                       </node>
                     </node>
@@ -6011,7 +6011,7 @@
                 <ref role="37wK5l" to="ic9i:31DJKq8yqW4" resolve="isReady" />
               </node>
               <node concept="37vLTw" id="4br3RNON0AF" role="2Oq$k0">
-                <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestRunState" />
+                <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestProcessRunState" />
               </node>
             </node>
           </node>
@@ -6082,7 +6082,7 @@
         <node concept="3clFbF" id="2A5UIbg6_9R" role="3cqZAp">
           <node concept="2OqwBi" id="2A5UIbg6_Rw" role="3clFbG">
             <node concept="37vLTw" id="2A5UIbg6_9Q" role="2Oq$k0">
-              <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestRunState" />
+              <ref role="3cqZAo" node="78MxLJAHuiW" resolve="myTestProcessRunState" />
             </node>
             <node concept="liA8E" id="2A5UIbg6KDE" role="2OqNvi">
               <ref role="37wK5l" to="ic9i:2A5UIbg6Ezp" resolve="reset" />
@@ -6433,14 +6433,14 @@
       <node concept="3uibUv" id="5QXtzFzLka9" role="1tU5fm">
         <ref role="3uigEE" to="33ny:~List" resolve="List" />
         <node concept="3uibUv" id="5QXtzFzLkWA" role="11_B2D">
-          <ref role="3uigEE" node="5QXtzFzIPMx" resolve="SelectionChangeListener" />
+          <ref role="3uigEE" node="5QXtzFzIPMx" resolve="JUnitInterpreterScopeAndPanels.SelectionChangeListener" />
         </node>
       </node>
       <node concept="2ShNRf" id="5QXtzFzLrzl" role="33vP2m">
         <node concept="1pGfFk" id="5QXtzFzLu_h" role="2ShVmc">
           <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;()" resolve="ArrayList" />
           <node concept="3uibUv" id="5QXtzFzLwe$" role="1pMfVU">
-            <ref role="3uigEE" node="5QXtzFzIPMx" resolve="SelectionChangeListener" />
+            <ref role="3uigEE" node="5QXtzFzIPMx" resolve="JUnitInterpreterScopeAndPanels.SelectionChangeListener" />
           </node>
         </node>
       </node>
@@ -6457,7 +6457,7 @@
           <ref role="3uigEE" node="1htmYMjXX7h" resolve="JUnitInterpreterRunType" />
         </node>
         <node concept="3uibUv" id="1htmYMk1Ofu" role="3rvSg0">
-          <ref role="3uigEE" node="1_3tIz4jG4t" resolve="PanelPerScope" />
+          <ref role="3uigEE" node="1_3tIz4jG4t" resolve="JUnitInterpreterScopeAndPanels.PanelPerScope" />
         </node>
       </node>
       <node concept="2ShNRf" id="41qKLiDKrdk" role="33vP2m">
@@ -6466,7 +6466,7 @@
             <ref role="3uigEE" node="1htmYMjXX7h" resolve="JUnitInterpreterRunType" />
           </node>
           <node concept="3uibUv" id="1htmYMk21MC" role="3rHtpV">
-            <ref role="3uigEE" node="1_3tIz4jG4t" resolve="PanelPerScope" />
+            <ref role="3uigEE" node="1_3tIz4jG4t" resolve="JUnitInterpreterScopeAndPanels.PanelPerScope" />
           </node>
         </node>
       </node>
@@ -6607,7 +6607,7 @@
           <node concept="37vLTI" id="1htmYMk2KEx" role="3clFbG">
             <node concept="2ShNRf" id="1_3tIz4C61z" role="37vLTx">
               <node concept="1pGfFk" id="1_3tIz4CgCO" role="2ShVmc">
-                <ref role="37wK5l" node="1_3tIz4CbYd" resolve="PanelPerScope" />
+                <ref role="37wK5l" node="1_3tIz4CbYd" resolve="JUnitInterpreterScopeAndPanels.PanelPerScope" />
                 <node concept="37vLTw" id="1_3tIz4CgCN" role="37wK5m">
                   <ref role="3cqZAo" node="1_bTry1O1rs" resolve="projectPanel" />
                 </node>
@@ -6628,7 +6628,7 @@
           <node concept="37vLTI" id="1htmYMk2OZv" role="3clFbG">
             <node concept="2ShNRf" id="1_3tIz4D0PT" role="37vLTx">
               <node concept="1pGfFk" id="1_3tIz4D2y2" role="2ShVmc">
-                <ref role="37wK5l" node="1_3tIz4CbYd" resolve="PanelPerScope" />
+                <ref role="37wK5l" node="1_3tIz4CbYd" resolve="JUnitInterpreterScopeAndPanels.PanelPerScope" />
                 <node concept="37vLTw" id="1_3tIz4D358" role="37wK5m">
                   <ref role="3cqZAo" node="1_bTry1O5fr" resolve="modulePanel" />
                 </node>
@@ -6658,7 +6658,7 @@
             </node>
             <node concept="2ShNRf" id="1_3tIz4D61B" role="37vLTx">
               <node concept="1pGfFk" id="1_3tIz4D61C" role="2ShVmc">
-                <ref role="37wK5l" node="1_3tIz4CbYd" resolve="PanelPerScope" />
+                <ref role="37wK5l" node="1_3tIz4CbYd" resolve="JUnitInterpreterScopeAndPanels.PanelPerScope" />
                 <node concept="37vLTw" id="1_3tIz4D61D" role="37wK5m">
                   <ref role="3cqZAo" node="1_bTry1O5hX" resolve="modelPanel" />
                 </node>
@@ -6679,7 +6679,7 @@
             </node>
             <node concept="2ShNRf" id="1_3tIz4D6aD" role="37vLTx">
               <node concept="1pGfFk" id="1_3tIz4D6aE" role="2ShVmc">
-                <ref role="37wK5l" node="1_3tIz4CbYd" resolve="PanelPerScope" />
+                <ref role="37wK5l" node="1_3tIz4CbYd" resolve="JUnitInterpreterScopeAndPanels.PanelPerScope" />
                 <node concept="37vLTw" id="1_3tIz4D6aF" role="37wK5m">
                   <ref role="3cqZAo" node="1_3tIz4nUp0" resolve="myClassesChooser" />
                 </node>
@@ -6700,7 +6700,7 @@
             </node>
             <node concept="2ShNRf" id="1_3tIz4D6yn" role="37vLTx">
               <node concept="1pGfFk" id="1_3tIz4D6yo" role="2ShVmc">
-                <ref role="37wK5l" node="1_3tIz4CbYd" resolve="PanelPerScope" />
+                <ref role="37wK5l" node="1_3tIz4CbYd" resolve="JUnitInterpreterScopeAndPanels.PanelPerScope" />
                 <node concept="37vLTw" id="1_3tIz4D6yp" role="37wK5m">
                   <ref role="3cqZAo" node="1_3tIz4nUoX" resolve="myMethodsChooser" />
                 </node>
@@ -7897,7 +7897,7 @@
               <node concept="3cpWsn" id="1_3tIz50NTh" role="3cpWs9">
                 <property role="TrG5h" value="scopePanel" />
                 <node concept="3uibUv" id="1_3tIz50NTi" role="1tU5fm">
-                  <ref role="3uigEE" node="1_3tIz4jG4t" resolve="PanelPerScope" />
+                  <ref role="3uigEE" node="1_3tIz4jG4t" resolve="JUnitInterpreterScopeAndPanels.PanelPerScope" />
                 </node>
                 <node concept="3EllGN" id="1_3tIz50RFz" role="33vP2m">
                   <node concept="37vLTw" id="1_3tIz50S99" role="3ElVtu">
@@ -8166,7 +8166,7 @@
                     <ref role="3cqZAo" node="1_3tIz5ELEA" resolve="border" />
                   </node>
                   <node concept="2YIFZM" id="1_3tIz5GxbH" role="37wK5m">
-                    <ref role="1Pybhc" to="g1qu:~JBUI$Borders" resolve="Borders" />
+                    <ref role="1Pybhc" to="g1qu:~JBUI$Borders" resolve="JBUI.Borders" />
                     <ref role="37wK5l" to="g1qu:~JBUI$Borders.empty(int,int,int,int)" resolve="empty" />
                     <node concept="37vLTw" id="1_3tIz5MCwl" role="37wK5m">
                       <ref role="3cqZAo" node="1_3tIz5MCwi" resolve="scaledSz" />
@@ -8365,7 +8365,7 @@
         <property role="TrG5h" value="listener" />
         <property role="3TUv4t" value="true" />
         <node concept="3uibUv" id="5QXtzFzIE3y" role="1tU5fm">
-          <ref role="3uigEE" node="5QXtzFzIPMx" resolve="SelectionChangeListener" />
+          <ref role="3uigEE" node="5QXtzFzIPMx" resolve="JUnitInterpreterScopeAndPanels.SelectionChangeListener" />
         </node>
       </node>
     </node>
@@ -8457,7 +8457,7 @@
                               <node concept="3cpWsn" id="5QXtzFzLPHl" role="1Duv9x">
                                 <property role="TrG5h" value="listener" />
                                 <node concept="3uibUv" id="5QXtzFzLQrc" role="1tU5fm">
-                                  <ref role="3uigEE" node="5QXtzFzIPMx" resolve="SelectionChangeListener" />
+                                  <ref role="3uigEE" node="5QXtzFzIPMx" resolve="JUnitInterpreterScopeAndPanels.SelectionChangeListener" />
                                 </node>
                               </node>
                               <node concept="37vLTw" id="5QXtzFzLRGu" role="1DdaDG">
@@ -9495,7 +9495,7 @@
               <node concept="liA8E" id="1_3tIz5uEBG" role="2OqNvi">
                 <ref role="37wK5l" to="dxuu:~JComponent.setBorder(javax.swing.border.Border)" resolve="setBorder" />
                 <node concept="2YIFZM" id="1_3tIz5uHad" role="37wK5m">
-                  <ref role="1Pybhc" to="g1qu:~JBUI$Borders" resolve="Borders" />
+                  <ref role="1Pybhc" to="g1qu:~JBUI$Borders" resolve="JBUI.Borders" />
                   <ref role="37wK5l" to="g1qu:~JBUI$Borders.empty(int,int,int,int)" resolve="empty" />
                   <node concept="3cmrfG" id="1_3tIz5uHH9" role="37wK5m">
                     <property role="3cmrfH" value="0" />
@@ -10622,7 +10622,7 @@
       <property role="3TUv4t" value="true" />
       <node concept="3Tm6S6" id="1_3tIz4yL$t" role="1B3o_S" />
       <node concept="3uibUv" id="1_3tIz4yRlB" role="1tU5fm">
-        <ref role="3uigEE" node="1_3tIz4jFUU" resolve="ScopeAndPanelsForInterpreterSettings" />
+        <ref role="3uigEE" node="1_3tIz4jFUU" resolve="JUnitInterpreterScopeAndPanels" />
       </node>
     </node>
     <node concept="2tJIrI" id="1_3tIz4v58u" role="jymVt" />
@@ -10720,7 +10720,7 @@
           <node concept="37vLTI" id="1_3tIz4zg$Z" role="3clFbG">
             <node concept="2ShNRf" id="1_3tIz4zhnE" role="37vLTx">
               <node concept="1pGfFk" id="1_3tIz4zlka" role="2ShVmc">
-                <ref role="37wK5l" node="1_3tIz4lzAW" resolve="ScopeAndPanelsForInterpreterSettings" />
+                <ref role="37wK5l" node="1_3tIz4lzAW" resolve="JUnitInterpreterScopeAndPanels" />
                 <node concept="37vLTw" id="1_3tIz4zoVz" role="37wK5m">
                   <ref role="3cqZAo" node="1_bTry1W3A$" resolve="project" />
                 </node>
@@ -11065,7 +11065,7 @@
                 <node concept="YeOm9" id="3vnmwWFEIHR" role="2ShVmc">
                   <node concept="1Y3b0j" id="3vnmwWFEIHU" role="YeSDq">
                     <property role="2bfB8j" value="true" />
-                    <ref role="1Y3XeK" to="xygl:~Task$Modal" resolve="Modal" />
+                    <ref role="1Y3XeK" to="xygl:~Task$Modal" resolve="Task.Modal" />
                     <ref role="37wK5l" to="xygl:~Task$Modal.&lt;init&gt;(com.intellij.openapi.project.Project,java.lang.String,boolean)" resolve="Task.Modal" />
                     <node concept="2OqwBi" id="4YEli8eCFwJ" role="37wK5m">
                       <node concept="37vLTw" id="4YEli8eCEF4" role="2Oq$k0">
@@ -11300,7 +11300,7 @@
     <node concept="2tJIrI" id="4gBl0l5H3mI" role="jymVt" />
     <node concept="QsSxf" id="5gyVhZ1bmql" role="Qtgdg">
       <property role="TrG5h" value="PROJECT" />
-      <ref role="37wK5l" node="5gyVhZ1bml9" resolve="JUnitRunTypes" />
+      <ref role="37wK5l" node="5gyVhZ1bml9" resolve="JUnitInterpreterRunTypes" />
       <node concept="3clFb_" id="5gyVhZ1bmqm" role="2HKRsH">
         <property role="TrG5h" value="doCollect" />
         <node concept="_YKpA" id="4YEli8eDgCs" role="3clF45">
@@ -11478,7 +11478,7 @@
     </node>
     <node concept="QsSxf" id="5gyVhZ1bmp3" role="Qtgdg">
       <property role="TrG5h" value="MODULE" />
-      <ref role="37wK5l" node="5gyVhZ1bml9" resolve="JUnitRunTypes" />
+      <ref role="37wK5l" node="5gyVhZ1bml9" resolve="JUnitInterpreterRunTypes" />
       <node concept="3clFb_" id="5gyVhZ1bmp4" role="2HKRsH">
         <property role="TrG5h" value="doCollect" />
         <node concept="_YKpA" id="4YEli8eDH9t" role="3clF45">
@@ -11830,7 +11830,7 @@
     </node>
     <node concept="QsSxf" id="5gyVhZ1bmnN" role="Qtgdg">
       <property role="TrG5h" value="MODEL" />
-      <ref role="37wK5l" node="5gyVhZ1bml9" resolve="JUnitRunTypes" />
+      <ref role="37wK5l" node="5gyVhZ1bml9" resolve="JUnitInterpreterRunTypes" />
       <node concept="3clFb_" id="5gyVhZ1bmnO" role="2HKRsH">
         <property role="TrG5h" value="doCollect" />
         <node concept="_YKpA" id="4YEli8eDdYC" role="3clF45">
@@ -12216,7 +12216,7 @@
     </node>
     <node concept="QsSxf" id="5gyVhZ1bmmw" role="Qtgdg">
       <property role="TrG5h" value="NODE" />
-      <ref role="37wK5l" node="5gyVhZ1bml9" resolve="JUnitRunTypes" />
+      <ref role="37wK5l" node="5gyVhZ1bml9" resolve="JUnitInterpreterRunTypes" />
       <node concept="3clFb_" id="5gyVhZ1bmmx" role="2HKRsH">
         <property role="TrG5h" value="doCollect" />
         <node concept="_YKpA" id="4YEli8eD41v" role="3clF45">
@@ -12558,7 +12558,7 @@
     </node>
     <node concept="QsSxf" id="5gyVhZ1bmld" role="Qtgdg">
       <property role="TrG5h" value="METHOD" />
-      <ref role="37wK5l" node="5gyVhZ1bml9" resolve="JUnitRunTypes" />
+      <ref role="37wK5l" node="5gyVhZ1bml9" resolve="JUnitInterpreterRunTypes" />
       <node concept="3clFb_" id="5gyVhZ1bmle" role="2HKRsH">
         <property role="TrG5h" value="doCollect" />
         <node concept="_YKpA" id="4YEli8eD6Ij" role="3clF45">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.junit.interpreter.run.configuration/org.iets3.core.junit.interpreter.run.configuration.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.junit.interpreter.run.configuration/org.iets3.core.junit.interpreter.run.configuration.msd
@@ -103,12 +103,11 @@
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
     <module reference="8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
-    <module reference="a1250a4d-c090-42c3-ad7c-d298a3357dd4(jetbrains.mps.make.runtime)" version="0" />
     <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="1" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
-    <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="1" />
+    <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="4" />
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="5" />
-    <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="0" />
+    <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="1" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />
     <module reference="d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)" version="0" />
     <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="2" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -354,7 +354,7 @@
     </node>
     <node concept="1l3spV" id="5wLtKNeSRRM" role="1l3spN">
       <node concept="m$_wl" id="5loVtKO1B0A" role="39821P">
-        <ref role="m_rDy" node="5loVtKNYW0J" resolve="org.iets3.core.JUnitInterpreterTest" />
+        <ref role="m_rDy" node="5loVtKNYW0J" resolve="org.iets3.core.junit.interpreter.run.configuration" />
         <node concept="pUk6x" id="5loVtKO1B35" role="pUk7w" />
       </node>
       <node concept="m$_wl" id="7$nPgK7znh$" role="39821P">


### PR DESCRIPTION
- fixes https://github.com/IETS3/iets3.opensource/issues/411
- more details are in the commit descriptions

There are two types of concepts that don't respect line wrapping at all: tables and test items. For test items and many other concepts, the issue is that they use vertical grid layouts to align editors nicely in a tabular form. This layout expects its content to contain horizontal layouts, so we can't use indent layouts for test items.

When a cell exceeds the maximum text width set by the user (preferences -> Editor -> MPS Editor -> Text width), its most right point becomes the new maximum width for the following cell and therefore they also break at this point instead at the text width.

I talked to @slisson about this and this would be hard to fix. There is always a tradeoff between line breaking and alignment of cells for us. Setting overflow-x to true, breaks tables and also most other stuff. The idea behind it was to allow single cells to exceed the maximum width e.g. images in the documentation but it seems like those cells are then not included in the layout calculation at all.

How to test: set the text width to a smaller value like 50. Here are some examples where the issues still happen. This needs to be addressed in a separate PR here or in MPS-Extensions:

-  http://127.0.0.1:63320/node?ref=r%3Ac26f3707-1ecb-413e-ba84-cd641318e760%28playground.sheets%29%2F5953575425760065569
-  http://127.0.0.1:63320/node?ref=r%3Acc6f834a-e980-4402-b501-57396f6330a8%28messages%40tests%29%2F5299123466388783842
-  http://127.0.0.1:63320/node?ref=r%3A109d7958-4308-4f2a-95cb-ea4731803298%28test.in.expr.os.algebraic%40tests%29%2F5955298286257384874
-  http://127.0.0.1:63320/node?ref=r%3A109d7958-4308-4f2a-95cb-ea4731803298%28test.in.expr.os.algebraic%40tests%29%2F2460310434946955886
-  http://127.0.0.1:63320/node?ref=r%3A206e2f16-1e9d-4dba-a48f-a14d1e82c7a3%28test.in.expr.os.applicationExamples%40tests%29%2F6527211908667104447
-  http://127.0.0.1:63320/node?ref=r%3A01a6c2ec-8e8f-4bd1-bb81-7468b52febee%28test.in.expr.os.contracts%40tests%29%2F1922523186437509723
-  http://127.0.0.1:63320/node?ref=r%3A5d61ba74-2fa4-4f6f-9f36-f36d4e99a4c5%28test.in.expr.os.mutable%40tests%29%2F4270802518593490248
-  http://127.0.0.1:63320/node?ref=r%3A4498a3f1-ffdc-46cb-b225-63bf7159e69e%28test.in.expr.os.stringvalidation%40tests%29%2F3709229751379473185
-  http://127.0.0.1:63320/node?ref=r%3Aae52e1b7-6479-4187-9e09-836b57124d46%28test.in.expr.os.utils%40tests%29%2F4693510969746621067
-   http://127.0.0.1:63320/node?ref=r%3A2309ed17-e7b4-45b5-b25e-2c0f3ea87e8b%28test.in.expr.os.collections%40tests%29%2F3989687177019288292
-    http://127.0.0.1:63320/node?ref=r%3Ad13efac1-a045-434f-8551-7b85e2be7d5e%28test.in.expr.os.dataflow%40tests%29%2F5733544478073029053
-    http://127.0.0.1:63320/node?ref=r%3A4498a3f1-ffdc-46cb-b225-63bf7159e69e%28test.in.expr.os.stringvalidation%40tests%29%2F3191633378143358597