### PR TITLE
Bugfix/decrease short lamba evaluation time

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
@@ -1750,7 +1750,7 @@
       </node>
     </node>
     <node concept="13i0hz" id="5s__jxCq8Sv" role="13h7CS">
-      <property role="TrG5h" value="putLamdaArg" />
+      <property role="TrG5h" value="putLambdaArg" />
       <node concept="3Tm1VV" id="5s__jxCq8Sw" role="1B3o_S" />
       <node concept="3cqZAl" id="5s__jxCq8Sx" role="3clF45" />
       <node concept="3clFbS" id="5s__jxCq8Sy" role="3clF47">
@@ -1780,7 +1780,7 @@
       </node>
     </node>
     <node concept="13i0hz" id="5s__jxCqcBE" role="13h7CS">
-      <property role="TrG5h" value="getLamdaArg" />
+      <property role="TrG5h" value="getLambdaArg" />
       <node concept="3Tm1VV" id="5s__jxCqcBF" role="1B3o_S" />
       <node concept="3clFbS" id="5s__jxCqcBH" role="3clF47">
         <node concept="3clFbF" id="5s__jxCqcBI" role="3cqZAp">
@@ -1812,7 +1812,7 @@
       </node>
     </node>
     <node concept="13i0hz" id="XbOhLk5ekn" role="13h7CS">
-      <property role="TrG5h" value="putLamda" />
+      <property role="TrG5h" value="putLambda" />
       <node concept="3Tm1VV" id="XbOhLk5eko" role="1B3o_S" />
       <node concept="3cqZAl" id="XbOhLk5ekp" role="3clF45" />
       <node concept="3clFbS" id="XbOhLk5ekq" role="3clF47">
@@ -1842,7 +1842,7 @@
       </node>
     </node>
     <node concept="13i0hz" id="XbOhLk5ek9" role="13h7CS">
-      <property role="TrG5h" value="getLamda" />
+      <property role="TrG5h" value="getLambda" />
       <node concept="3Tm1VV" id="XbOhLk5eka" role="1B3o_S" />
       <node concept="3clFbS" id="XbOhLk5ekb" role="3clF47">
         <node concept="3clFbF" id="XbOhLk5ekc" role="3cqZAp">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
@@ -1811,6 +1811,68 @@
         <ref role="ehGHo" to="zzzn:6zmBjqUkwse" resolve="LambdaArg" />
       </node>
     </node>
+    <node concept="13i0hz" id="XbOhLk5ekn" role="13h7CS">
+      <property role="TrG5h" value="putLamda" />
+      <node concept="3Tm1VV" id="XbOhLk5eko" role="1B3o_S" />
+      <node concept="3cqZAl" id="XbOhLk5ekp" role="3clF45" />
+      <node concept="3clFbS" id="XbOhLk5ekq" role="3clF47">
+        <node concept="3clFbF" id="XbOhLk5ekr" role="3cqZAp">
+          <node concept="2OqwBi" id="XbOhLk5eks" role="3clFbG">
+            <node concept="2JrnkZ" id="XbOhLk5ekt" role="2Oq$k0">
+              <node concept="13iPFW" id="XbOhLk5eku" role="2JrQYb" />
+            </node>
+            <node concept="liA8E" id="XbOhLk5ekv" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.putUserObject(java.lang.Object,java.lang.Object)" resolve="putUserObject" />
+              <node concept="10M0yZ" id="XbOhLk5fLj" role="37wK5m">
+                <ref role="3cqZAo" to="sxpq:XbOhLk4Bsh" resolve="USER_OBJECT_KEY_LAMBDA" />
+                <ref role="1PxDUh" to="sxpq:5s__jxCoQMv" resolve="ShortLambdaValue" />
+              </node>
+              <node concept="37vLTw" id="XbOhLk5ekx" role="37wK5m">
+                <ref role="3cqZAo" node="XbOhLk5eky" resolve="lambdaArg" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="XbOhLk5eky" role="3clF46">
+        <property role="TrG5h" value="lambdaArg" />
+        <node concept="3Tqbb2" id="XbOhLk5ekz" role="1tU5fm">
+          <ref role="ehGHo" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="XbOhLk5ek9" role="13h7CS">
+      <property role="TrG5h" value="getLamda" />
+      <node concept="3Tm1VV" id="XbOhLk5eka" role="1B3o_S" />
+      <node concept="3clFbS" id="XbOhLk5ekb" role="3clF47">
+        <node concept="3clFbF" id="XbOhLk5ekc" role="3cqZAp">
+          <node concept="1eOMI4" id="XbOhLk5ekd" role="3clFbG">
+            <node concept="10QFUN" id="XbOhLk5eke" role="1eOMHV">
+              <node concept="3Tqbb2" id="XbOhLk5ekf" role="10QFUM">
+                <ref role="ehGHo" to="zzzn:6zmBjqUkwse" resolve="LambdaArg" />
+              </node>
+              <node concept="1eOMI4" id="XbOhLk5ekg" role="10QFUP">
+                <node concept="2OqwBi" id="XbOhLk5ekh" role="1eOMHV">
+                  <node concept="2JrnkZ" id="XbOhLk5eki" role="2Oq$k0">
+                    <node concept="13iPFW" id="XbOhLk5ekj" role="2JrQYb" />
+                  </node>
+                  <node concept="liA8E" id="XbOhLk5ekk" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.getUserObject(java.lang.Object)" resolve="getUserObject" />
+                    <node concept="10M0yZ" id="XbOhLk5gsG" role="37wK5m">
+                      <ref role="3cqZAo" to="sxpq:XbOhLk4Bsh" resolve="USER_OBJECT_KEY_LAMBDA" />
+                      <ref role="1PxDUh" to="sxpq:5s__jxCoQMv" resolve="ShortLambdaValue" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="XbOhLk5ekm" role="3clF45">
+        <ref role="ehGHo" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
+      </node>
+    </node>
     <node concept="13i0hz" id="5s__jxDLZVE" role="13h7CS">
       <property role="TrG5h" value="getNodeMapping" />
       <node concept="3Tm1VV" id="5s__jxDLZVF" role="1B3o_S" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
@@ -1749,6 +1749,158 @@
         <ref role="3uigEE" to="oq0c:3ni3WieuV7z" resolve="EffectDescriptor" />
       </node>
     </node>
+    <node concept="13i0hz" id="5s__jxCq8Sv" role="13h7CS">
+      <property role="TrG5h" value="putLamdaArg" />
+      <node concept="3Tm1VV" id="5s__jxCq8Sw" role="1B3o_S" />
+      <node concept="3cqZAl" id="5s__jxCq8Sx" role="3clF45" />
+      <node concept="3clFbS" id="5s__jxCq8Sy" role="3clF47">
+        <node concept="3clFbF" id="5s__jxCq8Sz" role="3cqZAp">
+          <node concept="2OqwBi" id="5s__jxCq8S$" role="3clFbG">
+            <node concept="2JrnkZ" id="5s__jxCq8S_" role="2Oq$k0">
+              <node concept="13iPFW" id="5s__jxCq8SA" role="2JrQYb" />
+            </node>
+            <node concept="liA8E" id="5s__jxCq8SB" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.putUserObject(java.lang.Object,java.lang.Object)" resolve="putUserObject" />
+              <node concept="10M0yZ" id="5s__jxCqbTx" role="37wK5m">
+                <ref role="3cqZAo" to="sxpq:5s__jxCpjNV" resolve="USER_OBJECT_KEY_LAMBDAARG" />
+                <ref role="1PxDUh" to="sxpq:5s__jxCoQMv" resolve="ShortLambdaValue" />
+              </node>
+              <node concept="37vLTw" id="5s__jxCq8SD" role="37wK5m">
+                <ref role="3cqZAo" node="5s__jxCqaIo" resolve="lambdaArg" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5s__jxCqaIo" role="3clF46">
+        <property role="TrG5h" value="lambdaArg" />
+        <node concept="3Tqbb2" id="5s__jxCqaIn" role="1tU5fm">
+          <ref role="ehGHo" to="zzzn:6zmBjqUkwse" resolve="LambdaArg" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="5s__jxCqcBE" role="13h7CS">
+      <property role="TrG5h" value="getLamdaArg" />
+      <node concept="3Tm1VV" id="5s__jxCqcBF" role="1B3o_S" />
+      <node concept="3clFbS" id="5s__jxCqcBH" role="3clF47">
+        <node concept="3clFbF" id="5s__jxCqcBI" role="3cqZAp">
+          <node concept="1eOMI4" id="5s__jxCqhoK" role="3clFbG">
+            <node concept="10QFUN" id="5s__jxCqhoH" role="1eOMHV">
+              <node concept="3Tqbb2" id="5s__jxCqhwO" role="10QFUM">
+                <ref role="ehGHo" to="zzzn:6zmBjqUkwse" resolve="LambdaArg" />
+              </node>
+              <node concept="1eOMI4" id="5s__jxCqhcE" role="10QFUP">
+                <node concept="2OqwBi" id="5s__jxCqcBJ" role="1eOMHV">
+                  <node concept="2JrnkZ" id="5s__jxCqcBK" role="2Oq$k0">
+                    <node concept="13iPFW" id="5s__jxCqcBL" role="2JrQYb" />
+                  </node>
+                  <node concept="liA8E" id="5s__jxCqcBM" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.getUserObject(java.lang.Object)" resolve="getUserObject" />
+                    <node concept="10M0yZ" id="5s__jxCqcBN" role="37wK5m">
+                      <ref role="3cqZAo" to="sxpq:5s__jxCpjNV" resolve="USER_OBJECT_KEY_LAMBDAARG" />
+                      <ref role="1PxDUh" to="sxpq:5s__jxCoQMv" resolve="ShortLambdaValue" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="5s__jxCqcBQ" role="3clF45">
+        <ref role="ehGHo" to="zzzn:6zmBjqUkwse" resolve="LambdaArg" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="5s__jxDLZVE" role="13h7CS">
+      <property role="TrG5h" value="getNodeMapping" />
+      <node concept="3Tm1VV" id="5s__jxDLZVF" role="1B3o_S" />
+      <node concept="3rvAFt" id="5s__jxDLZVG" role="3clF45">
+        <node concept="3Tqbb2" id="5s__jxDLZVH" role="3rvQeY" />
+        <node concept="3Tqbb2" id="5s__jxDLZVI" role="3rvSg0" />
+      </node>
+      <node concept="3clFbS" id="5s__jxDLZVJ" role="3clF47">
+        <node concept="3clFbJ" id="5s__jxDLZVK" role="3cqZAp">
+          <node concept="3clFbS" id="5s__jxDLZVL" role="3clFbx">
+            <node concept="3cpWs6" id="5s__jxDLZVM" role="3cqZAp">
+              <node concept="10QFUN" id="5s__jxDLZVN" role="3cqZAk">
+                <node concept="3rvAFt" id="5s__jxDLZVO" role="10QFUM">
+                  <node concept="3Tqbb2" id="5s__jxDLZVP" role="3rvQeY" />
+                  <node concept="3Tqbb2" id="5s__jxDLZVQ" role="3rvSg0" />
+                </node>
+                <node concept="1eOMI4" id="5s__jxDLZVR" role="10QFUP">
+                  <node concept="2OqwBi" id="5s__jxDLZVS" role="1eOMHV">
+                    <node concept="2JrnkZ" id="5s__jxDLZVT" role="2Oq$k0">
+                      <node concept="13iPFW" id="5s__jxDLZVU" role="2JrQYb" />
+                    </node>
+                    <node concept="liA8E" id="5s__jxDLZVV" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SNode.getUserObject(java.lang.Object)" resolve="getUserObject" />
+                      <node concept="10M0yZ" id="5s__jxDLZVW" role="37wK5m">
+                        <ref role="3cqZAo" to="sxpq:6ITtBskT0za" resolve="USER_OBJECT_KEY" />
+                        <ref role="1PxDUh" to="sxpq:$yb$20f$a5" resolve="LambdaValue" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2ZW3vV" id="5s__jxDLZVX" role="3clFbw">
+            <node concept="2OqwBi" id="5s__jxDLZVY" role="2ZW6bz">
+              <node concept="2JrnkZ" id="5s__jxDLZVZ" role="2Oq$k0">
+                <node concept="13iPFW" id="5s__jxDLZW0" role="2JrQYb" />
+              </node>
+              <node concept="liA8E" id="5s__jxDLZW1" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SNode.getUserObject(java.lang.Object)" resolve="getUserObject" />
+                <node concept="10M0yZ" id="5s__jxDLZW2" role="37wK5m">
+                  <ref role="3cqZAo" to="sxpq:6ITtBskT0za" resolve="USER_OBJECT_KEY" />
+                  <ref role="1PxDUh" to="sxpq:$yb$20f$a5" resolve="LambdaValue" />
+                </node>
+              </node>
+            </node>
+            <node concept="3uibUv" id="5s__jxDLZW3" role="2ZW6by">
+              <ref role="3uigEE" to="33ny:~Map" resolve="Map" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5s__jxDLZW4" role="3cqZAp">
+          <node concept="10Nm6u" id="5s__jxDLZW5" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="5s__jxDLZW6" role="2AJF6D">
+        <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="5s__jxDLZW7" role="13h7CS">
+      <property role="TrG5h" value="putNodeMapping" />
+      <node concept="3Tm1VV" id="5s__jxDLZW8" role="1B3o_S" />
+      <node concept="3cqZAl" id="5s__jxDLZW9" role="3clF45" />
+      <node concept="3clFbS" id="5s__jxDLZWa" role="3clF47">
+        <node concept="3clFbF" id="5s__jxDLZWb" role="3cqZAp">
+          <node concept="2OqwBi" id="5s__jxDLZWc" role="3clFbG">
+            <node concept="2JrnkZ" id="5s__jxDLZWd" role="2Oq$k0">
+              <node concept="13iPFW" id="5s__jxDLZWe" role="2JrQYb" />
+            </node>
+            <node concept="liA8E" id="5s__jxDLZWf" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.putUserObject(java.lang.Object,java.lang.Object)" resolve="putUserObject" />
+              <node concept="10M0yZ" id="5s__jxDLZWg" role="37wK5m">
+                <ref role="3cqZAo" to="sxpq:6ITtBskT0za" resolve="USER_OBJECT_KEY" />
+                <ref role="1PxDUh" to="sxpq:$yb$20f$a5" resolve="LambdaValue" />
+              </node>
+              <node concept="37vLTw" id="5s__jxDLZWh" role="37wK5m">
+                <ref role="3cqZAo" node="5s__jxDLZWi" resolve="map" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="5s__jxDLZWi" role="3clF46">
+        <property role="TrG5h" value="map" />
+        <node concept="3rvAFt" id="5s__jxDLZWj" role="1tU5fm">
+          <node concept="3Tqbb2" id="5s__jxDLZWk" role="3rvQeY" />
+          <node concept="3Tqbb2" id="5s__jxDLZWl" role="3rvSg0" />
+        </node>
+      </node>
+    </node>
     <node concept="13hLZK" id="6zmBjqUm7On" role="13h7CW">
       <node concept="3clFbS" id="6zmBjqUm7Oo" role="2VODD2">
         <node concept="3clFbF" id="7SZA7UeM0l2" role="3cqZAp">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/plugin.mps
@@ -17,6 +17,7 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -63,9 +64,16 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg">
         <property id="8606350594693632173" name="isTransient" index="eg7rD" />
         <property id="1240249534625" name="isVolatile" index="34CwA1" />
@@ -101,6 +109,7 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
@@ -123,9 +132,17 @@
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
+      <concept id="1068581242867" name="jetbrains.mps.baseLanguage.structure.LongType" flags="in" index="3cpWsb" />
+      <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
       <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
+      <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="nn" index="1gVbGN">
+        <child id="1160998896846" name="condition" index="1gVkn0" />
+      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -153,9 +170,13 @@
         <child id="1144231399730" name="condition" index="1Dwp0S" />
         <child id="1144231408325" name="iteration" index="1Dwrff" />
       </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
@@ -169,12 +190,19 @@
         <reference id="5455284157994012188" name="link" index="2pIpSl" />
         <child id="1595412875168045827" name="initValue" index="28nt2d" />
       </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
       <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
         <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
       </concept>
       <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
         <reference id="5455284157993910961" name="concept" index="2pJxaS" />
         <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
       </concept>
       <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
         <child id="8182547171709752112" name="expression" index="36biLW" />
@@ -199,6 +227,9 @@
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
@@ -227,8 +258,26 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
+        <property id="709746936026609031" name="linkId" index="3V$3ak" />
+        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
+      </concept>
+      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
+        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
@@ -261,6 +310,7 @@
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
+      <concept id="1227022210526" name="jetbrains.mps.baseLanguage.collections.structure.ClearAllElementsOperation" flags="nn" index="2Kehj3" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
@@ -356,92 +406,53 @@
       <node concept="3cqZAl" id="$yb$20fE3B" role="3clF45" />
       <node concept="3Tm1VV" id="$yb$20fE3C" role="1B3o_S" />
       <node concept="3clFbS" id="$yb$20fE3D" role="3clF47">
-        <node concept="3clFbF" id="3u8VfJfq07n" role="3cqZAp">
-          <node concept="37vLTI" id="3u8VfJfq1JI" role="3clFbG">
-            <node concept="2OqwBi" id="3u8VfJfq4DF" role="37vLTx">
-              <node concept="37vLTw" id="3u8VfJfq3hs" role="2Oq$k0">
-                <ref role="3cqZAo" node="$yb$20fE4t" resolve="le" />
-              </node>
-              <node concept="2qgKlT" id="3u8VfJfq6pn" role="2OqNvi">
-                <ref role="37wK5l" to="5s8v:3u8VfJfplfS" resolve="getNodeMapping" />
+        <node concept="3clFbF" id="3u8VfJfqhGS" role="3cqZAp">
+          <node concept="37vLTI" id="3u8VfJfqj6G" role="3clFbG">
+            <node concept="2ShNRf" id="3u8VfJfqkHA" role="37vLTx">
+              <node concept="3rGOSV" id="3u8VfJfqkFP" role="2ShVmc">
+                <node concept="3Tqbb2" id="3u8VfJfqkFQ" role="3rHrn6" />
+                <node concept="3Tqbb2" id="3u8VfJfqkFR" role="3rHtpV" />
               </node>
             </node>
-            <node concept="37vLTw" id="3u8VfJfq07l" role="37vLTJ">
+            <node concept="37vLTw" id="3u8VfJfqhGQ" role="37vLTJ">
               <ref role="3cqZAo" node="dsAFRk0GB0" resolve="mapping" />
             </node>
           </node>
         </node>
-        <node concept="3clFbJ" id="3u8VfJfqbfu" role="3cqZAp">
-          <node concept="3clFbS" id="3u8VfJfqbfw" role="3clFbx">
-            <node concept="3clFbF" id="3u8VfJfqhGS" role="3cqZAp">
-              <node concept="37vLTI" id="3u8VfJfqj6G" role="3clFbG">
-                <node concept="2ShNRf" id="3u8VfJfqkHA" role="37vLTx">
-                  <node concept="3rGOSV" id="3u8VfJfqkFP" role="2ShVmc">
-                    <node concept="3Tqbb2" id="3u8VfJfqkFQ" role="3rHrn6" />
-                    <node concept="3Tqbb2" id="3u8VfJfqkFR" role="3rHtpV" />
-                  </node>
-                </node>
-                <node concept="37vLTw" id="3u8VfJfqhGQ" role="37vLTJ">
-                  <ref role="3cqZAo" node="dsAFRk0GB0" resolve="mapping" />
-                </node>
+        <node concept="3clFbF" id="1ZCJf$ejaT0" role="3cqZAp">
+          <node concept="2OqwBi" id="1ZCJf$ejdxs" role="3clFbG">
+            <node concept="37vLTw" id="1ZCJf$ejaSY" role="2Oq$k0">
+              <ref role="3cqZAo" node="$yb$20fE4t" resolve="le" />
+            </node>
+            <node concept="2qgKlT" id="1ZCJf$ejg$k" role="2OqNvi">
+              <ref role="37wK5l" to="5s8v:1ZCJf$ej28Z" resolve="putNodeMapping" />
+              <node concept="37vLTw" id="1ZCJf$ejhqU" role="37wK5m">
+                <ref role="3cqZAo" node="dsAFRk0GB0" resolve="mapping" />
               </node>
             </node>
-            <node concept="3clFbF" id="1ZCJf$ejaT0" role="3cqZAp">
-              <node concept="2OqwBi" id="1ZCJf$ejdxs" role="3clFbG">
-                <node concept="37vLTw" id="1ZCJf$ejaSY" role="2Oq$k0">
+          </node>
+        </node>
+        <node concept="3clFbF" id="dsAFRk0SAw" role="3cqZAp">
+          <node concept="37vLTI" id="dsAFRk0Ts4" role="3clFbG">
+            <node concept="37vLTw" id="dsAFRk0SAu" role="37vLTJ">
+              <ref role="3cqZAo" node="$yb$20fATA" resolve="lambda" />
+            </node>
+            <node concept="1PxgMI" id="14bmjk2oWAH" role="37vLTx">
+              <property role="1BlNFB" value="true" />
+              <node concept="chp4Y" id="14bmjk2oWAI" role="3oSUPX">
+                <ref role="cht4Q" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
+              </node>
+              <node concept="2YIFZM" id="14bmjk2oWAJ" role="1m5AlR">
+                <ref role="1Pybhc" to="w1kc:~CopyUtil" resolve="CopyUtil" />
+                <ref role="37wK5l" to="w1kc:~CopyUtil.copy(org.jetbrains.mps.openapi.model.SNode,java.util.Map,boolean)" resolve="copy" />
+                <node concept="37vLTw" id="14bmjk2oWAK" role="37wK5m">
                   <ref role="3cqZAo" node="$yb$20fE4t" resolve="le" />
                 </node>
-                <node concept="2qgKlT" id="1ZCJf$ejg$k" role="2OqNvi">
-                  <ref role="37wK5l" to="5s8v:1ZCJf$ej28Z" resolve="putNodeMapping" />
-                  <node concept="37vLTw" id="1ZCJf$ejhqU" role="37wK5m">
-                    <ref role="3cqZAo" node="dsAFRk0GB0" resolve="mapping" />
-                  </node>
+                <node concept="37vLTw" id="14bmjk2oWAL" role="37wK5m">
+                  <ref role="3cqZAo" node="dsAFRk0GB0" resolve="mapping" />
                 </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="dsAFRk0SAw" role="3cqZAp">
-              <node concept="37vLTI" id="dsAFRk0Ts4" role="3clFbG">
-                <node concept="37vLTw" id="dsAFRk0SAu" role="37vLTJ">
-                  <ref role="3cqZAo" node="$yb$20fATA" resolve="lambda" />
-                </node>
-                <node concept="1PxgMI" id="14bmjk2oWAH" role="37vLTx">
-                  <property role="1BlNFB" value="true" />
-                  <node concept="chp4Y" id="14bmjk2oWAI" role="3oSUPX">
-                    <ref role="cht4Q" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
-                  </node>
-                  <node concept="2YIFZM" id="14bmjk2oWAJ" role="1m5AlR">
-                    <ref role="1Pybhc" to="w1kc:~CopyUtil" resolve="CopyUtil" />
-                    <ref role="37wK5l" to="w1kc:~CopyUtil.copy(org.jetbrains.mps.openapi.model.SNode,java.util.Map,boolean)" resolve="copy" />
-                    <node concept="37vLTw" id="14bmjk2oWAK" role="37wK5m">
-                      <ref role="3cqZAo" node="$yb$20fE4t" resolve="le" />
-                    </node>
-                    <node concept="37vLTw" id="14bmjk2oWAL" role="37wK5m">
-                      <ref role="3cqZAo" node="dsAFRk0GB0" resolve="mapping" />
-                    </node>
-                    <node concept="3clFbT" id="14bmjk2oWAM" role="37wK5m">
-                      <property role="3clFbU" value="true" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbC" id="3u8VfJfqeg9" role="3clFbw">
-            <node concept="10Nm6u" id="3u8VfJfqfSK" role="3uHU7w" />
-            <node concept="37vLTw" id="3u8VfJfqd6n" role="3uHU7B">
-              <ref role="3cqZAo" node="dsAFRk0GB0" resolve="mapping" />
-            </node>
-          </node>
-          <node concept="9aQIb" id="14bmjk2p0S6" role="9aQIa">
-            <node concept="3clFbS" id="14bmjk2p0S7" role="9aQI4">
-              <node concept="3clFbF" id="14bmjk2p2qO" role="3cqZAp">
-                <node concept="37vLTI" id="14bmjk2p4Qk" role="3clFbG">
-                  <node concept="37vLTw" id="14bmjk2y_S4" role="37vLTx">
-                    <ref role="3cqZAo" node="$yb$20fE4t" resolve="le" />
-                  </node>
-                  <node concept="37vLTw" id="14bmjk2p2qN" role="37vLTJ">
-                    <ref role="3cqZAo" node="$yb$20fATA" resolve="lambda" />
-                  </node>
+                <node concept="3clFbT" id="14bmjk2oWAM" role="37wK5m">
+                  <property role="3clFbU" value="true" />
                 </node>
               </node>
             </node>
@@ -1007,6 +1018,20 @@
             </node>
           </node>
         </node>
+        <node concept="1X3_iC" id="4X7jg4xLykf" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3cpWs8" id="2gng9$EZN1p" role="8Wnug">
+            <node concept="3cpWsn" id="2gng9$EZN1q" role="3cpWs9">
+              <property role="TrG5h" value="start" />
+              <node concept="3cpWsb" id="2gng9$EZN1r" role="1tU5fm" />
+              <node concept="2YIFZM" id="1joq1DK4sn9" role="33vP2m">
+                <ref role="37wK5l" to="wyt6:~System.nanoTime()" resolve="nanoTime" />
+                <ref role="1Pybhc" to="wyt6:~System" resolve="System" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="$yb$20l8Hu" role="3cqZAp">
           <node concept="3cpWsn" id="$yb$20l8Hv" role="3cpWs9">
             <property role="TrG5h" value="res" />
@@ -1014,14 +1039,6 @@
               <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
             </node>
             <node concept="2OqwBi" id="$yb$20l8Hx" role="33vP2m">
-              <node concept="2OqwBi" id="$yb$20l8Hy" role="2Oq$k0">
-                <node concept="37vLTw" id="$yb$20l8Hz" role="2Oq$k0">
-                  <ref role="3cqZAo" node="$yb$20l8GT" resolve="context" />
-                </node>
-                <node concept="liA8E" id="$yb$20l8H$" role="2OqNvi">
-                  <ref role="37wK5l" to="2ahs:2ALJBcrni7v" resolve="getRootInterpreter" />
-                </node>
-              </node>
               <node concept="liA8E" id="$yb$20l8H_" role="2OqNvi">
                 <ref role="37wK5l" to="2ahs:2X4$XGmegKw" resolve="evaluate" />
                 <node concept="2OqwBi" id="7lHetQyBwnX" role="37wK5m">
@@ -1045,9 +1062,94 @@
                   <ref role="3cqZAo" node="5ya_dKpjuUl" resolve="stopOnStop" />
                 </node>
               </node>
+              <node concept="2OqwBi" id="1joq1DK9lUe" role="2Oq$k0">
+                <node concept="37vLTw" id="1joq1DK9lUf" role="2Oq$k0">
+                  <ref role="3cqZAo" node="$yb$20l8GT" resolve="context" />
+                </node>
+                <node concept="liA8E" id="1joq1DK9lUg" role="2OqNvi">
+                  <ref role="37wK5l" to="2ahs:2ALJBcrni7v" resolve="getRootInterpreter" />
+                </node>
+              </node>
             </node>
           </node>
         </node>
+        <node concept="1X3_iC" id="4X7jg4xL$8E" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3cpWs8" id="6z6ktjM1XDw" role="8Wnug">
+            <node concept="3cpWsn" id="6z6ktjM1XDx" role="3cpWs9">
+              <property role="TrG5h" value="stopp" />
+              <node concept="3cpWsb" id="6z6ktjM1XDy" role="1tU5fm" />
+              <node concept="2YIFZM" id="1joq1DK4vJE" role="33vP2m">
+                <ref role="37wK5l" to="wyt6:~System.nanoTime()" resolve="nanoTime" />
+                <ref role="1Pybhc" to="wyt6:~System" resolve="System" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="4X7jg4xL$8F" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="2gng9$EYqjy" role="8Wnug">
+            <node concept="2OqwBi" id="2gng9$EYte0" role="3clFbG">
+              <node concept="10M0yZ" id="2gng9$EYqVO" role="2Oq$k0">
+                <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+                <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              </node>
+              <node concept="liA8E" id="2gng9$EYvRH" role="2OqNvi">
+                <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                <node concept="3cpWs3" id="2gng9$EZ7nI" role="37wK5m">
+                  <node concept="3cpWs3" id="2gng9$EYNFl" role="3uHU7B">
+                    <node concept="3cpWs3" id="2gng9$EYFqU" role="3uHU7B">
+                      <node concept="3cpWs3" id="2gng9$EYTHh" role="3uHU7B">
+                        <node concept="Xl_RD" id="2gng9$EYW42" role="3uHU7w">
+                          <property role="Xl_RC" value=" / caching:" />
+                        </node>
+                        <node concept="3cpWs3" id="2gng9$EYQ2U" role="3uHU7B">
+                          <node concept="Xl_RD" id="2gng9$EYyD3" role="3uHU7B">
+                            <property role="Xl_RC" value="&lt;     Lambda&gt; EXPR:" />
+                          </node>
+                          <node concept="37vLTw" id="2gng9$EYRk2" role="3uHU7w">
+                            <ref role="3cqZAo" node="$yb$20l8GQ" resolve="evaluatedArgs" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="1joq1DK9pM7" role="3uHU7w">
+                        <node concept="1eOMI4" id="1joq1DKdrYd" role="2Oq$k0">
+                          <node concept="10QFUN" id="1joq1DKdtxu" role="1eOMHV">
+                            <node concept="3uibUv" id="1joq1DKdvkG" role="10QFUM">
+                              <ref role="3uigEE" to="pbu6:6iqfHNC0mHl" resolve="IETS3ExprContext" />
+                            </node>
+                            <node concept="37vLTw" id="1joq1DK9nUQ" role="10QFUP">
+                              <ref role="3cqZAo" node="$yb$20l8GT" resolve="context" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="1joq1DK9Jb4" role="2OqNvi">
+                          <ref role="37wK5l" to="pbu6:4Pi6J8BUEA2" resolve="isCachingEnabled" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="2gng9$EYZvQ" role="3uHU7w">
+                      <property role="Xl_RC" value=" TIME/ns:" />
+                    </node>
+                  </node>
+                  <node concept="1eOMI4" id="2gng9$EZhZk" role="3uHU7w">
+                    <node concept="3cpWsd" id="2gng9$EZdTO" role="1eOMHV">
+                      <node concept="37vLTw" id="2gng9$EZ8Ss" role="3uHU7B">
+                        <ref role="3cqZAo" node="6z6ktjM1XDx" resolve="stopp" />
+                      </node>
+                      <node concept="37vLTw" id="2gng9$EZe0n" role="3uHU7w">
+                        <ref role="3cqZAo" node="2gng9$EZN1q" resolve="start" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="2gng9$EZFEs" role="3cqZAp" />
         <node concept="3clFbF" id="dsAFRk0Yco" role="3cqZAp">
           <node concept="2OqwBi" id="dsAFRk15Sz" role="3clFbG">
             <node concept="2OqwBi" id="dsAFRk11WP" role="2Oq$k0">
@@ -2474,6 +2576,1314 @@
       <node concept="2AHcQZ" id="5Win3SAejgZ" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="5s__jxCoQMv">
+    <property role="TrG5h" value="ShortLambdaValue" />
+    <node concept="Wx3nA" id="3fi3fTlpKtk" role="jymVt">
+      <property role="TrG5h" value="USER_OBJECT_KEY_MAPPING" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm1VV" id="3fi3fTlpKtl" role="1B3o_S" />
+      <node concept="17QB3L" id="3fi3fTlpKtm" role="1tU5fm" />
+      <node concept="Xl_RD" id="3fi3fTlpKtn" role="33vP2m">
+        <property role="Xl_RC" value="shortLambdaMapping" />
+      </node>
+    </node>
+    <node concept="Wx3nA" id="5s__jxCpjNV" role="jymVt">
+      <property role="TrG5h" value="USER_OBJECT_KEY_LAMBDAARG" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm1VV" id="5s__jxCpjNW" role="1B3o_S" />
+      <node concept="17QB3L" id="5s__jxCpjNX" role="1tU5fm" />
+      <node concept="Xl_RD" id="5s__jxCpjNY" role="33vP2m">
+        <property role="Xl_RC" value="LambdaArg" />
+      </node>
+    </node>
+    <node concept="312cEg" id="3fi3fTlpKto" role="jymVt">
+      <property role="34CwA1" value="false" />
+      <property role="eg7rD" value="false" />
+      <property role="TrG5h" value="lambda" />
+      <property role="3TUv4t" value="false" />
+      <node concept="3Tm6S6" id="3fi3fTlpKtp" role="1B3o_S" />
+      <node concept="3Tqbb2" id="3fi3fTlpKtq" role="1tU5fm">
+        <ref role="ehGHo" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
+      </node>
+      <node concept="10Nm6u" id="3fi3fTlpKtr" role="33vP2m" />
+    </node>
+    <node concept="312cEg" id="IFu7oT5N0i" role="jymVt">
+      <property role="TrG5h" value="shortLambda" />
+      <node concept="3Tm6S6" id="IFu7oT5HUn" role="1B3o_S" />
+      <node concept="3Tqbb2" id="IFu7oT5MiZ" role="1tU5fm">
+        <ref role="ehGHo" to="zzzn:6zmBjqUm7MQ" resolve="ShortLambdaExpression" />
+      </node>
+      <node concept="10Nm6u" id="IFu7oT5OBc" role="33vP2m" />
+    </node>
+    <node concept="312cEg" id="3fi3fTlpKts" role="jymVt">
+      <property role="TrG5h" value="mapping" />
+      <node concept="3Tm6S6" id="3fi3fTlpKtt" role="1B3o_S" />
+      <node concept="3rvAFt" id="3fi3fTlpKtu" role="1tU5fm">
+        <node concept="3Tqbb2" id="3fi3fTlpKtv" role="3rvQeY" />
+        <node concept="3Tqbb2" id="3fi3fTlpKtw" role="3rvSg0" />
+      </node>
+    </node>
+    <node concept="312cEg" id="3fi3fTlpKtx" role="jymVt">
+      <property role="34CwA1" value="false" />
+      <property role="eg7rD" value="false" />
+      <property role="TrG5h" value="stopOnStop" />
+      <property role="3TUv4t" value="false" />
+      <node concept="3Tm6S6" id="3fi3fTlpKty" role="1B3o_S" />
+      <node concept="10P_77" id="3fi3fTlpKtz" role="1tU5fm" />
+      <node concept="3clFbT" id="3fi3fTlpKt$" role="33vP2m">
+        <property role="3clFbU" value="false" />
+      </node>
+    </node>
+    <node concept="312cEg" id="5s__jxCvpsu" role="jymVt">
+      <property role="TrG5h" value="newLambdaArgCreated" />
+      <node concept="3Tm6S6" id="5s__jxCvm_W" role="1B3o_S" />
+      <node concept="10P_77" id="5s__jxCvoYp" role="1tU5fm" />
+    </node>
+    <node concept="2tJIrI" id="3fi3fTlpKt_" role="jymVt" />
+    <node concept="3clFbW" id="3fi3fTlpKtB" role="jymVt">
+      <node concept="37vLTG" id="3fi3fTlpKtC" role="3clF46">
+        <property role="TrG5h" value="le" />
+        <node concept="3Tqbb2" id="3fi3fTlpKtD" role="1tU5fm">
+          <ref role="ehGHo" to="zzzn:6zmBjqUm7MQ" resolve="ShortLambdaExpression" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3fi3fTlpKtE" role="3clF46">
+        <property role="TrG5h" value="ctx" />
+        <node concept="3uibUv" id="3fi3fTlpKtF" role="1tU5fm">
+          <ref role="3uigEE" to="2ahs:4X7QcQ31ENp" resolve="IContext" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3fi3fTlpKtG" role="3clF46">
+        <property role="TrG5h" value="coverage" />
+        <node concept="3uibUv" id="3fi3fTlpKtH" role="1tU5fm">
+          <ref role="3uigEE" to="2ahs:4_qY3E5ifTh" resolve="ICoverageAnalyzer" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3fi3fTlpKtI" role="3clF46">
+        <property role="TrG5h" value="stopOnStop" />
+        <node concept="10P_77" id="3fi3fTlpKtJ" role="1tU5fm" />
+      </node>
+      <node concept="3cqZAl" id="3fi3fTlpKtK" role="3clF45" />
+      <node concept="3Tm1VV" id="3fi3fTlpKtL" role="1B3o_S" />
+      <node concept="3clFbS" id="3fi3fTlpKtM" role="3clF47">
+        <node concept="3clFbF" id="3fi3fTlpKtZ" role="3cqZAp">
+          <node concept="37vLTI" id="3fi3fTlpKu0" role="3clFbG">
+            <node concept="2ShNRf" id="3fi3fTlpKu1" role="37vLTx">
+              <node concept="3rGOSV" id="3fi3fTlpKu2" role="2ShVmc">
+                <node concept="3Tqbb2" id="3fi3fTlpKu3" role="3rHrn6" />
+                <node concept="3Tqbb2" id="3fi3fTlpKu4" role="3rHtpV" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="3fi3fTlpKu5" role="37vLTJ">
+              <ref role="3cqZAo" node="3fi3fTlpKts" resolve="mapping" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5s__jxDMlw_" role="3cqZAp">
+          <node concept="2OqwBi" id="5s__jxDMnsI" role="3clFbG">
+            <node concept="37vLTw" id="5s__jxDMlwz" role="2Oq$k0">
+              <ref role="3cqZAo" node="3fi3fTlpKtC" resolve="le" />
+            </node>
+            <node concept="2qgKlT" id="5s__jxDMpZv" role="2OqNvi">
+              <ref role="37wK5l" to="5s8v:5s__jxDLZW7" resolve="putNodeMapping" />
+              <node concept="37vLTw" id="5s__jxDMrR0" role="37wK5m">
+                <ref role="3cqZAo" node="3fi3fTlpKts" resolve="mapping" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="IFu7oT5Pm9" role="3cqZAp">
+          <node concept="37vLTI" id="IFu7oT5SZo" role="3clFbG">
+            <node concept="37vLTw" id="IFu7oT5UMB" role="37vLTx">
+              <ref role="3cqZAo" node="3fi3fTlpKtC" resolve="le" />
+            </node>
+            <node concept="37vLTw" id="IFu7oT5Pm7" role="37vLTJ">
+              <ref role="3cqZAo" node="IFu7oT5N0i" resolve="shortLambda" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="IFu7oT4tI3" role="3cqZAp">
+          <node concept="37vLTI" id="IFu7oT4vAM" role="3clFbG">
+            <node concept="37vLTw" id="IFu7oT4tI1" role="37vLTJ">
+              <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
+            </node>
+            <node concept="2ShNRf" id="49WTic8ey5E" role="37vLTx">
+              <node concept="3zrR0B" id="49WTic8ey5F" role="2ShVmc">
+                <node concept="3Tqbb2" id="49WTic8ey5G" role="3zrR0E">
+                  <ref role="ehGHo" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3fi3fTlpKub" role="3cqZAp">
+          <node concept="37vLTI" id="3fi3fTlpKuc" role="3clFbG">
+            <node concept="2OqwBi" id="IFu7oT4AXD" role="37vLTJ">
+              <node concept="37vLTw" id="3fi3fTlpKud" role="2Oq$k0">
+                <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
+              </node>
+              <node concept="3TrEf2" id="IFu7oT4CR$" role="2OqNvi">
+                <ref role="3Tt5mk" to="zzzn:6zmBjqUkwH3" resolve="expression" />
+              </node>
+            </node>
+            <node concept="1PxgMI" id="2gng9$EqaKS" role="37vLTx">
+              <property role="1BlNFB" value="true" />
+              <node concept="chp4Y" id="2gng9$EqdW_" role="3oSUPX">
+                <ref role="cht4Q" to="hm2y:6sdnDbSla17" resolve="Expression" />
+              </node>
+              <node concept="2YIFZM" id="3fi3fTlpKug" role="1m5AlR">
+                <ref role="1Pybhc" to="w1kc:~CopyUtil" resolve="CopyUtil" />
+                <ref role="37wK5l" to="w1kc:~CopyUtil.copy(org.jetbrains.mps.openapi.model.SNode,java.util.Map,boolean)" resolve="copy" />
+                <node concept="2OqwBi" id="IFu7oT4E1e" role="37wK5m">
+                  <node concept="37vLTw" id="3fi3fTlpKuh" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3fi3fTlpKtC" resolve="le" />
+                  </node>
+                  <node concept="3TrEf2" id="IFu7oT4HQE" role="2OqNvi">
+                    <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="3fi3fTlpKui" role="37wK5m">
+                  <ref role="3cqZAo" node="3fi3fTlpKts" resolve="mapping" />
+                </node>
+                <node concept="3clFbT" id="3fi3fTlpKuj" role="37wK5m">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7cphKbKYWrc" role="3cqZAp">
+          <node concept="2OqwBi" id="7cphKbKYZU4" role="3clFbG">
+            <node concept="2OqwBi" id="7cphKbKYWXy" role="2Oq$k0">
+              <node concept="37vLTw" id="7cphKbKYWHQ" role="2Oq$k0">
+                <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
+              </node>
+              <node concept="3Tsc0h" id="7cphKbKYXk5" role="2OqNvi">
+                <ref role="3TtcxE" to="zzzn:6zmBjqUkws7" resolve="args" />
+              </node>
+            </node>
+            <node concept="2Kehj3" id="7cphKbKZ42m" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5s__jxCqyey" role="3cqZAp">
+          <node concept="3cpWsn" id="5s__jxCqyez" role="3cpWs9">
+            <property role="TrG5h" value="lambdaArg" />
+            <node concept="3Tqbb2" id="5s__jxCqxAz" role="1tU5fm">
+              <ref role="ehGHo" to="zzzn:6zmBjqUkwse" resolve="LambdaArg" />
+            </node>
+            <node concept="2OqwBi" id="5s__jxCqye$" role="33vP2m">
+              <node concept="37vLTw" id="5s__jxCqye_" role="2Oq$k0">
+                <ref role="3cqZAo" node="3fi3fTlpKtC" resolve="le" />
+              </node>
+              <node concept="2qgKlT" id="5s__jxCqyeA" role="2OqNvi">
+                <ref role="37wK5l" to="5s8v:5s__jxCqcBE" resolve="getLamdaArg" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="5s__jxCqBlr" role="3cqZAp">
+          <node concept="3clFbS" id="5s__jxCqBlt" role="3clFbx">
+            <node concept="3clFbF" id="5s__jxCvtcA" role="3cqZAp">
+              <node concept="37vLTI" id="5s__jxCvw8m" role="3clFbG">
+                <node concept="3clFbT" id="5s__jxCvy42" role="37vLTx">
+                  <property role="3clFbU" value="true" />
+                </node>
+                <node concept="37vLTw" id="5s__jxCvtc$" role="37vLTJ">
+                  <ref role="3cqZAo" node="5s__jxCvpsu" resolve="newLambdaArgCreated" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="5s__jxCr4WN" role="3cqZAp">
+              <node concept="37vLTI" id="5s__jxCr6QE" role="3clFbG">
+                <node concept="37vLTw" id="5s__jxCr4WL" role="37vLTJ">
+                  <ref role="3cqZAo" node="5s__jxCqyez" resolve="lambdaArg" />
+                </node>
+                <node concept="2pJPEk" id="49WTic8eCUg" role="37vLTx">
+                  <node concept="2pJPED" id="49WTic8eCUh" role="2pJPEn">
+                    <ref role="2pJxaS" to="zzzn:6zmBjqUkwse" resolve="LambdaArg" />
+                    <node concept="2pJxcG" id="49WTic8eFv5" role="2pJxcM">
+                      <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                      <node concept="WxPPo" id="uuJ7IpZtuT" role="28ntcv">
+                        <node concept="Xl_RD" id="49WTic8eFEu" role="WxPPp">
+                          <property role="Xl_RC" value="it" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="5s__jxCqV3Z" role="3cqZAp">
+              <node concept="2OqwBi" id="5s__jxCqX96" role="3clFbG">
+                <node concept="37vLTw" id="5s__jxCqV3X" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3fi3fTlpKtC" resolve="le" />
+                </node>
+                <node concept="2qgKlT" id="5s__jxCqZgn" role="2OqNvi">
+                  <ref role="37wK5l" to="5s8v:5s__jxCq8Sv" resolve="putLamdaArg" />
+                  <node concept="37vLTw" id="5s__jxCr0ql" role="37wK5m">
+                    <ref role="3cqZAo" node="5s__jxCqyez" resolve="lambdaArg" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="5s__jxCqNBB" role="3clFbw">
+            <node concept="10Nm6u" id="5s__jxCqOYl" role="3uHU7w" />
+            <node concept="37vLTw" id="5s__jxCqLew" role="3uHU7B">
+              <ref role="3cqZAo" node="5s__jxCqyez" resolve="lambdaArg" />
+            </node>
+          </node>
+          <node concept="9aQIb" id="5s__jxCuiDH" role="9aQIa">
+            <node concept="3clFbS" id="5s__jxCuiDI" role="9aQI4">
+              <node concept="3clFbF" id="5s__jxCvzTe" role="3cqZAp">
+                <node concept="37vLTI" id="5s__jxCvzTf" role="3clFbG">
+                  <node concept="3clFbT" id="5s__jxCvzTg" role="37vLTx" />
+                  <node concept="37vLTw" id="5s__jxCvzTh" role="37vLTJ">
+                    <ref role="3cqZAo" node="5s__jxCvpsu" resolve="newLambdaArgCreated" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="7cphKbKO6qr" role="3cqZAp">
+          <node concept="3cpWsn" id="7cphKbKO6qs" role="3cpWs9">
+            <property role="TrG5h" value="ttt" />
+            <node concept="3Tqbb2" id="7cphKbKO6qp" role="1tU5fm">
+              <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
+            </node>
+            <node concept="2OqwBi" id="7cphKbKO6qt" role="33vP2m">
+              <node concept="1PxgMI" id="7cphKbKO6qu" role="2Oq$k0">
+                <node concept="chp4Y" id="7cphKbKO6qv" role="3oSUPX">
+                  <ref role="cht4Q" to="zzzn:6zmBjqUm7Mf" resolve="IShortLambdaContainer" />
+                </node>
+                <node concept="2OqwBi" id="7cphKbKO6qw" role="1m5AlR">
+                  <node concept="1mfA1w" id="7cphKbKO6qy" role="2OqNvi" />
+                  <node concept="37vLTw" id="IFu7oT50Sb" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3fi3fTlpKtC" resolve="le" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2qgKlT" id="7cphKbKO6qz" role="2OqNvi">
+                <ref role="37wK5l" to="5s8v:6zmBjqUm7MF" resolve="requiredType" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5s__jxDPOrl" role="3cqZAp">
+          <node concept="37vLTI" id="5s__jxDPVYt" role="3clFbG">
+            <node concept="37vLTw" id="5s__jxDPXKc" role="37vLTx">
+              <ref role="3cqZAo" node="7cphKbKO6qs" resolve="ttt" />
+            </node>
+            <node concept="2OqwBi" id="5s__jxDPQwi" role="37vLTJ">
+              <node concept="37vLTw" id="5s__jxDPOrj" role="2Oq$k0">
+                <ref role="3cqZAo" node="5s__jxCqyez" resolve="lambdaArg" />
+              </node>
+              <node concept="3TrEf2" id="5s__jxDPU5V" role="2OqNvi">
+                <ref role="3Tt5mk" to="zzzn:6zmBjqUkwsc" resolve="type" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="49WTic8eyK7" role="3cqZAp">
+          <node concept="2OqwBi" id="49WTic8ezyo" role="3clFbG">
+            <node concept="2OqwBi" id="49WTic8eyN7" role="2Oq$k0">
+              <node concept="37vLTw" id="49WTic8eyK5" role="2Oq$k0">
+                <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
+              </node>
+              <node concept="3Tsc0h" id="49WTic8eyT3" role="2OqNvi">
+                <ref role="3TtcxE" to="zzzn:6zmBjqUkws7" resolve="args" />
+              </node>
+            </node>
+            <node concept="TSZUe" id="49WTic8e$IN" role="2OqNvi">
+              <node concept="37vLTw" id="49WTic8eCUs" role="25WWJ7">
+                <ref role="3cqZAo" node="5s__jxCqyez" resolve="lambdaArg" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="IFu7oT4P9t" role="3cqZAp">
+          <node concept="2OqwBi" id="IFu7oT4P9u" role="3clFbG">
+            <node concept="2OqwBi" id="IFu7oT4P9v" role="2Oq$k0">
+              <node concept="2OqwBi" id="IFu7oT4P9w" role="2Oq$k0">
+                <node concept="37vLTw" id="IFu7oT4P9x" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
+                </node>
+                <node concept="3TrEf2" id="IFu7oT4P9y" role="2OqNvi">
+                  <ref role="3Tt5mk" to="zzzn:6zmBjqUkwH3" resolve="expression" />
+                </node>
+              </node>
+              <node concept="2Rf3mk" id="IFu7oT4P9z" role="2OqNvi">
+                <node concept="1xMEDy" id="IFu7oT4P9$" role="1xVPHs">
+                  <node concept="chp4Y" id="IFu7oT4P9_" role="ri$Ld">
+                    <ref role="cht4Q" to="zzzn:6zmBjqUmsuo" resolve="ShortLambdaItExpression" />
+                  </node>
+                </node>
+                <node concept="1xIGOp" id="IFu7oT4P9A" role="1xVPHs" />
+              </node>
+            </node>
+            <node concept="2es0OD" id="IFu7oT4P9B" role="2OqNvi">
+              <node concept="1bVj0M" id="IFu7oT4P9C" role="23t8la">
+                <node concept="3clFbS" id="IFu7oT4P9D" role="1bW5cS">
+                  <node concept="3SKdUt" id="IFu7oT4P9E" role="3cqZAp">
+                    <node concept="1PaTwC" id="IFu7oT4P9F" role="1aUNEU">
+                      <node concept="3oM_SD" id="IFu7oT4P9G" role="1PaTwD">
+                        <property role="3oM_SC" value="do" />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4P9H" role="1PaTwD">
+                        <property role="3oM_SC" value="not" />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4P9I" role="1PaTwD">
+                        <property role="3oM_SC" value="go" />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4P9J" role="1PaTwD">
+                        <property role="3oM_SC" value="into" />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4P9K" role="1PaTwD">
+                        <property role="3oM_SC" value="nested" />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4P9L" role="1PaTwD">
+                        <property role="3oM_SC" value="short" />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4P9M" role="1PaTwD">
+                        <property role="3oM_SC" value="lambda" />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4P9N" role="1PaTwD">
+                        <property role="3oM_SC" value="expressions," />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4P9O" role="1PaTwD">
+                        <property role="3oM_SC" value="otherwise" />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4P9P" role="1PaTwD">
+                        <property role="3oM_SC" value="all" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3SKdUt" id="IFu7oT4P9Q" role="3cqZAp">
+                    <node concept="1PaTwC" id="IFu7oT4P9R" role="1aUNEU">
+                      <node concept="3oM_SD" id="IFu7oT4P9S" role="1PaTwD">
+                        <property role="3oM_SC" value="&quot;it&quot;s" />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4P9T" role="1PaTwD">
+                        <property role="3oM_SC" value="are" />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4P9U" role="1PaTwD">
+                        <property role="3oM_SC" value="replaced" />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4P9V" role="1PaTwD">
+                        <property role="3oM_SC" value="with" />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4P9W" role="1PaTwD">
+                        <property role="3oM_SC" value="a" />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4P9X" role="1PaTwD">
+                        <property role="3oM_SC" value="ref" />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4P9Y" role="1PaTwD">
+                        <property role="3oM_SC" value="to" />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4P9Z" role="1PaTwD">
+                        <property role="3oM_SC" value="the" />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4Pa0" role="1PaTwD">
+                        <property role="3oM_SC" value="same" />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4Pa1" role="1PaTwD">
+                        <property role="3oM_SC" value="lambda" />
+                      </node>
+                      <node concept="3oM_SD" id="IFu7oT4Pa2" role="1PaTwD">
+                        <property role="3oM_SC" value="arg!" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="IFu7oT4Pa3" role="3cqZAp">
+                    <node concept="3clFbS" id="IFu7oT4Pa4" role="3clFbx">
+                      <node concept="3cpWs8" id="dsAFRkcKGy" role="3cqZAp">
+                        <node concept="3cpWsn" id="dsAFRkcKG_" role="3cpWs9">
+                          <property role="TrG5h" value="argRef" />
+                          <node concept="3Tqbb2" id="dsAFRkcKGw" role="1tU5fm">
+                            <ref role="ehGHo" to="zzzn:6zmBjqUkHal" resolve="LambdaArgRef" />
+                          </node>
+                          <node concept="2pJPEk" id="49WTic8eCHY" role="33vP2m">
+                            <node concept="2pJPED" id="49WTic8eCKF" role="2pJPEn">
+                              <ref role="2pJxaS" to="zzzn:6zmBjqUkHal" resolve="LambdaArgRef" />
+                              <node concept="2pIpSj" id="49WTic8eCQh" role="2pJxcM">
+                                <ref role="2pIpSl" to="zzzn:6zmBjqUkHam" resolve="arg" />
+                                <node concept="36biLy" id="49WTic8eDst" role="28nt2d">
+                                  <node concept="2OqwBi" id="5s__jxCrrD6" role="36biLW">
+                                    <node concept="2OqwBi" id="5s__jxCrkT0" role="2Oq$k0">
+                                      <node concept="37vLTw" id="5s__jxCrh$s" role="2Oq$k0">
+                                        <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
+                                      </node>
+                                      <node concept="3Tsc0h" id="5s__jxCrmBb" role="2OqNvi">
+                                        <ref role="3TtcxE" to="zzzn:6zmBjqUkws7" resolve="args" />
+                                      </node>
+                                    </node>
+                                    <node concept="34jXtK" id="5s__jxCr_3a" role="2OqNvi">
+                                      <node concept="3cmrfG" id="5s__jxCrAqq" role="25WWJ7">
+                                        <property role="3cmrfH" value="0" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="dsAFRkcNEu" role="3cqZAp">
+                        <node concept="37vLTI" id="dsAFRkcPtk" role="3clFbG">
+                          <node concept="37vLTw" id="dsAFRkcPM0" role="37vLTx">
+                            <ref role="3cqZAo" node="dsAFRkcKG_" resolve="argRef" />
+                          </node>
+                          <node concept="3EllGN" id="dsAFRkcOWL" role="37vLTJ">
+                            <node concept="37vLTw" id="dsAFRkcPhO" role="3ElVtu">
+                              <ref role="3cqZAo" node="IFu7oT4Pak" resolve="it" />
+                            </node>
+                            <node concept="37vLTw" id="dsAFRkcNEs" role="3ElQJh">
+                              <ref role="3cqZAo" node="3fi3fTlpKts" resolve="mapping" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="49WTic8eCyZ" role="3cqZAp">
+                        <node concept="2OqwBi" id="49WTic8eCA1" role="3clFbG">
+                          <node concept="37vLTw" id="49WTic8eCyY" role="2Oq$k0">
+                            <ref role="3cqZAo" node="IFu7oT4Pak" resolve="it" />
+                          </node>
+                          <node concept="1P9Npp" id="49WTic8eCFh" role="2OqNvi">
+                            <node concept="37vLTw" id="dsAFRkcN1G" role="1P9ThW">
+                              <ref role="3cqZAo" node="dsAFRkcKG_" resolve="argRef" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1Wc70l" id="IFu7oT4Pa5" role="3clFbw">
+                      <node concept="2OqwBi" id="IFu7oT4Pa6" role="3uHU7w">
+                        <node concept="2OqwBi" id="IFu7oT4Pa7" role="2Oq$k0">
+                          <node concept="37vLTw" id="IFu7oT4Pa8" role="2Oq$k0">
+                            <ref role="3cqZAo" node="IFu7oT4Pak" resolve="it" />
+                          </node>
+                          <node concept="2Xjw5R" id="IFu7oT4Pa9" role="2OqNvi">
+                            <node concept="1xMEDy" id="IFu7oT4Paa" role="1xVPHs">
+                              <node concept="chp4Y" id="IFu7oT4Pab" role="ri$Ld">
+                                <ref role="cht4Q" to="zzzn:6zmBjqUm7MQ" resolve="ShortLambdaExpression" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3w_OXm" id="IFu7oT4Pac" role="2OqNvi" />
+                      </node>
+                      <node concept="3clFbC" id="IFu7oT4Pad" role="3uHU7B">
+                        <node concept="37vLTw" id="IFu7oT4Pae" role="3uHU7w">
+                          <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
+                        </node>
+                        <node concept="2OqwBi" id="IFu7oT4Paf" role="3uHU7B">
+                          <node concept="37vLTw" id="IFu7oT4Pag" role="2Oq$k0">
+                            <ref role="3cqZAo" node="IFu7oT4Pak" resolve="it" />
+                          </node>
+                          <node concept="2Xjw5R" id="IFu7oT4Pah" role="2OqNvi">
+                            <node concept="1xMEDy" id="IFu7oT4Pai" role="1xVPHs">
+                              <node concept="chp4Y" id="IFu7oT4Paj" role="ri$Ld">
+                                <ref role="cht4Q" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="IFu7oT4Pak" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="IFu7oT4Pal" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="IFu7oT4Med" role="3cqZAp" />
+        <node concept="3clFbF" id="3fi3fTlpKut" role="3cqZAp">
+          <node concept="37vLTI" id="3fi3fTlpKuu" role="3clFbG">
+            <node concept="37vLTw" id="3fi3fTlpKuv" role="37vLTx">
+              <ref role="3cqZAo" node="3fi3fTlpKtI" resolve="stopOnStop" />
+            </node>
+            <node concept="2OqwBi" id="3fi3fTlpKuw" role="37vLTJ">
+              <node concept="Xjq3P" id="3fi3fTlpKux" role="2Oq$k0" />
+              <node concept="2OwXpG" id="3fi3fTlpKuy" role="2OqNvi">
+                <ref role="2Oxat5" node="3fi3fTlpKtx" resolve="stopOnStop" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3fi3fTlpKuz" role="3cqZAp">
+          <node concept="3cpWsn" id="3fi3fTlpKu$" role="3cpWs9">
+            <property role="TrG5h" value="tobBeCaptured" />
+            <node concept="A3Dl8" id="3fi3fTlpKu_" role="1tU5fm">
+              <node concept="3Tqbb2" id="3fi3fTlpKuA" role="A3Ik2">
+                <ref role="ehGHo" to="hm2y:6rGLT0TevEL" resolve="IRef" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3fi3fTlpKuB" role="33vP2m">
+              <node concept="2OqwBi" id="3fi3fTlpKuC" role="2Oq$k0">
+                <node concept="2OqwBi" id="3fi3fTlpKuD" role="2Oq$k0">
+                  <node concept="37vLTw" id="3fi3fTlpKuE" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
+                  </node>
+                  <node concept="3TrEf2" id="3fi3fTlpKuF" role="2OqNvi">
+                    <ref role="3Tt5mk" to="zzzn:6zmBjqUkwH3" resolve="expression" />
+                  </node>
+                </node>
+                <node concept="2Rf3mk" id="3fi3fTlpKuG" role="2OqNvi">
+                  <node concept="1xMEDy" id="3fi3fTlpKuH" role="1xVPHs">
+                    <node concept="chp4Y" id="3fi3fTlpKuI" role="ri$Ld">
+                      <ref role="cht4Q" to="hm2y:6rGLT0TevEL" resolve="IRef" />
+                    </node>
+                  </node>
+                  <node concept="1xIGOp" id="3fi3fTlpKuJ" role="1xVPHs" />
+                </node>
+              </node>
+              <node concept="3zZkjj" id="3fi3fTlpKuK" role="2OqNvi">
+                <node concept="1bVj0M" id="3fi3fTlpKuL" role="23t8la">
+                  <node concept="3clFbS" id="3fi3fTlpKuM" role="1bW5cS">
+                    <node concept="3clFbF" id="3fi3fTlpKuN" role="3cqZAp">
+                      <node concept="2OqwBi" id="3fi3fTlpKuO" role="3clFbG">
+                        <node concept="2qgKlT" id="3fi3fTlpKuP" role="2OqNvi">
+                          <ref role="37wK5l" to="pbu6:22hm_0zJBUZ" resolve="targetStateIsMutable" />
+                        </node>
+                        <node concept="37vLTw" id="3fi3fTlpKuQ" role="2Oq$k0">
+                          <ref role="3cqZAo" node="3fi3fTlpKuR" resolve="it" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="3fi3fTlpKuR" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="3fi3fTlpKuS" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="3fi3fTlpKuT" role="3cqZAp">
+          <node concept="2GrKxI" id="3fi3fTlpKuU" role="2Gsz3X">
+            <property role="TrG5h" value="c" />
+          </node>
+          <node concept="3clFbS" id="3fi3fTlpKuV" role="2LFqv$">
+            <node concept="3cpWs8" id="3fi3fTlpKuW" role="3cqZAp">
+              <node concept="3cpWsn" id="3fi3fTlpKuX" role="3cpWs9">
+                <property role="TrG5h" value="cv" />
+                <node concept="3Tqbb2" id="3fi3fTlpKuY" role="1tU5fm">
+                  <ref role="ehGHo" to="zzzn:22hm_0zJHU7" resolve="CapturedValue" />
+                </node>
+                <node concept="2pJPEk" id="3fi3fTlpKuZ" role="33vP2m">
+                  <node concept="2pJPED" id="3fi3fTlpKv0" role="2pJPEn">
+                    <ref role="2pJxaS" to="zzzn:22hm_0zJHU7" resolve="CapturedValue" />
+                    <node concept="2pIpSj" id="3fi3fTlpKv1" role="2pJxcM">
+                      <ref role="2pIpSl" to="hm2y:7D7uZV2iYAD" resolve="type" />
+                      <node concept="36biLy" id="3fi3fTlpKv2" role="28nt2d">
+                        <node concept="1PxgMI" id="3fi3fTlpKv3" role="36biLW">
+                          <node concept="chp4Y" id="3fi3fTlpKv4" role="3oSUPX">
+                            <ref role="cht4Q" to="hm2y:6sdnDbSlaok" resolve="Type" />
+                          </node>
+                          <node concept="2OqwBi" id="3fi3fTlpKv5" role="1m5AlR">
+                            <node concept="2OqwBi" id="3fi3fTlpKv6" role="2Oq$k0">
+                              <node concept="2OqwBi" id="3fi3fTlpKv7" role="2Oq$k0">
+                                <node concept="2GrUjf" id="3fi3fTlpKv8" role="2Oq$k0">
+                                  <ref role="2Gs0qQ" node="3fi3fTlpKuU" resolve="c" />
+                                </node>
+                                <node concept="2qgKlT" id="3fi3fTlpKv9" role="2OqNvi">
+                                  <ref role="37wK5l" to="pbu6:6rGLT0TevFd" resolve="target" />
+                                </node>
+                              </node>
+                              <node concept="3JvlWi" id="3fi3fTlpKva" role="2OqNvi" />
+                            </node>
+                            <node concept="1$rogu" id="3fi3fTlpKvb" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="3fi3fTlpKvc" role="3cqZAp">
+              <node concept="2OqwBi" id="3fi3fTlpKvd" role="3clFbG">
+                <node concept="37vLTw" id="3fi3fTlpKve" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3fi3fTlpKuX" resolve="cv" />
+                </node>
+                <node concept="2qgKlT" id="3fi3fTlpKvf" role="2OqNvi">
+                  <ref role="37wK5l" to="5s8v:22hm_0zJHWz" resolve="setValue" />
+                  <node concept="2OqwBi" id="3fi3fTlpKvg" role="37wK5m">
+                    <node concept="2OqwBi" id="3fi3fTlpKvh" role="2Oq$k0">
+                      <node concept="37vLTw" id="3fi3fTlpKvi" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3fi3fTlpKtE" resolve="ctx" />
+                      </node>
+                      <node concept="liA8E" id="3fi3fTlpKvj" role="2OqNvi">
+                        <ref role="37wK5l" to="2ahs:2ALJBcrni7v" resolve="getRootInterpreter" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="3fi3fTlpKvk" role="2OqNvi">
+                      <ref role="37wK5l" to="2ahs:2X4$XGmegKw" resolve="evaluate" />
+                      <node concept="2OqwBi" id="3fi3fTlpKvl" role="37wK5m">
+                        <node concept="2GrUjf" id="3fi3fTlpKvm" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="3fi3fTlpKuU" resolve="c" />
+                        </node>
+                        <node concept="2qgKlT" id="3fi3fTlpKvn" role="2OqNvi">
+                          <ref role="37wK5l" to="pbu6:6rGLT0TevFd" resolve="target" />
+                        </node>
+                      </node>
+                      <node concept="37vLTw" id="3fi3fTlpKvo" role="37wK5m">
+                        <ref role="3cqZAo" node="3fi3fTlpKtE" resolve="ctx" />
+                      </node>
+                      <node concept="37vLTw" id="3fi3fTlpKvp" role="37wK5m">
+                        <ref role="3cqZAo" node="3fi3fTlpKtG" resolve="coverage" />
+                      </node>
+                      <node concept="10Nm6u" id="3fi3fTlpKvq" role="37wK5m" />
+                      <node concept="37vLTw" id="3fi3fTlpKvr" role="37wK5m">
+                        <ref role="3cqZAo" node="3fi3fTlpKtI" resolve="stopOnStop" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="3fi3fTlpKvs" role="3cqZAp">
+              <node concept="2OqwBi" id="3fi3fTlpKvt" role="3clFbG">
+                <node concept="2GrUjf" id="3fi3fTlpKvu" role="2Oq$k0">
+                  <ref role="2Gs0qQ" node="3fi3fTlpKuU" resolve="c" />
+                </node>
+                <node concept="1P9Npp" id="3fi3fTlpKvv" role="2OqNvi">
+                  <node concept="37vLTw" id="3fi3fTlpKvw" role="1P9ThW">
+                    <ref role="3cqZAo" node="3fi3fTlpKuX" resolve="cv" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="37vLTw" id="3fi3fTlpKvx" role="2GsD0m">
+            <ref role="3cqZAo" node="3fi3fTlpKu$" resolve="tobBeCaptured" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3fi3fTlqvjf" role="jymVt" />
+    <node concept="3clFb_" id="3fi3fTlpKvI" role="jymVt">
+      <property role="1EzhhJ" value="false" />
+      <property role="TrG5h" value="toString" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <node concept="3Tm1VV" id="3fi3fTlpKvJ" role="1B3o_S" />
+      <node concept="3uibUv" id="3fi3fTlpKvK" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~String" resolve="String" />
+      </node>
+      <node concept="3clFbS" id="3fi3fTlpKvL" role="3clF47">
+        <node concept="3cpWs8" id="3fi3fTlpKvM" role="3cqZAp">
+          <node concept="3cpWsn" id="3fi3fTlpKvN" role="3cpWs9">
+            <property role="TrG5h" value="bv" />
+            <node concept="17QB3L" id="3fi3fTlpKvO" role="1tU5fm" />
+            <node concept="Xl_RD" id="3fi3fTlpKvP" role="33vP2m">
+              <property role="Xl_RC" value="" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="3fi3fTlpKvQ" role="3cqZAp">
+          <node concept="3clFbS" id="3fi3fTlpKvR" role="3clFbx">
+            <node concept="3clFbF" id="3fi3fTlpKvS" role="3cqZAp">
+              <node concept="37vLTI" id="3fi3fTlpKvT" role="3clFbG">
+                <node concept="3cpWs3" id="3fi3fTlpKvU" role="37vLTx">
+                  <node concept="Xl_RD" id="3fi3fTlpKvV" role="3uHU7w">
+                    <property role="Xl_RC" value="" />
+                  </node>
+                  <node concept="37vLTw" id="3fi3fTlpKvW" role="3uHU7B">
+                    <ref role="3cqZAo" node="2rOWEwsBaIo" resolve="boundValues" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="3fi3fTlpKvX" role="37vLTJ">
+                  <ref role="3cqZAo" node="3fi3fTlpKvN" resolve="bv" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="3fi3fTlpKvY" role="3clFbw">
+            <node concept="2OqwBi" id="3fi3fTlpKvZ" role="2Oq$k0">
+              <node concept="Xjq3P" id="3fi3fTlpKw0" role="2Oq$k0" />
+              <node concept="2OwXpG" id="3fi3fTlpKw1" role="2OqNvi">
+                <ref role="2Oxat5" node="2rOWEwsBaIo" resolve="boundValues" />
+              </node>
+            </node>
+            <node concept="3GX2aA" id="3fi3fTlpKw2" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="3fi3fTlpKw3" role="3cqZAp">
+          <node concept="3cpWs3" id="3fi3fTlpKw4" role="3clFbG">
+            <node concept="3cpWs3" id="3fi3fTlpKw5" role="3uHU7B">
+              <node concept="37vLTw" id="3fi3fTlpKw6" role="3uHU7w">
+                <ref role="3cqZAo" node="3fi3fTlpKvN" resolve="bv" />
+              </node>
+              <node concept="3cpWs3" id="3fi3fTlpKw7" role="3uHU7B">
+                <node concept="Xl_RD" id="3fi3fTlpKw8" role="3uHU7B">
+                  <property role="Xl_RC" value="&lt;lambda " />
+                </node>
+                <node concept="2OqwBi" id="3fi3fTlpKw9" role="3uHU7w">
+                  <node concept="2OqwBi" id="3fi3fTlpKwa" role="2Oq$k0">
+                    <node concept="Xjq3P" id="3fi3fTlpKwb" role="2Oq$k0" />
+                    <node concept="2OwXpG" id="3fi3fTlpKwc" role="2OqNvi">
+                      <ref role="2Oxat5" node="3fi3fTlpKto" resolve="lambda" />
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="3fi3fTlpKwd" role="2OqNvi">
+                    <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="Xl_RD" id="3fi3fTlpKwe" role="3uHU7w">
+              <property role="Xl_RC" value="&gt;" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="3fi3fTlpKwf" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3fi3fTlpKwg" role="jymVt" />
+    <node concept="3clFb_" id="3fi3fTlpKwh" role="jymVt">
+      <property role="TrG5h" value="copy" />
+      <property role="1EzhhJ" value="false" />
+      <node concept="37vLTG" id="3fi3fTlpKwi" role="3clF46">
+        <property role="TrG5h" value="ctx" />
+        <node concept="3uibUv" id="3fi3fTlpKwj" role="1tU5fm">
+          <ref role="3uigEE" to="2ahs:4X7QcQ31ENp" resolve="IContext" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3fi3fTlpKwk" role="3clF46">
+        <property role="TrG5h" value="coverage" />
+        <node concept="3uibUv" id="3fi3fTlpKwl" role="1tU5fm">
+          <ref role="3uigEE" to="2ahs:4_qY3E5ifTh" resolve="ICoverageAnalyzer" />
+        </node>
+      </node>
+      <node concept="3uibUv" id="3fi3fTlpKwm" role="3clF45">
+        <ref role="3uigEE" node="$yb$20kU6$" resolve="ExecutableValue" />
+      </node>
+      <node concept="3Tm1VV" id="3fi3fTlpKwn" role="1B3o_S" />
+      <node concept="3clFbS" id="3fi3fTlpKwo" role="3clF47">
+        <node concept="3cpWs8" id="3fi3fTlpKwp" role="3cqZAp">
+          <node concept="3cpWsn" id="3fi3fTlpKwq" role="3cpWs9">
+            <property role="TrG5h" value="copy" />
+            <node concept="3uibUv" id="3fi3fTlpKwr" role="1tU5fm">
+              <ref role="3uigEE" node="5s__jxCoQMv" resolve="ShortLambdaValue" />
+            </node>
+            <node concept="2ShNRf" id="3fi3fTlpKws" role="33vP2m">
+              <node concept="1pGfFk" id="3fi3fTlpKwt" role="2ShVmc">
+                <ref role="37wK5l" node="3fi3fTlpKtB" resolve="ShortLambdaValue" />
+                <node concept="37vLTw" id="3fi3fTlpKwu" role="37wK5m">
+                  <ref role="3cqZAo" node="IFu7oT5N0i" resolve="shortLambda" />
+                </node>
+                <node concept="37vLTw" id="3fi3fTlpKwv" role="37wK5m">
+                  <ref role="3cqZAo" node="3fi3fTlpKwi" resolve="ctx" />
+                </node>
+                <node concept="37vLTw" id="3fi3fTlpKww" role="37wK5m">
+                  <ref role="3cqZAo" node="3fi3fTlpKwk" resolve="coverage" />
+                </node>
+                <node concept="37vLTw" id="3fi3fTlpKwx" role="37wK5m">
+                  <ref role="3cqZAo" node="3fi3fTlpKtx" resolve="stopOnStop" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3fi3fTlpKwy" role="3cqZAp">
+          <node concept="2OqwBi" id="3fi3fTlpKwz" role="3clFbG">
+            <node concept="2OqwBi" id="3fi3fTlpKw$" role="2Oq$k0">
+              <node concept="37vLTw" id="3fi3fTlpKw_" role="2Oq$k0">
+                <ref role="3cqZAo" node="3fi3fTlpKwq" resolve="copy" />
+              </node>
+              <node concept="2OwXpG" id="3fi3fTlpKwA" role="2OqNvi">
+                <ref role="2Oxat5" node="2rOWEwsBaIo" resolve="boundValues" />
+              </node>
+            </node>
+            <node concept="X8dFx" id="3fi3fTlpKwB" role="2OqNvi">
+              <node concept="2OqwBi" id="3fi3fTlpKwC" role="25WWJ7">
+                <node concept="Xjq3P" id="3fi3fTlpKwD" role="2Oq$k0" />
+                <node concept="2OwXpG" id="3fi3fTlpKwE" role="2OqNvi">
+                  <ref role="2Oxat5" node="2rOWEwsBaIo" resolve="boundValues" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3fi3fTlpKwF" role="3cqZAp">
+          <node concept="37vLTw" id="3fi3fTlpKwG" role="3clFbG">
+            <ref role="3cqZAo" node="3fi3fTlpKwq" resolve="copy" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="3fi3fTmWUT9" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3fi3fTlpKwH" role="jymVt" />
+    <node concept="2tJIrI" id="3fi3fTlpKwI" role="jymVt" />
+    <node concept="3clFb_" id="3fi3fTlpKwJ" role="jymVt">
+      <property role="TrG5h" value="executeEvaluated" />
+      <property role="1EzhhJ" value="false" />
+      <node concept="3uibUv" id="3fi3fTlpKwK" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+      </node>
+      <node concept="3Tm1VV" id="3fi3fTlpKwL" role="1B3o_S" />
+      <node concept="37vLTG" id="3fi3fTlpKwM" role="3clF46">
+        <property role="TrG5h" value="evaluatedArgs" />
+        <node concept="_YKpA" id="3fi3fTlpKwN" role="1tU5fm">
+          <node concept="3uibUv" id="3fi3fTlpKwO" role="_ZDj9">
+            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="3fi3fTlpKwP" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <node concept="3uibUv" id="3fi3fTlpKwQ" role="1tU5fm">
+          <ref role="3uigEE" to="2ahs:4X7QcQ31ENp" resolve="IContext" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3fi3fTlpKwR" role="3clF46">
+        <property role="TrG5h" value="coverage" />
+        <node concept="3uibUv" id="3fi3fTlpKwS" role="1tU5fm">
+          <ref role="3uigEE" to="2ahs:4_qY3E5ifTh" resolve="ICoverageAnalyzer" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3fi3fTlpKwT" role="3clF46">
+        <property role="TrG5h" value="contextTrace" />
+        <node concept="3uibUv" id="3fi3fTlpKwU" role="1tU5fm">
+          <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="3fi3fTlpKwV" role="3clF46">
+        <property role="TrG5h" value="stopOnStop" />
+        <node concept="10P_77" id="3fi3fTlpKwW" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="3fi3fTlpKwX" role="3clF47">
+        <node concept="3clFbF" id="3fi3fTlpKwY" role="3cqZAp">
+          <node concept="2OqwBi" id="3fi3fTlpKwZ" role="3clFbG">
+            <node concept="37vLTw" id="3fi3fTlpKx0" role="2Oq$k0">
+              <ref role="3cqZAo" node="3fi3fTlpKwP" resolve="context" />
+            </node>
+            <node concept="liA8E" id="3fi3fTlpKx1" role="2OqNvi">
+              <ref role="37wK5l" to="2ahs:2pAf7L4El8y" resolve="pushEnvironment" />
+              <node concept="37vLTw" id="3fi3fTlpKx2" role="37wK5m">
+                <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
+              </node>
+              <node concept="10Nm6u" id="3fi3fTlpKx3" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="1gVbGN" id="3fi3fTpD5TP" role="3cqZAp">
+          <node concept="3clFbC" id="3fi3fTpDhee" role="1gVkn0">
+            <node concept="3cmrfG" id="3fi3fTpDl0y" role="3uHU7w">
+              <property role="3cmrfH" value="1" />
+            </node>
+            <node concept="2OqwBi" id="3fi3fTpD9EK" role="3uHU7B">
+              <node concept="37vLTw" id="3fi3fTpD7pK" role="2Oq$k0">
+                <ref role="3cqZAo" node="3fi3fTlpKwM" resolve="evaluatedArgs" />
+              </node>
+              <node concept="34oBXx" id="3fi3fTpDdh2" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="IFu7oT5kRY" role="3cqZAp" />
+        <node concept="3clFbF" id="IFu7oT5oCH" role="3cqZAp">
+          <node concept="2OqwBi" id="IFu7oT5oCI" role="3clFbG">
+            <node concept="2OqwBi" id="IFu7oT5oCJ" role="2Oq$k0">
+              <node concept="37vLTw" id="IFu7oT5oCK" role="2Oq$k0">
+                <ref role="3cqZAo" node="3fi3fTlpKwP" resolve="context" />
+              </node>
+              <node concept="liA8E" id="IFu7oT5oCL" role="2OqNvi">
+                <ref role="37wK5l" to="2ahs:2X4$XGmeh8R" resolve="getEnvironment" />
+              </node>
+            </node>
+            <node concept="liA8E" id="IFu7oT5oCM" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Map.put(java.lang.Object,java.lang.Object)" resolve="put" />
+              <node concept="2OqwBi" id="IFu7oT5oCN" role="37wK5m">
+                <node concept="2OqwBi" id="IFu7oT5oCO" role="2Oq$k0">
+                  <node concept="37vLTw" id="IFu7oT5oCP" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
+                  </node>
+                  <node concept="3Tsc0h" id="IFu7oT5oCQ" role="2OqNvi">
+                    <ref role="3TtcxE" to="zzzn:6zmBjqUkws7" resolve="args" />
+                  </node>
+                </node>
+                <node concept="34jXtK" id="IFu7oT5oCR" role="2OqNvi">
+                  <node concept="3cmrfG" id="IFu7oT5vCj" role="25WWJ7">
+                    <property role="3cmrfH" value="0" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="IFu7oT5oCT" role="37wK5m">
+                <node concept="37vLTw" id="IFu7oT5oCU" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3fi3fTlpKwM" resolve="evaluatedArgs" />
+                </node>
+                <node concept="34jXtK" id="IFu7oT5oCV" role="2OqNvi">
+                  <node concept="3cmrfG" id="IFu7oT5ygO" role="25WWJ7">
+                    <property role="3cmrfH" value="0" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3fi3fTp$ghQ" role="3cqZAp" />
+        <node concept="3cpWs8" id="3fi3fTlpKy6" role="3cqZAp">
+          <node concept="3cpWsn" id="3fi3fTlpKy7" role="3cpWs9">
+            <property role="TrG5h" value="tt" />
+            <node concept="3uibUv" id="3fi3fTlpKy8" role="1tU5fm">
+              <ref role="3uigEE" to="2ahs:7cNsFS_gTK8" resolve="ComputationTrace" />
+            </node>
+            <node concept="2ShNRf" id="3fi3fTlpKy9" role="33vP2m">
+              <node concept="1pGfFk" id="3fi3fTlpKya" role="2ShVmc">
+                <ref role="37wK5l" to="2ahs:5d4Vabvrrqt" resolve="ComputationTrace" />
+                <node concept="37vLTw" id="3fi3fTlpKyb" role="37wK5m">
+                  <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
+                </node>
+                <node concept="3clFbT" id="3fi3fTlpKyc" role="37wK5m" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3fi3fTlpKyd" role="3cqZAp">
+          <node concept="2OqwBi" id="3fi3fTlpKye" role="3clFbG">
+            <node concept="37vLTw" id="3fi3fTlpKyf" role="2Oq$k0">
+              <ref role="3cqZAo" node="3fi3fTlpKwT" resolve="contextTrace" />
+            </node>
+            <node concept="liA8E" id="3fi3fTlpKyg" role="2OqNvi">
+              <ref role="37wK5l" to="2ahs:1FJItavexS7" resolve="addChild" />
+              <node concept="37vLTw" id="3fi3fTlpKyh" role="37wK5m">
+                <ref role="3cqZAo" node="3fi3fTlpKy7" resolve="tt" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="4X7jg4xLpCt" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3cpWs8" id="5s__jxCsPBW" role="8Wnug">
+            <node concept="3cpWsn" id="5s__jxCsPBX" role="3cpWs9">
+              <property role="TrG5h" value="start" />
+              <node concept="3cpWsb" id="5s__jxCsPBY" role="1tU5fm" />
+              <node concept="2YIFZM" id="5s__jxCsPBZ" role="33vP2m">
+                <ref role="37wK5l" to="wyt6:~System.nanoTime()" resolve="nanoTime" />
+                <ref role="1Pybhc" to="wyt6:~System" resolve="System" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="5s__jxCsPC6" role="3cqZAp">
+          <node concept="3cpWsn" id="5s__jxCsPC7" role="3cpWs9">
+            <property role="TrG5h" value="res" />
+            <node concept="3uibUv" id="5s__jxCsPC8" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+            </node>
+            <node concept="2OqwBi" id="5s__jxCsPC9" role="33vP2m">
+              <node concept="liA8E" id="5s__jxCsPCb" role="2OqNvi">
+                <ref role="37wK5l" to="2ahs:2X4$XGmegKw" resolve="evaluate" />
+                <node concept="2OqwBi" id="5s__jxCsPCc" role="37wK5m">
+                  <node concept="37vLTw" id="5s__jxCsPCd" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
+                  </node>
+                  <node concept="3TrEf2" id="5s__jxCsPCe" role="2OqNvi">
+                    <ref role="3Tt5mk" to="zzzn:6zmBjqUkwH3" resolve="expression" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="5s__jxCsPCf" role="37wK5m">
+                  <ref role="3cqZAo" node="3fi3fTlpKwP" resolve="context" />
+                </node>
+                <node concept="37vLTw" id="5s__jxCsPCg" role="37wK5m">
+                  <ref role="3cqZAo" node="3fi3fTlpKwR" resolve="coverage" />
+                </node>
+                <node concept="37vLTw" id="5s__jxCsPCh" role="37wK5m">
+                  <ref role="3cqZAo" node="3fi3fTlpKy7" resolve="tt" />
+                </node>
+                <node concept="37vLTw" id="5s__jxCsPCi" role="37wK5m">
+                  <ref role="3cqZAo" node="3fi3fTlpKwV" resolve="stopOnStop" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5s__jxCsPC3" role="2Oq$k0">
+                <node concept="37vLTw" id="5s__jxCsPC4" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3fi3fTlpKwP" resolve="context" />
+                </node>
+                <node concept="liA8E" id="5s__jxCsPC5" role="2OqNvi">
+                  <ref role="37wK5l" to="2ahs:2ALJBcrni7v" resolve="getRootInterpreter" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="4X7jg4xLr$r" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3cpWs8" id="5s__jxCsPCj" role="8Wnug">
+            <node concept="3cpWsn" id="5s__jxCsPCk" role="3cpWs9">
+              <property role="TrG5h" value="stopp" />
+              <node concept="3cpWsb" id="5s__jxCsPCl" role="1tU5fm" />
+              <node concept="2YIFZM" id="5s__jxCsPCm" role="33vP2m">
+                <ref role="37wK5l" to="wyt6:~System.nanoTime()" resolve="nanoTime" />
+                <ref role="1Pybhc" to="wyt6:~System" resolve="System" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1X3_iC" id="4X7jg4xLr$s" role="lGtFl">
+          <property role="3V$3am" value="statement" />
+          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
+          <node concept="3clFbF" id="5s__jxCsPCn" role="8Wnug">
+            <node concept="2OqwBi" id="5s__jxCsPCo" role="3clFbG">
+              <node concept="10M0yZ" id="5s__jxCsPCp" role="2Oq$k0">
+                <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+                <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              </node>
+              <node concept="liA8E" id="5s__jxCsPCq" role="2OqNvi">
+                <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+                <node concept="3cpWs3" id="5s__jxCsPCr" role="37wK5m">
+                  <node concept="3cpWs3" id="5s__jxCsPCs" role="3uHU7B">
+                    <node concept="3cpWs3" id="5s__jxCsPCt" role="3uHU7B">
+                      <node concept="3cpWs3" id="5s__jxCwfcS" role="3uHU7B">
+                        <node concept="Xl_RD" id="5s__jxCwbCH" role="3uHU7w">
+                          <property role="Xl_RC" value=" / caching " />
+                        </node>
+                        <node concept="3cpWs3" id="5s__jxCw8aK" role="3uHU7B">
+                          <node concept="3cpWs3" id="5s__jxCsPCu" role="3uHU7B">
+                            <node concept="Xl_RD" id="5s__jxCsPCv" role="3uHU7w">
+                              <property role="Xl_RC" value=" / +LambdaArg:" />
+                            </node>
+                            <node concept="3cpWs3" id="5s__jxCsPCw" role="3uHU7B">
+                              <node concept="Xl_RD" id="5s__jxCsPCx" role="3uHU7B">
+                                <property role="Xl_RC" value="&lt;ShortLambda&gt; EXPR:" />
+                              </node>
+                              <node concept="37vLTw" id="5s__jxCsPCy" role="3uHU7w">
+                                <ref role="3cqZAo" node="3fi3fTlpKwM" resolve="evaluatedArgs" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="37vLTw" id="5s__jxCwh2a" role="3uHU7w">
+                            <ref role="3cqZAo" node="5s__jxCvpsu" resolve="newLambdaArgCreated" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="5s__jxCsPCz" role="3uHU7w">
+                        <node concept="1eOMI4" id="5s__jxCsPC$" role="2Oq$k0">
+                          <node concept="10QFUN" id="5s__jxCsPC_" role="1eOMHV">
+                            <node concept="3uibUv" id="5s__jxCsPCA" role="10QFUM">
+                              <ref role="3uigEE" to="pbu6:6iqfHNC0mHl" resolve="IETS3ExprContext" />
+                            </node>
+                            <node concept="37vLTw" id="5s__jxCsPCB" role="10QFUP">
+                              <ref role="3cqZAo" node="3fi3fTlpKwP" resolve="context" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="5s__jxCsPCC" role="2OqNvi">
+                          <ref role="37wK5l" to="pbu6:4Pi6J8BUEA2" resolve="isCachingEnabled" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="5s__jxCsPCD" role="3uHU7w">
+                      <property role="Xl_RC" value=" TIME/ns:" />
+                    </node>
+                  </node>
+                  <node concept="1eOMI4" id="5s__jxCsPCE" role="3uHU7w">
+                    <node concept="3cpWsd" id="5s__jxCsPCF" role="1eOMHV">
+                      <node concept="37vLTw" id="5s__jxCsPCG" role="3uHU7B">
+                        <ref role="3cqZAo" node="5s__jxCsPCk" resolve="stopp" />
+                      </node>
+                      <node concept="37vLTw" id="5s__jxCsPCH" role="3uHU7w">
+                        <ref role="3cqZAo" node="5s__jxCsPBX" resolve="start" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3fi3fTpCAjY" role="3cqZAp" />
+        <node concept="3clFbF" id="3fi3fTlpKyx" role="3cqZAp">
+          <node concept="2OqwBi" id="3fi3fTlpKyy" role="3clFbG">
+            <node concept="2OqwBi" id="3fi3fTlpKyz" role="2Oq$k0">
+              <node concept="37vLTw" id="3fi3fTlpKy$" role="2Oq$k0">
+                <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
+              </node>
+              <node concept="2Rf3mk" id="3fi3fTlpKy_" role="2OqNvi">
+                <node concept="1xIGOp" id="3fi3fTlpKyA" role="1xVPHs" />
+              </node>
+            </node>
+            <node concept="2es0OD" id="3fi3fTlpKyB" role="2OqNvi">
+              <node concept="1bVj0M" id="3fi3fTlpKyC" role="23t8la">
+                <node concept="3clFbS" id="3fi3fTlpKyD" role="1bW5cS">
+                  <node concept="3clFbF" id="3fi3fTlpKyE" role="3cqZAp">
+                    <node concept="2OqwBi" id="3fi3fTlpKyF" role="3clFbG">
+                      <node concept="37vLTw" id="3fi3fTlpKyG" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3fi3fTlpKts" resolve="mapping" />
+                      </node>
+                      <node concept="2es0OD" id="3fi3fTlpKyH" role="2OqNvi">
+                        <node concept="1bVj0M" id="3fi3fTlpKyI" role="23t8la">
+                          <node concept="3clFbS" id="3fi3fTlpKyJ" role="1bW5cS">
+                            <node concept="3clFbJ" id="3fi3fTlpKyK" role="3cqZAp">
+                              <node concept="2YIFZM" id="3fi3fTlpKyL" role="3clFbw">
+                                <ref role="37wK5l" to="pbu6:7LZDtvhyLWZ" resolve="isNodeCovered" />
+                                <ref role="1Pybhc" to="pbu6:7LZDtvhy76p" resolve="IDefaultCoverageAnalyzer" />
+                                <node concept="2OqwBi" id="3fi3fTlpKyM" role="37wK5m">
+                                  <node concept="37vLTw" id="3fi3fTlpKyN" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="3fi3fTlpKyY" resolve="mapping" />
+                                  </node>
+                                  <node concept="3AV6Ez" id="3fi3fTlpKyO" role="2OqNvi" />
+                                </node>
+                              </node>
+                              <node concept="3clFbS" id="3fi3fTlpKyP" role="3clFbx">
+                                <node concept="3clFbF" id="3fi3fTlpKyQ" role="3cqZAp">
+                                  <node concept="2OqwBi" id="3fi3fTlpKyR" role="3clFbG">
+                                    <node concept="37vLTw" id="3fi3fTlpKyS" role="2Oq$k0">
+                                      <ref role="3cqZAo" node="3fi3fTlpKwR" resolve="coverage" />
+                                    </node>
+                                    <node concept="liA8E" id="3fi3fTlpKyT" role="2OqNvi">
+                                      <ref role="37wK5l" to="2ahs:RaqQlV4lZg" resolve="coverValue" />
+                                      <node concept="2OqwBi" id="3fi3fTlpKyU" role="37wK5m">
+                                        <node concept="37vLTw" id="3fi3fTlpKyV" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="3fi3fTlpKyY" resolve="mapping" />
+                                        </node>
+                                        <node concept="3AY5_j" id="3fi3fTlpKyW" role="2OqNvi" />
+                                      </node>
+                                      <node concept="10Nm6u" id="3fi3fTlpKyX" role="37wK5m" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="gl6BB" id="3fi3fTlpKyY" role="1bW2Oz">
+                            <property role="TrG5h" value="mapping" />
+                            <node concept="2jxLKc" id="3fi3fTlpKyZ" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs8" id="3fi3fTlpKz0" role="3cqZAp">
+                    <node concept="3cpWsn" id="3fi3fTlpKz1" role="3cpWs9">
+                      <property role="TrG5h" value="originalNode" />
+                      <node concept="3Tqbb2" id="3fi3fTlpKz2" role="1tU5fm" />
+                      <node concept="2OqwBi" id="3fi3fTlpKz3" role="33vP2m">
+                        <node concept="2OqwBi" id="3fi3fTlpKz4" role="2Oq$k0">
+                          <node concept="37vLTw" id="3fi3fTlpKz5" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3fi3fTlpKts" resolve="mapping" />
+                          </node>
+                          <node concept="3lbrtF" id="3fi3fTlpKz6" role="2OqNvi" />
+                        </node>
+                        <node concept="1z4cxt" id="3fi3fTlpKz7" role="2OqNvi">
+                          <node concept="1bVj0M" id="3fi3fTlpKz8" role="23t8la">
+                            <node concept="3clFbS" id="3fi3fTlpKz9" role="1bW5cS">
+                              <node concept="3clFbF" id="3fi3fTlpKza" role="3cqZAp">
+                                <node concept="3clFbC" id="3fi3fTlpKzb" role="3clFbG">
+                                  <node concept="37vLTw" id="3fi3fTlpKzc" role="3uHU7w">
+                                    <ref role="3cqZAo" node="3fi3fTlpKzs" resolve="descendant" />
+                                  </node>
+                                  <node concept="3EllGN" id="3fi3fTlpKzd" role="3uHU7B">
+                                    <node concept="37vLTw" id="3fi3fTlpKze" role="3ElVtu">
+                                      <ref role="3cqZAo" node="3fi3fTlpKzg" resolve="key" />
+                                    </node>
+                                    <node concept="37vLTw" id="3fi3fTlpKzf" role="3ElQJh">
+                                      <ref role="3cqZAo" node="3fi3fTlpKts" resolve="mapping" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="gl6BB" id="3fi3fTlpKzg" role="1bW2Oz">
+                              <property role="TrG5h" value="key" />
+                              <node concept="2jxLKc" id="3fi3fTlpKzh" role="1tU5fm" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbJ" id="3fi3fTlpKzi" role="3cqZAp">
+                    <node concept="3clFbS" id="3fi3fTlpKzj" role="3clFbx">
+                      <node concept="3clFbF" id="3fi3fTlpKzk" role="3cqZAp">
+                        <node concept="2OqwBi" id="3fi3fTlpKzl" role="3clFbG">
+                          <node concept="37vLTw" id="3fi3fTlpKzm" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3fi3fTlpKwR" resolve="coverage" />
+                          </node>
+                          <node concept="liA8E" id="3fi3fTlpKzn" role="2OqNvi">
+                            <ref role="37wK5l" to="2ahs:RaqQlV4lZg" resolve="coverValue" />
+                            <node concept="37vLTw" id="3fi3fTlpKzo" role="37wK5m">
+                              <ref role="3cqZAo" node="3fi3fTlpKz1" resolve="originalNode" />
+                            </node>
+                            <node concept="10Nm6u" id="3fi3fTlpKzp" role="37wK5m" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2YIFZM" id="3fi3fTlpKzq" role="3clFbw">
+                      <ref role="37wK5l" to="pbu6:7LZDtvhyLWZ" resolve="isNodeCovered" />
+                      <ref role="1Pybhc" to="pbu6:7LZDtvhy76p" resolve="IDefaultCoverageAnalyzer" />
+                      <node concept="37vLTw" id="3fi3fTlpKzr" role="37wK5m">
+                        <ref role="3cqZAo" node="3fi3fTlpKzs" resolve="descendant" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="3fi3fTlpKzs" role="1bW2Oz">
+                  <property role="TrG5h" value="descendant" />
+                  <node concept="2jxLKc" id="3fi3fTlpKzt" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3fi3fTlpKzu" role="3cqZAp">
+          <node concept="2OqwBi" id="3fi3fTlpKzv" role="3clFbG">
+            <node concept="37vLTw" id="3fi3fTlpKzw" role="2Oq$k0">
+              <ref role="3cqZAo" node="3fi3fTlpKy7" resolve="tt" />
+            </node>
+            <node concept="liA8E" id="3fi3fTlpKzx" role="2OqNvi">
+              <ref role="37wK5l" to="2ahs:7obiejAu3TD" resolve="setValue" />
+              <node concept="37vLTw" id="3fi3fTlpKzy" role="37wK5m">
+                <ref role="3cqZAo" node="5s__jxCsPC7" resolve="res" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3fi3fTlpKzz" role="3cqZAp">
+          <node concept="2OqwBi" id="3fi3fTlpKz$" role="3clFbG">
+            <node concept="37vLTw" id="3fi3fTlpKz_" role="2Oq$k0">
+              <ref role="3cqZAo" node="3fi3fTlpKwP" resolve="context" />
+            </node>
+            <node concept="liA8E" id="3fi3fTlpKzA" role="2OqNvi">
+              <ref role="37wK5l" to="2ahs:2pAf7L4EmGp" resolve="popEnvironment" />
+              <node concept="37vLTw" id="3fi3fTlpKzB" role="37wK5m">
+                <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="3fi3fTlpKzC" role="3cqZAp">
+          <node concept="37vLTw" id="3fi3fTlpKzD" role="3cqZAk">
+            <ref role="3cqZAo" node="5s__jxCsPC7" resolve="res" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="3fi3fTmWYbt" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="5s__jxCpvbq" role="jymVt" />
+    <node concept="2tJIrI" id="5s__jxCoR7u" role="jymVt" />
+    <node concept="3Tm1VV" id="5s__jxCoQMw" role="1B3o_S" />
+    <node concept="3uibUv" id="5s__jxCp4EB" role="1zkMxy">
+      <ref role="3uigEE" node="$yb$20kU6$" resolve="ExecutableValue" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/plugin.mps
@@ -17,13 +17,9 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
-    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
-        <child id="1082485599096" name="statements" index="9aQI4" />
-      </concept>
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -64,16 +60,9 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
-      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
-        <reference id="1144433057691" name="classifier" index="1PxDUh" />
-      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
-      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
-        <child id="1070534934091" name="type" index="10QFUM" />
-        <child id="1070534934092" name="expression" index="10QFUP" />
-      </concept>
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg">
         <property id="8606350594693632173" name="isTransient" index="eg7rD" />
         <property id="1240249534625" name="isVolatile" index="34CwA1" />
@@ -111,7 +100,6 @@
       </concept>
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
-        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
@@ -132,17 +120,9 @@
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
-      <concept id="1068581242867" name="jetbrains.mps.baseLanguage.structure.LongType" flags="in" index="3cpWsb" />
-      <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
-        <child id="1079359253376" name="expression" index="1eOMHV" />
-      </concept>
       <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
-      <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="nn" index="1gVbGN">
-        <child id="1160998896846" name="condition" index="1gVkn0" />
-      </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
@@ -258,18 +238,8 @@
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
-      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
-        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
-      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
-      </concept>
-      <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
-        <property id="709746936026609031" name="linkId" index="3V$3ak" />
-        <property id="709746936026609029" name="role_DebugInfo" index="3V$3am" />
-      </concept>
-      <concept id="4452961908202556907" name="jetbrains.mps.lang.core.structure.BaseCommentAttribute" flags="ng" index="1X3_iC">
-        <child id="3078666699043039389" name="commentedNode" index="8Wnug" />
       </concept>
     </language>
     <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
@@ -346,7 +316,7 @@
       <node concept="3Tm1VV" id="6ITtBskSWbF" role="1B3o_S" />
       <node concept="17QB3L" id="6ITtBskT0bQ" role="1tU5fm" />
       <node concept="Xl_RD" id="6ITtBskT2G0" role="33vP2m">
-        <property role="Xl_RC" value="shortLambdaMapping" />
+        <property role="Xl_RC" value="LambdaMapping" />
       </node>
     </node>
     <node concept="312cEg" id="$yb$20fATA" role="jymVt">
@@ -1018,20 +988,6 @@
             </node>
           </node>
         </node>
-        <node concept="1X3_iC" id="4X7jg4xLykf" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3cpWs8" id="2gng9$EZN1p" role="8Wnug">
-            <node concept="3cpWsn" id="2gng9$EZN1q" role="3cpWs9">
-              <property role="TrG5h" value="start" />
-              <node concept="3cpWsb" id="2gng9$EZN1r" role="1tU5fm" />
-              <node concept="2YIFZM" id="1joq1DK4sn9" role="33vP2m">
-                <ref role="37wK5l" to="wyt6:~System.nanoTime()" resolve="nanoTime" />
-                <ref role="1Pybhc" to="wyt6:~System" resolve="System" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3cpWs8" id="$yb$20l8Hu" role="3cqZAp">
           <node concept="3cpWsn" id="$yb$20l8Hv" role="3cpWs9">
             <property role="TrG5h" value="res" />
@@ -1068,82 +1024,6 @@
                 </node>
                 <node concept="liA8E" id="1joq1DK9lUg" role="2OqNvi">
                   <ref role="37wK5l" to="2ahs:2ALJBcrni7v" resolve="getRootInterpreter" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="4X7jg4xL$8E" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3cpWs8" id="6z6ktjM1XDw" role="8Wnug">
-            <node concept="3cpWsn" id="6z6ktjM1XDx" role="3cpWs9">
-              <property role="TrG5h" value="stopp" />
-              <node concept="3cpWsb" id="6z6ktjM1XDy" role="1tU5fm" />
-              <node concept="2YIFZM" id="1joq1DK4vJE" role="33vP2m">
-                <ref role="37wK5l" to="wyt6:~System.nanoTime()" resolve="nanoTime" />
-                <ref role="1Pybhc" to="wyt6:~System" resolve="System" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="4X7jg4xL$8F" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="2gng9$EYqjy" role="8Wnug">
-            <node concept="2OqwBi" id="2gng9$EYte0" role="3clFbG">
-              <node concept="10M0yZ" id="2gng9$EYqVO" role="2Oq$k0">
-                <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
-                <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-              </node>
-              <node concept="liA8E" id="2gng9$EYvRH" role="2OqNvi">
-                <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
-                <node concept="3cpWs3" id="2gng9$EZ7nI" role="37wK5m">
-                  <node concept="3cpWs3" id="2gng9$EYNFl" role="3uHU7B">
-                    <node concept="3cpWs3" id="2gng9$EYFqU" role="3uHU7B">
-                      <node concept="3cpWs3" id="2gng9$EYTHh" role="3uHU7B">
-                        <node concept="Xl_RD" id="2gng9$EYW42" role="3uHU7w">
-                          <property role="Xl_RC" value=" / caching:" />
-                        </node>
-                        <node concept="3cpWs3" id="2gng9$EYQ2U" role="3uHU7B">
-                          <node concept="Xl_RD" id="2gng9$EYyD3" role="3uHU7B">
-                            <property role="Xl_RC" value="&lt;     Lambda&gt; EXPR:" />
-                          </node>
-                          <node concept="37vLTw" id="2gng9$EYRk2" role="3uHU7w">
-                            <ref role="3cqZAo" node="$yb$20l8GQ" resolve="evaluatedArgs" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="1joq1DK9pM7" role="3uHU7w">
-                        <node concept="1eOMI4" id="1joq1DKdrYd" role="2Oq$k0">
-                          <node concept="10QFUN" id="1joq1DKdtxu" role="1eOMHV">
-                            <node concept="3uibUv" id="1joq1DKdvkG" role="10QFUM">
-                              <ref role="3uigEE" to="pbu6:6iqfHNC0mHl" resolve="IETS3ExprContext" />
-                            </node>
-                            <node concept="37vLTw" id="1joq1DK9nUQ" role="10QFUP">
-                              <ref role="3cqZAo" node="$yb$20l8GT" resolve="context" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="liA8E" id="1joq1DK9Jb4" role="2OqNvi">
-                          <ref role="37wK5l" to="pbu6:4Pi6J8BUEA2" resolve="isCachingEnabled" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="Xl_RD" id="2gng9$EYZvQ" role="3uHU7w">
-                      <property role="Xl_RC" value=" TIME/ns:" />
-                    </node>
-                  </node>
-                  <node concept="1eOMI4" id="2gng9$EZhZk" role="3uHU7w">
-                    <node concept="3cpWsd" id="2gng9$EZdTO" role="1eOMHV">
-                      <node concept="37vLTw" id="2gng9$EZ8Ss" role="3uHU7B">
-                        <ref role="3cqZAo" node="6z6ktjM1XDx" resolve="stopp" />
-                      </node>
-                      <node concept="37vLTw" id="2gng9$EZe0n" role="3uHU7w">
-                        <ref role="3cqZAo" node="2gng9$EZN1q" resolve="start" />
-                      </node>
-                    </node>
-                  </node>
                 </node>
               </node>
             </node>
@@ -2586,7 +2466,7 @@
       <node concept="3Tm1VV" id="3fi3fTlpKtl" role="1B3o_S" />
       <node concept="17QB3L" id="3fi3fTlpKtm" role="1tU5fm" />
       <node concept="Xl_RD" id="3fi3fTlpKtn" role="33vP2m">
-        <property role="Xl_RC" value="shortLambdaMapping" />
+        <property role="Xl_RC" value="ShortLambdaMapping" />
       </node>
     </node>
     <node concept="Wx3nA" id="5s__jxCpjNV" role="jymVt">
@@ -2596,6 +2476,15 @@
       <node concept="17QB3L" id="5s__jxCpjNX" role="1tU5fm" />
       <node concept="Xl_RD" id="5s__jxCpjNY" role="33vP2m">
         <property role="Xl_RC" value="LambdaArg" />
+      </node>
+    </node>
+    <node concept="Wx3nA" id="XbOhLk4Bsh" role="jymVt">
+      <property role="TrG5h" value="USER_OBJECT_KEY_LAMBDA" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm1VV" id="XbOhLk4Bsi" role="1B3o_S" />
+      <node concept="17QB3L" id="XbOhLk4Bsj" role="1tU5fm" />
+      <node concept="Xl_RD" id="XbOhLk4Bsk" role="33vP2m">
+        <property role="Xl_RC" value="Lambda" />
       </node>
     </node>
     <node concept="312cEg" id="3fi3fTlpKto" role="jymVt">
@@ -2635,11 +2524,6 @@
       <node concept="3clFbT" id="3fi3fTlpKt$" role="33vP2m">
         <property role="3clFbU" value="false" />
       </node>
-    </node>
-    <node concept="312cEg" id="5s__jxCvpsu" role="jymVt">
-      <property role="TrG5h" value="newLambdaArgCreated" />
-      <node concept="3Tm6S6" id="5s__jxCvm_W" role="1B3o_S" />
-      <node concept="10P_77" id="5s__jxCvoYp" role="1tU5fm" />
     </node>
     <node concept="2tJIrI" id="3fi3fTlpKt_" role="jymVt" />
     <node concept="3clFbW" id="3fi3fTlpKtB" role="jymVt">
@@ -2704,67 +2588,105 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="IFu7oT4tI3" role="3cqZAp">
-          <node concept="37vLTI" id="IFu7oT4vAM" role="3clFbG">
-            <node concept="37vLTw" id="IFu7oT4tI1" role="37vLTJ">
+        <node concept="3clFbF" id="XbOhLk5rQG" role="3cqZAp">
+          <node concept="37vLTI" id="XbOhLk5v$A" role="3clFbG">
+            <node concept="2OqwBi" id="XbOhLk5yGO" role="37vLTx">
+              <node concept="37vLTw" id="XbOhLk5xkw" role="2Oq$k0">
+                <ref role="3cqZAo" node="3fi3fTlpKtC" resolve="le" />
+              </node>
+              <node concept="2qgKlT" id="XbOhLk5$Ln" role="2OqNvi">
+                <ref role="37wK5l" to="5s8v:XbOhLk5ek9" resolve="getLamda" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="XbOhLk5rQE" role="37vLTJ">
               <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
             </node>
-            <node concept="2ShNRf" id="49WTic8ey5E" role="37vLTx">
-              <node concept="3zrR0B" id="49WTic8ey5F" role="2ShVmc">
-                <node concept="3Tqbb2" id="49WTic8ey5G" role="3zrR0E">
-                  <ref role="ehGHo" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
+          </node>
+        </node>
+        <node concept="3clFbJ" id="XbOhLk5BuE" role="3cqZAp">
+          <node concept="3clFbS" id="XbOhLk5BuG" role="3clFbx">
+            <node concept="3clFbF" id="IFu7oT4tI3" role="3cqZAp">
+              <node concept="37vLTI" id="IFu7oT4vAM" role="3clFbG">
+                <node concept="37vLTw" id="IFu7oT4tI1" role="37vLTJ">
+                  <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
+                </node>
+                <node concept="2ShNRf" id="49WTic8ey5E" role="37vLTx">
+                  <node concept="3zrR0B" id="49WTic8ey5F" role="2ShVmc">
+                    <node concept="3Tqbb2" id="49WTic8ey5G" role="3zrR0E">
+                      <ref role="ehGHo" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="3fi3fTlpKub" role="3cqZAp">
+              <node concept="37vLTI" id="3fi3fTlpKuc" role="3clFbG">
+                <node concept="2OqwBi" id="IFu7oT4AXD" role="37vLTJ">
+                  <node concept="37vLTw" id="3fi3fTlpKud" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
+                  </node>
+                  <node concept="3TrEf2" id="IFu7oT4CR$" role="2OqNvi">
+                    <ref role="3Tt5mk" to="zzzn:6zmBjqUkwH3" resolve="expression" />
+                  </node>
+                </node>
+                <node concept="1PxgMI" id="2gng9$EqaKS" role="37vLTx">
+                  <property role="1BlNFB" value="true" />
+                  <node concept="chp4Y" id="2gng9$EqdW_" role="3oSUPX">
+                    <ref role="cht4Q" to="hm2y:6sdnDbSla17" resolve="Expression" />
+                  </node>
+                  <node concept="2YIFZM" id="3fi3fTlpKug" role="1m5AlR">
+                    <ref role="1Pybhc" to="w1kc:~CopyUtil" resolve="CopyUtil" />
+                    <ref role="37wK5l" to="w1kc:~CopyUtil.copy(org.jetbrains.mps.openapi.model.SNode,java.util.Map,boolean)" resolve="copy" />
+                    <node concept="2OqwBi" id="IFu7oT4E1e" role="37wK5m">
+                      <node concept="37vLTw" id="3fi3fTlpKuh" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3fi3fTlpKtC" resolve="le" />
+                      </node>
+                      <node concept="3TrEf2" id="IFu7oT4HQE" role="2OqNvi">
+                        <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="3fi3fTlpKui" role="37wK5m">
+                      <ref role="3cqZAo" node="3fi3fTlpKts" resolve="mapping" />
+                    </node>
+                    <node concept="3clFbT" id="3fi3fTlpKuj" role="37wK5m">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7cphKbKYWrc" role="3cqZAp">
+              <node concept="2OqwBi" id="7cphKbKYZU4" role="3clFbG">
+                <node concept="2OqwBi" id="7cphKbKYWXy" role="2Oq$k0">
+                  <node concept="37vLTw" id="7cphKbKYWHQ" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
+                  </node>
+                  <node concept="3Tsc0h" id="7cphKbKYXk5" role="2OqNvi">
+                    <ref role="3TtcxE" to="zzzn:6zmBjqUkws7" resolve="args" />
+                  </node>
+                </node>
+                <node concept="2Kehj3" id="7cphKbKZ42m" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="3clFbF" id="XbOhLk5Pff" role="3cqZAp">
+              <node concept="2OqwBi" id="XbOhLk5QDE" role="3clFbG">
+                <node concept="37vLTw" id="XbOhLk5Pfd" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3fi3fTlpKtC" resolve="le" />
+                </node>
+                <node concept="2qgKlT" id="XbOhLk5SI_" role="2OqNvi">
+                  <ref role="37wK5l" to="5s8v:XbOhLk5ekn" resolve="putLamda" />
+                  <node concept="37vLTw" id="XbOhLk5TWD" role="37wK5m">
+                    <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
+                  </node>
                 </node>
               </node>
             </node>
           </node>
-        </node>
-        <node concept="3clFbF" id="3fi3fTlpKub" role="3cqZAp">
-          <node concept="37vLTI" id="3fi3fTlpKuc" role="3clFbG">
-            <node concept="2OqwBi" id="IFu7oT4AXD" role="37vLTJ">
-              <node concept="37vLTw" id="3fi3fTlpKud" role="2Oq$k0">
-                <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
-              </node>
-              <node concept="3TrEf2" id="IFu7oT4CR$" role="2OqNvi">
-                <ref role="3Tt5mk" to="zzzn:6zmBjqUkwH3" resolve="expression" />
-              </node>
+          <node concept="3clFbC" id="XbOhLk5E3z" role="3clFbw">
+            <node concept="10Nm6u" id="XbOhLk5Flg" role="3uHU7w" />
+            <node concept="37vLTw" id="XbOhLk5CRJ" role="3uHU7B">
+              <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
             </node>
-            <node concept="1PxgMI" id="2gng9$EqaKS" role="37vLTx">
-              <property role="1BlNFB" value="true" />
-              <node concept="chp4Y" id="2gng9$EqdW_" role="3oSUPX">
-                <ref role="cht4Q" to="hm2y:6sdnDbSla17" resolve="Expression" />
-              </node>
-              <node concept="2YIFZM" id="3fi3fTlpKug" role="1m5AlR">
-                <ref role="1Pybhc" to="w1kc:~CopyUtil" resolve="CopyUtil" />
-                <ref role="37wK5l" to="w1kc:~CopyUtil.copy(org.jetbrains.mps.openapi.model.SNode,java.util.Map,boolean)" resolve="copy" />
-                <node concept="2OqwBi" id="IFu7oT4E1e" role="37wK5m">
-                  <node concept="37vLTw" id="3fi3fTlpKuh" role="2Oq$k0">
-                    <ref role="3cqZAo" node="3fi3fTlpKtC" resolve="le" />
-                  </node>
-                  <node concept="3TrEf2" id="IFu7oT4HQE" role="2OqNvi">
-                    <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
-                  </node>
-                </node>
-                <node concept="37vLTw" id="3fi3fTlpKui" role="37wK5m">
-                  <ref role="3cqZAo" node="3fi3fTlpKts" resolve="mapping" />
-                </node>
-                <node concept="3clFbT" id="3fi3fTlpKuj" role="37wK5m">
-                  <property role="3clFbU" value="true" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="7cphKbKYWrc" role="3cqZAp">
-          <node concept="2OqwBi" id="7cphKbKYZU4" role="3clFbG">
-            <node concept="2OqwBi" id="7cphKbKYWXy" role="2Oq$k0">
-              <node concept="37vLTw" id="7cphKbKYWHQ" role="2Oq$k0">
-                <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
-              </node>
-              <node concept="3Tsc0h" id="7cphKbKYXk5" role="2OqNvi">
-                <ref role="3TtcxE" to="zzzn:6zmBjqUkws7" resolve="args" />
-              </node>
-            </node>
-            <node concept="2Kehj3" id="7cphKbKZ42m" role="2OqNvi" />
           </node>
         </node>
         <node concept="3cpWs8" id="5s__jxCqyey" role="3cqZAp">
@@ -2785,16 +2707,6 @@
         </node>
         <node concept="3clFbJ" id="5s__jxCqBlr" role="3cqZAp">
           <node concept="3clFbS" id="5s__jxCqBlt" role="3clFbx">
-            <node concept="3clFbF" id="5s__jxCvtcA" role="3cqZAp">
-              <node concept="37vLTI" id="5s__jxCvw8m" role="3clFbG">
-                <node concept="3clFbT" id="5s__jxCvy42" role="37vLTx">
-                  <property role="3clFbU" value="true" />
-                </node>
-                <node concept="37vLTw" id="5s__jxCvtc$" role="37vLTJ">
-                  <ref role="3cqZAo" node="5s__jxCvpsu" resolve="newLambdaArgCreated" />
-                </node>
-              </node>
-            </node>
             <node concept="3clFbF" id="5s__jxCr4WN" role="3cqZAp">
               <node concept="37vLTI" id="5s__jxCr6QE" role="3clFbG">
                 <node concept="37vLTw" id="5s__jxCr4WL" role="37vLTJ">
@@ -2830,22 +2742,10 @@
             </node>
           </node>
           <node concept="3clFbC" id="5s__jxCqNBB" role="3clFbw">
-            <node concept="10Nm6u" id="5s__jxCqOYl" role="3uHU7w" />
             <node concept="37vLTw" id="5s__jxCqLew" role="3uHU7B">
               <ref role="3cqZAo" node="5s__jxCqyez" resolve="lambdaArg" />
             </node>
-          </node>
-          <node concept="9aQIb" id="5s__jxCuiDH" role="9aQIa">
-            <node concept="3clFbS" id="5s__jxCuiDI" role="9aQI4">
-              <node concept="3clFbF" id="5s__jxCvzTe" role="3cqZAp">
-                <node concept="37vLTI" id="5s__jxCvzTf" role="3clFbG">
-                  <node concept="3clFbT" id="5s__jxCvzTg" role="37vLTx" />
-                  <node concept="37vLTw" id="5s__jxCvzTh" role="37vLTJ">
-                    <ref role="3cqZAo" node="5s__jxCvpsu" resolve="newLambdaArgCreated" />
-                  </node>
-                </node>
-              </node>
-            </node>
+            <node concept="10Nm6u" id="5s__jxCqOYl" role="3uHU7w" />
           </node>
         </node>
         <node concept="3cpWs8" id="7cphKbKO6qr" role="3cqZAp">
@@ -3012,20 +2912,8 @@
                               <node concept="2pIpSj" id="49WTic8eCQh" role="2pJxcM">
                                 <ref role="2pIpSl" to="zzzn:6zmBjqUkHam" resolve="arg" />
                                 <node concept="36biLy" id="49WTic8eDst" role="28nt2d">
-                                  <node concept="2OqwBi" id="5s__jxCrrD6" role="36biLW">
-                                    <node concept="2OqwBi" id="5s__jxCrkT0" role="2Oq$k0">
-                                      <node concept="37vLTw" id="5s__jxCrh$s" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="3fi3fTlpKto" resolve="lambda" />
-                                      </node>
-                                      <node concept="3Tsc0h" id="5s__jxCrmBb" role="2OqNvi">
-                                        <ref role="3TtcxE" to="zzzn:6zmBjqUkws7" resolve="args" />
-                                      </node>
-                                    </node>
-                                    <node concept="34jXtK" id="5s__jxCr_3a" role="2OqNvi">
-                                      <node concept="3cmrfG" id="5s__jxCrAqq" role="25WWJ7">
-                                        <property role="3cmrfH" value="0" />
-                                      </node>
-                                    </node>
+                                  <node concept="37vLTw" id="XbOhLjUBqz" role="36biLW">
+                                    <ref role="3cqZAo" node="5s__jxCqyez" resolve="lambdaArg" />
                                   </node>
                                 </node>
                               </node>
@@ -3327,7 +3215,7 @@
               </node>
               <node concept="3cpWs3" id="3fi3fTlpKw7" role="3uHU7B">
                 <node concept="Xl_RD" id="3fi3fTlpKw8" role="3uHU7B">
-                  <property role="Xl_RC" value="&lt;lambda " />
+                  <property role="Xl_RC" value="&lt;shortlambda " />
                 </node>
                 <node concept="2OqwBi" id="3fi3fTlpKw9" role="3uHU7w">
                   <node concept="2OqwBi" id="3fi3fTlpKwa" role="2Oq$k0">
@@ -3482,20 +3370,7 @@
             </node>
           </node>
         </node>
-        <node concept="1gVbGN" id="3fi3fTpD5TP" role="3cqZAp">
-          <node concept="3clFbC" id="3fi3fTpDhee" role="1gVkn0">
-            <node concept="3cmrfG" id="3fi3fTpDl0y" role="3uHU7w">
-              <property role="3cmrfH" value="1" />
-            </node>
-            <node concept="2OqwBi" id="3fi3fTpD9EK" role="3uHU7B">
-              <node concept="37vLTw" id="3fi3fTpD7pK" role="2Oq$k0">
-                <ref role="3cqZAo" node="3fi3fTlpKwM" resolve="evaluatedArgs" />
-              </node>
-              <node concept="34oBXx" id="3fi3fTpDdh2" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="IFu7oT5kRY" role="3cqZAp" />
+        <node concept="3clFbH" id="XbOhLjWYwG" role="3cqZAp" />
         <node concept="3clFbF" id="IFu7oT5oCH" role="3cqZAp">
           <node concept="2OqwBi" id="IFu7oT5oCI" role="3clFbG">
             <node concept="2OqwBi" id="IFu7oT5oCJ" role="2Oq$k0">
@@ -3536,7 +3411,6 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="3fi3fTp$ghQ" role="3cqZAp" />
         <node concept="3cpWs8" id="3fi3fTlpKy6" role="3cqZAp">
           <node concept="3cpWsn" id="3fi3fTlpKy7" role="3cpWs9">
             <property role="TrG5h" value="tt" />
@@ -3563,20 +3437,6 @@
               <ref role="37wK5l" to="2ahs:1FJItavexS7" resolve="addChild" />
               <node concept="37vLTw" id="3fi3fTlpKyh" role="37wK5m">
                 <ref role="3cqZAo" node="3fi3fTlpKy7" resolve="tt" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="4X7jg4xLpCt" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3cpWs8" id="5s__jxCsPBW" role="8Wnug">
-            <node concept="3cpWsn" id="5s__jxCsPBX" role="3cpWs9">
-              <property role="TrG5h" value="start" />
-              <node concept="3cpWsb" id="5s__jxCsPBY" role="1tU5fm" />
-              <node concept="2YIFZM" id="5s__jxCsPBZ" role="33vP2m">
-                <ref role="37wK5l" to="wyt6:~System.nanoTime()" resolve="nanoTime" />
-                <ref role="1Pybhc" to="wyt6:~System" resolve="System" />
               </node>
             </node>
           </node>
@@ -3617,92 +3477,6 @@
                 </node>
                 <node concept="liA8E" id="5s__jxCsPC5" role="2OqNvi">
                   <ref role="37wK5l" to="2ahs:2ALJBcrni7v" resolve="getRootInterpreter" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="4X7jg4xLr$r" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3cpWs8" id="5s__jxCsPCj" role="8Wnug">
-            <node concept="3cpWsn" id="5s__jxCsPCk" role="3cpWs9">
-              <property role="TrG5h" value="stopp" />
-              <node concept="3cpWsb" id="5s__jxCsPCl" role="1tU5fm" />
-              <node concept="2YIFZM" id="5s__jxCsPCm" role="33vP2m">
-                <ref role="37wK5l" to="wyt6:~System.nanoTime()" resolve="nanoTime" />
-                <ref role="1Pybhc" to="wyt6:~System" resolve="System" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1X3_iC" id="4X7jg4xLr$s" role="lGtFl">
-          <property role="3V$3am" value="statement" />
-          <property role="3V$3ak" value="f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123136/1068581517665" />
-          <node concept="3clFbF" id="5s__jxCsPCn" role="8Wnug">
-            <node concept="2OqwBi" id="5s__jxCsPCo" role="3clFbG">
-              <node concept="10M0yZ" id="5s__jxCsPCp" role="2Oq$k0">
-                <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
-                <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
-              </node>
-              <node concept="liA8E" id="5s__jxCsPCq" role="2OqNvi">
-                <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
-                <node concept="3cpWs3" id="5s__jxCsPCr" role="37wK5m">
-                  <node concept="3cpWs3" id="5s__jxCsPCs" role="3uHU7B">
-                    <node concept="3cpWs3" id="5s__jxCsPCt" role="3uHU7B">
-                      <node concept="3cpWs3" id="5s__jxCwfcS" role="3uHU7B">
-                        <node concept="Xl_RD" id="5s__jxCwbCH" role="3uHU7w">
-                          <property role="Xl_RC" value=" / caching " />
-                        </node>
-                        <node concept="3cpWs3" id="5s__jxCw8aK" role="3uHU7B">
-                          <node concept="3cpWs3" id="5s__jxCsPCu" role="3uHU7B">
-                            <node concept="Xl_RD" id="5s__jxCsPCv" role="3uHU7w">
-                              <property role="Xl_RC" value=" / +LambdaArg:" />
-                            </node>
-                            <node concept="3cpWs3" id="5s__jxCsPCw" role="3uHU7B">
-                              <node concept="Xl_RD" id="5s__jxCsPCx" role="3uHU7B">
-                                <property role="Xl_RC" value="&lt;ShortLambda&gt; EXPR:" />
-                              </node>
-                              <node concept="37vLTw" id="5s__jxCsPCy" role="3uHU7w">
-                                <ref role="3cqZAo" node="3fi3fTlpKwM" resolve="evaluatedArgs" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="37vLTw" id="5s__jxCwh2a" role="3uHU7w">
-                            <ref role="3cqZAo" node="5s__jxCvpsu" resolve="newLambdaArgCreated" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="5s__jxCsPCz" role="3uHU7w">
-                        <node concept="1eOMI4" id="5s__jxCsPC$" role="2Oq$k0">
-                          <node concept="10QFUN" id="5s__jxCsPC_" role="1eOMHV">
-                            <node concept="3uibUv" id="5s__jxCsPCA" role="10QFUM">
-                              <ref role="3uigEE" to="pbu6:6iqfHNC0mHl" resolve="IETS3ExprContext" />
-                            </node>
-                            <node concept="37vLTw" id="5s__jxCsPCB" role="10QFUP">
-                              <ref role="3cqZAo" node="3fi3fTlpKwP" resolve="context" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="liA8E" id="5s__jxCsPCC" role="2OqNvi">
-                          <ref role="37wK5l" to="pbu6:4Pi6J8BUEA2" resolve="isCachingEnabled" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="Xl_RD" id="5s__jxCsPCD" role="3uHU7w">
-                      <property role="Xl_RC" value=" TIME/ns:" />
-                    </node>
-                  </node>
-                  <node concept="1eOMI4" id="5s__jxCsPCE" role="3uHU7w">
-                    <node concept="3cpWsd" id="5s__jxCsPCF" role="1eOMHV">
-                      <node concept="37vLTw" id="5s__jxCsPCG" role="3uHU7B">
-                        <ref role="3cqZAo" node="5s__jxCsPCk" resolve="stopp" />
-                      </node>
-                      <node concept="37vLTw" id="5s__jxCsPCH" role="3uHU7w">
-                        <ref role="3cqZAo" node="5s__jxCsPBX" resolve="start" />
-                      </node>
-                    </node>
-                  </node>
                 </node>
               </node>
             </node>
@@ -3879,7 +3653,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" />
       </node>
     </node>
-    <node concept="2tJIrI" id="5s__jxCpvbq" role="jymVt" />
     <node concept="2tJIrI" id="5s__jxCoR7u" role="jymVt" />
     <node concept="3Tm1VV" id="5s__jxCoQMw" role="1B3o_S" />
     <node concept="3uibUv" id="5s__jxCp4EB" role="1zkMxy">

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.lambda.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.lambda.interpreter/models/plugin.mps
@@ -1341,28 +1341,11 @@
       <node concept="3dA_Gj" id="$o50RKwSys" role="3vQZUl">
         <node concept="9aQIb" id="$o50RKwSyu" role="3vcmbn">
           <node concept="3clFbS" id="$o50RKwSyw" role="9aQI4">
-            <node concept="3cpWs8" id="$o50RKyA3A" role="3cqZAp">
-              <node concept="3cpWsn" id="$o50RKyA3D" role="3cpWs9">
-                <property role="TrG5h" value="explicitLambda" />
-                <node concept="3Tqbb2" id="$o50RKyA3$" role="1tU5fm">
-                  <ref role="ehGHo" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
-                </node>
-                <node concept="2OqwBi" id="$yb$20fEyA" role="33vP2m">
-                  <node concept="oxGPV" id="$yb$20fEwv" role="2Oq$k0" />
-                  <node concept="2qgKlT" id="$yb$20fEBz" role="2OqNvi">
-                    <ref role="37wK5l" to="5s8v:$yb$20fCkw" resolve="makeExplicitLambda" />
-                    <node concept="oxNuS" id="6ovbtsiW1rd" role="37wK5m" />
-                  </node>
-                </node>
-              </node>
-            </node>
             <node concept="3cpWs6" id="$o50RKwSIW" role="3cqZAp">
               <node concept="2ShNRf" id="$yb$20fEoZ" role="3cqZAk">
                 <node concept="1pGfFk" id="$yb$20fEwf" role="2ShVmc">
-                  <ref role="37wK5l" to="sxpq:$yb$20fE3_" resolve="LambdaValue" />
-                  <node concept="37vLTw" id="$o50RKyACe" role="37wK5m">
-                    <ref role="3cqZAo" node="$o50RKyA3D" resolve="explicitLambda" />
-                  </node>
+                  <ref role="37wK5l" to="sxpq:3fi3fTlpKtB" resolve="ShortLambdaValue" />
+                  <node concept="oxGPV" id="5s__jxCsmeE" role="37wK5m" />
                   <node concept="oxNuS" id="22hm_0zJz3I" role="37wK5m" />
                   <node concept="3fckFw" id="4_qY3E6GDzf" role="37wK5m" />
                   <node concept="3clFbT" id="5ya_dKpuVVq" role="37wK5m">
@@ -1660,15 +1643,15 @@
     <node concept="qq9P1" id="$yb$20hN8F" role="qq9xR">
       <property role="2TnfIJ" value="true" />
       <ref role="qq9wM" to="zzzn:6zmBjqUkHal" resolve="LambdaArgRef" />
-      <node concept="3vetai" id="64rKhdUOBCf" role="3vQZUl">
-        <node concept="3EllGN" id="6ovbtsiX_CS" role="3vdyny">
-          <node concept="2OqwBi" id="6ovbtsiX_CT" role="3ElVtu">
-            <node concept="oxGPV" id="6ovbtsiX_CU" role="2Oq$k0" />
-            <node concept="3TrEf2" id="6ovbtsiX_CV" role="2OqNvi">
+      <node concept="3vetai" id="5s__jxCNwxE" role="3vQZUl">
+        <node concept="3EllGN" id="5s__jxC$bSj" role="3vdyny">
+          <node concept="2OqwBi" id="5s__jxC$bSk" role="3ElVtu">
+            <node concept="oxGPV" id="5s__jxC$bSl" role="2Oq$k0" />
+            <node concept="3TrEf2" id="5s__jxC$bSm" role="2OqNvi">
               <ref role="3Tt5mk" to="zzzn:6zmBjqUkHam" resolve="arg" />
             </node>
           </node>
-          <node concept="TvHiN" id="6ovbtsiX_CW" role="3ElQJh" />
+          <node concept="TvHiN" id="5s__jxC$bSn" role="3ElQJh" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/models/org.iets3.core.expr.tracing.plugin.plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/models/org.iets3.core.expr.tracing.plugin.plugin.mps
@@ -3571,54 +3571,70 @@
       <node concept="3clFbS" id="kZqQ80bew$" role="3clF47">
         <node concept="3clFbJ" id="kZqQ80bew_" role="3cqZAp">
           <node concept="3clFbS" id="kZqQ80bewA" role="3clFbx">
-            <node concept="1QHqEK" id="4_BA2XOJyem" role="3cqZAp">
-              <node concept="1QHqEC" id="4_BA2XOJyeo" role="1QHqEI">
-                <node concept="3clFbS" id="4_BA2XOJyeq" role="1bW5cS">
-                  <node concept="3clFbF" id="kZqQ80bewB" role="3cqZAp">
-                    <node concept="2OqwBi" id="kZqQ80bewC" role="3clFbG">
-                      <node concept="2YIFZM" id="kZqQ80bewD" role="2Oq$k0">
-                        <ref role="1Pybhc" to="bd8o:~ApplicationManager" resolve="ApplicationManager" />
-                        <ref role="37wK5l" to="bd8o:~ApplicationManager.getApplication()" resolve="getApplication" />
+            <node concept="3clFbF" id="kZqQ80bewB" role="3cqZAp">
+              <node concept="2OqwBi" id="kZqQ80bewC" role="3clFbG">
+                <node concept="2YIFZM" id="kZqQ80bewD" role="2Oq$k0">
+                  <ref role="1Pybhc" to="bd8o:~ApplicationManager" resolve="ApplicationManager" />
+                  <ref role="37wK5l" to="bd8o:~ApplicationManager.getApplication()" resolve="getApplication" />
+                </node>
+                <node concept="liA8E" id="kZqQ80bewE" role="2OqNvi">
+                  <ref role="37wK5l" to="bd8o:~Application.invokeLater(java.lang.Runnable)" resolve="invokeLater" />
+                  <node concept="1bVj0M" id="kZqQ80bewF" role="37wK5m">
+                    <node concept="3clFbS" id="kZqQ80bewG" role="1bW5cS">
+                      <node concept="3cpWs8" id="XbOhLk0uis" role="3cqZAp">
+                        <node concept="3cpWsn" id="XbOhLk0uiv" role="3cpWs9">
+                          <property role="TrG5h" value="presentation" />
+                          <node concept="17QB3L" id="XbOhLk0uiq" role="1tU5fm" />
+                        </node>
                       </node>
-                      <node concept="liA8E" id="kZqQ80bewE" role="2OqNvi">
-                        <ref role="37wK5l" to="bd8o:~Application.invokeLater(java.lang.Runnable)" resolve="invokeLater" />
-                        <node concept="1bVj0M" id="kZqQ80bewF" role="37wK5m">
-                          <node concept="3clFbS" id="kZqQ80bewG" role="1bW5cS">
-                            <node concept="3clFbF" id="kZqQ80bewH" role="3cqZAp">
-                              <node concept="2YIFZM" id="kZqQ80bewI" role="3clFbG">
-                                <ref role="1Pybhc" to="jkm4:~Messages" resolve="Messages" />
-                                <ref role="37wK5l" to="jkm4:~Messages.showErrorDialog(java.lang.String,java.lang.String)" resolve="showErrorDialog" />
-                                <node concept="3cpWs3" id="kZqQ80bewJ" role="37wK5m">
-                                  <node concept="2OqwBi" id="kZqQ80bewK" role="3uHU7w">
-                                    <node concept="2qgKlT" id="kZqQ80bewN" role="2OqNvi">
-                                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                                    </node>
-                                    <node concept="37vLTw" id="kZqQ80cV$z" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="3ApArNFASW2" resolve="node" />
-                                    </node>
+                      <node concept="1QHqEK" id="4_BA2XOJyem" role="3cqZAp">
+                        <node concept="1QHqEC" id="4_BA2XOJyeo" role="1QHqEI">
+                          <node concept="3clFbS" id="4_BA2XOJyeq" role="1bW5cS">
+                            <node concept="3clFbF" id="XbOhLk0CTr" role="3cqZAp">
+                              <node concept="37vLTI" id="XbOhLk0FRL" role="3clFbG">
+                                <node concept="2OqwBi" id="XbOhLk0K0x" role="37vLTx">
+                                  <node concept="37vLTw" id="XbOhLk0If7" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="3ApArNFASW2" resolve="node" />
                                   </node>
-                                  <node concept="Xl_RD" id="kZqQ80bewO" role="3uHU7B">
-                                    <property role="Xl_RC" value="The trace was null for node \n" />
+                                  <node concept="2qgKlT" id="XbOhLk0P14" role="2OqNvi">
+                                    <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
                                   </node>
                                 </node>
-                                <node concept="Xl_RD" id="kZqQ80bewP" role="37wK5m">
-                                  <property role="Xl_RC" value="Tracing" />
+                                <node concept="37vLTw" id="XbOhLk0CTq" role="37vLTJ">
+                                  <ref role="3cqZAo" node="XbOhLk0uiv" resolve="presentation" />
                                 </node>
                               </node>
                             </node>
                           </node>
                         </node>
+                        <node concept="2OqwBi" id="4_BA2XOJD6d" role="ukAjM">
+                          <node concept="37vLTw" id="4_BA2XOJ_SZ" role="2Oq$k0">
+                            <ref role="3cqZAo" to="jpm3:3ApArNFASVZ" resolve="mpsProject" />
+                          </node>
+                          <node concept="liA8E" id="4_BA2XOJGmz" role="2OqNvi">
+                            <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbF" id="kZqQ80bewH" role="3cqZAp">
+                        <node concept="2YIFZM" id="kZqQ80bewI" role="3clFbG">
+                          <ref role="1Pybhc" to="jkm4:~Messages" resolve="Messages" />
+                          <ref role="37wK5l" to="jkm4:~Messages.showErrorDialog(java.lang.String,java.lang.String)" resolve="showErrorDialog" />
+                          <node concept="3cpWs3" id="kZqQ80bewJ" role="37wK5m">
+                            <node concept="37vLTw" id="XbOhLk0Syx" role="3uHU7w">
+                              <ref role="3cqZAo" node="XbOhLk0uiv" resolve="presentation" />
+                            </node>
+                            <node concept="Xl_RD" id="kZqQ80bewO" role="3uHU7B">
+                              <property role="Xl_RC" value="The trace was null for node \n" />
+                            </node>
+                          </node>
+                          <node concept="Xl_RD" id="kZqQ80bewP" role="37wK5m">
+                            <property role="Xl_RC" value="Tracing" />
+                          </node>
+                        </node>
                       </node>
                     </node>
                   </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="4_BA2XOJD6d" role="ukAjM">
-                <node concept="37vLTw" id="4_BA2XOJ_SZ" role="2Oq$k0">
-                  <ref role="3cqZAo" to="jpm3:3ApArNFASVZ" resolve="mpsProject" />
-                </node>
-                <node concept="liA8E" id="4_BA2XOJGmz" role="2OqNvi">
-                  <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/models/org.iets3.core.expr.tracing.plugin.plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.tracing.plugin/models/org.iets3.core.expr.tracing.plugin.plugin.mps
@@ -467,6 +467,7 @@
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
@@ -7734,6 +7735,27 @@
             </node>
           </node>
         </node>
+        <node concept="3cpWs8" id="5s__jxDMzPQ" role="3cqZAp">
+          <node concept="3cpWsn" id="5s__jxDMzPR" role="3cpWs9">
+            <property role="TrG5h" value="shortLambdaNode" />
+            <node concept="3Tqbb2" id="5s__jxDMzPS" role="1tU5fm">
+              <ref role="ehGHo" to="zzzn:6zmBjqUm7MQ" resolve="ShortLambdaExpression" />
+            </node>
+            <node concept="2OqwBi" id="5s__jxDMzPT" role="33vP2m">
+              <node concept="37vLTw" id="5s__jxDMzPU" role="2Oq$k0">
+                <ref role="3cqZAo" node="2a_JeWFLmG1" resolve="node" />
+              </node>
+              <node concept="2Xjw5R" id="5s__jxDMzPV" role="2OqNvi">
+                <node concept="1xMEDy" id="5s__jxDMzPW" role="1xVPHs">
+                  <node concept="chp4Y" id="5s__jxDMzPX" role="ri$Ld">
+                    <ref role="cht4Q" to="zzzn:6zmBjqUm7MQ" resolve="ShortLambdaExpression" />
+                  </node>
+                </node>
+                <node concept="1xIGOp" id="5s__jxDMzPY" role="1xVPHs" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbJ" id="2a_JeWFLqKw" role="3cqZAp">
           <node concept="3clFbS" id="2a_JeWFLqKy" role="3clFbx">
             <node concept="3cpWs6" id="2a_JeWFLvKl" role="3cqZAp">
@@ -7742,10 +7764,18 @@
               </node>
             </node>
           </node>
-          <node concept="3clFbC" id="2a_JeWFLt3g" role="3clFbw">
-            <node concept="10Nm6u" id="2a_JeWFLu5p" role="3uHU7w" />
-            <node concept="37vLTw" id="2a_JeWFLsiP" role="3uHU7B">
-              <ref role="3cqZAo" node="2a_JeWFLo38" resolve="lambdaNode" />
+          <node concept="1Wc70l" id="5s__jxDMPva" role="3clFbw">
+            <node concept="3clFbC" id="5s__jxDMR2D" role="3uHU7w">
+              <node concept="10Nm6u" id="5s__jxDMS7K" role="3uHU7w" />
+              <node concept="37vLTw" id="5s__jxDMQmH" role="3uHU7B">
+                <ref role="3cqZAo" node="5s__jxDMzPR" resolve="shortLambdaNode" />
+              </node>
+            </node>
+            <node concept="3clFbC" id="2a_JeWFLt3g" role="3uHU7B">
+              <node concept="37vLTw" id="2a_JeWFLsiP" role="3uHU7B">
+                <ref role="3cqZAo" node="2a_JeWFLo38" resolve="lambdaNode" />
+              </node>
+              <node concept="10Nm6u" id="2a_JeWFLu5p" role="3uHU7w" />
             </node>
           </node>
         </node>
@@ -7765,12 +7795,28 @@
               <node concept="3Tqbb2" id="2a_JeWFMP6s" role="3rvQeY" />
               <node concept="3Tqbb2" id="2a_JeWFMP6t" role="3rvSg0" />
             </node>
-            <node concept="2OqwBi" id="2a_JeWFMP6u" role="33vP2m">
-              <node concept="37vLTw" id="2a_JeWFMP6v" role="2Oq$k0">
-                <ref role="3cqZAo" node="2a_JeWFLo38" resolve="lambdaNode" />
+            <node concept="3K4zz7" id="5s__jxDMTdS" role="33vP2m">
+              <node concept="2OqwBi" id="5s__jxDMV4H" role="3K4Cdx">
+                <node concept="37vLTw" id="5s__jxDMUr3" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2a_JeWFLo38" resolve="lambdaNode" />
+                </node>
+                <node concept="3w_OXm" id="5s__jxDMWAw" role="2OqNvi" />
               </node>
-              <node concept="2qgKlT" id="2a_JeWFMP6w" role="2OqNvi">
-                <ref role="37wK5l" to="5s8v:3u8VfJfplfS" resolve="getNodeMapping" />
+              <node concept="2OqwBi" id="5s__jxDMYFl" role="3K4E3e">
+                <node concept="37vLTw" id="5s__jxDMXQN" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5s__jxDMzPR" resolve="shortLambdaNode" />
+                </node>
+                <node concept="2qgKlT" id="5s__jxDN01V" role="2OqNvi">
+                  <ref role="37wK5l" to="5s8v:5s__jxDLZVE" resolve="getNodeMapping" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5s__jxDNpUy" role="3K4GZi">
+                <node concept="37vLTw" id="5s__jxDN1iI" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2a_JeWFLo38" resolve="lambdaNode" />
+                </node>
+                <node concept="2qgKlT" id="5s__jxDNrhO" role="2OqNvi">
+                  <ref role="37wK5l" to="5s8v:3u8VfJfplfS" resolve="getNodeMapping" />
+                </node>
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -3623,6 +3623,11 @@
             <ref role="3bR37D" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
           </node>
         </node>
+        <node concept="1SiIV0" id="4X7jg4xF$FY" role="3bR37C">
+          <node concept="3bR9La" id="4X7jg4xF$FZ" role="1SiIV1">
+            <ref role="3bR37D" node="49WTic8jAD5" resolve="org.iets3.core.expr.lambda" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="6JPXQMQs0pX" role="2G$12L">
         <property role="BnDLt" value="true" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.lambda@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.lambda@tests.mps
@@ -15,7 +15,11 @@
       </concept>
     </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
+      <concept id="5849458724932670346" name="org.iets3.core.expr.collections.structure.BracketOp" flags="ng" index="2yLE0X">
+        <child id="5849458724932670347" name="index" index="2yLE0W" />
+      </concept>
       <concept id="5585772046594451299" name="org.iets3.core.expr.collections.structure.SumOp" flags="ng" index="2$5g5R" />
+      <concept id="8872269265513219132" name="org.iets3.core.expr.collections.structure.AsImmutableListOp" flags="ng" index="2TEanv" />
       <concept id="3989687177013570767" name="org.iets3.core.expr.collections.structure.UpToTarget" flags="ng" index="1hzhIm" />
       <concept id="7554398283340640412" name="org.iets3.core.expr.collections.structure.MapOp" flags="ng" index="3iw6QE" />
       <concept id="7554398283340715406" name="org.iets3.core.expr.collections.structure.WhereOp" flags="ng" index="3izCyS" />
@@ -101,6 +105,7 @@
       <concept id="5285810042889815162" name="org.iets3.core.expr.tests.structure.EmptyTestItem" flags="ng" index="3dYjL0" />
     </language>
     <language id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes">
+      <concept id="7971844778467001950" name="org.iets3.core.expr.simpleTypes.structure.OtherwiseLiteral" flags="ng" index="2fHqz8" />
       <concept id="8219602584782245544" name="org.iets3.core.expr.simpleTypes.structure.NumberType" flags="ng" index="mLuIC" />
       <concept id="5115872837157054169" name="org.iets3.core.expr.simpleTypes.structure.IntegerType" flags="ng" index="30bXR$" />
       <concept id="5115872837157054170" name="org.iets3.core.expr.simpleTypes.structure.NumberLiteral" flags="ng" index="30bXRB">
@@ -1553,104 +1558,266 @@
     <property role="1XBH2A" value="true" />
     <property role="TrG5h" value="LambdaPerformance" />
     <node concept="_ixoA" id="5Uvdaw9dYmy" role="_iOnB" />
-    <node concept="2zPypq" id="5Uvdaw9dY89" role="_iOnB">
+    <node concept="2zPypq" id="449GR6ed830" role="_iOnB">
       <property role="TrG5h" value="max" />
-      <node concept="30bXRB" id="5s__jxCufYD" role="2lDidJ">
-        <property role="30bXRw" value="3" />
+      <node concept="30bXRB" id="XbOhLjWL0v" role="2lDidJ">
+        <property role="30bXRw" value="50" />
       </node>
     </node>
-    <node concept="2zPypq" id="5Uvdaw9dY8O" role="_iOnB">
+    <node concept="2zPypq" id="449GR6ed8cj" role="_iOnB">
       <property role="TrG5h" value="numbers" />
-      <node concept="1QScDb" id="5Uvdaw9dY9O" role="2lDidJ">
-        <node concept="1hzhIm" id="5Uvdaw9dYbt" role="1QScD9">
-          <node concept="30dDZf" id="5Uvdaw9dYg2" role="2lDidJ">
-            <node concept="30bXRB" id="5Uvdaw9dYiM" role="30dEs_">
+      <node concept="1QScDb" id="XbOhLkclC6" role="2lDidJ">
+        <node concept="2TEanv" id="XbOhLkcmmG" role="1QScD9" />
+        <node concept="1QScDb" id="2gng9$EsDaL" role="2lDidJ">
+          <node concept="30bsCy" id="2gng9$EsCwT" role="2lDidJ">
+            <node concept="30bXRB" id="2gng9$EsCPr" role="2lDidJ">
               <property role="30bXRw" value="1" />
             </node>
-            <node concept="_emDc" id="5Uvdaw9dYdK" role="30dEsF">
-              <ref role="_emDf" node="5Uvdaw9dY89" resolve="max" />
-            </node>
           </node>
-        </node>
-        <node concept="30bsCy" id="5Uvdaw9dY91" role="2lDidJ">
-          <node concept="30bXRB" id="5Uvdaw9dY98" role="2lDidJ">
-            <property role="30bXRw" value="1" />
+          <node concept="1hzhIm" id="2gng9$Ets0H" role="1QScD9">
+            <node concept="30dDZf" id="XbOhLjT4x6" role="2lDidJ">
+              <node concept="30bXRB" id="XbOhLjT4Ma" role="30dEs_">
+                <property role="30bXRw" value="1" />
+              </node>
+              <node concept="_emDc" id="2gng9$EtsuZ" role="30dEsF">
+                <ref role="_emDf" node="449GR6ed830" resolve="max" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
     </node>
+    <node concept="_ixoA" id="XbOhLk4HWv" role="_iOnB" />
+    <node concept="1aga60" id="2gng9$ErMtY" role="_iOnB">
+      <property role="TrG5h" value="shortlambdatest" />
+      <node concept="1aduha" id="2gng9$ErMQD" role="1ahQXP">
+        <node concept="2fGnzi" id="2gng9$ErWbE" role="1aduh9">
+          <node concept="2fGnzd" id="2gng9$ErWbF" role="2fGnxs">
+            <node concept="30d7iD" id="2gng9$ErWMt" role="2fGnzS">
+              <node concept="30bXRB" id="2gng9$ErWM$" role="30dEs_">
+                <property role="30bXRw" value="1" />
+              </node>
+              <node concept="1QScDb" id="2gng9$ErWr_" role="30dEsF">
+                <node concept="3iB8M5" id="2gng9$ErWDI" role="1QScD9" />
+                <node concept="1afdae" id="2gng9$ErWnq" role="2lDidJ">
+                  <ref role="1afue_" node="2gng9$ErMUZ" resolve="list" />
+                </node>
+              </node>
+            </node>
+            <node concept="1af_rf" id="2gng9$ErNIE" role="2fGnzA">
+              <ref role="1afhQb" node="2gng9$ErMtY" resolve="shortlambdatest" />
+              <node concept="1QScDb" id="2gng9$ErOaG" role="1afhQ5">
+                <node concept="1afdae" id="2gng9$ErO5x" role="2lDidJ">
+                  <ref role="1afue_" node="2gng9$ErMUZ" resolve="list" />
+                </node>
+                <node concept="3izCyS" id="2gng9$ErTOI" role="1QScD9">
+                  <node concept="3izI60" id="2gng9$ErUaC" role="2lDidJ">
+                    <node concept="30d7iD" id="2gng9$ErUnq" role="2lDidJ">
+                      <node concept="2yLE0X" id="2gng9$EsncR" role="30dEs_">
+                        <node concept="30bXRB" id="2gng9$EsncZ" role="2yLE0W">
+                          <property role="30bXRw" value="0" />
+                        </node>
+                        <node concept="1afdae" id="2gng9$ErUxK" role="2lDidJ">
+                          <ref role="1afue_" node="2gng9$ErMUZ" resolve="list" />
+                        </node>
+                      </node>
+                      <node concept="3izPEI" id="2gng9$ErUgD" role="30dEsF" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2fGnzd" id="2gng9$ErWbG" role="2fGnxs">
+            <node concept="2yLE0X" id="2gng9$Esqpm" role="2fGnzA">
+              <node concept="30bXRB" id="2gng9$Esqpu" role="2yLE0W">
+                <property role="30bXRw" value="0" />
+              </node>
+              <node concept="1afdae" id="2gng9$ErXUi" role="2lDidJ">
+                <ref role="1afue_" node="2gng9$ErMUZ" resolve="list" />
+              </node>
+            </node>
+            <node concept="2fHqz8" id="2gng9$ErZpK" role="2fGnzS" />
+          </node>
+        </node>
+      </node>
+      <node concept="1ahQXy" id="2gng9$ErMUZ" role="1ahQWs">
+        <property role="TrG5h" value="list" />
+        <node concept="3iBYCm" id="2gng9$EslCm" role="3ix9CU">
+          <node concept="mLuIC" id="2gng9$Esm11" role="3iBWmK" />
+        </node>
+      </node>
+      <node concept="mLuIC" id="2gng9$ErV_$" role="2zM23F" />
+    </node>
+    <node concept="1aga60" id="2gng9$Es3DU" role="_iOnB">
+      <property role="TrG5h" value="lambdatest" />
+      <node concept="1aduha" id="2gng9$Es3DV" role="1ahQXP">
+        <node concept="2fGnzi" id="2gng9$Es3DW" role="1aduh9">
+          <node concept="2fGnzd" id="2gng9$Es3DX" role="2fGnxs">
+            <node concept="30d7iD" id="2gng9$Es3DY" role="2fGnzS">
+              <node concept="30bXRB" id="2gng9$Es3DZ" role="30dEs_">
+                <property role="30bXRw" value="1" />
+              </node>
+              <node concept="1QScDb" id="2gng9$Es3E0" role="30dEsF">
+                <node concept="3iB8M5" id="2gng9$Es3E1" role="1QScD9" />
+                <node concept="1afdae" id="2gng9$Es3E2" role="2lDidJ">
+                  <ref role="1afue_" node="2gng9$Es3Ei" resolve="list" />
+                </node>
+              </node>
+            </node>
+            <node concept="1af_rf" id="2gng9$Es3E3" role="2fGnzA">
+              <ref role="1afhQb" node="2gng9$Es3DU" resolve="lambdatest" />
+              <node concept="1QScDb" id="2gng9$Es3E4" role="1afhQ5">
+                <node concept="1afdae" id="2gng9$Es3E5" role="2lDidJ">
+                  <ref role="1afue_" node="2gng9$Es3Ei" resolve="list" />
+                </node>
+                <node concept="3izCyS" id="2gng9$Es3E6" role="1QScD9">
+                  <node concept="3ix9CK" id="2gng9$Es5eN" role="2lDidJ">
+                    <node concept="3ix9CS" id="2gng9$Es5eO" role="3ix9CL">
+                      <property role="TrG5h" value="it" />
+                      <node concept="mLuIC" id="2gng9$Es5nB" role="3ix9CU" />
+                    </node>
+                    <node concept="30d7iD" id="2gng9$Es5_I" role="3ix9pP">
+                      <node concept="2yLE0X" id="2gng9$Esp6w" role="30dEs_">
+                        <node concept="30bXRB" id="2gng9$Esp6C" role="2yLE0W">
+                          <property role="30bXRw" value="0" />
+                        </node>
+                        <node concept="1afdae" id="2gng9$Es5IZ" role="2lDidJ">
+                          <ref role="1afue_" node="2gng9$Es3Ei" resolve="list" />
+                        </node>
+                      </node>
+                      <node concept="3ix4Yz" id="2gng9$Es5rO" role="30dEsF">
+                        <ref role="3ix4Yw" node="2gng9$Es5eO" resolve="it" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2fGnzd" id="2gng9$Es3Ed" role="2fGnxs">
+            <node concept="2yLE0X" id="2gng9$Esoic" role="2fGnzA">
+              <node concept="1afdae" id="2gng9$Es3Eg" role="2lDidJ">
+                <ref role="1afue_" node="2gng9$Es3Ei" resolve="list" />
+              </node>
+              <node concept="30bXRB" id="2gng9$EWPJC" role="2yLE0W">
+                <property role="30bXRw" value="0" />
+              </node>
+            </node>
+            <node concept="2fHqz8" id="2gng9$Es3Eh" role="2fGnzS" />
+          </node>
+        </node>
+      </node>
+      <node concept="1ahQXy" id="2gng9$Es3Ei" role="1ahQWs">
+        <property role="TrG5h" value="list" />
+        <node concept="3iBYCm" id="2gng9$EsjTk" role="3ix9CU">
+          <node concept="mLuIC" id="2gng9$EskcQ" role="3iBWmK" />
+        </node>
+      </node>
+      <node concept="mLuIC" id="2gng9$Esrh7" role="2zM23F" />
+    </node>
+    <node concept="_ixoA" id="2gng9$ErVaJ" role="_iOnB" />
+    <node concept="_fkuM" id="XbOhLjT0GZ" role="_iOnB">
+      <property role="TrG5h" value="test1" />
+      <node concept="_fkuZ" id="2gng9$ErZSH" role="_fkp5">
+        <node concept="_fku$" id="2gng9$ErZSI" role="_fkur" />
+        <node concept="1af_rf" id="2gng9$Es014" role="_fkuY">
+          <ref role="1afhQb" node="2gng9$ErMtY" resolve="shortlambdatest" />
+          <node concept="_emDc" id="2gng9$Es09l" role="1afhQ5">
+            <ref role="_emDf" node="449GR6ed8cj" resolve="numbers" />
+          </node>
+        </node>
+        <node concept="_emDc" id="2gng9$Es2P6" role="_fkuS">
+          <ref role="_emDf" node="449GR6ed830" resolve="max" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="2gng9$Es6ns" role="_fkp5">
+        <node concept="_fku$" id="2gng9$Es6nt" role="_fkur" />
+        <node concept="1af_rf" id="2gng9$Es6nu" role="_fkuY">
+          <ref role="1afhQb" node="2gng9$Es3DU" resolve="lambdatest" />
+          <node concept="_emDc" id="2gng9$Es6nv" role="1afhQ5">
+            <ref role="_emDf" node="449GR6ed8cj" resolve="numbers" />
+          </node>
+        </node>
+        <node concept="_emDc" id="2gng9$Es6nw" role="_fkuS">
+          <ref role="_emDf" node="449GR6ed830" resolve="max" />
+        </node>
+      </node>
+    </node>
+    <node concept="_ixoA" id="XbOhLjT0GT" role="_iOnB" />
+    <node concept="_ixoA" id="XbOhLjT0GV" role="_iOnB" />
     <node concept="_ixoA" id="1joq1DK80Fd" role="_iOnB" />
     <node concept="_ixoA" id="3t5WX7ItVme" role="_iOnB" />
     <node concept="_fkuM" id="449GR6ed7OP" role="_iOnB">
-      <property role="TrG5h" value="test" />
+      <property role="TrG5h" value="test2" />
       <node concept="_fkuZ" id="1joq1DKd1cx" role="_fkp5">
         <node concept="_fku$" id="1joq1DKd1cy" role="_fkur" />
         <node concept="1QScDb" id="1joq1DKd1c_" role="_fkuY">
           <node concept="3iB8M5" id="3sgpXexhBbF" role="1QScD9" />
           <node concept="1QScDb" id="1joq1DKd1cB" role="2lDidJ">
-            <node concept="3izCyS" id="1joq1DKd1cC" role="1QScD9">
-              <node concept="3ix9CK" id="1joq1DKd1cD" role="2lDidJ">
-                <node concept="3ix9CS" id="1joq1DKd1cE" role="3ix9CL">
+            <node concept="3izCyS" id="XbOhLk49Ml" role="1QScD9">
+              <node concept="3ix9CK" id="XbOhLk4aua" role="2lDidJ">
+                <node concept="3ix9CS" id="XbOhLk4aub" role="3ix9CL">
                   <property role="TrG5h" value="it" />
-                  <node concept="mLuIC" id="1joq1DKd1cF" role="3ix9CU" />
+                  <node concept="mLuIC" id="XbOhLk4auc" role="3ix9CU" />
                 </node>
-                <node concept="30deo4" id="1joq1DKd1cG" role="3ix9pP">
-                  <node concept="30deo4" id="1joq1DKd1cH" role="30dEsF">
-                    <node concept="30deo4" id="1joq1DKd1cI" role="30dEsF">
-                      <node concept="30deo4" id="1joq1DKd1cJ" role="30dEsF">
-                        <node concept="30d7iD" id="1joq1DKd1cK" role="30dEsF">
-                          <node concept="3ix4Yz" id="1joq1DKd1cL" role="30dEsF">
-                            <ref role="3ix4Yw" node="1joq1DKd1cE" resolve="it" />
+                <node concept="30deo4" id="XbOhLk4aud" role="3ix9pP">
+                  <node concept="30deo4" id="XbOhLk4aue" role="30dEsF">
+                    <node concept="30deo4" id="XbOhLk4auf" role="30dEsF">
+                      <node concept="30deo4" id="XbOhLk4aug" role="30dEsF">
+                        <node concept="30d7iD" id="XbOhLk4auh" role="30dEsF">
+                          <node concept="3ix4Yz" id="XbOhLk4aui" role="30dEsF">
+                            <ref role="3ix4Yw" node="XbOhLk4aub" resolve="it" />
                           </node>
-                          <node concept="30bXRB" id="1joq1DKd1cM" role="30dEs_">
+                          <node concept="30bXRB" id="XbOhLk4auj" role="30dEs_">
                             <property role="30bXRw" value="0" />
                           </node>
                         </node>
-                        <node concept="30d7iD" id="1joq1DKd1cN" role="30dEs_">
-                          <node concept="3ix4Yz" id="1joq1DKd1cO" role="30dEsF">
-                            <ref role="3ix4Yw" node="1joq1DKd1cE" resolve="it" />
+                        <node concept="30d7iD" id="XbOhLk4auk" role="30dEs_">
+                          <node concept="3ix4Yz" id="XbOhLk4aul" role="30dEsF">
+                            <ref role="3ix4Yw" node="XbOhLk4aub" resolve="it" />
                           </node>
-                          <node concept="30bXRB" id="1joq1DKd1cP" role="30dEs_">
+                          <node concept="30bXRB" id="XbOhLk4aum" role="30dEs_">
                             <property role="30bXRw" value="-1" />
                           </node>
                         </node>
                       </node>
-                      <node concept="30d7iD" id="1joq1DKd1cQ" role="30dEs_">
-                        <node concept="3ix4Yz" id="1joq1DKd1cR" role="30dEsF">
-                          <ref role="3ix4Yw" node="1joq1DKd1cE" resolve="it" />
+                      <node concept="30d7iD" id="XbOhLk4aun" role="30dEs_">
+                        <node concept="3ix4Yz" id="XbOhLk4auo" role="30dEsF">
+                          <ref role="3ix4Yw" node="XbOhLk4aub" resolve="it" />
                         </node>
-                        <node concept="30bXRB" id="1joq1DKd1cS" role="30dEs_">
+                        <node concept="30bXRB" id="XbOhLk4aup" role="30dEs_">
                           <property role="30bXRw" value="-2" />
                         </node>
                       </node>
                     </node>
-                    <node concept="30d7iD" id="1joq1DKd1cT" role="30dEs_">
-                      <node concept="3ix4Yz" id="1joq1DKd1cU" role="30dEsF">
-                        <ref role="3ix4Yw" node="1joq1DKd1cE" resolve="it" />
+                    <node concept="30d7iD" id="XbOhLk4auq" role="30dEs_">
+                      <node concept="3ix4Yz" id="XbOhLk4aur" role="30dEsF">
+                        <ref role="3ix4Yw" node="XbOhLk4aub" resolve="it" />
                       </node>
-                      <node concept="30bXRB" id="1joq1DKd1cV" role="30dEs_">
+                      <node concept="30bXRB" id="XbOhLk4aus" role="30dEs_">
                         <property role="30bXRw" value="-3" />
                       </node>
                     </node>
                   </node>
-                  <node concept="30d7iD" id="1joq1DKd1cW" role="30dEs_">
-                    <node concept="30bXRB" id="1joq1DKd1cX" role="30dEs_">
+                  <node concept="30d7iD" id="XbOhLk4aut" role="30dEs_">
+                    <node concept="30bXRB" id="XbOhLk4auu" role="30dEs_">
                       <property role="30bXRw" value="-4" />
                     </node>
-                    <node concept="3ix4Yz" id="1joq1DKd1cY" role="30dEsF">
-                      <ref role="3ix4Yw" node="1joq1DKd1cE" resolve="it" />
+                    <node concept="3ix4Yz" id="XbOhLk4auv" role="30dEsF">
+                      <ref role="3ix4Yw" node="XbOhLk4aub" resolve="it" />
                     </node>
                   </node>
                 </node>
               </node>
             </node>
             <node concept="_emDc" id="1joq1DKd1cZ" role="2lDidJ">
-              <ref role="_emDf" node="5Uvdaw9dY8O" resolve="numbers" />
+              <ref role="_emDf" node="449GR6ed8cj" resolve="numbers" />
             </node>
           </node>
         </node>
         <node concept="_emDc" id="1joq1DKfka5" role="_fkuS">
-          <ref role="_emDf" node="5Uvdaw9dY89" resolve="max" />
+          <ref role="_emDf" node="449GR6ed830" resolve="max" />
         </node>
       </node>
       <node concept="_fkuZ" id="1joq1DKd1c4" role="_fkp5">
@@ -1658,7 +1825,7 @@
         <node concept="1QScDb" id="1joq1DKd1c8" role="_fkuY">
           <node concept="3iB8M5" id="3sgpXexhBVh" role="1QScD9" />
           <node concept="1QScDb" id="1joq1DKd1ca" role="2lDidJ">
-            <node concept="3izCyS" id="1joq1DKd1cb" role="1QScD9">
+            <node concept="3izCyS" id="XbOhLk4bQa" role="1QScD9">
               <node concept="3izI60" id="5s__jxCoG63" role="2lDidJ">
                 <node concept="30deo4" id="5s__jxCoG64" role="2lDidJ">
                   <node concept="30deo4" id="5s__jxCoG65" role="30dEsF">
@@ -1701,12 +1868,12 @@
               </node>
             </node>
             <node concept="_emDc" id="1joq1DKd1cw" role="2lDidJ">
-              <ref role="_emDf" node="5Uvdaw9dY8O" resolve="numbers" />
+              <ref role="_emDf" node="449GR6ed8cj" resolve="numbers" />
             </node>
           </node>
         </node>
         <node concept="_emDc" id="1joq1DKfk5C" role="_fkuS">
-          <ref role="_emDf" node="5Uvdaw9dY89" resolve="max" />
+          <ref role="_emDf" node="449GR6ed830" resolve="max" />
         </node>
       </node>
       <node concept="_fkuZ" id="5s__jxC$3ju" role="_fkp5">
@@ -1757,12 +1924,12 @@
               </node>
             </node>
             <node concept="_emDc" id="5s__jxC$3jS" role="2lDidJ">
-              <ref role="_emDf" node="5Uvdaw9dY8O" resolve="numbers" />
+              <ref role="_emDf" node="449GR6ed8cj" resolve="numbers" />
             </node>
           </node>
         </node>
         <node concept="_emDc" id="5s__jxC$3jT" role="_fkuS">
-          <ref role="_emDf" node="5Uvdaw9dY89" resolve="max" />
+          <ref role="_emDf" node="449GR6ed830" resolve="max" />
         </node>
       </node>
       <node concept="_fkuZ" id="5s__jxDPvTF" role="_fkp5">
@@ -1827,12 +1994,12 @@
               </node>
             </node>
             <node concept="_emDc" id="5s__jxDPvU7" role="2lDidJ">
-              <ref role="_emDf" node="5Uvdaw9dY8O" resolve="numbers" />
+              <ref role="_emDf" node="449GR6ed8cj" resolve="numbers" />
             </node>
           </node>
         </node>
         <node concept="_emDc" id="5s__jxDPvU8" role="_fkuS">
-          <ref role="_emDf" node="5Uvdaw9dY89" resolve="max" />
+          <ref role="_emDf" node="449GR6ed830" resolve="max" />
         </node>
       </node>
       <node concept="1z9TsT" id="3t5WX7ItVmk" role="lGtFl">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.lambda@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.lambda@tests.mps
@@ -16,7 +16,9 @@
     </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="5585772046594451299" name="org.iets3.core.expr.collections.structure.SumOp" flags="ng" index="2$5g5R" />
+      <concept id="3989687177013570767" name="org.iets3.core.expr.collections.structure.UpToTarget" flags="ng" index="1hzhIm" />
       <concept id="7554398283340640412" name="org.iets3.core.expr.collections.structure.MapOp" flags="ng" index="3iw6QE" />
+      <concept id="7554398283340715406" name="org.iets3.core.expr.collections.structure.WhereOp" flags="ng" index="3izCyS" />
       <concept id="7554398283339850572" name="org.iets3.core.expr.collections.structure.FirstOp" flags="ng" index="3iB7TU" />
       <concept id="7554398283339796915" name="org.iets3.core.expr.collections.structure.SizeOp" flags="ng" index="3iB8M5" />
       <concept id="7554398283339749509" name="org.iets3.core.expr.collections.structure.CollectionType" flags="ng" index="3iBWmN">
@@ -62,6 +64,7 @@
       <concept id="5115872837157187871" name="org.iets3.core.expr.base.structure.ParensExpression" flags="ng" index="30bsCy" />
       <concept id="5115872837156761033" name="org.iets3.core.expr.base.structure.EqualsExpression" flags="ng" index="30cPrO" />
       <concept id="5115872837156687764" name="org.iets3.core.expr.base.structure.GreaterExpression" flags="ng" index="30d7iD" />
+      <concept id="5115872837156724025" name="org.iets3.core.expr.base.structure.LogicalAndExpression" flags="ng" index="30deo4" />
       <concept id="5115872837156652453" name="org.iets3.core.expr.base.structure.MinusExpression" flags="ng" index="30dvUo" />
       <concept id="5115872837156578671" name="org.iets3.core.expr.base.structure.MulExpression" flags="ng" index="30dDTi" />
       <concept id="5115872837156578546" name="org.iets3.core.expr.base.structure.PlusExpression" flags="ng" index="30dDZf" />
@@ -71,6 +74,14 @@
       </concept>
       <concept id="9002563722476995145" name="org.iets3.core.expr.base.structure.DotExpression" flags="ng" index="1QScDb">
         <child id="9002563722476995147" name="target" index="1QScD9" />
+      </concept>
+    </language>
+    <language id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext">
+      <concept id="2557074442922380897" name="de.slisson.mps.richtext.structure.Text" flags="ng" index="19SGf9">
+        <child id="2557074442922392302" name="words" index="19SJt6" />
+      </concept>
+      <concept id="2557074442922438156" name="de.slisson.mps.richtext.structure.Word" flags="ng" index="19SUe$">
+        <property id="2557074442922438158" name="escapedValue" index="19SUeA" />
       </concept>
     </language>
     <language id="d441fba0-f46b-43cd-b723-dad7b65da615" name="org.iets3.core.expr.tests">
@@ -117,7 +128,18 @@
       <concept id="4790956042240570348" name="org.iets3.core.expr.toplevel.structure.FunctionCall" flags="ng" index="1af_rf" />
       <concept id="4790956042240148643" name="org.iets3.core.expr.toplevel.structure.Function" flags="ng" index="1aga60" />
     </language>
+    <language id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base">
+      <concept id="8375407818529178006" name="com.mbeddr.core.base.structure.TextBlock" flags="ng" index="OjmMv">
+        <child id="8375407818529178007" name="text" index="OjmMu" />
+      </concept>
+      <concept id="3857533489766146428" name="com.mbeddr.core.base.structure.ElementDocumentation" flags="ng" index="1z9TsT">
+        <child id="4052432714772608243" name="text" index="1w35rA" />
+      </concept>
+    </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
@@ -1526,6 +1548,304 @@
   </node>
   <node concept="2XOHcx" id="4rZeNQ6M9GV">
     <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
+  </node>
+  <node concept="_iOnU" id="449GR6ed7OO">
+    <property role="1XBH2A" value="true" />
+    <property role="TrG5h" value="LambdaPerformance" />
+    <node concept="_ixoA" id="5Uvdaw9dYmy" role="_iOnB" />
+    <node concept="2zPypq" id="5Uvdaw9dY89" role="_iOnB">
+      <property role="TrG5h" value="max" />
+      <node concept="30bXRB" id="5s__jxCufYD" role="2lDidJ">
+        <property role="30bXRw" value="3" />
+      </node>
+    </node>
+    <node concept="2zPypq" id="5Uvdaw9dY8O" role="_iOnB">
+      <property role="TrG5h" value="numbers" />
+      <node concept="1QScDb" id="5Uvdaw9dY9O" role="2lDidJ">
+        <node concept="1hzhIm" id="5Uvdaw9dYbt" role="1QScD9">
+          <node concept="30dDZf" id="5Uvdaw9dYg2" role="2lDidJ">
+            <node concept="30bXRB" id="5Uvdaw9dYiM" role="30dEs_">
+              <property role="30bXRw" value="1" />
+            </node>
+            <node concept="_emDc" id="5Uvdaw9dYdK" role="30dEsF">
+              <ref role="_emDf" node="5Uvdaw9dY89" resolve="max" />
+            </node>
+          </node>
+        </node>
+        <node concept="30bsCy" id="5Uvdaw9dY91" role="2lDidJ">
+          <node concept="30bXRB" id="5Uvdaw9dY98" role="2lDidJ">
+            <property role="30bXRw" value="1" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="_ixoA" id="1joq1DK80Fd" role="_iOnB" />
+    <node concept="_ixoA" id="3t5WX7ItVme" role="_iOnB" />
+    <node concept="_fkuM" id="449GR6ed7OP" role="_iOnB">
+      <property role="TrG5h" value="test" />
+      <node concept="_fkuZ" id="1joq1DKd1cx" role="_fkp5">
+        <node concept="_fku$" id="1joq1DKd1cy" role="_fkur" />
+        <node concept="1QScDb" id="1joq1DKd1c_" role="_fkuY">
+          <node concept="3iB8M5" id="3sgpXexhBbF" role="1QScD9" />
+          <node concept="1QScDb" id="1joq1DKd1cB" role="2lDidJ">
+            <node concept="3izCyS" id="1joq1DKd1cC" role="1QScD9">
+              <node concept="3ix9CK" id="1joq1DKd1cD" role="2lDidJ">
+                <node concept="3ix9CS" id="1joq1DKd1cE" role="3ix9CL">
+                  <property role="TrG5h" value="it" />
+                  <node concept="mLuIC" id="1joq1DKd1cF" role="3ix9CU" />
+                </node>
+                <node concept="30deo4" id="1joq1DKd1cG" role="3ix9pP">
+                  <node concept="30deo4" id="1joq1DKd1cH" role="30dEsF">
+                    <node concept="30deo4" id="1joq1DKd1cI" role="30dEsF">
+                      <node concept="30deo4" id="1joq1DKd1cJ" role="30dEsF">
+                        <node concept="30d7iD" id="1joq1DKd1cK" role="30dEsF">
+                          <node concept="3ix4Yz" id="1joq1DKd1cL" role="30dEsF">
+                            <ref role="3ix4Yw" node="1joq1DKd1cE" resolve="it" />
+                          </node>
+                          <node concept="30bXRB" id="1joq1DKd1cM" role="30dEs_">
+                            <property role="30bXRw" value="0" />
+                          </node>
+                        </node>
+                        <node concept="30d7iD" id="1joq1DKd1cN" role="30dEs_">
+                          <node concept="3ix4Yz" id="1joq1DKd1cO" role="30dEsF">
+                            <ref role="3ix4Yw" node="1joq1DKd1cE" resolve="it" />
+                          </node>
+                          <node concept="30bXRB" id="1joq1DKd1cP" role="30dEs_">
+                            <property role="30bXRw" value="-1" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="30d7iD" id="1joq1DKd1cQ" role="30dEs_">
+                        <node concept="3ix4Yz" id="1joq1DKd1cR" role="30dEsF">
+                          <ref role="3ix4Yw" node="1joq1DKd1cE" resolve="it" />
+                        </node>
+                        <node concept="30bXRB" id="1joq1DKd1cS" role="30dEs_">
+                          <property role="30bXRw" value="-2" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="30d7iD" id="1joq1DKd1cT" role="30dEs_">
+                      <node concept="3ix4Yz" id="1joq1DKd1cU" role="30dEsF">
+                        <ref role="3ix4Yw" node="1joq1DKd1cE" resolve="it" />
+                      </node>
+                      <node concept="30bXRB" id="1joq1DKd1cV" role="30dEs_">
+                        <property role="30bXRw" value="-3" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="30d7iD" id="1joq1DKd1cW" role="30dEs_">
+                    <node concept="30bXRB" id="1joq1DKd1cX" role="30dEs_">
+                      <property role="30bXRw" value="-4" />
+                    </node>
+                    <node concept="3ix4Yz" id="1joq1DKd1cY" role="30dEsF">
+                      <ref role="3ix4Yw" node="1joq1DKd1cE" resolve="it" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="_emDc" id="1joq1DKd1cZ" role="2lDidJ">
+              <ref role="_emDf" node="5Uvdaw9dY8O" resolve="numbers" />
+            </node>
+          </node>
+        </node>
+        <node concept="_emDc" id="1joq1DKfka5" role="_fkuS">
+          <ref role="_emDf" node="5Uvdaw9dY89" resolve="max" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="1joq1DKd1c4" role="_fkp5">
+        <node concept="_fku$" id="1joq1DKd1c5" role="_fkur" />
+        <node concept="1QScDb" id="1joq1DKd1c8" role="_fkuY">
+          <node concept="3iB8M5" id="3sgpXexhBVh" role="1QScD9" />
+          <node concept="1QScDb" id="1joq1DKd1ca" role="2lDidJ">
+            <node concept="3izCyS" id="1joq1DKd1cb" role="1QScD9">
+              <node concept="3izI60" id="5s__jxCoG63" role="2lDidJ">
+                <node concept="30deo4" id="5s__jxCoG64" role="2lDidJ">
+                  <node concept="30deo4" id="5s__jxCoG65" role="30dEsF">
+                    <node concept="30deo4" id="5s__jxCoG66" role="30dEsF">
+                      <node concept="30deo4" id="5s__jxCoG67" role="30dEsF">
+                        <node concept="30d7iD" id="5s__jxCoG68" role="30dEsF">
+                          <node concept="3izPEI" id="5s__jxCoG69" role="30dEsF" />
+                          <node concept="30bXRB" id="5s__jxCoG6a" role="30dEs_">
+                            <property role="30bXRw" value="0" />
+                          </node>
+                        </node>
+                        <node concept="30d7iD" id="5s__jxCoG6b" role="30dEs_">
+                          <node concept="3izPEI" id="5s__jxCoG6c" role="30dEsF" />
+                          <node concept="30bXRB" id="5s__jxCoG6d" role="30dEs_">
+                            <property role="30bXRw" value="-1" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="30d7iD" id="5s__jxCoG6e" role="30dEs_">
+                        <node concept="3izPEI" id="5s__jxCoG6f" role="30dEsF" />
+                        <node concept="30bXRB" id="5s__jxCoG6g" role="30dEs_">
+                          <property role="30bXRw" value="-2" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="30d7iD" id="5s__jxCoG6h" role="30dEs_">
+                      <node concept="3izPEI" id="5s__jxCoG6i" role="30dEsF" />
+                      <node concept="30bXRB" id="5s__jxCoG6j" role="30dEs_">
+                        <property role="30bXRw" value="-3" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="30d7iD" id="5s__jxCoG6k" role="30dEs_">
+                    <node concept="30bXRB" id="5s__jxCoG6l" role="30dEs_">
+                      <property role="30bXRw" value="-4" />
+                    </node>
+                    <node concept="3izPEI" id="5s__jxCoG6m" role="30dEsF" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="_emDc" id="1joq1DKd1cw" role="2lDidJ">
+              <ref role="_emDf" node="5Uvdaw9dY8O" resolve="numbers" />
+            </node>
+          </node>
+        </node>
+        <node concept="_emDc" id="1joq1DKfk5C" role="_fkuS">
+          <ref role="_emDf" node="5Uvdaw9dY89" resolve="max" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="5s__jxC$3ju" role="_fkp5">
+        <node concept="_fku$" id="5s__jxC$3jv" role="_fkur" />
+        <node concept="1QScDb" id="5s__jxC$3jw" role="_fkuY">
+          <node concept="3iB8M5" id="5s__jxC$3jx" role="1QScD9" />
+          <node concept="1QScDb" id="5s__jxC$3jy" role="2lDidJ">
+            <node concept="3izCyS" id="5s__jxC$3jz" role="1QScD9">
+              <node concept="3izI60" id="5s__jxC$3j$" role="2lDidJ">
+                <node concept="30deo4" id="5s__jxC$3j_" role="2lDidJ">
+                  <node concept="30deo4" id="5s__jxC$3jA" role="30dEsF">
+                    <node concept="30deo4" id="5s__jxC$3jB" role="30dEsF">
+                      <node concept="30deo4" id="5s__jxC$3jC" role="30dEsF">
+                        <node concept="30d7iD" id="5s__jxC$3jD" role="30dEsF">
+                          <node concept="3izPEI" id="5s__jxC$3jE" role="30dEsF" />
+                          <node concept="30bXRB" id="5s__jxC$3jF" role="30dEs_">
+                            <property role="30bXRw" value="0" />
+                          </node>
+                        </node>
+                        <node concept="30d7iD" id="5s__jxC$3jG" role="30dEs_">
+                          <node concept="3izPEI" id="5s__jxC$3jH" role="30dEsF" />
+                          <node concept="30bXRB" id="5s__jxC$3jI" role="30dEs_">
+                            <property role="30bXRw" value="-1" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="30d7iD" id="5s__jxC$3jJ" role="30dEs_">
+                        <node concept="3izPEI" id="5s__jxC$3jK" role="30dEsF" />
+                        <node concept="30bXRB" id="5s__jxC$3jL" role="30dEs_">
+                          <property role="30bXRw" value="-2" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="30d7iD" id="5s__jxC$3jM" role="30dEs_">
+                      <node concept="3izPEI" id="5s__jxC$3jN" role="30dEsF" />
+                      <node concept="30bXRB" id="5s__jxC$3jO" role="30dEs_">
+                        <property role="30bXRw" value="-3" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="30d7iD" id="5s__jxC$3jP" role="30dEs_">
+                    <node concept="30bXRB" id="5s__jxC$3jQ" role="30dEs_">
+                      <property role="30bXRw" value="-4" />
+                    </node>
+                    <node concept="3izPEI" id="5s__jxC$3jR" role="30dEsF" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="_emDc" id="5s__jxC$3jS" role="2lDidJ">
+              <ref role="_emDf" node="5Uvdaw9dY8O" resolve="numbers" />
+            </node>
+          </node>
+        </node>
+        <node concept="_emDc" id="5s__jxC$3jT" role="_fkuS">
+          <ref role="_emDf" node="5Uvdaw9dY89" resolve="max" />
+        </node>
+      </node>
+      <node concept="_fkuZ" id="5s__jxDPvTF" role="_fkp5">
+        <node concept="_fku$" id="5s__jxDPvTG" role="_fkur" />
+        <node concept="1QScDb" id="5s__jxDPvTH" role="_fkuY">
+          <node concept="3iB8M5" id="5s__jxDPvTI" role="1QScD9" />
+          <node concept="1QScDb" id="5s__jxDPvTJ" role="2lDidJ">
+            <node concept="3izCyS" id="5s__jxDPvTK" role="1QScD9">
+              <node concept="3ix9CK" id="5s__jxDPvTL" role="2lDidJ">
+                <node concept="3ix9CS" id="5s__jxDPvTM" role="3ix9CL">
+                  <property role="TrG5h" value="it" />
+                  <node concept="mLuIC" id="5s__jxDPvTN" role="3ix9CU" />
+                </node>
+                <node concept="30deo4" id="5s__jxDPvTO" role="3ix9pP">
+                  <node concept="30deo4" id="5s__jxDPvTP" role="30dEsF">
+                    <node concept="30deo4" id="5s__jxDPvTQ" role="30dEsF">
+                      <node concept="30deo4" id="5s__jxDPvTR" role="30dEsF">
+                        <node concept="30d7iD" id="5s__jxDPvTS" role="30dEsF">
+                          <node concept="3ix4Yz" id="5s__jxDPvTT" role="30dEsF">
+                            <ref role="3ix4Yw" node="5s__jxDPvTM" resolve="it" />
+                          </node>
+                          <node concept="30bXRB" id="5s__jxDPvTU" role="30dEs_">
+                            <property role="30bXRw" value="0" />
+                          </node>
+                        </node>
+                        <node concept="30d7iD" id="5s__jxDPvTV" role="30dEs_">
+                          <node concept="3ix4Yz" id="5s__jxDPvTW" role="30dEsF">
+                            <ref role="3ix4Yw" node="5s__jxDPvTM" resolve="it" />
+                          </node>
+                          <node concept="30bXRB" id="5s__jxDPvTX" role="30dEs_">
+                            <property role="30bXRw" value="-1" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="30d7iD" id="5s__jxDPvTY" role="30dEs_">
+                        <node concept="3ix4Yz" id="5s__jxDPvTZ" role="30dEsF">
+                          <ref role="3ix4Yw" node="5s__jxDPvTM" resolve="it" />
+                        </node>
+                        <node concept="30bXRB" id="5s__jxDPvU0" role="30dEs_">
+                          <property role="30bXRw" value="-2" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="30d7iD" id="5s__jxDPvU1" role="30dEs_">
+                      <node concept="3ix4Yz" id="5s__jxDPvU2" role="30dEsF">
+                        <ref role="3ix4Yw" node="5s__jxDPvTM" resolve="it" />
+                      </node>
+                      <node concept="30bXRB" id="5s__jxDPvU3" role="30dEs_">
+                        <property role="30bXRw" value="-3" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="30d7iD" id="5s__jxDPvU4" role="30dEs_">
+                    <node concept="30bXRB" id="5s__jxDPvU5" role="30dEs_">
+                      <property role="30bXRw" value="-4" />
+                    </node>
+                    <node concept="3ix4Yz" id="5s__jxDPvU6" role="30dEsF">
+                      <ref role="3ix4Yw" node="5s__jxDPvTM" resolve="it" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="_emDc" id="5s__jxDPvU7" role="2lDidJ">
+              <ref role="_emDf" node="5Uvdaw9dY8O" resolve="numbers" />
+            </node>
+          </node>
+        </node>
+        <node concept="_emDc" id="5s__jxDPvU8" role="_fkuS">
+          <ref role="_emDf" node="5Uvdaw9dY89" resolve="max" />
+        </node>
+      </node>
+      <node concept="1z9TsT" id="3t5WX7ItVmk" role="lGtFl">
+        <node concept="OjmMv" id="3t5WX7ItVml" role="1w35rA">
+          <node concept="19SGf9" id="3t5WX7ItVmm" role="OjmMu">
+            <node concept="19SUe$" id="3t5WX7ItVmn" role="19SJt6">
+              <property role="19SUeA" value="TODO: create an assert statement to compare execution/evaluation time  of different expressions" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="_ixoA" id="5Uvdaw9eDHf" role="_iOnB" />
   </node>
 </model>
 


### PR DESCRIPTION
Addresses:  #1226

This PR decreases the evaluation time for ShortLambdaExpressions (without a breaking change).

The main problem of the old approach was, that caching could not be applied, because the nodes used to evaluate the expression was recreated on every interpretation. 

Also a fix in the trace explorer was done.