### PR TITLE
issue warning for bang operator in case of non-option expression type

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
@@ -276,6 +276,9 @@
       </concept>
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1207055528241" name="jetbrains.mps.lang.typesystem.structure.WarningStatement" flags="nn" index="a7r0C">
+        <child id="1207055552304" name="warningText" index="a7wSD" />
+      </concept>
       <concept id="1766949807893567867" name="jetbrains.mps.lang.typesystem.structure.OverridesConceptFunction" flags="ig" index="bXqS6" />
       <concept id="1185788614172" name="jetbrains.mps.lang.typesystem.structure.NormalTypeClause" flags="ng" index="mw_s8">
         <child id="1185788644032" name="normalType" index="mwGJk" />
@@ -11143,6 +11146,47 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="3eH6BL2UU3s" role="1B3o_S" />
+  </node>
+  <node concept="18kY7G" id="6rS$_kMPZL2">
+    <property role="TrG5h" value="check_BangOp" />
+    <node concept="3clFbS" id="6rS$_kMPZL3" role="18ibNy">
+      <node concept="3clFbJ" id="6rS$_kMQ0WU" role="3cqZAp">
+        <node concept="3fqX7Q" id="6rS$_kMQ2_Q" role="3clFbw">
+          <node concept="2OqwBi" id="6rS$_kMQ2_S" role="3fr31v">
+            <node concept="2OqwBi" id="6rS$_kMQ2_T" role="2Oq$k0">
+              <node concept="2OqwBi" id="6rS$_kMQ2_U" role="2Oq$k0">
+                <node concept="1YBJjd" id="6rS$_kMQ2_V" role="2Oq$k0">
+                  <ref role="1YBMHb" node="6rS$_kMPZL5" resolve="bangOp" />
+                </node>
+                <node concept="3TrEf2" id="6rS$_kMQ2_W" role="2OqNvi">
+                  <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
+                </node>
+              </node>
+              <node concept="3JvlWi" id="6rS$_kMQ2_X" role="2OqNvi" />
+            </node>
+            <node concept="1mIQ4w" id="6rS$_kMQ2_Y" role="2OqNvi">
+              <node concept="chp4Y" id="6rS$_kMQ2_Z" role="cj9EA">
+                <ref role="cht4Q" to="hm2y:2rOWEwsEjcg" resolve="OptionType" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbS" id="6rS$_kMQ0WW" role="3clFbx">
+          <node concept="a7r0C" id="6rS$_kMQ2Ju" role="3cqZAp">
+            <node concept="Xl_RD" id="6rS$_kMQ2JB" role="a7wSD">
+              <property role="Xl_RC" value="Bang operator applied for an expression of a non-option type" />
+            </node>
+            <node concept="1YBJjd" id="6rS$_kMQ2UR" role="1urrMF">
+              <ref role="1YBMHb" node="6rS$_kMPZL5" resolve="bangOp" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="6rS$_kMPZL5" role="1YuTPh">
+      <property role="TrG5h" value="bangOp" />
+      <ref role="1YaFvo" to="hm2y:24Fec4173Us" resolve="BangOp" />
+    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -18704,9 +18704,7 @@
       <node concept="_iOnV" id="3N4k0eSJKEP" role="1qenE9">
         <property role="TrG5h" value="options" />
         <node concept="7CXmI" id="3N4k0eSJKJc" role="lGtFl">
-          <node concept="7OXhh" id="3N4k0eSJKJd" role="7EUXB">
-            <property role="G7GLP" value="true" />
-          </node>
+          <node concept="7OXhh" id="3N4k0eSJKJd" role="7EUXB" />
         </node>
         <node concept="2zPypq" id="3N4k0eSJPou" role="_iOnC">
           <property role="TrG5h" value="x" />
@@ -18867,6 +18865,23 @@
           <node concept="wdKpt" id="2$mkTNp$YhK" role="2lDidJ">
             <node concept="_emDc" id="24Fec41hnmE" role="2lDidJ">
               <ref role="_emDf" node="3N4k0eSJPou" resolve="x" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="6rS$_kMYE5Q" role="_iOnC">
+          <property role="TrG5h" value="xDeOptedTwice" />
+          <node concept="wdKpt" id="6rS$_kMYGUP" role="2lDidJ">
+            <node concept="wdKpt" id="6rS$_kMYH78" role="2lDidJ">
+              <node concept="_emDc" id="6rS$_kMYGUt" role="2lDidJ">
+                <ref role="_emDf" node="3N4k0eSJPou" resolve="x" />
+              </node>
+            </node>
+            <node concept="7CXmI" id="4OZmL8HJRId" role="lGtFl">
+              <node concept="29bkU" id="4OZmL8HJS8e" role="7EUXB">
+                <node concept="2PQEqo" id="4OZmL8HJS8f" role="3lydCh">
+                  <ref role="39XzEq" to="t4jv:6rS$_kMQ2Ju" />
+                </node>
+              </node>
             </node>
           </node>
         </node>


### PR DESCRIPTION
Bang operator (`!`) normally cannot be used for expressions of a non-option type. However, this scenario is still possible if the model has been refactored or if the user unconsciously created an expression with bang operator placed there before the actual expression. Although the interpreter can still handle this scenario, it's probably a code-smell and could cause other unwanted side-effects in user models.

To avoid usage of bang operator for non-option expression types, there is now a warning informing the user of a potential problem.