### PR TITLE
core.expr: Make it possible to deactivate string constraints through the PrimitiveTypeMapper extension point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 - A NullPointerException was fixed for cases where a node implementing IValidNamedConcept had no name.
 - When calculating the supertype of number types, the precision is now correctly set to infinite when one of the types has an infinite precision.
+- The primitiveTypeMapper extension supports a new method `PrimitiveTypeMapper#useStringConstraints` that can be set to false to disable string types with constraints and go back to regular string types.
 
 ## April 2025
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/plugin.mps
@@ -1396,6 +1396,19 @@
       <node concept="3Tm1VV" id="1DSLxNDLbg7" role="1B3o_S" />
       <node concept="10P_77" id="1DSLxNDLe7n" role="3clF45" />
     </node>
+    <node concept="2tJIrI" id="2Jw_KdeTWNN" role="jymVt" />
+    <node concept="3clFb_" id="2Jw_KdeUfi2" role="jymVt">
+      <property role="TrG5h" value="useStringConstraints" />
+      <node concept="3clFbS" id="2Jw_KdeUfi5" role="3clF47">
+        <node concept="3clFbF" id="2Jw_KdeUg5M" role="3cqZAp">
+          <node concept="3clFbT" id="2Jw_Kdf7Hq2" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2Jw_KdeUc0n" role="1B3o_S" />
+      <node concept="10P_77" id="2Jw_KdeUfgb" role="3clF45" />
+    </node>
   </node>
   <node concept="vrV6u" id="WieAE6FJqt">
     <property role="TrG5h" value="primitiveTypeMapper" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/constraints.mps
@@ -1354,5 +1354,19 @@
       </node>
     </node>
   </node>
+  <node concept="1M2fIO" id="2Jw_Kdf9LH9">
+    <property role="3GE5qa" value="string" />
+    <ref role="1M2myG" to="5qo5:2xPWNWpoRmG" resolve="StringTypeWithConstraint" />
+    <node concept="9S07l" id="2Jw_Kdf9LHa" role="9Vyp8">
+      <node concept="3clFbS" id="2Jw_Kdf9LHb" role="2VODD2">
+        <node concept="3clFbF" id="2Jw_Kdf9LUR" role="3cqZAp">
+          <node concept="2YIFZM" id="2Jw_Kdf9LXS" role="3clFbG">
+            <ref role="37wK5l" to="xfg9:2Jw_KdeVcY2" resolve="useStringConstraints" />
+            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/editor.mps
@@ -246,9 +246,6 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
-        <property id="1068580123138" name="value" index="3clFbU" />
-      </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
@@ -1945,9 +1942,10 @@
       <node concept="1eYWM2" id="2xPWNWp$vnN" role="3EZMnx">
         <node concept="1eYwpX" id="2xPWNWp$vnO" role="1eYxym">
           <node concept="3clFbS" id="2xPWNWp$vnP" role="2VODD2">
-            <node concept="3clFbF" id="2xPWNWp$MrS" role="3cqZAp">
-              <node concept="3clFbT" id="2xPWNWp$MrR" role="3clFbG">
-                <property role="3clFbU" value="true" />
+            <node concept="3clFbF" id="2Jw_KdeVc6N" role="3cqZAp">
+              <node concept="2YIFZM" id="2Jw_KdeW0$u" role="3clFbG">
+                <ref role="37wK5l" to="xfg9:2Jw_KdeVcY2" resolve="useStringConstraints" />
+                <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/typesystem.mps
@@ -556,54 +556,82 @@
     <property role="TrG5h" value="typeof_StringLiteral" />
     <property role="3GE5qa" value="string" />
     <node concept="3clFbS" id="4rZeNQ6Pjwj" role="18ibNy">
-      <node concept="1Z5TYs" id="4rZeNQ6Pj$q" role="3cqZAp">
-        <node concept="mw_s8" id="4rZeNQ6Pj$t" role="1ZfhK$">
-          <node concept="1Z2H0r" id="4rZeNQ6Pjwv" role="mwGJk">
-            <node concept="1YBJjd" id="4rZeNQ6PjwJ" role="1Z2MuG">
-              <ref role="1YBMHb" node="4rZeNQ6Pjwl" resolve="sl" />
+      <node concept="3clFbJ" id="2Jw_KdeX7dx" role="3cqZAp">
+        <node concept="3clFbS" id="2Jw_KdeX7dz" role="3clFbx">
+          <node concept="1Z5TYs" id="4rZeNQ6Pj$q" role="3cqZAp">
+            <node concept="mw_s8" id="4rZeNQ6Pj$t" role="1ZfhK$">
+              <node concept="1Z2H0r" id="4rZeNQ6Pjwv" role="mwGJk">
+                <node concept="1YBJjd" id="4rZeNQ6PjwJ" role="1Z2MuG">
+                  <ref role="1YBMHb" node="4rZeNQ6Pjwl" resolve="sl" />
+                </node>
+              </node>
             </node>
-          </node>
-        </node>
-        <node concept="mw_s8" id="hTGlT9U4aN" role="1ZfhKB">
-          <node concept="2pJPEk" id="2xPWNWpqoAU" role="mwGJk">
-            <node concept="2pJPED" id="2xPWNWpqoAW" role="2pJPEn">
-              <ref role="2pJxaS" to="5qo5:2xPWNWpoRmG" resolve="StringTypeWithConstraint" />
-              <node concept="2pIpSj" id="2xPWNWpqoOr" role="2pJxcM">
-                <ref role="2pIpSl" to="5qo5:2xPWNWprAOp" resolve="constraint" />
-                <node concept="36biLy" id="2xPWNWpqpxY" role="28nt2d">
-                  <node concept="2pJPEk" id="hTGlT9U0Ol" role="36biLW">
-                    <node concept="2pJPED" id="hTGlT9U0On" role="2pJPEn">
-                      <ref role="2pJxaS" to="tpfo:h5OC9$H" resolve="StringLiteralRegexp" />
-                      <node concept="2pJxcG" id="hTGlT9U0SX" role="2pJxcM">
-                        <ref role="2pJxcJ" to="tpfo:h5OCbxf" resolve="text" />
-                        <node concept="WxPPo" id="hTGlT9U0Vy" role="28ntcv">
-                          <node concept="3K4zz7" id="3g7FMHmyHgA" role="WxPPp">
-                            <node concept="2OqwBi" id="3g7FMHmyHwR" role="3K4E3e">
-                              <node concept="1YBJjd" id="3g7FMHmyHkd" role="2Oq$k0">
-                                <ref role="1YBMHb" node="4rZeNQ6Pjwl" resolve="sl" />
-                              </node>
-                              <node concept="3TrcHB" id="3g7FMHmyHyi" role="2OqNvi">
-                                <ref role="3TsBF5" to="5qo5:4rZeNQ6OYRb" resolve="value" />
-                              </node>
-                            </node>
-                            <node concept="Xl_RD" id="3g7FMHmyHB3" role="3K4GZi">
-                              <property role="Xl_RC" value="" />
-                            </node>
-                            <node concept="2OqwBi" id="3g7FMHmyF9a" role="3K4Cdx">
-                              <node concept="2OqwBi" id="hTGlT9U1bJ" role="2Oq$k0">
-                                <node concept="1YBJjd" id="hTGlT9U0Vw" role="2Oq$k0">
-                                  <ref role="1YBMHb" node="4rZeNQ6Pjwl" resolve="sl" />
+            <node concept="mw_s8" id="hTGlT9U4aN" role="1ZfhKB">
+              <node concept="2pJPEk" id="2xPWNWpqoAU" role="mwGJk">
+                <node concept="2pJPED" id="2xPWNWpqoAW" role="2pJPEn">
+                  <ref role="2pJxaS" to="5qo5:2xPWNWpoRmG" resolve="StringTypeWithConstraint" />
+                  <node concept="2pIpSj" id="2xPWNWpqoOr" role="2pJxcM">
+                    <ref role="2pIpSl" to="5qo5:2xPWNWprAOp" resolve="constraint" />
+                    <node concept="36biLy" id="2xPWNWpqpxY" role="28nt2d">
+                      <node concept="2pJPEk" id="hTGlT9U0Ol" role="36biLW">
+                        <node concept="2pJPED" id="hTGlT9U0On" role="2pJPEn">
+                          <ref role="2pJxaS" to="tpfo:h5OC9$H" resolve="StringLiteralRegexp" />
+                          <node concept="2pJxcG" id="hTGlT9U0SX" role="2pJxcM">
+                            <ref role="2pJxcJ" to="tpfo:h5OCbxf" resolve="text" />
+                            <node concept="WxPPo" id="hTGlT9U0Vy" role="28ntcv">
+                              <node concept="3K4zz7" id="3g7FMHmyHgA" role="WxPPp">
+                                <node concept="2OqwBi" id="3g7FMHmyHwR" role="3K4E3e">
+                                  <node concept="1YBJjd" id="3g7FMHmyHkd" role="2Oq$k0">
+                                    <ref role="1YBMHb" node="4rZeNQ6Pjwl" resolve="sl" />
+                                  </node>
+                                  <node concept="3TrcHB" id="3g7FMHmyHyi" role="2OqNvi">
+                                    <ref role="3TsBF5" to="5qo5:4rZeNQ6OYRb" resolve="value" />
+                                  </node>
                                 </node>
-                                <node concept="3TrcHB" id="hTGlT9U1$E" role="2OqNvi">
-                                  <ref role="3TsBF5" to="5qo5:4rZeNQ6OYRb" resolve="value" />
+                                <node concept="Xl_RD" id="3g7FMHmyHB3" role="3K4GZi">
+                                  <property role="Xl_RC" value="" />
+                                </node>
+                                <node concept="2OqwBi" id="3g7FMHmyF9a" role="3K4Cdx">
+                                  <node concept="2OqwBi" id="hTGlT9U1bJ" role="2Oq$k0">
+                                    <node concept="1YBJjd" id="hTGlT9U0Vw" role="2Oq$k0">
+                                      <ref role="1YBMHb" node="4rZeNQ6Pjwl" resolve="sl" />
+                                    </node>
+                                    <node concept="3TrcHB" id="hTGlT9U1$E" role="2OqNvi">
+                                      <ref role="3TsBF5" to="5qo5:4rZeNQ6OYRb" resolve="value" />
+                                    </node>
+                                  </node>
+                                  <node concept="17RvpY" id="3g7FMHmyG0L" role="2OqNvi" />
                                 </node>
                               </node>
-                              <node concept="17RvpY" id="3g7FMHmyG0L" role="2OqNvi" />
                             </node>
                           </node>
                         </node>
                       </node>
                     </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2YIFZM" id="2Jw_KdeX7kE" role="3clFbw">
+          <ref role="37wK5l" to="xfg9:2Jw_KdeVcY2" resolve="useStringConstraints" />
+          <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+        </node>
+        <node concept="9aQIb" id="2Jw_KdeX7Aa" role="9aQIa">
+          <node concept="3clFbS" id="2Jw_KdeX7Ab" role="9aQI4">
+            <node concept="1Z5TYs" id="2Jw_KdeX88o" role="3cqZAp">
+              <node concept="mw_s8" id="2Jw_KdeX88r" role="1ZfhK$">
+                <node concept="1Z2H0r" id="2Jw_KdeX7OX" role="mwGJk">
+                  <node concept="1YBJjd" id="2Jw_KdeX7Uk" role="1Z2MuG">
+                    <ref role="1YBMHb" node="4rZeNQ6Pjwl" resolve="sl" />
+                  </node>
+                </node>
+              </node>
+              <node concept="mw_s8" id="4rZeNQ6Pj$I" role="1ZfhKB">
+                <node concept="2pJPEk" id="4rZeNQ6Pj$E" role="mwGJk">
+                  <node concept="2pJPED" id="4rZeNQ6Pj$T" role="2pJPEn">
+                    <ref role="2pJxaS" to="5qo5:4rZeNQ6OYR7" resolve="StringType" />
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.runtime/models/runtime.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.runtime/models/runtime.mps
@@ -1445,6 +1445,24 @@
       <node concept="10P_77" id="1DSLxNDLgVN" role="3clF45" />
       <node concept="3Tm1VV" id="1DSLxNDLgVO" role="1B3o_S" />
     </node>
+    <node concept="2tJIrI" id="2Jw_KdeUiPj" role="jymVt" />
+    <node concept="2YIFZL" id="2Jw_KdeVcY2" role="jymVt">
+      <property role="TrG5h" value="useStringConstraints" />
+      <node concept="3clFbS" id="2Jw_KdeVcY4" role="3clF47">
+        <node concept="3clFbF" id="2Jw_KdeVcY5" role="3cqZAp">
+          <node concept="2OqwBi" id="2Jw_KdeVcY6" role="3clFbG">
+            <node concept="1rXfSq" id="2Jw_KdeVcY7" role="2Oq$k0">
+              <ref role="37wK5l" node="2Qbt$1tTQn5" resolve="resolveMapper" />
+            </node>
+            <node concept="liA8E" id="2Jw_KdeVcY8" role="2OqNvi">
+              <ref role="37wK5l" to="oq0c:2Jw_KdeUfi2" resolve="useStringConstraints" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="2Jw_KdeVcYa" role="3clF45" />
+      <node concept="3Tm1VV" id="2Jw_KdeVcY9" role="1B3o_S" />
+    </node>
     <node concept="2tJIrI" id="2Qbt$1tTQb0" role="jymVt" />
     <node concept="3Tm1VV" id="2Qbt$1tTQaI" role="1B3o_S" />
   </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.plugin.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.plugin.mps
@@ -8,6 +8,8 @@
     <use id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension" version="2" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
   </languages>
   <imports>
     <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" />
@@ -16,6 +18,10 @@
     <import index="i3ya" ref="r:4f64e2f0-6a4e-4db3-b3bf-7977f44949b6(org.iets3.core.expr.typetags.physunits.structure)" />
     <import index="x0pf" ref="r:d4f1532d-fc5c-419f-84ee-daef42867c8e(org.iets3.core.expr.typetags.physunits.typesystem)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="9mim" ref="r:5bf19129-2710-45a6-906e-9ee2d0977853(org.iets3.core.expr.simpleTypes.plugin)" />
+    <import index="oq0c" ref="r:6c6155f0-4bbe-4af5-8c26-244d570e21e4(org.iets3.core.expr.base.plugin)" />
+    <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -23,6 +29,11 @@
       <concept id="7520713872864775836" name="jetbrains.mps.lang.plugin.standalone.structure.StandalonePluginDescriptor" flags="ng" index="2DaZZR" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
@@ -32,6 +43,10 @@
       </concept>
       <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
         <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
       <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
         <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
@@ -44,6 +59,10 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
@@ -51,6 +70,7 @@
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <child id="1095933932569" name="implementedInterface" index="EKbjA" />
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
@@ -61,6 +81,7 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -82,15 +103,31 @@
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1073063089578" name="jetbrains.mps.baseLanguage.structure.SuperMethodCall" flags="nn" index="3nyPlj" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
@@ -99,6 +136,10 @@
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
+        <reference id="1116615189566" name="classifier" index="3VsUkX" />
+      </concept>
     </language>
     <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
       <concept id="126958800891274162" name="jetbrains.mps.lang.extension.structure.Extension" flags="ig" index="1lYeZD">
@@ -116,6 +157,11 @@
       <concept id="6478870542308703666" name="jetbrains.mps.baseLanguage.lightweightdsl.structure.MemberPlaceholder" flags="ng" index="3tTeZs">
         <property id="6478870542308703667" name="caption" index="3tTeZt" />
         <reference id="6478870542308703669" name="decl" index="3tTeZr" />
+      </concept>
+    </language>
+    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
+      <concept id="6332851714983831325" name="jetbrains.mps.baseLanguage.logging.structure.MsgStatement" flags="ng" index="2xdQw9">
+        <child id="5721587534047265374" name="message" index="9lYJi" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
@@ -491,6 +537,215 @@
       <node concept="q3mfm" id="7TK9se3Zi5o" role="3clF45">
         <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
         <ref role="1QQUv3" node="7TK9se3Zi5i" resolve="get" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="3p6$WoErNuK">
+    <property role="TrG5h" value="TestStringConstraintsPrimitiveTypeMapper" />
+    <node concept="Wx3nA" id="1t_lOkUhePP" role="jymVt">
+      <property role="TrG5h" value="priorityDelta" />
+      <node concept="3Tm6S6" id="1t_lOkUhdQD" role="1B3o_S" />
+      <node concept="10Oyi0" id="1t_lOkUhevX" role="1tU5fm" />
+      <node concept="3cmrfG" id="1t_lOkUhf25" role="33vP2m">
+        <property role="3cmrfH" value="-2" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1t_lOkUhf7U" role="jymVt" />
+    <node concept="3Tm1VV" id="3p6$WoErNuL" role="1B3o_S" />
+    <node concept="3uibUv" id="1t_lOkU8DdU" role="1zkMxy">
+      <ref role="3uigEE" to="9mim:3p6$WoErNuK" resolve="SimpleTypesPrimitiveTypeMapper" />
+    </node>
+    <node concept="2YIFZL" id="1t_lOkUhm8p" role="jymVt">
+      <property role="TrG5h" value="enable" />
+      <node concept="3clFbS" id="1t_lOkUhm8q" role="3clF47">
+        <node concept="3clFbF" id="1t_lOkUhm8r" role="3cqZAp">
+          <node concept="37vLTI" id="1t_lOkUhm8s" role="3clFbG">
+            <node concept="3cmrfG" id="1t_lOkUhm8t" role="37vLTx">
+              <property role="3cmrfH" value="2" />
+            </node>
+            <node concept="37vLTw" id="3iqDEt4GARW" role="37vLTJ">
+              <ref role="3cqZAo" node="1t_lOkUhePP" resolve="priorityDelta" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1t_lOkUhpIo" role="3cqZAp">
+          <node concept="2YIFZM" id="1t_lOkUhpIp" role="3clFbG">
+            <ref role="37wK5l" to="xfg9:3scC7xmH7fx" resolve="invalidateCache" />
+            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1t_lOkUnmf2" role="3cqZAp">
+          <node concept="3cpWsn" id="1t_lOkUnmf3" role="3cpWs9">
+            <property role="TrG5h" value="msg" />
+            <node concept="17QB3L" id="1t_lOkUnl8L" role="1tU5fm" />
+            <node concept="3cpWs3" id="1t_lOkUnmf4" role="33vP2m">
+              <node concept="2OqwBi" id="1t_lOkUnmf5" role="3uHU7w">
+                <node concept="3VsKOn" id="1t_lOkUnmf6" role="2Oq$k0">
+                  <ref role="3VsUkX" node="3p6$WoErNuK" resolve="TestStringConstraintsPrimitiveTypeMapper" />
+                </node>
+                <node concept="liA8E" id="1t_lOkUnmf7" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Class.getName()" resolve="getName" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="1t_lOkUnmf8" role="3uHU7B">
+                <property role="Xl_RC" value="enabled " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2xdQw9" id="1t_lOkUnhQO" role="3cqZAp">
+          <node concept="37vLTw" id="1t_lOkUnmf9" role="9lYJi">
+            <ref role="3cqZAo" node="1t_lOkUnmf3" resolve="msg" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="1t_lOkUnoHs" role="3cqZAp">
+          <node concept="2OqwBi" id="1t_lOkUnoHt" role="3clFbG">
+            <node concept="10M0yZ" id="1t_lOkUnoHu" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+            </node>
+            <node concept="liA8E" id="1t_lOkUnoHv" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="37vLTw" id="1t_lOkUnoHw" role="37wK5m">
+                <ref role="3cqZAo" node="1t_lOkUnmf3" resolve="msg" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1t_lOkUhm8v" role="1B3o_S" />
+      <node concept="3cqZAl" id="1t_lOkUhm8w" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="1t_lOkUhmnl" role="jymVt" />
+    <node concept="2YIFZL" id="1t_lOkUhhqx" role="jymVt">
+      <property role="TrG5h" value="disable" />
+      <node concept="3clFbS" id="1t_lOkUhhq$" role="3clF47">
+        <node concept="3clFbF" id="1t_lOkUhiUV" role="3cqZAp">
+          <node concept="37vLTI" id="1t_lOkUhloA" role="3clFbG">
+            <node concept="3cmrfG" id="1t_lOkUhlA_" role="37vLTx">
+              <property role="3cmrfH" value="-2" />
+            </node>
+            <node concept="37vLTw" id="3iqDEt4GATA" role="37vLTJ">
+              <ref role="3cqZAo" node="1t_lOkUhePP" resolve="priorityDelta" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1t_lOkUhpab" role="3cqZAp">
+          <node concept="2YIFZM" id="1t_lOkUhpzn" role="3clFbG">
+            <ref role="37wK5l" to="xfg9:3scC7xmH7fx" resolve="invalidateCache" />
+            <ref role="1Pybhc" to="xfg9:2Qbt$1tTQaH" resolve="PTF" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="1t_lOkUnlvh" role="3cqZAp">
+          <node concept="3cpWsn" id="1t_lOkUnlvi" role="3cpWs9">
+            <property role="TrG5h" value="msg" />
+            <node concept="17QB3L" id="1t_lOkUnl8W" role="1tU5fm" />
+            <node concept="3cpWs3" id="1t_lOkUnlvj" role="33vP2m">
+              <node concept="2OqwBi" id="1t_lOkUnlvk" role="3uHU7w">
+                <node concept="3VsKOn" id="1t_lOkUnlvl" role="2Oq$k0">
+                  <ref role="3VsUkX" node="3p6$WoErNuK" resolve="TestStringConstraintsPrimitiveTypeMapper" />
+                </node>
+                <node concept="liA8E" id="1t_lOkUnlvm" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Class.getName()" resolve="getName" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="1t_lOkUnlvn" role="3uHU7B">
+                <property role="Xl_RC" value="disabled " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2xdQw9" id="1t_lOkUnd42" role="3cqZAp">
+          <node concept="37vLTw" id="1t_lOkUnlvo" role="9lYJi">
+            <ref role="3cqZAo" node="1t_lOkUnlvi" resolve="msg" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="1t_lOkUnnjt" role="3cqZAp">
+          <node concept="2OqwBi" id="1t_lOkUnnjq" role="3clFbG">
+            <node concept="10M0yZ" id="1t_lOkUnnjr" role="2Oq$k0">
+              <ref role="1PxDUh" to="wyt6:~System" resolve="System" />
+              <ref role="3cqZAo" to="wyt6:~System.out" resolve="out" />
+            </node>
+            <node concept="liA8E" id="1t_lOkUnnjs" role="2OqNvi">
+              <ref role="37wK5l" to="guwi:~PrintStream.println(java.lang.String)" resolve="println" />
+              <node concept="37vLTw" id="1t_lOkUnnEo" role="37wK5m">
+                <ref role="3cqZAo" node="1t_lOkUnlvi" resolve="msg" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1t_lOkUhgAI" role="1B3o_S" />
+      <node concept="3cqZAl" id="1t_lOkUhhjt" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="1t_lOkUhioB" role="jymVt" />
+    <node concept="3clFb_" id="1t_lOkUcJMO" role="jymVt">
+      <property role="TrG5h" value="getPriorityLevel" />
+      <node concept="10Oyi0" id="1t_lOkUcJMP" role="3clF45" />
+      <node concept="3Tm1VV" id="1t_lOkUcJMQ" role="1B3o_S" />
+      <node concept="3clFbS" id="1t_lOkUcJMU" role="3clF47">
+        <node concept="3clFbF" id="1t_lOkUcJMX" role="3cqZAp">
+          <node concept="3cpWs3" id="1t_lOkUcMrm" role="3clFbG">
+            <node concept="37vLTw" id="1t_lOkUhfM$" role="3uHU7w">
+              <ref role="3cqZAo" node="1t_lOkUhePP" resolve="priorityDelta" />
+            </node>
+            <node concept="3nyPlj" id="1t_lOkUcJMW" role="3uHU7B">
+              <ref role="37wK5l" to="9mim:3p6$WoErNw8" resolve="getPriorityLevel" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1t_lOkUcJMV" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1t_lOkUhfW_" role="jymVt" />
+    <node concept="3clFb_" id="3iqDEt4JfKY" role="jymVt">
+      <property role="TrG5h" value="useStringConstraints" />
+      <node concept="3Tm1VV" id="3iqDEt4JfL2" role="1B3o_S" />
+      <node concept="10P_77" id="3iqDEt4JfL3" role="3clF45" />
+      <node concept="3clFbS" id="3iqDEt4JfL5" role="3clF47">
+        <node concept="3clFbF" id="3iqDEt4JiVD" role="3cqZAp">
+          <node concept="3clFbT" id="3iqDEt4JiVC" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="3iqDEt4JfL6" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1t_lOkUhg6_" role="jymVt" />
+  </node>
+  <node concept="1lYeZD" id="WieAE6MnzD">
+    <property role="2bfB8j" value="true" />
+    <property role="TrG5h" value="TestStringConstraintsPrimitiveTypeMapper_extension" />
+    <ref role="1lYe$Y" to="oq0c:WieAE6FJqt" resolve="primitiveTypeMapper" />
+    <node concept="3Tm1VV" id="5NPKd17x9zQ" role="1B3o_S" />
+    <node concept="2tJIrI" id="5NPKd17x9zS" role="jymVt" />
+    <node concept="3tTeZs" id="1t_lOkUdpdM" role="jymVt">
+      <property role="3tTeZt" value="activate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0CPy" resolve="activate" />
+    </node>
+    <node concept="3tTeZs" id="1t_lOkUcssQ" role="jymVt">
+      <property role="3tTeZt" value="deactivate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+    </node>
+    <node concept="2tJIrI" id="5NPKd17x9zT" role="jymVt" />
+    <node concept="q3mfD" id="5NPKd17x9zU" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="5NPKd17x9zV" role="1B3o_S" />
+      <node concept="3clFbS" id="5NPKd17x9zW" role="3clF47">
+        <node concept="3clFbF" id="1t_lOkUcsps" role="3cqZAp">
+          <node concept="2ShNRf" id="3scC7xmHczd" role="3clFbG">
+            <node concept="HV5vD" id="3scC7xmHcze" role="2ShVmc">
+              <ref role="HV5vE" node="3p6$WoErNuK" resolve="TestStringConstraintsPrimitiveTypeMapper" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="5NPKd17x9zX" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="5NPKd17x9zU" resolve="get" />
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -42,6 +42,8 @@
     <import index="ym7l" ref="r:050f6d52-a81b-4b31-9a1c-531c1a04708e(org.iets3.core.expr.simpleTypes.typesystem)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="h60k" ref="r:2ef874f0-eb83-423c-afd2-f0c0921489b8(org.iets3.core.expr.simpleTypes.migration)" />
+    <import index="cp9o" ref="r:df6d55ea-0ac0-4364-9581-8cb45ef224d6(test.ts.expr.os.plugin)" />
+    <import index="1ka" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.typechecking(MPS.Core/)" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
@@ -51,6 +53,8 @@
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="2325284917965760583" name="jetbrains.mps.lang.test.structure.BeforeTestsMethod" flags="ig" index="0EjCn" />
+      <concept id="2325284917965760584" name="jetbrains.mps.lang.test.structure.AfterTestsMethod" flags="ig" index="0EjCo" />
       <concept id="1215507671101" name="jetbrains.mps.lang.test.structure.NodeErrorCheckOperation" flags="ng" index="1TM$A">
         <child id="8489045168660938517" name="errorRef" index="3lydEf" />
       </concept>
@@ -94,6 +98,8 @@
       </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="2325284917965993569" name="beforeTests" index="0EEgL" />
+        <child id="2325284917965993580" name="afterTests" index="0EEgW" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
         <child id="1217501895093" name="testMethods" index="1SL9yI" />
       </concept>
@@ -177,6 +183,9 @@
       </concept>
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
@@ -32122,6 +32131,75 @@
           <node concept="m5gfS" id="1$atYL2B6pK" role="2zM23F">
             <node concept="30bXR$" id="1$atYL2B6pL" role="m5gfT" />
             <node concept="30bXR$" id="1$atYL2B6pM" role="m5gfT" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="3iqDEt4GRQk">
+    <property role="TrG5h" value="stringConstraintsDisabled" />
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <node concept="1qefOq" id="3iqDEt4NJtm" role="1SKRRt">
+      <node concept="2zPypq" id="3iqDEt4NJZR" role="1qenE9">
+        <property role="TrG5h" value="a" />
+        <node concept="30bdrP" id="3iqDEt4NK0_" role="2lDidJ">
+          <property role="30bdrQ" value="hello" />
+        </node>
+        <node concept="L5Cqj" id="3iqDEt4NK05" role="2zM23F">
+          <node concept="1ZmeGV" id="3iqDEt4NK0l" role="1_tvlM">
+            <ref role="1ZmksB" node="45$ooctvHpr" resolve="hello" />
+          </node>
+          <node concept="7CXmI" id="3iqDEt4NZLV" role="lGtFl">
+            <node concept="39XrGg" id="3iqDEt4NZVN" role="7EUXB">
+              <node concept="2u4KIi" id="3iqDEt4NZVO" role="39rjcI">
+                <ref role="39XzEq" to="2e51:2Jw_Kdf9LHa" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1LZb2c" id="3iqDEt4LZP7" role="1SL9yI">
+      <property role="TrG5h" value="typeCalculation" />
+      <node concept="3cqZAl" id="3iqDEt4LZP8" role="3clF45" />
+      <node concept="3clFbS" id="3iqDEt4LZPc" role="3clF47">
+        <node concept="3GXo0L" id="3iqDEt4M1bt" role="3cqZAp">
+          <node concept="2c44tf" id="3iqDEt4M1fP" role="3tpDZB">
+            <node concept="30bdrU" id="3iqDEt4M1h8" role="2c44tc" />
+          </node>
+          <node concept="2OqwBi" id="3iqDEt4M0vu" role="3tpDZA">
+            <node concept="2YIFZM" id="3iqDEt4M01Z" role="2Oq$k0">
+              <ref role="37wK5l" to="1ka:~TypecheckingFacade.getFromContext()" resolve="getFromContext" />
+              <ref role="1Pybhc" to="1ka:~TypecheckingFacade" resolve="TypecheckingFacade" />
+            </node>
+            <node concept="liA8E" id="3iqDEt4M10q" role="2OqNvi">
+              <ref role="37wK5l" to="1ka:~TypecheckingFacade.getTypeOf(org.jetbrains.mps.openapi.model.SNode)" resolve="getTypeOf" />
+              <node concept="2c44tf" id="3iqDEt4M11a" role="37wK5m">
+                <node concept="30bdrP" id="3iqDEt4M12_" role="2c44tc">
+                  <property role="30bdrQ" value="Test" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="0EjCn" id="3iqDEt4I49k" role="0EEgL">
+      <node concept="3clFbS" id="3iqDEt4I49l" role="2VODD2">
+        <node concept="3clFbF" id="3iqDEt4I4fl" role="3cqZAp">
+          <node concept="2YIFZM" id="3iqDEt4I4l1" role="3clFbG">
+            <ref role="37wK5l" to="cp9o:1t_lOkUhm8p" resolve="enable" />
+            <ref role="1Pybhc" to="cp9o:3p6$WoErNuK" resolve="TestStringConstraintsPrimitiveTypeMapper" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="0EjCo" id="3iqDEt4I4nf" role="0EEgW">
+      <node concept="3clFbS" id="3iqDEt4I4ng" role="2VODD2">
+        <node concept="3clFbF" id="3iqDEt4I4u4" role="3cqZAp">
+          <node concept="2YIFZM" id="3iqDEt4I4$4" role="3clFbG">
+            <ref role="37wK5l" to="cp9o:1t_lOkUhhqx" resolve="disable" />
+            <ref role="1Pybhc" to="cp9o:3p6$WoErNuK" resolve="TestStringConstraintsPrimitiveTypeMapper" />
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
@@ -55,6 +55,7 @@
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="2" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:daafa647-f1f7-4b0b-b096-69cd7c8408c0:jetbrains.mps.baseLanguage.regexp" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />


### PR DESCRIPTION
The primitiveTypeMapper extension supports a new method, `PrimitiveTypeMapper#useStringConstraints, ` which can be set to false to disable string types with constraints and go back to regular string types. The default implementation activates the string constraints, so we don't have another breaking change. Fixes https://github.com/IETS3/iets3.opensource/issues/1182