### PR TITLE
Add language o.i.core.trace.test to deployed languages

### DIFF
--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -14390,6 +14390,9 @@
         <node concept="L2wRC" id="7K$Mm86tjry" role="39821P">
           <ref role="L2wRA" node="7K$Mm86tjeJ" resolve="test.iets3.core.tracequery" />
         </node>
+        <node concept="L2wRC" id="3F6B64FaYH3" role="39821P">
+          <ref role="L2wRA" node="1oxkC6pg3$7" resolve="org.iets3.core.trace.test" />
+        </node>
         <node concept="L2wRC" id="2i81Z9BQeRa" role="39821P">
           <ref role="L2wRA" node="2i81Z9BQeAe" resolve="test.iets3.safety.attributes" />
         </node>


### PR DESCRIPTION
This solves #1292. The missing test language `o.i.core.trace.test` is deployed now in the `org.iets3.core.trace.test` plugin.

Questions for the reviewers:
- Why do we deploy the test solutions at all? 
- Could it be a problem if we now deploy an additional language for the tests? 