### PR TITLE
sbom: include only runtime configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## June 2025
+
+### Changed
+
+- Published SBOM contains dependencies only from runtime configurations
+
 ## May 2025
 
 ### Changed

--- a/build.gradle
+++ b/build.gradle
@@ -584,4 +584,8 @@ cyclonedxBom {
     outputFormat = "json"
     // Don't include license texts in generated SBOMs
     includeLicenseText = false
+    // Include runtime only deps (bundled libs, language libs, mps)
+    def runtimeConfigs = bundledDeps.collect {it.configName }
+    runtimeConfigs.addAll([configurations.mps.name, configurations.languageLibs.name])
+    includeConfigs = runtimeConfigs
 }


### PR DESCRIPTION
Published SBOM for the main `org.iets3.opensource` publication contains dependencies from runtime configurations only.