### PR TITLE
expr.simpleTypes: use infinite precision if any of the number types in the supertype calculation has an infinite precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 ### Fixed
 
 - A NullPointerException was fixed for cases where a node implementing IValidNamedConcept had no name.
+- When calculating the supertype of number types, the precision is now correctly set to infinite when one of the types has an infinite precision.
 
 ## April 2025
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/plugin.mps
@@ -383,6 +383,7 @@
       <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
@@ -2948,37 +2949,80 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="1PW6P0ZLhfA" role="3cqZAp">
-          <node concept="2OqwBi" id="1PW6P0ZLhfB" role="3clFbG">
-            <node concept="37vLTw" id="1PW6P0ZLhfC" role="2Oq$k0">
-              <ref role="3cqZAo" node="1PW6P0ZLhep" resolve="res" />
+        <node concept="3clFbJ" id="7xgxWxI5AlJ" role="3cqZAp">
+          <node concept="3clFbS" id="7xgxWxI5AlL" role="3clFbx">
+            <node concept="3clFbF" id="7xgxWxI6Bn9" role="3cqZAp">
+              <node concept="2OqwBi" id="7xgxWxI6EVw" role="3clFbG">
+                <node concept="37vLTw" id="7xgxWxI6Bn7" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1PW6P0ZLhep" resolve="res" />
+                </node>
+                <node concept="2qgKlT" id="7xgxWxI6MjF" role="2OqNvi">
+                  <ref role="37wK5l" to="b1h1:7Wa2sv3G6bK" resolve="setInfinitePrecision" />
+                </node>
+              </node>
             </node>
-            <node concept="2qgKlT" id="1PW6P0ZLhfD" role="2OqNvi">
-              <ref role="37wK5l" to="b1h1:19PglA21KtA" resolve="setPrecision" />
-              <node concept="2YIFZM" id="1PW6P0ZLhfE" role="37wK5m">
-                <ref role="1Pybhc" to="oq0c:2NHHcg2EXna" resolve="InfHelper" />
-                <ref role="37wK5l" to="oq0c:2NHHcg2HhuB" resolve="maxInt" />
-                <node concept="2OqwBi" id="1PW6P0ZLhfF" role="37wK5m">
-                  <node concept="37vLTw" id="1PW6P0ZLhfG" role="2Oq$k0">
-                    <ref role="3cqZAo" node="1PW6P0ZLhfS" resolve="types" />
+          </node>
+          <node concept="2OqwBi" id="7xgxWxI5OKp" role="3clFbw">
+            <node concept="37vLTw" id="7xgxWxI5EoF" role="2Oq$k0">
+              <ref role="3cqZAo" node="1PW6P0ZLhfS" resolve="types" />
+            </node>
+            <node concept="2HwmR7" id="7xgxWxI5ZN_" role="2OqNvi">
+              <node concept="1bVj0M" id="7xgxWxI5ZNB" role="23t8la">
+                <node concept="3clFbS" id="7xgxWxI5ZNC" role="1bW5cS">
+                  <node concept="3clFbF" id="7xgxWxI6dWG" role="3cqZAp">
+                    <node concept="2OqwBi" id="7xgxWxI6hk7" role="3clFbG">
+                      <node concept="37vLTw" id="7xgxWxI6dWF" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7xgxWxI5ZND" resolve="it" />
+                      </node>
+                      <node concept="2qgKlT" id="7xgxWxI6lDP" role="2OqNvi">
+                        <ref role="37wK5l" to="b1h1:7Wa2sv3Gi_T" resolve="isInfinitePrecision" />
+                      </node>
+                    </node>
                   </node>
-                  <node concept="3$u5V9" id="1PW6P0ZLhfH" role="2OqNvi">
-                    <node concept="1bVj0M" id="1PW6P0ZLhfI" role="23t8la">
-                      <node concept="3clFbS" id="1PW6P0ZLhfJ" role="1bW5cS">
-                        <node concept="3clFbF" id="1PW6P0ZLhfK" role="3cqZAp">
-                          <node concept="2OqwBi" id="1PW6P0ZLhfL" role="3clFbG">
-                            <node concept="37vLTw" id="1PW6P0ZLhfM" role="2Oq$k0">
-                              <ref role="3cqZAo" node="4z0AnX817e4" resolve="it" />
+                </node>
+                <node concept="gl6BB" id="7xgxWxI5ZND" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="7xgxWxI5ZNE" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="9aQIb" id="7xgxWxI6Qa0" role="9aQIa">
+            <node concept="3clFbS" id="7xgxWxI6Qa1" role="9aQI4">
+              <node concept="3clFbF" id="1PW6P0ZLhfA" role="3cqZAp">
+                <node concept="2OqwBi" id="1PW6P0ZLhfB" role="3clFbG">
+                  <node concept="37vLTw" id="1PW6P0ZLhfC" role="2Oq$k0">
+                    <ref role="3cqZAo" node="1PW6P0ZLhep" resolve="res" />
+                  </node>
+                  <node concept="2qgKlT" id="1PW6P0ZLhfD" role="2OqNvi">
+                    <ref role="37wK5l" to="b1h1:19PglA21KtA" resolve="setPrecision" />
+                    <node concept="2YIFZM" id="1PW6P0ZLhfE" role="37wK5m">
+                      <ref role="1Pybhc" to="oq0c:2NHHcg2EXna" resolve="InfHelper" />
+                      <ref role="37wK5l" to="oq0c:2NHHcg2HhuB" resolve="maxInt" />
+                      <node concept="2OqwBi" id="1PW6P0ZLhfF" role="37wK5m">
+                        <node concept="37vLTw" id="1PW6P0ZLhfG" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1PW6P0ZLhfS" resolve="types" />
+                        </node>
+                        <node concept="3$u5V9" id="1PW6P0ZLhfH" role="2OqNvi">
+                          <node concept="1bVj0M" id="1PW6P0ZLhfI" role="23t8la">
+                            <node concept="3clFbS" id="1PW6P0ZLhfJ" role="1bW5cS">
+                              <node concept="3clFbF" id="1PW6P0ZLhfK" role="3cqZAp">
+                                <node concept="2OqwBi" id="1PW6P0ZLhfL" role="3clFbG">
+                                  <node concept="37vLTw" id="1PW6P0ZLhfM" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="4z0AnX817e4" resolve="it" />
+                                  </node>
+                                  <node concept="2qgKlT" id="1PW6P0ZLhfN" role="2OqNvi">
+                                    <ref role="37wK5l" to="b1h1:19PglA20ASE" resolve="precision" />
+                                  </node>
+                                </node>
+                              </node>
                             </node>
-                            <node concept="2qgKlT" id="1PW6P0ZLhfN" role="2OqNvi">
-                              <ref role="37wK5l" to="b1h1:19PglA20ASE" resolve="precision" />
+                            <node concept="gl6BB" id="4z0AnX817e4" role="1bW2Oz">
+                              <property role="TrG5h" value="it" />
+                              <node concept="2jxLKc" id="4z0AnX817e5" role="1tU5fm" />
                             </node>
                           </node>
                         </node>
-                      </node>
-                      <node concept="gl6BB" id="4z0AnX817e4" role="1bW2Oz">
-                        <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="4z0AnX817e5" role="1tU5fm" />
                       </node>
                     </node>
                   </node>
@@ -2987,6 +3031,7 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="7xgxWxI67wE" role="3cqZAp" />
         <node concept="3cpWs6" id="1PW6P0ZLhfQ" role="3cqZAp">
           <node concept="37vLTw" id="1PW6P0ZLhfR" role="3cqZAk">
             <ref role="3cqZAo" node="1PW6P0ZLhep" resolve="res" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.LeastCommonSuperType@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.LeastCommonSuperType@tests.mps
@@ -54,6 +54,20 @@
       </concept>
       <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
     </language>
+    <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
+      <concept id="1330041117646892901" name="org.iets3.core.expr.collections.structure.CollectionSizeSpec" flags="ng" index="2gteSW">
+        <property id="1330041117646892912" name="max" index="2gteSD" />
+        <property id="1330041117646892911" name="min" index="2gteSQ" />
+      </concept>
+      <concept id="7554398283339749509" name="org.iets3.core.expr.collections.structure.CollectionType" flags="ng" index="3iBWmN">
+        <child id="3989687176989764921" name="sizeConstraint" index="1ietDw" />
+        <child id="7554398283339749510" name="baseType" index="3iBWmK" />
+      </concept>
+      <concept id="7554398283339759319" name="org.iets3.core.expr.collections.structure.ListLiteral" flags="ng" index="3iBYfx">
+        <child id="7554398283339759320" name="elements" index="3iBYfI" />
+      </concept>
+      <concept id="7554398283339757344" name="org.iets3.core.expr.collections.structure.ListType" flags="ng" index="3iBYCm" />
+    </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1219920932475" name="jetbrains.mps.baseLanguage.structure.VariableArityType" flags="in" index="8X2XB">
@@ -198,9 +212,9 @@
       <concept id="1330041117646892924" name="org.iets3.core.expr.simpleTypes.structure.NumberPrecSpec" flags="ng" index="2gteS_">
         <property id="1330041117646892934" name="prec" index="2gteVv" />
       </concept>
-      <concept id="1330041117646892901" name="org.iets3.core.expr.simpleTypes.structure.NumberRangeSpec" flags="ng" index="2gteSW">
-        <property id="1330041117646892912" name="max" index="2gteSD" />
-        <property id="1330041117646892911" name="min" index="2gteSQ" />
+      <concept id="1330041117646892901" name="org.iets3.core.expr.simpleTypes.structure.NumberRangeSpec" flags="ng" index="2gteSX">
+        <property id="1330041117646892912" name="max" index="2gteSE" />
+        <property id="1330041117646892911" name="min" index="2gteSR" />
       </concept>
       <concept id="8219602584782245544" name="org.iets3.core.expr.simpleTypes.structure.NumberType" flags="ng" index="mLuIC">
         <child id="1330041117646892920" name="range" index="2gteSx" />
@@ -216,6 +230,7 @@
         <property id="5115872837157252555" name="value" index="30bdrQ" />
       </concept>
       <concept id="5115872837157252551" name="org.iets3.core.expr.simpleTypes.structure.StringType" flags="ng" index="30bdrU" />
+      <concept id="5115872837157054284" name="org.iets3.core.expr.simpleTypes.structure.RealType" flags="ng" index="30bXLL" />
       <concept id="5115872837157054169" name="org.iets3.core.expr.simpleTypes.structure.IntegerType" flags="ng" index="30bXR$" />
       <concept id="5115872837157054170" name="org.iets3.core.expr.simpleTypes.structure.NumberLiteral" flags="ng" index="30bXRB">
         <property id="5115872837157054173" name="value" index="30bXRw" />
@@ -244,6 +259,9 @@
       <concept id="8811147530084018358" name="org.iets3.core.expr.toplevel.structure.RecordDeclaration" flags="ng" index="2Ss9d8" />
       <concept id="4790956042240570348" name="org.iets3.core.expr.toplevel.structure.FunctionCall" flags="ng" index="1af_rf" />
       <concept id="4790956042240148643" name="org.iets3.core.expr.toplevel.structure.Function" flags="ng" index="1aga60" />
+      <concept id="7740953487933794886" name="org.iets3.core.expr.toplevel.structure.SectionMarker" flags="ng" index="1Ws0TD">
+        <property id="7740953487933876080" name="label" index="1WsWdv" />
+      </concept>
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
@@ -452,9 +470,9 @@
             <node concept="7CXmI" id="7JCDpchUzPE" role="lGtFl">
               <node concept="30Omv" id="7JCDpchU$0s" role="7EUXB">
                 <node concept="mLuIC" id="7JCDpchUDWs" role="31d$z">
-                  <node concept="2gteSW" id="7JCDpchUDWy" role="2gteSx">
-                    <property role="2gteSQ" value="1" />
-                    <property role="2gteSD" value="1" />
+                  <node concept="2gteSX" id="7JCDpchUDWy" role="2gteSx">
+                    <property role="2gteSR" value="1" />
+                    <property role="2gteSE" value="1" />
                   </node>
                   <node concept="2gteS_" id="7JCDpchUDWx" role="2gteVg">
                     <property role="2gteVv" value="0" />
@@ -505,18 +523,18 @@
               <node concept="30Omv" id="7JCDpchU$ox" role="7EUXB">
                 <node concept="m5gfS" id="7JCDpchUDJ9" role="31d$z">
                   <node concept="mLuIC" id="7JCDpchUDJx" role="m5gfT">
-                    <node concept="2gteSW" id="7JCDpchUDJy" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="1" />
+                    <node concept="2gteSX" id="7JCDpchUDJy" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="1" />
                     </node>
                     <node concept="2gteS_" id="7JCDpchUDJz" role="2gteVg">
                       <property role="2gteVv" value="0" />
                     </node>
                   </node>
                   <node concept="mLuIC" id="7JCDpchUDJu" role="m5gfT">
-                    <node concept="2gteSW" id="7JCDpchUDJv" role="2gteSx">
-                      <property role="2gteSQ" value="12" />
-                      <property role="2gteSD" value="12" />
+                    <node concept="2gteSX" id="7JCDpchUDJv" role="2gteSx">
+                      <property role="2gteSR" value="12" />
+                      <property role="2gteSE" value="12" />
                     </node>
                     <node concept="2gteS_" id="7JCDpchUDJw" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -556,18 +574,18 @@
             <node concept="30Omv" id="1wgc0l$LgJl" role="7EUXB">
               <node concept="m5gfS" id="1wgc0l$LiN2" role="31d$z">
                 <node concept="mLuIC" id="1wgc0l$LiN3" role="m5gfT">
-                  <node concept="2gteSW" id="1wgc0l$LiN4" role="2gteSx">
-                    <property role="2gteSQ" value="1" />
-                    <property role="2gteSD" value="1" />
+                  <node concept="2gteSX" id="1wgc0l$LiN4" role="2gteSx">
+                    <property role="2gteSR" value="1" />
+                    <property role="2gteSE" value="1" />
                   </node>
                   <node concept="2gteS_" id="1wgc0l$LiN5" role="2gteVg">
                     <property role="2gteVv" value="0" />
                   </node>
                 </node>
                 <node concept="mLuIC" id="1wgc0l$LiN6" role="m5gfT">
-                  <node concept="2gteSW" id="1wgc0l$LiN7" role="2gteSx">
-                    <property role="2gteSQ" value="2" />
-                    <property role="2gteSD" value="2" />
+                  <node concept="2gteSX" id="1wgc0l$LiN7" role="2gteSx">
+                    <property role="2gteSR" value="2" />
+                    <property role="2gteSE" value="2" />
                   </node>
                   <node concept="2gteS_" id="1wgc0l$LiN8" role="2gteVg">
                     <property role="2gteVv" value="0" />
@@ -615,18 +633,18 @@
             <node concept="30Omv" id="1wgc0l$Ljm0" role="7EUXB">
               <node concept="m5gfS" id="1wgc0l$Ljm1" role="31d$z">
                 <node concept="mLuIC" id="1wgc0l$Ljm2" role="m5gfT">
-                  <node concept="2gteSW" id="1wgc0l$Ljm3" role="2gteSx">
-                    <property role="2gteSQ" value="2" />
-                    <property role="2gteSD" value="2" />
+                  <node concept="2gteSX" id="1wgc0l$Ljm3" role="2gteSx">
+                    <property role="2gteSR" value="2" />
+                    <property role="2gteSE" value="2" />
                   </node>
                   <node concept="2gteS_" id="1wgc0l$Ljm4" role="2gteVg">
                     <property role="2gteVv" value="0" />
                   </node>
                 </node>
                 <node concept="mLuIC" id="1wgc0l$Ljm5" role="m5gfT">
-                  <node concept="2gteSW" id="1wgc0l$Ljm6" role="2gteSx">
-                    <property role="2gteSQ" value="1" />
-                    <property role="2gteSD" value="1" />
+                  <node concept="2gteSX" id="1wgc0l$Ljm6" role="2gteSx">
+                    <property role="2gteSR" value="1" />
+                    <property role="2gteSE" value="1" />
                   </node>
                   <node concept="2gteS_" id="1wgc0l$Ljm7" role="2gteVg">
                     <property role="2gteVv" value="0" />
@@ -669,18 +687,18 @@
               <node concept="m5gfS" id="1wgc0l$LkhQ" role="31d$z">
                 <node concept="m5gfS" id="1wgc0l$NbLh" role="m5gfT">
                   <node concept="mLuIC" id="1wgc0l$NbLi" role="m5gfT">
-                    <node concept="2gteSW" id="1wgc0l$NbLj" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="1" />
+                    <node concept="2gteSX" id="1wgc0l$NbLj" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="1" />
                     </node>
                     <node concept="2gteS_" id="1wgc0l$NbLk" role="2gteVg">
                       <property role="2gteVv" value="0" />
                     </node>
                   </node>
                   <node concept="mLuIC" id="1wgc0l$NbLl" role="m5gfT">
-                    <node concept="2gteSW" id="1wgc0l$NbLm" role="2gteSx">
-                      <property role="2gteSQ" value="2" />
-                      <property role="2gteSD" value="2" />
+                    <node concept="2gteSX" id="1wgc0l$NbLm" role="2gteSx">
+                      <property role="2gteSR" value="2" />
+                      <property role="2gteSE" value="2" />
                     </node>
                     <node concept="2gteS_" id="1wgc0l$NbLn" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -699,18 +717,18 @@
                 </node>
                 <node concept="m5gfS" id="1wgc0l$NbOl" role="m5gfT">
                   <node concept="mLuIC" id="1wgc0l$NbOm" role="m5gfT">
-                    <node concept="2gteSW" id="1wgc0l$NbOn" role="2gteSx">
-                      <property role="2gteSQ" value="2" />
-                      <property role="2gteSD" value="2" />
+                    <node concept="2gteSX" id="1wgc0l$NbOn" role="2gteSx">
+                      <property role="2gteSR" value="2" />
+                      <property role="2gteSE" value="2" />
                     </node>
                     <node concept="2gteS_" id="1wgc0l$NbOo" role="2gteVg">
                       <property role="2gteVv" value="0" />
                     </node>
                   </node>
                   <node concept="mLuIC" id="1wgc0l$NbOp" role="m5gfT">
-                    <node concept="2gteSW" id="1wgc0l$NbOq" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="1" />
+                    <node concept="2gteSX" id="1wgc0l$NbOq" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="1" />
                     </node>
                     <node concept="2gteS_" id="1wgc0l$NbOr" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -733,9 +751,9 @@
           <node concept="1ahQXy" id="1wgc0l$MUa9" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="1wgc0l$MXE9" role="3ix9CU">
-              <node concept="2gteSW" id="1wgc0l$MXEj" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="1" />
+              <node concept="2gteSX" id="1wgc0l$MXEj" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="1" />
               </node>
             </node>
           </node>
@@ -782,18 +800,18 @@
             <node concept="30Omv" id="1wgc0l$N6yu" role="7EUXB">
               <node concept="m5gfS" id="1wgc0l$N6yv" role="31d$z">
                 <node concept="mLuIC" id="1wgc0l$N6yw" role="m5gfT">
-                  <node concept="2gteSW" id="1wgc0l$N6yx" role="2gteSx">
-                    <property role="2gteSQ" value="1" />
-                    <property role="2gteSD" value="2" />
+                  <node concept="2gteSX" id="1wgc0l$N6yx" role="2gteSx">
+                    <property role="2gteSR" value="1" />
+                    <property role="2gteSE" value="2" />
                   </node>
                   <node concept="2gteS_" id="1wgc0l$N6yy" role="2gteVg">
                     <property role="2gteVv" value="0" />
                   </node>
                 </node>
                 <node concept="mLuIC" id="1wgc0l$N6yz" role="m5gfT">
-                  <node concept="2gteSW" id="1wgc0l$N6y$" role="2gteSx">
-                    <property role="2gteSQ" value="1" />
-                    <property role="2gteSD" value="2" />
+                  <node concept="2gteSX" id="1wgc0l$N6y$" role="2gteSx">
+                    <property role="2gteSR" value="1" />
+                    <property role="2gteSE" value="2" />
                   </node>
                   <node concept="2gteS_" id="1wgc0l$N6y_" role="2gteVg">
                     <property role="2gteVv" value="0" />
@@ -807,9 +825,9 @@
           <node concept="1ahQXy" id="1wgc0l$N6yC" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="1wgc0l$N6yD" role="3ix9CU">
-              <node concept="2gteSW" id="1wgc0l$N6yE" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="1" />
+              <node concept="2gteSX" id="1wgc0l$N6yE" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="1" />
               </node>
             </node>
           </node>
@@ -846,18 +864,18 @@
             <node concept="30Omv" id="1wgc0l$NtU8" role="7EUXB">
               <node concept="m5gfS" id="1wgc0l$NtU9" role="31d$z">
                 <node concept="mLuIC" id="1wgc0l$NtUa" role="m5gfT">
-                  <node concept="2gteSW" id="1wgc0l$NtUb" role="2gteSx">
-                    <property role="2gteSQ" value="1" />
-                    <property role="2gteSD" value="2" />
+                  <node concept="2gteSX" id="1wgc0l$NtUb" role="2gteSx">
+                    <property role="2gteSR" value="1" />
+                    <property role="2gteSE" value="2" />
                   </node>
                   <node concept="2gteS_" id="1wgc0l$NtUc" role="2gteVg">
                     <property role="2gteVv" value="0" />
                   </node>
                 </node>
                 <node concept="mLuIC" id="1wgc0l$NtUd" role="m5gfT">
-                  <node concept="2gteSW" id="1wgc0l$NtUe" role="2gteSx">
-                    <property role="2gteSQ" value="1" />
-                    <property role="2gteSD" value="2" />
+                  <node concept="2gteSX" id="1wgc0l$NtUe" role="2gteSx">
+                    <property role="2gteSR" value="1" />
+                    <property role="2gteSE" value="2" />
                   </node>
                   <node concept="2gteS_" id="1wgc0l$NtUf" role="2gteVg">
                     <property role="2gteVv" value="0" />
@@ -871,9 +889,9 @@
           <node concept="1ahQXy" id="1wgc0l$NtUi" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="1wgc0l$NtUj" role="3ix9CU">
-              <node concept="2gteSW" id="1wgc0l$NtUk" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="1" />
+              <node concept="2gteSX" id="1wgc0l$NtUk" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="1" />
               </node>
             </node>
           </node>
@@ -945,18 +963,18 @@
               <node concept="188GKf" id="1wgc0l$OmXD" role="31d$z">
                 <node concept="m5gfS" id="1wgc0l$Looi" role="188GKc">
                   <node concept="mLuIC" id="1wgc0l$Looj" role="m5gfT">
-                    <node concept="2gteSW" id="1wgc0l$Look" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="2" />
+                    <node concept="2gteSX" id="1wgc0l$Look" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="2" />
                     </node>
                     <node concept="2gteS_" id="1wgc0l$Lool" role="2gteVg">
                       <property role="2gteVv" value="0" />
                     </node>
                   </node>
                   <node concept="mLuIC" id="1wgc0l$Loom" role="m5gfT">
-                    <node concept="2gteSW" id="1wgc0l$Loon" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="2" />
+                    <node concept="2gteSX" id="1wgc0l$Loon" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="2" />
                     </node>
                     <node concept="2gteS_" id="1wgc0l$Looo" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -972,9 +990,9 @@
                     </node>
                   </node>
                   <node concept="mLuIC" id="1wgc0l$On0H" role="m5gfT">
-                    <node concept="2gteSW" id="1wgc0l$On0I" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="1" />
+                    <node concept="2gteSX" id="1wgc0l$On0I" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="1" />
                     </node>
                     <node concept="2gteS_" id="1wgc0l$On0J" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -997,9 +1015,9 @@
           <node concept="1ahQXy" id="1wgc0l$NKP5" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="1wgc0l$NLrf" role="3ix9CU">
-              <node concept="2gteSW" id="1wgc0l$NLrp" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="2" />
+              <node concept="2gteSX" id="1wgc0l$NLrp" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="2" />
               </node>
             </node>
           </node>
@@ -1095,18 +1113,18 @@
               <node concept="188GKf" id="6unC0YG8nnZ" role="31d$z">
                 <node concept="m5gfS" id="6unC0YG8no0" role="188GKc">
                   <node concept="mLuIC" id="6unC0YG8no1" role="m5gfT">
-                    <node concept="2gteSW" id="6unC0YG8no2" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="2" />
+                    <node concept="2gteSX" id="6unC0YG8no2" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="2" />
                     </node>
                     <node concept="2gteS_" id="6unC0YG8no3" role="2gteVg">
                       <property role="2gteVv" value="0" />
                     </node>
                   </node>
                   <node concept="mLuIC" id="6unC0YG8no4" role="m5gfT">
-                    <node concept="2gteSW" id="6unC0YG8no5" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="2" />
+                    <node concept="2gteSX" id="6unC0YG8no5" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="2" />
                     </node>
                     <node concept="2gteS_" id="6unC0YG8no6" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -1118,9 +1136,9 @@
                 <node concept="m5gfS" id="6unC0YG8no9" role="188GKc">
                   <node concept="30bdrU" id="6unC0YG8noa" role="m5gfT" />
                   <node concept="mLuIC" id="6unC0YG8nob" role="m5gfT">
-                    <node concept="2gteSW" id="6unC0YG8noc" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="3.3" />
+                    <node concept="2gteSX" id="6unC0YG8noc" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="3.3" />
                     </node>
                     <node concept="2gteS_" id="6unC0YG8nod" role="2gteVg">
                       <property role="2gteVv" value="1" />
@@ -1135,9 +1153,9 @@
           <node concept="1ahQXy" id="6unC0YG8nog" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="6unC0YG8noh" role="3ix9CU">
-              <node concept="2gteSW" id="6unC0YG8noi" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="3" />
+              <node concept="2gteSX" id="6unC0YG8noi" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="3" />
               </node>
             </node>
           </node>
@@ -1233,18 +1251,18 @@
               <node concept="188GKf" id="6unC0YG8O8f" role="31d$z">
                 <node concept="m5gfS" id="6unC0YG8O8g" role="188GKc">
                   <node concept="mLuIC" id="6unC0YG8O8h" role="m5gfT">
-                    <node concept="2gteSW" id="6unC0YG8O8i" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="2" />
+                    <node concept="2gteSX" id="6unC0YG8O8i" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="2" />
                     </node>
                     <node concept="2gteS_" id="6unC0YG8O8j" role="2gteVg">
                       <property role="2gteVv" value="0" />
                     </node>
                   </node>
                   <node concept="mLuIC" id="6unC0YG8O8k" role="m5gfT">
-                    <node concept="2gteSW" id="6unC0YG8O8l" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="2" />
+                    <node concept="2gteSX" id="6unC0YG8O8l" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="2" />
                     </node>
                     <node concept="2gteS_" id="6unC0YG8O8m" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -1256,9 +1274,9 @@
                 <node concept="m5gfS" id="6unC0YG8O8p" role="188GKc">
                   <node concept="30bdrU" id="6unC0YG8O8q" role="m5gfT" />
                   <node concept="mLuIC" id="6unC0YG8O8r" role="m5gfT">
-                    <node concept="2gteSW" id="6unC0YG8O8s" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="2.3" />
+                    <node concept="2gteSX" id="6unC0YG8O8s" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="2.3" />
                     </node>
                     <node concept="2gteS_" id="6unC0YG8O8t" role="2gteVg">
                       <property role="2gteVv" value="1" />
@@ -1273,9 +1291,9 @@
           <node concept="1ahQXy" id="6unC0YG8O8w" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="6unC0YG8O8x" role="3ix9CU">
-              <node concept="2gteSW" id="6unC0YG8O8y" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="3" />
+              <node concept="2gteSX" id="6unC0YG8O8y" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="3" />
               </node>
             </node>
           </node>
@@ -1345,18 +1363,18 @@
               <node concept="188GKf" id="6unC0YG7J0$" role="31d$z">
                 <node concept="m5gfS" id="6unC0YG7J0_" role="188GKc">
                   <node concept="mLuIC" id="6unC0YG7J0A" role="m5gfT">
-                    <node concept="2gteSW" id="6unC0YG7J0B" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="2" />
+                    <node concept="2gteSX" id="6unC0YG7J0B" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="2" />
                     </node>
                     <node concept="2gteS_" id="6unC0YG7J0C" role="2gteVg">
                       <property role="2gteVv" value="0" />
                     </node>
                   </node>
                   <node concept="mLuIC" id="6unC0YG7J0D" role="m5gfT">
-                    <node concept="2gteSW" id="6unC0YG7J0E" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="2" />
+                    <node concept="2gteSX" id="6unC0YG7J0E" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="2" />
                     </node>
                     <node concept="2gteS_" id="6unC0YG7J0F" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -1372,9 +1390,9 @@
                     </node>
                   </node>
                   <node concept="mLuIC" id="6unC0YG7J0K" role="m5gfT">
-                    <node concept="2gteSW" id="6unC0YG7J0L" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="1" />
+                    <node concept="2gteSX" id="6unC0YG7J0L" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="1" />
                     </node>
                     <node concept="2gteS_" id="6unC0YG7J0M" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -1393,9 +1411,9 @@
           <node concept="1ahQXy" id="6unC0YG7J0P" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="6unC0YG7J0Q" role="3ix9CU">
-              <node concept="2gteSW" id="6unC0YG7J0R" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="2" />
+              <node concept="2gteSX" id="6unC0YG7J0R" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="2" />
               </node>
             </node>
           </node>
@@ -1486,9 +1504,9 @@
             <node concept="30Omv" id="2Ml_6NDLEyI" role="7EUXB">
               <node concept="m5gfS" id="2Ml_6NDLEyK" role="31d$z">
                 <node concept="mLuIC" id="2Ml_6NDLEyL" role="m5gfT">
-                  <node concept="2gteSW" id="2Ml_6NDLEyM" role="2gteSx">
-                    <property role="2gteSQ" value="0" />
-                    <property role="2gteSD" value="1" />
+                  <node concept="2gteSX" id="2Ml_6NDLEyM" role="2gteSx">
+                    <property role="2gteSR" value="0" />
+                    <property role="2gteSE" value="1" />
                   </node>
                   <node concept="2gteS_" id="2Ml_6NDLEyN" role="2gteVg">
                     <property role="2gteVv" value="0" />
@@ -1496,9 +1514,9 @@
                 </node>
                 <node concept="m5gfS" id="2Ml_6NDMxqf" role="m5gfT">
                   <node concept="mLuIC" id="2Ml_6NDNibV" role="m5gfT">
-                    <node concept="2gteSW" id="2Ml_6NDNicI" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="2" />
+                    <node concept="2gteSX" id="2Ml_6NDNicI" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="2" />
                     </node>
                     <node concept="2gteS_" id="2Ml_6NDSY$q" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -1508,9 +1526,9 @@
                   <node concept="30bdrU" id="2Ml_6NDNij7" role="m5gfT" />
                 </node>
                 <node concept="mLuIC" id="2Ml_6NDMxrx" role="m5gfT">
-                  <node concept="2gteSW" id="2Ml_6NDMxsb" role="2gteSx">
-                    <property role="2gteSQ" value="3" />
-                    <property role="2gteSD" value="3.1" />
+                  <node concept="2gteSX" id="2Ml_6NDMxsb" role="2gteSx">
+                    <property role="2gteSR" value="3" />
+                    <property role="2gteSE" value="3.1" />
                   </node>
                   <node concept="2gteS_" id="2Ml_6NDMxu9" role="2gteVg">
                     <property role="2gteVv" value="1" />
@@ -1522,9 +1540,9 @@
           <node concept="1ahQXy" id="2Ml_6NDLEz0" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="2Ml_6NDLEz1" role="3ix9CU">
-              <node concept="2gteSW" id="2Ml_6NDLEz2" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="1" />
+              <node concept="2gteSX" id="2Ml_6NDLEz2" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="1" />
               </node>
             </node>
           </node>
@@ -1608,9 +1626,9 @@
               <node concept="188GKf" id="2Ml_6NDRQXc" role="31d$z">
                 <node concept="m5gfS" id="2Ml_6NDRQZ7" role="188GKc">
                   <node concept="mLuIC" id="2Ml_6NDRQZ8" role="m5gfT">
-                    <node concept="2gteSW" id="2Ml_6NDRQZ9" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="1" />
+                    <node concept="2gteSX" id="2Ml_6NDRQZ9" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="1" />
                     </node>
                     <node concept="2gteS_" id="2Ml_6NDRQZa" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -1618,9 +1636,9 @@
                   </node>
                   <node concept="m5gfS" id="2Ml_6NDRQZb" role="m5gfT">
                     <node concept="mLuIC" id="2Ml_6NDRQZc" role="m5gfT">
-                      <node concept="2gteSW" id="2Ml_6NDRQZd" role="2gteSx">
-                        <property role="2gteSQ" value="1" />
-                        <property role="2gteSD" value="1" />
+                      <node concept="2gteSX" id="2Ml_6NDRQZd" role="2gteSx">
+                        <property role="2gteSR" value="1" />
+                        <property role="2gteSE" value="1" />
                       </node>
                       <node concept="2gteS_" id="2Ml_6NDRQZe" role="2gteVg">
                         <property role="2gteVv" value="0" />
@@ -1640,9 +1658,9 @@
                 </node>
                 <node concept="m5gfS" id="2Ml_6NDRQYX" role="188GKc">
                   <node concept="mLuIC" id="2Ml_6NDRQYY" role="m5gfT">
-                    <node concept="2gteSW" id="2Ml_6NDRQYZ" role="2gteSx">
-                      <property role="2gteSQ" value="0" />
-                      <property role="2gteSD" value="0" />
+                    <node concept="2gteSX" id="2Ml_6NDRQYZ" role="2gteSx">
+                      <property role="2gteSR" value="0" />
+                      <property role="2gteSE" value="0" />
                     </node>
                     <node concept="2gteS_" id="2Ml_6NDRQZ0" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -1650,9 +1668,9 @@
                   </node>
                   <node concept="m5gfS" id="2Ml_6NDRQZ1" role="m5gfT">
                     <node concept="mLuIC" id="2Ml_6NDRQZ2" role="m5gfT">
-                      <node concept="2gteSW" id="2Ml_6NDRQZ3" role="2gteSx">
-                        <property role="2gteSQ" value="2" />
-                        <property role="2gteSD" value="2" />
+                      <node concept="2gteSX" id="2Ml_6NDRQZ3" role="2gteSx">
+                        <property role="2gteSR" value="2" />
+                        <property role="2gteSE" value="2" />
                       </node>
                       <node concept="2gteS_" id="2Ml_6NDRQZ4" role="2gteVg">
                         <property role="2gteVv" value="0" />
@@ -1672,9 +1690,9 @@
           <node concept="1ahQXy" id="2Ml_6NDNil5" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="2Ml_6NDNil6" role="3ix9CU">
-              <node concept="2gteSW" id="2Ml_6NDNil7" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="1" />
+              <node concept="2gteSX" id="2Ml_6NDNil7" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="1" />
               </node>
             </node>
           </node>
@@ -1752,18 +1770,18 @@
           <node concept="1ahQXy" id="3A7Uik3oRNs" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="3A7Uik3oRNt" role="3ix9CU">
-              <node concept="2gteSW" id="3A7Uik3oRNu" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="3" />
+              <node concept="2gteSX" id="3A7Uik3oRNu" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="3" />
               </node>
             </node>
           </node>
           <node concept="7CXmI" id="3A7Uik3oRN_" role="lGtFl">
             <node concept="30Omv" id="3A7Uik3oRNA" role="7EUXB">
               <node concept="mLuIC" id="3A7Uik3oU$k" role="31d$z">
-                <node concept="2gteSW" id="3A7Uik3oU$r" role="2gteSx">
-                  <property role="2gteSQ" value="-5" />
-                  <property role="2gteSD" value="5.7" />
+                <node concept="2gteSX" id="3A7Uik3oU$r" role="2gteSx">
+                  <property role="2gteSR" value="-5" />
+                  <property role="2gteSE" value="5.7" />
                 </node>
                 <node concept="2gteS_" id="3A7Uik3oU$J" role="2gteVg">
                   <property role="2gteVv" value="1" />
@@ -1845,9 +1863,9 @@
           <node concept="1ahQXy" id="2Ml_6NDT9E6" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="2Ml_6NDT9E7" role="3ix9CU">
-              <node concept="2gteSW" id="2Ml_6NDT9E8" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="3" />
+              <node concept="2gteSX" id="2Ml_6NDT9E8" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="3" />
               </node>
             </node>
           </node>
@@ -1855,9 +1873,9 @@
             <node concept="30Omv" id="2Ml_6NDT9Ea" role="7EUXB">
               <node concept="188GKf" id="2Ml_6NDTaEc" role="31d$z">
                 <node concept="mLuIC" id="2Ml_6NDT9Eb" role="188GKc">
-                  <node concept="2gteSW" id="2Ml_6NDT9Ec" role="2gteSx">
-                    <property role="2gteSQ" value="-5" />
-                    <property role="2gteSD" value="5.7" />
+                  <node concept="2gteSX" id="2Ml_6NDT9Ec" role="2gteSx">
+                    <property role="2gteSR" value="-5" />
+                    <property role="2gteSE" value="5.7" />
                   </node>
                   <node concept="2gteS_" id="2Ml_6NDT9Ed" role="2gteVg">
                     <property role="2gteVv" value="1" />
@@ -1949,9 +1967,9 @@
           <node concept="1ahQXy" id="2Ml_6NDTkZB" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="2Ml_6NDTkZC" role="3ix9CU">
-              <node concept="2gteSW" id="2Ml_6NDTkZD" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="3" />
+              <node concept="2gteSX" id="2Ml_6NDTkZD" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="3" />
               </node>
             </node>
           </node>
@@ -1959,9 +1977,9 @@
             <node concept="30Omv" id="2Ml_6NDTkZF" role="7EUXB">
               <node concept="188GKf" id="2Ml_6NDTkZG" role="31d$z">
                 <node concept="mLuIC" id="2Ml_6NDTkZI" role="188GKc">
-                  <node concept="2gteSW" id="2Ml_6NDTkZJ" role="2gteSx">
-                    <property role="2gteSQ" value="-5" />
-                    <property role="2gteSD" value="1" />
+                  <node concept="2gteSX" id="2Ml_6NDTkZJ" role="2gteSx">
+                    <property role="2gteSR" value="-5" />
+                    <property role="2gteSE" value="1" />
                   </node>
                   <node concept="2gteS_" id="2Ml_6NDTkZK" role="2gteVg">
                     <property role="2gteVv" value="0" />
@@ -2075,9 +2093,9 @@
           <node concept="1ahQXy" id="2Ml_6NDTrK$" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="2Ml_6NDTrK_" role="3ix9CU">
-              <node concept="2gteSW" id="2Ml_6NDTrKA" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="3" />
+              <node concept="2gteSX" id="2Ml_6NDTrKA" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="3" />
               </node>
             </node>
           </node>
@@ -2086,9 +2104,9 @@
               <node concept="Uns6S" id="2Ml_6NDTURM" role="31d$z">
                 <node concept="188GKf" id="2Ml_6NDTURN" role="Uns6T">
                   <node concept="mLuIC" id="2Ml_6NDTURQ" role="188GKc">
-                    <node concept="2gteSW" id="2Ml_6NDTURR" role="2gteSx">
-                      <property role="2gteSQ" value="-5" />
-                      <property role="2gteSD" value="1" />
+                    <node concept="2gteSX" id="2Ml_6NDTURR" role="2gteSx">
+                      <property role="2gteSR" value="-5" />
+                      <property role="2gteSE" value="1" />
                     </node>
                     <node concept="2gteS_" id="2Ml_6NDTURS" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -2254,27 +2272,27 @@
           <node concept="1ahQXy" id="3A7Uik3ozva" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="3A7Uik3ozvb" role="3ix9CU">
-              <node concept="2gteSW" id="3A7Uik3ozvc" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="3" />
+              <node concept="2gteSX" id="3A7Uik3ozvc" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="3" />
               </node>
             </node>
           </node>
           <node concept="1ahQXy" id="3A7Uik3oIss" role="1ahQWs">
             <property role="TrG5h" value="b" />
             <node concept="mLuIC" id="3A7Uik3oIIl" role="3ix9CU">
-              <node concept="2gteSW" id="3A7Uik3oIIv" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="4" />
+              <node concept="2gteSX" id="3A7Uik3oIIv" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="4" />
               </node>
             </node>
           </node>
           <node concept="1ahQXy" id="3A7Uik3oIJ0" role="1ahQWs">
             <property role="TrG5h" value="c" />
             <node concept="mLuIC" id="3A7Uik3oJ0N" role="3ix9CU">
-              <node concept="2gteSW" id="3A7Uik3oJ0X" role="2gteSx">
-                <property role="2gteSQ" value="1" />
-                <property role="2gteSD" value="2" />
+              <node concept="2gteSX" id="3A7Uik3oJ0X" role="2gteSx">
+                <property role="2gteSR" value="1" />
+                <property role="2gteSE" value="2" />
               </node>
             </node>
           </node>
@@ -2283,9 +2301,9 @@
               <node concept="188GKf" id="3A7Uik3ozvf" role="31d$z">
                 <node concept="2vmvy5" id="3A7Uik3ozvg" role="188GKc" />
                 <node concept="mLuIC" id="3A7Uik3ozvi" role="188GKc">
-                  <node concept="2gteSW" id="3A7Uik3ozvj" role="2gteSx">
-                    <property role="2gteSQ" value="1" />
-                    <property role="2gteSD" value="26" />
+                  <node concept="2gteSX" id="3A7Uik3ozvj" role="2gteSx">
+                    <property role="2gteSR" value="1" />
+                    <property role="2gteSE" value="26" />
                   </node>
                   <node concept="2gteS_" id="3A7Uik3ozvk" role="2gteVg">
                     <property role="2gteVv" value="1" />
@@ -2445,27 +2463,27 @@
           <node concept="1ahQXy" id="3A7Uik3oNHI" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="3A7Uik3oNHJ" role="3ix9CU">
-              <node concept="2gteSW" id="3A7Uik3oNHK" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="3" />
+              <node concept="2gteSX" id="3A7Uik3oNHK" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="3" />
               </node>
             </node>
           </node>
           <node concept="1ahQXy" id="3A7Uik3oNHL" role="1ahQWs">
             <property role="TrG5h" value="b" />
             <node concept="mLuIC" id="3A7Uik3oNHM" role="3ix9CU">
-              <node concept="2gteSW" id="3A7Uik3oNHN" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="4" />
+              <node concept="2gteSX" id="3A7Uik3oNHN" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="4" />
               </node>
             </node>
           </node>
           <node concept="1ahQXy" id="3A7Uik3oNHO" role="1ahQWs">
             <property role="TrG5h" value="c" />
             <node concept="mLuIC" id="3A7Uik3oNHP" role="3ix9CU">
-              <node concept="2gteSW" id="3A7Uik3oNHQ" role="2gteSx">
-                <property role="2gteSQ" value="1" />
-                <property role="2gteSD" value="2" />
+              <node concept="2gteSX" id="3A7Uik3oNHQ" role="2gteSx">
+                <property role="2gteSR" value="1" />
+                <property role="2gteSE" value="2" />
               </node>
             </node>
           </node>
@@ -2475,9 +2493,9 @@
                 <node concept="188GKf" id="3A7Uik3oNHU" role="Uns6T">
                   <node concept="2vmvy5" id="3A7Uik3oNHV" role="188GKc" />
                   <node concept="mLuIC" id="3A7Uik3oNHX" role="188GKc">
-                    <node concept="2gteSW" id="3A7Uik3oNHY" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="26" />
+                    <node concept="2gteSX" id="3A7Uik3oNHY" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="26" />
                     </node>
                     <node concept="2gteS_" id="3A7Uik3oNHZ" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -2644,27 +2662,27 @@
           <node concept="1ahQXy" id="3A7Uik3oPIG" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="3A7Uik3oPIH" role="3ix9CU">
-              <node concept="2gteSW" id="3A7Uik3oPII" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="3" />
+              <node concept="2gteSX" id="3A7Uik3oPII" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="3" />
               </node>
             </node>
           </node>
           <node concept="1ahQXy" id="3A7Uik3oPIJ" role="1ahQWs">
             <property role="TrG5h" value="b" />
             <node concept="mLuIC" id="3A7Uik3oPIK" role="3ix9CU">
-              <node concept="2gteSW" id="3A7Uik3oPIL" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="4" />
+              <node concept="2gteSX" id="3A7Uik3oPIL" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="4" />
               </node>
             </node>
           </node>
           <node concept="1ahQXy" id="3A7Uik3oPIM" role="1ahQWs">
             <property role="TrG5h" value="c" />
             <node concept="mLuIC" id="3A7Uik3oPIN" role="3ix9CU">
-              <node concept="2gteSW" id="3A7Uik3oPIO" role="2gteSx">
-                <property role="2gteSQ" value="1" />
-                <property role="2gteSD" value="2" />
+              <node concept="2gteSX" id="3A7Uik3oPIO" role="2gteSx">
+                <property role="2gteSR" value="1" />
+                <property role="2gteSE" value="2" />
               </node>
             </node>
           </node>
@@ -2674,9 +2692,9 @@
                 <node concept="188GKf" id="3A7Uik3oPIS" role="Uns6T">
                   <node concept="2vmvy5" id="3A7Uik3oPIT" role="188GKc" />
                   <node concept="mLuIC" id="3A7Uik3oPIV" role="188GKc">
-                    <node concept="2gteSW" id="3A7Uik3oPIW" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="26" />
+                    <node concept="2gteSX" id="3A7Uik3oPIW" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="26" />
                     </node>
                     <node concept="2gteS_" id="3A7Uik3oPIX" role="2gteVg">
                       <property role="2gteVv" value="1" />
@@ -2833,18 +2851,18 @@
           <node concept="1ahQXy" id="3A7Uik3oH8h" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="3A7Uik3oH8i" role="3ix9CU">
-              <node concept="2gteSW" id="3A7Uik3oH8j" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="3" />
+              <node concept="2gteSX" id="3A7Uik3oH8j" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="3" />
               </node>
             </node>
           </node>
           <node concept="1ahQXy" id="3A7Uik3p1$W" role="1ahQWs">
             <property role="TrG5h" value="b" />
             <node concept="mLuIC" id="3A7Uik3p1$X" role="3ix9CU">
-              <node concept="2gteSW" id="3A7Uik3p1$Y" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="4" />
+              <node concept="2gteSX" id="3A7Uik3p1$Y" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="4" />
               </node>
             </node>
           </node>
@@ -2854,9 +2872,9 @@
                 <node concept="188GKf" id="3A7Uik3oH8n" role="Uns6T">
                   <node concept="2vmvy5" id="3A7Uik3oH8o" role="188GKc" />
                   <node concept="mLuIC" id="3A7Uik3oH8q" role="188GKc">
-                    <node concept="2gteSW" id="3A7Uik3oH8r" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="26" />
+                    <node concept="2gteSX" id="3A7Uik3oH8r" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="26" />
                     </node>
                     <node concept="2gteS_" id="3A7Uik3oH8s" role="2gteVg">
                       <property role="2gteVv" value="1" />
@@ -2921,9 +2939,9 @@
               <node concept="188GKf" id="3sm5hNvpfhk" role="31d$z">
                 <node concept="2vmvy5" id="H8GgRp$kzb" role="188GKc" />
                 <node concept="mLuIC" id="H8GgRpw_Nj" role="188GKc">
-                  <node concept="2gteSW" id="H8GgRp_5w8" role="2gteSx">
-                    <property role="2gteSQ" value="123" />
-                    <property role="2gteSD" value="123" />
+                  <node concept="2gteSX" id="H8GgRp_5w8" role="2gteSx">
+                    <property role="2gteSR" value="123" />
+                    <property role="2gteSE" value="123" />
                   </node>
                   <node concept="2gteS_" id="H8GgRp_5xH" role="2gteVg">
                     <property role="2gteVv" value="0" />
@@ -2986,9 +3004,9 @@
               <node concept="188GKf" id="738HPfh5HK7" role="31d$z">
                 <node concept="2vmvy5" id="738HPfh5HK8" role="188GKc" />
                 <node concept="mLuIC" id="738HPfh5HK9" role="188GKc">
-                  <node concept="2gteSW" id="738HPfh5HKa" role="2gteSx">
-                    <property role="2gteSQ" value="123" />
-                    <property role="2gteSD" value="123" />
+                  <node concept="2gteSX" id="738HPfh5HKa" role="2gteSx">
+                    <property role="2gteSR" value="123" />
+                    <property role="2gteSE" value="123" />
                   </node>
                   <node concept="2gteS_" id="738HPfh5HKb" role="2gteVg">
                     <property role="2gteVv" value="0" />
@@ -3114,6 +3132,234 @@
           </node>
         </node>
         <node concept="_ixoA" id="H8GgRpw8nM" role="_iOnB" />
+        <node concept="1Ws0TD" id="7xgxWxHYtHw" role="_iOnB">
+          <property role="1WsWdv" value="Problem: Supertype calculation of int and number[-∞|∞]{inf}" />
+        </node>
+        <node concept="_ixoA" id="7xgxWxHYzGH" role="_iOnB" />
+        <node concept="2zPypq" id="7xgxWxHYJCx" role="_iOnB">
+          <property role="TrG5h" value="bool" />
+          <node concept="2vmpnb" id="7xgxWxHYMzV" role="2lDidJ" />
+        </node>
+        <node concept="2zPypq" id="7xgxWxHYSAL" role="_iOnB">
+          <property role="TrG5h" value="int" />
+          <node concept="30bXRB" id="7xgxWxHYVym" role="2lDidJ">
+            <property role="30bXRw" value="42" />
+          </node>
+          <node concept="30bXR$" id="7xgxWxHYVy9" role="2zM23F" />
+        </node>
+        <node concept="2zPypq" id="7xgxWxHYYtP" role="_iOnB">
+          <property role="TrG5h" value="real" />
+          <node concept="30bXRB" id="7xgxWxHZ1pm" role="2lDidJ">
+            <property role="30bXRw" value="42" />
+          </node>
+          <node concept="30bXLL" id="7xgxWxHZ1p9" role="2zM23F" />
+        </node>
+        <node concept="_ixoA" id="7xgxWxIPjWo" role="_iOnB" />
+        <node concept="2zPypq" id="7xgxWxIPjWs" role="_iOnB">
+          <property role="TrG5h" value="x" />
+          <node concept="30bXRB" id="7xgxWxIPmXe" role="2lDidJ">
+            <property role="30bXRw" value="42" />
+          </node>
+          <node concept="mLuIC" id="7xgxWxIPmVH" role="2zM23F">
+            <node concept="2gteSX" id="7xgxWxIPmVS" role="2gteSx">
+              <property role="2gteSR" value="-42" />
+              <property role="2gteSE" value="42" />
+            </node>
+            <node concept="2gteS_" id="7xgxWxIPmW$" role="2gteVg">
+              <property role="2gteVv" value="inf" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7xgxWxIPmYb" role="_iOnB">
+          <property role="TrG5h" value="ft" />
+          <node concept="30bXRB" id="7xgxWxIPpUj" role="2lDidJ">
+            <property role="30bXRw" value="42" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="7xgxWxIPsPI" role="_iOnB">
+          <property role="TrG5h" value="expected_list" />
+          <node concept="3iBYfx" id="7xgxWxIPvL9" role="2lDidJ">
+            <node concept="_emDc" id="7xgxWxIPvLm" role="3iBYfI">
+              <ref role="_emDf" node="7xgxWxIPjWs" resolve="x" />
+            </node>
+            <node concept="_emDc" id="7xgxWxIPvLM" role="3iBYfI">
+              <ref role="_emDf" node="7xgxWxIPmYb" resolve="ft" />
+            </node>
+            <node concept="7CXmI" id="7xgxWxIPvQw" role="lGtFl">
+              <node concept="30Omv" id="7xgxWxIPvTj" role="7EUXB">
+                <node concept="3iBYCm" id="7xgxWxITG_T" role="31d$z">
+                  <node concept="2gteSW" id="7xgxWxITGA6" role="1ietDw">
+                    <property role="2gteSQ" value="2" />
+                    <property role="2gteSD" value="2" />
+                  </node>
+                  <node concept="mLuIC" id="7xgxWxITGA7" role="3iBWmK">
+                    <node concept="2gteSX" id="7xgxWxITGA8" role="2gteSx">
+                      <property role="2gteSR" value="-42" />
+                      <property role="2gteSE" value="42" />
+                    </node>
+                    <node concept="2gteS_" id="7xgxWxITGA9" role="2gteVg">
+                      <property role="2gteVv" value="inf" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="7xgxWxHZ1q2" role="_iOnB" />
+        <node concept="2zPypq" id="7xgxWxHZ1q6" role="_iOnB">
+          <property role="TrG5h" value="number_0_decimal_digits" />
+          <node concept="30bXRB" id="7xgxWxHZ4rc" role="2lDidJ">
+            <property role="30bXRw" value="42" />
+          </node>
+          <node concept="mLuIC" id="7xgxWxHZ4q7" role="2zM23F">
+            <node concept="2gteSX" id="7xgxWxHZ4qi" role="2gteSx" />
+            <node concept="2gteS_" id="7xgxWxHZ4qy" role="2gteVg">
+              <property role="2gteVv" value="0" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7xgxWxHZ4s8" role="_iOnB">
+          <property role="TrG5h" value="number_9_decimal_digits" />
+          <node concept="30bXRB" id="7xgxWxHZ4s9" role="2lDidJ">
+            <property role="30bXRw" value="42" />
+          </node>
+          <node concept="mLuIC" id="7xgxWxHZ4sa" role="2zM23F">
+            <node concept="2gteSX" id="7xgxWxHZ4sb" role="2gteSx" />
+            <node concept="2gteS_" id="7xgxWxHZ4sc" role="2gteVg">
+              <property role="2gteVv" value="9" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="7xgxWxHZ7u0" role="_iOnB">
+          <property role="TrG5h" value="number_inf_decimal_digits" />
+          <node concept="30bXRB" id="7xgxWxHZ7u1" role="2lDidJ">
+            <property role="30bXRw" value="42" />
+          </node>
+          <node concept="mLuIC" id="7xgxWxHZ7u2" role="2zM23F">
+            <node concept="2gteSX" id="7xgxWxHZ7u3" role="2gteSx" />
+            <node concept="2gteS_" id="7xgxWxHZ7u4" role="2gteVg">
+              <property role="2gteVv" value="inf" />
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="7xgxWxHYGHy" role="_iOnB" />
+        <node concept="2zPypq" id="7xgxWxHYhSW" role="_iOnB">
+          <property role="TrG5h" value="expected_real" />
+          <node concept="2fGnzi" id="7xgxWxHYAF5" role="2lDidJ">
+            <node concept="2fGnzd" id="7xgxWxHYAF6" role="2fGnxs">
+              <node concept="_emDc" id="7xgxWxHZarP" role="2fGnzS">
+                <ref role="_emDf" node="7xgxWxHYJCx" resolve="bool" />
+              </node>
+              <node concept="_emDc" id="7xgxWxHZasg" role="2fGnzA">
+                <ref role="_emDf" node="7xgxWxHYSAL" resolve="int" />
+              </node>
+            </node>
+            <node concept="2fGnzd" id="7xgxWxHYAF7" role="2fGnxs">
+              <node concept="2fHqz8" id="7xgxWxHZgyO" role="2fGnzS" />
+              <node concept="_emDc" id="7xgxWxHZmz8" role="2fGnzA">
+                <ref role="_emDf" node="7xgxWxHYYtP" resolve="real" />
+              </node>
+            </node>
+            <node concept="7CXmI" id="7xgxWxI8qEU" role="lGtFl">
+              <node concept="30Omv" id="7xgxWxI8qMA" role="7EUXB">
+                <node concept="30bXLL" id="7xgxWxI8qUj" role="31d$z" />
+              </node>
+            </node>
+          </node>
+          <node concept="30bXLL" id="7xgxWxHYAEU" role="2zM23F" />
+        </node>
+        <node concept="_ixoA" id="7xgxWxHZs$Q" role="_iOnB" />
+        <node concept="2zPypq" id="7xgxWxHZ_Ao" role="_iOnB">
+          <property role="TrG5h" value="understandable_real" />
+          <node concept="2fGnzi" id="7xgxWxHZCxP" role="2lDidJ">
+            <node concept="2fGnzd" id="7xgxWxHZCxQ" role="2fGnxs">
+              <node concept="_emDc" id="7xgxWxHZCyi" role="2fGnzS">
+                <ref role="_emDf" node="7xgxWxHYJCx" resolve="bool" />
+              </node>
+              <node concept="_emDc" id="7xgxWxHZI_3" role="2fGnzA">
+                <ref role="_emDf" node="7xgxWxHYSAL" resolve="int" />
+              </node>
+            </node>
+            <node concept="2fGnzd" id="7xgxWxHZCxR" role="2fGnxs">
+              <node concept="2fHqz8" id="7xgxWxHZIyN" role="2fGnzS" />
+              <node concept="_emDc" id="7xgxWxHZIB_" role="2fGnzA">
+                <ref role="_emDf" node="7xgxWxHZ4s8" resolve="number_9_decimal_digits" />
+              </node>
+            </node>
+            <node concept="7CXmI" id="7xgxWxI8qUp" role="lGtFl">
+              <node concept="30Omv" id="7xgxWxI8r25" role="7EUXB">
+                <node concept="30bXLL" id="7xgxWxI8r9N" role="31d$z" />
+              </node>
+            </node>
+          </node>
+          <node concept="30bXLL" id="7xgxWxHZCxE" role="2zM23F" />
+        </node>
+        <node concept="_ixoA" id="7xgxWxI06Mw" role="_iOnB" />
+        <node concept="2zPypq" id="7xgxWxI0cCi" role="_iOnB">
+          <property role="TrG5h" value="unexpected_int" />
+          <node concept="2fGnzi" id="7xgxWxI0fBM" role="2lDidJ">
+            <node concept="2fGnzd" id="7xgxWxI0fBN" role="2fGnxs">
+              <node concept="_emDc" id="7xgxWxI0lFC" role="2fGnzS">
+                <ref role="_emDf" node="7xgxWxHYJCx" resolve="bool" />
+              </node>
+              <node concept="_emDc" id="7xgxWxI0rNP" role="2fGnzA">
+                <ref role="_emDf" node="7xgxWxHYSAL" resolve="int" />
+              </node>
+            </node>
+            <node concept="2fGnzd" id="7xgxWxI0fBO" role="2fGnxs">
+              <node concept="2fHqz8" id="7xgxWxI0y02" role="2fGnzS" />
+              <node concept="_emDc" id="7xgxWxI0y4d" role="2fGnzA">
+                <ref role="_emDf" node="7xgxWxHZ7u0" resolve="number_inf_decimal_digits" />
+              </node>
+            </node>
+            <node concept="7CXmI" id="7xgxWxI8xjS" role="lGtFl">
+              <node concept="30Omv" id="7xgxWxI8xr$" role="7EUXB">
+                <node concept="30bXLL" id="7xgxWxI8xzh" role="31d$z" />
+              </node>
+            </node>
+          </node>
+          <node concept="30bXLL" id="7xgxWxI8qqO" role="2zM23F" />
+        </node>
+        <node concept="_ixoA" id="7xgxWxI0CMe" role="_iOnB" />
+        <node concept="2zPypq" id="7xgxWxI0IGB" role="_iOnB">
+          <property role="TrG5h" value="unexpected_number_0_decimal_digits" />
+          <node concept="2fGnzi" id="7xgxWxI0RH3" role="2lDidJ">
+            <node concept="2fGnzd" id="7xgxWxI0RH4" role="2fGnxs">
+              <node concept="_emDc" id="7xgxWxI0XQF" role="2fGnzS">
+                <ref role="_emDf" node="7xgxWxHYJCx" resolve="bool" />
+              </node>
+              <node concept="_emDc" id="7xgxWxI0XXr" role="2fGnzA">
+                <ref role="_emDf" node="7xgxWxHZ1q6" resolve="number_0_decimal_digits" />
+              </node>
+            </node>
+            <node concept="2fGnzd" id="7xgxWxI0RH5" role="2fGnxs">
+              <node concept="2fHqz8" id="7xgxWxI0XRo" role="2fGnzS" />
+              <node concept="_emDc" id="7xgxWxI0Y4i" role="2fGnzA">
+                <ref role="_emDf" node="7xgxWxHZ7u0" resolve="number_inf_decimal_digits" />
+              </node>
+            </node>
+            <node concept="7CXmI" id="7xgxWxI8xzr" role="lGtFl">
+              <node concept="30Omv" id="7xgxWxI8xFs" role="7EUXB">
+                <node concept="mLuIC" id="7xgxWxITHl5" role="31d$z">
+                  <node concept="2gteSX" id="7xgxWxITHlb" role="2gteSx">
+                    <property role="2gteSR" value="-∞" />
+                    <property role="2gteSE" value="∞" />
+                  </node>
+                  <node concept="2gteS_" id="7xgxWxITHla" role="2gteVg">
+                    <property role="2gteVv" value="inf" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="mLuIC" id="7xgxWxIH2mB" role="2zM23F">
+            <node concept="2gteSX" id="7xgxWxIH2mC" role="2gteSx" />
+            <node concept="2gteS_" id="7xgxWxIH2mD" role="2gteVg">
+              <property role="2gteVv" value="inf" />
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>
@@ -3182,9 +3428,9 @@
                     </node>
                   </node>
                   <node concept="mLuIC" id="7iQqdOBdT4k" role="2c7tTw">
-                    <node concept="2gteSW" id="7iQqdOBdT4l" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="1" />
+                    <node concept="2gteSX" id="7iQqdOBdT4l" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="1" />
                     </node>
                     <node concept="2gteS_" id="7iQqdOBdT4m" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -3198,9 +3444,9 @@
                     </node>
                   </node>
                   <node concept="mLuIC" id="7iQqdOBdT4n" role="2c7tTw">
-                    <node concept="2gteSW" id="7iQqdOBdT4o" role="2gteSx">
-                      <property role="2gteSQ" value="2" />
-                      <property role="2gteSD" value="2" />
+                    <node concept="2gteSX" id="7iQqdOBdT4o" role="2gteSx">
+                      <property role="2gteSR" value="2" />
+                      <property role="2gteSE" value="2" />
                     </node>
                     <node concept="2gteS_" id="7iQqdOBdT4p" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -3270,9 +3516,9 @@
                     </node>
                   </node>
                   <node concept="mLuIC" id="7iQqdOBerW0" role="2c7tTw">
-                    <node concept="2gteSW" id="7iQqdOBerW1" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="1" />
+                    <node concept="2gteSX" id="7iQqdOBerW1" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="1" />
                     </node>
                     <node concept="2gteS_" id="7iQqdOBerW2" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -3286,9 +3532,9 @@
                     </node>
                   </node>
                   <node concept="mLuIC" id="7iQqdOBerW6" role="2c7tTw">
-                    <node concept="2gteSW" id="7iQqdOBerW7" role="2gteSx">
-                      <property role="2gteSQ" value="2" />
-                      <property role="2gteSD" value="2" />
+                    <node concept="2gteSX" id="7iQqdOBerW7" role="2gteSx">
+                      <property role="2gteSR" value="2" />
+                      <property role="2gteSE" value="2" />
                     </node>
                     <node concept="2gteS_" id="7iQqdOBerW8" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -3339,9 +3585,9 @@
                       </node>
                     </node>
                     <node concept="mLuIC" id="7iQqdOBeEMK" role="2c7tTw">
-                      <node concept="2gteSW" id="7iQqdOBeEML" role="2gteSx">
-                        <property role="2gteSQ" value="1" />
-                        <property role="2gteSD" value="1" />
+                      <node concept="2gteSX" id="7iQqdOBeEML" role="2gteSx">
+                        <property role="2gteSR" value="1" />
+                        <property role="2gteSE" value="1" />
                       </node>
                       <node concept="2gteS_" id="7iQqdOBeEMM" role="2gteVg">
                         <property role="2gteVv" value="0" />
@@ -3355,9 +3601,9 @@
                       </node>
                     </node>
                     <node concept="mLuIC" id="7iQqdOBeEMN" role="2c7tTw">
-                      <node concept="2gteSW" id="7iQqdOBeEMO" role="2gteSx">
-                        <property role="2gteSQ" value="2" />
-                        <property role="2gteSD" value="2" />
+                      <node concept="2gteSX" id="7iQqdOBeEMO" role="2gteSx">
+                        <property role="2gteSR" value="2" />
+                        <property role="2gteSE" value="2" />
                       </node>
                       <node concept="2gteS_" id="7iQqdOBeEMP" role="2gteVg">
                         <property role="2gteVv" value="0" />
@@ -3383,9 +3629,9 @@
                       </node>
                     </node>
                     <node concept="mLuIC" id="7iQqdOBeEMT" role="2c7tTw">
-                      <node concept="2gteSW" id="7iQqdOBeEMU" role="2gteSx">
-                        <property role="2gteSQ" value="1" />
-                        <property role="2gteSD" value="1" />
+                      <node concept="2gteSX" id="7iQqdOBeEMU" role="2gteSx">
+                        <property role="2gteSR" value="1" />
+                        <property role="2gteSE" value="1" />
                       </node>
                       <node concept="2gteS_" id="7iQqdOBeEMV" role="2gteVg">
                         <property role="2gteVv" value="0" />
@@ -3399,9 +3645,9 @@
                       </node>
                     </node>
                     <node concept="mLuIC" id="7iQqdOBeEMW" role="2c7tTw">
-                      <node concept="2gteSW" id="7iQqdOBeEMX" role="2gteSx">
-                        <property role="2gteSQ" value="2" />
-                        <property role="2gteSD" value="2" />
+                      <node concept="2gteSX" id="7iQqdOBeEMX" role="2gteSx">
+                        <property role="2gteSR" value="2" />
+                        <property role="2gteSE" value="2" />
                       </node>
                       <node concept="2gteS_" id="7iQqdOBeEMY" role="2gteVg">
                         <property role="2gteVv" value="0" />
@@ -3472,9 +3718,9 @@
                     </node>
                   </node>
                   <node concept="mLuIC" id="7iQqdOBeLhz" role="2c7tTw">
-                    <node concept="2gteSW" id="7iQqdOBeLh$" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="1" />
+                    <node concept="2gteSX" id="7iQqdOBeLh$" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="1" />
                     </node>
                     <node concept="2gteS_" id="7iQqdOBeLh_" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -3488,9 +3734,9 @@
                     </node>
                   </node>
                   <node concept="mLuIC" id="7iQqdOBeLhA" role="2c7tTw">
-                    <node concept="2gteSW" id="7iQqdOBeLhB" role="2gteSx">
-                      <property role="2gteSQ" value="2" />
-                      <property role="2gteSD" value="2" />
+                    <node concept="2gteSX" id="7iQqdOBeLhB" role="2gteSx">
+                      <property role="2gteSR" value="2" />
+                      <property role="2gteSE" value="2" />
                     </node>
                     <node concept="2gteS_" id="7iQqdOBeLhC" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -3505,9 +3751,9 @@
           <node concept="1ahQXy" id="7iQqdOBeLhF" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="7iQqdOBeLhG" role="3ix9CU">
-              <node concept="2gteSW" id="7iQqdOBeLhH" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="1" />
+              <node concept="2gteSX" id="7iQqdOBeLhH" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="1" />
               </node>
             </node>
           </node>
@@ -3599,9 +3845,9 @@
                       </node>
                     </node>
                     <node concept="mLuIC" id="7iQqdOBeOcd" role="2c7tTw">
-                      <node concept="2gteSW" id="7iQqdOBeOce" role="2gteSx">
-                        <property role="2gteSQ" value="1" />
-                        <property role="2gteSD" value="1" />
+                      <node concept="2gteSX" id="7iQqdOBeOce" role="2gteSx">
+                        <property role="2gteSR" value="1" />
+                        <property role="2gteSE" value="1" />
                       </node>
                       <node concept="2gteS_" id="7iQqdOBeOcf" role="2gteVg">
                         <property role="2gteVv" value="0" />
@@ -3615,9 +3861,9 @@
                       </node>
                     </node>
                     <node concept="mLuIC" id="7iQqdOBeOcj" role="2c7tTw">
-                      <node concept="2gteSW" id="7iQqdOBeOck" role="2gteSx">
-                        <property role="2gteSQ" value="2" />
-                        <property role="2gteSD" value="2" />
+                      <node concept="2gteSX" id="7iQqdOBeOck" role="2gteSx">
+                        <property role="2gteSR" value="2" />
+                        <property role="2gteSE" value="2" />
                       </node>
                       <node concept="2gteS_" id="7iQqdOBeOcl" role="2gteVg">
                         <property role="2gteVv" value="0" />
@@ -3630,9 +3876,9 @@
                 <node concept="m5gfS" id="7iQqdOBeReI" role="188GKc">
                   <node concept="2c7tTJ" id="7iQqdOBeReJ" role="m5gfT">
                     <node concept="mLuIC" id="7iQqdOBeReM" role="2c7tTw">
-                      <node concept="2gteSW" id="7iQqdOBeReN" role="2gteSx">
-                        <property role="2gteSQ" value="1" />
-                        <property role="2gteSD" value="1" />
+                      <node concept="2gteSX" id="7iQqdOBeReN" role="2gteSx">
+                        <property role="2gteSR" value="1" />
+                        <property role="2gteSE" value="1" />
                       </node>
                       <node concept="2gteS_" id="7iQqdOBeReO" role="2gteVg">
                         <property role="2gteVv" value="0" />
@@ -3651,9 +3897,9 @@
                       </node>
                     </node>
                     <node concept="mLuIC" id="7iQqdOBeReS" role="2c7tTw">
-                      <node concept="2gteSW" id="7iQqdOBeReT" role="2gteSx">
-                        <property role="2gteSQ" value="2" />
-                        <property role="2gteSD" value="2" />
+                      <node concept="2gteSX" id="7iQqdOBeReT" role="2gteSx">
+                        <property role="2gteSR" value="2" />
+                        <property role="2gteSE" value="2" />
                       </node>
                       <node concept="2gteS_" id="7iQqdOBeReU" role="2gteVg">
                         <property role="2gteVv" value="0" />
@@ -3677,9 +3923,9 @@
           <node concept="1ahQXy" id="7iQqdOBeNJ1" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="7iQqdOBeNJ2" role="3ix9CU">
-              <node concept="2gteSW" id="7iQqdOBeNJ3" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="2" />
+              <node concept="2gteSX" id="7iQqdOBeNJ3" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="2" />
               </node>
             </node>
           </node>
@@ -3770,9 +4016,9 @@
                     </node>
                   </node>
                   <node concept="mLuIC" id="x6NxUzq8CH" role="2c7tTw">
-                    <node concept="2gteSW" id="x6NxUzq8CI" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="1" />
+                    <node concept="2gteSX" id="x6NxUzq8CI" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="1" />
                     </node>
                     <node concept="2gteS_" id="x6NxUzq8CJ" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -3786,9 +4032,9 @@
                     </node>
                   </node>
                   <node concept="mLuIC" id="x6NxUzq8CN" role="2c7tTw">
-                    <node concept="2gteSW" id="x6NxUzq8CO" role="2gteSx">
-                      <property role="2gteSQ" value="2" />
-                      <property role="2gteSD" value="2" />
+                    <node concept="2gteSX" id="x6NxUzq8CO" role="2gteSx">
+                      <property role="2gteSR" value="2" />
+                      <property role="2gteSE" value="2" />
                     </node>
                     <node concept="2gteS_" id="x6NxUzq8CP" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -3803,9 +4049,9 @@
           <node concept="1ahQXy" id="x6NxUzq8D7" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="x6NxUzq8D8" role="3ix9CU">
-              <node concept="2gteSW" id="x6NxUzq8D9" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="2" />
+              <node concept="2gteSX" id="x6NxUzq8D9" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="2" />
               </node>
             </node>
           </node>
@@ -3895,9 +4141,9 @@
                       </node>
                     </node>
                     <node concept="mLuIC" id="x6NxUzqOzm" role="2c7tTw">
-                      <node concept="2gteSW" id="x6NxUzqOzn" role="2gteSx">
-                        <property role="2gteSQ" value="1" />
-                        <property role="2gteSD" value="1" />
+                      <node concept="2gteSX" id="x6NxUzqOzn" role="2gteSx">
+                        <property role="2gteSR" value="1" />
+                        <property role="2gteSE" value="1" />
                       </node>
                       <node concept="2gteS_" id="x6NxUzqOzo" role="2gteVg">
                         <property role="2gteVv" value="0" />
@@ -3911,9 +4157,9 @@
                       </node>
                     </node>
                     <node concept="mLuIC" id="x6NxUzqOzs" role="2c7tTw">
-                      <node concept="2gteSW" id="x6NxUzqOzt" role="2gteSx">
-                        <property role="2gteSQ" value="2" />
-                        <property role="2gteSD" value="2" />
+                      <node concept="2gteSX" id="x6NxUzqOzt" role="2gteSx">
+                        <property role="2gteSR" value="2" />
+                        <property role="2gteSE" value="2" />
                       </node>
                       <node concept="2gteS_" id="x6NxUzqOzu" role="2gteVg">
                         <property role="2gteVv" value="0" />
@@ -3926,9 +4172,9 @@
                 <node concept="m5gfS" id="x6NxUzqOzx" role="188GKc">
                   <node concept="2c7tTJ" id="x6NxUzqOzy" role="m5gfT">
                     <node concept="mLuIC" id="x6NxUzqOzz" role="2c7tTw">
-                      <node concept="2gteSW" id="x6NxUzqOz$" role="2gteSx">
-                        <property role="2gteSQ" value="1" />
-                        <property role="2gteSD" value="1" />
+                      <node concept="2gteSX" id="x6NxUzqOz$" role="2gteSx">
+                        <property role="2gteSR" value="1" />
+                        <property role="2gteSE" value="1" />
                       </node>
                       <node concept="2gteS_" id="x6NxUzqOz_" role="2gteVg">
                         <property role="2gteVv" value="0" />
@@ -3947,9 +4193,9 @@
                       </node>
                     </node>
                     <node concept="mLuIC" id="x6NxUzqOzF" role="2c7tTw">
-                      <node concept="2gteSW" id="x6NxUzqOzG" role="2gteSx">
-                        <property role="2gteSQ" value="2" />
-                        <property role="2gteSD" value="2" />
+                      <node concept="2gteSX" id="x6NxUzqOzG" role="2gteSx">
+                        <property role="2gteSR" value="2" />
+                        <property role="2gteSE" value="2" />
                       </node>
                       <node concept="2gteS_" id="x6NxUzqOzH" role="2gteVg">
                         <property role="2gteVv" value="0" />
@@ -3969,9 +4215,9 @@
           <node concept="1ahQXy" id="x6NxUzqoyx" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="x6NxUzqoyy" role="3ix9CU">
-              <node concept="2gteSW" id="x6NxUzqoyz" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="2" />
+              <node concept="2gteSX" id="x6NxUzqoyz" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="2" />
               </node>
             </node>
           </node>
@@ -4036,9 +4282,9 @@
                       </node>
                     </node>
                     <node concept="mLuIC" id="x6NxUzqOLo" role="2c7tTw">
-                      <node concept="2gteSW" id="x6NxUzqOLp" role="2gteSx">
-                        <property role="2gteSQ" value="1" />
-                        <property role="2gteSD" value="1" />
+                      <node concept="2gteSX" id="x6NxUzqOLp" role="2gteSx">
+                        <property role="2gteSR" value="1" />
+                        <property role="2gteSE" value="1" />
                       </node>
                       <node concept="2gteS_" id="x6NxUzqOLq" role="2gteVg">
                         <property role="2gteVv" value="0" />
@@ -4052,9 +4298,9 @@
                       </node>
                     </node>
                     <node concept="mLuIC" id="x6NxUzqOLu" role="2c7tTw">
-                      <node concept="2gteSW" id="x6NxUzqOLv" role="2gteSx">
-                        <property role="2gteSQ" value="2" />
-                        <property role="2gteSD" value="2" />
+                      <node concept="2gteSX" id="x6NxUzqOLv" role="2gteSx">
+                        <property role="2gteSR" value="2" />
+                        <property role="2gteSE" value="2" />
                       </node>
                       <node concept="2gteS_" id="x6NxUzqOLw" role="2gteVg">
                         <property role="2gteVv" value="0" />
@@ -4070,9 +4316,9 @@
           <node concept="1ahQXy" id="x6NxUzqOLM" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="x6NxUzqOLN" role="3ix9CU">
-              <node concept="2gteSW" id="x6NxUzqOLO" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="2" />
+              <node concept="2gteSX" id="x6NxUzqOLO" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="2" />
               </node>
             </node>
           </node>
@@ -4197,9 +4443,9 @@
                     </node>
                   </node>
                   <node concept="mLuIC" id="x6NxUzr_Co" role="2c7tTw">
-                    <node concept="2gteSW" id="x6NxUzr_Cp" role="2gteSx">
-                      <property role="2gteSQ" value="0" />
-                      <property role="2gteSD" value="1" />
+                    <node concept="2gteSX" id="x6NxUzr_Cp" role="2gteSx">
+                      <property role="2gteSR" value="0" />
+                      <property role="2gteSE" value="1" />
                     </node>
                     <node concept="2gteS_" id="x6NxUzr_Cq" role="2gteVg">
                       <property role="2gteVv" value="0" />
@@ -4214,9 +4460,9 @@
                       </node>
                     </node>
                     <node concept="mLuIC" id="x6NxUzr_Cs" role="2c7tTw">
-                      <node concept="2gteSW" id="x6NxUzr_Ct" role="2gteSx">
-                        <property role="2gteSQ" value="1" />
-                        <property role="2gteSD" value="2" />
+                      <node concept="2gteSX" id="x6NxUzr_Ct" role="2gteSx">
+                        <property role="2gteSR" value="1" />
+                        <property role="2gteSE" value="2" />
                       </node>
                       <node concept="2gteS_" id="x6NxUzr_Cu" role="2gteVg">
                         <property role="2gteVv" value="0" />
@@ -4227,9 +4473,9 @@
                   <node concept="30bdrU" id="x6NxUzr_Cw" role="m5gfT" />
                 </node>
                 <node concept="mLuIC" id="x6NxUzr_Cx" role="m5gfT">
-                  <node concept="2gteSW" id="x6NxUzr_Cy" role="2gteSx">
-                    <property role="2gteSQ" value="3" />
-                    <property role="2gteSD" value="3.1" />
+                  <node concept="2gteSX" id="x6NxUzr_Cy" role="2gteSx">
+                    <property role="2gteSR" value="3" />
+                    <property role="2gteSE" value="3.1" />
                   </node>
                   <node concept="2gteS_" id="x6NxUzr_Cz" role="2gteVg">
                     <property role="2gteVv" value="1" />
@@ -4241,9 +4487,9 @@
           <node concept="1ahQXy" id="x6NxUzr_C$" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="x6NxUzr_C_" role="3ix9CU">
-              <node concept="2gteSW" id="x6NxUzr_CA" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="1" />
+              <node concept="2gteSX" id="x6NxUzr_CA" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="1" />
               </node>
             </node>
           </node>
@@ -4519,27 +4765,27 @@
           <node concept="1ahQXy" id="6gJ9U953H_t" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="6gJ9U953H_u" role="3ix9CU">
-              <node concept="2gteSW" id="6gJ9U953H_v" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="3" />
+              <node concept="2gteSX" id="6gJ9U953H_v" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="3" />
               </node>
             </node>
           </node>
           <node concept="1ahQXy" id="6gJ9U953H_w" role="1ahQWs">
             <property role="TrG5h" value="b" />
             <node concept="mLuIC" id="6gJ9U953H_x" role="3ix9CU">
-              <node concept="2gteSW" id="6gJ9U953H_y" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="4" />
+              <node concept="2gteSX" id="6gJ9U953H_y" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="4" />
               </node>
             </node>
           </node>
           <node concept="1ahQXy" id="6gJ9U953H_z" role="1ahQWs">
             <property role="TrG5h" value="c" />
             <node concept="mLuIC" id="6gJ9U953H_$" role="3ix9CU">
-              <node concept="2gteSW" id="6gJ9U953H__" role="2gteSx">
-                <property role="2gteSQ" value="1" />
-                <property role="2gteSD" value="2" />
+              <node concept="2gteSX" id="6gJ9U953H__" role="2gteSx">
+                <property role="2gteSR" value="1" />
+                <property role="2gteSE" value="2" />
               </node>
             </node>
           </node>
@@ -4553,9 +4799,9 @@
                     </node>
                   </node>
                   <node concept="mLuIC" id="6gJ9U953H_F" role="2c7tTw">
-                    <node concept="2gteSW" id="6gJ9U953H_G" role="2gteSx">
-                      <property role="2gteSQ" value="1" />
-                      <property role="2gteSD" value="6" />
+                    <node concept="2gteSX" id="6gJ9U953H_G" role="2gteSx">
+                      <property role="2gteSR" value="1" />
+                      <property role="2gteSE" value="6" />
                     </node>
                     <node concept="2gteS_" id="6gJ9U953H_H" role="2gteVg">
                       <property role="2gteVv" value="1" />
@@ -4725,27 +4971,27 @@
           <node concept="1ahQXy" id="6gJ9U954qtg" role="1ahQWs">
             <property role="TrG5h" value="a" />
             <node concept="mLuIC" id="6gJ9U954qth" role="3ix9CU">
-              <node concept="2gteSW" id="6gJ9U954qti" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="3" />
+              <node concept="2gteSX" id="6gJ9U954qti" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="3" />
               </node>
             </node>
           </node>
           <node concept="1ahQXy" id="6gJ9U954qtj" role="1ahQWs">
             <property role="TrG5h" value="b" />
             <node concept="mLuIC" id="6gJ9U954qtk" role="3ix9CU">
-              <node concept="2gteSW" id="6gJ9U954qtl" role="2gteSx">
-                <property role="2gteSQ" value="0" />
-                <property role="2gteSD" value="4" />
+              <node concept="2gteSX" id="6gJ9U954qtl" role="2gteSx">
+                <property role="2gteSR" value="0" />
+                <property role="2gteSE" value="4" />
               </node>
             </node>
           </node>
           <node concept="1ahQXy" id="6gJ9U954qtm" role="1ahQWs">
             <property role="TrG5h" value="c" />
             <node concept="mLuIC" id="6gJ9U954qtn" role="3ix9CU">
-              <node concept="2gteSW" id="6gJ9U954qto" role="2gteSx">
-                <property role="2gteSQ" value="1" />
-                <property role="2gteSD" value="2" />
+              <node concept="2gteSX" id="6gJ9U954qto" role="2gteSx">
+                <property role="2gteSR" value="1" />
+                <property role="2gteSE" value="2" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.base@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.base@tests.mps
@@ -209,7 +209,7 @@
                       <property role="2gteSD" value="∞" />
                     </node>
                     <node concept="2gteS_" id="S9ITXNmIOs" role="2gteVg">
-                      <property role="2gteVv" value="0" />
+                      <property role="2gteVv" value="inf" />
                     </node>
                   </node>
                 </node>


### PR DESCRIPTION
- When calculating the super type of number types, the precision is now correctly set to infinite when one of the types has an infinite precision.
- fixes #1004 
