### PR TITLE
Bugfix/assessments and coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 ### Fixed
 
 - Expressions of ShortLambdas are now correctly updated and used for interpretation after they are changed
+- API for coverage calculation and restored original functionality. Coverage is now calculated during interpreter execution
+- Duplicated colors for PARTIAL and IGNORED 
+
+### Added
+- CI tests for InterpreterCoverageAssQuery which make use use the calculated coverage data
 
 ## May 2025
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -26553,13 +26553,13 @@
             <node concept="1pGfFk" id="7LZDtvhKJOU" role="2ShVmc">
               <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
               <node concept="3cmrfG" id="7LZDtvhKJOV" role="37wK5m">
-                <property role="3cmrfH" value="237" />
+                <property role="3cmrfH" value="244" />
               </node>
               <node concept="3cmrfG" id="7LZDtvhKJOW" role="37wK5m">
-                <property role="3cmrfH" value="134" />
+                <property role="3cmrfH" value="244" />
               </node>
               <node concept="3cmrfG" id="7LZDtvhKJOX" role="37wK5m">
-                <property role="3cmrfH" value="0" />
+                <property role="3cmrfH" value="244" />
               </node>
             </node>
           </node>
@@ -26567,13 +26567,13 @@
             <node concept="1pGfFk" id="7LZDtvhKJOZ" role="2ShVmc">
               <ref role="37wK5l" to="z60i:~Color.&lt;init&gt;(int,int,int)" resolve="Color" />
               <node concept="3cmrfG" id="7LZDtvhKJP0" role="37wK5m">
-                <property role="3cmrfH" value="237" />
+                <property role="3cmrfH" value="244" />
               </node>
               <node concept="3cmrfG" id="7LZDtvhKJP1" role="37wK5m">
-                <property role="3cmrfH" value="134" />
+                <property role="3cmrfH" value="244" />
               </node>
               <node concept="3cmrfG" id="7LZDtvhKJP2" role="37wK5m">
-                <property role="3cmrfH" value="0" />
+                <property role="3cmrfH" value="244" />
               </node>
             </node>
           </node>
@@ -26676,14 +26676,14 @@
             <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
             <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
             <node concept="Xl_RD" id="7LZDtvhKJP_" role="37wK5m">
-              <property role="Xl_RC" value="#E4FFDB" />
+              <property role="Xl_RC" value="#F4F4F4" />
             </node>
           </node>
           <node concept="2YIFZM" id="7LZDtvhKJPA" role="37wK5m">
             <ref role="1Pybhc" to="z60i:~Color" resolve="Color" />
             <ref role="37wK5l" to="z60i:~Color.decode(java.lang.String)" resolve="decode" />
             <node concept="Xl_RD" id="7LZDtvhKJPB" role="37wK5m">
-              <property role="Xl_RC" value="#E4FFDB" />
+              <property role="Xl_RC" value="#F4F4F4" />
             </node>
           </node>
         </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -3975,10 +3975,19 @@
         </node>
         <node concept="3clFbF" id="5af9jCuTGIN" role="3cqZAp">
           <node concept="2OqwBi" id="5af9jCuTHfg" role="3clFbG">
-            <node concept="2ShNRf" id="5af9jCuTGIJ" role="2Oq$k0">
-              <node concept="HV5vD" id="5af9jCuTHaF" role="2ShVmc">
-                <property role="373rjd" value="true" />
-                <ref role="HV5vE" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+            <node concept="2OqwBi" id="RnCcjkcqZZ" role="2Oq$k0">
+              <node concept="2ShNRf" id="5af9jCuTGIJ" role="2Oq$k0">
+                <node concept="HV5vD" id="5af9jCuTHaF" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="HV5vE" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                </node>
+              </node>
+              <node concept="liA8E" id="RnCcjkcrj8" role="2OqNvi">
+                <ref role="37wK5l" to="pbu6:2nydsCfw1oG" resolve="withCoverAnalyzer" />
+                <node concept="2YIFZM" id="RnCcjkcrj9" role="37wK5m">
+                  <ref role="37wK5l" to="pbu6:7LZDtvhWVCM" resolve="newInstance" />
+                  <ref role="1Pybhc" to="pbu6:7LZDtvhy76p" resolve="IDefaultCoverageAnalyzer" />
+                </node>
               </node>
             </node>
             <node concept="liA8E" id="5af9jCuTHpJ" role="2OqNvi">
@@ -4287,16 +4296,25 @@
           <node concept="3clFbS" id="4KZjPKUdF$2" role="3clFbx">
             <node concept="3clFbF" id="5af9jCuTJT3" role="3cqZAp">
               <node concept="2OqwBi" id="5af9jCuTLaw" role="3clFbG">
-                <node concept="2OqwBi" id="5af9jCuTMzC" role="2Oq$k0">
-                  <node concept="2ShNRf" id="5af9jCuTJSZ" role="2Oq$k0">
-                    <node concept="HV5vD" id="5af9jCuTKGX" role="2ShVmc">
-                      <property role="373rjd" value="true" />
-                      <ref role="HV5vE" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                <node concept="2OqwBi" id="RnCcjkoFd9" role="2Oq$k0">
+                  <node concept="2OqwBi" id="5af9jCuTMzC" role="2Oq$k0">
+                    <node concept="liA8E" id="5af9jCuTN0B" role="2OqNvi">
+                      <ref role="37wK5l" to="pbu6:2nydsCfvLxS" resolve="withComputationTrace" />
+                      <node concept="3clFbT" id="5af9jCuTN0E" role="37wK5m" />
+                    </node>
+                    <node concept="2ShNRf" id="5af9jCuTJSZ" role="2Oq$k0">
+                      <node concept="HV5vD" id="5af9jCuTKGX" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="HV5vE" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                      </node>
                     </node>
                   </node>
-                  <node concept="liA8E" id="5af9jCuTN0B" role="2OqNvi">
-                    <ref role="37wK5l" to="pbu6:2nydsCfvLxS" resolve="withComputationTrace" />
-                    <node concept="3clFbT" id="5af9jCuTN0E" role="37wK5m" />
+                  <node concept="liA8E" id="RnCcjkoGxr" role="2OqNvi">
+                    <ref role="37wK5l" to="pbu6:2nydsCfw1oG" resolve="withCoverAnalyzer" />
+                    <node concept="2YIFZM" id="RnCcjkoGxs" role="37wK5m">
+                      <ref role="37wK5l" to="pbu6:7LZDtvhWVCM" resolve="newInstance" />
+                      <ref role="1Pybhc" to="pbu6:7LZDtvhy76p" resolve="IDefaultCoverageAnalyzer" />
+                    </node>
                   </node>
                 </node>
                 <node concept="liA8E" id="5af9jCuTLD4" role="2OqNvi">
@@ -10522,16 +10540,25 @@
                       <ref role="3cqZAo" node="4945UtSiwdl" resolve="actualVal" />
                     </node>
                     <node concept="2OqwBi" id="5af9jCuTXkX" role="37vLTx">
-                      <node concept="2OqwBi" id="5af9jCuTVYl" role="2Oq$k0">
-                        <node concept="2ShNRf" id="5af9jCuTUiF" role="2Oq$k0">
-                          <node concept="HV5vD" id="5af9jCuTVkD" role="2ShVmc">
-                            <property role="373rjd" value="true" />
-                            <ref role="HV5vE" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                      <node concept="2OqwBi" id="RnCcjkcAEU" role="2Oq$k0">
+                        <node concept="2OqwBi" id="5af9jCuTVYl" role="2Oq$k0">
+                          <node concept="2ShNRf" id="5af9jCuTUiF" role="2Oq$k0">
+                            <node concept="HV5vD" id="5af9jCuTVkD" role="2ShVmc">
+                              <property role="373rjd" value="true" />
+                              <ref role="HV5vE" to="pbu6:2nydsCfyYD0" resolve="IETS3ExprEvaluator" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="5af9jCuTWEk" role="2OqNvi">
+                            <ref role="37wK5l" to="pbu6:2nydsCfvLxS" resolve="withComputationTrace" />
+                            <node concept="3clFbT" id="5af9jCuTWEn" role="37wK5m" />
                           </node>
                         </node>
-                        <node concept="liA8E" id="5af9jCuTWEk" role="2OqNvi">
-                          <ref role="37wK5l" to="pbu6:2nydsCfvLxS" resolve="withComputationTrace" />
-                          <node concept="3clFbT" id="5af9jCuTWEn" role="37wK5m" />
+                        <node concept="liA8E" id="RnCcjkcFdI" role="2OqNvi">
+                          <ref role="37wK5l" to="pbu6:2nydsCfw1oG" resolve="withCoverAnalyzer" />
+                          <node concept="2YIFZM" id="RnCcjkcMM0" role="37wK5m">
+                            <ref role="37wK5l" to="pbu6:7LZDtvhWVCM" resolve="newInstance" />
+                            <ref role="1Pybhc" to="pbu6:7LZDtvhy76p" resolve="IDefaultCoverageAnalyzer" />
+                          </node>
                         </node>
                       </node>
                       <node concept="liA8E" id="5af9jCuTY0S" role="2OqNvi">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -5985,27 +5985,6 @@
           </node>
         </node>
         <node concept="3clFbH" id="18$bUx5bjkt" role="3cqZAp" />
-        <node concept="3clFbF" id="7sHl0myf4J0" role="3cqZAp">
-          <node concept="2OqwBi" id="7sHl0myf4Jm" role="3clFbG">
-            <node concept="37vLTw" id="2AZbPfMaNf1" role="2Oq$k0">
-              <ref role="3cqZAo" node="7sHl0myf4IT" resolve="summaries" />
-            </node>
-            <node concept="TSZUe" id="7sHl0myf4Js" role="2OqNvi">
-              <node concept="BsUDl" id="18$bUx5m9UE" role="25WWJ7">
-                <ref role="37wK5l" to="hwgx:7sHl0myfjm0" resolve="createDefaultSummary" />
-                <node concept="1PxgMI" id="18$bUx5mbyt" role="37wK5m">
-                  <node concept="2OqwBi" id="18$bUx5maN8" role="1m5AlR">
-                    <node concept="13iPFW" id="18$bUx5mayu" role="2Oq$k0" />
-                    <node concept="1mfA1w" id="18$bUx5mbbG" role="2OqNvi" />
-                  </node>
-                  <node concept="chp4Y" id="6b_jefnKzbB" role="3oSUPX">
-                    <ref role="cht4Q" to="vs0r:K292flwCEW" resolve="Assessment" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3clFbH" id="RaqQlV9BM7" role="3cqZAp" />
         <node concept="3cpWs8" id="RaqQlV9NYh" role="3cqZAp">
           <node concept="3cpWsn" id="RaqQlV9NYi" role="3cpWs9">
@@ -6149,6 +6128,28 @@
             </node>
             <node concept="liA8E" id="RaqQlVakQv" role="2OqNvi">
               <ref role="37wK5l" to="pbu6:7LZDtvhF5Hq" resolve="getData" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3GrH812f3i2" role="3cqZAp" />
+        <node concept="3clFbF" id="7sHl0myf4J0" role="3cqZAp">
+          <node concept="2OqwBi" id="7sHl0myf4Jm" role="3clFbG">
+            <node concept="37vLTw" id="2AZbPfMaNf1" role="2Oq$k0">
+              <ref role="3cqZAo" node="7sHl0myf4IT" resolve="summaries" />
+            </node>
+            <node concept="TSZUe" id="7sHl0myf4Js" role="2OqNvi">
+              <node concept="BsUDl" id="18$bUx5m9UE" role="25WWJ7">
+                <ref role="37wK5l" to="hwgx:7sHl0myfjm0" resolve="createDefaultSummary" />
+                <node concept="1PxgMI" id="18$bUx5mbyt" role="37wK5m">
+                  <node concept="2OqwBi" id="18$bUx5maN8" role="1m5AlR">
+                    <node concept="13iPFW" id="18$bUx5mayu" role="2Oq$k0" />
+                    <node concept="1mfA1w" id="18$bUx5mbbG" role="2OqNvi" />
+                  </node>
+                  <node concept="chp4Y" id="6b_jefnKzbB" role="3oSUPX">
+                    <ref role="cht4Q" to="vs0r:K292flwCEW" resolve="Assessment" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
@@ -15675,6 +15676,27 @@
     <node concept="3Tm1VV" id="7LZDtvgGNLT" role="1B3o_S" />
     <node concept="3uibUv" id="7LZDtvgGNMh" role="3HQHJm">
       <ref role="3uigEE" to="gdgh:5zG5$Lyex1G" resolve="IResult" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="3GrH810ODtI">
+    <property role="3GE5qa" value="assessment.interpreter" />
+    <ref role="13h7C2" to="av4b:18$bUx5b55w" resolve="InterpreterCoverageAssSummary" />
+    <node concept="13hLZK" id="3GrH810ODtJ" role="13h7CW">
+      <node concept="3clFbS" id="3GrH810ODtK" role="2VODD2">
+        <node concept="3clFbF" id="3GrH811yan3" role="3cqZAp">
+          <node concept="37vLTI" id="3GrH811ycRf" role="3clFbG">
+            <node concept="3cmrfG" id="3GrH811ycRx" role="37vLTx">
+              <property role="3cmrfH" value="75" />
+            </node>
+            <node concept="2OqwBi" id="3GrH811yan5" role="37vLTJ">
+              <node concept="13iPFW" id="3GrH811yan6" role="2Oq$k0" />
+              <node concept="3TrcHB" id="3GrH811yan7" role="2OqNvi">
+                <ref role="3TsBF5" to="av4b:3GrH80ZVmzh" resolve="coverageThreshold" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
@@ -2255,12 +2255,22 @@
     <node concept="3EZMnI" id="18$bUx5b5aH" role="2wV5jI">
       <node concept="l2Vlx" id="18$bUx5b5aI" role="2iSdaV" />
       <node concept="3F0ifn" id="18$bUx5b5aD" role="3EZMnx">
-        <property role="3F0ifm" value="coverage" />
+        <property role="3F0ifm" value="ratio" />
       </node>
       <node concept="3F0A7n" id="18$bUx5b5aW" role="3EZMnx">
         <ref role="1NtTu8" to="av4b:18$bUx5b57P" resolve="coverageRatio" />
       </node>
       <node concept="3F0ifn" id="18$bUx5b5b9" role="3EZMnx">
+        <property role="3F0ifm" value="%" />
+      </node>
+      <node concept="3F0ifn" id="3GrH8102FQr" role="3EZMnx" />
+      <node concept="3F0ifn" id="3GrH80ZVnsZ" role="3EZMnx">
+        <property role="3F0ifm" value="threshold" />
+      </node>
+      <node concept="3F0A7n" id="3GrH80ZVnwS" role="3EZMnx">
+        <ref role="1NtTu8" to="av4b:3GrH80ZVmzh" resolve="coverageThreshold" />
+      </node>
+      <node concept="3F0ifn" id="3GrH812ZHzP" role="3EZMnx">
         <property role="3F0ifm" value="%" />
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/structure.mps
@@ -427,6 +427,11 @@
       <property role="TrG5h" value="coverageRatio" />
       <ref role="AX2Wp" to="tpck:fKAQMTA" resolve="integer" />
     </node>
+    <node concept="1TJgyi" id="3GrH80ZVmzh" role="1TKVEl">
+      <property role="IQ2nx" value="4259196335530272977" />
+      <property role="TrG5h" value="coverageThreshold" />
+      <ref role="AX2Wp" to="tpck:fKAQMTA" resolve="integer" />
+    </node>
   </node>
   <node concept="1TIwiD" id="4XlPKep95_T">
     <property role="EcuMT" value="5716711712470882681" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -15200,6 +15200,31 @@
           <ref role="3bR37D" node="4C_RnzfEE1P" resolve="org.iets3.core.expr.base.runtime" />
         </node>
       </node>
+      <node concept="1SiIV0" id="3GrH80Zd3XV" role="3bR37C">
+        <node concept="3bR9La" id="3GrH80Zd3XW" role="1SiIV1">
+          <ref role="3bR37D" node="ub9nkyRnyj" resolve="org.iets3.core.expr.tests" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3GrH80Zd3XX" role="3bR37C">
+        <node concept="3bR9La" id="3GrH80Zd3XY" role="1SiIV1">
+          <ref role="3bR37D" node="5a_u3OzLedQ" resolve="org.iets3.core.expr.adt" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3GrH80ZB_ri" role="3bR37C">
+        <node concept="3bR9La" id="3GrH80ZB_rj" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3GrH80ZB_rk" role="3bR37C">
+        <node concept="3bR9La" id="3GrH80ZB_rl" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:mXGwHwhVPj" resolve="JDK" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3GrH80ZB_rm" role="3bR37C">
+        <node concept="3bR9La" id="3GrH80ZB_rn" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:1TaHNgiIbIQ" resolve="MPS.Core" />
+        </node>
+      </node>
     </node>
     <node concept="1E1JtA" id="7YuIrXB5Sn0" role="3989C9">
       <property role="BnDLt" value="true" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/algebraic@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/algebraic@tests.mps
@@ -11,7 +11,16 @@
     <devkit ref="ce1cf8e2-ad23-4a29-b20d-ca13a97e194f(org.iets3.core.expr.advanced.devkit)" />
     <devkit ref="b2a65b84-7ec9-404f-8602-f16394bb1d98(org.iets3.core.expr.stateful.devkit)" />
   </languages>
-  <imports />
+  <imports>
+    <import index="lmd" ref="r:a6074908-e483-4c8e-80b5-5dbf8b24df4c(org.iets3.core.expr.path.structure)" />
+    <import index="yv47" ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" />
+    <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
+    <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
+    <import index="zzzn" ref="r:af0af2e7-f7e1-4536-83b5-6bf010d4afd2(org.iets3.core.expr.lambda.structure)" />
+    <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" />
+    <import index="700h" ref="r:61b1de80-490d-4fee-8e95-b956503290e9(org.iets3.core.expr.collections.structure)" />
+    <import index="v0r8" ref="r:8ef260d4-7762-457a-8d33-23916aa626ab(org.iets3.core.expr.adt.structure)" implicit="true" />
+  </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
       <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
@@ -141,7 +150,33 @@
       <concept id="8255774724000586868" name="org.iets3.core.expr.tests.structure.ReportTestItem" flags="ng" index="2F9BGE">
         <child id="543569365052056267" name="actual" index="_fkuZ" />
       </concept>
+      <concept id="4137027550727647612" name="org.iets3.core.expr.tests.structure.LanguageRef" flags="ng" index="1aipRv">
+        <child id="4137027550727647984" name="lang" index="1aipTj" />
+      </concept>
+      <concept id="4137027550728847170" name="org.iets3.core.expr.tests.structure.IgnoredConcept" flags="ng" index="1amXfx">
+        <reference id="4137027550728847334" name="concept" index="1amXd5" />
+      </concept>
+      <concept id="4137027550720478450" name="org.iets3.core.expr.tests.structure.InterpreterCoverageAssQuery" flags="ng" index="1bQQ1h" />
+      <concept id="4137027550720482705" name="org.iets3.core.expr.tests.structure.InterpreterCoverageAssResult" flags="ng" index="1bQR4M">
+        <property id="4137027550720484225" name="comment" index="1bQOWy" />
+        <reference id="4137027550720483094" name="concept" index="1bQReP" />
+      </concept>
       <concept id="5285810042889815162" name="org.iets3.core.expr.tests.structure.EmptyTestItem" flags="ng" index="3dYjL0" />
+      <concept id="5716711712470882681" name="org.iets3.core.expr.tests.structure.AbstractCoverageQuery" flags="ng" index="3msoTU">
+        <child id="4137027550727662489" name="languages" index="1aissU" />
+        <child id="4137027550729731592" name="scope" index="1al_aF" />
+        <child id="4137027550728939664" name="ignoredConcepts" index="1am$gN" />
+      </concept>
+      <concept id="1307222191605829984" name="org.iets3.core.expr.tests.structure.InterpreterCoverageAssSummary" flags="ng" index="1n27V8">
+        <property id="1307222191605830133" name="coverageRatio" index="1n27Tt" />
+      </concept>
+      <concept id="993724751390561556" name="org.iets3.core.expr.tests.structure.InterpreterValueStat" flags="ng" index="1QVVTL">
+        <property id="993724751390561557" name="label" index="1QVVTK" />
+        <property id="993724751390561559" name="value" index="1QVVTM" />
+      </concept>
+      <concept id="993724751390561555" name="org.iets3.core.expr.tests.structure.InterpreterValueSummary" flags="ng" index="1QVVTQ">
+        <child id="993724751390561646" name="valueStats" index="1QVVSb" />
+      </concept>
     </language>
     <language id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes">
       <concept id="7971844778467001950" name="org.iets3.core.expr.simpleTypes.structure.OtherwiseLiteral" flags="ng" index="2fHqz8" />
@@ -258,8 +293,31 @@
       <concept id="5955298286248677251" name="org.iets3.core.expr.adt.structure.GenericAlgebraicType" flags="ng" index="1LZjuY" />
     </language>
     <language id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base">
+      <concept id="8490595898229124557" name="com.mbeddr.core.base.structure.CurrentModelScope" flags="ng" index="28wkCQ" />
+      <concept id="671216505796623802" name="com.mbeddr.core.base.structure.DefaultAssessmentSummary" flags="ng" index="qc_Tx">
+        <property id="671216505796623807" name="newlyAdded" index="qc_T$" />
+        <property id="671216505796623806" name="ok" index="qc_T_" />
+        <property id="671216505796623805" name="totalCount" index="qc_TA" />
+      </concept>
       <concept id="8375407818529178006" name="com.mbeddr.core.base.structure.TextBlock" flags="ng" index="OjmMv">
         <child id="8375407818529178007" name="text" index="OjmMu" />
+      </concept>
+      <concept id="865293814733114043" name="com.mbeddr.core.base.structure.AssessmentContainer" flags="ng" index="3pwaUo">
+        <child id="865293814733114045" name="assessments" index="3pwaUu" />
+      </concept>
+      <concept id="865293814733114044" name="com.mbeddr.core.base.structure.Assessment" flags="ng" index="3pwaUv">
+        <property id="4423545983997787056" name="lastUpdatedBy" index="2iEaKi" />
+        <property id="4423545983997782838" name="lastUpdatedOn" index="2iEbMk" />
+        <property id="8691429746170824734" name="sorted" index="1Ema5g" />
+        <child id="671216505796427450" name="summaries" index="q3PPx" />
+        <child id="865293814733115677" name="query" index="3pwbkY" />
+        <child id="865293814733118687" name="results" index="3pwbzW" />
+      </concept>
+      <concept id="865293814733118686" name="com.mbeddr.core.base.structure.AssessmentResultEntry" flags="ng" index="3pwbzX">
+        <property id="6619757161337247129" name="lastFound" index="3J1cY9" />
+        <property id="2711621784018180488" name="isNew" index="1OfcgH" />
+        <child id="865293814733133843" name="result" index="3pwfKK" />
+        <child id="6619757161337461931" name="comment" index="3J00qV" />
       </concept>
       <concept id="3857533489766146428" name="com.mbeddr.core.base.structure.ElementDocumentation" flags="ng" index="1z9TsT">
         <child id="4052432714772608243" name="text" index="1w35rA" />
@@ -269,6 +327,12 @@
       <concept id="4255172619715417408" name="org.iets3.core.expr.mutable.structure.UpdateItExpression" flags="ng" index="3j5BQN" />
       <concept id="4255172619711277794" name="org.iets3.core.expr.mutable.structure.BoxUpdateTarget" flags="ng" index="3sPC8h" />
       <concept id="4255172619710740510" name="org.iets3.core.expr.mutable.structure.BoxExpression" flags="ng" index="3sRH3H" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="3542851458883438784" name="jetbrains.mps.lang.smodel.structure.LanguageId" flags="nn" index="2V$Bhx">
+        <property id="3542851458883439831" name="namespace" index="2V$B1Q" />
+        <property id="3542851458883439832" name="languageId" index="2V$B1T" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -5148,6 +5212,572 @@
   </node>
   <node concept="2XOHcx" id="4rZeNQ6M9GV">
     <property role="2XOHcw" value="${iets3.github.opensource.home}/code/languages/org.iets3.opensource" />
+  </node>
+  <node concept="3pwaUo" id="3MHhZL0CVjV">
+    <property role="TrG5h" value="InterpreterCoverageForAlgebraic" />
+    <node concept="3pwaUv" id="3MHhZL0CVjW" role="3pwaUu">
+      <property role="TrG5h" value="InterpreterCoverage" />
+      <property role="1Ema5g" value="true" />
+      <property role="2iEbMk" value="1752568114065" />
+      <property role="2iEaKi" value="arimer" />
+      <node concept="1bQQ1h" id="3MHhZL0CVv9" role="3pwbkY">
+        <node concept="1amXfx" id="RnCcjkviXq" role="1am$gN">
+          <ref role="1amXd5" to="hm2y:6sdnDbSlaok" resolve="Type" />
+        </node>
+        <node concept="28wkCQ" id="3MHhZL0CVva" role="1al_aF" />
+        <node concept="1aipRv" id="6bUn_ThMGB0" role="1aissU">
+          <node concept="2V$Bhx" id="6bUn_ThNpQF" role="1aipTj">
+            <property role="2V$B1T" value="5fe6cb13-2fbd-4e21-9842-785bdd6fc5b1" />
+            <property role="2V$B1Q" value="org.iets3.core.expr.adt" />
+          </node>
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9_I" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114028" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9_J" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9_K" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9_L" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9$2" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:28$LOSAJ7nc" resolve="ReplaceWith" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9$U" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9$V" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9$W" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9$X" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zP" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:28$LOSALaA2" resolve="Copy" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9_M" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114028" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9_N" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9_O" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9_P" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9$3" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:28$LOSAMCgX" resolve="Size" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9_y" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114028" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9_z" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9_$" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9__" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zZ" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="v0r8:28$LOSBq9bH" resolve="Parent" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9$E" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9$F" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9$G" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9$H" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zL" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:28$LOSBqa1k" resolve="Ancestor" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9_2" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9_3" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9_4" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9_5" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zR" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:7aipPVpFzdB" resolve="LocDotTarget" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9_Q" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114028" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9_R" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9_S" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9_T" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9$4" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="v0r8:7aipPVpLOAL" resolve="SrcDotTarget" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9_A" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114028" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9_B" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9_C" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9_D" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9$0" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:28$LOSAcnmu" resolve="QuoteExpression" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9_E" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114028" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9_F" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9_G" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9_H" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9$1" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="v0r8:28$LOSAcnob" resolve="QuotedTermType" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9A6" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114028" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9A7" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9A8" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9A9" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9$8" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:28$LOSAeeCX" resolve="UnquoteExpression" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9A2" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114028" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9A3" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9A4" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9A5" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9$7" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:5a_u3Ozlh9S" resolve="TraverseExpr" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9_Y" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114028" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9_Z" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9A0" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9A1" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9$6" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="v0r8:5a_u3Ozlhai" resolve="TraversalTopDown" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9_U" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114028" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9_V" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9_W" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9_X" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9$5" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="v0r8:5a_u3Ozlhaw" resolve="TraversalBottomUp" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9$i" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9$j" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9$k" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9$l" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zF" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="v0r8:28$LOSBCtT$" resolve="AlgebraicConstructorArg" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9_e" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9_f" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9_g" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9_h" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zU" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="v0r8:28$LOSBF$h3" resolve="Multi" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9$q" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9$r" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9$s" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9$t" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zH" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="v0r8:5a_u3OyMtco" resolve="AlgebraicDeclaration" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9$e" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9$f" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9$g" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9$h" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zE" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="v0r8:5a_u3OyMttW" resolve="AlgebraicConstructor" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9$y" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9$z" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9$$" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9$_" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zJ" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:5a_u3OyMvaf" resolve="AlgebraicType" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9$m" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9$n" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9$o" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9$p" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zG" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:5a_u3OyM_sl" resolve="AlgebraicConstructorType" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9$u" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9$v" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9$w" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9$x" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zI" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:5a_u3OyMSN$" resolve="AlgebraicTerm" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9$a" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9$b" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9$c" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9$d" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zD" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:5a_u3OyQ3QL" resolve="AlgebraicArgAccess" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9_a" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9_b" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9_c" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9_d" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zT" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:5a_u3OySk7g" resolve="MatchExpr" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9_6" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9_7" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9_8" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9_9" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zS" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:5a_u3OySk8l" resolve="MatchCase" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9Aa" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114028" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9Ab" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9Ac" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9Ad" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9$9" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="v0r8:5a_u3OySBZU" resolve="WildcardExpr" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9$Q" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9$R" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9$S" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9$T" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zO" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:5a_u3OyTCgG" resolve="CaseItExpr" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9_i" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9_j" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9_k" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9_l" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zV" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="v0r8:5a_u3OyUzm8" resolve="NameAnnotation" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9_m" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9_n" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9_o" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9_p" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zW" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:5a_u3OyVzbv" resolve="NameAnnotationRefExpr" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9_q" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114028" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9_r" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9_s" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9_t" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zX" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="v0r8:5a_u3OyYLey" resolve="NameExpr" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9_u" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114028" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9_v" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9_w" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9_x" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zY" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:5a_u3Oz3q2f" resolve="NameExprRefExpr" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9$M" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9$N" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9$O" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9$P" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zN" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:5a_u3Oz5b39" resolve="CaseCondition" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9$Y" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9$Z" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9_0" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9_1" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zQ" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:5a_u3Ozm4Y3" resolve="GenericAlgebraicType" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9$I" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9$J" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9$K" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9$L" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zM" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="v0r8:5a_u3OzRz1z" resolve="AnyType" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="RnCcjku9$A" role="3pwbzW">
+        <property role="3J1cY9" value="1752568114027" />
+        <property role="1OfcgH" value="true" />
+        <node concept="OjmMv" id="RnCcjku9$B" role="3J00qV">
+          <node concept="19SGf9" id="RnCcjku9$C" role="OjmMu">
+            <node concept="19SUe$" id="RnCcjku9$D" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="RnCcjku9zK" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="v0r8:5a_u3OzYsEy" resolve="AllComponentsExpr" />
+        </node>
+      </node>
+      <node concept="qc_Tx" id="RnCcjkuk2j" role="q3PPx">
+        <property role="qc_TA" value="33" />
+        <property role="qc_T$" value="33" />
+        <property role="qc_T_" value="0" />
+      </node>
+      <node concept="1QVVTQ" id="RnCcjkuk2k" role="q3PPx">
+        <node concept="1QVVTL" id="RnCcjkuk2l" role="1QVVSb">
+          <property role="1QVVTK" value="decimal.max" />
+          <property role="1QVVTM" value="&lt;no value&gt;" />
+        </node>
+        <node concept="1QVVTL" id="RnCcjkuk2m" role="1QVVSb">
+          <property role="1QVVTK" value="decimal.min" />
+          <property role="1QVVTM" value="&lt;no value&gt;" />
+        </node>
+        <node concept="1QVVTL" id="RnCcjkuk2n" role="1QVVSb">
+          <property role="1QVVTK" value="decimal.zero" />
+          <property role="1QVVTM" value="&lt;no value&gt;" />
+        </node>
+        <node concept="1QVVTL" id="RnCcjkuk2o" role="1QVVSb">
+          <property role="1QVVTK" value="integer.zero" />
+          <property role="1QVVTM" value="true" />
+        </node>
+        <node concept="1QVVTL" id="RnCcjkuk2p" role="1QVVSb">
+          <property role="1QVVTK" value="integer.max" />
+          <property role="1QVVTM" value="99" />
+        </node>
+        <node concept="1QVVTL" id="RnCcjkuk2q" role="1QVVSb">
+          <property role="1QVVTK" value="decimal.minusOne" />
+          <property role="1QVVTM" value="&lt;no value&gt;" />
+        </node>
+        <node concept="1QVVTL" id="RnCcjkuk2r" role="1QVVSb">
+          <property role="1QVVTK" value="integer.one" />
+          <property role="1QVVTM" value="true" />
+        </node>
+        <node concept="1QVVTL" id="RnCcjkuk2s" role="1QVVSb">
+          <property role="1QVVTK" value="integer.minusOne" />
+          <property role="1QVVTM" value="true" />
+        </node>
+        <node concept="1QVVTL" id="RnCcjkuk2t" role="1QVVSb">
+          <property role="1QVVTK" value="decimal.one" />
+          <property role="1QVVTM" value="&lt;no value&gt;" />
+        </node>
+        <node concept="1QVVTL" id="RnCcjkuk2u" role="1QVVSb">
+          <property role="1QVVTK" value="integer.min" />
+          <property role="1QVVTM" value="0" />
+        </node>
+      </node>
+      <node concept="1n27V8" id="RnCcjkuk2i" role="q3PPx">
+        <property role="1n27Tt" value="61" />
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.assessmentUtils.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.assessmentUtils.mps
@@ -1,0 +1,652 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:c3404ca7-2556-4517-b7d5-ec378ad78058(test.in.expr.os.assessmentUtils)">
+  <persistence version="9" />
+  <languages>
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="817e4e70-961e-4a95-98a1-15e9f32231f1" name="jetbrains.mps.ide.httpsupport" version="0" />
+  </languages>
+  <imports>
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" />
+    <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
+    <import index="av4b" ref="r:ba7faab6-2b80-43d5-8b95-0c440665312c(org.iets3.core.expr.tests.structure)" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="nn" index="1gVbGN">
+        <child id="1160998896846" name="condition" index="1gVkn0" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+    </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5858074156537516430" name="jetbrains.mps.baseLanguage.javadoc.structure.ReturnBlockDocTag" flags="ng" index="x79VA">
+        <property id="5858074156537516431" name="text" index="x79VB" />
+      </concept>
+      <concept id="6832197706140518104" name="jetbrains.mps.baseLanguage.javadoc.structure.DocMethodParameterReference" flags="ng" index="zr_55" />
+      <concept id="6832197706140518103" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseParameterReference" flags="ng" index="zr_5a">
+        <reference id="6832197706140518108" name="param" index="zr_51" />
+      </concept>
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
+        <child id="5383422241790532083" name="tags" index="3nqlJM" />
+      </concept>
+      <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690881930" name="jetbrains.mps.baseLanguage.javadoc.structure.ParameterBlockDocTag" flags="ng" index="TUZQ0">
+        <property id="8465538089690881934" name="text" index="TUZQ4" />
+        <child id="6832197706140518123" name="parameter" index="zr_5Q" />
+      </concept>
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+      <concept id="1172073500303" name="jetbrains.mps.baseLanguage.unitTest.structure.Message" flags="ng" index="3_1$Yv">
+        <child id="1172073511101" name="message" index="3_1BAH" />
+      </concept>
+      <concept id="1172075514136" name="jetbrains.mps.baseLanguage.unitTest.structure.MessageHolder" flags="ngI" index="3_9gw8">
+        <child id="1172075534298" name="message" index="3_9lra" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
+        <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
+      </concept>
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+    </language>
+    <language id="817e4e70-961e-4a95-98a1-15e9f32231f1" name="jetbrains.mps.ide.httpsupport">
+      <concept id="1829257266377339186" name="jetbrains.mps.ide.httpsupport.structure.Node_getURLOperation" flags="ng" index="2$mYbS" />
+    </language>
+  </registry>
+  <node concept="312cEu" id="2TlZyI4PF$d">
+    <property role="TrG5h" value="AssessmentAnalyzer" />
+    <node concept="312cEg" id="3GrH80ZhwMn" role="jymVt">
+      <property role="TrG5h" value="assessment" />
+      <node concept="3Tm1VV" id="3GrH80ZAYQi" role="1B3o_S" />
+      <node concept="3Tqbb2" id="3GrH80ZhwKI" role="1tU5fm">
+        <ref role="ehGHo" to="vs0r:K292flwCEW" resolve="Assessment" />
+      </node>
+      <node concept="10Nm6u" id="3GrH80Zi5go" role="33vP2m" />
+    </node>
+    <node concept="2tJIrI" id="3GrH80ZhOeP" role="jymVt" />
+    <node concept="3clFbW" id="3GrH80ZhOhK" role="jymVt">
+      <node concept="37vLTG" id="3GrH80YOyR1" role="3clF46">
+        <property role="TrG5h" value="nodeId" />
+        <node concept="17QB3L" id="3GrH80YOyR0" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="3GrH80YOyR5" role="3clF46">
+        <property role="TrG5h" value="mdlName" />
+        <node concept="17QB3L" id="3GrH80YOyRp" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="3GrH80YOWAx" role="3clF46">
+        <property role="TrG5h" value="mdlID" />
+        <node concept="17QB3L" id="3GrH80YOWUp" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="3GrH80ZhR1y" role="3clF46">
+        <property role="TrG5h" value="repo" />
+        <node concept="3uibUv" id="3GrH80ZhTH2" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
+      <node concept="3cqZAl" id="3GrH80ZhOhM" role="3clF45" />
+      <node concept="3Tm1VV" id="3GrH80ZhOhN" role="1B3o_S" />
+      <node concept="3clFbS" id="3GrH80ZhOhO" role="3clF47">
+        <node concept="3clFbF" id="3GrH80ZhORq" role="3cqZAp">
+          <node concept="37vLTI" id="3GrH80ZhPiI" role="3clFbG">
+            <node concept="2OqwBi" id="3GrH80ZhOXs" role="37vLTJ">
+              <node concept="Xjq3P" id="3GrH80ZhORp" role="2Oq$k0" />
+              <node concept="2OwXpG" id="3GrH80ZhP3T" role="2OqNvi">
+                <ref role="2Oxat5" node="3GrH80ZhwMn" resolve="assessment" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="3GrH80Zi11F" role="37vLTx">
+              <node concept="Xjq3P" id="3GrH80Zi0QM" role="2Oq$k0" />
+              <node concept="liA8E" id="3GrH80Zi1dX" role="2OqNvi">
+                <ref role="37wK5l" node="3GrH80ZhYQh" resolve="deserialize" />
+                <node concept="37vLTw" id="3GrH80Zi1it" role="37wK5m">
+                  <ref role="3cqZAo" node="3GrH80YOyR1" resolve="nodeId" />
+                </node>
+                <node concept="37vLTw" id="3GrH80Zi1rb" role="37wK5m">
+                  <ref role="3cqZAo" node="3GrH80YOyR5" resolve="mdlName" />
+                </node>
+                <node concept="37vLTw" id="3GrH80Zi2h7" role="37wK5m">
+                  <ref role="3cqZAo" node="3GrH80YOWAx" resolve="mdlID" />
+                </node>
+                <node concept="37vLTw" id="3GrH80Zi2pC" role="37wK5m">
+                  <ref role="3cqZAo" node="3GrH80ZhR1y" resolve="repo" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3GrH80ZhOgk" role="jymVt" />
+    <node concept="3clFb_" id="3GrH80ZhYQh" role="jymVt">
+      <property role="TrG5h" value="deserialize" />
+      <node concept="37vLTG" id="3GrH80Zi0qn" role="3clF46">
+        <property role="TrG5h" value="nodeId" />
+        <node concept="17QB3L" id="3GrH80Zi0qo" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="3GrH80Zi0qp" role="3clF46">
+        <property role="TrG5h" value="mdlName" />
+        <node concept="17QB3L" id="3GrH80Zi0qq" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="3GrH80Zi0qr" role="3clF46">
+        <property role="TrG5h" value="mdlID" />
+        <node concept="17QB3L" id="3GrH80Zi0qs" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="3GrH80Zi0qt" role="3clF46">
+        <property role="TrG5h" value="repo" />
+        <node concept="3uibUv" id="3GrH80Zi0qu" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="3GrH80ZhYQk" role="3clF47">
+        <node concept="3cpWs8" id="3GrH80ZhUG7" role="3cqZAp">
+          <node concept="3cpWsn" id="3GrH80ZhUG8" role="3cpWs9">
+            <property role="TrG5h" value="node" />
+            <node concept="3Tqbb2" id="3GrH80ZhVio" role="1tU5fm" />
+            <node concept="2OqwBi" id="3GrH80ZhUG9" role="33vP2m">
+              <node concept="2YIFZM" id="3GrH80ZhUGa" role="2Oq$k0">
+                <ref role="37wK5l" to="w1kc:~SNodePointer.deserialize(java.lang.String)" resolve="deserialize" />
+                <ref role="1Pybhc" to="w1kc:~SNodePointer" resolve="SNodePointer" />
+                <node concept="3cpWs3" id="3GrH80ZhUGb" role="37wK5m">
+                  <node concept="37vLTw" id="3GrH80ZhUGc" role="3uHU7w">
+                    <ref role="3cqZAo" node="3GrH80Zi0qn" resolve="nodeId" />
+                  </node>
+                  <node concept="3cpWs3" id="3GrH80ZhUGd" role="3uHU7B">
+                    <node concept="3cpWs3" id="3GrH80ZhUGe" role="3uHU7B">
+                      <node concept="Xl_RD" id="3GrH80ZhUGf" role="3uHU7w">
+                        <property role="Xl_RC" value=")" />
+                      </node>
+                      <node concept="3cpWs3" id="3GrH80ZhUGg" role="3uHU7B">
+                        <node concept="3cpWs3" id="3GrH80ZhUGh" role="3uHU7B">
+                          <node concept="37vLTw" id="3GrH80ZhUGi" role="3uHU7B">
+                            <ref role="3cqZAo" node="3GrH80Zi0qr" resolve="mdlID" />
+                          </node>
+                          <node concept="Xl_RD" id="3GrH80ZhUGj" role="3uHU7w">
+                            <property role="Xl_RC" value="(" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="3GrH80ZhUGk" role="3uHU7w">
+                          <ref role="3cqZAo" node="3GrH80Zi0qp" resolve="mdlName" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="3GrH80ZhUGl" role="3uHU7w">
+                      <property role="Xl_RC" value="/" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="liA8E" id="3GrH80ZhUGm" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SNodeReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                <node concept="37vLTw" id="3GrH80ZhUGn" role="37wK5m">
+                  <ref role="3cqZAo" node="3GrH80Zi0qt" resolve="repo" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1gVbGN" id="3GrH80ZhWcf" role="3cqZAp">
+          <node concept="2OqwBi" id="3GrH80ZhWXc" role="1gVkn0">
+            <node concept="37vLTw" id="3GrH80ZhWwk" role="2Oq$k0">
+              <ref role="3cqZAo" node="3GrH80ZhUG8" resolve="node" />
+            </node>
+            <node concept="1mIQ4w" id="3GrH80ZhX95" role="2OqNvi">
+              <node concept="chp4Y" id="3GrH80ZhXxz" role="cj9EA">
+                <ref role="cht4Q" to="vs0r:K292flwCEW" resolve="Assessment" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3GrH80Zi3LP" role="3cqZAp">
+          <node concept="1PxgMI" id="3GrH80Zi4z8" role="3clFbG">
+            <node concept="chp4Y" id="3GrH80Zi4Bj" role="3oSUPX">
+              <ref role="cht4Q" to="vs0r:K292flwCEW" resolve="Assessment" />
+            </node>
+            <node concept="37vLTw" id="3GrH80Zi3LN" role="1m5AlR">
+              <ref role="3cqZAo" node="3GrH80ZhUG8" resolve="node" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="3GrH80ZhYyf" role="1B3o_S" />
+      <node concept="3Tqbb2" id="3GrH80ZhZaw" role="3clF45">
+        <ref role="ehGHo" to="vs0r:K292flwCEW" resolve="Assessment" />
+      </node>
+      <node concept="P$JXv" id="3GrH80ZAIsk" role="lGtFl">
+        <node concept="TZ5HA" id="3GrH80ZAIsl" role="TZ5H$">
+          <node concept="1dT_AC" id="3GrH80ZAIsm" role="1dT_Ay">
+            <property role="1dT_AB" value="We can't use node pointers, because some generator is dropping assessments." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="3GrH80ZAJAo" role="TZ5H$">
+          <node concept="1dT_AC" id="3GrH80ZAJAp" role="1dT_Ay">
+            <property role="1dT_AB" value="Therefor we use their underlying node/model IDs to deserialize" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="3GrH80ZAIsn" role="3nqlJM">
+          <property role="TUZQ4" value="nodeId" />
+          <node concept="zr_55" id="3GrH80ZAIsp" role="zr_5Q">
+            <ref role="zr_51" node="3GrH80Zi0qn" resolve="nodeId" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="3GrH80ZAIsq" role="3nqlJM">
+          <property role="TUZQ4" value="mdlName" />
+          <node concept="zr_55" id="3GrH80ZAIss" role="zr_5Q">
+            <ref role="zr_51" node="3GrH80Zi0qp" resolve="mdlName" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="3GrH80ZAIst" role="3nqlJM">
+          <property role="TUZQ4" value="mdlID" />
+          <node concept="zr_55" id="3GrH80ZAIsv" role="zr_5Q">
+            <ref role="zr_51" node="3GrH80Zi0qr" resolve="mdlID" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="3GrH80ZAIsw" role="3nqlJM">
+          <property role="TUZQ4" value="repo" />
+          <node concept="zr_55" id="3GrH80ZAIsy" role="zr_5Q">
+            <ref role="zr_51" node="3GrH80Zi0qt" resolve="repo" />
+          </node>
+        </node>
+        <node concept="x79VA" id="3GrH80ZAIsz" role="3nqlJM">
+          <property role="x79VB" value="assessment" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="3GrH80ZhYeh" role="jymVt" />
+    <node concept="3clFb_" id="3GrH80ZhwJl" role="jymVt">
+      <property role="TrG5h" value="checkCoverage" />
+      <node concept="3clFbS" id="3GrH80ZhwJo" role="3clF47">
+        <node concept="3cpWs8" id="m6kRveNlw$" role="3cqZAp">
+          <node concept="3cpWsn" id="m6kRveNlw_" role="3cpWs9">
+            <property role="TrG5h" value="summary" />
+            <node concept="3Tqbb2" id="m6kRveNlk_" role="1tU5fm">
+              <ref role="ehGHo" to="av4b:18$bUx5b55w" resolve="InterpreterCoverageAssSummary" />
+            </node>
+            <node concept="2OqwBi" id="m6kRveNlwA" role="33vP2m">
+              <node concept="2OqwBi" id="m6kRveNlwB" role="2Oq$k0">
+                <node concept="2OqwBi" id="m6kRveNlwC" role="2Oq$k0">
+                  <node concept="37vLTw" id="m6kRveNlwD" role="2Oq$k0">
+                    <ref role="3cqZAo" node="3GrH80ZhwMn" resolve="assessment" />
+                  </node>
+                  <node concept="3Tsc0h" id="m6kRveNlwE" role="2OqNvi">
+                    <ref role="3TtcxE" to="vs0r:_gCXGjnZUU" resolve="summaries" />
+                  </node>
+                </node>
+                <node concept="v3k3i" id="m6kRveNlwF" role="2OqNvi">
+                  <node concept="chp4Y" id="m6kRveNlwG" role="v3oSu">
+                    <ref role="cht4Q" to="av4b:18$bUx5b55w" resolve="InterpreterCoverageAssSummary" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1uHKPH" id="m6kRveNlwH" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3GrH80ZV$1A" role="3cqZAp">
+          <node concept="3cpWsn" id="3GrH80ZV$1B" role="3cpWs9">
+            <property role="TrG5h" value="minThresholdOld" />
+            <node concept="10Oyi0" id="3GrH80ZV$1C" role="1tU5fm" />
+            <node concept="2OqwBi" id="3GrH80ZV$1D" role="33vP2m">
+              <node concept="37vLTw" id="m6kRveNlwI" role="2Oq$k0">
+                <ref role="3cqZAo" node="m6kRveNlw_" resolve="node" />
+              </node>
+              <node concept="3TrcHB" id="3GrH80ZV$1M" role="2OqNvi">
+                <ref role="3TsBF5" to="av4b:3GrH80ZVmzh" resolve="coverageThreshold" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="3GrH812qhZU" role="3cqZAp">
+          <node concept="1PaTwC" id="3GrH812qhZV" role="1aUNEU">
+            <node concept="3oM_SD" id="3GrH812qi98" role="1PaTwD">
+              <property role="3oM_SC" value="we" />
+            </node>
+            <node concept="3oM_SD" id="3GrH812qi99" role="1PaTwD">
+              <property role="3oM_SC" value="need" />
+            </node>
+            <node concept="3oM_SD" id="3GrH812qi9a" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="3GrH812qi9b" role="1PaTwD">
+              <property role="3oM_SC" value="get" />
+            </node>
+            <node concept="3oM_SD" id="3GrH812qi9c" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="3GrH812qi9d" role="1PaTwD">
+              <property role="3oM_SC" value="threshold" />
+            </node>
+            <node concept="3oM_SD" id="3GrH812qi9e" role="1PaTwD">
+              <property role="3oM_SC" value="before" />
+            </node>
+            <node concept="3oM_SD" id="3GrH812qi9f" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="3GrH812qi9g" role="1PaTwD">
+              <property role="3oM_SC" value="update," />
+            </node>
+            <node concept="3oM_SD" id="3GrH812qi9h" role="1PaTwD">
+              <property role="3oM_SC" value="otherwise" />
+            </node>
+            <node concept="3oM_SD" id="3GrH812qi9i" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="3GrH812qi9j" role="1PaTwD">
+              <property role="3oM_SC" value="value" />
+            </node>
+            <node concept="3oM_SD" id="3GrH812qi9k" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="3GrH812qi9l" role="1PaTwD">
+              <property role="3oM_SC" value="lost" />
+            </node>
+            <node concept="3oM_SD" id="3GrH812qi9m" role="1PaTwD">
+              <property role="3oM_SC" value="due" />
+            </node>
+            <node concept="3oM_SD" id="3GrH812qi9n" role="1PaTwD">
+              <property role="3oM_SC" value="to:" />
+            </node>
+            <node concept="3oM_SD" id="3GrH812qi9p" role="1PaTwD">
+              <property role="3oM_SC" value="http://127.0.0.1:63320/node?ref=r%3Afd2980c8-676c-4b19-b524-18c70e02f8b7%28com.mbeddr.core.base.behavior%29%2F6657644269294788388" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3GrH80ZcoP0" role="3cqZAp">
+          <node concept="2OqwBi" id="3GrH80ZcoP1" role="3clFbG">
+            <node concept="37vLTw" id="3GrH80ZcoP2" role="2Oq$k0">
+              <ref role="3cqZAo" node="3GrH80ZhwMn" resolve="assessment" />
+            </node>
+            <node concept="2qgKlT" id="3GrH80ZcoP3" role="2OqNvi">
+              <ref role="37wK5l" to="hwgx:3jNX2XuLy_p" resolve="update" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3GrH80ZcoP4" role="3cqZAp">
+          <node concept="3cpWsn" id="3GrH80ZcoP5" role="3cpWs9">
+            <property role="TrG5h" value="coverageRatio" />
+            <node concept="10Oyi0" id="3GrH80ZcoP6" role="1tU5fm" />
+            <node concept="2OqwBi" id="3GrH80ZcoP7" role="33vP2m">
+              <node concept="37vLTw" id="m6kRveNlwJ" role="2Oq$k0">
+                <ref role="3cqZAo" node="m6kRveNlw_" resolve="node" />
+              </node>
+              <node concept="3TrcHB" id="3GrH80ZcoPg" role="2OqNvi">
+                <ref role="3TsBF5" to="av4b:18$bUx5b57P" resolve="coverageRatio" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3GrH80ZVAoF" role="3cqZAp" />
+        <node concept="3vwNmj" id="3GrH80ZVxwz" role="3cqZAp">
+          <node concept="2d3UOw" id="3GrH80ZVzPm" role="3vwVQn">
+            <node concept="37vLTw" id="3GrH80ZV_M1" role="3uHU7w">
+              <ref role="3cqZAo" node="3GrH80ZV$1B" resolve="minThreshold" />
+            </node>
+            <node concept="37vLTw" id="3GrH80ZVxJf" role="3uHU7B">
+              <ref role="3cqZAo" node="3GrH80ZcoP5" resolve="coverageRatio" />
+            </node>
+          </node>
+          <node concept="3_1$Yv" id="3GrH810ruW9" role="3_9lra">
+            <node concept="3cpWs3" id="m6kRveNkxI" role="3_1BAH">
+              <node concept="2OqwBi" id="m6kRveNnEL" role="3uHU7w">
+                <node concept="37vLTw" id="m6kRveNQtC" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3GrH80ZhwMn" resolve="assessment" />
+                </node>
+                <node concept="2$mYbS" id="m6kRveNq5n" role="2OqNvi" />
+              </node>
+              <node concept="3cpWs3" id="m6kRveNhGo" role="3uHU7B">
+                <node concept="3cpWs3" id="3GrH811hyyh" role="3uHU7B">
+                  <node concept="3cpWs3" id="3GrH811hueI" role="3uHU7B">
+                    <node concept="3cpWs3" id="3GrH811hoMl" role="3uHU7B">
+                      <node concept="3cpWs3" id="3GrH811htlx" role="3uHU7B">
+                        <node concept="Xl_RD" id="3GrH811htlT" role="3uHU7w">
+                          <property role="Xl_RC" value="%" />
+                        </node>
+                        <node concept="3cpWs3" id="3GrH811hpEK" role="3uHU7B">
+                          <node concept="Xl_RD" id="3GrH811hoMr" role="3uHU7B">
+                            <property role="Xl_RC" value="Coverage ratio:" />
+                          </node>
+                          <node concept="37vLTw" id="3GrH811hrjG" role="3uHU7w">
+                            <ref role="3cqZAo" node="3GrH80ZcoP5" resolve="coverageRatio" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Xl_RD" id="3GrH811hueO" role="3uHU7w">
+                        <property role="Xl_RC" value=" lower then minimum threshold" />
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="3GrH811hvi0" role="3uHU7w">
+                      <ref role="3cqZAo" node="3GrH80ZV$1B" resolve="minThreshold" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="3GrH811hyyD" role="3uHU7w">
+                    <property role="Xl_RC" value="%" />
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="m6kRveNiAh" role="3uHU7w">
+                  <property role="Xl_RC" value=" in assessment " />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="m6kRvfj84D" role="3cqZAp">
+          <node concept="1PaTwC" id="m6kRvfj84E" role="1aUNEU">
+            <node concept="3oM_SD" id="m6kRvfj8dj" role="1PaTwD">
+              <property role="3oM_SC" value="we" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfj8dk" role="1PaTwD">
+              <property role="3oM_SC" value="need" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfj8dl" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfj8dm" role="1PaTwD">
+              <property role="3oM_SC" value="re-assign" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfj8dn" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfj8do" role="1PaTwD">
+              <property role="3oM_SC" value="value" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfj8dp" role="1PaTwD">
+              <property role="3oM_SC" value="because" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfj8dq" role="1PaTwD">
+              <property role="3oM_SC" value="it" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfj8dr" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfj9VE" role="1PaTwD">
+              <property role="3oM_SC" value="overwritten" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfjb4D" role="1PaTwD">
+              <property role="3oM_SC" value="during" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfjb4U" role="1PaTwD">
+              <property role="3oM_SC" value="creating" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfjb5b" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfjb5c" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfjb5d" role="1PaTwD">
+              <property role="3oM_SC" value="new" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfjb5u" role="1PaTwD">
+              <property role="3oM_SC" value="summary" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="m6kRvfkaGE" role="3cqZAp">
+          <node concept="37vLTI" id="m6kRvfkeS0" role="3clFbG">
+            <node concept="37vLTw" id="m6kRvfkgbl" role="37vLTx">
+              <ref role="3cqZAo" node="3GrH80ZV$1B" resolve="minThresholdOld" />
+            </node>
+            <node concept="2OqwBi" id="m6kRvfkbCU" role="37vLTJ">
+              <node concept="2OqwBi" id="m6kRvfkaGG" role="2Oq$k0">
+                <node concept="2OqwBi" id="m6kRvfkaGH" role="2Oq$k0">
+                  <node concept="2OqwBi" id="m6kRvfkaGI" role="2Oq$k0">
+                    <node concept="37vLTw" id="m6kRvfkaGJ" role="2Oq$k0">
+                      <ref role="3cqZAo" node="3GrH80ZhwMn" resolve="assessment" />
+                    </node>
+                    <node concept="3Tsc0h" id="m6kRvfkaGK" role="2OqNvi">
+                      <ref role="3TtcxE" to="vs0r:_gCXGjnZUU" resolve="summaries" />
+                    </node>
+                  </node>
+                  <node concept="v3k3i" id="m6kRvfkaGL" role="2OqNvi">
+                    <node concept="chp4Y" id="m6kRvfkaGM" role="v3oSu">
+                      <ref role="cht4Q" to="av4b:18$bUx5b55w" resolve="InterpreterCoverageAssSummary" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="1uHKPH" id="m6kRvfkaGN" role="2OqNvi" />
+              </node>
+              <node concept="3TrcHB" id="m6kRvfkcFN" role="2OqNvi">
+                <ref role="3TsBF5" to="av4b:3GrH80ZVmzh" resolve="coverageThreshold" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="3GrH80ZhOha" role="1B3o_S" />
+      <node concept="3cqZAl" id="3GrH80ZhwJb" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="2TlZyI4PF$G" role="1B3o_S" />
+  </node>
+</model>
+

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.assessmentUtils.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.assessmentUtils.mps
@@ -419,7 +419,7 @@
             <node concept="10Oyi0" id="3GrH80ZV$1C" role="1tU5fm" />
             <node concept="2OqwBi" id="3GrH80ZV$1D" role="33vP2m">
               <node concept="37vLTw" id="m6kRveNlwI" role="2Oq$k0">
-                <ref role="3cqZAo" node="m6kRveNlw_" resolve="node" />
+                <ref role="3cqZAo" node="m6kRveNlw_" resolve="summary" />
               </node>
               <node concept="3TrcHB" id="3GrH80ZV$1M" role="2OqNvi">
                 <ref role="3TsBF5" to="av4b:3GrH80ZVmzh" resolve="coverageThreshold" />
@@ -498,7 +498,7 @@
             <node concept="10Oyi0" id="3GrH80ZcoP6" role="1tU5fm" />
             <node concept="2OqwBi" id="3GrH80ZcoP7" role="33vP2m">
               <node concept="37vLTw" id="m6kRveNlwJ" role="2Oq$k0">
-                <ref role="3cqZAo" node="m6kRveNlw_" resolve="node" />
+                <ref role="3cqZAo" node="m6kRveNlw_" resolve="summary" />
               </node>
               <node concept="3TrcHB" id="3GrH80ZcoPg" role="2OqNvi">
                 <ref role="3TsBF5" to="av4b:18$bUx5b57P" resolve="coverageRatio" />
@@ -510,7 +510,7 @@
         <node concept="3vwNmj" id="3GrH80ZVxwz" role="3cqZAp">
           <node concept="2d3UOw" id="3GrH80ZVzPm" role="3vwVQn">
             <node concept="37vLTw" id="3GrH80ZV_M1" role="3uHU7w">
-              <ref role="3cqZAo" node="3GrH80ZV$1B" resolve="minThreshold" />
+              <ref role="3cqZAo" node="3GrH80ZV$1B" resolve="minThresholdOld" />
             </node>
             <node concept="37vLTw" id="3GrH80ZVxJf" role="3uHU7B">
               <ref role="3cqZAo" node="3GrH80ZcoP5" resolve="coverageRatio" />
@@ -546,7 +546,7 @@
                       </node>
                     </node>
                     <node concept="37vLTw" id="3GrH811hvi0" role="3uHU7w">
-                      <ref role="3cqZAo" node="3GrH80ZV$1B" resolve="minThreshold" />
+                      <ref role="3cqZAo" node="3GrH80ZV$1B" resolve="minThresholdOld" />
                     </node>
                   </node>
                   <node concept="Xl_RD" id="3GrH811hyyD" role="3uHU7w">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.records@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.records@tests.mps
@@ -6,17 +6,30 @@
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="-1" />
     <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="-1" />
     <use id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext" version="-1" />
+    <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
     <devkit ref="c4e521ab-b605-4ef9-a7c3-68075da058f0(org.iets3.core.expr.core.devkit)" />
   </languages>
   <imports>
+    <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
+    <import index="7obj" ref="r:c3404ca7-2556-4517-b7d5-ec378ad78058(test.in.expr.os.assessmentUtils)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="av4b" ref="r:ba7faab6-2b80-43d5-8b95-0c440665312c(org.iets3.core.expr.tests.structure)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
     <import index="yv47" ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" implicit="true" />
+    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
       <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
       </concept>
+      <concept id="1225467090849" name="jetbrains.mps.lang.test.structure.ProjectExpression" flags="nn" index="1jxXqW" />
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="1217501895093" name="testMethods" index="1SL9yI" />
+      </concept>
+      <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
     </language>
     <language id="2f7e2e35-6e74-4c43-9fa5-2465d68f5996" name="org.iets3.core.expr.collections">
       <concept id="6095949300270588116" name="org.iets3.core.expr.collections.structure.IsNotEmptyOp" flags="ng" index="nW$_3" />
@@ -56,6 +69,65 @@
         <child id="4931785860342371141" name="seed" index="1YsmDp" />
       </concept>
       <concept id="4931785860342338319" name="org.iets3.core.expr.collections.structure.FoldLeftOp" flags="ng" index="1XzICj" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+        <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="nn" index="1gVbGN">
+        <child id="1160998896846" name="condition" index="1gVkn0" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
     </language>
     <language id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base">
       <concept id="229512757698888199" name="org.iets3.core.base.structure.IOptionallyNamed" flags="ngI" index="pfQq$">
@@ -148,6 +220,7 @@
         <child id="4137027550728939664" name="ignoredConcepts" index="1am$gN" />
       </concept>
       <concept id="1307222191605829984" name="org.iets3.core.expr.tests.structure.InterpreterCoverageAssSummary" flags="ng" index="1n27V8">
+        <property id="4259196335530272977" name="coverageThreshold" index="4XHLh" />
         <property id="1307222191605830133" name="coverageRatio" index="1n27Tt" />
       </concept>
       <concept id="6723982381150106591" name="org.iets3.core.expr.tests.structure.ContainsString" flags="ng" index="3_fT66" />
@@ -191,6 +264,7 @@
       <concept id="5115872837157054170" name="org.iets3.core.expr.simpleTypes.structure.NumberLiteral" flags="ng" index="30bXRB">
         <property id="5115872837157054173" name="value" index="30bXRw" />
       </concept>
+      <concept id="5994308065090560488" name="org.iets3.core.expr.simpleTypes.structure.StringLengthTarget" flags="ng" index="1uMQU5" />
     </language>
     <language id="71934284-d7d1-45ee-a054-8c072591085f" name="org.iets3.core.expr.toplevel">
       <concept id="8293738266741050660" name="org.iets3.core.expr.toplevel.structure.ProjectOp" flags="ng" index="22cOCA">
@@ -214,6 +288,7 @@
         <reference id="543569365051789114" name="constant" index="_emDf" />
       </concept>
       <concept id="543569365052765011" name="org.iets3.core.expr.toplevel.structure.EmptyToplevelContent" flags="ng" index="_ixoA" />
+      <concept id="3315773615451992747" name="org.iets3.core.expr.toplevel.structure.TypedefContractValExpr" flags="ng" index="QCKKy" />
       <concept id="8811147530085329320" name="org.iets3.core.expr.toplevel.structure.RecordLiteral" flags="ng" index="2S399m">
         <child id="8811147530085329323" name="memberValues" index="2S399l" />
       </concept>
@@ -255,6 +330,12 @@
       <concept id="1249392911699110107" name="org.iets3.core.expr.toplevel.structure.RecordChangeTarget" flags="ng" index="3vStjw">
         <child id="1249392911699129399" name="setters" index="3vSgwc" />
       </concept>
+      <concept id="7740953487936183912" name="org.iets3.core.expr.toplevel.structure.Typedef" flags="ng" index="1WbbD7">
+        <child id="7740953487936183915" name="originalType" index="1WbbD4" />
+      </concept>
+      <concept id="7740953487936184022" name="org.iets3.core.expr.toplevel.structure.TypedefType" flags="ng" index="1WbbFT">
+        <reference id="7740953487936184023" name="typedef" index="1WbbFS" />
+      </concept>
     </language>
     <language id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base">
       <concept id="8490595898229124557" name="com.mbeddr.core.base.structure.CurrentModelScope" flags="ng" index="28wkCQ" />
@@ -291,6 +372,10 @@
         <property id="3542851458883439831" name="namespace" index="2V$B1Q" />
         <property id="3542851458883439832" name="languageId" index="2V$B1T" />
       </concept>
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -310,6 +395,14 @@
     <language id="f3eafff0-30d2-46d6-9150-f0f3b880ce27" name="org.iets3.core.expr.path">
       <concept id="7814222126786013807" name="org.iets3.core.expr.path.structure.PathElement" flags="ng" index="3o_JK">
         <reference id="7814222126786013810" name="member" index="3o_JH" />
+      </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
     <language id="9464fa06-5ab9-409b-9274-64ab29588457" name="org.iets3.core.expr.lambda">
@@ -3875,11 +3968,31 @@
   <node concept="_iOnU" id="7cphKbKqVBQ">
     <property role="TrG5h" value="grouping" />
     <property role="1XBH2A" value="true" />
+    <node concept="1WbbD7" id="3GrH80YQfj8" role="_iOnB">
+      <property role="TrG5h" value="Name" />
+      <node concept="30bdrU" id="3GrH80YZ1Nu" role="1WbbD4" />
+      <node concept="I61D5" id="3GrH80YZGQf" role="I61D6">
+        <node concept="InuEK" id="3GrH80YZIjN" role="I61D1">
+          <node concept="30d7iD" id="3GrH80YZRI8" role="2lDidJ">
+            <node concept="30bXRB" id="3GrH80YZRIg" role="30dEs_">
+              <property role="30bXRw" value="0" />
+            </node>
+            <node concept="1QScDb" id="3GrH80YZJdt" role="30dEsF">
+              <node concept="QCKKy" id="3GrH80YZIkl" role="2lDidJ" />
+              <node concept="1uMQU5" id="3GrH80YZQRD" role="1QScD9" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="_ixoA" id="3GrH80YXdZg" role="_iOnB" />
     <node concept="2Ss9d8" id="7cphKbKqWTD" role="_iOnB">
       <property role="TrG5h" value="Item" />
       <node concept="2Ss9d7" id="7cphKbKqWUl" role="S5Trm">
         <property role="TrG5h" value="name" />
-        <node concept="30bdrU" id="7cphKbKqWUD" role="2S399n" />
+        <node concept="1WbbFT" id="3GrH80YZ3tm" role="2S399n">
+          <ref role="1WbbFS" node="3GrH80YQfj8" resolve="Name" />
+        </node>
       </node>
       <node concept="2Ss9d7" id="7cphKbKqWUX" role="S5Trm">
         <property role="TrG5h" value="price" />
@@ -3901,6 +4014,16 @@
         <property role="TrG5h" value="categories" />
         <node concept="3iBWmN" id="7cphKbKwNCp" role="2S399n">
           <node concept="30bdrU" id="7cphKbKwNTm" role="3iBWmK" />
+        </node>
+        <node concept="I61D5" id="3GrH80Z0a96" role="I61D6">
+          <node concept="InuEK" id="3GrH80Z0bwu" role="I61D1">
+            <node concept="1QScDb" id="3GrH80Z0bxi" role="2lDidJ">
+              <node concept="XrbUJ" id="3GrH80Z0bwU" role="2lDidJ">
+                <ref role="XrbUP" node="7cphKbKuAyY" resolve="categories" />
+              </node>
+              <node concept="nW$_3" id="3GrH80Z0eb6" role="1QScD9" />
+            </node>
+          </node>
         </node>
       </node>
       <node concept="2Ss9d7" id="7cphKbKwPcY" role="S5Trm">
@@ -4386,7 +4509,7 @@
     <node concept="3pwaUv" id="3MHhZL0CVjW" role="3pwaUu">
       <property role="TrG5h" value="InterpreterCoverageRecord" />
       <property role="1Ema5g" value="true" />
-      <property role="2iEbMk" value="1752578118469" />
+      <property role="2iEbMk" value="1752586724121" />
       <property role="2iEaKi" value="arimer" />
       <node concept="1bQQ1h" id="3MHhZL0CVv9" role="3pwbkY">
         <node concept="1amXfx" id="RnCcjkviXq" role="1am$gN">
@@ -4469,447 +4592,593 @@
           <ref role="1amXd5" to="yv47:58eyHuUiMwN" resolve="EmptyMember" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK41o" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118453" />
-        <node concept="OjmMv" id="3GrH80XK41p" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK41q" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK41r" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZolP" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832991" />
+        <node concept="OjmMv" id="3GrH80YZolQ" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZolR" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZolS" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK40y" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolj" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:ub9nkyG$WT" resolve="ConstantRef" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK41k" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118453" />
-        <node concept="OjmMv" id="3GrH80XK41l" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK41m" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK41n" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZolL" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832991" />
+        <node concept="OjmMv" id="3GrH80YZolM" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZolN" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZolO" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK40x" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZoli" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:69zaTr1HgRc" resolve="Constant" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK42g" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118453" />
-        <node concept="OjmMv" id="3GrH80XK42h" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK42i" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK42j" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZolT" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832991" />
+        <node concept="OjmMv" id="3GrH80YZolU" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZolV" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZolW" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK40K" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolk" role="3pwfKK">
           <property role="1bQOWy" value="Missing." />
           <ref role="1bQReP" to="yv47:2uR5X5azSbn" resolve="ExtensionFunctionCall" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK42s" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118453" />
-        <node concept="OjmMv" id="3GrH80XK42t" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK42u" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK42v" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZom5" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832991" />
+        <node concept="OjmMv" id="3GrH80YZom6" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZom7" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZom8" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK40N" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZoln" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:49WTic8f4iz" resolve="Function" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK42w" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118453" />
-        <node concept="OjmMv" id="3GrH80XK42x" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK42y" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK42z" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZom9" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832991" />
+        <node concept="OjmMv" id="3GrH80YZoma" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZomb" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZomc" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK40O" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolo" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:49WTic8gFfG" resolve="FunctionCall" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK42o" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118453" />
-        <node concept="OjmMv" id="3GrH80XK42p" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK42q" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK42r" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZom1" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832991" />
+        <node concept="OjmMv" id="3GrH80YZom2" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZom3" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZom4" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK40M" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolm" role="3pwfKK">
           <property role="1bQOWy" value="Missing." />
           <ref role="1bQReP" to="yv47:49WTic8hwXW" resolve="FunRef" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK43C" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118454" />
-        <node concept="OjmMv" id="3GrH80XK43D" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK43E" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK43F" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZon9" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832992" />
+        <node concept="OjmMv" id="3GrH80YZona" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZonb" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZonc" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK416" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolC" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:SRvqsNmWc8" resolve="RecordMemberRefInConstraint" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK43o" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118454" />
-        <node concept="OjmMv" id="3GrH80XK43p" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK43q" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK43r" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZomT" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832992" />
+        <node concept="OjmMv" id="3GrH80YZomU" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZomV" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZomW" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK412" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZol$" role="3pwfKK">
           <property role="1bQOWy" value="Missing." />
           <ref role="1bQReP" to="yv47:3sWKo0E1oB0" resolve="RecordComparisonOrder" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK43K" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118454" />
-        <node concept="OjmMv" id="3GrH80XK43L" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK43M" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK43N" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZonh" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832993" />
+        <node concept="OjmMv" id="3GrH80YZoni" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZonj" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZonk" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK418" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolE" role="3pwfKK">
           <property role="1bQOWy" value="Missing." />
           <ref role="1bQReP" to="yv47:6JZACDWOa9c" resolve="ReferenceableFlag" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK43s" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118454" />
-        <node concept="OjmMv" id="3GrH80XK43t" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK43u" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK43v" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZomX" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832992" />
+        <node concept="OjmMv" id="3GrH80YZomY" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZomZ" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZon0" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK413" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZol_" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:7D7uZV2dYyQ" resolve="RecordDeclaration" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK43$" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118454" />
-        <node concept="OjmMv" id="3GrH80XK43_" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK43A" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK43B" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZon5" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832992" />
+        <node concept="OjmMv" id="3GrH80YZon6" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZon7" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZon8" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK415" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolB" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:7D7uZV2dYyT" resolve="RecordMember" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK43w" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118454" />
-        <node concept="OjmMv" id="3GrH80XK43x" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK43y" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK43z" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZon1" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832992" />
+        <node concept="OjmMv" id="3GrH80YZon2" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZon3" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZon4" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK414" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolA" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:7D7uZV2iYAC" resolve="RecordLiteral" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK41g" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118421" />
-        <node concept="OjmMv" id="3GrH80XK41h" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK41i" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK41j" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZolH" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832991" />
+        <node concept="OjmMv" id="3GrH80YZolI" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZolJ" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZolK" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK40w" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolh" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:4ptnK4jbqZj" resolve="BuilderExpression" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK42k" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118453" />
-        <node concept="OjmMv" id="3GrH80XK42l" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK42m" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK42n" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZolX" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832991" />
+        <node concept="OjmMv" id="3GrH80YZolY" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZolZ" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZom0" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK40L" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZoll" role="3pwfKK">
           <property role="1bQOWy" value="Missing." />
           <ref role="1bQReP" to="yv47:4ptnK4jbqZG" resolve="FieldSetter" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK43G" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118454" />
-        <node concept="OjmMv" id="3GrH80XK43H" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK43I" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK43J" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZond" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832993" />
+        <node concept="OjmMv" id="3GrH80YZone" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZonf" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZong" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK417" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolD" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:4ptnK4jbr8M" resolve="RecordTypeAdapter" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK43k" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118454" />
-        <node concept="OjmMv" id="3GrH80XK43l" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK43m" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK43n" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZomP" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832992" />
+        <node concept="OjmMv" id="3GrH80YZomQ" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZomR" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZomS" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK411" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolz" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:15mJ3JeHQzr" resolve="RecordChangeTarget" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK42S" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118453" />
-        <node concept="OjmMv" id="3GrH80XK42T" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK42U" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK42V" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZomt" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832992" />
+        <node concept="OjmMv" id="3GrH80YZomu" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZomv" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZomw" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK40U" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolt" role="3pwfKK">
           <property role="1bQOWy" value="Missing." />
           <ref role="1bQReP" to="yv47:15mJ3JeHQzQ" resolve="NewValueSetter" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK430" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118454" />
-        <node concept="OjmMv" id="3GrH80XK431" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK432" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK433" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZom_" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832992" />
+        <node concept="OjmMv" id="3GrH80YZomA" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZomB" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZomC" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK40W" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolv" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:HywGhj0hJO" resolve="OldValueExpr" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK42W" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118454" />
-        <node concept="OjmMv" id="3GrH80XK42X" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK42Y" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK42Z" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZomx" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832992" />
+        <node concept="OjmMv" id="3GrH80YZomy" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZomz" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZom$" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK40V" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolu" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:HywGhj4ZhL" resolve="OldMemberRef" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK42$" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118453" />
-        <node concept="OjmMv" id="3GrH80XK42_" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK42A" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK42B" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZomd" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832992" />
+        <node concept="OjmMv" id="3GrH80YZome" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZomf" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZomg" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK40P" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolp" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:7cphKbKnRmi" resolve="GroupByOp" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK42C" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118453" />
-        <node concept="OjmMv" id="3GrH80XK42D" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK42E" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK42F" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZomh" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832992" />
+        <node concept="OjmMv" id="3GrH80YZomi" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZomj" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZomk" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK40Q" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolq" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:7cphKbKssrq" resolve="GroupKeyTarget" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK42G" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118453" />
-        <node concept="OjmMv" id="3GrH80XK42H" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK42I" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK42J" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZoml" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832992" />
+        <node concept="OjmMv" id="3GrH80YZomm" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZomn" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZomo" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK40R" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolr" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:7cphKbKuFYS" resolve="GroupMembersTarget" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK43c" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118454" />
-        <node concept="OjmMv" id="3GrH80XK43d" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK43e" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK43f" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZomL" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832992" />
+        <node concept="OjmMv" id="3GrH80YZomM" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZomN" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZomO" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK40Z" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZoly" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:7cphKbLawO$" resolve="ProjectOp" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK438" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118454" />
-        <node concept="OjmMv" id="3GrH80XK439" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK43a" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK43b" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZomH" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832992" />
+        <node concept="OjmMv" id="3GrH80YZomI" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZomJ" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZomK" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK40Y" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolx" role="3pwfKK">
           <property role="1bQOWy" value="Missing." />
           <ref role="1bQReP" to="yv47:7cphKbLawOC" resolve="ProjectMember" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK434" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118454" />
-        <node concept="OjmMv" id="3GrH80XK435" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK436" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK437" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZomD" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832992" />
+        <node concept="OjmMv" id="3GrH80YZomE" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZomF" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZomG" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK40X" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolw" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:7cphKbLg8An" resolve="ProjectIt" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK42K" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118453" />
-        <node concept="OjmMv" id="3GrH80XK42L" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK42M" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK42N" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZomp" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832992" />
+        <node concept="OjmMv" id="3GrH80YZomq" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZomr" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZoms" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK40S" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZols" role="3pwfKK">
           <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:7cphKbLtLQW" resolve="InlineRecordMemberAccess" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK43W" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118454" />
-        <node concept="OjmMv" id="3GrH80XK43X" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK43Y" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK43Z" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZonp" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832993" />
+        <node concept="OjmMv" id="3GrH80YZonq" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZonr" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZons" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK41b" role="3pwfKK">
-          <property role="1bQOWy" value="Missing." />
+        <node concept="1bQR4M" id="3GrH80YZolG" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
           <ref role="1bQReP" to="yv47:2S3ZC$oCfaF" resolve="TypedefContractValExpr" />
         </node>
       </node>
-      <node concept="3pwbzX" id="3GrH80XK43S" role="3pwbzW">
-        <property role="3J1cY9" value="1752578118454" />
-        <node concept="OjmMv" id="3GrH80XK43T" role="3J00qV">
-          <node concept="19SGf9" id="3GrH80XK43U" role="OjmMu">
-            <node concept="19SUe$" id="3GrH80XK43V" role="19SJt6">
+      <node concept="3pwbzX" id="3GrH80YZonl" role="3pwbzW">
+        <property role="3J1cY9" value="1752581832993" />
+        <node concept="OjmMv" id="3GrH80YZonm" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80YZonn" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80YZono" role="19SJt6">
               <property role="19SUeA" value=" " />
             </node>
           </node>
         </node>
-        <node concept="1bQR4M" id="3GrH80XK41a" role="3pwfKK">
+        <node concept="1bQR4M" id="3GrH80YZolF" role="3pwfKK">
           <property role="1bQOWy" value="Missing." />
           <ref role="1bQReP" to="yv47:6HHp2WngtTC" resolve="Typedef" />
         </node>
       </node>
-      <node concept="qc_Tx" id="3GrH80YvetE" role="q3PPx">
-        <property role="qc_TA" value="29" />
+      <node concept="qc_Tx" id="3GrH80ZBkmj" role="q3PPx">
+        <property role="qc_TA" value="28" />
         <property role="qc_T$" value="0" />
         <property role="qc_T_" value="0" />
       </node>
-      <node concept="1QVVTQ" id="3GrH80YvetF" role="q3PPx">
-        <node concept="1QVVTL" id="3GrH80YvetG" role="1QVVSb">
+      <node concept="1QVVTQ" id="3GrH80ZBkmk" role="q3PPx">
+        <node concept="1QVVTL" id="3GrH80ZBkml" role="1QVVSb">
           <property role="1QVVTK" value="decimal.max" />
           <property role="1QVVTM" value="2.0" />
         </node>
-        <node concept="1QVVTL" id="3GrH80YvetH" role="1QVVSb">
+        <node concept="1QVVTL" id="3GrH80ZBkmm" role="1QVVSb">
           <property role="1QVVTK" value="decimal.min" />
           <property role="1QVVTM" value="1.0" />
         </node>
-        <node concept="1QVVTL" id="3GrH80YvetI" role="1QVVSb">
+        <node concept="1QVVTL" id="3GrH80ZBkmn" role="1QVVSb">
           <property role="1QVVTK" value="decimal.zero" />
           <property role="1QVVTM" value="true" />
         </node>
-        <node concept="1QVVTL" id="3GrH80YvetJ" role="1QVVSb">
+        <node concept="1QVVTL" id="3GrH80ZBkmo" role="1QVVSb">
           <property role="1QVVTK" value="integer.zero" />
           <property role="1QVVTM" value="true" />
         </node>
-        <node concept="1QVVTL" id="3GrH80YvetK" role="1QVVSb">
+        <node concept="1QVVTL" id="3GrH80ZBkmp" role="1QVVSb">
           <property role="1QVVTK" value="integer.max" />
           <property role="1QVVTM" value="400" />
         </node>
-        <node concept="1QVVTL" id="3GrH80YvetL" role="1QVVSb">
+        <node concept="1QVVTL" id="3GrH80ZBkmq" role="1QVVSb">
           <property role="1QVVTK" value="decimal.minusOne" />
           <property role="1QVVTM" value="true" />
         </node>
-        <node concept="1QVVTL" id="3GrH80YvetM" role="1QVVSb">
+        <node concept="1QVVTL" id="3GrH80ZBkmr" role="1QVVSb">
           <property role="1QVVTK" value="integer.one" />
           <property role="1QVVTM" value="true" />
         </node>
-        <node concept="1QVVTL" id="3GrH80YvetN" role="1QVVSb">
+        <node concept="1QVVTL" id="3GrH80ZBkms" role="1QVVSb">
           <property role="1QVVTK" value="integer.minusOne" />
           <property role="1QVVTM" value="true" />
         </node>
-        <node concept="1QVVTL" id="3GrH80YvetO" role="1QVVSb">
+        <node concept="1QVVTL" id="3GrH80ZBkmt" role="1QVVSb">
           <property role="1QVVTK" value="decimal.one" />
           <property role="1QVVTM" value="true" />
         </node>
-        <node concept="1QVVTL" id="3GrH80YvetP" role="1QVVSb">
+        <node concept="1QVVTL" id="3GrH80ZBkmu" role="1QVVSb">
           <property role="1QVVTK" value="integer.min" />
           <property role="1QVVTM" value="0" />
         </node>
       </node>
-      <node concept="1n27V8" id="3GrH80YvetD" role="q3PPx">
-        <property role="1n27Tt" value="66" />
+      <node concept="1n27V8" id="3GrH80ZBkmi" role="q3PPx">
+        <property role="1n27Tt" value="72" />
+        <property role="4XHLh" value="72" />
+      </node>
+    </node>
+  </node>
+  <node concept="1lH9Xt" id="3GrH80YO2M1">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="ExecuteInterpreterCoverageForRecords" />
+    <node concept="1LZb2c" id="3GrH80YO2M4" role="1SL9yI">
+      <property role="TrG5h" value="checkCoverageRatio" />
+      <node concept="3cqZAl" id="3GrH80YO2M5" role="3clF45" />
+      <node concept="3clFbS" id="3GrH80YO2M6" role="3clF47">
+        <node concept="3SKdUt" id="m6kRvfl8UV" role="3cqZAp">
+          <node concept="1PaTwC" id="m6kRvfl8UW" role="1aUNEU">
+            <node concept="3oM_SD" id="m6kRvfl8UX" role="1PaTwD">
+              <property role="3oM_SC" value="coordinates" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfl8Xt" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfl8Xu" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfl8Xv" role="1PaTwD">
+              <property role="3oM_SC" value="assessment" />
+            </node>
+            <node concept="3oM_SD" id="m6kRvfl8Xy" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="29yoqQs_qgg" role="1PaTwD">
+              <property role="3oM_SC" value="trigger" />
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="29yoqQs_qoN" role="3cqZAp">
+          <node concept="1PaTwC" id="29yoqQs_qoO" role="1aUNEU">
+            <node concept="3oM_SD" id="29yoqQs_qze" role="1PaTwD">
+              <property role="3oM_SC" value="assessment.model./getModelID()" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3GrH80YOVfQ" role="3cqZAp">
+          <node concept="3cpWsn" id="3GrH80YOVfT" role="3cpWs9">
+            <property role="TrG5h" value="mdlId" />
+            <node concept="17QB3L" id="3GrH80YOVfO" role="1tU5fm" />
+            <node concept="Xl_RD" id="3GrH80YOVk4" role="33vP2m">
+              <property role="Xl_RC" value="r:fcb91210-c6db-4de0-81c0-ca99e48fd25a" />
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="29yoqQs_sKB" role="3cqZAp">
+          <node concept="1PaTwC" id="29yoqQs_sKC" role="1aUNEU">
+            <node concept="3oM_SD" id="29yoqQs_sMC" role="1PaTwD">
+              <property role="3oM_SC" value="assessmentNode.model.name" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3GrH80YOXfB" role="3cqZAp">
+          <node concept="3cpWsn" id="3GrH80YOXfC" role="3cpWs9">
+            <property role="TrG5h" value="mdlName" />
+            <node concept="17QB3L" id="3GrH80YOXfD" role="1tU5fm" />
+            <node concept="Xl_RD" id="3GrH80YOXfE" role="33vP2m">
+              <property role="Xl_RC" value="test.in.expr.os.records@tests" />
+            </node>
+          </node>
+        </node>
+        <node concept="3SKdUt" id="29yoqQs_sXk" role="3cqZAp">
+          <node concept="1PaTwC" id="29yoqQs_sXl" role="1aUNEU">
+            <node concept="3oM_SD" id="29yoqQs_t5R" role="1PaTwD">
+              <property role="3oM_SC" value="assessmentNode/.getNodeID().toString()" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3GrH80YP4pc" role="3cqZAp">
+          <node concept="3cpWsn" id="3GrH80YP4pd" role="3cpWs9">
+            <property role="TrG5h" value="nodId" />
+            <node concept="17QB3L" id="3GrH80YP4o8" role="1tU5fm" />
+            <node concept="Xl_RD" id="3GrH80YP4pe" role="33vP2m">
+              <property role="Xl_RC" value="4372229961988420860" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="3GrH80YP4Hu" role="3cqZAp" />
+        <node concept="3cpWs8" id="3GrH80ZAOI_" role="3cqZAp">
+          <node concept="3cpWsn" id="3GrH80ZAOIA" role="3cpWs9">
+            <property role="TrG5h" value="helper" />
+            <node concept="3uibUv" id="3GrH80ZAOyx" role="1tU5fm">
+              <ref role="3uigEE" to="7obj:2TlZyI4PF$d" resolve="AssessmentAnalyzer" />
+            </node>
+            <node concept="2ShNRf" id="3GrH80ZAOIB" role="33vP2m">
+              <node concept="1pGfFk" id="3GrH80ZAOIC" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="7obj:3GrH80ZhOhK" resolve="AssessmentAnalyzer" />
+                <node concept="37vLTw" id="3GrH80ZAOID" role="37wK5m">
+                  <ref role="3cqZAo" node="3GrH80YP4pd" resolve="nodId" />
+                </node>
+                <node concept="37vLTw" id="3GrH80ZAOIE" role="37wK5m">
+                  <ref role="3cqZAo" node="3GrH80YOXfC" resolve="mdlName" />
+                </node>
+                <node concept="37vLTw" id="3GrH80ZAOIF" role="37wK5m">
+                  <ref role="3cqZAo" node="3GrH80YOVfT" resolve="mdlId" />
+                </node>
+                <node concept="2OqwBi" id="3GrH80ZAOIG" role="37wK5m">
+                  <node concept="1jxXqW" id="3GrH80ZAOIH" role="2Oq$k0" />
+                  <node concept="liA8E" id="3GrH80ZAOII" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3GrH80ZB0jU" role="3cqZAp">
+          <node concept="3cpWsn" id="3GrH80ZB0jV" role="3cpWs9">
+            <property role="TrG5h" value="ass" />
+            <node concept="3Tqbb2" id="3GrH80ZB0jw" role="1tU5fm">
+              <ref role="ehGHo" to="vs0r:K292flwCEW" resolve="Assessment" />
+            </node>
+            <node concept="2OqwBi" id="3GrH80ZB0jW" role="33vP2m">
+              <node concept="37vLTw" id="3GrH80ZB0jX" role="2Oq$k0">
+                <ref role="3cqZAo" node="3GrH80ZAOIA" resolve="helper" />
+              </node>
+              <node concept="2OwXpG" id="3GrH80ZB0jY" role="2OqNvi">
+                <ref role="2Oxat5" to="7obj:3GrH80ZhwMn" resolve="assessment" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1gVbGN" id="3GrH80YP6eQ" role="3cqZAp">
+          <node concept="2OqwBi" id="3GrH80YP6vs" role="1gVkn0">
+            <node concept="37vLTw" id="3GrH80YP6hq" role="2Oq$k0">
+              <ref role="3cqZAo" node="3GrH80ZB0jV" resolve="ass" />
+            </node>
+            <node concept="3x8VRR" id="3GrH80YP6WR" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="3GrH80ZB17S" role="3cqZAp" />
+        <node concept="3clFbF" id="3GrH80ZB19u" role="3cqZAp">
+          <node concept="2OqwBi" id="3GrH80ZB1il" role="3clFbG">
+            <node concept="37vLTw" id="3GrH80ZB19s" role="2Oq$k0">
+              <ref role="3cqZAo" node="3GrH80ZAOIA" resolve="helper" />
+            </node>
+            <node concept="liA8E" id="3GrH80ZB1r$" role="2OqNvi">
+              <ref role="37wK5l" to="7obj:3GrH80ZhwJl" resolve="checkCoverage" />
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.records@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.records@tests.mps
@@ -6,11 +6,11 @@
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="-1" />
     <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="-1" />
     <use id="92d2ea16-5a42-4fdf-a676-c7604efe3504" name="de.slisson.mps.richtext" version="-1" />
-    <devkit ref="ec967770-4707-442f-baaf-a8b7bb554717(org.iets3.core.expr.genall.core.devkit)" />
     <devkit ref="c4e521ab-b605-4ef9-a7c3-68075da058f0(org.iets3.core.expr.core.devkit)" />
   </languages>
   <imports>
-    <import index="pq1l" ref="r:93cd1fe8-b296-405c-a6e6-040c940ccfa1(org.iets3.core.expr.toplevel.plugin)" />
+    <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
+    <import index="yv47" ref="r:da65683e-ff6f-430d-ab68-32a77df72c93(org.iets3.core.expr.toplevel.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -126,10 +126,29 @@
         <property id="7740953487931061385" name="referenceOnlyLocalStuff" index="1XBH2A" />
         <child id="543569365052711058" name="contents" index="_iOnB" />
       </concept>
+      <concept id="4137027550727647612" name="org.iets3.core.expr.tests.structure.LanguageRef" flags="ng" index="1aipRv">
+        <child id="4137027550727647984" name="lang" index="1aipTj" />
+      </concept>
+      <concept id="4137027550728847170" name="org.iets3.core.expr.tests.structure.IgnoredConcept" flags="ng" index="1amXfx">
+        <reference id="4137027550728847334" name="concept" index="1amXd5" />
+      </concept>
+      <concept id="4137027550720478450" name="org.iets3.core.expr.tests.structure.InterpreterCoverageAssQuery" flags="ng" index="1bQQ1h" />
+      <concept id="4137027550720482705" name="org.iets3.core.expr.tests.structure.InterpreterCoverageAssResult" flags="ng" index="1bQR4M">
+        <property id="4137027550720484225" name="comment" index="1bQOWy" />
+        <reference id="4137027550720483094" name="concept" index="1bQReP" />
+      </concept>
       <concept id="5285810042889815162" name="org.iets3.core.expr.tests.structure.EmptyTestItem" flags="ng" index="3dYjL0" />
       <concept id="1925389232535425850" name="org.iets3.core.expr.tests.structure.AndMatcher" flags="ng" index="1h6CxO">
         <child id="1925389232535425913" name="right" index="1h6CwR" />
         <child id="1925389232535425911" name="left" index="1h6CwT" />
+      </concept>
+      <concept id="5716711712470882681" name="org.iets3.core.expr.tests.structure.AbstractCoverageQuery" flags="ng" index="3msoTU">
+        <child id="4137027550727662489" name="languages" index="1aissU" />
+        <child id="4137027550729731592" name="scope" index="1al_aF" />
+        <child id="4137027550728939664" name="ignoredConcepts" index="1am$gN" />
+      </concept>
+      <concept id="1307222191605829984" name="org.iets3.core.expr.tests.structure.InterpreterCoverageAssSummary" flags="ng" index="1n27V8">
+        <property id="1307222191605830133" name="coverageRatio" index="1n27Tt" />
       </concept>
       <concept id="6723982381150106591" name="org.iets3.core.expr.tests.structure.ContainsString" flags="ng" index="3_fT66" />
       <concept id="6723982381143750170" name="org.iets3.core.expr.tests.structure.AssertThatTestItem" flags="ng" index="3_nDh3">
@@ -139,6 +158,13 @@
       <concept id="6723982381145448848" name="org.iets3.core.expr.tests.structure.IsValidRecord" flags="ng" index="3_u8f9" />
       <concept id="6723982381145831383" name="org.iets3.core.expr.tests.structure.IsInvalid" flags="ng" index="3_vHme">
         <child id="6723982381151129394" name="messageMatcher" index="3_bYPF" />
+      </concept>
+      <concept id="993724751390561556" name="org.iets3.core.expr.tests.structure.InterpreterValueStat" flags="ng" index="1QVVTL">
+        <property id="993724751390561557" name="label" index="1QVVTK" />
+        <property id="993724751390561559" name="value" index="1QVVTM" />
+      </concept>
+      <concept id="993724751390561555" name="org.iets3.core.expr.tests.structure.InterpreterValueSummary" flags="ng" index="1QVVTQ">
+        <child id="993724751390561646" name="valueStats" index="1QVVSb" />
       </concept>
       <concept id="7740953487929753437" name="org.iets3.core.expr.tests.structure.NamedAssertRef" flags="ng" index="1XGHHM">
         <reference id="7740953487929753441" name="item" index="1XGHHe" />
@@ -179,9 +205,7 @@
       <concept id="8293738266727773586" name="org.iets3.core.expr.toplevel.structure.GroupByOp" flags="ng" index="23hzag" />
       <concept id="8293738266729562040" name="org.iets3.core.expr.toplevel.structure.GroupMembersTarget" flags="ng" index="23oZyU" />
       <concept id="8293738266728974042" name="org.iets3.core.expr.toplevel.structure.GroupKeyTarget" flags="ng" index="23q87o" />
-      <concept id="7782108600709718604" name="org.iets3.core.expr.toplevel.structure.ReferenceableFlag" flags="ng" index="nbNz6">
-        <reference id="7782108600710563457" name="idMember" index="n8xKb" />
-      </concept>
+      <concept id="7782108600709718604" name="org.iets3.core.expr.toplevel.structure.ReferenceableFlag" flags="ng" index="nbNz6" />
       <concept id="3980268926893656512" name="org.iets3.core.expr.toplevel.structure.RecordComparisonOrder" flags="ng" index="tekx0">
         <reference id="3980268926893656513" name="member" index="tekx1" />
       </concept>
@@ -233,11 +257,39 @@
       </concept>
     </language>
     <language id="d4280a54-f6df-4383-aa41-d1b2bffa7eb1" name="com.mbeddr.core.base">
+      <concept id="8490595898229124557" name="com.mbeddr.core.base.structure.CurrentModelScope" flags="ng" index="28wkCQ" />
+      <concept id="671216505796623802" name="com.mbeddr.core.base.structure.DefaultAssessmentSummary" flags="ng" index="qc_Tx">
+        <property id="671216505796623807" name="newlyAdded" index="qc_T$" />
+        <property id="671216505796623806" name="ok" index="qc_T_" />
+        <property id="671216505796623805" name="totalCount" index="qc_TA" />
+      </concept>
       <concept id="8375407818529178006" name="com.mbeddr.core.base.structure.TextBlock" flags="ng" index="OjmMv">
         <child id="8375407818529178007" name="text" index="OjmMu" />
       </concept>
+      <concept id="865293814733114043" name="com.mbeddr.core.base.structure.AssessmentContainer" flags="ng" index="3pwaUo">
+        <child id="865293814733114045" name="assessments" index="3pwaUu" />
+      </concept>
+      <concept id="865293814733114044" name="com.mbeddr.core.base.structure.Assessment" flags="ng" index="3pwaUv">
+        <property id="4423545983997787056" name="lastUpdatedBy" index="2iEaKi" />
+        <property id="4423545983997782838" name="lastUpdatedOn" index="2iEbMk" />
+        <property id="8691429746170824734" name="sorted" index="1Ema5g" />
+        <child id="671216505796427450" name="summaries" index="q3PPx" />
+        <child id="865293814733115677" name="query" index="3pwbkY" />
+        <child id="865293814733118687" name="results" index="3pwbzW" />
+      </concept>
+      <concept id="865293814733118686" name="com.mbeddr.core.base.structure.AssessmentResultEntry" flags="ng" index="3pwbzX">
+        <property id="6619757161337247129" name="lastFound" index="3J1cY9" />
+        <child id="865293814733133843" name="result" index="3pwfKK" />
+        <child id="6619757161337461931" name="comment" index="3J00qV" />
+      </concept>
       <concept id="3857533489766146428" name="com.mbeddr.core.base.structure.ElementDocumentation" flags="ng" index="1z9TsT">
         <child id="4052432714772608243" name="text" index="1w35rA" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="3542851458883438784" name="jetbrains.mps.lang.smodel.structure.LanguageId" flags="nn" index="2V$Bhx">
+        <property id="3542851458883439831" name="namespace" index="2V$B1Q" />
+        <property id="3542851458883439832" name="languageId" index="2V$B1T" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -308,9 +360,7 @@
         <property role="TrG5h" value="firstName" />
         <node concept="30bdrU" id="6JZACDWVZuB" role="2S399n" />
       </node>
-      <node concept="nbNz6" id="6JZACDWVZ_m" role="nbNzx">
-        <ref role="n8xKb" node="6JZACDWVZtR" resolve="name" />
-      </node>
+      <node concept="nbNz6" id="6JZACDWVZ_m" role="nbNzx" />
     </node>
     <node concept="_ixoA" id="6JZACDWVZuJ" role="_iOnB" />
     <node concept="2zPypq" id="6JZACDWVZv8" role="_iOnB">
@@ -3979,9 +4029,6 @@
       <property role="TrG5h" value="testing" />
       <node concept="_fkuZ" id="7cphKbKu$_U" role="_fkp5">
         <node concept="_fku$" id="7cphKbKu$_V" role="_fkur" />
-        <node concept="_emDc" id="7cphKbKu$YL" role="_fkuY">
-          <ref role="_emDf" node="7cphKbKqXjT" resolve="keys" />
-        </node>
         <node concept="3iBYfx" id="7cphKbKu$Zf" role="_fkuS">
           <node concept="30bdrP" id="7cphKbKuA9R" role="3iBYfI">
             <property role="30bdrQ" value="Markus" />
@@ -3989,6 +4036,9 @@
           <node concept="30bdrP" id="7cphKbKuAiT" role="3iBYfI">
             <property role="30bdrQ" value="Peter" />
           </node>
+        </node>
+        <node concept="_emDc" id="7cphKbKu$YL" role="_fkuY">
+          <ref role="_emDf" node="7cphKbKqXjT" resolve="keys" />
         </node>
       </node>
       <node concept="_fkuZ" id="7cphKbKztl8" role="_fkp5">
@@ -4330,6 +4380,538 @@
       </node>
     </node>
     <node concept="_ixoA" id="7cphKbKM242" role="_iOnB" />
+  </node>
+  <node concept="3pwaUo" id="3MHhZL0CVjV">
+    <property role="TrG5h" value="InterpreterCoverageRecord" />
+    <node concept="3pwaUv" id="3MHhZL0CVjW" role="3pwaUu">
+      <property role="TrG5h" value="InterpreterCoverageRecord" />
+      <property role="1Ema5g" value="true" />
+      <property role="2iEbMk" value="1752578118469" />
+      <property role="2iEaKi" value="arimer" />
+      <node concept="1bQQ1h" id="3MHhZL0CVv9" role="3pwbkY">
+        <node concept="1amXfx" id="RnCcjkviXq" role="1am$gN">
+          <ref role="1amXd5" to="hm2y:6sdnDbSlaok" resolve="Type" />
+        </node>
+        <node concept="1amXfx" id="3GrH80XKI0y" role="1am$gN">
+          <ref role="1amXd5" to="yv47:c36CPsxOj8" resolve="EnumIndexOp" />
+          <node concept="1z9TsT" id="3GrH80XMiD6" role="lGtFl">
+            <node concept="OjmMv" id="3GrH80XMiD7" role="1w35rA">
+              <node concept="19SGf9" id="3GrH80XMiD8" role="OjmMu">
+                <node concept="19SUe$" id="3GrH80XMiD9" role="19SJt6">
+                  <property role="19SUeA" value="We ignore all enum stuff on purpose&#10;because this is not part of our test model " />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1amXfx" id="3GrH80XKUxl" role="1am$gN">
+          <ref role="1amXd5" to="yv47:2zwra1$QhrC" resolve="AllLitList" />
+        </node>
+        <node concept="1amXfx" id="3GrH80XL728" role="1am$gN">
+          <ref role="1amXd5" to="yv47:3Y6fbK1h_yq" resolve="EnumValueAccessor" />
+        </node>
+        <node concept="1amXfx" id="3GrH80XLjyV" role="1am$gN">
+          <ref role="1amXd5" to="yv47:4zsmO3KtfVR" resolve="QualifierRef" />
+        </node>
+        <node concept="1amXfx" id="3GrH80XLw3I" role="1am$gN">
+          <ref role="1amXd5" to="yv47:5ElkanPQwmt" resolve="EnumIsTarget" />
+        </node>
+        <node concept="1amXfx" id="3GrH80XLG$x" role="1am$gN">
+          <ref role="1amXd5" to="yv47:67Y8mp$DMUI" resolve="EnumDeclaration" />
+        </node>
+        <node concept="1amXfx" id="3GrH80XMiDa" role="1am$gN">
+          <ref role="1amXd5" to="yv47:67Y8mp$DMVh" resolve="EnumLiteral" />
+        </node>
+        <node concept="1amXfx" id="3GrH80XMv9X" role="1am$gN">
+          <ref role="1amXd5" to="yv47:67Y8mp$DNr5" resolve="EnumLiteralRef" />
+        </node>
+        <node concept="1amXfx" id="3GrH80XMFEK" role="1am$gN">
+          <ref role="1amXd5" to="yv47:67Y8mp$DNr5" resolve="EnumLiteralRef" />
+        </node>
+        <node concept="1amXfx" id="3GrH80XMSbz" role="1am$gN">
+          <ref role="1amXd5" to="yv47:6PMVc5H_jNZ" resolve="EnumSortByLiteral" />
+        </node>
+        <node concept="1amXfx" id="3GrH80XN4Gm" role="1am$gN">
+          <ref role="1amXd5" to="yv47:6PMVc5H_jNZ" resolve="EnumSortByLiteral" />
+        </node>
+        <node concept="1amXfx" id="3GrH80XNhd9" role="1am$gN">
+          <ref role="1amXd5" to="yv47:6PMVc5H_jNZ" resolve="EnumSortByLiteral" />
+        </node>
+        <node concept="1amXfx" id="3GrH80XNtHW" role="1am$gN">
+          <ref role="1amXd5" to="yv47:6PMVc5H_jO2" resolve="EnumSortByValue" />
+        </node>
+        <node concept="28wkCQ" id="3MHhZL0CVva" role="1al_aF" />
+        <node concept="1aipRv" id="6bUn_ThMGB0" role="1aissU">
+          <node concept="2V$Bhx" id="3GrH80XK1Wz" role="1aipTj">
+            <property role="2V$B1T" value="71934284-d7d1-45ee-a054-8c072591085f" />
+            <property role="2V$B1Q" value="org.iets3.core.expr.toplevel" />
+          </node>
+        </node>
+        <node concept="1amXfx" id="3GrH80XNKCv" role="1am$gN">
+          <ref role="1amXd5" to="yv47:6PMVc5H_jO5" resolve="EnumSortByDeclaration" />
+        </node>
+        <node concept="1amXfx" id="3GrH80XOd_9" role="1am$gN">
+          <ref role="1amXd5" to="yv47:6WstIz8MK67" resolve="EnumIsInTarget" />
+        </node>
+        <node concept="1amXfx" id="3GrH80XOmL3" role="1am$gN">
+          <ref role="1amXd5" to="yv47:6WstIz8MKZd" resolve="EnumIsInSelector" />
+        </node>
+        <node concept="1amXfx" id="3GrH80XOvDr" role="1am$gN">
+          <ref role="1amXd5" to="yv47:ub9nkyKjdj" resolve="EmptyToplevelContent" />
+        </node>
+        <node concept="1amXfx" id="3GrH80XOCge" role="1am$gN">
+          <ref role="1amXd5" to="yv47:6HHp2Wn7mD6" resolve="SectionMarker" />
+        </node>
+        <node concept="1amXfx" id="3GrH80XOK_s" role="1am$gN">
+          <ref role="1amXd5" to="yv47:ub9nkyK62f" resolve="Library" />
+        </node>
+        <node concept="1amXfx" id="3GrH80Yw8cL" role="1am$gN">
+          <ref role="1amXd5" to="yv47:58eyHuUiMwN" resolve="EmptyMember" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK41o" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118453" />
+        <node concept="OjmMv" id="3GrH80XK41p" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK41q" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK41r" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK40y" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:ub9nkyG$WT" resolve="ConstantRef" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK41k" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118453" />
+        <node concept="OjmMv" id="3GrH80XK41l" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK41m" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK41n" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK40x" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:69zaTr1HgRc" resolve="Constant" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK42g" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118453" />
+        <node concept="OjmMv" id="3GrH80XK42h" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK42i" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK42j" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK40K" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="yv47:2uR5X5azSbn" resolve="ExtensionFunctionCall" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK42s" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118453" />
+        <node concept="OjmMv" id="3GrH80XK42t" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK42u" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK42v" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK40N" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:49WTic8f4iz" resolve="Function" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK42w" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118453" />
+        <node concept="OjmMv" id="3GrH80XK42x" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK42y" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK42z" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK40O" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:49WTic8gFfG" resolve="FunctionCall" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK42o" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118453" />
+        <node concept="OjmMv" id="3GrH80XK42p" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK42q" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK42r" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK40M" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="yv47:49WTic8hwXW" resolve="FunRef" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK43C" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118454" />
+        <node concept="OjmMv" id="3GrH80XK43D" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK43E" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK43F" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK416" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:SRvqsNmWc8" resolve="RecordMemberRefInConstraint" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK43o" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118454" />
+        <node concept="OjmMv" id="3GrH80XK43p" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK43q" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK43r" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK412" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="yv47:3sWKo0E1oB0" resolve="RecordComparisonOrder" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK43K" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118454" />
+        <node concept="OjmMv" id="3GrH80XK43L" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK43M" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK43N" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK418" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="yv47:6JZACDWOa9c" resolve="ReferenceableFlag" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK43s" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118454" />
+        <node concept="OjmMv" id="3GrH80XK43t" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK43u" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK43v" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK413" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:7D7uZV2dYyQ" resolve="RecordDeclaration" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK43$" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118454" />
+        <node concept="OjmMv" id="3GrH80XK43_" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK43A" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK43B" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK415" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:7D7uZV2dYyT" resolve="RecordMember" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK43w" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118454" />
+        <node concept="OjmMv" id="3GrH80XK43x" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK43y" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK43z" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK414" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:7D7uZV2iYAC" resolve="RecordLiteral" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK41g" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118421" />
+        <node concept="OjmMv" id="3GrH80XK41h" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK41i" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK41j" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK40w" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:4ptnK4jbqZj" resolve="BuilderExpression" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK42k" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118453" />
+        <node concept="OjmMv" id="3GrH80XK42l" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK42m" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK42n" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK40L" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="yv47:4ptnK4jbqZG" resolve="FieldSetter" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK43G" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118454" />
+        <node concept="OjmMv" id="3GrH80XK43H" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK43I" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK43J" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK417" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:4ptnK4jbr8M" resolve="RecordTypeAdapter" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK43k" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118454" />
+        <node concept="OjmMv" id="3GrH80XK43l" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK43m" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK43n" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK411" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:15mJ3JeHQzr" resolve="RecordChangeTarget" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK42S" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118453" />
+        <node concept="OjmMv" id="3GrH80XK42T" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK42U" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK42V" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK40U" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="yv47:15mJ3JeHQzQ" resolve="NewValueSetter" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK430" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118454" />
+        <node concept="OjmMv" id="3GrH80XK431" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK432" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK433" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK40W" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:HywGhj0hJO" resolve="OldValueExpr" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK42W" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118454" />
+        <node concept="OjmMv" id="3GrH80XK42X" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK42Y" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK42Z" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK40V" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:HywGhj4ZhL" resolve="OldMemberRef" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK42$" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118453" />
+        <node concept="OjmMv" id="3GrH80XK42_" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK42A" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK42B" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK40P" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:7cphKbKnRmi" resolve="GroupByOp" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK42C" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118453" />
+        <node concept="OjmMv" id="3GrH80XK42D" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK42E" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK42F" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK40Q" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:7cphKbKssrq" resolve="GroupKeyTarget" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK42G" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118453" />
+        <node concept="OjmMv" id="3GrH80XK42H" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK42I" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK42J" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK40R" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:7cphKbKuFYS" resolve="GroupMembersTarget" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK43c" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118454" />
+        <node concept="OjmMv" id="3GrH80XK43d" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK43e" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK43f" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK40Z" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:7cphKbLawO$" resolve="ProjectOp" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK438" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118454" />
+        <node concept="OjmMv" id="3GrH80XK439" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK43a" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK43b" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK40Y" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="yv47:7cphKbLawOC" resolve="ProjectMember" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK434" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118454" />
+        <node concept="OjmMv" id="3GrH80XK435" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK436" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK437" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK40X" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:7cphKbLg8An" resolve="ProjectIt" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK42K" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118453" />
+        <node concept="OjmMv" id="3GrH80XK42L" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK42M" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK42N" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK40S" role="3pwfKK">
+          <property role="1bQOWy" value="Covered." />
+          <ref role="1bQReP" to="yv47:7cphKbLtLQW" resolve="InlineRecordMemberAccess" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK43W" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118454" />
+        <node concept="OjmMv" id="3GrH80XK43X" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK43Y" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK43Z" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK41b" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="yv47:2S3ZC$oCfaF" resolve="TypedefContractValExpr" />
+        </node>
+      </node>
+      <node concept="3pwbzX" id="3GrH80XK43S" role="3pwbzW">
+        <property role="3J1cY9" value="1752578118454" />
+        <node concept="OjmMv" id="3GrH80XK43T" role="3J00qV">
+          <node concept="19SGf9" id="3GrH80XK43U" role="OjmMu">
+            <node concept="19SUe$" id="3GrH80XK43V" role="19SJt6">
+              <property role="19SUeA" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="1bQR4M" id="3GrH80XK41a" role="3pwfKK">
+          <property role="1bQOWy" value="Missing." />
+          <ref role="1bQReP" to="yv47:6HHp2WngtTC" resolve="Typedef" />
+        </node>
+      </node>
+      <node concept="qc_Tx" id="3GrH80YvetE" role="q3PPx">
+        <property role="qc_TA" value="29" />
+        <property role="qc_T$" value="0" />
+        <property role="qc_T_" value="0" />
+      </node>
+      <node concept="1QVVTQ" id="3GrH80YvetF" role="q3PPx">
+        <node concept="1QVVTL" id="3GrH80YvetG" role="1QVVSb">
+          <property role="1QVVTK" value="decimal.max" />
+          <property role="1QVVTM" value="2.0" />
+        </node>
+        <node concept="1QVVTL" id="3GrH80YvetH" role="1QVVSb">
+          <property role="1QVVTK" value="decimal.min" />
+          <property role="1QVVTM" value="1.0" />
+        </node>
+        <node concept="1QVVTL" id="3GrH80YvetI" role="1QVVSb">
+          <property role="1QVVTK" value="decimal.zero" />
+          <property role="1QVVTM" value="true" />
+        </node>
+        <node concept="1QVVTL" id="3GrH80YvetJ" role="1QVVSb">
+          <property role="1QVVTK" value="integer.zero" />
+          <property role="1QVVTM" value="true" />
+        </node>
+        <node concept="1QVVTL" id="3GrH80YvetK" role="1QVVSb">
+          <property role="1QVVTK" value="integer.max" />
+          <property role="1QVVTM" value="400" />
+        </node>
+        <node concept="1QVVTL" id="3GrH80YvetL" role="1QVVSb">
+          <property role="1QVVTK" value="decimal.minusOne" />
+          <property role="1QVVTM" value="true" />
+        </node>
+        <node concept="1QVVTL" id="3GrH80YvetM" role="1QVVSb">
+          <property role="1QVVTK" value="integer.one" />
+          <property role="1QVVTM" value="true" />
+        </node>
+        <node concept="1QVVTL" id="3GrH80YvetN" role="1QVVSb">
+          <property role="1QVVTK" value="integer.minusOne" />
+          <property role="1QVVTM" value="true" />
+        </node>
+        <node concept="1QVVTL" id="3GrH80YvetO" role="1QVVSb">
+          <property role="1QVVTK" value="decimal.one" />
+          <property role="1QVVTM" value="true" />
+        </node>
+        <node concept="1QVVTL" id="3GrH80YvetP" role="1QVVSb">
+          <property role="1QVVTK" value="integer.min" />
+          <property role="1QVVTM" value="0" />
+        </node>
+      </node>
+      <node concept="1n27V8" id="3GrH80YvetD" role="q3PPx">
+        <property role="1n27Tt" value="66" />
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/test.in.expr.os.msd
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/test.in.expr.os.msd
@@ -27,6 +27,7 @@
     <dependency reexport="false">1c761cfd-81b1-4794-9999-148fa76881b8(org.iets3.core.expr.typetags.units.si)</dependency>
     <dependency reexport="false">7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)</dependency>
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
+    <dependency reexport="false">5fe6cb13-2fbd-4e21-9842-785bdd6fc5b1(org.iets3.core.expr.adt)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
@@ -140,8 +141,10 @@
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
     <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="1" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
+    <module reference="5fe6cb13-2fbd-4e21-9842-785bdd6fc5b1(org.iets3.core.expr.adt)" version="8" />
     <module reference="79d5345e-e919-477c-b448-d9d5f36e2f92(org.iets3.core.expr.adt.interpreter)" version="0" />
     <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="20" />
+    <module reference="b76a0f63-5959-456b-993a-c796cc0d0c13(org.iets3.core.expr.base.collections.stubs)" version="0" />
     <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
     <module reference="00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)" version="0" />
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/test.in.expr.os.msd
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/test.in.expr.os.msd
@@ -28,6 +28,10 @@
     <dependency reexport="false">7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)</dependency>
     <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
     <dependency reexport="false">5fe6cb13-2fbd-4e21-9842-785bdd6fc5b1(org.iets3.core.expr.adt)</dependency>
+    <dependency reexport="false">d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
+    <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
@@ -48,11 +52,13 @@
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:daafa647-f1f7-4b0b-b096-69cd7c8408c0:jetbrains.mps.baseLanguage.regexp" version="0" />
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:817e4e70-961e-4a95-98a1-15e9f32231f1:jetbrains.mps.ide.httpsupport" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:c0080a47-7e37-4558-bee9-9ae18e690549:jetbrains.mps.lang.extension" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:db8bd035-3f51-41d8-8fed-954c202d18be:org.iets3.analysis.base" version="0" />
     <language slang="l:7b68d745-a7b8-48b9-bd9c-05c0f8725a35:org.iets3.core.base" version="0" />
@@ -125,10 +131,12 @@
     <module reference="f0fff802-6d26-4d2e-b89d-391357265626(de.slisson.mps.hacks.editor)" version="0" />
     <module reference="92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
     <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
     <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
     <module reference="daafa647-f1f7-4b0b-b096-69cd7c8408c0(jetbrains.mps.baseLanguage.regexp)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="f61473f9-130f-42f6-b98d-6c438812c2f6(jetbrains.mps.baseLanguage.unitTest)" version="0" />
     <module reference="23865718-e2ed-41b5-a132-0da1d04e266d(jetbrains.mps.ide.httpsupport.manager)" version="0" />
     <module reference="ae6d8005-36be-4cb6-945b-8c8cfc033c51(jetbrains.mps.ide.httpsupport.runtime)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
@@ -138,6 +146,7 @@
     <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
     <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
     <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+    <module reference="8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
     <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="1" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
@@ -175,6 +184,7 @@
     <module reference="4621d3e3-b8a3-4bbe-b7ac-234b6e2d1d68(org.iets3.core.expr.temporal)" version="4" />
     <module reference="06aa4a64-087b-49de-99ac-5bfea95ff839(org.iets3.core.expr.temporal.interpreter)" version="0" />
     <module reference="17ecc6b6-d106-4b60-87a9-3fde52f92301(org.iets3.core.expr.temporal.runtime)" version="0" />
+    <module reference="d441fba0-f46b-43cd-b723-dad7b65da615(org.iets3.core.expr.tests)" version="5" />
     <module reference="71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)" version="4" />
     <module reference="b0e7c6a8-b47d-4637-b0e8-e5bfd486c4e8(org.iets3.core.expr.tracing.plugin)" version="0" />
     <module reference="b4ec5624-2e67-4a4e-9ece-34bcbf966115(org.iets3.core.expr.typetags.lib.interpreter)" version="0" />


### PR DESCRIPTION
This is a first PR of a series of PRs in the context of Assessments. The goal is to test our assessments and integrate their execution in a CI server. In this PR the InterpreterCoverageAssQuery was fixed and setup for testing. Initially  this assessment was accidentially broken in https://github.com/IETS3/iets3.opensource/pull/743.

### Provided Fixes
- Fixes https://github.com/IETS3/iets3.opensource/issues/1366 by enabling the collection of coverage data by default (as initially intended)
- Fixes https://github.com/IETS3/iets3.opensource/issues/1391 by adding a new color for ignored nodes


### Provided quality enchancements 
- added some rudimentary [API](http://127.0.0.1:63320/node?ref=r%3Ac3404ca7-2556-4517-b7d5-ec378ad78058%28test.in.expr.os.assessmentUtils%29%2F3338854161630804237) to invoke assessments from tests and execute them on CI
- added a [ExecuteInterpreterCoverageForRecords](http://127.0.0.1:63320/node?ref=r%3Afcb91210-c6db-4de0-81c0-ca99e48fd25a%28test.in.expr.os.records%40tests%29%2F4259196335511579777) test that updates an assessment and performs unit tests
- added a [InterpreterCoverageAssSummary.coverageThreshold](http://127.0.0.1:63320/node?ref=r%3Aba7faab6-2b80-43d5-8b95-0c440665312c%28org.iets3.core.expr.tests.structure%29%2F4259196335530272977) property