### PR TITLE
Activate all missing tests

### DIFF
--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -16201,16 +16201,6 @@
           </node>
         </node>
       </node>
-      <node concept="1SiIV0" id="4aAsKjbTJHl" role="3bR37C">
-        <node concept="3bR9La" id="4aAsKjbTJHm" role="1SiIV1">
-          <ref role="3bR37D" to="ffeo:7Kfy9QB6L4X" resolve="jetbrains.mps.lang.editor" />
-        </node>
-      </node>
-      <node concept="1SiIV0" id="4aAsKjbTNo$" role="3bR37C">
-        <node concept="3bR9La" id="4aAsKjbTNo_" role="1SiIV1">
-          <ref role="3bR37D" to="90a9:7klUZA6XM5Q" resolve="de.slisson.mps.conditionalEditor" />
-        </node>
-      </node>
       <node concept="1SiIV0" id="4aAsKjbTNoS" role="3bR37C">
         <node concept="1Busua" id="4aAsKjbTNoT" role="1SiIV1">
           <ref role="1Busuk" to="90a9:7klUZA6XM5Q" resolve="de.slisson.mps.conditionalEditor" />
@@ -16346,6 +16336,7 @@
       <property role="BnDLt" value="true" />
       <property role="TrG5h" value="test.components.functional" />
       <property role="3LESm3" value="339619e2-78b9-4a69-859d-32ce3eea1939" />
+      <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
       <node concept="398BVA" id="277EWw0imxX" role="3LF7KH">
         <ref role="398BVh" node="OJuIQp$deE" resolve="iets3.lang.opensource" />
         <node concept="2Ry0Ak" id="277EWw0imyh" role="iGT6I">
@@ -16468,6 +16459,7 @@
       <property role="BnDLt" value="true" />
       <property role="TrG5h" value="test.iets3.components.toplevel.adapter" />
       <property role="3LESm3" value="e58cb7a2-4782-4210-a236-05de0d75c6b2" />
+      <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
       <node concept="398BVA" id="2i81Z9BQeJ7" role="3LF7KH">
         <ref role="398BVh" node="OJuIQp$deE" resolve="iets3.lang.opensource" />
         <node concept="2Ry0Ak" id="2i81Z9BQeJb" role="iGT6I">
@@ -16523,6 +16515,7 @@
       <property role="BnDLt" value="true" />
       <property role="TrG5h" value="test.iets3.core.mapping" />
       <property role="3LESm3" value="12ae53bc-0d28-4b54-88e3-48a56519294d" />
+      <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
       <node concept="398BVA" id="4dUR79id6QC" role="3LF7KH">
         <ref role="398BVh" node="OJuIQp$deE" resolve="iets3.lang.opensource" />
         <node concept="2Ry0Ak" id="4dUR79id6QG" role="iGT6I">
@@ -16588,6 +16581,7 @@
       <property role="BnDLt" value="true" />
       <property role="TrG5h" value="test.iets3.core.tracequery" />
       <property role="3LESm3" value="785e2843-aa64-4743-afec-47634f9d78a4" />
+      <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
       <node concept="398BVA" id="7K$Mm86tjfE" role="3LF7KH">
         <ref role="398BVh" node="OJuIQp$deE" resolve="iets3.lang.opensource" />
         <node concept="2Ry0Ak" id="7K$Mm86tjfW" role="iGT6I">
@@ -16668,6 +16662,7 @@
       <property role="BnDLt" value="true" />
       <property role="TrG5h" value="test.iets3.safety.attributes" />
       <property role="3LESm3" value="e58538db-560d-4e78-b9c3-9ba00ad59397" />
+      <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
       <node concept="398BVA" id="2i81Z9BQeBx" role="3LF7KH">
         <ref role="398BVh" node="OJuIQp$deE" resolve="iets3.lang.opensource" />
         <node concept="2Ry0Ak" id="2i81Z9BQeB_" role="iGT6I">
@@ -17094,6 +17089,7 @@
       <property role="BnDLt" value="true" />
       <property role="TrG5h" value="test.org.iets3.protocol.transport" />
       <property role="3LESm3" value="5d4bc982-a658-41f9-a32e-1221b26a9dae" />
+      <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
       <node concept="398BVA" id="4dUR79iwSk0" role="3LF7KH">
         <ref role="398BVh" node="OJuIQp$deE" resolve="iets3.lang.opensource" />
         <node concept="2Ry0Ak" id="4dUR79iwSk4" role="iGT6I">
@@ -17159,6 +17155,7 @@
       <property role="BnDLt" value="true" />
       <property role="TrG5h" value="test.org.iets3.variability.configuration.base" />
       <property role="3LESm3" value="69c0c18f-9200-46ca-96d1-e564692dce0c" />
+      <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
       <node concept="398BVA" id="7tVUji9MfMe" role="3LF7KH">
         <ref role="398BVh" node="OJuIQp$deE" resolve="iets3.lang.opensource" />
         <node concept="2Ry0Ak" id="7tVUji9MfMh" role="iGT6I">
@@ -17234,6 +17231,7 @@
       <property role="BnDLt" value="true" />
       <property role="TrG5h" value="test.org.iets3.variability.featuremodel.base" />
       <property role="3LESm3" value="d09d86d3-0476-4f57-a9bf-aab3e36e3aee" />
+      <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
       <node concept="398BVA" id="7tVUji9MfSu" role="3LF7KH">
         <ref role="398BVh" node="OJuIQp$deE" resolve="iets3.lang.opensource" />
         <node concept="2Ry0Ak" id="7tVUji9MfSv" role="iGT6I">
@@ -17370,6 +17368,7 @@
       <property role="BnDLt" value="true" />
       <property role="TrG5h" value="test.ts.components.hardware" />
       <property role="3LESm3" value="6992992b-820e-4e23-b697-e246fb887cc9" />
+      <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
       <node concept="398BVA" id="4dUR79id6MD" role="3LF7KH">
         <ref role="398BVh" node="OJuIQp$deE" resolve="iets3.lang.opensource" />
         <node concept="2Ry0Ak" id="4dUR79id6MH" role="iGT6I">
@@ -17611,6 +17610,7 @@
       <property role="BnDLt" value="true" />
       <property role="TrG5h" value="test.ts.expr.os.comma" />
       <property role="3LESm3" value="d4ce91b2-257c-4780-a3fa-98d1f50ce822" />
+      <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
       <node concept="398BVA" id="5CKJX630vhh" role="3LF7KH">
         <ref role="398BVh" node="OJuIQp$deE" resolve="iets3.lang.opensource" />
         <node concept="2Ry0Ak" id="5CKJX630vhk" role="iGT6I">
@@ -17731,6 +17731,33 @@
           <ref role="398BVh" node="OJuIQp$deE" resolve="iets3.lang.opensource" />
         </node>
       </node>
+      <node concept="22LTRM" id="IJ8MgPZlN9" role="22LTRK">
+        <ref role="22LTRN" node="IJ8MgPVKAO" resolve="test.org.iets3.analysis.base" />
+      </node>
+      <node concept="22LTRM" id="1WrO9kaEJAs" role="22LTRK">
+        <ref role="22LTRN" node="4dUR79id6Q_" resolve="test.iets3.core.mapping" />
+      </node>
+      <node concept="22LTRM" id="1WrO9kaEJAv" role="22LTRK">
+        <ref role="22LTRN" node="4dUR79iwSjX" resolve="test.org.iets3.protocol.transport" />
+      </node>
+      <node concept="22LTRM" id="1WrO9kaEJAy" role="22LTRK">
+        <ref role="22LTRN" node="277EWw0imxa" resolve="test.components.functional" />
+      </node>
+      <node concept="22LTRM" id="1WrO9kaEJA_" role="22LTRK">
+        <ref role="22LTRN" node="2i81Z9BQeI$" resolve="test.iets3.components.toplevel.adapter" />
+      </node>
+      <node concept="22LTRM" id="48ZWgAGrv_8" role="22LTRK">
+        <ref role="22LTRN" node="48ZWgAGrsP1" resolve="test.ts.components.core" />
+      </node>
+      <node concept="22LTRM" id="1WrO9kaEJAC" role="22LTRK">
+        <ref role="22LTRN" node="4dUR79id6MA" resolve="test.ts.components.hardware" />
+      </node>
+      <node concept="22LTRM" id="5kwEgmAh92W" role="22LTRK">
+        <ref role="22LTRN" node="5kwEgmAh8J_" resolve="test.org.iets3.core.comments" />
+      </node>
+      <node concept="22LTRM" id="4ToqgmJmYtN" role="22LTRK">
+        <ref role="22LTRN" node="6xvglc6Du8w" resolve="test.ex.core.expr.genjava" />
+      </node>
       <node concept="22LTRM" id="OJuIQp_hdf" role="22LTRK">
         <ref role="22LTRN" node="OJuIQp$d7j" resolve="test.in.expr.os" />
       </node>
@@ -17740,17 +17767,20 @@
       <node concept="22LTRM" id="5IOlOc8vuMy" role="22LTRK">
         <ref role="22LTRN" node="5IOlOc8uq2z" resolve="test.ts.expr.os" />
       </node>
-      <node concept="22LTRM" id="5kwEgmAh92W" role="22LTRK">
-        <ref role="22LTRN" node="5kwEgmAh8J_" resolve="test.org.iets3.core.comments" />
+      <node concept="22LTRM" id="1WrO9kaEJRE" role="22LTRK">
+        <ref role="22LTRN" node="5CKJX630vfX" resolve="test.ts.expr.os.comma" />
       </node>
-      <node concept="22LTRM" id="48ZWgAGrv_8" role="22LTRK">
-        <ref role="22LTRN" node="48ZWgAGrsP1" resolve="test.ts.components.core" />
+      <node concept="22LTRM" id="1WrO9kaEJRH" role="22LTRK">
+        <ref role="22LTRN" node="2i81Z9BQeAe" resolve="test.iets3.safety.attributes" />
       </node>
-      <node concept="22LTRM" id="4ToqgmJmYtN" role="22LTRK">
-        <ref role="22LTRN" node="6xvglc6Du8w" resolve="test.ex.core.expr.genjava" />
+      <node concept="22LTRM" id="1WrO9kaEJRK" role="22LTRK">
+        <ref role="22LTRN" node="7K$Mm86tjeJ" resolve="test.iets3.core.tracequery" />
       </node>
-      <node concept="22LTRM" id="IJ8MgPZlN9" role="22LTRK">
-        <ref role="22LTRN" node="IJ8MgPVKAO" resolve="test.org.iets3.analysis.base" />
+      <node concept="22LTRM" id="1WrO9kaEJAm" role="22LTRK">
+        <ref role="22LTRN" node="7tVUji9MfMb" resolve="test.org.iets3.variability.configuration.base" />
+      </node>
+      <node concept="22LTRM" id="1WrO9kaEJAp" role="22LTRK">
+        <ref role="22LTRN" node="7tVUji9MfSt" resolve="test.org.iets3.variability.featuremodel.base" />
       </node>
     </node>
     <node concept="2vP9LM" id="3ZBI8Awdbww" role="1hWBAP">

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.adapt_to_feature_model@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.adapt_to_feature_model@tests.mps
@@ -22,9 +22,6 @@
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -10304,9 +10301,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="3jXl0WzZ1kN">
-    <property role="2XOHcw" value="${iets3.github.core.home}/code/languages/org.iets3.core" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.attribute@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.attribute@tests.mps
@@ -25,9 +25,6 @@
         <child id="1215604436604" name="nodeOperations" index="7EUXB" />
       </concept>
       <concept id="1215607067978" name="jetbrains.mps.lang.test.structure.CheckNodeForErrorMessagesOperation" flags="ng" index="7OXhh" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -583,9 +580,6 @@
         <node concept="12i7jc" id="wgC743w6mO" role="12i2BX" />
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="3jXl0WzZ1kN">
-    <property role="2XOHcw" value="${iets3.github.core.home}/code/languages/org.iets3.core" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.checking_rules@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.checking_rules@tests.mps
@@ -50,9 +50,6 @@
       </concept>
       <concept id="4531408400486526326" name="jetbrains.mps.lang.test.structure.WarningStatementReference" flags="ng" index="2PQEqo" />
       <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -1888,9 +1885,6 @@
         <node concept="12i7jc" id="6nIjcSfet4y" role="12i2BX" />
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="3jXl0WzZ1kN">
-    <property role="2XOHcw" value="${iets3.github.core.home}/code/languages/org.iets3.core" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.cycle_detection@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.cycle_detection@tests.mps
@@ -18,9 +18,6 @@
         <child id="1215604436604" name="nodeOperations" index="7EUXB" />
       </concept>
       <concept id="1215607067978" name="jetbrains.mps.lang.test.structure.CheckNodeForErrorMessagesOperation" flags="ng" index="7OXhh" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -226,9 +223,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="3jXl0WzZ1kN">
-    <property role="2XOHcw" value="${iets3.github.core.home}/code/languages/org.iets3.core" />
   </node>
   <node concept="1lH9Xt" id="3eg222GrGLa">
     <property role="TrG5h" value="CycleDetection_ErrorConfig" />

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.documentation@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.documentation@tests.mps
@@ -33,9 +33,6 @@
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
       </concept>
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
         <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
       </concept>
@@ -181,9 +178,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="3jXl0WzZ1kN">
-    <property role="2XOHcw" value="${iets3.github.core.home}/code/languages/org.iets3.core" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.editor@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.editor@tests.mps
@@ -33,9 +33,6 @@
         <reference id="5449224527592117654" name="checkingReference" index="1BTHP0" />
         <child id="3655334166513314307" name="nodes" index="3KTr4d" />
       </concept>
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1216993439383" name="methods" index="1qtyYc" />
@@ -2670,9 +2667,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="3jXl0WzZ1kN">
-    <property role="2XOHcw" value="${iets3.github.core.home}/code/languages/org.iets3.core" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.inheritance@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.inheritance@tests.mps
@@ -41,9 +41,6 @@
         <child id="1211979322383" name="after" index="JAdkl" />
       </concept>
       <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -6697,9 +6694,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="3jXl0WzZ1kN">
-    <property role="2XOHcw" value="${iets3.github.core.home}/code/languages/org.iets3.core" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.solver_base@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.solver_base@tests.mps
@@ -26,9 +26,6 @@
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
       <concept id="2325284917965760583" name="jetbrains.mps.lang.test.structure.BeforeTestsMethod" flags="ig" index="0EjCn" />
       <concept id="2325284917965760584" name="jetbrains.mps.lang.test.structure.AfterTestsMethod" flags="ig" index="0EjCo" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="2325284917965993569" name="beforeTests" index="0EEgL" />
@@ -747,9 +744,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="3jXl0WzZ1kN">
-    <property role="2XOHcw" value="${iets3.github.core.home}/code/languages/org.iets3.core" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.treewalker@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.treewalker@tests.mps
@@ -17,9 +17,6 @@
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -393,9 +390,6 @@
         <node concept="12i7jc" id="2T39iK2dn$F" role="12i2BX" />
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="3jXl0WzZ1kN">
-    <property role="2XOHcw" value="${iets3.github.core.home}/code/languages/org.iets3.core" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.using@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.using@tests.mps
@@ -26,9 +26,6 @@
       </concept>
       <concept id="4531408400486526326" name="jetbrains.mps.lang.test.structure.WarningStatementReference" flags="ng" index="2PQEqo" />
       <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -242,9 +239,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="3jXl0WzZ1kN">
-    <property role="2XOHcw" value="${iets3.github.core.home}/code/languages/org.iets3.core" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.featuremodel.base/models/test.org.iets3.variability.featuremodel.base.checking_rules@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.featuremodel.base/models/test.org.iets3.variability.featuremodel.base.checking_rules@tests.mps
@@ -3,12 +3,10 @@
   <persistence version="9" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
-    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="9b66c5c9-38bf-4315-a96f-9f4e212c69cb" name="org.iets3.variability.base" version="0" />
     <use id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base" version="22" />
     <use id="6b277d9a-d52d-416f-a209-1919bd737f50" name="org.iets3.core.expr.simpleTypes" version="11" />
     <use id="165f1d05-2506-4544-895e-1424f54166ec" name="org.iets3.variability.featuremodel.base" version="24" />
-    <use id="71226ee2-bbc4-45d2-a41d-20b97237156c" name="org.iets3.variability.configuration.base" version="1" />
   </languages>
   <imports>
     <import index="spuw" ref="r:ea20ecfb-5cc1-4867-966a-b2976cfc5ae3(org.iets3.variability.featuremodel.base.typesystem)" />
@@ -29,9 +27,6 @@
         <reference id="8333855927540250453" name="declaration" index="39XzEq" />
       </concept>
       <concept id="4531408400486526326" name="jetbrains.mps.lang.test.structure.WarningStatementReference" flags="ng" index="2PQEqo" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -801,9 +796,6 @@
         <node concept="12i7jc" id="49uhBwav8mp" role="12i2BX" />
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="3jXl0WzZ1kN">
-    <property role="2XOHcw" value="${iets3.github.core.home}/code/languages/org.iets3.core" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.featuremodel.base/models/test.org.iets3.variability.featuremodel.base.documentation@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.featuremodel.base/models/test.org.iets3.variability.featuremodel.base.documentation@tests.mps
@@ -32,9 +32,6 @@
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
       </concept>
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
         <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
       </concept>
@@ -146,9 +143,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="3jXl0WzZ1kN">
-    <property role="2XOHcw" value="${iets3.github.core.home}/code/languages/org.iets3.core" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.featuremodel.base/models/test.org.iets3.variability.featuremodel.base.editor@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.featuremodel.base/models/test.org.iets3.variability.featuremodel.base.editor@tests.mps
@@ -35,9 +35,6 @@
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
         <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
         <reference id="4239542196496929559" name="action" index="1iFR8X" />
       </concept>
@@ -1556,9 +1553,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="3jXl0WzZ1kN">
-    <property role="2XOHcw" value="${iets3.github.core.home}/code/languages/org.iets3.core" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.featuremodel.base/models/test.org.iets3.variability.featuremodel.base.explorer_editor@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.featuremodel.base/models/test.org.iets3.variability.featuremodel.base.explorer_editor@tests.mps
@@ -35,9 +35,6 @@
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
       </concept>
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -787,9 +784,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="3jXl0WzZ1kN">
-    <property role="2XOHcw" value="${iets3.github.core.home}/code/languages/org.iets3.core" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.featuremodel.base/models/test.org.iets3.variability.featuremodel.base.operational@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.featuremodel.base/models/test.org.iets3.variability.featuremodel.base.operational@tests.mps
@@ -27,9 +27,6 @@
         <reference id="5449224527592117654" name="checkingReference" index="1BTHP0" />
         <child id="3655334166513314307" name="nodes" index="3KTr4d" />
       </concept>
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -1302,9 +1299,6 @@
         <node concept="12i7jc" id="7dt0dw0bFCM" role="12i2BX" />
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="3jXl0WzZ1kN">
-    <property role="2XOHcw" value="${iets3.github.core.home}/code/languages/org.iets3.core" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.featuremodel.base/models/test.org.iets3.variability.featuremodel.base.solver_gen@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.featuremodel.base/models/test.org.iets3.variability.featuremodel.base.solver_gen@tests.mps
@@ -20,9 +20,6 @@
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
       <concept id="2325284917965760583" name="jetbrains.mps.lang.test.structure.BeforeTestsMethod" flags="ig" index="0EjCn" />
       <concept id="2325284917965760584" name="jetbrains.mps.lang.test.structure.AfterTestsMethod" flags="ig" index="0EjCo" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="2325284917965993569" name="beforeTests" index="0EEgL" />
@@ -325,9 +322,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="3jXl0WzZ1kN">
-    <property role="2XOHcw" value="${iets3.github.core.home}/code/languages/org.iets3.core" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.featuremodel.base/models/test.org.iets3.variability.featuremodel.base.treewalker@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.featuremodel.base/models/test.org.iets3.variability.featuremodel.base.treewalker@tests.mps
@@ -16,9 +16,6 @@
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -249,9 +246,6 @@
         <node concept="12i7jc" id="2T39iK2dn$F" role="12i2BX" />
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="3jXl0WzZ1kN">
-    <property role="2XOHcw" value="${iets3.github.core.home}/code/languages/org.iets3.core" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.featuremodel.base/models/test.org.iets3.variability.featuremodel.base.using@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.featuremodel.base/models/test.org.iets3.variability.featuremodel.base.using@tests.mps
@@ -23,9 +23,6 @@
         <reference id="8333855927540250453" name="declaration" index="39XzEq" />
       </concept>
       <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
-      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
-        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
-      </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
         <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
@@ -173,9 +170,6 @@
         </node>
       </node>
     </node>
-  </node>
-  <node concept="2XOHcx" id="3jXl0WzZ1kN">
-    <property role="2XOHcw" value="${iets3.github.core.home}/code/languages/org.iets3.core" />
   </node>
 </model>
 


### PR DESCRIPTION
There are 360 Tests in OS that are not being executed in CI because they were not listed in the build script's run section.
Most of them are core tests that were moved some time ago.
This PR added them there.