### PR TITLE
1318: Rename plugin org.iets3.safety to org.iets3.safety.os

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 ### Fixed
 
+- Plugin org.iets3.safety was renamed to org.iets3.safety.os fixing the name collision with a plugin in org.iets3.core 
+
 - A NullPointerException was fixed for cases where a node implementing IValidNamedConcept had no name.
 
 ## April 2025

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -514,7 +514,7 @@
         <node concept="pUk6x" id="1D8fMMrKjdR" role="pUk7w" />
       </node>
       <node concept="m$_wl" id="3NHTh2QYZqh" role="39821P">
-        <ref role="m_rDy" node="3NHTh2QYZdS" resolve="org.iets3.safety" />
+        <ref role="m_rDy" node="3NHTh2QYZdS" resolve="org.iets3.safety.os" />
         <node concept="pUk6x" id="3NHTh2QYZtd" role="pUk7w" />
       </node>
       <node concept="m$_wl" id="1PzuxQOWHfM" role="39821P">
@@ -14228,7 +14228,7 @@
         </node>
       </node>
       <node concept="m$f5U" id="3NHTh2QYZlB" role="m$_yh">
-        <ref role="m$f5T" node="3NHTh2QYYvQ" resolve="org.iets3.safety" />
+        <ref role="m$f5T" node="3NHTh2QYYvQ" resolve="org.iets3.safety.os" />
       </node>
       <node concept="m$_yC" id="3NHTh2QZ0aB" role="m$_yJ">
         <ref role="m$_y1" node="5wLtKNeSRRD" resolve="org.iets3.core.os" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -14211,15 +14211,15 @@
       </node>
     </node>
     <node concept="m$_wf" id="3NHTh2QYZdS" role="3989C9">
-      <property role="m$_wk" value="org.iets3.safety" />
+      <property role="m$_wk" value="org.iets3.safety.os" />
       <node concept="3_J27D" id="3NHTh2QYZdU" role="m$_yQ">
         <node concept="3Mxwew" id="3NHTh2QYZhW" role="3MwsjC">
-          <property role="3MwjfP" value="org.iets3.safety" />
+          <property role="3MwjfP" value="org.iets3.safety.os" />
         </node>
       </node>
       <node concept="3_J27D" id="3NHTh2QYZdW" role="m_cZH">
         <node concept="3Mxwew" id="3NHTh2QYZiH" role="3MwsjC">
-          <property role="3MwjfP" value="org.iets3.safety" />
+          <property role="3MwjfP" value="org.iets3.safety.os" />
         </node>
       </node>
       <node concept="3_J27D" id="3NHTh2QYZdY" role="m$_w8">
@@ -14235,7 +14235,7 @@
       </node>
     </node>
     <node concept="2G$12M" id="3NHTh2QYYvQ" role="3989C9">
-      <property role="TrG5h" value="org.iets3.safety" />
+      <property role="TrG5h" value="org.iets3.safety.os" />
       <node concept="1E1JtD" id="3NHTh2QYY_W" role="2G$12L">
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="org.iets3.safety.attributes" />


### PR DESCRIPTION
Rename plugin org.iets3.safety because this name collides with a plugin with same name in core (#1318)

