### PR TITLE
expr.lambda: fixed cast

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
@@ -1849,7 +1849,7 @@
           <node concept="1eOMI4" id="XbOhLk5ekd" role="3clFbG">
             <node concept="10QFUN" id="XbOhLk5eke" role="1eOMHV">
               <node concept="3Tqbb2" id="XbOhLk5ekf" role="10QFUM">
-                <ref role="ehGHo" to="zzzn:6zmBjqUkwse" resolve="LambdaArg" />
+                <ref role="ehGHo" to="zzzn:6zmBjqUkws6" resolve="LambdaExpression" />
               </node>
               <node concept="1eOMI4" id="XbOhLk5ekg" role="10QFUP">
                 <node concept="2OqwBi" id="XbOhLk5ekh" role="1eOMHV">


### PR DESCRIPTION
Looked like a cast went side ways. I've changed the target type to the correct one. 