### PR TITLE
improve renderReadable/getPresentation implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## September 2025
+
+### Fixed
+
+- The renderReadable/getPresentation implementations were improved and are now equivalent in all concepts.
+
 ## July 2025
 
 ### Fixed

--- a/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/behavior.mps
@@ -20,6 +20,9 @@
     <import index="5zyv" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.concurrent(JDK/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="dzyv" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time.temporal(JDK/)" />
+    <import index="ao3" ref="7124e466-fc92-4803-a656-d7a6b7eb3910/java:jetbrains.mps.text(MPS.TextGen/)" />
+    <import index="kpbf" ref="7124e466-fc92-4803-a656-d7a6b7eb3910/java:jetbrains.mps.text.impl(MPS.TextGen/)" />
+    <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -1533,10 +1536,185 @@
         </node>
       </node>
     </node>
+    <node concept="13i0hz" id="4oS6BnMaYjr" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnMaYjQ" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMaYjR" role="3clF47">
+        <node concept="3cpWs8" id="4oS6BnMfgFk" role="3cqZAp">
+          <node concept="3cpWsn" id="4oS6BnMfgFl" role="3cpWs9">
+            <property role="TrG5h" value="text" />
+            <node concept="3uibUv" id="4oS6BnMfgFm" role="1tU5fm">
+              <ref role="3uigEE" to="xfg9:4oS6BnMcix1" resolve="StringRepresentation" />
+            </node>
+            <node concept="2YIFZM" id="4oS6BnMfk5a" role="33vP2m">
+              <ref role="37wK5l" to="xfg9:4oS6BnMcjBJ" resolve="forShortSentence" />
+              <ref role="1Pybhc" to="xfg9:4oS6BnMcix1" resolve="StringRepresentation" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMfkeX" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMfkyQ" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMfkeV" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMfgFl" resolve="representation" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMfkVv" role="2OqNvi">
+              <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+              <node concept="Xl_RD" id="4oS6BnMb3gG" role="37wK5m">
+                <property role="Xl_RC" value="@solver:" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMgE_V" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMgEUO" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMgE_T" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMfgFl" resolve="representation" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMgFmw" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMgQjs" resolve="appendWithSpace" />
+              <node concept="2OqwBi" id="4oS6BnMgFQ3" role="37wK5m">
+                <node concept="13iPFW" id="4oS6BnMgFsl" role="2Oq$k0" />
+                <node concept="3TrcHB" id="4oS6BnMgGdX" role="2OqNvi">
+                  <ref role="3TsBF5" to="l80j:17Nm8oCo8O2" resolve="mode" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4oS6BnMblFd" role="3cqZAp">
+          <node concept="3clFbS" id="4oS6BnMblFf" role="3clFbx">
+            <node concept="3clFbF" id="4oS6BnMhFv7" role="3cqZAp">
+              <node concept="2OqwBi" id="4oS6BnMhGpr" role="3clFbG">
+                <node concept="37vLTw" id="4oS6BnMhFv6" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4oS6BnMfgFl" resolve="text" />
+                </node>
+                <node concept="liA8E" id="4oS6BnMhGX4" role="2OqNvi">
+                  <ref role="37wK5l" to="xfg9:4oS6BnMfnH9" resolve="appendWithSpace" />
+                  <node concept="Xl_RD" id="4oS6BnMhH2z" role="37wK5m">
+                    <property role="Xl_RC" value="with timeout = " />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4oS6BnMhIE_" role="3cqZAp">
+              <node concept="2OqwBi" id="4oS6BnMhIGD" role="3clFbG">
+                <node concept="37vLTw" id="4oS6BnMhIEz" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4oS6BnMfgFl" resolve="text" />
+                </node>
+                <node concept="liA8E" id="4oS6BnMhIQh" role="2OqNvi">
+                  <ref role="37wK5l" to="xfg9:4oS6BnMjbhG" resolve="append" />
+                  <node concept="2OqwBi" id="4oS6BnMhKwZ" role="37wK5m">
+                    <node concept="13iPFW" id="4oS6BnMhIWM" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="4oS6BnMhKTQ" role="2OqNvi">
+                      <ref role="3TsBF5" to="l80j:2GQBRFCFk_3" resolve="timeout" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4oS6BnMiTlf" role="3cqZAp">
+              <node concept="2OqwBi" id="4oS6BnMiTMH" role="3clFbG">
+                <node concept="37vLTw" id="4oS6BnMiTld" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4oS6BnMfgFl" resolve="text" />
+                </node>
+                <node concept="liA8E" id="4oS6BnMiURh" role="2OqNvi">
+                  <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+                  <node concept="Xl_RD" id="4oS6BnMiUZY" role="37wK5m">
+                    <property role="Xl_RC" value="s" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3eOSWO" id="2ZalWa8IAb0" role="3clFbw">
+            <node concept="2OqwBi" id="2ZalWa8IzFd" role="3uHU7B">
+              <node concept="13iPFW" id="4oS6BnMbmOb" role="2Oq$k0" />
+              <node concept="3TrcHB" id="2ZalWa8I$e6" role="2OqNvi">
+                <ref role="3TsBF5" to="l80j:2GQBRFCFk_3" resolve="timeout" />
+              </node>
+            </node>
+            <node concept="3cmrfG" id="2ZalWa8IAom" role="3uHU7w">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMbZ39" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMc0xy" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMbZ37" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMfgFl" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMc1M8" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMUIdM" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMaYjS" role="3clF45" />
+    </node>
   </node>
   <node concept="13h7C7" id="XhdFKvYcsC">
     <property role="3GE5qa" value="adapter" />
     <ref role="13h7C2" to="l80j:XhdFKvXQxo" resolve="ErrorSolverTask" />
+    <node concept="13i0hz" id="4oS6BnMakhZ" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnMakiq" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMakir" role="3clF47">
+        <node concept="3cpWs8" id="4oS6BnMcKyQ" role="3cqZAp">
+          <node concept="3cpWsn" id="4oS6BnMcKyR" role="3cpWs9">
+            <property role="TrG5h" value="text" />
+            <node concept="3uibUv" id="4oS6BnMcKyS" role="1tU5fm">
+              <ref role="3uigEE" to="xfg9:4oS6BnMcix1" resolve="StringRepresentation" />
+            </node>
+            <node concept="2YIFZM" id="4oS6BnMdltY" role="33vP2m">
+              <ref role="37wK5l" to="xfg9:4oS6BnMcl4R" resolve="forMultipleSentences" />
+              <ref role="1Pybhc" to="xfg9:4oS6BnMcix1" resolve="StringRepresentation" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMdlA3" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMdmE0" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMdlA1" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMcKyR" resolve="presentation" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMdn4D" role="2OqNvi">
+              <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+              <node concept="Xl_RD" id="4oS6BnMan87" role="37wK5m">
+                <property role="Xl_RC" value="Errors during task creation:" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMdnOn" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMdoIl" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMdnOl" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMcKyR" resolve="presentation" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMdW2n" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMeeyx" resolve="appendNodesVertically" />
+              <node concept="2OqwBi" id="4oS6BnMdWvC" role="37wK5m">
+                <node concept="13iPFW" id="4oS6BnMdW6k" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="4oS6BnMdWP_" role="2OqNvi">
+                  <ref role="3TtcxE" to="l80j:XhdFKvXSNY" resolve="errors" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMaH9B" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMaHrn" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMaH9_" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMcKyR" resolve="presentation" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMaH$3" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMUIdM" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMakis" role="3clF45" />
+    </node>
     <node concept="13hLZK" id="XhdFKvYcsD" role="13h7CW">
       <node concept="3clFbS" id="XhdFKvYcsE" role="2VODD2" />
     </node>
@@ -2045,6 +2223,29 @@
     </node>
     <node concept="13hLZK" id="1ScogIcAG8f" role="13h7CW">
       <node concept="3clFbS" id="1ScogIcAG8g" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMai2W">
+    <property role="3GE5qa" value="adapter" />
+    <ref role="13h7C2" to="l80j:XhdFKvXSNr" resolve="ErrorMessage" />
+    <node concept="13hLZK" id="4oS6BnMai2X" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMai2Y" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMai3f" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnMai3E" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMai3F" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMaiRX" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMaj3W" role="3clFbG">
+            <node concept="13iPFW" id="4oS6BnMaiRS" role="2Oq$k0" />
+            <node concept="3TrcHB" id="4oS6BnMajhj" role="2OqNvi">
+              <ref role="3TsBF5" to="l80j:XhdFKvXSNs" resolve="msg" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMai3G" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/models/behavior.mps
@@ -1556,7 +1556,7 @@
         <node concept="3clFbF" id="4oS6BnMfkeX" role="3cqZAp">
           <node concept="2OqwBi" id="4oS6BnMfkyQ" role="3clFbG">
             <node concept="37vLTw" id="4oS6BnMfkeV" role="2Oq$k0">
-              <ref role="3cqZAo" node="4oS6BnMfgFl" resolve="representation" />
+              <ref role="3cqZAo" node="4oS6BnMfgFl" resolve="text" />
             </node>
             <node concept="liA8E" id="4oS6BnMfkVv" role="2OqNvi">
               <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
@@ -1569,7 +1569,7 @@
         <node concept="3clFbF" id="4oS6BnMgE_V" role="3cqZAp">
           <node concept="2OqwBi" id="4oS6BnMgEUO" role="3clFbG">
             <node concept="37vLTw" id="4oS6BnMgE_T" role="2Oq$k0">
-              <ref role="3cqZAo" node="4oS6BnMfgFl" resolve="representation" />
+              <ref role="3cqZAo" node="4oS6BnMfgFl" resolve="text" />
             </node>
             <node concept="liA8E" id="4oS6BnMgFmw" role="2OqNvi">
               <ref role="37wK5l" to="xfg9:4oS6BnMgQjs" resolve="appendWithSpace" />
@@ -1676,7 +1676,7 @@
         <node concept="3clFbF" id="4oS6BnMdlA3" role="3cqZAp">
           <node concept="2OqwBi" id="4oS6BnMdmE0" role="3clFbG">
             <node concept="37vLTw" id="4oS6BnMdlA1" role="2Oq$k0">
-              <ref role="3cqZAo" node="4oS6BnMcKyR" resolve="presentation" />
+              <ref role="3cqZAo" node="4oS6BnMcKyR" resolve="text" />
             </node>
             <node concept="liA8E" id="4oS6BnMdn4D" role="2OqNvi">
               <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
@@ -1689,10 +1689,10 @@
         <node concept="3clFbF" id="4oS6BnMdnOn" role="3cqZAp">
           <node concept="2OqwBi" id="4oS6BnMdoIl" role="3clFbG">
             <node concept="37vLTw" id="4oS6BnMdnOl" role="2Oq$k0">
-              <ref role="3cqZAo" node="4oS6BnMcKyR" resolve="presentation" />
+              <ref role="3cqZAo" node="4oS6BnMcKyR" resolve="text" />
             </node>
             <node concept="liA8E" id="4oS6BnMdW2n" role="2OqNvi">
-              <ref role="37wK5l" to="xfg9:4oS6BnMeeyx" resolve="appendNodesVertically" />
+              <ref role="37wK5l" to="xfg9:4oS6BnMeeyx" resolve="appendVertically" />
               <node concept="2OqwBi" id="4oS6BnMdWvC" role="37wK5m">
                 <node concept="13iPFW" id="4oS6BnMdW6k" role="2Oq$k0" />
                 <node concept="3Tsc0h" id="4oS6BnMdWP_" role="2OqNvi">
@@ -1705,7 +1705,7 @@
         <node concept="3clFbF" id="4oS6BnMaH9B" role="3cqZAp">
           <node concept="2OqwBi" id="4oS6BnMaHrn" role="3clFbG">
             <node concept="37vLTw" id="4oS6BnMaH9_" role="2Oq$k0">
-              <ref role="3cqZAo" node="4oS6BnMcKyR" resolve="presentation" />
+              <ref role="3cqZAo" node="4oS6BnMcKyR" resolve="text" />
             </node>
             <node concept="liA8E" id="4oS6BnMaH$3" role="2OqNvi">
               <ref role="37wK5l" to="xfg9:4oS6BnMUIdM" resolve="toString" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/org.iets3.analysis.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.analysis.base/org.iets3.analysis.base.mpl
@@ -21,6 +21,8 @@
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
     <dependency reexport="false">742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)</dependency>
     <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
+    <dependency reexport="false">7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)</dependency>
+    <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:63e0e566-5131-447e-90e3-12ea330e1a00:com.mbeddr.mpsutil.blutil" version="3" />
@@ -76,6 +78,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
@@ -112,6 +115,7 @@
     <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="1" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
     <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="20" />
+    <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
   </dependencyVersions>
   <extendedLanguages>
     <extendedLanguage>7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)</extendedLanguage>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.functional/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.functional/models/behavior.mps
@@ -33,6 +33,7 @@
     <import index="l80j" ref="r:9e71c0de-f9ab-4b67-96cc-7d9c857513f6(org.iets3.analysis.base.structure)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="hnhi" ref="r:d354209e-0bea-497f-b905-d66f72900fa8(org.iets3.analysis.base.plugin)" />
+    <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
@@ -115,6 +116,9 @@
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1092119917967" name="jetbrains.mps.baseLanguage.structure.MulExpression" flags="nn" index="17qRlL" />
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
@@ -437,6 +441,96 @@
     <ref role="13h7C2" to="874t:6LfBX8YiZFy" resolve="DataItemPortType" />
     <node concept="13hLZK" id="6LfBX8YlLlB" role="13h7CW">
       <node concept="3clFbS" id="6LfBX8YlLlC" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMm4ZV" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnMm50m" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMm50n" role="3clF47">
+        <node concept="3cpWs8" id="4oS6BnMm87H" role="3cqZAp">
+          <node concept="3cpWsn" id="4oS6BnMm87I" role="3cpWs9">
+            <property role="TrG5h" value="text" />
+            <node concept="3uibUv" id="4oS6BnMm87J" role="1tU5fm">
+              <ref role="3uigEE" to="xfg9:4oS6BnMcix1" resolve="StringRepresentation" />
+            </node>
+            <node concept="2ShNRf" id="4oS6BnMm88K" role="33vP2m">
+              <node concept="1pGfFk" id="4oS6BnMm8ob" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="xfg9:4oS6BnMcMsd" resolve="StringRepresentation" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMm9gk" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMm9Ev" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMm9gi" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMm87I" resolve="txt" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMm9Tb" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMgdrs" resolve="append" />
+              <node concept="2OqwBi" id="4oS6BnMman2" role="37wK5m">
+                <node concept="13iPFW" id="4oS6BnMm9XX" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnMmaEL" role="2OqNvi">
+                  <ref role="3Tt5mk" to="874t:6LfBX8YiZFz" resolve="ref" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4oS6BnMmcCw" role="3cqZAp">
+          <node concept="3clFbS" id="4oS6BnMmcCy" role="3clFbx">
+            <node concept="3clFbF" id="4oS6BnMmff4" role="3cqZAp">
+              <node concept="2OqwBi" id="4oS6BnMmfvO" role="3clFbG">
+                <node concept="37vLTw" id="4oS6BnMmff2" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4oS6BnMm87I" resolve="txt" />
+                </node>
+                <node concept="liA8E" id="4oS6BnMmfKj" role="2OqNvi">
+                  <ref role="37wK5l" to="xfg9:4oS6BnMfnH9" resolve="appendWithSpace" />
+                  <node concept="Xl_RD" id="4oS6BnMmg1w" role="37wK5m">
+                    <property role="Xl_RC" value="with" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4oS6BnMmh2Q" role="3cqZAp">
+              <node concept="2OqwBi" id="4oS6BnMmhkO" role="3clFbG">
+                <node concept="37vLTw" id="4oS6BnMmh2O" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4oS6BnMm87I" resolve="txt" />
+                </node>
+                <node concept="liA8E" id="4oS6BnMmjQS" role="2OqNvi">
+                  <ref role="37wK5l" to="xfg9:4oS6BnMgdrs" resolve="append" />
+                  <node concept="2OqwBi" id="4oS6BnMmldF" role="37wK5m">
+                    <node concept="13iPFW" id="4oS6BnMmkJG" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="4oS6BnMmlzu" role="2OqNvi">
+                      <ref role="3Tt5mk" to="874t:63szzhgR20q" resolve="constraint" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="4oS6BnMmeR6" role="3clFbw">
+            <node concept="2OqwBi" id="4oS6BnMmemA" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMme4Z" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnMmeDU" role="2OqNvi">
+                <ref role="3Tt5mk" to="874t:63szzhgR20q" resolve="constraint" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="4oS6BnMmf8e" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMmmzQ" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMmpi7" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMmmzO" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMm87I" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMmp_b" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMUIdM" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMm50o" role="3clF45" />
     </node>
     <node concept="13i0hz" id="6LfBX8YlLlD" role="13h7CS">
       <property role="13i0iv" value="false" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.functional/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.functional/models/behavior.mps
@@ -464,7 +464,7 @@
         <node concept="3clFbF" id="4oS6BnMm9gk" role="3cqZAp">
           <node concept="2OqwBi" id="4oS6BnMm9Ev" role="3clFbG">
             <node concept="37vLTw" id="4oS6BnMm9gi" role="2Oq$k0">
-              <ref role="3cqZAo" node="4oS6BnMm87I" resolve="txt" />
+              <ref role="3cqZAo" node="4oS6BnMm87I" resolve="text" />
             </node>
             <node concept="liA8E" id="4oS6BnMm9Tb" role="2OqNvi">
               <ref role="37wK5l" to="xfg9:4oS6BnMgdrs" resolve="append" />
@@ -482,7 +482,7 @@
             <node concept="3clFbF" id="4oS6BnMmff4" role="3cqZAp">
               <node concept="2OqwBi" id="4oS6BnMmfvO" role="3clFbG">
                 <node concept="37vLTw" id="4oS6BnMmff2" role="2Oq$k0">
-                  <ref role="3cqZAo" node="4oS6BnMm87I" resolve="txt" />
+                  <ref role="3cqZAo" node="4oS6BnMm87I" resolve="text" />
                 </node>
                 <node concept="liA8E" id="4oS6BnMmfKj" role="2OqNvi">
                   <ref role="37wK5l" to="xfg9:4oS6BnMfnH9" resolve="appendWithSpace" />
@@ -495,7 +495,7 @@
             <node concept="3clFbF" id="4oS6BnMmh2Q" role="3cqZAp">
               <node concept="2OqwBi" id="4oS6BnMmhkO" role="3clFbG">
                 <node concept="37vLTw" id="4oS6BnMmh2O" role="2Oq$k0">
-                  <ref role="3cqZAo" node="4oS6BnMm87I" resolve="txt" />
+                  <ref role="3cqZAo" node="4oS6BnMm87I" resolve="text" />
                 </node>
                 <node concept="liA8E" id="4oS6BnMmjQS" role="2OqNvi">
                   <ref role="37wK5l" to="xfg9:4oS6BnMgdrs" resolve="append" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.functional/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.functional/models/structure.mps
@@ -153,6 +153,7 @@
     <property role="TrG5h" value="DataItemPortType" />
     <property role="3GE5qa" value="data" />
     <property role="EcuMT" value="7804632404593474274" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyj" id="63szzhgR20q" role="1TKVEi">
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="constraint" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.functional/org.iets3.components.functional.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.functional/org.iets3.components.functional.mpl
@@ -34,6 +34,7 @@
     <dependency reexport="false">db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)</dependency>
     <dependency reexport="false">7a5dda62-9140-4668-ab76-d5ed1746f2b2(jetbrains.mps.lang.typesystem)</dependency>
     <dependency reexport="false">71934284-d7d1-45ee-a054-8c072591085f(org.iets3.core.expr.toplevel)</dependency>
+    <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:120e1c9d-4e27-4478-b2af-b2c3bd3850b0:com.mbeddr.mpsutil.editor.querylist" version="0" />
@@ -136,6 +137,7 @@
     <module reference="583939be-ded0-4735-a055-a74f8477fc34(org.iets3.core.attributes)" version="0" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
     <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="20" />
+    <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />
     <module reference="f3eafff0-30d2-46d6-9150-f0f3b880ce27(org.iets3.core.expr.path)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.components.functional/org.iets3.components.functional.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.components.functional/org.iets3.components.functional.mpl
@@ -89,6 +89,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="2374bc90-7e37-41f1-a9c4-c2e35194c36a(com.mbeddr.doc)" version="0" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/models/behavior.mps
@@ -18,6 +18,8 @@
     <import index="700h" ref="r:61b1de80-490d-4fee-8e95-b956503290e9(org.iets3.core.expr.collections.structure)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="j10v" ref="b76a0f63-5959-456b-993a-c796cc0d0c13/java:org.pcollections(org.iets3.core.expr.base.collections.stubs/)" />
+    <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
+    <import index="kpbf" ref="7124e466-fc92-4803-a656-d7a6b7eb3910/java:jetbrains.mps.text.impl(MPS.TextGen/)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -173,6 +175,7 @@
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC">
         <reference id="1139880128956" name="concept" index="1A9B2P" />
       </concept>
@@ -191,6 +194,7 @@
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
+      <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
@@ -1395,6 +1399,110 @@
     <node concept="13hLZK" id="5a_u3OyUFKs" role="13h7CW">
       <node concept="3clFbS" id="5a_u3OyUFKt" role="2VODD2" />
     </node>
+    <node concept="13i0hz" id="4oS6BnN7WH7" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnN7WHy" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnN7WHz" role="3clF47">
+        <node concept="3cpWs8" id="4oS6BnN7XH7" role="3cqZAp">
+          <node concept="3cpWsn" id="4oS6BnN7XH8" role="3cpWs9">
+            <property role="TrG5h" value="text" />
+            <node concept="3uibUv" id="4oS6BnN7XH9" role="1tU5fm">
+              <ref role="3uigEE" to="xfg9:4oS6BnMcix1" resolve="StringRepresentation" />
+            </node>
+            <node concept="2YIFZM" id="4oS6BnN7XXc" role="33vP2m">
+              <ref role="37wK5l" to="xfg9:4oS6BnMcl4R" resolve="forMultipleSentences" />
+              <ref role="1Pybhc" to="xfg9:4oS6BnMcix1" resolve="StringRepresentation" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnN7Y0D" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnN7Yiq" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnN7Y0B" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnN7XH8" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnN7YCh" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMgdrs" resolve="append" />
+              <node concept="2OqwBi" id="4oS6BnN80bC" role="37wK5m">
+                <node concept="13iPFW" id="4oS6BnN7ZS5" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnN81k$" role="2OqNvi">
+                  <ref role="3Tt5mk" to="v0r8:5a_u3OySk8s" resolve="pattern" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4oS6BnN81x5" role="3cqZAp">
+          <node concept="3clFbS" id="4oS6BnN81x7" role="3clFbx">
+            <node concept="3clFbF" id="4oS6BnN82qh" role="3cqZAp">
+              <node concept="2OqwBi" id="4oS6BnN82Fu" role="3clFbG">
+                <node concept="37vLTw" id="4oS6BnN82qf" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4oS6BnN7XH8" resolve="text" />
+                </node>
+                <node concept="liA8E" id="4oS6BnN832d" role="2OqNvi">
+                  <ref role="37wK5l" to="xfg9:4oS6BnMgZBe" resolve="appendWithSpace" />
+                  <node concept="2OqwBi" id="4oS6BnN83c_" role="37wK5m">
+                    <node concept="13iPFW" id="4oS6BnN835_" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="4oS6BnN83h6" role="2OqNvi">
+                      <ref role="3Tt5mk" to="v0r8:5a_u3Oz5b2N" resolve="cond" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="4oS6BnN81Zt" role="3clFbw">
+            <node concept="2OqwBi" id="4oS6BnN81K7" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnN81zw" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnN81Nf" role="2OqNvi">
+                <ref role="3Tt5mk" to="v0r8:5a_u3Oz5b2N" resolve="cond" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="4oS6BnN82jj" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnN84rk" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnN84G9" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnN84ri" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnN7XH8" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnN856d" role="2OqNvi">
+              <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+              <node concept="Xl_RD" id="4oS6BnN85et" role="37wK5m">
+                <property role="Xl_RC" value=" =&gt; " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnN8a3D" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnN8anj" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnN8a3B" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnN7XH8" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnN8aNh" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMgdrs" resolve="append" />
+              <node concept="2OqwBi" id="4oS6BnN8b52" role="37wK5m">
+                <node concept="13iPFW" id="4oS6BnN8aTQ" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnN8bcK" role="2OqNvi">
+                  <ref role="3Tt5mk" to="v0r8:5a_u3OySk8u" resolve="result" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnN8bsV" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnN8bv4" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnN8bsT" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnN7XH8" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnN8bGK" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMUIdM" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnN7WH$" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="5a_u3OyUFKM" role="13h7CS">
       <property role="13i0iv" value="false" />
       <property role="13i0it" value="false" />
@@ -1474,6 +1582,22 @@
     <node concept="13hLZK" id="5a_u3OyZrU$" role="13h7CW">
       <node concept="3clFbS" id="5a_u3OyZrU_" role="2VODD2" />
     </node>
+    <node concept="13i0hz" id="4oS6BnN8Ec9" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnN8Eca" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnN8Ecn" role="3clF47">
+        <node concept="3clFbF" id="JV9IWPOHTm" role="3cqZAp">
+          <node concept="2OqwBi" id="JV9IWPOI96" role="3clFbG">
+            <node concept="13iPFW" id="JV9IWPOHU6" role="2Oq$k0" />
+            <node concept="2qgKlT" id="JV9IWPOIyf" role="2OqNvi">
+              <ref role="37wK5l" node="5a_u3Oz33tz" resolve="getName" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnN8Eco" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="5a_u3OyZrUO" role="13h7CS">
       <property role="13i0iv" value="false" />
       <property role="13i0it" value="false" />
@@ -1534,29 +1658,43 @@
       </node>
       <node concept="17QB3L" id="5a_u3Oz33vp" role="3clF45" />
     </node>
-    <node concept="13i0hz" id="JV9IWPOH_F" role="13h7CS">
-      <property role="TrG5h" value="getPresentation" />
-      <property role="13i0it" value="false" />
-      <property role="13i0iv" value="false" />
-      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
-      <node concept="3Tm1VV" id="JV9IWPOH_G" role="1B3o_S" />
-      <node concept="3clFbS" id="JV9IWPOH_W" role="3clF47">
-        <node concept="3clFbF" id="JV9IWPOHTm" role="3cqZAp">
-          <node concept="2OqwBi" id="JV9IWPOI96" role="3clFbG">
-            <node concept="13iPFW" id="JV9IWPOHU6" role="2Oq$k0" />
-            <node concept="2qgKlT" id="JV9IWPOIyf" role="2OqNvi">
-              <ref role="37wK5l" node="5a_u3Oz33tz" resolve="getName" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="17QB3L" id="JV9IWPOH_X" role="3clF45" />
-    </node>
   </node>
   <node concept="13h7C7" id="5a_u3OyZrYW">
     <ref role="13h7C2" to="v0r8:5a_u3OyUzm8" resolve="NameAnnotation" />
     <node concept="13hLZK" id="5a_u3OyZrYX" role="13h7CW">
       <node concept="3clFbS" id="5a_u3OyZrYY" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnND1bo" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnND1bN" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnND1bO" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnND2Vj" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnND7B5" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnND85p" role="3uHU7w">
+              <node concept="13iPFW" id="4oS6BnND7BV" role="2Oq$k0" />
+              <node concept="3TrcHB" id="4oS6BnND8y9" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="4oS6BnND5gx" role="3uHU7B">
+              <node concept="2OqwBi" id="4oS6BnND3PG" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnND3ee" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnND2Vi" role="2Oq$k0" />
+                  <node concept="1mfA1w" id="4oS6BnND3Ew" role="2OqNvi" />
+                </node>
+                <node concept="2qgKlT" id="4oS6BnND40P" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="4oS6BnND5g$" role="3uHU7w">
+                <property role="Xl_RC" value="@" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnND1bP" role="3clF45" />
     </node>
     <node concept="13i0hz" id="5a_u3OyZrZd" role="13h7CS">
       <property role="13i0iv" value="false" />
@@ -1762,6 +1900,64 @@
         </node>
       </node>
     </node>
+    <node concept="13i0hz" id="4oS6BnMoO$d" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMoO$e" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMoO$r" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMoPzw" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMoVmm" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnMoVmp" role="3uHU7w">
+              <property role="Xl_RC" value=")" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMoUAI" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMoUyw" role="3uHU7B">
+                <node concept="3cpWs3" id="4oS6BnMoTr3" role="3uHU7B">
+                  <node concept="3cpWs3" id="4oS6BnMoSTh" role="3uHU7B">
+                    <node concept="2OqwBi" id="4oS6BnMoQTW" role="3uHU7B">
+                      <node concept="2OqwBi" id="4oS6BnMoPO7" role="2Oq$k0">
+                        <node concept="13iPFW" id="4oS6BnMoPzt" role="2Oq$k0" />
+                        <node concept="2yIwOk" id="4oS6BnMoQbr" role="2OqNvi" />
+                      </node>
+                      <node concept="3n3YKJ" id="4oS6BnMoRCS" role="2OqNvi" />
+                    </node>
+                    <node concept="Xl_RD" id="4oS6BnMoSTk" role="3uHU7w">
+                      <property role="Xl_RC" value="[" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="4oS6BnMoUcw" role="3uHU7w">
+                    <node concept="2OqwBi" id="4oS6BnMoTCj" role="2Oq$k0">
+                      <node concept="13iPFW" id="4oS6BnMoTs1" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="4oS6BnMoU0a" role="2OqNvi">
+                        <ref role="3Tt5mk" to="v0r8:5a_u3Ozlhb3" resolve="strategy" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="4oS6BnMoUsi" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="4oS6BnMoUyz" role="3uHU7w">
+                  <property role="Xl_RC" value="](" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnMoURX" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnMoUDE" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnMoUCd" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnMoUFP" role="2OqNvi">
+                    <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4oS6BnMoVe6" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMoO$s" role="3clF45" />
+    </node>
   </node>
   <node concept="13h7C7" id="5a_u3OzmaNv">
     <ref role="13h7C2" to="v0r8:5a_u3OySk7g" resolve="MatchExpr" />
@@ -1811,6 +2007,141 @@
           </node>
         </node>
       </node>
+    </node>
+    <node concept="13i0hz" id="4oS6BnMQiYf" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMQiYg" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMQiYt" role="3clF47">
+        <node concept="3cpWs8" id="4oS6BnMQkGJ" role="3cqZAp">
+          <node concept="3cpWsn" id="4oS6BnMQkGK" role="3cpWs9">
+            <property role="TrG5h" value="text" />
+            <node concept="3uibUv" id="4oS6BnMQkGL" role="1tU5fm">
+              <ref role="3uigEE" to="xfg9:4oS6BnMcix1" resolve="StringRepresentation" />
+            </node>
+            <node concept="2YIFZM" id="4oS6BnMQkWY" role="33vP2m">
+              <ref role="37wK5l" to="xfg9:4oS6BnMcl4R" resolve="forMultipleSentences" />
+              <ref role="1Pybhc" to="xfg9:4oS6BnMcix1" resolve="StringRepresentation" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMQl0o" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMQljB" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMQl0m" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMQkGK" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMQm$L" role="2OqNvi">
+              <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+              <node concept="2OqwBi" id="4oS6BnMQogk" role="37wK5m">
+                <node concept="2OqwBi" id="4oS6BnMQn73" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnMQmD$" role="2Oq$k0" />
+                  <node concept="2yIwOk" id="4oS6BnMQnBT" role="2OqNvi" />
+                </node>
+                <node concept="3n3YKJ" id="4oS6BnMQp4z" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMQqmo" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMQqz0" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMQqmm" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMQkGK" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMQqDw" role="2OqNvi">
+              <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+              <node concept="Xl_RD" id="4oS6BnMQqGY" role="37wK5m">
+                <property role="Xl_RC" value="(" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMQrGq" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMQrHW" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMQrGo" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMQkGK" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMQrPA" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMgdrs" resolve="append" />
+              <node concept="2OqwBi" id="4oS6BnMQs0D" role="37wK5m">
+                <node concept="13iPFW" id="4oS6BnMQrXY" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnMQs6q" role="2OqNvi">
+                  <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMQskS" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMQsnl" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMQskQ" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMQkGK" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMQswd" role="2OqNvi">
+              <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+              <node concept="Xl_RD" id="4oS6BnMQsA3" role="37wK5m">
+                <property role="Xl_RC" value=")\n" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMQtaX" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMQthn" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMQtaV" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMQkGK" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMQtrp" role="2OqNvi">
+              <ref role="37wK5l" to="kpbf:~TextAreaImpl.increaseIndent()" resolve="increaseIndent" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMQtDu" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMQtKH" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMQtDs" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMQkGK" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMQtV$" role="2OqNvi">
+              <ref role="37wK5l" to="kpbf:~TextAreaImpl.indent()" resolve="indent" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMQK44" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMQKxf" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMQK42" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMQkGK" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMQKY5" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMeeyx" resolve="appendVertically" />
+              <node concept="2OqwBi" id="4oS6BnMQLGB" role="37wK5m">
+                <node concept="13iPFW" id="4oS6BnMQL8k" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="4oS6BnMQMkY" role="2OqNvi">
+                  <ref role="3TtcxE" to="v0r8:5a_u3OySka2" resolve="cases" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMQH0i" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMQHfN" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMQH0g" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMQkGK" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMQHrH" role="2OqNvi">
+              <ref role="37wK5l" to="kpbf:~TextAreaImpl.decreaseIndent()" resolve="decreaseIndent" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMQQ$7" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMQQTM" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMQQ$5" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMQkGK" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMQRvX" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMUIdM" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMQiYu" role="3clF45" />
     </node>
     <node concept="13i0hz" id="28$LOSAaYxM" role="13h7CS">
       <property role="13i0iv" value="false" />
@@ -2482,6 +2813,223 @@
     </node>
     <node concept="13hLZK" id="28$LOSBI7uw" role="13h7CW">
       <node concept="3clFbS" id="28$LOSBI7ux" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMoce7">
+    <ref role="13h7C2" to="v0r8:5a_u3OyTCgG" resolve="CaseItExpr" />
+    <node concept="13hLZK" id="4oS6BnMoce8" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMoce9" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMoceq" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMocer" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMoceC" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMod53" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMoent" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnModkw" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMod4Y" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4oS6BnModDk" role="2OqNvi" />
+            </node>
+            <node concept="3n3YKJ" id="4oS6BnMof5p" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMoceD" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMo_5X">
+    <ref role="13h7C2" to="v0r8:5a_u3OzYsEy" resolve="AllComponentsExpr" />
+    <node concept="13hLZK" id="4oS6BnMo_5Y" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMo_5Z" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMo_6g" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMo_6h" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMo_6u" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMo_ds" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMoAvQ" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMo_sT" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMo_dn" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4oS6BnMo_LH" role="2OqNvi" />
+            </node>
+            <node concept="3n3YKJ" id="4oS6BnMoBdM" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMo_6v" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMoBeC">
+    <ref role="13h7C2" to="v0r8:5a_u3OyVzbv" resolve="NameAnnotationRefExpr" />
+    <node concept="13hLZK" id="4oS6BnMoBeD" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMoBeE" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMoBeV" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMoBeW" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMoBf9" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMoC5$" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMoCXr" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMoCl1" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMoC5v" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnMoCDP" role="2OqNvi">
+                <ref role="3Tt5mk" to="v0r8:5a_u3OyVzbD" resolve="nameAnnotation" />
+              </node>
+            </node>
+            <node concept="3TrcHB" id="4oS6BnMoDuu" role="2OqNvi">
+              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMoBfa" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMoDyi">
+    <ref role="13h7C2" to="v0r8:5a_u3Oz3q2f" resolve="NameExprRefExpr" />
+    <node concept="13hLZK" id="4oS6BnMoDyj" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMoDyk" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMoDy_" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMoDyA" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMoDyN" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMoDDL" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMoEzW" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMoDTe" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMoDDG" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnMoEe2" role="2OqNvi">
+                <ref role="3Tt5mk" to="v0r8:5a_u3Oz3q2j" resolve="nameExpr" />
+              </node>
+            </node>
+            <node concept="3TrcHB" id="4oS6BnMoG6H" role="2OqNvi">
+              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMoDyO" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMoGfr">
+    <property role="3GE5qa" value="quote" />
+    <ref role="13h7C2" to="v0r8:28$LOSAcnmu" resolve="QuoteExpression" />
+    <node concept="13hLZK" id="4oS6BnMoGfs" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMoGft" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMoGfI" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMoGfJ" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMoGfW" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMoHQc" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMoOqk" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnMoOqn" role="3uHU7w">
+              <property role="Xl_RC" value="]" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMoMUR" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMoL6G" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnMoJ8A" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnMoI5D" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnMoHQb" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnMoIqt" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnMoJQx" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="4oS6BnMoL7y" role="3uHU7w">
+                  <property role="Xl_RC" value="[" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnMoNSn" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnMoNmT" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnMoMVP" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnMoNGg" role="2OqNvi">
+                    <ref role="3Tt5mk" to="v0r8:28$LOSAcnmv" resolve="term" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4oS6BnMoOi3" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMoGfX" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMoVr9">
+    <property role="3GE5qa" value="quote" />
+    <ref role="13h7C2" to="v0r8:28$LOSAeeCX" resolve="UnquoteExpression" />
+    <node concept="13hLZK" id="4oS6BnMoVra" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMoVrb" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMoVrs" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMoVrt" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMoVrE" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMoWhP" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMp2QV" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnMp2QY" role="3uHU7w">
+              <property role="Xl_RC" value="]" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMp1CO" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMoZBl" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnMoXCb" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnMoWxY" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnMoWhK" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnMoWTi" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnMoYn7" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="4oS6BnMoZBo" role="3uHU7w">
+                  <property role="Xl_RC" value="[" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnMp2rR" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnMp1PY" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnMp1DG" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnMp2dP" role="2OqNvi">
+                    <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4oS6BnMp2KJ" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMoVrF" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMp2Vm">
+    <ref role="13h7C2" to="v0r8:5a_u3OySBZU" resolve="WildcardExpr" />
+    <node concept="13hLZK" id="4oS6BnMp2Vn" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMp2Vo" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMp2VD" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMp2VE" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMp2VR" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMp32P" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMp4oN" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMp3iY" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMp32K" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4oS6BnMp3Ei" role="2OqNvi" />
+            </node>
+            <node concept="3n3YKJ" id="4oS6BnMp57Q" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMp2VS" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/org.iets3.core.expr.adt.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.adt/org.iets3.core.expr.adt.mpl
@@ -84,6 +84,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/behavior.mps
@@ -742,61 +742,6 @@
     <node concept="13hLZK" id="4rZeNQ6MpZ_" role="13h7CW">
       <node concept="3clFbS" id="4rZeNQ6MpZA" role="2VODD2" />
     </node>
-    <node concept="13i0hz" id="2ft7KAXZMVq" role="13h7CS">
-      <property role="TrG5h" value="getPresentation" />
-      <property role="13i0it" value="false" />
-      <property role="13i0iv" value="false" />
-      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
-      <node concept="3Tm1VV" id="2ft7KAXZMWy" role="1B3o_S" />
-      <node concept="3clFbS" id="2ft7KAXZMZa" role="3clF47">
-        <node concept="3clFbF" id="2ft7KAXZN2T" role="3cqZAp">
-          <node concept="3cpWs3" id="2ft7KAXZOfJ" role="3clFbG">
-            <node concept="2OqwBi" id="2ft7KAXZOA8" role="3uHU7w">
-              <node concept="2OqwBi" id="2ft7KAXZOms" role="2Oq$k0">
-                <node concept="13iPFW" id="2ft7KAXZOjc" role="2Oq$k0" />
-                <node concept="3TrEf2" id="2ft7KAXZOtF" role="2OqNvi">
-                  <ref role="3Tt5mk" to="hm2y:4rZeNQ6MpKo" resolve="right" />
-                </node>
-              </node>
-              <node concept="2qgKlT" id="2ft7KAXZOFR" role="2OqNvi">
-                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-              </node>
-            </node>
-            <node concept="3cpWs3" id="2ft7KAXZO9a" role="3uHU7B">
-              <node concept="3cpWs3" id="2ft7KAXZNBJ" role="3uHU7B">
-                <node concept="3cpWs3" id="2ft7KAXZNxJ" role="3uHU7B">
-                  <node concept="2OqwBi" id="2ft7KAXZNlk" role="3uHU7B">
-                    <node concept="2OqwBi" id="2ft7KAXZN5j" role="2Oq$k0">
-                      <node concept="13iPFW" id="2ft7KAXZN2R" role="2Oq$k0" />
-                      <node concept="3TrEf2" id="2ft7KAXZN9V" role="2OqNvi">
-                        <ref role="3Tt5mk" to="hm2y:4rZeNQ6MpKm" resolve="left" />
-                      </node>
-                    </node>
-                    <node concept="2qgKlT" id="2ft7KAXZNqQ" role="2OqNvi">
-                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                    </node>
-                  </node>
-                  <node concept="Xl_RD" id="2ft7KAXZNxM" role="3uHU7w">
-                    <property role="Xl_RC" value=" " />
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="2ft7KAXZNUG" role="3uHU7w">
-                  <node concept="3n3YKJ" id="6b_jefnKx$H" role="2OqNvi" />
-                  <node concept="2OqwBi" id="6b_jefnKx$F" role="2Oq$k0">
-                    <node concept="2yIwOk" id="6b_jefnKx$G" role="2OqNvi" />
-                    <node concept="13iPFW" id="2ft7KAXZNCW" role="2Oq$k0" />
-                  </node>
-                </node>
-              </node>
-              <node concept="Xl_RD" id="2ft7KAXZO9d" role="3uHU7w">
-                <property role="Xl_RC" value=" " />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="17QB3L" id="2ft7KAXZMZb" role="3clF45" />
-    </node>
     <node concept="13i0hz" id="6GySMNjD8lF" role="13h7CS">
       <property role="13i0iv" value="false" />
       <property role="13i0it" value="false" />
@@ -4704,6 +4649,22 @@
       <node concept="3Tm1VV" id="6kR0qIbI2yj" role="1B3o_S" />
       <node concept="3clFbS" id="6kR0qIbI2yk" role="3clF47" />
       <node concept="17QB3L" id="6kR0qIbI2yq" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnNB6W9" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNB6Wa" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNB6Wb" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNB6Wc" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnNB6Wd" role="3clFbG">
+            <node concept="13iPFW" id="4oS6BnNB6We" role="2Oq$k0" />
+            <node concept="2qgKlT" id="4oS6BnNB6Wf" role="2OqNvi">
+              <ref role="37wK5l" node="6kR0qIbI2yi" resolve="renderReadable" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNB6Wg" role="3clF45" />
     </node>
     <node concept="13i0hz" id="6zmBjqUivyF" role="13h7CS">
       <property role="13i0iv" value="false" />
@@ -12367,6 +12328,22 @@
     </node>
     <node concept="13hLZK" id="6UxFDrx4fGg" role="13h7CW">
       <node concept="3clFbS" id="6UxFDrx4fGh" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMpNo0" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnMpNor" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMpNos" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMpP0z" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMpPlS" role="3clFbG">
+            <node concept="13iPFW" id="4oS6BnMpP0u" role="2Oq$k0" />
+            <node concept="2qgKlT" id="4oS6BnMpPMY" role="2OqNvi">
+              <ref role="37wK5l" node="HywGhj7ndd" resolve="renderReadable" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMpNot" role="3clF45" />
     </node>
     <node concept="13i0hz" id="2PhSkOg8M7M" role="13h7CS">
       <property role="13i0iv" value="false" />
@@ -20559,6 +20536,43 @@
         </node>
       </node>
     </node>
+    <node concept="13i0hz" id="4oS6BnNEW4z" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNEW4Y" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNEW4Z" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNEW$N" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNF0GD" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNF1A8" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnNF18x" role="2Oq$k0">
+                <node concept="13iPFW" id="4oS6BnNF0Hv" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnNF1qT" role="2OqNvi">
+                  <ref role="3Tt5mk" to="hm2y:4hW8Ne0bR4I" resolve="condition" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="4oS6BnNF1Sh" role="2OqNvi">
+                <ref role="37wK5l" node="4Y0vh0cfqjE" resolve="renderReadable" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNEYEA" role="3uHU7B">
+              <node concept="2OqwBi" id="4oS6BnNEXhy" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnNEWOm" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnNEW$M" role="2Oq$k0" />
+                  <node concept="1mfA1w" id="4oS6BnNEX6g" role="2OqNvi" />
+                </node>
+                <node concept="2qgKlT" id="4oS6BnNEXqO" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="4oS6BnNEYED" role="3uHU7w">
+                <property role="Xl_RC" value="\n R if " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNEW50" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="4hW8Ne0ns4c" role="13h7CS">
       <property role="13i0iv" value="false" />
       <property role="13i0it" value="false" />
@@ -23888,27 +23902,59 @@
       <property role="TrG5h" value="renderReadable" />
       <ref role="13i0hy" node="4Y0vh0cfqjE" resolve="renderReadable" />
       <node concept="3clFbS" id="3nVyItrZCO2" role="3clF47">
-        <node concept="3clFbF" id="3nVyItrZCO$" role="3cqZAp">
-          <node concept="3cpWs3" id="3nVyItrZEYA" role="3clFbG">
-            <node concept="Xl_RD" id="3nVyItrZEYD" role="3uHU7w">
-              <property role="Xl_RC" value="&gt;" />
-            </node>
-            <node concept="3cpWs3" id="3nVyItrZD56" role="3uHU7B">
-              <node concept="Xl_RD" id="3nVyItrZCOz" role="3uHU7B">
-                <property role="Xl_RC" value="empty&lt;" />
-              </node>
-              <node concept="2OqwBi" id="3nVyItrZE1S" role="3uHU7w">
-                <node concept="2OqwBi" id="3nVyItrZDiI" role="2Oq$k0">
-                  <node concept="13iPFW" id="3nVyItrZD5m" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="3nVyItrZDzl" role="2OqNvi">
-                    <ref role="3Tt5mk" to="hm2y:3nVyItrZBNa" resolve="type" />
+        <node concept="3clFbJ" id="4oS6BnNli67" role="3cqZAp">
+          <node concept="3clFbS" id="4oS6BnNli69" role="3clFbx">
+            <node concept="3cpWs6" id="4oS6BnNljFZ" role="3cqZAp">
+              <node concept="3cpWs3" id="3nVyItrZEYA" role="3cqZAk">
+                <node concept="Xl_RD" id="3nVyItrZEYD" role="3uHU7w">
+                  <property role="Xl_RC" value="&gt;" />
+                </node>
+                <node concept="3cpWs3" id="3nVyItrZD56" role="3uHU7B">
+                  <node concept="3cpWs3" id="4oS6BnNljNI" role="3uHU7B">
+                    <node concept="2OqwBi" id="4oS6BnNllHk" role="3uHU7B">
+                      <node concept="2OqwBi" id="4oS6BnNlkzN" role="2Oq$k0">
+                        <node concept="13iPFW" id="4oS6BnNlk0p" role="2Oq$k0" />
+                        <node concept="2yIwOk" id="4oS6BnNlkXb" role="2OqNvi" />
+                      </node>
+                      <node concept="3n3YKJ" id="4oS6BnNlmmN" role="2OqNvi" />
+                    </node>
+                    <node concept="Xl_RD" id="3nVyItrZCOz" role="3uHU7w">
+                      <property role="Xl_RC" value="&lt;" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="3nVyItrZE1S" role="3uHU7w">
+                    <node concept="2OqwBi" id="3nVyItrZDiI" role="2Oq$k0">
+                      <node concept="13iPFW" id="3nVyItrZD5m" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="3nVyItrZDzl" role="2OqNvi">
+                        <ref role="3Tt5mk" to="hm2y:3nVyItrZBNa" resolve="type" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="3nVyItrZE_E" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                    </node>
                   </node>
                 </node>
-                <node concept="2qgKlT" id="3nVyItrZE_E" role="2OqNvi">
-                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                </node>
               </node>
             </node>
+          </node>
+          <node concept="2OqwBi" id="4oS6BnNljem" role="3clFbw">
+            <node concept="2OqwBi" id="4oS6BnNliBD" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnNli7e" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnNlj0X" role="2OqNvi">
+                <ref role="3Tt5mk" to="hm2y:3nVyItrZBNa" resolve="type" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="4oS6BnNljwL" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="4oS6BnNlmEa" role="3cqZAp" />
+        <node concept="3cpWs6" id="4oS6BnNlmLY" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnNlmUn" role="3cqZAk">
+            <node concept="2OqwBi" id="4oS6BnNlmPY" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnNlmOi" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4oS6BnNlmSy" role="2OqNvi" />
+            </node>
+            <node concept="3n3YKJ" id="4oS6BnNlmYf" role="2OqNvi" />
           </node>
         </node>
       </node>
@@ -26036,6 +26082,30 @@
   <node concept="13h7C7" id="5Ys_ngSnA9l">
     <property role="3GE5qa" value="numeric" />
     <ref role="13h7C2" to="hm2y:5Ys_ngSnA9h" resolve="HexValue" />
+    <node concept="13i0hz" id="4oS6BnNEOaS" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNEObj" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNEObk" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNERxL" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNETgj" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNEVJz" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnNEVnJ" role="2Oq$k0">
+                <node concept="13iPFW" id="4oS6BnNEUIb" role="2Oq$k0" />
+                <node concept="1mfA1w" id="4oS6BnNEVBv" role="2OqNvi" />
+              </node>
+              <node concept="2qgKlT" id="4oS6BnNEVSU" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+              </node>
+            </node>
+            <node concept="Xl_RD" id="4oS6BnNES08" role="3uHU7B">
+              <property role="Xl_RC" value="@hex value " />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNEObl" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="2KEzU_juQOS" role="13h7CS">
       <property role="TrG5h" value="setProperty" />
       <node concept="3Tm1VV" id="2KEzU_juQOT" role="1B3o_S" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/org.iets3.core.expr.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/org.iets3.core.expr.base.mpl
@@ -97,6 +97,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/org.iets3.core.expr.collections.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.collections/org.iets3.core.expr.collections.mpl
@@ -96,6 +96,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/org.iets3.core.expr.data.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.data/org.iets3.core.expr.data.mpl
@@ -75,6 +75,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.dataflow/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.dataflow/models/behavior.mps
@@ -10,8 +10,11 @@
     <import index="zzzn" ref="r:af0af2e7-f7e1-4536-83b5-6bf010d4afd2(org.iets3.core.expr.lambda.structure)" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
     <import index="gx5r" ref="r:a9ed28db-11a2-453b-b8cd-4dbf2ae73280(org.iets3.core.expr.dataflow.structure)" />
+    <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="6bz1" ref="r:d3905048-7598-4a84-931a-cbbcbcda146d(jetbrains.mps.lang.intentions.methods)" implicit="true" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
+    <import index="kpbf" ref="7124e466-fc92-4803-a656-d7a6b7eb3910/java:jetbrains.mps.text.impl(MPS.TextGen/)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -71,11 +74,15 @@
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -127,6 +134,9 @@
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
@@ -259,6 +269,7 @@
         <child id="1197932505799" name="map" index="3ElQJh" />
         <child id="1197932525128" name="key" index="3ElVtu" />
       </concept>
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
   <node concept="13h7C7" id="30L$xlcejMF">
@@ -2405,6 +2416,202 @@
     </node>
     <node concept="2tJIrI" id="2vkvJYTeLKw" role="jymVt" />
     <node concept="3Tm1VV" id="2vkvJYTeLGu" role="1B3o_S" />
+  </node>
+  <node concept="13h7C7" id="4oS6BnMrEPr">
+    <property role="3GE5qa" value="ports" />
+    <ref role="13h7C2" to="gx5r:4YhD5cZsmN3" resolve="InportRef" />
+    <node concept="13hLZK" id="4oS6BnMrEPs" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMrEPt" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMrEPY" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMrEPZ" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMrEQc" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMrEX6" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMrFMD" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMrFcz" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMrEX1" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnMrFxn" role="2OqNvi">
+                <ref role="3Tt5mk" to="gx5r:4YhD5cZsmN4" resolve="port" />
+              </node>
+            </node>
+            <node concept="3TrcHB" id="4oS6BnMrGdW" role="2OqNvi">
+              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMrEQd" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMPotF">
+    <ref role="13h7C2" to="gx5r:2vkvJYT6dDU" resolve="BlockCallExpr" />
+    <node concept="13hLZK" id="4oS6BnMPotG" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMPotH" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMPotY" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMPotZ" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMPouc" role="3clF47">
+        <node concept="3cpWs8" id="4oS6BnMPoDF" role="3cqZAp">
+          <node concept="3cpWsn" id="4oS6BnMPoDG" role="3cpWs9">
+            <property role="TrG5h" value="text" />
+            <node concept="3uibUv" id="4oS6BnMPoDH" role="1tU5fm">
+              <ref role="3uigEE" to="xfg9:4oS6BnMcix1" resolve="StringRepresentation" />
+            </node>
+            <node concept="2ShNRf" id="4oS6BnMPoEc" role="33vP2m">
+              <node concept="1pGfFk" id="4oS6BnMPoI_" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="xfg9:4oS6BnMcMsd" resolve="StringRepresentation" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMPoJn" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMPp1Z" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMPoJl" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMPoDG" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMPpmu" role="2OqNvi">
+              <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+              <node concept="2OqwBi" id="4oS6BnMPqkx" role="37wK5m">
+                <node concept="2OqwBi" id="4oS6BnMPpGJ" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnMPpor" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnMPq3_" role="2OqNvi">
+                    <ref role="3Tt5mk" to="gx5r:2vkvJYT6dHv" resolve="block" />
+                  </node>
+                </node>
+                <node concept="3TrcHB" id="4oS6BnMPqXJ" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4oS6BnMPsWK" role="3cqZAp">
+          <node concept="3clFbS" id="4oS6BnMPsWM" role="3clFbx">
+            <node concept="3clFbF" id="4oS6BnMPBdP" role="3cqZAp">
+              <node concept="2OqwBi" id="4oS6BnMPBte" role="3clFbG">
+                <node concept="37vLTw" id="4oS6BnMPBdO" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4oS6BnMPoDG" resolve="text" />
+                </node>
+                <node concept="liA8E" id="4oS6BnMPBNX" role="2OqNvi">
+                  <ref role="37wK5l" to="xfg9:4oS6BnMdvcE" resolve="append" />
+                  <node concept="2OqwBi" id="4oS6BnMPCaT" role="37wK5m">
+                    <node concept="13iPFW" id="4oS6BnMPBZR" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="4oS6BnMPCg8" role="2OqNvi">
+                      <ref role="3TtcxE" to="gx5r:2vkvJYT6dHx" resolve="paramValues" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="4oS6BnMPFoe" role="37wK5m">
+                    <property role="Xl_RC" value="," />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="4oS6BnMPx9H" role="3clFbw">
+            <node concept="2OqwBi" id="4oS6BnMPtcn" role="2Oq$k0">
+              <node concept="2OqwBi" id="4oS6BnMPt5o" role="2Oq$k0">
+                <node concept="13iPFW" id="4oS6BnMPsZi" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnMPt7R" role="2OqNvi">
+                  <ref role="3Tt5mk" to="gx5r:2vkvJYT6dHv" resolve="block" />
+                </node>
+              </node>
+              <node concept="3Tsc0h" id="4oS6BnMPtfa" role="2OqNvi">
+                <ref role="3TtcxE" to="gx5r:5Q9FzcI8h1i" resolve="params" />
+              </node>
+            </node>
+            <node concept="3GX2aA" id="4oS6BnMP_8u" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMPFEK" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMPG3g" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMPFEI" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMPoDG" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMPGsS" role="2OqNvi">
+              <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+              <node concept="Xl_RD" id="4oS6BnMPG$C" role="37wK5m">
+                <property role="Xl_RC" value="(" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMPHq5" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMPHq6" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMPHq7" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMPoDG" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMPHq8" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMdvcE" resolve="append" />
+              <node concept="2OqwBi" id="4oS6BnMPHq9" role="37wK5m">
+                <node concept="13iPFW" id="4oS6BnMPHqa" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="4oS6BnMPHqb" role="2OqNvi">
+                  <ref role="3TtcxE" to="gx5r:2vkvJYT6dH$" resolve="inputs" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="4oS6BnMPHqc" role="37wK5m">
+                <property role="Xl_RC" value="," />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMPJ6_" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMPJqW" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMPJ6z" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMPoDG" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMPJVB" role="2OqNvi">
+              <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+              <node concept="Xl_RD" id="4oS6BnMPK6K" role="37wK5m">
+                <property role="Xl_RC" value=")" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMPLe$" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMPLkR" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMPLey" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMPoDG" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMPLBc" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMUIdM" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMPoud" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMPLOr">
+    <ref role="13h7C2" to="gx5r:2vkvJYSMWJ7" resolve="ParamRef" />
+    <node concept="13hLZK" id="4oS6BnMPLOs" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMPLOt" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMPLOI" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMPLOJ" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMPLOW" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMPLVR" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMPMKg" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMPMbk" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMPLVM" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnMPMw8" role="2OqNvi">
+                <ref role="3Tt5mk" to="gx5r:2vkvJYSMWJA" resolve="param" />
+              </node>
+            </node>
+            <node concept="3TrcHB" id="4oS6BnMPN92" role="2OqNvi">
+              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMPLOX" role="3clF45" />
+    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.dataflow/org.iets3.core.expr.dataflow.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.dataflow/org.iets3.core.expr.dataflow.mpl
@@ -15,6 +15,7 @@
     <dependency reexport="false">1144260c-e9a5-49a2-9add-39a1a1a7077e(de.itemis.mps.editor.diagram.runtime)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">cee4aa62-aca9-4f26-9602-75129cd457c9(org.iets3.core.expr.dataflow)</dependency>
+    <dependency reexport="false">dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="2" />
@@ -74,6 +75,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
@@ -113,6 +115,7 @@
     <module reference="db8bd035-3f51-41d8-8fed-954c202d18be(org.iets3.analysis.base)" version="1" />
     <module reference="7b68d745-a7b8-48b9-bd9c-05c0f8725a35(org.iets3.core.base)" version="0" />
     <module reference="cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)" version="20" />
+    <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
     <module reference="2f7e2e35-6e74-4c43-9fa5-2465d68f5996(org.iets3.core.expr.collections)" version="11" />
     <module reference="cee4aa62-aca9-4f26-9602-75129cd457c9(org.iets3.core.expr.dataflow)" version="2" />
     <module reference="9464fa06-5ab9-409b-9274-64ab29588457(org.iets3.core.expr.lambda)" version="5" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.datetime/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.datetime/models/behavior.mps
@@ -37,6 +37,7 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
@@ -144,6 +145,13 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
         <reference id="5455284157994012188" name="link" index="2pIpSl" />
@@ -191,6 +199,9 @@
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -207,6 +218,15 @@
       <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
         <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
+        <child id="1240687658305" name="delimiter" index="3uJOhx" />
+      </concept>
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
     </language>
   </registry>
   <node concept="13h7C7" id="3nGzaxURagF">
@@ -793,9 +813,36 @@
       <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
       <node concept="3Tm1VV" id="3nGzaxUXNjx" role="1B3o_S" />
       <node concept="3clFbS" id="3nGzaxUXNj$" role="3clF47">
-        <node concept="3clFbF" id="3nGzaxUXNjJ" role="3cqZAp">
-          <node concept="Xl_RD" id="3nGzaxUXNjI" role="3clFbG">
-            <property role="Xl_RC" value="" />
+        <node concept="3clFbF" id="4oS6BnN9TMM" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNa2ON" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnNa2OQ" role="3uHU7w">
+              <property role="Xl_RC" value="]" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnN9Z7k" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnN9Xjk" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnN9Vi3" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnN9U5H" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnN9TML" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnN9Uy0" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnN9W32" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="4oS6BnN9Xjn" role="3uHU7w">
+                  <property role="Xl_RC" value="[" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnNa1fx" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnN9Z_S" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnN9Z8i" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnNa02I" role="2OqNvi">
+                    <ref role="3Tt5mk" to="mi3w:3nGzaxUXsgk" resolve="year" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4oS6BnNa1$p" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -1395,6 +1442,62 @@
   <node concept="13h7C7" id="3HiHZeybQv9">
     <property role="3GE5qa" value="time" />
     <ref role="13h7C2" to="mi3w:3HiHZey9lUa" resolve="TimeLiteral" />
+    <node concept="13i0hz" id="4oS6BnMP7d1" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMP7d2" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMP7df" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMP8mG" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMPion" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnMPioq" role="3uHU7w">
+              <property role="Xl_RC" value="\\" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMPihL" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMPifU" role="3uHU7B">
+                <node concept="3cpWs3" id="4oS6BnMPh2M" role="3uHU7B">
+                  <node concept="3cpWs3" id="4oS6BnMPeXG" role="3uHU7B">
+                    <node concept="3cpWs3" id="4oS6BnMPbLw" role="3uHU7B">
+                      <node concept="2OqwBi" id="4oS6BnMP9Lq" role="3uHU7B">
+                        <node concept="2OqwBi" id="4oS6BnMP8Ct" role="2Oq$k0">
+                          <node concept="13iPFW" id="4oS6BnMP8mF" role="2Oq$k0" />
+                          <node concept="2yIwOk" id="4oS6BnMP92g" role="2OqNvi" />
+                        </node>
+                        <node concept="3n3YKJ" id="4oS6BnMPaxh" role="2OqNvi" />
+                      </node>
+                      <node concept="2OqwBi" id="4oS6BnMPdyk" role="3uHU7w">
+                        <node concept="13iPFW" id="4oS6BnMPcQ1" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="4oS6BnMPdWw" role="2OqNvi">
+                          <ref role="3TsBF5" to="mi3w:3HiHZey9lUb" resolve="hh" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="4oS6BnMPeXJ" role="3uHU7w">
+                      <property role="Xl_RC" value=":" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="4oS6BnMPhgd" role="3uHU7w">
+                    <node concept="13iPFW" id="4oS6BnMPh2P" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="4oS6BnMPhXL" role="2OqNvi">
+                      <ref role="3TsBF5" to="mi3w:3HiHZey9lUd" resolve="mm" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="4oS6BnMPifX" role="3uHU7w">
+                  <property role="Xl_RC" value=":" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnMPijs" role="3uHU7w">
+                <node concept="13iPFW" id="4oS6BnMPihO" role="2Oq$k0" />
+                <node concept="3TrcHB" id="4oS6BnMPilI" role="2OqNvi">
+                  <ref role="3TsBF5" to="mi3w:3HiHZeyb5uA" resolve="ss" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMP7dg" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="3HiHZeydxpU" role="13h7CS">
       <property role="TrG5h" value="toTime" />
       <node concept="3Tm1VV" id="3HiHZeydxpV" role="1B3o_S" />
@@ -1974,6 +2077,148 @@
     </node>
     <node concept="13hLZK" id="5xLzI609Ewe" role="13h7CW">
       <node concept="3clFbS" id="5xLzI609Ewf" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMOJk9">
+    <property role="3GE5qa" value="date" />
+    <ref role="13h7C2" to="mi3w:7aRvJQF3FvQ" resolve="BeginningOfTIME" />
+    <node concept="13hLZK" id="4oS6BnMOJka" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMOJkb" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMOJks" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMOJkt" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMOJkE" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMOJql" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMOKGJ" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMOJDM" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMOJqg" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4oS6BnMOJYA" role="2OqNvi" />
+            </node>
+            <node concept="3n3YKJ" id="4oS6BnMOLqG" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMOJkF" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMOLry">
+    <ref role="13h7C2" to="mi3w:7MYpJaZ9zRp" resolve="CurrentDateExpr" />
+    <node concept="13hLZK" id="4oS6BnMOLrz" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMOLr$" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMOLrP" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMOLrQ" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMOLs3" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMOLyY" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMOMPJ" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMOLMr" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMOLyT" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4oS6BnMOM7f" role="2OqNvi" />
+            </node>
+            <node concept="3n3YKJ" id="4oS6BnMONz_" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMOLs4" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMON$r">
+    <property role="3GE5qa" value="date.earlylate" />
+    <ref role="13h7C2" to="mi3w:1RwPUjzgk0y" resolve="AbstractEarliestLastestExpression" />
+    <node concept="13hLZK" id="4oS6BnMON$s" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMON$t" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMON$I" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMON$J" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMON$W" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMONFR" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMP40P" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnMP40S" role="3uHU7w">
+              <property role="Xl_RC" value=")" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMORe4" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMOQWo" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnMOOYh" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnMONVk" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnMONFM" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnMOOg8" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnMOPGd" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="4oS6BnMOQWr" role="3uHU7w">
+                  <property role="Xl_RC" value="(" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnMP0AC" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnMOTZy" role="2Oq$k0">
+                  <node concept="2OqwBi" id="4oS6BnMORvE" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnMOReW" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="4oS6BnMORxh" role="2OqNvi">
+                      <ref role="3TtcxE" to="mi3w:1RwPUjzgk0z" resolve="values" />
+                    </node>
+                  </node>
+                  <node concept="3$u5V9" id="4oS6BnMOX2H" role="2OqNvi">
+                    <node concept="1bVj0M" id="4oS6BnMOX2J" role="23t8la">
+                      <node concept="3clFbS" id="4oS6BnMOX2K" role="1bW5cS">
+                        <node concept="3clFbF" id="4oS6BnMOX9o" role="3cqZAp">
+                          <node concept="2OqwBi" id="4oS6BnMOXnJ" role="3clFbG">
+                            <node concept="37vLTw" id="4oS6BnMOX9n" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4oS6BnMOX2L" resolve="it" />
+                            </node>
+                            <node concept="2qgKlT" id="4oS6BnMP01j" role="2OqNvi">
+                              <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gl6BB" id="4oS6BnMOX2L" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="4oS6BnMOX2M" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3uJxvA" id="4oS6BnMP2Cf" role="2OqNvi">
+                  <node concept="Xl_RD" id="4oS6BnMP3Wx" role="3uJOhx">
+                    <property role="Xl_RC" value="," />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMON$X" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMP49o">
+    <property role="3GE5qa" value="range.literals" />
+    <ref role="13h7C2" to="mi3w:41xkdV7Z9B0" resolve="EmptyRangeLiteral" />
+    <node concept="13hLZK" id="4oS6BnMP49p" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMP49q" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMP49F" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMP49G" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMP49T" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMP4h4" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMP69a" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMP4yn" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMP4gZ" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4oS6BnMP5qh" role="2OqNvi" />
+            </node>
+            <node concept="3n3YKJ" id="4oS6BnMP6Tb" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMP49U" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.datetime/org.iets3.core.expr.datetime.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.datetime/org.iets3.core.expr.datetime.mpl
@@ -74,6 +74,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.doc/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.doc/models/behavior.mps
@@ -950,6 +950,43 @@
     <node concept="13hLZK" id="4vZ65iKiy9X" role="13h7CW">
       <node concept="3clFbS" id="4vZ65iKiy9Y" role="2VODD2" />
     </node>
+    <node concept="13i0hz" id="4oS6BnNGu0t" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNGu0S" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNGu0T" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNGujB" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNGzVb" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNG$ww" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnNG$mx" role="2Oq$k0">
+                <node concept="13iPFW" id="4oS6BnNGzW7" role="2Oq$k0" />
+                <node concept="1mfA1w" id="4oS6BnNG$o6" role="2OqNvi" />
+              </node>
+              <node concept="2qgKlT" id="4oS6BnNG$Ga" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNGzTg" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnNGvzH" role="3uHU7B">
+                <node concept="Xl_RD" id="4oS6BnNGujA" role="3uHU7B">
+                  <property role="Xl_RC" value="@bookmark " />
+                </node>
+                <node concept="2OqwBi" id="4oS6BnNGwkT" role="3uHU7w">
+                  <node concept="13iPFW" id="4oS6BnNGvE_" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="4oS6BnNGwDN" role="2OqNvi">
+                    <ref role="3TsBF5" to="34lm:4vZ65iKiy85" resolve="label" />
+                  </node>
+                </node>
+              </node>
+              <node concept="Xl_RD" id="4oS6BnNGzTj" role="3uHU7w">
+                <property role="Xl_RC" value="\n" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNGu0U" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="4vZ65iKiyaa" role="13h7CS">
       <property role="13i0iv" value="false" />
       <property role="13i0it" value="false" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/org.iets3.core.expr.genjava.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.base/org.iets3.core.expr.genjava.base.mpl
@@ -68,6 +68,7 @@
         <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+        <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
         <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
         <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
         <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.simpleTypes/org.iets3.core.expr.genjava.simpleTypes.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.simpleTypes/org.iets3.core.expr.genjava.simpleTypes.mpl
@@ -63,6 +63,7 @@
         <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+        <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
         <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
         <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
         <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.util/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.util/models/behavior.mps
@@ -5,7 +5,231 @@
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
-  <imports />
-  <registry />
+  <imports>
+    <import index="5pht" ref="r:2963f1d9-ee74-48d9-8a07-471e05081e4f(org.iets3.core.expr.genjava.util.structure)" />
+    <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
+    <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
+      <concept id="1225194240794" name="jetbrains.mps.lang.behavior.structure.ConceptBehavior" flags="ng" index="13h7C7">
+        <reference id="1225194240799" name="concept" index="13h7C2" />
+        <child id="1225194240805" name="method" index="13h7CS" />
+        <child id="1225194240801" name="constructor" index="13h7CW" />
+      </concept>
+      <concept id="1225194413805" name="jetbrains.mps.lang.behavior.structure.ConceptConstructorDeclaration" flags="in" index="13hLZK" />
+      <concept id="1225194472830" name="jetbrains.mps.lang.behavior.structure.ConceptMethodDeclaration" flags="ng" index="13i0hz">
+        <reference id="1225194472831" name="overriddenMethod" index="13i0hy" />
+      </concept>
+      <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
+      <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
+        <child id="1240687658305" name="delimiter" index="3uJOhx" />
+      </concept>
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
+    </language>
+  </registry>
+  <node concept="13h7C7" id="4oS6BnMs3xd">
+    <ref role="13h7C2" to="5pht:5Jw72wdhdVW" resolve="KFMultiConditional" />
+    <node concept="13hLZK" id="4oS6BnMs3xe" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMs3xf" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMs3xw" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMs3xx" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMs3xI" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMs3CC" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMsj3c" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnMsj3f" role="3uHU7w">
+              <property role="Xl_RC" value=")" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMs6Qn" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMs6$z" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnMs4PN" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnMs3S5" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnMs3Cz" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnMs47E" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnMs5ko" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="4oS6BnMs6$A" role="3uHU7w">
+                  <property role="Xl_RC" value="(" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnMse0x" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnMs9DW" role="2Oq$k0">
+                  <node concept="2OqwBi" id="4oS6BnMs77V" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnMs6Rl" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="4oS6BnMs79y" role="2OqNvi">
+                      <ref role="3TtcxE" to="5pht:5Jw72wdniYD" resolve="operands" />
+                    </node>
+                  </node>
+                  <node concept="3$u5V9" id="4oS6BnMsbGb" role="2OqNvi">
+                    <node concept="1bVj0M" id="4oS6BnMsbGd" role="23t8la">
+                      <node concept="3clFbS" id="4oS6BnMsbGe" role="1bW5cS">
+                        <node concept="3clFbF" id="4oS6BnMsbMQ" role="3cqZAp">
+                          <node concept="2OqwBi" id="4oS6BnMsc1d" role="3clFbG">
+                            <node concept="37vLTw" id="4oS6BnMsbMP" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4oS6BnMsbGf" resolve="it" />
+                            </node>
+                            <node concept="2qgKlT" id="4oS6BnMsdrc" role="2OqNvi">
+                              <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gl6BB" id="4oS6BnMsbGf" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="4oS6BnMsbGg" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3uJxvA" id="4oS6BnMsfOM" role="2OqNvi">
+                  <node concept="Xl_RD" id="4oS6BnMshd5" role="3uJOhx">
+                    <property role="Xl_RC" value="," />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMs3xJ" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMU93M">
+    <ref role="13h7C2" to="5pht:2FeCPocbIIQ" resolve="KFMaybeNot" />
+    <node concept="13hLZK" id="4oS6BnMU93N" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMU93O" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMU945" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMU946" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMU94j" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMU9bp" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMUjBU" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnMUjBX" role="3uHU7w">
+              <property role="Xl_RC" value=")" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMUhhT" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMUgvS" role="3uHU7B">
+                <node concept="3cpWs3" id="4oS6BnMUedt" role="3uHU7B">
+                  <node concept="3cpWs3" id="4oS6BnMUcbX" role="3uHU7B">
+                    <node concept="2OqwBi" id="4oS6BnMUasb" role="3uHU7B">
+                      <node concept="2OqwBi" id="4oS6BnMU9s0" role="2Oq$k0">
+                        <node concept="13iPFW" id="4oS6BnMU9bo" role="2Oq$k0" />
+                        <node concept="2yIwOk" id="4oS6BnMU9HE" role="2OqNvi" />
+                      </node>
+                      <node concept="3n3YKJ" id="4oS6BnMUaVJ" role="2OqNvi" />
+                    </node>
+                    <node concept="Xl_RD" id="4oS6BnMUcc0" role="3uHU7w">
+                      <property role="Xl_RC" value="(" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="4oS6BnMUepM" role="3uHU7w">
+                    <node concept="13iPFW" id="4oS6BnMUedw" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="4oS6BnMUeFZ" role="2OqNvi">
+                      <ref role="3TsBF5" to="5pht:2FeCPocbIP7" resolve="negate" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="4oS6BnMUgvV" role="3uHU7w">
+                  <property role="Xl_RC" value=")(" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnMYhFc" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnMUijk" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnMUhBb" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnMUiWr" role="2OqNvi">
+                    <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4oS6BnMYhVI" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMU94k" role="3clF45" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/behavior.mps
@@ -33,6 +33,7 @@
     <import index="sxpq" ref="r:51edfe99-0380-475c-a3e9-1d4425eac12f(org.iets3.core.expr.lambda.plugin)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="kpbf" ref="7124e466-fc92-4803-a656-d7a6b7eb3910/java:jetbrains.mps.text.impl(MPS.TextGen/)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -113,6 +114,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -252,6 +256,7 @@
       <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
         <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
       </concept>
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC">
         <reference id="1139880128956" name="concept" index="1A9B2P" />
       </concept>
@@ -288,7 +293,9 @@
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
+      <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
@@ -406,6 +413,9 @@
         <child id="1197687035757" name="valueType" index="3rHtpV" />
       </concept>
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
+        <child id="1240687658305" name="delimiter" index="3uJOhx" />
+      </concept>
       <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1225730411176" name="jetbrains.mps.baseLanguage.collections.structure.FindLastOperation" flags="nn" index="1zesIP" />
@@ -3603,24 +3613,6 @@
       </node>
       <node concept="17QB3L" id="ZYPG76BgMM" role="3clF45" />
     </node>
-    <node concept="13i0hz" id="1XjPJYAwN7m" role="13h7CS">
-      <property role="TrG5h" value="getPresentation" />
-      <property role="13i0it" value="false" />
-      <property role="13i0iv" value="false" />
-      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
-      <node concept="3Tm1VV" id="1XjPJYAwN8u" role="1B3o_S" />
-      <node concept="3clFbS" id="1XjPJYAwNbj" role="3clF47">
-        <node concept="3cpWs6" id="1XjPJYAwNiJ" role="3cqZAp">
-          <node concept="2OqwBi" id="1XjPJYAwNoj" role="3cqZAk">
-            <node concept="13iPFW" id="1XjPJYAwNiZ" role="2Oq$k0" />
-            <node concept="3TrcHB" id="1XjPJYAwNzr" role="2OqNvi">
-              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="17QB3L" id="1XjPJYAwNbk" role="3clF45" />
-    </node>
     <node concept="13i0hz" id="5ElkanPXwPk" role="13h7CS">
       <property role="13i0iv" value="false" />
       <property role="13i0it" value="false" />
@@ -5818,6 +5810,171 @@
     <node concept="13hLZK" id="1VmWkC0$en_" role="13h7CW">
       <node concept="3clFbS" id="1VmWkC0$enA" role="2VODD2" />
     </node>
+    <node concept="13i0hz" id="4oS6BnMNC_B" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMNC_C" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMNC_P" role="3clF47">
+        <node concept="3cpWs8" id="4oS6BnMNLXn" role="3cqZAp">
+          <node concept="3cpWsn" id="4oS6BnMNLXo" role="3cpWs9">
+            <property role="TrG5h" value="text" />
+            <node concept="3uibUv" id="4oS6BnMNLXp" role="1tU5fm">
+              <ref role="3uigEE" to="xfg9:4oS6BnMcix1" resolve="StringRepresentation" />
+            </node>
+            <node concept="2ShNRf" id="4oS6BnMNLYr" role="33vP2m">
+              <node concept="1pGfFk" id="4oS6BnMNMfv" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="xfg9:4oS6BnMcMsd" resolve="StringRepresentation" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMNMhj" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMNMza" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMNMhh" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMNLXo" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMNMOF" role="2OqNvi">
+              <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+              <node concept="2OqwBi" id="4oS6BnMNOTL" role="37wK5m">
+                <node concept="2OqwBi" id="4oS6BnMNNwZ" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnMNMRk" role="2Oq$k0" />
+                  <node concept="2yIwOk" id="4oS6BnMNOeT" role="2OqNvi" />
+                </node>
+                <node concept="3n3YKJ" id="4oS6BnMNPGt" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMNS7T" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMNSq_" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMNS7R" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMNLXo" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMNSIx" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMfnH9" resolve="appendWithSpace" />
+              <node concept="2OqwBi" id="4oS6BnMNT_h" role="37wK5m">
+                <node concept="13iPFW" id="4oS6BnMNSOh" role="2Oq$k0" />
+                <node concept="3TrcHB" id="4oS6BnMNUWr" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4oS6BnMNWT4" role="3cqZAp">
+          <node concept="3clFbS" id="4oS6BnMNWT6" role="3clFbx">
+            <node concept="3clFbF" id="4oS6BnNLpoM" role="3cqZAp">
+              <node concept="2OqwBi" id="4oS6BnNLpKV" role="3clFbG">
+                <node concept="37vLTw" id="4oS6BnNLpoK" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4oS6BnMNLXo" resolve="text" />
+                </node>
+                <node concept="liA8E" id="4oS6BnNLqhz" role="2OqNvi">
+                  <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+                  <node concept="Xl_RD" id="4oS6BnNLqsB" role="37wK5m">
+                    <property role="Xl_RC" value=": " />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4oS6BnMNYNe" role="3cqZAp">
+              <node concept="2OqwBi" id="4oS6BnMNZ3l" role="3clFbG">
+                <node concept="37vLTw" id="4oS6BnMNYNc" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4oS6BnMNLXo" resolve="text" />
+                </node>
+                <node concept="liA8E" id="4oS6BnMNZo3" role="2OqNvi">
+                  <ref role="37wK5l" to="xfg9:4oS6BnMgdrs" resolve="append" />
+                  <node concept="2OqwBi" id="4oS6BnMNZ$7" role="37wK5m">
+                    <node concept="13iPFW" id="4oS6BnMNZt8" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="4oS6BnMO0t2" role="2OqNvi">
+                      <ref role="3Tt5mk" to="hm2y:69zaTr1EKHX" resolve="type" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="4oS6BnMNYk_" role="3clFbw">
+            <node concept="2OqwBi" id="4oS6BnMNXn1" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMNWT9" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnMNY6E" role="2OqNvi">
+                <ref role="3Tt5mk" to="hm2y:69zaTr1EKHX" resolve="type" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="4oS6BnMNYEL" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4oS6BnMO0EQ" role="3cqZAp">
+          <node concept="3clFbS" id="4oS6BnMO0ES" role="3clFbx">
+            <node concept="3clFbF" id="4oS6BnMO3XG" role="3cqZAp">
+              <node concept="2OqwBi" id="4oS6BnMO4gX" role="3clFbG">
+                <node concept="37vLTw" id="4oS6BnMO3XE" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4oS6BnMNLXo" resolve="text" />
+                </node>
+                <node concept="liA8E" id="4oS6BnMO4AM" role="2OqNvi">
+                  <ref role="37wK5l" to="xfg9:4oS6BnMgZBe" resolve="appendWithSpace" />
+                  <node concept="2OqwBi" id="4oS6BnMO56e" role="37wK5m">
+                    <node concept="13iPFW" id="4oS6BnMO4Gc" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="4oS6BnMO5cq" role="2OqNvi">
+                      <ref role="3Tt5mk" to="hm2y:KaZMgy4Ily" resolve="contract" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="4oS6BnMO3xa" role="3clFbw">
+            <node concept="2OqwBi" id="4oS6BnMO0NT" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMO0JA" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnMO3e3" role="2OqNvi">
+                <ref role="3Tt5mk" to="hm2y:KaZMgy4Ily" resolve="contract" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="4oS6BnMO3OF" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMO5q2" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMO5yR" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMO5q0" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMNLXo" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMO5Iv" role="2OqNvi">
+              <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+              <node concept="Xl_RD" id="4oS6BnMO5P5" role="37wK5m">
+                <property role="Xl_RC" value=" = " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMO93f" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMO9rf" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMO93d" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMNLXo" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMOaMz" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMgdrs" resolve="append" />
+              <node concept="2OqwBi" id="4oS6BnMOcpS" role="37wK5m">
+                <node concept="13iPFW" id="4oS6BnMObqu" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnMOdeT" role="2OqNvi">
+                  <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMOhZf" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMOim6" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMOhZd" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMNLXo" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMOjtd" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMUIdM" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMNC_Q" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="1VmWkC0$enJ" role="13h7CS">
       <property role="13i0iv" value="false" />
       <property role="13i0it" value="false" />
@@ -6105,6 +6262,73 @@
     </node>
     <node concept="13hLZK" id="6NpHfQ5A3W1" role="13h7CW">
       <node concept="3clFbS" id="6NpHfQ5A3W2" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnNG_Ul">
+    <ref role="13h7C2" to="zzzn:3RtoCziFOU9" resolve="AttachedConstraint" />
+    <node concept="13hLZK" id="4oS6BnNG_Um" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnNG_Un" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnNG_US" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNG_Vj" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNG_Vk" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNGA1W" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNGC8d" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNGJId" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnNGEV6" role="2Oq$k0">
+                <node concept="2OqwBi" id="4oS6BnNGCpE" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnNGC99" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="4oS6BnNGCrf" role="2OqNvi">
+                    <ref role="3TtcxE" to="zzzn:3RtoCziFOUj" resolve="constraints" />
+                  </node>
+                </node>
+                <node concept="3$u5V9" id="4oS6BnNGHrR" role="2OqNvi">
+                  <node concept="1bVj0M" id="4oS6BnNGHrT" role="23t8la">
+                    <node concept="3clFbS" id="4oS6BnNGHrU" role="1bW5cS">
+                      <node concept="3clFbF" id="4oS6BnNGHs7" role="3cqZAp">
+                        <node concept="2OqwBi" id="4oS6BnNGHXi" role="3clFbG">
+                          <node concept="37vLTw" id="4oS6BnNGHs6" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4oS6BnNGHrV" resolve="it" />
+                          </node>
+                          <node concept="2qgKlT" id="4oS6BnNGINm" role="2OqNvi">
+                            <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="4oS6BnNGHrV" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="4oS6BnNGHrW" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3uJxvA" id="4oS6BnNGKXo" role="2OqNvi">
+                <node concept="Xl_RD" id="4oS6BnNGM5R" role="3uJOhx">
+                  <property role="Xl_RC" value="," />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNGC6i" role="3uHU7B">
+              <node concept="2OqwBi" id="4oS6BnNGAD1" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnNGAg7" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnNGA1R" role="2Oq$k0" />
+                  <node concept="1mfA1w" id="4oS6BnNGAvM" role="2OqNvi" />
+                </node>
+                <node concept="2qgKlT" id="4oS6BnNGAMp" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="4oS6BnNGC6l" role="3uHU7w">
+                <property role="Xl_RC" value="\n" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNG_Vl" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/org.iets3.core.expr.lambda.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/org.iets3.core.expr.lambda.mpl
@@ -85,6 +85,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/models/behavior.mps
@@ -751,7 +751,7 @@
                   <node concept="3cpWs3" id="HywGhj7LoI" role="3uHU7B">
                     <node concept="3cpWs3" id="HywGhj7KWR" role="3uHU7B">
                       <node concept="Xl_RD" id="6kR0qIbHSRt" role="3uHU7B">
-                        <property role="Xl_RC" value="&lt;product&gt;(" />
+                        <property role="Xl_RC" value="product(" />
                       </node>
                       <node concept="2OqwBi" id="1br4Vy9oyR" role="3uHU7w">
                         <node concept="2OqwBi" id="1br4Vy9oyS" role="2Oq$k0">
@@ -826,7 +826,7 @@
                   <node concept="3cpWs3" id="HywGhj7MCi" role="3uHU7B">
                     <node concept="3cpWs3" id="HywGhj7MCj" role="3uHU7B">
                       <node concept="Xl_RD" id="HywGhj7MCk" role="3uHU7B">
-                        <property role="Xl_RC" value="&lt;sum&gt;" />
+                        <property role="Xl_RC" value="sum" />
                       </node>
                       <node concept="2OqwBi" id="1br4Vy9o$G" role="3uHU7w">
                         <node concept="2OqwBi" id="1br4Vy9o$H" role="2Oq$k0">
@@ -1655,6 +1655,82 @@
   </node>
   <node concept="13h7C7" id="3iWt5eg_dvL">
     <ref role="13h7C2" to="1qv1:3iWt5efOhM1" resolve="IntegralExpression" />
+    <node concept="13i0hz" id="4oS6BnML$9e" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnML$9f" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnML$9s" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMLCao" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMLPBn" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnMLPBq" role="3uHU7w">
+              <property role="Xl_RC" value=")" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMLOLv" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMLOHa" role="3uHU7B">
+                <node concept="3cpWs3" id="4oS6BnMLOj0" role="3uHU7B">
+                  <node concept="3cpWs3" id="4oS6BnMLOfQ" role="3uHU7B">
+                    <node concept="3cpWs3" id="4oS6BnMLJbA" role="3uHU7B">
+                      <node concept="3cpWs3" id="4oS6BnMLF6f" role="3uHU7B">
+                        <node concept="2OqwBi" id="4oS6BnMLDnz" role="3uHU7B">
+                          <node concept="2OqwBi" id="4oS6BnMLCpP" role="2Oq$k0">
+                            <node concept="13iPFW" id="4oS6BnMLCan" role="2Oq$k0" />
+                            <node concept="2yIwOk" id="4oS6BnMLCDq" role="2OqNvi" />
+                          </node>
+                          <node concept="3n3YKJ" id="4oS6BnMLDQ4" role="2OqNvi" />
+                        </node>
+                        <node concept="Xl_RD" id="4oS6BnMLF6i" role="3uHU7w">
+                          <property role="Xl_RC" value="(" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="4oS6BnMLLJf" role="3uHU7w">
+                        <node concept="2OqwBi" id="4oS6BnMLJAH" role="2Oq$k0">
+                          <node concept="13iPFW" id="4oS6BnMLJbD" role="2Oq$k0" />
+                          <node concept="3TrEf2" id="4oS6BnMLJQP" role="2OqNvi">
+                            <ref role="3Tt5mk" to="1qv1:3iWt5efOwZ1" resolve="lower" />
+                          </node>
+                        </node>
+                        <node concept="2qgKlT" id="4oS6BnMLN8L" role="2OqNvi">
+                          <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="4oS6BnMLOfT" role="3uHU7w">
+                      <property role="Xl_RC" value="," />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="4oS6BnMLOwS" role="3uHU7w">
+                    <node concept="2OqwBi" id="4oS6BnMLOsd" role="2Oq$k0">
+                      <node concept="13iPFW" id="4oS6BnMLOj3" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="4oS6BnMLOuo" role="2OqNvi">
+                        <ref role="3Tt5mk" to="1qv1:3iWt5efOwZ2" resolve="upper" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="4oS6BnMLOzn" role="2OqNvi">
+                      <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="4oS6BnMLOHd" role="3uHU7w">
+                  <property role="Xl_RC" value="," />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnMLP8k" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnMLOPx" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnMLON_" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnMLOSg" role="2OqNvi">
+                    <ref role="3Tt5mk" to="1qv1:3iWt5efOwZ3" resolve="body" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4oS6BnMLPxU" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnML$9t" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="3iWt5eg_dvW" role="13h7CS">
       <property role="TrG5h" value="compute" />
       <node concept="3Tm1VV" id="3iWt5eg_dvX" role="1B3o_S" />
@@ -1923,6 +1999,53 @@
       <node concept="3Tqbb2" id="41vYFO2K_gO" role="3clF45">
         <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
       </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMLQsQ">
+    <property role="3GE5qa" value="rat" />
+    <ref role="13h7C2" to="1qv1:5mz5Tt_ip39" resolve="RatExpr" />
+    <node concept="13hLZK" id="4oS6BnMLQsR" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMLQsS" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMLQt9" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMLQta" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMLQtn" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMLQ$i" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMLY3V" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnMLY3Y" role="3uHU7w">
+              <property role="Xl_RC" value="]" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMLVm9" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMLT$m" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnMLROA" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnMLQOr" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnMLQ$d" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnMLR65" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnMLSk8" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="4oS6BnMLT$p" role="3uHU7w">
+                  <property role="Xl_RC" value="[" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnMLWNk" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnMLW2N" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnMLVn1" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnMLW_i" role="2OqNvi">
+                    <ref role="3Tt5mk" to="1qv1:5mz5Tt_ip43" resolve="value" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4oS6BnMLX3o" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMLQto" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/org.iets3.core.expr.math.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.math/org.iets3.core.expr.math.mpl
@@ -87,6 +87,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="28583149-5b6e-4663-9c02-b9a8fa3cb099(com.mbeddr.mpsutil.contextactions.runtime)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/models/behavior.mps
@@ -913,5 +913,55 @@
       <node concept="3clFbS" id="12O03AaUK2f" role="2VODD2" />
     </node>
   </node>
+  <node concept="13h7C7" id="4oS6BnMLoX9">
+    <ref role="13h7C2" to="kelk:3vxfdxbnLby" resolve="CoercionIt" />
+    <node concept="13hLZK" id="4oS6BnMLoXa" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMLoXb" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMLoXs" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMLoXt" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMLoXE" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMLp4P" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMLqkk" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMLpki" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMLp4K" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4oS6BnMLpAb" role="2OqNvi" />
+            </node>
+            <node concept="3n3YKJ" id="4oS6BnMLqUn" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMLoXF" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMLqVd">
+    <ref role="13h7C2" to="kelk:3vxfdxbdack" resolve="MessageNamespaceRef" />
+    <node concept="13hLZK" id="4oS6BnMLqVe" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMLqVf" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMLqVw" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMLqVx" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMLqVI" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMLr2T" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMLrN5" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMLrim" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMLr2O" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnMLr$f" role="2OqNvi">
+                <ref role="3Tt5mk" to="kelk:3vxfdxbdacB" resolve="namespace" />
+              </node>
+            </node>
+            <node concept="3TrcHB" id="4oS6BnMLs6o" role="2OqNvi">
+              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMLqVJ" role="3clF45" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/org.iets3.core.expr.messages.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.messages/org.iets3.core.expr.messages.mpl
@@ -73,6 +73,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.mutable/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.mutable/models/behavior.mps
@@ -170,6 +170,7 @@
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
@@ -182,6 +183,7 @@
         <child id="1145567471833" name="createdType" index="2T96Bj" />
       </concept>
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
+      <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="1144146199828" name="jetbrains.mps.lang.smodel.structure.Node_CopyOperation" flags="nn" index="1$rogu" />
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
@@ -228,6 +230,9 @@
       </concept>
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
+        <child id="1240687658305" name="delimiter" index="3uJOhx" />
+      </concept>
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
     </language>
   </registry>
@@ -1101,9 +1106,36 @@
       <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
       <node concept="3Tm1VV" id="7bd8pkl7yo1" role="1B3o_S" />
       <node concept="3clFbS" id="7bd8pkl7yo4" role="3clF47">
-        <node concept="3clFbF" id="7bd8pkl81m0" role="3cqZAp">
-          <node concept="Xl_RD" id="7bd8pkl81lZ" role="3clFbG">
-            <property role="Xl_RC" value="" />
+        <node concept="3clFbF" id="4oS6BnNvtMV" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNvy1F" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnNvy1I" role="3uHU7w">
+              <property role="Xl_RC" value=")" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNvxqs" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnNvx8V" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnNvv9n" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnNvu3y" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnNvtMU" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnNvuqQ" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnNvvSH" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="4oS6BnNvx8Y" role="3uHU7w">
+                  <property role="Xl_RC" value="(" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnNvxDa" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnNvxsi" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnNvxrk" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnNvxtT" role="2OqNvi">
+                    <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4oS6BnNvy0w" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -1708,9 +1740,55 @@
       <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
       <node concept="3Tm1VV" id="4IV0h47MS0A" role="1B3o_S" />
       <node concept="3clFbS" id="4IV0h47MS0D" role="3clF47">
-        <node concept="3clFbF" id="4IV0h47MS0T" role="3cqZAp">
-          <node concept="Xl_RD" id="4IV0h47MS0S" role="3clFbG">
-            <property role="Xl_RC" value="" />
+        <node concept="3clFbF" id="4oS6BnNvB_N" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNvGCy" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNvRn6" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnNvKOg" role="2Oq$k0">
+                <node concept="2OqwBi" id="4oS6BnNvH_B" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnNvGUI" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="4oS6BnNvIjs" role="2OqNvi">
+                    <ref role="3TtcxE" to="8lgj:4IV0h47Jb3L" resolve="contextValues" />
+                  </node>
+                </node>
+                <node concept="3$u5V9" id="4oS6BnNvNNu" role="2OqNvi">
+                  <node concept="1bVj0M" id="4oS6BnNvNNw" role="23t8la">
+                    <node concept="3clFbS" id="4oS6BnNvNNx" role="1bW5cS">
+                      <node concept="3clFbF" id="4oS6BnNvNTV" role="3cqZAp">
+                        <node concept="2OqwBi" id="4oS6BnNvO8i" role="3clFbG">
+                          <node concept="37vLTw" id="4oS6BnNvNTU" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4oS6BnNvNNy" resolve="it" />
+                          </node>
+                          <node concept="2qgKlT" id="4oS6BnNvPAB" role="2OqNvi">
+                            <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="4oS6BnNvNNy" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="4oS6BnNvNNz" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3uJxvA" id="4oS6BnNvTog" role="2OqNvi">
+                <node concept="Xl_RD" id="4oS6BnNvUK1" role="3uJOhx">
+                  <property role="Xl_RC" value="," />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNvEQy" role="3uHU7B">
+              <node concept="2OqwBi" id="4oS6BnNvCSd" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnNvBPg" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnNvB_M" role="2Oq$k0" />
+                  <node concept="2yIwOk" id="4oS6BnNvCa4" role="2OqNvi" />
+                </node>
+                <node concept="3n3YKJ" id="4oS6BnNvDAn" role="2OqNvi" />
+              </node>
+              <node concept="Xl_RD" id="4oS6BnNvEQ_" role="3uHU7w">
+                <property role="Xl_RC" value="(" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -1731,8 +1809,16 @@
       <node concept="3Tm1VV" id="4IV0h47NhDn" role="1B3o_S" />
       <node concept="3clFbS" id="4IV0h47NhDq" role="3clF47">
         <node concept="3clFbF" id="4IV0h47NhDE" role="3cqZAp">
-          <node concept="Xl_RD" id="4IV0h47NhDD" role="3clFbG">
-            <property role="Xl_RC" value="" />
+          <node concept="2OqwBi" id="4oS6BnNgREn" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNgR8T" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnNgQTs" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnNgRtH" role="2OqNvi">
+                <ref role="3Tt5mk" to="8lgj:4IV0h47Gcwt" resolve="arg" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="4oS6BnNgRWe" role="2OqNvi">
+              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+            </node>
           </node>
         </node>
       </node>
@@ -2151,6 +2237,45 @@
           </node>
         </node>
       </node>
+    </node>
+    <node concept="13i0hz" id="4oS6BnNvUVp" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNvUVO" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNvUVP" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNvV1o" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNvX$Y" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNvY38" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnNvXQm" role="2Oq$k0">
+                <node concept="13iPFW" id="4oS6BnNvX_P" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnNvXRW" role="2OqNvi">
+                  <ref role="3Tt5mk" to="8lgj:4IV0h47hCX_" resolve="value" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="4oS6BnNvYnZ" role="2OqNvi">
+                <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNvXdA" role="3uHU7B">
+              <node concept="2OqwBi" id="4oS6BnNvVIF" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnNvVfF" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnNvV1j" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnNvVy1" role="2OqNvi">
+                    <ref role="3Tt5mk" to="8lgj:4IV0h47hCXz" resolve="argument" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4oS6BnNvVXU" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="4oS6BnNvXdD" role="3uHU7w">
+                <property role="Xl_RC" value=" = " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNvUVQ" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.mutable/org.iets3.core.expr.mutable.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.mutable/org.iets3.core.expr.mutable.mpl
@@ -79,6 +79,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.natlang/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.natlang/models/behavior.mps
@@ -11,6 +11,7 @@
     <import index="zzzn" ref="r:af0af2e7-f7e1-4536-83b5-6bf010d4afd2(org.iets3.core.expr.lambda.structure)" />
     <import index="tbr6" ref="r:6a005c26-87c0-43c4-8cf3-49ffba1099df(de.slisson.mps.richtext.behavior)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -100,6 +101,7 @@
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC" />
+      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
@@ -336,6 +338,48 @@
           </node>
         </node>
       </node>
+    </node>
+    <node concept="13i0hz" id="4oS6BnNI_LH" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNI_M8" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNI_M9" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNI_Th" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNIEoj" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNIFGS" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnNIEN$" role="2Oq$k0">
+                <node concept="13iPFW" id="4oS6BnNIEpk" role="2Oq$k0" />
+                <node concept="1mfA1w" id="4oS6BnNIF1I" role="2OqNvi" />
+              </node>
+              <node concept="2qgKlT" id="4oS6BnNIGcg" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNICr7" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnNIB9n" role="3uHU7B">
+                <node concept="Xl_RD" id="4oS6BnNI_Tg" role="3uHU7B">
+                  <property role="Xl_RC" value="@syntax{" />
+                </node>
+                <node concept="2OqwBi" id="4oS6BnNIBUg" role="3uHU7w">
+                  <node concept="2OqwBi" id="4oS6BnNIBzy" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnNIB9L" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="4oS6BnNIBL8" role="2OqNvi">
+                      <ref role="3Tt5mk" to="1xa4:1u1U5lETVju" resolve="syntax" />
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="4oS6BnNIC5A" role="2OqNvi">
+                    <ref role="37wK5l" to="tbr6:3Q5enzfMT4l" resolve="asTextString" />
+                  </node>
+                </node>
+              </node>
+              <node concept="Xl_RD" id="4oS6BnNICrY" role="3uHU7w">
+                <property role="Xl_RC" value="}\n" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNI_Ma" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.process/models/org.iets3.core.expr.process.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.process/models/org.iets3.core.expr.process.behavior.mps
@@ -24,6 +24,8 @@
     <import index="xlxw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.math(JDK/)" />
     <import index="j10v" ref="b76a0f63-5959-456b-993a-c796cc0d0c13/java:org.pcollections(org.iets3.core.expr.base.collections.stubs/)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -209,6 +211,7 @@
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
         <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
@@ -216,6 +219,7 @@
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
+      <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
@@ -269,9 +273,31 @@
       <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
       <node concept="3Tm1VV" id="7WFhXJlQoyj" role="1B3o_S" />
       <node concept="3clFbS" id="7WFhXJlQoym" role="3clF47">
-        <node concept="3clFbF" id="7WFhXJlQoy_" role="3cqZAp">
-          <node concept="Xl_RD" id="7WFhXJlQoy$" role="3clFbG">
-            <property role="Xl_RC" value="" />
+        <node concept="3clFbF" id="4oS6BnNbGSZ" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNbN0n" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNbNMl" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnNbNdx" role="2Oq$k0">
+                <node concept="13iPFW" id="4oS6BnNbN1f" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnNbN_o" role="2OqNvi">
+                  <ref role="3Tt5mk" to="7y2b:1mDdTGkuFU" resolve="process" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="4oS6BnNbOeI" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNbKf0" role="3uHU7B">
+              <node concept="2OqwBi" id="4oS6BnNbIfr" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnNbH9A" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnNbGSY" role="2Oq$k0" />
+                  <node concept="2yIwOk" id="4oS6BnNbHwU" role="2OqNvi" />
+                </node>
+                <node concept="3n3YKJ" id="4oS6BnNbIYM" role="2OqNvi" />
+              </node>
+              <node concept="Xl_RD" id="4oS6BnNbKf3" role="3uHU7w">
+                <property role="Xl_RC" value="(" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -366,6 +392,27 @@
     <node concept="13hLZK" id="7WFhXJlTg_x" role="13h7CW">
       <node concept="3clFbS" id="7WFhXJlTg_y" role="2VODD2" />
     </node>
+    <node concept="13i0hz" id="4oS6BnNbOrs" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNbOrt" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNbOr$" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNbON7" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnNbPMm" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNbP3I" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnNbON6" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnNbPr2" role="2OqNvi">
+                <ref role="3Tt5mk" to="7y2b:7WFhXJlQoxK" resolve="process" />
+              </node>
+            </node>
+            <node concept="3TrcHB" id="4oS6BnNbQp3" role="2OqNvi">
+              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNbOr_" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="7WFhXJlTg_F" role="13h7CS">
       <property role="13i0iv" value="false" />
       <property role="13i0it" value="false" />
@@ -399,9 +446,31 @@
       <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
       <node concept="3Tm1VV" id="Z4fkwzeP1h" role="1B3o_S" />
       <node concept="3clFbS" id="Z4fkwzeP1k" role="3clF47">
-        <node concept="3clFbF" id="Z4fkwzeP1$" role="3cqZAp">
-          <node concept="Xl_RD" id="Z4fkwzeP1z" role="3clFbG">
-            <property role="Xl_RC" value="" />
+        <node concept="3clFbF" id="4oS6BnNbyPC" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNbCZE" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnNbCZH" role="3uHU7w">
+              <property role="Xl_RC" value="]" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNbAKx" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnNbAuP" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnNb$ww" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnNbz55" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnNbyP_" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnNbzMn" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnNb_eE" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="4oS6BnNbAuS" role="3uHU7w">
+                  <property role="Xl_RC" value="[" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnNbB1i" role="3uHU7w">
+                <node concept="13iPFW" id="4oS6BnNbAK$" role="2Oq$k0" />
+                <node concept="3TrcHB" id="4oS6BnNbB2T" role="2OqNvi">
+                  <ref role="3TsBF5" to="7y2b:Z4fkwzeNZ7" resolve="id" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -1263,6 +1332,23 @@
     <ref role="13h7C2" to="7y2b:4IV0h47Eqmo" resolve="SenderContextArg" />
     <node concept="13hLZK" id="4IV0h47Eqnt" role="13h7CW">
       <node concept="3clFbS" id="4IV0h47Eqnu" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnNvYwh" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNvYwG" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNvYwH" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNvZnf" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnNw0xt" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNvZ$e" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnNvZne" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4oS6BnNvZO4" role="2OqNvi" />
+            </node>
+            <node concept="3n3YKJ" id="4oS6BnNw1dv" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNvYwI" role="3clF45" />
     </node>
     <node concept="13i0hz" id="4IV0h47EqnH" role="13h7CS">
       <property role="TrG5h" value="expectedType" />
@@ -2255,6 +2341,30 @@
       <node concept="3Tqbb2" id="41vYFO2KBJH" role="3clF45">
         <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
       </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMLjmP">
+    <property role="3GE5qa" value="interceptor" />
+    <ref role="13h7C2" to="7y2b:4IV0h47I93P" resolve="AnySenderExpr" />
+    <node concept="13hLZK" id="4oS6BnMLjmQ" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMLjmR" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMLjn8" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMLjn9" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMLjnm" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMLjul" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMLkLg" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMLjIj" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMLjug" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4oS6BnMLk37" role="2OqNvi" />
+            </node>
+            <node concept="3n3YKJ" id="4oS6BnMLlvb" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMLjnn" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.process/org.iets3.core.expr.process.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.process/org.iets3.core.expr.process.mpl
@@ -83,6 +83,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.query/models/org.iets3.core.expr.query.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.query/models/org.iets3.core.expr.query.behavior.mps
@@ -13,6 +13,9 @@
     <import index="ysgh" ref="r:9ed37aa3-295d-400f-9a08-9c363b19e30b(org.iets3.core.expr.query.structure)" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
+    <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
+    <import index="kpbf" ref="7124e466-fc92-4803-a656-d7a6b7eb3910/java:jetbrains.mps.text.impl(MPS.TextGen/)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -29,6 +32,7 @@
       <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -49,6 +53,7 @@
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -59,9 +64,14 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
@@ -69,6 +79,13 @@
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
@@ -91,6 +108,7 @@
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
@@ -101,6 +119,8 @@
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
+      <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
@@ -123,6 +143,27 @@
     <ref role="13h7C2" to="ysgh:5QDPRL$oUsO" resolve="QueryFilter" />
     <node concept="13hLZK" id="5QDPRL$oUZt" role="13h7CW">
       <node concept="3clFbS" id="5QDPRL$oUZu" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMVCqD" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnMVCr4" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMVCr5" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMVECy" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMVFBM" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMVEFt" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMVECx" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnMVEGx" role="2OqNvi">
+                <ref role="3Tt5mk" to="s7zn:5cK3QOc9w5h" resolve="function" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="4oS6BnMVHV3" role="2OqNvi">
+              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMVCr6" role="3clF45" />
     </node>
     <node concept="13i0hz" id="5QDPRL$oV4L" role="13h7CS">
       <property role="TrG5h" value="createMetaFunction" />
@@ -249,6 +290,27 @@
   </node>
   <node concept="13h7C7" id="5QDPRL$qi1G">
     <ref role="13h7C2" to="ysgh:5QDPRL$qhvL" resolve="QueryTransform" />
+    <node concept="13i0hz" id="4oS6BnMVIqU" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnMVIrl" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMVIrm" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMVJs4" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMVKyU" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMVJFx" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMVJs3" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnMVJXq" role="2OqNvi">
+                <ref role="3Tt5mk" to="s7zn:5cK3QOc9w5h" resolve="function" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="4oS6BnMVL80" role="2OqNvi">
+              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMVIrn" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="5QDPRL$qiYz" role="13h7CS">
       <property role="TrG5h" value="createMetaFunction" />
       <ref role="13i0hy" to="rnpa:5cK3QOc9qti" resolve="createMetaFunction" />
@@ -327,6 +389,27 @@
     <ref role="13h7C2" to="ysgh:5QDPRL$x3FP" resolve="QueryGroupBy" />
     <node concept="13hLZK" id="5QDPRL$xmN5" role="13h7CW">
       <node concept="3clFbS" id="5QDPRL$xmN6" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMVSW_" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnMVSX0" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMVSX1" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMVTiy" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMVU40" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMVTxZ" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMVTix" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnMVTNS" role="2OqNvi">
+                <ref role="3Tt5mk" to="s7zn:5cK3QOc9w5h" resolve="function" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="4oS6BnMVUnW" role="2OqNvi">
+              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMVSX2" role="3clF45" />
     </node>
     <node concept="13i0hz" id="5QDPRL$xmQ7" role="13h7CS">
       <property role="TrG5h" value="createMetaFunction" />
@@ -432,6 +515,27 @@
     <ref role="13h7C2" to="ysgh:5QDPRL$xy5s" resolve="QueryGroupBuild" />
     <node concept="13hLZK" id="5QDPRL$xzqD" role="13h7CW">
       <node concept="3clFbS" id="5QDPRL$xzqE" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMVUTc" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnMVUTB" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMVUTC" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMVW5R" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMVWRR" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMVWl$" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMVW5Q" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnMVWBt" role="2OqNvi">
+                <ref role="3Tt5mk" to="s7zn:5cK3QOc9w5h" resolve="function" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="4oS6BnMVXbN" role="2OqNvi">
+              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMVUTD" role="3clF45" />
     </node>
     <node concept="13i0hz" id="5QDPRL$xztF" role="13h7CS">
       <property role="TrG5h" value="createMetaFunction" />
@@ -618,6 +722,285 @@
           </node>
         </node>
       </node>
+    </node>
+    <node concept="13i0hz" id="4oS6BnMVLfG" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnMVLg7" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMVLg8" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMVNcs" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMVRib" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMVS4e" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnMVRFQ" role="2Oq$k0">
+                <node concept="13iPFW" id="4oS6BnMVRji" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnMVRRI" role="2OqNvi">
+                  <ref role="3Tt5mk" to="ysgh:5QDPRL$xyOH" resolve="build" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="4oS6BnMVSoL" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMVP$i" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMVOsy" role="3uHU7B">
+                <node concept="Xl_RD" id="4oS6BnMVNcr" role="3uHU7B">
+                  <property role="Xl_RC" value="by " />
+                </node>
+                <node concept="2OqwBi" id="4oS6BnMVOTx" role="3uHU7w">
+                  <node concept="2OqwBi" id="4oS6BnMVOGI" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnMVOs_" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="4oS6BnMVOHR" role="2OqNvi">
+                      <ref role="3Tt5mk" to="ysgh:5QDPRL$x3ZY" resolve="by" />
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="4oS6BnMVPdw" role="2OqNvi">
+                    <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                  </node>
+                </node>
+              </node>
+              <node concept="Xl_RD" id="4oS6BnMVP$l" role="3uHU7w">
+                <property role="Xl_RC" value=" build " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMVLg9" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMKKv1">
+    <ref role="13h7C2" to="ysgh:5QDPRL$ohHz" resolve="QueryExpr" />
+    <node concept="13hLZK" id="4oS6BnMKKv2" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMKKv3" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMUvg6" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMUvg7" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMUvgk" role="3clF47">
+        <node concept="3cpWs8" id="4oS6BnMKKvB" role="3cqZAp">
+          <node concept="3cpWsn" id="4oS6BnMKKvC" role="3cpWs9">
+            <property role="TrG5h" value="text" />
+            <node concept="3uibUv" id="4oS6BnMKKvD" role="1tU5fm">
+              <ref role="3uigEE" to="xfg9:4oS6BnMcix1" resolve="StringRepresentation" />
+            </node>
+            <node concept="2YIFZM" id="4oS6BnMKKDM" role="33vP2m">
+              <ref role="37wK5l" to="xfg9:4oS6BnMcl4R" resolve="forMultipleSentences" />
+              <ref role="1Pybhc" to="xfg9:4oS6BnMcix1" resolve="StringRepresentation" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMKKH8" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMKKVZ" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMKKH6" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMKKvC" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMKLeH" role="2OqNvi">
+              <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+              <node concept="2OqwBi" id="4oS6BnMKMwm" role="37wK5m">
+                <node concept="2OqwBi" id="4oS6BnMKL_7" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnMKLh9" role="2Oq$k0" />
+                  <node concept="2yIwOk" id="4oS6BnMKLTx" role="2OqNvi" />
+                </node>
+                <node concept="3n3YKJ" id="4oS6BnMKN8D" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMKPrL" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMKPIo" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMKPrJ" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMKKvC" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMKQ3k" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMfnH9" resolve="appendWithSpace" />
+              <node concept="Xl_RD" id="4oS6BnMKRtl" role="37wK5m">
+                <property role="Xl_RC" value="from " />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMKT$s" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMKTSN" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMKT$q" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMKKvC" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMKUJk" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMgdrs" resolve="append" />
+              <node concept="2OqwBi" id="4oS6BnMKVX7" role="37wK5m">
+                <node concept="13iPFW" id="4oS6BnMKVHB" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnMKYsr" role="2OqNvi">
+                  <ref role="3Tt5mk" to="ysgh:5QDPRL$oi4v" resolve="source" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4oS6BnMKYVo" role="3cqZAp">
+          <node concept="3clFbS" id="4oS6BnMKYVq" role="3clFbx">
+            <node concept="3clFbF" id="4oS6BnML1Sy" role="3cqZAp">
+              <node concept="2OqwBi" id="4oS6BnML27u" role="3clFbG">
+                <node concept="37vLTw" id="4oS6BnML1Sw" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4oS6BnMKKvC" resolve="text" />
+                </node>
+                <node concept="liA8E" id="4oS6BnML2oY" role="2OqNvi">
+                  <ref role="37wK5l" to="xfg9:4oS6BnMfnH9" resolve="appendWithSpace" />
+                  <node concept="Xl_RD" id="4oS6BnML2t7" role="37wK5m">
+                    <property role="Xl_RC" value="filter" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4oS6BnML3Gr" role="3cqZAp">
+              <node concept="2OqwBi" id="4oS6BnML3HW" role="3clFbG">
+                <node concept="37vLTw" id="4oS6BnML3Gp" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4oS6BnMKKvC" resolve="text" />
+                </node>
+                <node concept="liA8E" id="4oS6BnML6aj" role="2OqNvi">
+                  <ref role="37wK5l" to="xfg9:4oS6BnMgZBe" resolve="appendWithSpace" />
+                  <node concept="2OqwBi" id="4oS6BnML6wJ" role="37wK5m">
+                    <node concept="13iPFW" id="4oS6BnML6fM" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="4oS6BnML6Ob" role="2OqNvi">
+                      <ref role="3Tt5mk" to="ysgh:5QDPRL$pd_y" resolve="filter" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="4oS6BnML1nt" role="3clFbw">
+            <node concept="2OqwBi" id="4oS6BnML0MK" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnML0wO" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnML18v" role="2OqNvi">
+                <ref role="3Tt5mk" to="ysgh:5QDPRL$pd_y" resolve="filter" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="4oS6BnML1Jd" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4oS6BnML92G" role="3cqZAp">
+          <node concept="3clFbS" id="4oS6BnML92H" role="3clFbx">
+            <node concept="3clFbF" id="4oS6BnML92I" role="3cqZAp">
+              <node concept="2OqwBi" id="4oS6BnML92J" role="3clFbG">
+                <node concept="37vLTw" id="4oS6BnML92K" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4oS6BnMKKvC" resolve="text" />
+                </node>
+                <node concept="liA8E" id="4oS6BnML92L" role="2OqNvi">
+                  <ref role="37wK5l" to="xfg9:4oS6BnMfnH9" resolve="appendWithSpace" />
+                  <node concept="Xl_RD" id="4oS6BnML92M" role="37wK5m">
+                    <property role="Xl_RC" value="transform" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4oS6BnML92N" role="3cqZAp">
+              <node concept="2OqwBi" id="4oS6BnML92O" role="3clFbG">
+                <node concept="37vLTw" id="4oS6BnML92P" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4oS6BnMKKvC" resolve="text" />
+                </node>
+                <node concept="liA8E" id="4oS6BnML92Q" role="2OqNvi">
+                  <ref role="37wK5l" to="xfg9:4oS6BnMgZBe" resolve="appendWithSpace" />
+                  <node concept="2OqwBi" id="4oS6BnML92R" role="37wK5m">
+                    <node concept="13iPFW" id="4oS6BnML92S" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="4oS6BnML92T" role="2OqNvi">
+                      <ref role="3Tt5mk" to="ysgh:5QDPRL$qmK4" resolve="transform" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="4oS6BnML92U" role="3clFbw">
+            <node concept="2OqwBi" id="4oS6BnML92V" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnML92W" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnML92X" role="2OqNvi">
+                <ref role="3Tt5mk" to="ysgh:5QDPRL$qmK4" resolve="transform" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="4oS6BnML92Y" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4oS6BnML9XE" role="3cqZAp">
+          <node concept="3clFbS" id="4oS6BnML9XF" role="3clFbx">
+            <node concept="3clFbF" id="4oS6BnML9XG" role="3cqZAp">
+              <node concept="2OqwBi" id="4oS6BnML9XH" role="3clFbG">
+                <node concept="37vLTw" id="4oS6BnML9XI" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4oS6BnMKKvC" resolve="text" />
+                </node>
+                <node concept="liA8E" id="4oS6BnML9XJ" role="2OqNvi">
+                  <ref role="37wK5l" to="xfg9:4oS6BnMfnH9" resolve="appendWithSpace" />
+                  <node concept="Xl_RD" id="4oS6BnML9XK" role="37wK5m">
+                    <property role="Xl_RC" value="group" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4oS6BnML9XL" role="3cqZAp">
+              <node concept="2OqwBi" id="4oS6BnML9XM" role="3clFbG">
+                <node concept="37vLTw" id="4oS6BnML9XN" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4oS6BnMKKvC" resolve="text" />
+                </node>
+                <node concept="liA8E" id="4oS6BnML9XO" role="2OqNvi">
+                  <ref role="37wK5l" to="xfg9:4oS6BnMgZBe" resolve="appendWithSpace" />
+                  <node concept="2OqwBi" id="4oS6BnML9XP" role="37wK5m">
+                    <node concept="13iPFW" id="4oS6BnML9XQ" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="4oS6BnML9XR" role="2OqNvi">
+                      <ref role="3Tt5mk" to="ysgh:5QDPRL$x5n_" resolve="group" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="4oS6BnML9XS" role="3clFbw">
+            <node concept="2OqwBi" id="4oS6BnML9XT" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnML9XU" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnML9XV" role="2OqNvi">
+                <ref role="3Tt5mk" to="ysgh:5QDPRL$x5n_" resolve="group" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="4oS6BnML9XW" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMLekm" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMLeQx" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMLekk" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMKKvC" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMLfVu" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMUIdM" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMUvgl" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMVzSh">
+    <ref role="13h7C2" to="ysgh:5QDPRL$pwTW" resolve="QuerySource" />
+    <node concept="13hLZK" id="4oS6BnMVzSi" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMVzSj" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMVzS$" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnMVzSZ" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMVzT0" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMVzXI" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMV$Bj" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMV$aR" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMVzXD" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnMV$ol" role="2OqNvi">
+                <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="4oS6BnMV$UW" role="2OqNvi">
+              <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMVzT1" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.query/org.iets3.core.expr.query.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.query/org.iets3.core.expr.query.mpl
@@ -54,6 +54,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/models/org/iets3/core/expr/repl/behavior.mps
@@ -28,6 +28,9 @@
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
     <import index="xk6s" ref="r:7961970e-5737-42e2-b144-9bef3ad8d077(org.iets3.core.expr.tests.behavior)" />
     <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
+    <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
+    <import index="kpbf" ref="7124e466-fc92-4803-a656-d7a6b7eb3910/java:jetbrains.mps.text.impl(MPS.TextGen/)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -328,7 +331,9 @@
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
+      <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="334628810661441841" name="jetbrains.mps.lang.smodel.structure.AsSConcept" flags="nn" index="1rGIog" />
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
@@ -5055,6 +5060,88 @@
     <node concept="13hLZK" id="5xEoEMrDTKL" role="13h7CW">
       <node concept="3clFbS" id="5xEoEMrDTKM" role="2VODD2" />
     </node>
+    <node concept="13i0hz" id="4oS6BnMHWyG" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMHWyH" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMHWyU" role="3clF47">
+        <node concept="3cpWs8" id="4oS6BnMHWMb" role="3cqZAp">
+          <node concept="3cpWsn" id="4oS6BnMHWMc" role="3cpWs9">
+            <property role="TrG5h" value="text" />
+            <node concept="3uibUv" id="4oS6BnMHWMd" role="1tU5fm">
+              <ref role="3uigEE" to="xfg9:4oS6BnMcix1" resolve="StringRepresentation" />
+            </node>
+            <node concept="2ShNRf" id="4oS6BnMHWNg" role="33vP2m">
+              <node concept="1pGfFk" id="4oS6BnMHX41" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="37wK5l" to="xfg9:4oS6BnMcMsd" resolve="StringRepresentation" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMI0YA" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMI1gt" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMI0Y$" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMHWMc" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMI1$W" role="2OqNvi">
+              <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+              <node concept="2OqwBi" id="4oS6BnMI75K" role="37wK5m">
+                <node concept="2OqwBi" id="4oS6BnMI6vt" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnMI69G" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnMI6V5" role="2OqNvi">
+                    <ref role="3Tt5mk" to="wtll:5xEoEMrvqJb" resolve="label" />
+                  </node>
+                </node>
+                <node concept="3TrcHB" id="4oS6BnMI7pN" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4oS6BnMIbYV" role="3cqZAp">
+          <node concept="3clFbS" id="4oS6BnMIbYX" role="3clFbx">
+            <node concept="3clFbF" id="4oS6BnMI91o" role="3cqZAp">
+              <node concept="2OqwBi" id="4oS6BnMI9mG" role="3clFbG">
+                <node concept="37vLTw" id="4oS6BnMI91m" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4oS6BnMHWMc" resolve="text" />
+                </node>
+                <node concept="liA8E" id="4oS6BnMI9Hs" role="2OqNvi">
+                  <ref role="37wK5l" to="xfg9:4oS6BnMdvcE" resolve="append" />
+                  <node concept="2OqwBi" id="4oS6BnMIa2T" role="37wK5m">
+                    <node concept="13iPFW" id="4oS6BnMI9N2" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="4oS6BnMIdrJ" role="2OqNvi">
+                      <ref role="3TtcxE" to="wtll:5xEoEMrFs7k" resolve="actuals" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="4oS6BnMIdJ6" role="37wK5m">
+                    <property role="Xl_RC" value="," />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="4oS6BnMIcmQ" role="3clFbw">
+            <node concept="13iPFW" id="4oS6BnMIc1S" role="2Oq$k0" />
+            <node concept="2qgKlT" id="4oS6BnMIcKJ" role="2OqNvi">
+              <ref role="37wK5l" node="5xEoEMrFtHl" resolve="needsActuals" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMIdZC" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMIejo" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnMIdZA" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnMHWMc" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnMIeHl" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMUIdM" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMHWyV" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="3pIANU$YNt$" role="13h7CS">
       <property role="TrG5h" value="resolve" />
       <property role="13i0it" value="false" />
@@ -5477,6 +5564,85 @@
   <node concept="13h7C7" id="48DDwlwTgp2">
     <property role="3GE5qa" value="sheet" />
     <ref role="13h7C2" to="wtll:48DDwlwTb_l" resolve="SheetEmbedExpr" />
+    <node concept="13i0hz" id="4oS6BnMIokN" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMIokO" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMIol1" role="3clF47">
+        <node concept="3clFbJ" id="4oS6BnMIpOx" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMIqCm" role="3clFbw">
+            <node concept="2OqwBi" id="4oS6BnMIq1V" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMIpOU" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnMIqno" role="2OqNvi">
+                <ref role="3Tt5mk" to="wtll:48DDwlwTbQF" resolve="sheet" />
+              </node>
+            </node>
+            <node concept="3w_OXm" id="4oS6BnMIr6S" role="2OqNvi" />
+          </node>
+          <node concept="3clFbS" id="4oS6BnMIpOz" role="3clFbx">
+            <node concept="3cpWs6" id="4oS6BnMIram" role="3cqZAp">
+              <node concept="3cpWs3" id="4oS6BnMIvb4" role="3cqZAk">
+                <node concept="2OqwBi" id="4oS6BnMIvel" role="3uHU7w">
+                  <node concept="13iPFW" id="4oS6BnMIvcO" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="4oS6BnMIvgK" role="2OqNvi">
+                    <ref role="3TsBF5" to="wtll:48DDwlwTbMj" resolve="rows" />
+                  </node>
+                </node>
+                <node concept="3cpWs3" id="4oS6BnMIv88" role="3uHU7B">
+                  <node concept="3cpWs3" id="4oS6BnMIt8B" role="3uHU7B">
+                    <node concept="3cpWs3" id="4oS6BnMIt5U" role="3uHU7B">
+                      <node concept="3cpWs3" id="4oS6BnMIsbZ" role="3uHU7B">
+                        <node concept="Xl_RD" id="4oS6BnMIrb1" role="3uHU7B">
+                          <property role="Xl_RC" value="new sheet from " />
+                        </node>
+                        <node concept="2OqwBi" id="4oS6BnMIsvq" role="3uHU7w">
+                          <node concept="2OqwBi" id="4oS6BnMIsdo" role="2Oq$k0">
+                            <node concept="13iPFW" id="4oS6BnMIscI" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="4oS6BnMIseQ" role="2OqNvi">
+                              <ref role="3Tt5mk" to="wtll:3_Nra3E6OTO" resolve="template" />
+                            </node>
+                          </node>
+                          <node concept="3TrcHB" id="4oS6BnMIt3Y" role="2OqNvi">
+                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Xl_RD" id="4oS6BnMIt5X" role="3uHU7w">
+                        <property role="Xl_RC" value=" will be " />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="4oS6BnMItb4" role="3uHU7w">
+                      <node concept="13iPFW" id="4oS6BnMIt9U" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="4oS6BnMItd6" role="2OqNvi">
+                        <ref role="3TsBF5" to="wtll:48DDwlwTbMi" resolve="cols" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="4oS6BnMIv9I" role="3uHU7w">
+                    <property role="Xl_RC" value=" and " />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4oS6BnMIviI" role="3cqZAp" />
+        <node concept="3cpWs6" id="4oS6BnMIvkI" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMIvza" role="3cqZAk">
+            <node concept="2OqwBi" id="4oS6BnMIvqN" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMIvmL" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnMIvtx" role="2OqNvi">
+                <ref role="3Tt5mk" to="wtll:48DDwlwTbQF" resolve="sheet" />
+              </node>
+            </node>
+            <node concept="2qgKlT" id="4oS6BnMIvAc" role="2OqNvi">
+              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMIol2" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="48DDwlwTgpg" role="13h7CS">
       <property role="TrG5h" value="buildSheet" />
       <node concept="3Tm1VV" id="48DDwlwTgph" role="1B3o_S" />
@@ -5903,6 +6069,64 @@
   <node concept="13h7C7" id="4YhD5cZkdS9">
     <property role="3GE5qa" value="sheet.range" />
     <ref role="13h7C2" to="wtll:4YhD5cZkcH6" resolve="AbstractRangeExpr" />
+    <node concept="13i0hz" id="4oS6BnMH$Co" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMH$Cp" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMH$CA" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMHDSM" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMHMDF" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnMHMDI" role="3uHU7w">
+              <property role="Xl_RC" value="]" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMHMvh" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMHMs7" role="3uHU7B">
+                <node concept="3cpWs3" id="4oS6BnMHLi7" role="3uHU7B">
+                  <node concept="3cpWs3" id="4oS6BnMHHe6" role="3uHU7B">
+                    <node concept="2OqwBi" id="4oS6BnMHFfd" role="3uHU7B">
+                      <node concept="2OqwBi" id="4oS6BnMHE9p" role="2Oq$k0">
+                        <node concept="13iPFW" id="4oS6BnMHDSL" role="2Oq$k0" />
+                        <node concept="2yIwOk" id="4oS6BnMHEwG" role="2OqNvi" />
+                      </node>
+                      <node concept="3n3YKJ" id="4oS6BnMHFXX" role="2OqNvi" />
+                    </node>
+                    <node concept="Xl_RD" id="4oS6BnMHJy7" role="3uHU7w">
+                      <property role="Xl_RC" value="[" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="4oS6BnMHM3e" role="3uHU7w">
+                    <node concept="2OqwBi" id="4oS6BnMHLvh" role="2Oq$k0">
+                      <node concept="13iPFW" id="4oS6BnMHLiZ" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="4oS6BnMHLR7" role="2OqNvi">
+                        <ref role="3Tt5mk" to="wtll:4YhD5cZkcH7" resolve="from" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="4oS6BnMHMqA" role="2OqNvi">
+                      <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="4oS6BnMHMsa" role="3uHU7w">
+                  <property role="Xl_RC" value=".." />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnMHM_7" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnMHMwO" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnMHMvk" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnMHMyZ" role="2OqNvi">
+                    <ref role="3Tt5mk" to="wtll:4YhD5cZkcH8" resolve="to" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4oS6BnMHMBA" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMH$CB" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="5avmkTFlBXV" role="13h7CS">
       <property role="TrG5h" value="isLinearRange" />
       <node concept="3Tm1VV" id="5avmkTFlBXW" role="1B3o_S" />
@@ -6344,6 +6568,197 @@
     </node>
     <node concept="13hLZK" id="4YhD5cZkdSa" role="13h7CW">
       <node concept="3clFbS" id="4YhD5cZkdSb" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMHsAx">
+    <property role="3GE5qa" value="sheet" />
+    <ref role="13h7C2" to="wtll:5xEoEMrAqE3" resolve="CellArgRef" />
+    <node concept="13hLZK" id="4oS6BnMHsAy" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMHsAz" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMHsAO" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMHsAP" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMHsB2" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMHsIh" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMHtyE" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMHsXI" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMHsIc" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnMHtiy" role="2OqNvi">
+                <ref role="3Tt5mk" to="wtll:5xEoEMrAqE4" resolve="arg" />
+              </node>
+            </node>
+            <node concept="3TrcHB" id="4oS6BnMHtVs" role="2OqNvi">
+              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMHsB3" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMHtYI">
+    <property role="3GE5qa" value="sheet" />
+    <ref role="13h7C2" to="wtll:5avmkTFTZQz" resolve="LabelExpression" />
+    <node concept="13hLZK" id="4oS6BnMHtYJ" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMHtYK" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMHtZ1" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMHtZ2" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMHtZf" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMHuXG" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMHwdM" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMHxDa" role="3uHU7w">
+              <node concept="13iPFW" id="4oS6BnMHweN" role="2Oq$k0" />
+              <node concept="3TrcHB" id="4oS6BnMHy0y" role="2OqNvi">
+                <ref role="3TsBF5" to="wtll:5avmkTFTZQ$" resolve="text" />
+              </node>
+            </node>
+            <node concept="Xl_RD" id="4oS6BnMHuXF" role="3uHU7B">
+              <property role="Xl_RC" value="'" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMHtZg" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMHPoa">
+    <property role="3GE5qa" value="sheet.range" />
+    <ref role="13h7C2" to="wtll:4YhD5cZo8Ks" resolve="MakeRecordExpr" />
+    <node concept="13i0hz" id="4oS6BnMHPod" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMHPoe" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMHPof" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMHPog" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMHPoh" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnMHPoi" role="3uHU7w">
+              <property role="Xl_RC" value="]" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMHPoj" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMHPok" role="3uHU7B">
+                <node concept="3cpWs3" id="4oS6BnMHPol" role="3uHU7B">
+                  <node concept="3cpWs3" id="4oS6BnMHPom" role="3uHU7B">
+                    <node concept="3cpWs3" id="4oS6BnMHV4Y" role="3uHU7B">
+                      <node concept="Xl_RD" id="4oS6BnMHV51" role="3uHU7w">
+                        <property role="Xl_RC" value="&gt;" />
+                      </node>
+                      <node concept="3cpWs3" id="4oS6BnMHR1O" role="3uHU7B">
+                        <node concept="3cpWs3" id="4oS6BnMHQWg" role="3uHU7B">
+                          <node concept="2OqwBi" id="4oS6BnMHPon" role="3uHU7B">
+                            <node concept="2OqwBi" id="4oS6BnMHPoo" role="2Oq$k0">
+                              <node concept="13iPFW" id="4oS6BnMHPop" role="2Oq$k0" />
+                              <node concept="2yIwOk" id="4oS6BnMHPoq" role="2OqNvi" />
+                            </node>
+                            <node concept="3n3YKJ" id="4oS6BnMHPor" role="2OqNvi" />
+                          </node>
+                          <node concept="Xl_RD" id="4oS6BnMHQXR" role="3uHU7w">
+                            <property role="Xl_RC" value="&lt;" />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="4oS6BnMHRYk" role="3uHU7w">
+                          <node concept="2OqwBi" id="4oS6BnMHRhJ" role="2Oq$k0">
+                            <node concept="13iPFW" id="4oS6BnMHR3_" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="4oS6BnMHRGX" role="2OqNvi">
+                              <ref role="3Tt5mk" to="wtll:4YhD5cZo8Kt" resolve="record" />
+                            </node>
+                          </node>
+                          <node concept="2qgKlT" id="4oS6BnMHU2K" role="2OqNvi">
+                            <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="4oS6BnMHPos" role="3uHU7w">
+                      <property role="Xl_RC" value="[" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="4oS6BnMHPot" role="3uHU7w">
+                    <node concept="2OqwBi" id="4oS6BnMHPou" role="2Oq$k0">
+                      <node concept="13iPFW" id="4oS6BnMHPov" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="4oS6BnMHPow" role="2OqNvi">
+                        <ref role="3Tt5mk" to="wtll:4YhD5cZkcH7" resolve="from" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="4oS6BnMHPox" role="2OqNvi">
+                      <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="4oS6BnMHPoy" role="3uHU7w">
+                  <property role="Xl_RC" value=".." />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnMHPoz" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnMHPo$" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnMHPo_" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnMHPoA" role="2OqNvi">
+                    <ref role="3Tt5mk" to="wtll:4YhD5cZkcH8" resolve="to" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4oS6BnMHPoB" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMHPoC" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="4oS6BnMHPob" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMHPoc" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMIgCG">
+    <property role="3GE5qa" value="sheet" />
+    <ref role="13h7C2" to="wtll:7HzLUeHESCI" resolve="QuoteExpr" />
+    <node concept="13hLZK" id="4oS6BnMIgCH" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMIgCI" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMIgCZ" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMIgD0" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMIgDd" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMIgKL" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMInps" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnMInpv" role="3uHU7w">
+              <property role="Xl_RC" value=")" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMIknR" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMIk6b" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnMIi7c" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnMIh1o" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnMIgKG" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnMIhoF" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnMIiQ2" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="4oS6BnMIk6e" role="3uHU7w">
+                  <property role="Xl_RC" value="(" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnMIlUq" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnMIl3B" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnMIknU" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnMIlrJ" role="2OqNvi">
+                    <ref role="3Tt5mk" to="wtll:7HzLUeHESCJ" resolve="cell" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4oS6BnMImhM" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMIgDe" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/org.iets3.core.expr.repl.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.repl/org.iets3.core.expr.repl.mpl
@@ -203,6 +203,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
@@ -1309,24 +1309,6 @@
     <node concept="13hLZK" id="3NBP8_O4fqk" role="13h7CW">
       <node concept="3clFbS" id="3NBP8_O4fql" role="2VODD2" />
     </node>
-    <node concept="13i0hz" id="2ft7KAXZZ_W" role="13h7CS">
-      <property role="TrG5h" value="getPresentation" />
-      <property role="13i0it" value="false" />
-      <property role="13i0iv" value="false" />
-      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
-      <node concept="3Tm1VV" id="2ft7KAXZZB4" role="1B3o_S" />
-      <node concept="3clFbS" id="2ft7KAXZZB5" role="3clF47">
-        <node concept="3clFbF" id="2ft7KAXZZCP" role="3cqZAp">
-          <node concept="2OqwBi" id="2ft7KAXZZFh" role="3clFbG">
-            <node concept="13iPFW" id="2ft7KAXZZCK" role="2Oq$k0" />
-            <node concept="3TrcHB" id="2ft7KAXZZJT" role="2OqNvi">
-              <ref role="3TsBF5" to="5qo5:4rZeNQ6OYRb" resolve="value" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="17QB3L" id="2ft7KAXZZB6" role="3clF45" />
-    </node>
     <node concept="13i0hz" id="6kR0qIbHCKs" role="13h7CS">
       <property role="TrG5h" value="renderReadable" />
       <property role="13i0it" value="false" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/org.iets3.core.expr.simpleTypes.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/org.iets3.core.expr.simpleTypes.mpl
@@ -88,6 +88,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.statemachines/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.statemachines/models/behavior.mps
@@ -1873,8 +1873,16 @@
       <node concept="3Tm1VV" id="1mDdTGcZRR" role="1B3o_S" />
       <node concept="3clFbS" id="1mDdTGcZRU" role="3clF47">
         <node concept="3clFbF" id="1mDdTGcZSa" role="3cqZAp">
-          <node concept="Xl_RD" id="1mDdTGcZS9" role="3clFbG">
-            <property role="Xl_RC" value="" />
+          <node concept="2OqwBi" id="4oS6BnNd2Kw" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNd26m" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnNd1QT" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnNd2ra" role="2OqNvi">
+                <ref role="3Tt5mk" to="19m5:1mDdTG6VfT" resolve="param" />
+              </node>
+            </node>
+            <node concept="3TrcHB" id="4oS6BnNd3cq" role="2OqNvi">
+              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            </node>
           </node>
         </node>
       </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.statemachines/org.iets3.core.expr.statemachines.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.statemachines/org.iets3.core.expr.statemachines.mpl
@@ -79,6 +79,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/models/org.iets3.core.expr.stringvalidation.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/models/org.iets3.core.expr.stringvalidation.behavior.mps
@@ -11,7 +11,10 @@
     <import index="y9w8" ref="r:92c59e9f-983f-4c1f-bcfc-4dc3733c05db(org.iets3.core.expr.stringvalidation.runtime.runtime)" />
     <import index="3r88" ref="r:0561db97-8a79-45b6-97f8-a5fd9b986b44(org.iets3.core.expr.stringvalidation.structure)" />
     <import index="5qo5" ref="r:6d93ddb1-b0b0-4eee-8079-51303666672a(org.iets3.core.expr.simpleTypes.structure)" />
+    <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="kpbf" ref="7124e466-fc92-4803-a656-d7a6b7eb3910/java:jetbrains.mps.text.impl(MPS.TextGen/)" implicit="true" />
     <import index="hm2y" ref="r:66e07cb4-a4b0-4bf3-a36d-5e9ed1ff1bd3(org.iets3.core.expr.base.structure)" implicit="true" />
   </imports>
   <registry>
@@ -31,6 +34,7 @@
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
         <reference id="2820489544401957798" name="classifier" index="HV5vE" />
       </concept>
@@ -46,6 +50,9 @@
       </concept>
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
@@ -125,6 +132,7 @@
       <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC">
         <reference id="1139880128956" name="concept" index="1A9B2P" />
       </concept>
+      <concept id="8329979535468945057" name="jetbrains.mps.lang.smodel.structure.Node_PresentationOperation" flags="ng" index="2Iv5rx" />
       <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
@@ -160,6 +168,9 @@
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
       <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
+        <child id="1240687658305" name="delimiter" index="3uJOhx" />
+      </concept>
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
     </language>
   </registry>
@@ -213,6 +224,27 @@
   <node concept="13h7C7" id="4lCUG7OsQA8">
     <property role="3GE5qa" value="matches" />
     <ref role="13h7C2" to="3r88:4lCUG7OsQ_3" resolve="NamedMatchRef" />
+    <node concept="13i0hz" id="4oS6BnNk0xD" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNk0xE" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNk0xF" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNk1h_" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnNk21g" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNk1vn" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnNk1h$" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnNk1EO" role="2OqNvi">
+                <ref role="3Tt5mk" to="3r88:4lCUG7OsQ_4" resolve="match" />
+              </node>
+            </node>
+            <node concept="3TrcHB" id="4oS6BnNk393" role="2OqNvi">
+              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNk0xW" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="4lCUG7OsQAj" role="13h7CS">
       <property role="TrG5h" value="resolve" />
       <ref role="13i0hy" node="4lCUG7OsQyi" resolve="resolve" />
@@ -449,42 +481,63 @@
       <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
       <node concept="3clFbS" id="6KviS2K_F06" role="3clF47">
         <node concept="3clFbF" id="6KviS2K_F0K" role="3cqZAp">
-          <node concept="3cpWs3" id="6KviS2K_FiU" role="3clFbG">
-            <node concept="2OqwBi" id="6KviS2K_Hg4" role="3uHU7w">
-              <node concept="2OqwBi" id="6KviS2K_Fw3" role="2Oq$k0">
-                <node concept="13iPFW" id="6KviS2K_Fj1" role="2Oq$k0" />
-                <node concept="3Tsc0h" id="6KviS2K_FEL" role="2OqNvi">
-                  <ref role="3TtcxE" to="3r88:6KviS2KztF6" resolve="matches" />
+          <node concept="3cpWs3" id="4oS6BnNk8Vs" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnNk8Zf" role="3uHU7w">
+              <property role="Xl_RC" value="]" />
+            </node>
+            <node concept="3cpWs3" id="6KviS2K_FiU" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnNk82I" role="3uHU7B">
+                <node concept="Xl_RD" id="4oS6BnNk82L" role="3uHU7w">
+                  <property role="Xl_RC" value="[" />
+                </node>
+                <node concept="2OqwBi" id="4oS6BnNk6vS" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnNk5sV" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnNk54t" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnNk5HP" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnNk6Zt" role="2OqNvi" />
                 </node>
               </node>
-              <node concept="3$u5V9" id="6KviS2K_IBR" role="2OqNvi">
-                <node concept="1bVj0M" id="6KviS2K_IBT" role="23t8la">
-                  <node concept="3clFbS" id="6KviS2K_IBU" role="1bW5cS">
-                    <node concept="3clFbF" id="6KviS2K_IET" role="3cqZAp">
-                      <node concept="2OqwBi" id="6KviS2K_Jer" role="3clFbG">
-                        <node concept="2OqwBi" id="6KviS2K_IT0" role="2Oq$k0">
-                          <node concept="37vLTw" id="6KviS2K_IES" role="2Oq$k0">
-                            <ref role="3cqZAo" node="4z0AnX817eJ" resolve="it" />
-                          </node>
-                          <node concept="2qgKlT" id="6KviS2K_J7u" role="2OqNvi">
-                            <ref role="37wK5l" node="4lCUG7OsQyi" resolve="resolve" />
+              <node concept="2OqwBi" id="4oS6BnNk977" role="3uHU7w">
+                <node concept="2OqwBi" id="6KviS2K_Hg4" role="2Oq$k0">
+                  <node concept="2OqwBi" id="6KviS2K_Fw3" role="2Oq$k0">
+                    <node concept="13iPFW" id="6KviS2K_Fj1" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="6KviS2K_FEL" role="2OqNvi">
+                      <ref role="3TtcxE" to="3r88:6KviS2KztF6" resolve="matches" />
+                    </node>
+                  </node>
+                  <node concept="3$u5V9" id="6KviS2K_IBR" role="2OqNvi">
+                    <node concept="1bVj0M" id="6KviS2K_IBT" role="23t8la">
+                      <node concept="3clFbS" id="6KviS2K_IBU" role="1bW5cS">
+                        <node concept="3clFbF" id="6KviS2K_IET" role="3cqZAp">
+                          <node concept="2OqwBi" id="6KviS2K_Jer" role="3clFbG">
+                            <node concept="2OqwBi" id="6KviS2K_IT0" role="2Oq$k0">
+                              <node concept="37vLTw" id="6KviS2K_IES" role="2Oq$k0">
+                                <ref role="3cqZAo" node="4z0AnX817eJ" resolve="it" />
+                              </node>
+                              <node concept="2qgKlT" id="6KviS2K_J7u" role="2OqNvi">
+                                <ref role="37wK5l" node="4lCUG7OsQyi" resolve="resolve" />
+                              </node>
+                            </node>
+                            <node concept="2qgKlT" id="6KviS2K_JwG" role="2OqNvi">
+                              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                            </node>
                           </node>
                         </node>
-                        <node concept="2qgKlT" id="6KviS2K_JwG" role="2OqNvi">
-                          <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                        </node>
+                      </node>
+                      <node concept="gl6BB" id="4z0AnX817eJ" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="4z0AnX817eK" role="1tU5fm" />
                       </node>
                     </node>
                   </node>
-                  <node concept="gl6BB" id="4z0AnX817eJ" role="1bW2Oz">
-                    <property role="TrG5h" value="it" />
-                    <node concept="2jxLKc" id="4z0AnX817eK" role="1tU5fm" />
+                </node>
+                <node concept="3uJxvA" id="4oS6BnNkaV4" role="2OqNvi">
+                  <node concept="Xl_RD" id="4oS6BnNkcjz" role="3uJOhx">
+                    <property role="Xl_RC" value="," />
                   </node>
                 </node>
               </node>
-            </node>
-            <node concept="Xl_RD" id="6KviS2K_F0J" role="3uHU7B">
-              <property role="Xl_RC" value="one of " />
             </node>
           </node>
         </node>
@@ -560,8 +613,17 @@
               <property role="Xl_RC" value="]" />
             </node>
             <node concept="3cpWs3" id="6KviS2K_JRk" role="3uHU7B">
-              <node concept="Xl_RD" id="6KviS2K_J_2" role="3uHU7B">
-                <property role="Xl_RC" value="str[" />
+              <node concept="3cpWs3" id="4oS6BnNks3A" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnNktUC" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnNksLg" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnNks4i" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnNksX4" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnNkunQ" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="6KviS2K_J_2" role="3uHU7w">
+                  <property role="Xl_RC" value="[" />
+                </node>
               </node>
               <node concept="2OqwBi" id="6KviS2K_K4U" role="3uHU7w">
                 <node concept="13iPFW" id="6KviS2K_JRS" role="2Oq$k0" />
@@ -603,6 +665,66 @@
   <node concept="13h7C7" id="6KviS2K_ZF7">
     <property role="3GE5qa" value="clauses.positionbased" />
     <ref role="13h7C2" to="3r88:6KviS2KxsKA" resolve="PositionBasedValidationClause" />
+    <node concept="13i0hz" id="4oS6BnNiUeG" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNiUf7" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNiUf8" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNiV$a" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNj2EK" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNj3t1" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnNj36h" role="2Oq$k0">
+                <node concept="13iPFW" id="4oS6BnNj2Go" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnNj3iV" role="2OqNvi">
+                  <ref role="3Tt5mk" to="3r88:6KviS2KyOjv" resolve="match" />
+                </node>
+              </node>
+              <node concept="2Iv5rx" id="4oS6BnNj3Dv" role="2OqNvi" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNj2CR" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnNiZRy" role="3uHU7B">
+                <node concept="3cpWs3" id="4oS6BnNiZMF" role="3uHU7B">
+                  <node concept="3cpWs3" id="4oS6BnNiWOC" role="3uHU7B">
+                    <node concept="Xl_RD" id="4oS6BnNiV$9" role="3uHU7B">
+                      <property role="Xl_RC" value="at position " />
+                    </node>
+                    <node concept="2OqwBi" id="4oS6BnNiXMf" role="3uHU7w">
+                      <node concept="2OqwBi" id="4oS6BnNiXdA" role="2Oq$k0">
+                        <node concept="13iPFW" id="4oS6BnNiWOF" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="4oS6BnNiXp8" role="2OqNvi">
+                          <ref role="3Tt5mk" to="3r88:6KviS2KxsKE" resolve="pos" />
+                        </node>
+                      </node>
+                      <node concept="2qgKlT" id="4oS6BnNiXX_" role="2OqNvi">
+                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="4oS6BnNiZNy" role="3uHU7w">
+                    <property role="Xl_RC" value=" " />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="4oS6BnNj0AJ" role="3uHU7w">
+                  <node concept="2OqwBi" id="4oS6BnNj0h2" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnNiZR_" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="4oS6BnNj0t8" role="2OqNvi">
+                      <ref role="3Tt5mk" to="3r88:6KviS2KyOjs" resolve="kind" />
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="4oS6BnNj0MD" role="2OqNvi">
+                    <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                  </node>
+                </node>
+              </node>
+              <node concept="Xl_RD" id="4oS6BnNj2CU" role="3uHU7w">
+                <property role="Xl_RC" value=" be " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNiUf9" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="pOv0_Xnmml" role="13h7CS">
       <property role="TrG5h" value="makeX" />
       <ref role="13i0hy" node="5wF$o0BEPkN" resolve="makeX" />
@@ -674,6 +796,81 @@
   <node concept="13h7C7" id="2LaXqmX$gsf">
     <property role="3GE5qa" value="clauses.positionbased" />
     <ref role="13h7C2" to="3r88:2LaXqmX$cjT" resolve="RangeBasedValidationClause" />
+    <node concept="13i0hz" id="4oS6BnNj40a" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNj40_" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNj40A" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNj6b1" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNjf6v" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNjfnA" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnNjfav" role="2Oq$k0">
+                <node concept="13iPFW" id="4oS6BnNjf8D" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnNjfd9" role="2OqNvi">
+                  <ref role="3Tt5mk" to="3r88:2LaXqmX$cjW" resolve="match" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="4oS6BnNjf$t" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNjf4a" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnNjehr" role="3uHU7B">
+                <node concept="3cpWs3" id="4oS6BnNjefy" role="3uHU7B">
+                  <node concept="3cpWs3" id="4oS6BnNjbGw" role="3uHU7B">
+                    <node concept="3cpWs3" id="4oS6BnNj9h0" role="3uHU7B">
+                      <node concept="3cpWs3" id="4oS6BnNj86S" role="3uHU7B">
+                        <node concept="Xl_RD" id="4oS6BnNj6QN" role="3uHU7B">
+                          <property role="Xl_RC" value="range " />
+                        </node>
+                        <node concept="2OqwBi" id="4oS6BnNj8OR" role="3uHU7w">
+                          <node concept="2OqwBi" id="4oS6BnNj8wd" role="2Oq$k0">
+                            <node concept="13iPFW" id="4oS6BnNj87i" role="2Oq$k0" />
+                            <node concept="3TrEf2" id="4oS6BnNj8FJ" role="2OqNvi">
+                              <ref role="3Tt5mk" to="3r88:2LaXqmX$cjU" resolve="posStart" />
+                            </node>
+                          </node>
+                          <node concept="2qgKlT" id="4oS6BnNj90d" role="2OqNvi">
+                            <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="Xl_RD" id="4oS6BnNj9hR" role="3uHU7w">
+                        <property role="Xl_RC" value=" -&gt; " />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="4oS6BnNjcd0" role="3uHU7w">
+                      <node concept="2OqwBi" id="4oS6BnNjbRj" role="2Oq$k0">
+                        <node concept="13iPFW" id="4oS6BnNjbHx" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="4oS6BnNjc3p" role="2OqNvi">
+                          <ref role="3Tt5mk" to="3r88:2LaXqmX$cjX" resolve="posEnd" />
+                        </node>
+                      </node>
+                      <node concept="2qgKlT" id="4oS6BnNjcoU" role="2OqNvi">
+                        <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="4oS6BnNjef_" role="3uHU7w">
+                    <property role="Xl_RC" value=" " />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="4oS6BnNjeGW" role="3uHU7w">
+                  <node concept="13iPFW" id="4oS6BnNjej3" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnNjeTA" role="2OqNvi">
+                    <ref role="3Tt5mk" to="3r88:2LaXqmX$cjV" resolve="kind" />
+                  </node>
+                </node>
+              </node>
+              <node concept="Xl_RD" id="4oS6BnNjf4d" role="3uHU7w">
+                <property role="Xl_RC" value=" be " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNj40B" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="5wF$o0BFIdE" role="13h7CS">
       <property role="TrG5h" value="makeX" />
       <ref role="13i0hy" node="5wF$o0BEPkN" resolve="makeX" />
@@ -763,9 +960,13 @@
       <ref role="13i0hy" to="pbu6:6kR0qIbI2yi" resolve="renderReadable" />
       <node concept="3Tm1VV" id="3dTPcTThAXR" role="1B3o_S" />
       <node concept="3clFbS" id="3dTPcTThAXU" role="3clF47">
-        <node concept="3clFbF" id="3dTPcTThAXX" role="3cqZAp">
-          <node concept="Xl_RD" id="3dTPcTThAXW" role="3clFbG">
-            <property role="Xl_RC" value="ok" />
+        <node concept="3clFbF" id="4oS6BnNkwWZ" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnNkyo0" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNkxbi" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnNkwWY" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4oS6BnNkxDF" role="2OqNvi" />
+            </node>
+            <node concept="3n3YKJ" id="4oS6BnNkyPP" role="2OqNvi" />
           </node>
         </node>
       </node>
@@ -782,9 +983,13 @@
       <ref role="13i0hy" to="pbu6:6kR0qIbI2yi" resolve="renderReadable" />
       <node concept="3Tm1VV" id="3dTPcTThDf6" role="1B3o_S" />
       <node concept="3clFbS" id="3dTPcTThDf9" role="3clF47">
-        <node concept="3clFbF" id="3dTPcTThDfc" role="3cqZAp">
-          <node concept="Xl_RD" id="3dTPcTThDfb" role="3clFbG">
-            <property role="Xl_RC" value="messages" />
+        <node concept="3clFbF" id="4oS6BnNkvj8" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnNkwsI" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNkvxr" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnNkvj7" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4oS6BnNkvIX" role="2OqNvi" />
+            </node>
+            <node concept="3n3YKJ" id="4oS6BnNkwUR" role="2OqNvi" />
           </node>
         </node>
       </node>
@@ -795,6 +1000,88 @@
     <ref role="13h7C2" to="3r88:4lCUG7OqbH2" resolve="ValidateStringExpr" />
     <node concept="13hLZK" id="5wF$o0BEImE" role="13h7CW">
       <node concept="3clFbS" id="5wF$o0BEImF" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMRtzx" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMRtzy" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMRtzJ" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMRuEa" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMRQt9" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnMRQxH" role="3uHU7w">
+              <property role="Xl_RC" value="]" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMRB64" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMR_bg" role="3uHU7B">
+                <node concept="3cpWs3" id="4oS6BnMR$6p" role="3uHU7B">
+                  <node concept="3cpWs3" id="4oS6BnMRxFz" role="3uHU7B">
+                    <node concept="2OqwBi" id="4oS6BnMRvVB" role="3uHU7B">
+                      <node concept="2OqwBi" id="4oS6BnMRuUL" role="2Oq$k0">
+                        <node concept="13iPFW" id="4oS6BnMRuE9" role="2Oq$k0" />
+                        <node concept="2yIwOk" id="4oS6BnMRvcr" role="2OqNvi" />
+                      </node>
+                      <node concept="3n3YKJ" id="4oS6BnMRwr3" role="2OqNvi" />
+                    </node>
+                    <node concept="Xl_RD" id="4oS6BnMRxFA" role="3uHU7w">
+                      <property role="Xl_RC" value=" " />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="4oS6BnMR$L1" role="3uHU7w">
+                    <node concept="2OqwBi" id="4oS6BnMR$jz" role="2Oq$k0">
+                      <node concept="13iPFW" id="4oS6BnMR$7h" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="4oS6BnMR$_K" role="2OqNvi">
+                        <ref role="3Tt5mk" to="3r88:4lCUG7OsXN9" resolve="candidate" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="4oS6BnMR_3z" role="2OqNvi">
+                      <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="4oS6BnMR_bj" role="3uHU7w">
+                  <property role="Xl_RC" value="[" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnMRK4I" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnMRG9I" role="2Oq$k0">
+                  <node concept="2OqwBi" id="4oS6BnMRDUp" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnMRDe8" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="4oS6BnMREda" role="2OqNvi">
+                      <ref role="3TtcxE" to="3r88:4lCUG7OsY7n" resolve="clauses" />
+                    </node>
+                  </node>
+                  <node concept="3$u5V9" id="4oS6BnMRHKD" role="2OqNvi">
+                    <node concept="1bVj0M" id="4oS6BnMRHKF" role="23t8la">
+                      <node concept="3clFbS" id="4oS6BnMRHKG" role="1bW5cS">
+                        <node concept="3clFbF" id="4oS6BnMRHRg" role="3cqZAp">
+                          <node concept="2OqwBi" id="4oS6BnMRI46" role="3clFbG">
+                            <node concept="37vLTw" id="4oS6BnMRHRf" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4oS6BnMRHKH" resolve="it" />
+                            </node>
+                            <node concept="2qgKlT" id="4oS6BnMRJqX" role="2OqNvi">
+                              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gl6BB" id="4oS6BnMRHKH" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="4oS6BnMRHKI" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3uJxvA" id="4oS6BnMRM9B" role="2OqNvi">
+                  <node concept="Xl_RD" id="4oS6BnMRQk1" role="3uJOhx">
+                    <property role="Xl_RC" value="\n" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMRtzK" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="5wF$o0BEPkC">
@@ -817,6 +1104,23 @@
   <node concept="13h7C7" id="5wF$o0BFLym">
     <property role="3GE5qa" value="check.kind" />
     <ref role="13h7C2" to="3r88:4lCUG7OtrZ8" resolve="CheckKind" />
+    <node concept="13i0hz" id="4oS6BnNjfBi" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNjfBH" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNjfBI" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNjfHF" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnNjgK4" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNjfTE" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnNjfHE" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4oS6BnNjg33" role="2OqNvi" />
+            </node>
+            <node concept="3n3YKJ" id="4oS6BnNjhcd" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNjfBJ" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="5wF$o0BFLyx" role="13h7CS">
       <property role="TrG5h" value="makeX" />
       <property role="13i0it" value="true" />
@@ -882,6 +1186,110 @@
   <node concept="13h7C7" id="5wF$o0BLOaG">
     <property role="3GE5qa" value="clauses.occurencebased" />
     <ref role="13h7C2" to="3r88:4lCUG7OsY7m" resolve="OccurenceBasedValidationClause" />
+    <node concept="13i0hz" id="4oS6BnNih9w" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNih9V" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNih9W" role="3clF47">
+        <node concept="3cpWs8" id="4oS6BnNiifm" role="3cqZAp">
+          <node concept="3cpWsn" id="4oS6BnNiifn" role="3cpWs9">
+            <property role="TrG5h" value="text" />
+            <node concept="3uibUv" id="4oS6BnNiifo" role="1tU5fm">
+              <ref role="3uigEE" to="xfg9:4oS6BnMcix1" resolve="StringRepresentation" />
+            </node>
+            <node concept="2YIFZM" id="4oS6BnNiikP" role="33vP2m">
+              <ref role="37wK5l" to="xfg9:4oS6BnMcl4R" resolve="forMultipleSentences" />
+              <ref role="1Pybhc" to="xfg9:4oS6BnMcix1" resolve="StringRepresentation" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnNiiob" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnNiiEN" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnNiio9" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnNiifn" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnNiiUR" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMgdrs" resolve="append" />
+              <node concept="2OqwBi" id="4oS6BnNik1O" role="37wK5m">
+                <node concept="13iPFW" id="4oS6BnNijBU" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnNikg4" role="2OqNvi">
+                  <ref role="3Tt5mk" to="3r88:4lCUG7Ot7PN" resolve="occurence" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnNinBJ" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnNinSK" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnNinBH" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnNiifn" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnNiob4" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMgZBe" resolve="appendWithSpace" />
+              <node concept="2OqwBi" id="4oS6BnNiouA" role="37wK5m">
+                <node concept="13iPFW" id="4oS6BnNiof0" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnNioHH" role="2OqNvi">
+                  <ref role="3Tt5mk" to="3r88:4lCUG7Ot7PP" resolve="match" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnNiNIC" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnNiO1M" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnNiNIA" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnNiifn" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnNiOo4" role="2OqNvi">
+              <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+              <node concept="Xl_RD" id="4oS6BnNiOo6" role="37wK5m">
+                <property role="Xl_RC" value="[" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnNiK9C" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnNiKsF" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnNiK9A" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnNiifn" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnNiKKF" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMeeyx" resolve="appendVertically" />
+              <node concept="2OqwBi" id="4oS6BnNiL2$" role="37wK5m">
+                <node concept="13iPFW" id="4oS6BnNiKPP" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="4oS6BnNiQLX" role="2OqNvi">
+                  <ref role="3TtcxE" to="3r88:4lCUG7OtrY5" resolve="checks" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnNiPJ8" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnNiPJ9" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnNiPJa" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnNiifn" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnNiPJb" role="2OqNvi">
+              <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+              <node concept="Xl_RD" id="4oS6BnNiPJc" role="37wK5m">
+                <property role="Xl_RC" value="]" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnNiSBt" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnNiSZl" role="3clFbG">
+            <node concept="37vLTw" id="4oS6BnNiSBr" role="2Oq$k0">
+              <ref role="3cqZAo" node="4oS6BnNiifn" resolve="text" />
+            </node>
+            <node concept="liA8E" id="4oS6BnNiTuq" role="2OqNvi">
+              <ref role="37wK5l" to="xfg9:4oS6BnMUIdM" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNih9X" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="5wF$o0BLOaR" role="13h7CS">
       <property role="TrG5h" value="makeX" />
       <ref role="13i0hy" node="5wF$o0BEPkN" resolve="makeX" />
@@ -981,6 +1389,45 @@
   <node concept="13h7C7" id="5wF$o0BPZq5">
     <property role="3GE5qa" value="check.occurence" />
     <ref role="13h7C2" to="3r88:3dTPcTTdvOa" resolve="MaxCountCheck" />
+    <node concept="13i0hz" id="4oS6BnNjoZZ" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNjp00" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNjp01" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNjp02" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNjvUa" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnNjwkr" role="3uHU7w">
+              <property role="Xl_RC" value=" times" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNjtDO" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnNjp0b" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnNjp0c" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnNjp0d" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnNjp0e" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="4oS6BnNjp0f" role="2OqNvi">
+                      <ref role="3Tt5mk" to="3r88:4lCUG7OtrZL" resolve="kind" />
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="4oS6BnNjp0g" role="2OqNvi">
+                    <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="4oS6BnNjp0h" role="3uHU7w">
+                  <property role="Xl_RC" value=" occur more than " />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnNjtNy" role="3uHU7w">
+                <node concept="13iPFW" id="4oS6BnNjtDR" role="2Oq$k0" />
+                <node concept="3TrcHB" id="4oS6BnNjtZu" role="2OqNvi">
+                  <ref role="3TsBF5" to="3r88:3dTPcTTdvOb" resolve="value" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNjp0o" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="5wF$o0BPZqg" role="13h7CS">
       <property role="TrG5h" value="makeX" />
       <ref role="13i0hy" node="5wF$o0BLWcU" resolve="makeX" />
@@ -1022,6 +1469,59 @@
   <node concept="13h7C7" id="pOv0_X63kp">
     <property role="3GE5qa" value="check.occurence" />
     <ref role="13h7C2" to="3r88:4lCUG7OtrYr" resolve="AtPositionCheck" />
+    <node concept="13i0hz" id="4oS6BnNjhtw" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNjhtV" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNjhtW" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNjiDN" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNjmle" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNjm_6" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnNjmop" role="2Oq$k0">
+                <node concept="13iPFW" id="4oS6BnNjmmN" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnNjmqB" role="2OqNvi">
+                  <ref role="3Tt5mk" to="3r88:6KviS2Ku$hC" resolve="pos" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="4oS6BnNjmLx" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNjmi1" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnNjkyN" role="3uHU7B">
+                <node concept="3cpWs3" id="4oS6BnNjjfn" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnNjkPV" role="3uHU7B">
+                    <node concept="2OqwBi" id="4oS6BnNjiQW" role="2Oq$k0">
+                      <node concept="13iPFW" id="4oS6BnNjiDM" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="4oS6BnNjj2p" role="2OqNvi">
+                        <ref role="3Tt5mk" to="3r88:4lCUG7OtrZL" resolve="kind" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="4oS6BnNjl1m" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="4oS6BnNjjfq" role="3uHU7w">
+                    <property role="Xl_RC" value=" " />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="4oS6BnNjlMX" role="3uHU7w">
+                  <node concept="2OqwBi" id="4oS6BnNjl2$" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnNjkyQ" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnNjl4a" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnNjmgm" role="2OqNvi" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="4oS6BnNjmi4" role="3uHU7w">
+                <property role="Xl_RC" value=" " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNjhtX" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="pOv0_X63k$" role="13h7CS">
       <property role="TrG5h" value="makeX" />
       <ref role="13i0hy" node="5wF$o0BLWcU" resolve="makeX" />
@@ -1068,6 +1568,41 @@
   <node concept="13h7C7" id="pOv0_X8Utz">
     <property role="3GE5qa" value="check.occurence" />
     <ref role="13h7C2" to="3r88:6KviS2JcA9O" resolve="CannotRepeatCheck" />
+    <node concept="13i0hz" id="4oS6BnNjmWc" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNjmWd" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNjmWe" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNjmWf" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNjmWn" role="3clFbG">
+            <node concept="3cpWs3" id="4oS6BnNjmWo" role="3uHU7B">
+              <node concept="2OqwBi" id="4oS6BnNjmWp" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnNjmWq" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnNjmWr" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnNjmWs" role="2OqNvi">
+                    <ref role="3Tt5mk" to="3r88:4lCUG7OtrZL" resolve="kind" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4oS6BnNjmWt" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                </node>
+              </node>
+              <node concept="Xl_RD" id="4oS6BnNjmWu" role="3uHU7w">
+                <property role="Xl_RC" value=" " />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4oS6BnNjmWv" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnNjmWw" role="2Oq$k0">
+                <node concept="13iPFW" id="4oS6BnNjmWx" role="2Oq$k0" />
+                <node concept="2yIwOk" id="4oS6BnNjmWy" role="2OqNvi" />
+              </node>
+              <node concept="3n3YKJ" id="4oS6BnNjmWz" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNjmW_" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="pOv0_X8UtI" role="13h7CS">
       <property role="TrG5h" value="makeX" />
       <ref role="13i0hy" node="5wF$o0BLWcU" resolve="makeX" />
@@ -1103,6 +1638,59 @@
   <node concept="13h7C7" id="pOv0_Xa0N2">
     <property role="3GE5qa" value="check.occurence" />
     <ref role="13h7C2" to="3r88:2LaXqmXAgwW" resolve="PredecessorCheck" />
+    <node concept="13i0hz" id="4oS6BnNjw_R" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNjw_S" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNjw_T" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNjx5b" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNjCYf" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNjEtJ" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnNjE77" role="2Oq$k0">
+                <node concept="13iPFW" id="4oS6BnNjDtt" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnNjEjF" role="2OqNvi">
+                  <ref role="3Tt5mk" to="3r88:2LaXqmXAhKL" resolve="match" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="4oS6BnNjEE7" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNjCH7" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnNj_EY" role="3uHU7B">
+                <node concept="3cpWs3" id="4oS6BnNj_a8" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnNjyek" role="3uHU7B">
+                    <node concept="2OqwBi" id="4oS6BnNjxik" role="2Oq$k0">
+                      <node concept="13iPFW" id="4oS6BnNjx5a" role="2Oq$k0" />
+                      <node concept="2yIwOk" id="4oS6BnNjxwE" role="2OqNvi" />
+                    </node>
+                    <node concept="3n3YKJ" id="4oS6BnNjyEV" role="2OqNvi" />
+                  </node>
+                  <node concept="Xl_RD" id="4oS6BnNj_ab" role="3uHU7w">
+                    <property role="Xl_RC" value=" " />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="4oS6BnNjAGZ" role="3uHU7w">
+                  <node concept="2OqwBi" id="4oS6BnNjAl7" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnNj_VD" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="4oS6BnNjAx7" role="2OqNvi">
+                      <ref role="3Tt5mk" to="3r88:4lCUG7OtrZL" resolve="kind" />
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="4oS6BnNjASN" role="2OqNvi">
+                    <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                  </node>
+                </node>
+              </node>
+              <node concept="Xl_RD" id="4oS6BnNjCHa" role="3uHU7w">
+                <property role="Xl_RC" value=" be " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNjwAg" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="pOv0_Xa0Nd" role="13h7CS">
       <property role="TrG5h" value="makeX" />
       <ref role="13i0hy" node="5wF$o0BLWcU" resolve="makeX" />
@@ -1149,6 +1737,59 @@
   <node concept="13h7C7" id="pOv0_Xj362">
     <property role="3GE5qa" value="check.occurence" />
     <ref role="13h7C2" to="3r88:4xzR2e_wXqB" resolve="SuccessorCheck" />
+    <node concept="13i0hz" id="4oS6BnNjETR" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNjETS" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNjETT" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNjFpr" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNjLuD" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNjMfA" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnNjLSA" role="2Oq$k0">
+                <node concept="13iPFW" id="4oS6BnNjLuG" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnNjM5a" role="2OqNvi">
+                  <ref role="3Tt5mk" to="3r88:4xzR2e_wXqC" resolve="match" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="4oS6BnNjMrY" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNjJEs" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnNjIWU" role="3uHU7B">
+                <node concept="3cpWs3" id="4oS6BnNjIrc" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnNjGvq" role="3uHU7B">
+                    <node concept="2OqwBi" id="4oS6BnNjFA$" role="2Oq$k0">
+                      <node concept="13iPFW" id="4oS6BnNjFpq" role="2Oq$k0" />
+                      <node concept="2yIwOk" id="4oS6BnNjFM1" role="2OqNvi" />
+                    </node>
+                    <node concept="3n3YKJ" id="4oS6BnNjGWh" role="2OqNvi" />
+                  </node>
+                  <node concept="Xl_RD" id="4oS6BnNjIrU" role="3uHU7w">
+                    <property role="Xl_RC" value=" " />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="4oS6BnNjJt7" role="3uHU7w">
+                  <node concept="2OqwBi" id="4oS6BnNjJ7y" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnNjIXM" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="4oS6BnNjJjy" role="2OqNvi">
+                      <ref role="3Tt5mk" to="3r88:4lCUG7OtrZL" resolve="kind" />
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="4oS6BnNjJCV" role="2OqNvi">
+                    <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                  </node>
+                </node>
+              </node>
+              <node concept="Xl_RD" id="4oS6BnNjJEv" role="3uHU7w">
+                <property role="Xl_RC" value=" be " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNjEUg" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="pOv0_Xj36d" role="13h7CS">
       <property role="TrG5h" value="makeX" />
       <ref role="13i0hy" node="5wF$o0BLWcU" resolve="makeX" />
@@ -1195,6 +1836,23 @@
   <node concept="13h7C7" id="pOv0_Xm8hd">
     <property role="3GE5qa" value="check.occurence" />
     <ref role="13h7C2" to="3r88:6KviS2JdW9y" resolve="FailCheck" />
+    <node concept="13i0hz" id="4oS6BnNjoiS" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNjoiT" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNjoiU" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNjoiV" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnNjojb" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNjojc" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnNjojd" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4oS6BnNjoje" role="2OqNvi" />
+            </node>
+            <node concept="3n3YKJ" id="4oS6BnNjojf" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNjojh" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="pOv0_Xm8ho" role="13h7CS">
       <property role="TrG5h" value="makeX" />
       <ref role="13i0hy" node="5wF$o0BLWcU" resolve="makeX" />
@@ -1230,6 +1888,46 @@
   <node concept="13h7C7" id="pOv0_XsiX5">
     <property role="3GE5qa" value="matches" />
     <ref role="13h7C2" to="3r88:2LaXqmXpuda" resolve="AllSameCharMatcher" />
+    <node concept="13i0hz" id="4oS6BnNjQEV" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNjQF4" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNjQF5" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNjQKR" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNjVcu" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnNjVcx" role="3uHU7w">
+              <property role="Xl_RC" value="]" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNjUtq" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnNjUrr" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnNjS5$" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnNjQY0" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnNjQKQ" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnNjRnU" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnNjSya" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="4oS6BnNjUru" role="3uHU7w">
+                  <property role="Xl_RC" value="[" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnNjUZ9" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnNjUI3" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnNjUtt" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnNjUP$" role="2OqNvi">
+                    <ref role="3Tt5mk" to="3r88:2LaXqmXpudb" resolve="match" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4oS6BnNjVaX" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNjQF6" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="pOv0_XsiXg" role="13h7CS">
       <property role="TrG5h" value="makeX" />
       <ref role="13i0hy" node="5wF$o0BLTj$" resolve="makeX" />
@@ -1313,6 +2011,59 @@
   <node concept="13h7C7" id="pOv0_XAD9T">
     <property role="3GE5qa" value="matches" />
     <ref role="13h7C2" to="3r88:6KviS2KA7ya" resolve="SequenceMatcher" />
+    <node concept="13i0hz" id="4oS6BnNkcwq" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNkcwz" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNkcw$" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNkcBc" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNkrBv" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnNkrBy" role="3uHU7w">
+              <property role="Xl_RC" value="]" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNkp4b" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnNklTD" role="3uHU7B">
+                <node concept="3cpWs3" id="4oS6BnNkhzC" role="3uHU7B">
+                  <node concept="3cpWs3" id="4oS6BnNkfpW" role="3uHU7B">
+                    <node concept="2OqwBi" id="4oS6BnNkdHb" role="3uHU7B">
+                      <node concept="2OqwBi" id="4oS6BnNkcOl" role="2Oq$k0">
+                        <node concept="13iPFW" id="4oS6BnNkcBb" role="2Oq$k0" />
+                        <node concept="2yIwOk" id="4oS6BnNkcZM" role="2OqNvi" />
+                      </node>
+                      <node concept="3n3YKJ" id="4oS6BnNkea4" role="2OqNvi" />
+                    </node>
+                    <node concept="Xl_RD" id="4oS6BnNkfpZ" role="3uHU7w">
+                      <property role="Xl_RC" value="[" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="4oS6BnNkkmZ" role="3uHU7w">
+                    <node concept="2OqwBi" id="4oS6BnNkjmr" role="2Oq$k0">
+                      <node concept="13iPFW" id="4oS6BnNkjlt" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="4oS6BnNkjyr" role="2OqNvi">
+                        <ref role="3Tt5mk" to="3r88:6KviS2KA7yb" resolve="match" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="4oS6BnNkkOS" role="2OqNvi">
+                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="4oS6BnNklTG" role="3uHU7w">
+                  <property role="Xl_RC" value="*" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnNkpvB" role="3uHU7w">
+                <node concept="13iPFW" id="4oS6BnNkp5E" role="2Oq$k0" />
+                <node concept="3TrcHB" id="4oS6BnNkpGb" role="2OqNvi">
+                  <ref role="3TsBF5" to="3r88:6KviS2KA7yc" resolve="howOften" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNkcw_" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="pOv0_XADa4" role="13h7CS">
       <property role="TrG5h" value="makeX" />
       <ref role="13i0hy" node="5wF$o0BLTj$" resolve="makeX" />
@@ -1402,6 +2153,23 @@
   <node concept="13h7C7" id="pOv0_XWGgp">
     <property role="3GE5qa" value="clauses.occurencebased" />
     <ref role="13h7C2" to="3r88:4lCUG7Ot7PK" resolve="IfExistsOccurenceConstraint" />
+    <node concept="13i0hz" id="4oS6BnNjMQJ" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNjMRa" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNjMRb" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNjMYs" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnNjO7k" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNjNb_" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnNjMYr" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4oS6BnNjNnr" role="2OqNvi" />
+            </node>
+            <node concept="3n3YKJ" id="4oS6BnNjO$d" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNjMRc" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="pOv0_XWGg$" role="13h7CS">
       <property role="TrG5h" value="makeX" />
       <ref role="13i0hy" node="5wF$o0BLPlq" resolve="makeX" />
@@ -1433,6 +2201,23 @@
     <ref role="13h7C2" to="3r88:3dTPcTTh7Np" resolve="ValidateStringResultType" />
     <node concept="13hLZK" id="41vYFO2KF5T" role="13h7CW">
       <node concept="3clFbS" id="41vYFO2KF5U" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnNkz09" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNkz0a" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNkz0h" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNkz9v" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnNk$qh" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNkzq6" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnNkz9q" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4oS6BnNkzFK" role="2OqNvi" />
+            </node>
+            <node concept="3n3YKJ" id="4oS6BnNk$TQ" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNkz0i" role="3clF45" />
     </node>
     <node concept="13i0hz" id="41vYFO2KF6b" role="13h7CS">
       <property role="TrG5h" value="createDefaultVarExpr" />
@@ -1476,6 +2261,61 @@
       <node concept="3Tqbb2" id="41vYFO2KF6g" role="3clF45">
         <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
       </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnNjVEU">
+    <property role="3GE5qa" value="matches" />
+    <ref role="13h7C2" to="3r88:4lCUG7OsQwC" resolve="NamedElementaryMatchDecl" />
+    <node concept="13i0hz" id="4oS6BnNjVFd" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNjVFe" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNjVFf" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNjVFg" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNjYXp" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNk045" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnNjZuJ" role="2Oq$k0">
+                <node concept="13iPFW" id="4oS6BnNjYYH" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnNjZU9" role="2OqNvi">
+                  <ref role="3Tt5mk" to="3r88:4lCUG7OsQwF" resolve="match" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="4oS6BnNk0gi" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNjVFh" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnNjVFj" role="3uHU7B">
+                <node concept="3cpWs3" id="4oS6BnNjVFk" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnNjVFl" role="3uHU7B">
+                    <node concept="2OqwBi" id="4oS6BnNjVFm" role="2Oq$k0">
+                      <node concept="13iPFW" id="4oS6BnNjVFn" role="2Oq$k0" />
+                      <node concept="2yIwOk" id="4oS6BnNjVFo" role="2OqNvi" />
+                    </node>
+                    <node concept="3n3YKJ" id="4oS6BnNjVFp" role="2OqNvi" />
+                  </node>
+                  <node concept="Xl_RD" id="4oS6BnNjVFq" role="3uHU7w">
+                    <property role="Xl_RC" value=" " />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="4oS6BnNjVFs" role="3uHU7w">
+                  <node concept="13iPFW" id="4oS6BnNjVFt" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="4oS6BnNjXj2" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+              <node concept="Xl_RD" id="4oS6BnNjXFA" role="3uHU7w">
+                <property role="Xl_RC" value=" = " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNjVFw" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="4oS6BnNjVEV" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnNjVEW" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/models/org.iets3.core.expr.stringvalidation.structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/models/org.iets3.core.expr.stringvalidation.structure.mps
@@ -430,6 +430,7 @@
   <node concept="1TIwiD" id="3dTPcTTh7Np">
     <property role="EcuMT" value="3709229751379197145" />
     <property role="TrG5h" value="ValidateStringResultType" />
+    <property role="34LRSv" value="stringvalidationresult" />
     <ref role="1TJDcQ" to="hm2y:6sdnDbSlaok" resolve="Type" />
     <node concept="PrWs8" id="41vYFO2KF5R" role="PzmwI">
       <ref role="PrY4T" to="hm2y:60Qa1k_nI2f" resolve="ITypeSupportsDefaultValue" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/org.iets3.core.expr.stringvalidation.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.stringvalidation/org.iets3.core.expr.stringvalidation.mpl
@@ -63,6 +63,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/behavior.mps
@@ -34,6 +34,7 @@
       <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
@@ -113,6 +114,13 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
         <reference id="5455284157994012188" name="link" index="2pIpSl" />
@@ -159,6 +167,9 @@
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -169,6 +180,9 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
@@ -177,6 +191,10 @@
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
+        <child id="1240687658305" name="delimiter" index="3uJOhx" />
+      </concept>
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
     </language>
   </registry>
   <node concept="13h7C7" id="50smQ1V92Tn">
@@ -363,9 +381,36 @@
       <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
       <node concept="3Tm1VV" id="4voqclTE$G5" role="1B3o_S" />
       <node concept="3clFbS" id="4voqclTE$G8" role="3clF47">
-        <node concept="3clFbF" id="4voqclTE$Gn" role="3cqZAp">
-          <node concept="Xl_RD" id="4voqclTE$Gm" role="3clFbG">
-            <property role="Xl_RC" value="" />
+        <node concept="3clFbF" id="4oS6BnNkMbC" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNkQLY" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnNkQM1" role="3uHU7w">
+              <property role="Xl_RC" value=")" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNkPNk" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnNkPxC" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnNkNyJ" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnNkMsf" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnNkMbB" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnNkMNz" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnNkOhq" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="4oS6BnNkPxF" role="3uHU7w">
+                  <property role="Xl_RC" value="(" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnNkQlp" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnNkQ4X" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnNkPOc" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnNkQ6$" role="2OqNvi">
+                    <ref role="3Tt5mk" to="l462:4voqclTxdd8" resolve="value" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4oS6BnNkQEh" role="2OqNvi">
+                  <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -805,6 +850,130 @@
       <node concept="3Tqbb2" id="6C2wkq7mhkv" role="3clF45">
         <ref role="ehGHo" to="hm2y:6sdnDbSlaok" resolve="Type" />
       </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMGmvL">
+    <ref role="13h7C2" to="l462:7aRvJQF6gko" resolve="FullOverlapExpr" />
+    <node concept="13hLZK" id="4oS6BnMGmvM" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMGmvN" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMGmw4" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMGmw5" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMGmwi" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMGmBd" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMH77N" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnMH77Q" role="3uHU7w">
+              <property role="Xl_RC" value="]" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMGURJ" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMGUA3" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnMGnTB" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnMGmQE" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnMGmB8" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnMGnbu" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnMGoBz" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="4oS6BnMGUA6" role="3uHU7w">
+                  <property role="Xl_RC" value="[" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnMH3D_" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnMGY6A" role="2Oq$k0">
+                  <node concept="2OqwBi" id="4oS6BnMGViY" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnMGURM" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="4oS6BnMGVCl" role="2OqNvi">
+                      <ref role="3TtcxE" to="l462:7aRvJQF6gkp" resolve="values" />
+                    </node>
+                  </node>
+                  <node concept="3$u5V9" id="4oS6BnMH1af" role="2OqNvi">
+                    <node concept="1bVj0M" id="4oS6BnMH1ah" role="23t8la">
+                      <node concept="3clFbS" id="4oS6BnMH1ai" role="1bW5cS">
+                        <node concept="3clFbF" id="4oS6BnMH1gU" role="3cqZAp">
+                          <node concept="2OqwBi" id="4oS6BnMH1vh" role="3clFbG">
+                            <node concept="37vLTw" id="4oS6BnMH1gT" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4oS6BnMH1aj" resolve="it" />
+                            </node>
+                            <node concept="2qgKlT" id="4oS6BnMH2Y4" role="2OqNvi">
+                              <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gl6BB" id="4oS6BnMH1aj" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="4oS6BnMH1ak" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3uJxvA" id="4oS6BnMH5Fc" role="2OqNvi">
+                  <node concept="Xl_RD" id="4oS6BnMH73v" role="3uJOhx">
+                    <property role="Xl_RC" value="," />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMGmwj" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMHaI3">
+    <ref role="13h7C2" to="l462:3rApyZ4E9Wd" resolve="DefaultSliceValueExpr" />
+    <node concept="13hLZK" id="4oS6BnMHaI4" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMHaI5" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMHaIm" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMHaIn" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMHaI$" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMHaPv" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMHlcG" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMHmdr" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnMHlDe" role="2Oq$k0">
+                <node concept="13iPFW" id="4oS6BnMHlcJ" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnMHm1u" role="2OqNvi">
+                  <ref role="3Tt5mk" to="l462:3rApyZ4E9Wg" resolve="body" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="4oS6BnMHmyG" role="2OqNvi">
+                <ref role="37wK5l" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMHhJg" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMHgGz" role="3uHU7B">
+                <node concept="3cpWs3" id="4oS6BnMHebd" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnMHcbV" role="3uHU7B">
+                    <node concept="2OqwBi" id="4oS6BnMHb66" role="2Oq$k0">
+                      <node concept="13iPFW" id="4oS6BnMHaPq" role="2Oq$k0" />
+                      <node concept="2yIwOk" id="4oS6BnMHbtq" role="2OqNvi" />
+                    </node>
+                    <node concept="3n3YKJ" id="4oS6BnMHcUZ" role="2OqNvi" />
+                  </node>
+                  <node concept="Xl_RD" id="4oS6BnMHebg" role="3uHU7w">
+                    <property role="Xl_RC" value="[" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="4oS6BnMHh9l" role="3uHU7w">
+                  <node concept="13iPFW" id="4oS6BnMHgHr" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnMHhxc" role="2OqNvi">
+                    <ref role="3Tt5mk" to="l462:3rApyZ4E9We" resolve="value" />
+                  </node>
+                </node>
+              </node>
+              <node concept="Xl_RD" id="4oS6BnMHhJj" role="3uHU7w">
+                <property role="Xl_RC" value="] =&gt; " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMHaI_" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/models/editor.mps
@@ -952,6 +952,15 @@
       <node concept="PMmxH" id="1znK7yZde80" role="3EZMnx">
         <ref role="PMmxG" to="buwp:1znK7yZhztN" resolve="ExpressionKeywordAlias" />
       </node>
+      <node concept="3F0ifn" id="7aRvJQF6gl2" role="3EZMnx">
+        <property role="3F0ifm" value="[" />
+        <node concept="11L4FC" id="7aRvJQF6glw" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="11LMrY" id="7aRvJQF6gl_" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
       <node concept="3F2HdR" id="7aRvJQF6gla" role="3EZMnx">
         <property role="2czwfO" value="," />
         <ref role="1NtTu8" to="l462:7aRvJQF6gkp" resolve="values" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/org.iets3.core.expr.temporal.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.temporal/org.iets3.core.expr.temporal.mpl
@@ -88,6 +88,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/behavior.mps
@@ -15699,5 +15699,51 @@
       </node>
     </node>
   </node>
+  <node concept="13h7C7" id="4oS6BnMFCOA">
+    <ref role="13h7C2" to="av4b:7khFtBHvbuh" resolve="EvalAnythingExpr" />
+    <node concept="13hLZK" id="4oS6BnMFCOB" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMFCOC" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMFCOT" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMFCOU" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMFCP7" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMFCWH" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMFHbp" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnMFHbs" role="3uHU7w">
+              <property role="Xl_RC" value="]" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMFGtM" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMFGc6" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnMFEt7" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnMFDca" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnMFCWG" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnMFDIY" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnMFEVV" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="4oS6BnMFGc9" role="3uHU7w">
+                  <property role="Xl_RC" value="[" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnMFGVw" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnMFGIz" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnMFGtP" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4oS6BnMFGKa" role="2OqNvi">
+                    <ref role="3Tt5mk" to="av4b:7khFtBHvbui" resolve="anything" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="4oS6BnMFH5T" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMFCP8" role="3clF45" />
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/models/editor.mps
@@ -7187,7 +7187,7 @@
     <ref role="1XX52x" to="av4b:7khFtBHvbuh" resolve="EvalAnythingExpr" />
     <node concept="3EZMnI" id="7khFtBHvbuM" role="2wV5jI">
       <node concept="3F0ifn" id="7khFtBHvbuJ" role="3EZMnx">
-        <property role="3F0ifm" value="evalanything" />
+        <property role="3F0ifm" value="evalAnything" />
         <ref role="1k5W1q" to="itrz:3R2njxnikay" resolve="iets3GreyText" />
         <node concept="11LMrY" id="7khFtBHvbuZ" role="3F10Kt">
           <property role="VOm3f" value="true" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/org.iets3.core.expr.tests.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.tests/org.iets3.core.expr.tests.mpl
@@ -233,6 +233,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="920eaa0e-ecca-46bc-bee7-4e5c59213dd6(Testbench)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/models/org/iets3/core/expr/toplevel/behavior.mps
@@ -85,6 +85,7 @@
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
+      <concept id="5763944538902644732" name="jetbrains.mps.baseLanguage.structure.StaticMethodCallOperation" flags="ng" index="2PDubS" />
       <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
@@ -293,6 +294,7 @@
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
+      <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="334628810661441841" name="jetbrains.mps.lang.smodel.structure.AsSConcept" flags="nn" index="1rGIog" />
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
@@ -7828,6 +7830,27 @@
   <node concept="13h7C7" id="5L2mTKm_NI7">
     <property role="3GE5qa" value="enum" />
     <ref role="13h7C2" to="yv47:67Y8mp$DN2V" resolve="EnumType" />
+    <node concept="13i0hz" id="4oS6BnMEKTw" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnMEKTx" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMEKTC" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMEKTH" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMENni" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMEMzp" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMEMhC" role="2Oq$k0" />
+              <node concept="3TrEf2" id="4oS6BnMEMWo" role="2OqNvi">
+                <ref role="3Tt5mk" to="yv47:67Y8mp$DN3N" resolve="enum" />
+              </node>
+            </node>
+            <node concept="3TrcHB" id="4oS6BnMEO4h" role="2OqNvi">
+              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMEKTD" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="5L2mTKm_pxP" role="13h7CS">
       <property role="TrG5h" value="isSameAs" />
       <property role="13i0it" value="false" />
@@ -9912,19 +9935,58 @@
       <node concept="3Tm1VV" id="6WstIz8ML9V" role="1B3o_S" />
       <node concept="3clFbS" id="6WstIz8ML9W" role="3clF47">
         <node concept="3clFbF" id="6WstIz8ML9X" role="3cqZAp">
-          <node concept="3cpWs3" id="6WstIz8MLa0" role="3clFbG">
-            <node concept="Xl_RD" id="6WstIz8MLa1" role="3uHU7B">
-              <property role="Xl_RC" value="isIn" />
+          <node concept="3cpWs3" id="4oS6BnNayxe" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnNayRN" role="3uHU7w">
+              <property role="Xl_RC" value=")" />
             </node>
-            <node concept="2OqwBi" id="6WstIz8MLa2" role="3uHU7w">
-              <node concept="2OqwBi" id="6WstIz8MLa3" role="2Oq$k0">
-                <node concept="13iPFW" id="6WstIz8MLa4" role="2Oq$k0" />
-                <node concept="3Tsc0h" id="6WstIz8MMtP" role="2OqNvi">
-                  <ref role="3TtcxE" to="yv47:6WstIz8MK6a" resolve="selectors" />
+            <node concept="3cpWs3" id="6WstIz8MLa0" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnNaxln" role="3uHU7B">
+                <node concept="Xl_RD" id="4oS6BnNaxlq" role="3uHU7w">
+                  <property role="Xl_RC" value="(" />
+                </node>
+                <node concept="2OqwBi" id="4oS6BnNassl" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnNapig" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnNaoPr" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnNapDA" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnNatlo" role="2OqNvi" />
                 </node>
               </node>
-              <node concept="liA8E" id="6WstIz8MO14" role="2OqNvi">
-                <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+              <node concept="2OqwBi" id="6WstIz8MLa2" role="3uHU7w">
+                <node concept="2OqwBi" id="6WstIz8MLa3" role="2Oq$k0">
+                  <node concept="13iPFW" id="6WstIz8MLa4" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="6WstIz8MMtP" role="2OqNvi">
+                    <ref role="3TtcxE" to="yv47:6WstIz8MK6a" resolve="selectors" />
+                  </node>
+                </node>
+                <node concept="3$u5V9" id="4oS6BnNahqr" role="2OqNvi">
+                  <node concept="1bVj0M" id="4oS6BnNahqt" role="23t8la">
+                    <node concept="3clFbS" id="4oS6BnNahqu" role="1bW5cS">
+                      <node concept="3clFbF" id="4oS6BnNahtv" role="3cqZAp">
+                        <node concept="2OqwBi" id="4oS6BnNakAh" role="3clFbG">
+                          <node concept="2OqwBi" id="4oS6BnNahT9" role="2Oq$k0">
+                            <node concept="37vLTw" id="4oS6BnNahtu" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4oS6BnNahqv" resolve="it" />
+                            </node>
+                            <node concept="2qgKlT" id="4oS6BnNaihl" role="2OqNvi">
+                              <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                            </node>
+                          </node>
+                          <node concept="2PDubS" id="4oS6BnNalSt" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~String.join(java.lang.CharSequence,java.lang.CharSequence...)" resolve="join" />
+                            <node concept="Xl_RD" id="4oS6BnNamgO" role="37wK5m">
+                              <property role="Xl_RC" value="," />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="4oS6BnNahqv" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="4oS6BnNahqw" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -10288,6 +10350,48 @@
         </node>
       </node>
       <node concept="17QB3L" id="c36CPsAtHA" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnMEBFu">
+    <property role="3GE5qa" value="enum" />
+    <ref role="13h7C2" to="yv47:2zwra1$QhrC" resolve="AllLitList" />
+    <node concept="13hLZK" id="4oS6BnMEBFv" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnMEBFw" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnMEBFL" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMEBFM" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMEBFZ" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMEBNq" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnMEFkQ" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMEFRZ" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnMEFAs" role="2Oq$k0">
+                <node concept="13iPFW" id="4oS6BnMEFlI" role="2Oq$k0" />
+                <node concept="3TrEf2" id="4oS6BnMEFC3" role="2OqNvi">
+                  <ref role="3Tt5mk" to="yv47:2zwra1$QhMx" resolve="enumType" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="4oS6BnMEOP_" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMEF3a" role="3uHU7B">
+              <node concept="2OqwBi" id="4oS6BnMED5t" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnMEC37" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnMEBNl" role="2Oq$k0" />
+                  <node concept="2yIwOk" id="4oS6BnMECnk" role="2OqNvi" />
+                </node>
+                <node concept="3n3YKJ" id="4oS6BnMEDMZ" role="2OqNvi" />
+              </node>
+              <node concept="Xl_RD" id="4oS6BnMEF3d" role="3uHU7w">
+                <property role="Xl_RC" value="[" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMEBG0" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/org.iets3.core.expr.toplevel.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.toplevel/org.iets3.core.expr.toplevel.mpl
@@ -101,6 +101,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="28583149-5b6e-4663-9c02-b9a8fa3cb099(com.mbeddr.mpsutil.contextactions.runtime)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.behavior.mps
@@ -3072,37 +3072,6 @@
   </node>
   <node concept="13h7C7" id="5Q6EZP6JFxf">
     <ref role="13h7C2" to="i3ya:yGiRIEU5vF" resolve="StripUnitExpression" />
-    <node concept="13i0hz" id="2ZxHat_bRnH" role="13h7CS">
-      <property role="TrG5h" value="getPresentation" />
-      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
-      <node concept="3clFbS" id="2ZxHat_bRnI" role="3clF47">
-        <node concept="3cpWs6" id="2ZxHat_bS24" role="3cqZAp">
-          <node concept="3cpWs3" id="2ZxHat_bS25" role="3cqZAk">
-            <node concept="Xl_RD" id="2ZxHat_bS26" role="3uHU7w">
-              <property role="Xl_RC" value=")" />
-            </node>
-            <node concept="3cpWs3" id="2ZxHat_bS27" role="3uHU7B">
-              <node concept="Xl_RD" id="2ZxHat_bS28" role="3uHU7B">
-                <property role="Xl_RC" value="stripunit(" />
-              </node>
-              <node concept="2OqwBi" id="2ZxHat_bS29" role="3uHU7w">
-                <node concept="2OqwBi" id="2ZxHat_bS2a" role="2Oq$k0">
-                  <node concept="13iPFW" id="2ZxHat_bS2b" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="5Q6EZP6JGff" role="2OqNvi">
-                    <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
-                  </node>
-                </node>
-                <node concept="2qgKlT" id="5Q6EZP6LlLG" role="2OqNvi">
-                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="17QB3L" id="2ZxHat_bRnZ" role="3clF45" />
-      <node concept="3Tm1VV" id="2ZxHat_bRo0" role="1B3o_S" />
-    </node>
     <node concept="13i0hz" id="6kR0qIbI3Os" role="13h7CS">
       <property role="TrG5h" value="renderReadable" />
       <property role="13i0it" value="false" />
@@ -3113,11 +3082,20 @@
         <node concept="3clFbF" id="6kR0qIbI3Rx" role="3cqZAp">
           <node concept="3cpWs3" id="7T0s4RpLLy2" role="3clFbG">
             <node concept="Xl_RD" id="7T0s4RpLLy5" role="3uHU7w">
-              <property role="Xl_RC" value="&gt;" />
+              <property role="Xl_RC" value="]" />
             </node>
             <node concept="3cpWs3" id="7T0s4RpLLp2" role="3uHU7B">
-              <node concept="Xl_RD" id="7T0s4RpLLp5" role="3uHU7B">
-                <property role="Xl_RC" value="strip&lt;" />
+              <node concept="3cpWs3" id="4oS6BnNpNoz" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnNpPh0" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnNpNWC" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnNpNpn" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnNpOx6" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnNpQoz" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="7T0s4RpLLp5" role="3uHU7w">
+                  <property role="Xl_RC" value="[" />
+                </node>
               </node>
               <node concept="2OqwBi" id="7T0s4RpLLi1" role="3uHU7w">
                 <node concept="2OqwBi" id="6kR0qIbI3TV" role="2Oq$k0">
@@ -3905,55 +3883,6 @@
       </node>
       <node concept="10Oyi0" id="5Q6EZP65VML" role="3clF45" />
     </node>
-    <node concept="13i0hz" id="1vlo9S4gMC1" role="13h7CS">
-      <property role="TrG5h" value="getPresentation" />
-      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
-      <node concept="3clFbS" id="1vlo9S4gMEr" role="3clF47">
-        <node concept="3cpWs6" id="1vlo9S4gMQU" role="3cqZAp">
-          <node concept="3cpWs3" id="yGiRIEVw10" role="3cqZAk">
-            <node concept="Xl_RD" id="yGiRIEVw13" role="3uHU7w">
-              <property role="Xl_RC" value=")" />
-            </node>
-            <node concept="3cpWs3" id="1vlo9S4gQvx" role="3uHU7B">
-              <node concept="3cpWs3" id="1vlo9S4gPOl" role="3uHU7B">
-                <node concept="3cpWs3" id="1vlo9S4gO0r" role="3uHU7B">
-                  <node concept="2OqwBi" id="2$As5zwc0NO" role="3uHU7w">
-                    <node concept="2OqwBi" id="1vlo9S4gO7_" role="2Oq$k0">
-                      <node concept="13iPFW" id="1vlo9S4gO0S" role="2Oq$k0" />
-                      <node concept="3TrEf2" id="5Q6EZP65QzC" role="2OqNvi">
-                        <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
-                      </node>
-                    </node>
-                    <node concept="2qgKlT" id="5Q6EZP65RI1" role="2OqNvi">
-                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                    </node>
-                  </node>
-                  <node concept="Xl_RD" id="1vlo9S4gNCR" role="3uHU7B">
-                    <property role="Xl_RC" value="convert(" />
-                  </node>
-                </node>
-                <node concept="Xl_RD" id="1vlo9S4gPUD" role="3uHU7w">
-                  <property role="Xl_RC" value=" -&gt; " />
-                </node>
-              </node>
-              <node concept="2OqwBi" id="1vlo9S4gRCG" role="3uHU7w">
-                <node concept="2OqwBi" id="1vlo9S4gQHh" role="2Oq$k0">
-                  <node concept="13iPFW" id="1vlo9S4gQA9" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="5Q6EZP5YqDY" role="2OqNvi">
-                    <ref role="3Tt5mk" to="i3ya:1BdB9zGazEO" resolve="targetUnit" />
-                  </node>
-                </node>
-                <node concept="2qgKlT" id="15KrVXSHNpX" role="2OqNvi">
-                  <ref role="37wK5l" node="6Yx4TURG_yz" resolve="getName" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="17QB3L" id="1vlo9S4gMQQ" role="3clF45" />
-      <node concept="3Tm1VV" id="1vlo9S4gMQR" role="1B3o_S" />
-    </node>
     <node concept="13i0hz" id="6kR0qIbI0wq" role="13h7CS">
       <property role="TrG5h" value="renderReadable" />
       <property role="13i0it" value="false" />
@@ -3964,13 +3893,22 @@
         <node concept="3clFbF" id="6kR0qIbI0wt" role="3cqZAp">
           <node concept="3cpWs3" id="6kR0qIbI1xu" role="3clFbG">
             <node concept="Xl_RD" id="6kR0qIbI1xx" role="3uHU7w">
-              <property role="Xl_RC" value="&gt;" />
+              <property role="Xl_RC" value="]" />
             </node>
             <node concept="3cpWs3" id="6kR0qIbI1du" role="3uHU7B">
               <node concept="3cpWs3" id="6kR0qIbI17q" role="3uHU7B">
                 <node concept="3cpWs3" id="6kR0qIbI0Tc" role="3uHU7B">
-                  <node concept="Xl_RD" id="6kR0qIbI0Qj" role="3uHU7B">
-                    <property role="Xl_RC" value="convert&lt;" />
+                  <node concept="3cpWs3" id="4oS6BnNpDNF" role="3uHU7B">
+                    <node concept="2OqwBi" id="4oS6BnNpG0A" role="3uHU7B">
+                      <node concept="2OqwBi" id="4oS6BnNpEC4" role="2Oq$k0">
+                        <node concept="13iPFW" id="4oS6BnNpE3a" role="2Oq$k0" />
+                        <node concept="2yIwOk" id="4oS6BnNpFfP" role="2OqNvi" />
+                      </node>
+                      <node concept="3n3YKJ" id="4oS6BnNpH9L" role="2OqNvi" />
+                    </node>
+                    <node concept="Xl_RD" id="6kR0qIbI0Qj" role="3uHU7w">
+                      <property role="Xl_RC" value="[" />
+                    </node>
                   </node>
                   <node concept="2OqwBi" id="1br4Vy9oKg" role="3uHU7w">
                     <node concept="2OqwBi" id="1br4Vy9oKh" role="2Oq$k0">
@@ -20440,37 +20378,6 @@
     <node concept="13hLZK" id="14aBVbMOwMH" role="13h7CW">
       <node concept="3clFbS" id="14aBVbMOwMI" role="2VODD2" />
     </node>
-    <node concept="13i0hz" id="14aBVbMOErS" role="13h7CS">
-      <property role="TrG5h" value="getPresentation" />
-      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
-      <node concept="3clFbS" id="14aBVbMOErT" role="3clF47">
-        <node concept="3cpWs6" id="14aBVbMOErU" role="3cqZAp">
-          <node concept="3cpWs3" id="14aBVbMOErV" role="3cqZAk">
-            <node concept="Xl_RD" id="14aBVbMOErW" role="3uHU7w">
-              <property role="Xl_RC" value=")" />
-            </node>
-            <node concept="3cpWs3" id="14aBVbMOErZ" role="3uHU7B">
-              <node concept="2OqwBi" id="14aBVbMOEs0" role="3uHU7w">
-                <node concept="2OqwBi" id="14aBVbMOEs1" role="2Oq$k0">
-                  <node concept="13iPFW" id="14aBVbMOEs2" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="14aBVbMOEs3" role="2OqNvi">
-                    <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
-                  </node>
-                </node>
-                <node concept="2qgKlT" id="14aBVbMOEs4" role="2OqNvi">
-                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                </node>
-              </node>
-              <node concept="Xl_RD" id="14aBVbMOEs5" role="3uHU7B">
-                <property role="Xl_RC" value="noConvert(" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="17QB3L" id="14aBVbMOEsc" role="3clF45" />
-      <node concept="3Tm1VV" id="14aBVbMOEsd" role="1B3o_S" />
-    </node>
     <node concept="13i0hz" id="14aBVbMOCkG" role="13h7CS">
       <property role="TrG5h" value="renderReadable" />
       <property role="13i0it" value="false" />
@@ -20481,11 +20388,20 @@
         <node concept="3clFbF" id="14aBVbMOCkJ" role="3cqZAp">
           <node concept="3cpWs3" id="14aBVbMOCkK" role="3clFbG">
             <node concept="Xl_RD" id="14aBVbMOCkL" role="3uHU7w">
-              <property role="Xl_RC" value="&gt;" />
+              <property role="Xl_RC" value="]" />
             </node>
             <node concept="3cpWs3" id="14aBVbMOCkO" role="3uHU7B">
-              <node concept="Xl_RD" id="14aBVbMOCkP" role="3uHU7B">
-                <property role="Xl_RC" value="noConvert" />
+              <node concept="3cpWs3" id="4oS6BnNpMF4" role="3uHU7B">
+                <node concept="Xl_RD" id="4oS6BnNpMGc" role="3uHU7w">
+                  <property role="Xl_RC" value="[" />
+                </node>
+                <node concept="2OqwBi" id="4oS6BnNpK69" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnNpIIM" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnNpIax" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnNpJm1" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnNpLeB" role="2OqNvi" />
+                </node>
               </node>
               <node concept="2OqwBi" id="14aBVbMOCkQ" role="3uHU7w">
                 <node concept="2OqwBi" id="14aBVbMOCkR" role="2Oq$k0">
@@ -30160,6 +30076,46 @@
       <node concept="3uibUv" id="4zqoYUyQwIO" role="11_B2D">
         <ref role="3uigEE" node="7i1yFLlKmzB" resolve="DecimalMetricUnitPrefix" />
       </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="4oS6BnNIJk2">
+    <property role="3GE5qa" value="definition.unit" />
+    <ref role="13h7C2" to="i3ya:3V2fk_c6FtV" resolve="AllowNameShadowingAnnotation" />
+    <node concept="13hLZK" id="4oS6BnNIJk3" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnNIJk4" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnNIJkl" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnNIJkK" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNIJkL" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNIKjt" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNJOs8" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNIPAQ" role="3uHU7w">
+              <node concept="2OqwBi" id="4oS6BnNIOPL" role="2Oq$k0">
+                <node concept="13iPFW" id="4oS6BnNIOrB" role="2Oq$k0" />
+                <node concept="1mfA1w" id="4oS6BnNIPeL" role="2OqNvi" />
+              </node>
+              <node concept="2qgKlT" id="4oS6BnNIPRx" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+              </node>
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNIOqT" role="3uHU7B">
+              <node concept="2OqwBi" id="4oS6BnNIM5w" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnNIKxQ" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnNIKjs" role="2Oq$k0" />
+                  <node concept="2yIwOk" id="4oS6BnNILnD" role="2OqNvi" />
+                </node>
+                <node concept="3n3YKJ" id="4oS6BnNIN8w" role="2OqNvi" />
+              </node>
+              <node concept="Xl_RD" id="4oS6BnNJOKM" role="3uHU7w">
+                <property role="Xl_RC" value=" " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnNIJkM" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/org.iets3.core.expr.typetags.physunits.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/org.iets3.core.expr.typetags.physunits.mpl
@@ -110,6 +110,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/models/behavior.mps
@@ -2362,37 +2362,6 @@
   <node concept="13h7C7" id="5Q6EZP6JFxf">
     <property role="3GE5qa" value="conversion" />
     <ref role="13h7C2" to="b0gq:yGiRIEU5vF" resolve="StripUnitExpression" />
-    <node concept="13i0hz" id="2ZxHat_bRnH" role="13h7CS">
-      <property role="TrG5h" value="getPresentation" />
-      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
-      <node concept="3clFbS" id="2ZxHat_bRnI" role="3clF47">
-        <node concept="3cpWs6" id="2ZxHat_bS24" role="3cqZAp">
-          <node concept="3cpWs3" id="2ZxHat_bS25" role="3cqZAk">
-            <node concept="Xl_RD" id="2ZxHat_bS26" role="3uHU7w">
-              <property role="Xl_RC" value=")" />
-            </node>
-            <node concept="3cpWs3" id="2ZxHat_bS27" role="3uHU7B">
-              <node concept="Xl_RD" id="2ZxHat_bS28" role="3uHU7B">
-                <property role="Xl_RC" value="stripunit(" />
-              </node>
-              <node concept="2OqwBi" id="2ZxHat_bS29" role="3uHU7w">
-                <node concept="2OqwBi" id="2ZxHat_bS2a" role="2Oq$k0">
-                  <node concept="13iPFW" id="2ZxHat_bS2b" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="5Q6EZP6JGff" role="2OqNvi">
-                    <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
-                  </node>
-                </node>
-                <node concept="2qgKlT" id="5Q6EZP6LlLG" role="2OqNvi">
-                  <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="17QB3L" id="2ZxHat_bRnZ" role="3clF45" />
-      <node concept="3Tm1VV" id="2ZxHat_bRo0" role="1B3o_S" />
-    </node>
     <node concept="13i0hz" id="6kR0qIbI3Os" role="13h7CS">
       <property role="TrG5h" value="renderReadable" />
       <property role="13i0it" value="false" />
@@ -2403,11 +2372,20 @@
         <node concept="3clFbF" id="6kR0qIbI3Rx" role="3cqZAp">
           <node concept="3cpWs3" id="7T0s4RpLLy2" role="3clFbG">
             <node concept="Xl_RD" id="7T0s4RpLLy5" role="3uHU7w">
-              <property role="Xl_RC" value="&gt;" />
+              <property role="Xl_RC" value="]" />
             </node>
             <node concept="3cpWs3" id="7T0s4RpLLp2" role="3uHU7B">
-              <node concept="Xl_RD" id="7T0s4RpLLp5" role="3uHU7B">
-                <property role="Xl_RC" value="strip&lt;" />
+              <node concept="3cpWs3" id="4oS6BnNp9q4" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnNpbeJ" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnNp9Zj" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnNp9qY" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnNpauz" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnNpc0X" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="7T0s4RpLLp5" role="3uHU7w">
+                  <property role="Xl_RC" value="[" />
+                </node>
               </node>
               <node concept="2OqwBi" id="7T0s4RpLLi1" role="3uHU7w">
                 <node concept="2OqwBi" id="6kR0qIbI3TV" role="2Oq$k0">
@@ -3132,55 +3110,6 @@
       </node>
       <node concept="10Oyi0" id="5Q6EZP65VML" role="3clF45" />
     </node>
-    <node concept="13i0hz" id="1vlo9S4gMC1" role="13h7CS">
-      <property role="TrG5h" value="getPresentation" />
-      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
-      <node concept="3clFbS" id="1vlo9S4gMEr" role="3clF47">
-        <node concept="3cpWs6" id="1vlo9S4gMQU" role="3cqZAp">
-          <node concept="3cpWs3" id="yGiRIEVw10" role="3cqZAk">
-            <node concept="Xl_RD" id="yGiRIEVw13" role="3uHU7w">
-              <property role="Xl_RC" value=")" />
-            </node>
-            <node concept="3cpWs3" id="1vlo9S4gQvx" role="3uHU7B">
-              <node concept="3cpWs3" id="1vlo9S4gPOl" role="3uHU7B">
-                <node concept="3cpWs3" id="1vlo9S4gO0r" role="3uHU7B">
-                  <node concept="2OqwBi" id="2$As5zwc0NO" role="3uHU7w">
-                    <node concept="2OqwBi" id="1vlo9S4gO7_" role="2Oq$k0">
-                      <node concept="13iPFW" id="1vlo9S4gO0S" role="2Oq$k0" />
-                      <node concept="3TrEf2" id="5Q6EZP65QzC" role="2OqNvi">
-                        <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
-                      </node>
-                    </node>
-                    <node concept="2qgKlT" id="5Q6EZP65RI1" role="2OqNvi">
-                      <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                    </node>
-                  </node>
-                  <node concept="Xl_RD" id="1vlo9S4gNCR" role="3uHU7B">
-                    <property role="Xl_RC" value="convert(" />
-                  </node>
-                </node>
-                <node concept="Xl_RD" id="1vlo9S4gPUD" role="3uHU7w">
-                  <property role="Xl_RC" value=" -&gt; " />
-                </node>
-              </node>
-              <node concept="2OqwBi" id="1vlo9S4gRCG" role="3uHU7w">
-                <node concept="2OqwBi" id="1vlo9S4gQHh" role="2Oq$k0">
-                  <node concept="13iPFW" id="1vlo9S4gQA9" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="5Q6EZP5YqDY" role="2OqNvi">
-                    <ref role="3Tt5mk" to="b0gq:3$KQaHc3HJG" resolve="targetUnit" />
-                  </node>
-                </node>
-                <node concept="3TrcHB" id="1vlo9S4gRV5" role="2OqNvi">
-                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="17QB3L" id="1vlo9S4gMQQ" role="3clF45" />
-      <node concept="3Tm1VV" id="1vlo9S4gMQR" role="1B3o_S" />
-    </node>
     <node concept="13i0hz" id="6kR0qIbI0wq" role="13h7CS">
       <property role="TrG5h" value="renderReadable" />
       <property role="13i0it" value="false" />
@@ -3191,13 +3120,22 @@
         <node concept="3clFbF" id="6kR0qIbI0wt" role="3cqZAp">
           <node concept="3cpWs3" id="6kR0qIbI1xu" role="3clFbG">
             <node concept="Xl_RD" id="6kR0qIbI1xx" role="3uHU7w">
-              <property role="Xl_RC" value="&gt;" />
+              <property role="Xl_RC" value="]" />
             </node>
             <node concept="3cpWs3" id="6kR0qIbI1du" role="3uHU7B">
               <node concept="3cpWs3" id="6kR0qIbI17q" role="3uHU7B">
                 <node concept="3cpWs3" id="6kR0qIbI0Tc" role="3uHU7B">
-                  <node concept="Xl_RD" id="6kR0qIbI0Qj" role="3uHU7B">
-                    <property role="Xl_RC" value="convert&lt;" />
+                  <node concept="3cpWs3" id="4oS6BnNox_k" role="3uHU7B">
+                    <node concept="2OqwBi" id="4oS6BnNozvG" role="3uHU7B">
+                      <node concept="2OqwBi" id="4oS6BnNoycw" role="2Oq$k0">
+                        <node concept="13iPFW" id="4oS6BnNoxAy" role="2Oq$k0" />
+                        <node concept="2yIwOk" id="4oS6BnNoyID" role="2OqNvi" />
+                      </node>
+                      <node concept="3n3YKJ" id="4oS6BnNo$jg" role="2OqNvi" />
+                    </node>
+                    <node concept="Xl_RD" id="6kR0qIbI0Qj" role="3uHU7w">
+                      <property role="Xl_RC" value="[" />
+                    </node>
                   </node>
                   <node concept="2OqwBi" id="1br4Vy9oKg" role="3uHU7w">
                     <node concept="2OqwBi" id="1br4Vy9oKh" role="2Oq$k0">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/org.iets3.core.expr.typetags.units.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.units/org.iets3.core.expr.typetags.units.mpl
@@ -104,6 +104,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/models/behavior.mps
@@ -31,9 +31,9 @@
     <import index="u78q" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.typesystem.inference(MPS.Core/)" />
     <import index="xfg9" ref="r:ac28053f-2041-47f6-806b-ecfaca05a64a(org.iets3.core.expr.base.runtime.runtime)" />
     <import index="gdgh" ref="r:e4d9478b-ae0e-416e-be60-73d136571015(org.iets3.core.base.behavior)" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
     <import index="zzzn" ref="r:af0af2e7-f7e1-4536-83b5-6bf010d4afd2(org.iets3.core.expr.lambda.structure)" implicit="true" />
-    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -1051,8 +1051,40 @@
       <node concept="3Tm1VV" id="6kR0qIbHGoX" role="1B3o_S" />
       <node concept="3clFbS" id="6kR0qIbHGoY" role="3clF47">
         <node concept="3clFbF" id="6kR0qIbHGoZ" role="3cqZAp">
-          <node concept="Xl_RD" id="6kR0qIbHGp0" role="3clFbG">
-            <property role="Xl_RC" value="&lt;dectab&gt;" />
+          <node concept="3cpWs3" id="4oS6BnMD5cL" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnMD5cO" role="3uHU7w">
+              <property role="Xl_RC" value="]" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMCUJJ" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMCTIs" role="3uHU7B">
+                <node concept="3cpWs3" id="4oS6BnMC$in" role="3uHU7B">
+                  <node concept="Xl_RD" id="6kR0qIbHGp0" role="3uHU7B">
+                    <property role="Xl_RC" value="dectab[" />
+                  </node>
+                  <node concept="2OqwBi" id="4oS6BnMCULV" role="3uHU7w">
+                    <node concept="2OqwBi" id="4oS6BnMC$PU" role="2Oq$k0">
+                      <node concept="13iPFW" id="4oS6BnMC$iR" role="2Oq$k0" />
+                      <node concept="3Tsc0h" id="4oS6BnMCRhc" role="2OqNvi">
+                        <ref role="3TtcxE" to="kfo3:3DYDRw0K4d1" resolve="rowHeaders" />
+                      </node>
+                    </node>
+                    <node concept="34oBXx" id="4oS6BnMCXgg" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="4oS6BnMCTIv" role="3uHU7w">
+                  <property role="Xl_RC" value="x" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnMD0kz" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnMCXO2" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnMCXhY" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="4oS6BnMCXR5" role="2OqNvi">
+                    <ref role="3TtcxE" to="kfo3:3DYDRw0K4d4" resolve="colHeaders" />
+                  </node>
+                </node>
+                <node concept="34oBXx" id="4oS6BnMD2M8" role="2OqNvi" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -2435,7 +2467,7 @@
       <node concept="3clFbS" id="22hm_0$bcfl" role="3clF47">
         <node concept="3clFbF" id="22hm_0$bcjc" role="3cqZAp">
           <node concept="Xl_RD" id="22hm_0$bcjb" role="3clFbG">
-            <property role="Xl_RC" value="&lt;dectree&gt;" />
+            <property role="Xl_RC" value="dectree" />
           </node>
         </node>
       </node>
@@ -2561,6 +2593,22 @@
         </node>
       </node>
       <node concept="17QB3L" id="HywGhj8qtM" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="4oS6BnM$7sN" role="13h7CS">
+      <property role="TrG5h" value="getPresentation" />
+      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
+      <node concept="3Tm1VV" id="4oS6BnM$7te" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnM$7tf" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnM$8jp" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnM$8wy" role="3clFbG">
+            <node concept="13iPFW" id="4oS6BnM$8jk" role="2Oq$k0" />
+            <node concept="2qgKlT" id="4oS6BnM$8HZ" role="2OqNvi">
+              <ref role="37wK5l" node="HywGhj7Wee" resolve="renderReadable" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnM$7tg" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="HywGhj7VWE">
@@ -2713,8 +2761,40 @@
       <node concept="3Tm1VV" id="8XWEtdZOGz" role="1B3o_S" />
       <node concept="3clFbS" id="8XWEtdZOGA" role="3clF47">
         <node concept="3clFbF" id="8XWEtdZOHi" role="3cqZAp">
-          <node concept="Xl_RD" id="8XWEtdZOHh" role="3clFbG">
-            <property role="Xl_RC" value="&lt;multidectab&gt;" />
+          <node concept="3cpWs3" id="4oS6BnMDYg5" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnMDYg8" role="3uHU7w">
+              <property role="Xl_RC" value="]" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnMDRlW" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnMDRk3" role="3uHU7B">
+                <node concept="3cpWs3" id="4oS6BnMDJzd" role="3uHU7B">
+                  <node concept="Xl_RD" id="8XWEtdZOHh" role="3uHU7B">
+                    <property role="Xl_RC" value="multidectab[" />
+                  </node>
+                  <node concept="2OqwBi" id="4oS6BnMDN0n" role="3uHU7w">
+                    <node concept="2OqwBi" id="4oS6BnMDK8s" role="2Oq$k0">
+                      <node concept="13iPFW" id="4oS6BnMDJzH" role="2Oq$k0" />
+                      <node concept="3Tsc0h" id="4oS6BnMDKP8" role="2OqNvi">
+                        <ref role="3TtcxE" to="kfo3:7FuUjk_57K$" resolve="rows" />
+                      </node>
+                    </node>
+                    <node concept="34oBXx" id="4oS6BnMDOYa" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="4oS6BnMDRk6" role="3uHU7w">
+                  <property role="Xl_RC" value="x" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnMDTmH" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnMDRoN" role="2Oq$k0">
+                  <node concept="13iPFW" id="4oS6BnMDRn$" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="4oS6BnMDRra" role="2OqNvi">
+                    <ref role="3TtcxE" to="kfo3:7FuUjk_57Cw" resolve="colDefs" />
+                  </node>
+                </node>
+                <node concept="34oBXx" id="4oS6BnMDXNb" role="2OqNvi" />
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -5082,9 +5162,60 @@
       <ref role="13i0hy" to="pbu6:6kR0qIbI2yi" resolve="renderReadable" />
       <node concept="3Tm1VV" id="7EKPeISzRSL" role="1B3o_S" />
       <node concept="3clFbS" id="7EKPeISzRSO" role="3clF47">
-        <node concept="3clFbF" id="7EKPeISzRTl" role="3cqZAp">
-          <node concept="Xl_RD" id="7EKPeISzRTk" role="3clFbG">
-            <property role="Xl_RC" value="" />
+        <node concept="3clFbF" id="4oS6BnNwj4A" role="3cqZAp">
+          <node concept="3cpWs3" id="4oS6BnNwD$n" role="3clFbG">
+            <node concept="Xl_RD" id="4oS6BnNwEix" role="3uHU7w">
+              <property role="Xl_RC" value=")" />
+            </node>
+            <node concept="3cpWs3" id="4oS6BnNwo9j" role="3uHU7B">
+              <node concept="3cpWs3" id="4oS6BnNwmaV" role="3uHU7B">
+                <node concept="2OqwBi" id="4oS6BnNwkkt" role="3uHU7B">
+                  <node concept="2OqwBi" id="4oS6BnNwjkp" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnNwj4_" role="2Oq$k0" />
+                    <node concept="2yIwOk" id="4oS6BnNwjAk" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="4oS6BnNwkUG" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="4oS6BnNwmaY" role="3uHU7w">
+                  <property role="Xl_RC" value="(" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4oS6BnNwAdS" role="3uHU7w">
+                <node concept="2OqwBi" id="4oS6BnNwrmh" role="2Oq$k0">
+                  <node concept="2OqwBi" id="4oS6BnNwolY" role="2Oq$k0">
+                    <node concept="13iPFW" id="4oS6BnNwoah" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="4oS6BnNwoS4" role="2OqNvi">
+                      <ref role="3TtcxE" to="kfo3:7EKPeISwid6" resolve="values" />
+                    </node>
+                  </node>
+                  <node concept="3$u5V9" id="4oS6BnNwxOf" role="2OqNvi">
+                    <node concept="1bVj0M" id="4oS6BnNwxOh" role="23t8la">
+                      <node concept="3clFbS" id="4oS6BnNwxOi" role="1bW5cS">
+                        <node concept="3clFbF" id="4oS6BnNwxUP" role="3cqZAp">
+                          <node concept="2OqwBi" id="4oS6BnNwy9c" role="3clFbG">
+                            <node concept="37vLTw" id="4oS6BnNwxUO" role="2Oq$k0">
+                              <ref role="3cqZAo" node="4oS6BnNwxOj" resolve="it" />
+                            </node>
+                            <node concept="2qgKlT" id="4oS6BnNwz$R" role="2OqNvi">
+                              <ref role="37wK5l" node="7lDeIdaByVZ" resolve="renderReadable" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gl6BB" id="4oS6BnNwxOj" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="4oS6BnNwxOk" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3uJxvA" id="4oS6BnNwC8n" role="2OqNvi">
+                  <node concept="Xl_RD" id="4oS6BnNwDw8" role="3uJOhx">
+                    <property role="Xl_RC" value="," />
+                  </node>
+                </node>
+              </node>
+            </node>
           </node>
         </node>
       </node>
@@ -5444,6 +5575,23 @@
   <node concept="13h7C7" id="Nuz63e$fn0">
     <property role="3GE5qa" value="multidectab.expr" />
     <ref role="13h7C2" to="kfo3:Nuz63e$a8H" resolve="SameExpression" />
+    <node concept="13i0hz" id="4oS6BnMEa_d" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMEa_e" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMEa_r" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMEcf6" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMEduQ" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMEcuz" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnMEcf5" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4oS6BnMEcKs" role="2OqNvi" />
+            </node>
+            <node concept="3n3YKJ" id="4oS6BnMEe4P" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="4oS6BnMEa_s" role="3clF45" />
+    </node>
     <node concept="13i0hz" id="Nuz63e$fnb" role="13h7CS">
       <property role="TrG5h" value="effectiveContents" />
       <node concept="3Tm1VV" id="Nuz63e$fnc" role="1B3o_S" />
@@ -5964,11 +6112,11 @@
     <node concept="13hLZK" id="3eH6BL4fX3I" role="13h7CW">
       <node concept="3clFbS" id="3eH6BL4fX3J" role="2VODD2" />
     </node>
-    <node concept="13i0hz" id="3eH6BL4fZuh" role="13h7CS">
-      <property role="TrG5h" value="getPresentation" />
-      <ref role="13i0hy" to="tpcu:hEwIMiw" resolve="getPresentation" />
-      <node concept="3Tm1VV" id="3eH6BL4fZui" role="1B3o_S" />
-      <node concept="3clFbS" id="3eH6BL4fZuy" role="3clF47">
+    <node concept="13i0hz" id="4oS6BnMRWPA" role="13h7CS">
+      <property role="TrG5h" value="renderReadable" />
+      <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
+      <node concept="3Tm1VV" id="4oS6BnMRWPB" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnMRWPO" role="3clF47">
         <node concept="3clFbF" id="3eH6BL4fZF9" role="3cqZAp">
           <node concept="2OqwBi" id="3eH6BL4g0np" role="3clFbG">
             <node concept="2OqwBi" id="3eH6BL4fZUe" role="2Oq$k0">
@@ -5983,7 +6131,7 @@
           </node>
         </node>
       </node>
-      <node concept="17QB3L" id="3eH6BL4fZuz" role="3clF45" />
+      <node concept="17QB3L" id="4oS6BnMRWPP" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/org.iets3.core.expr.util.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.util/org.iets3.core.expr.util.mpl
@@ -91,6 +91,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="120e1c9d-4e27-4478-b2af-b2c3bd3850b0(com.mbeddr.mpsutil.editor.querylist)" version="0" />

--- a/code/languages/org.iets3.opensource/languages/test.ts.expr.os.nix/models/test.ts.expr.os.nix.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/test.ts.expr.os.nix/models/test.ts.expr.os.nix.behavior.mps
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:e165bd55-495b-4540-b305-b4266478685e(org.iets3.core.expr.genjava.stateMachineExample.behavior)">
+<model ref="r:730cc34f-cb3e-4039-b06d-ef031f40e4e8(test.ts.expr.os.nix.behavior)">
   <persistence version="9" />
   <languages>
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
-    <import index="44fz" ref="r:93558715-ee8d-4b41-af94-bc16c022d73d(org.iets3.core.expr.genjava.stateMachineExample.structure)" />
+    <import index="eddd" ref="r:76654092-7126-4d48-8113-566c63e58f87(test.ts.expr.os.nix.structure)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" implicit="true" />
-    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -48,12 +48,8 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
-        <reference id="1138056395725" name="property" index="3TsBF5" />
-      </concept>
-      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
-        <reference id="1138056516764" name="link" index="3Tt5mk" />
-      </concept>
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
+      <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
@@ -61,31 +57,27 @@
       </concept>
     </language>
   </registry>
-  <node concept="13h7C7" id="4oS6BnMOHwY">
-    <ref role="13h7C2" to="44fz:4NM7IHyCGeM" resolve="EventArgRef" />
-    <node concept="13hLZK" id="4oS6BnMOHwZ" role="13h7CW">
-      <node concept="3clFbS" id="4oS6BnMOHx0" role="2VODD2" />
+  <node concept="13h7C7" id="4oS6BnNlaxB">
+    <ref role="13h7C2" to="eddd:7DMIV6UA9Ve" resolve="NixLiteral" />
+    <node concept="13hLZK" id="4oS6BnNlaxC" role="13h7CW">
+      <node concept="3clFbS" id="4oS6BnNlaxD" role="2VODD2" />
     </node>
-    <node concept="13i0hz" id="4oS6BnMSUHA" role="13h7CS">
+    <node concept="13i0hz" id="4oS6BnNla_v" role="13h7CS">
       <property role="TrG5h" value="renderReadable" />
       <ref role="13i0hy" to="pbu6:4Y0vh0cfqjE" resolve="renderReadable" />
-      <node concept="3Tm1VV" id="4oS6BnMSUHB" role="1B3o_S" />
-      <node concept="3clFbS" id="4oS6BnMSUHO" role="3clF47">
-        <node concept="3clFbF" id="4oS6BnMSUOU" role="3cqZAp">
-          <node concept="2OqwBi" id="4oS6BnMSVCA" role="3clFbG">
-            <node concept="2OqwBi" id="4oS6BnMSV4n" role="2Oq$k0">
-              <node concept="13iPFW" id="4oS6BnMSUOT" role="2Oq$k0" />
-              <node concept="3TrEf2" id="4oS6BnMSVjW" role="2OqNvi">
-                <ref role="3Tt5mk" to="44fz:4NM7IHyCGh3" resolve="arg" />
-              </node>
+      <node concept="3Tm1VV" id="4oS6BnNla_w" role="1B3o_S" />
+      <node concept="3clFbS" id="4oS6BnNla_H" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnNlaGN" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnNlc4L" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnNlaZI" role="2Oq$k0">
+              <node concept="13iPFW" id="4oS6BnNlaGM" role="2Oq$k0" />
+              <node concept="2yIwOk" id="4oS6BnNlblw" role="2OqNvi" />
             </node>
-            <node concept="3TrcHB" id="4oS6BnMSVYs" role="2OqNvi">
-              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-            </node>
+            <node concept="3n3YKJ" id="4oS6BnNlc_V" role="2OqNvi" />
           </node>
         </node>
       </node>
-      <node concept="17QB3L" id="4oS6BnMSUHP" role="3clF45" />
+      <node concept="17QB3L" id="4oS6BnNla_I" role="3clF45" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/test.ts.expr.os.nix/test.ts.expr.os.nix.mpl
+++ b/code/languages/org.iets3.opensource/languages/test.ts.expr.os.nix/test.ts.expr.os.nix.mpl
@@ -23,6 +23,7 @@
     <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
+    <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
     <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="14" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.interpreter/org.iets3.core.expr.base.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.interpreter/org.iets3.core.expr.base.interpreter.msd
@@ -39,6 +39,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.runtime/models/runtime.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.runtime/models/runtime.mps
@@ -23,6 +23,8 @@
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
     <import index="pbu6" ref="r:83e946de-2a7f-4a4c-b3c9-4f671aa7f2db(org.iets3.core.expr.base.behavior)" />
     <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
+    <import index="kpbf" ref="7124e466-fc92-4803-a656-d7a6b7eb3910/java:jetbrains.mps.text.impl(MPS.TextGen/)" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -236,6 +238,9 @@
       </concept>
       <concept id="1178893518978" name="jetbrains.mps.baseLanguage.structure.ThisConstructorInvocation" flags="nn" index="1VxSAg" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+      <concept id="1200397529627" name="jetbrains.mps.baseLanguage.structure.CharConstant" flags="nn" index="1Xhbcc">
+        <property id="1200397540847" name="charConstant" index="1XhdNS" />
+      </concept>
       <concept id="8064396509828172209" name="jetbrains.mps.baseLanguage.structure.UnaryMinus" flags="nn" index="1ZRNhn" />
     </language>
     <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
@@ -297,6 +302,7 @@
       <concept id="1145567426890" name="jetbrains.mps.lang.smodel.structure.SNodeListCreator" flags="nn" index="2T8Vx0">
         <child id="1145567471833" name="createdType" index="2T96Bj" />
       </concept>
+      <concept id="1240170042401" name="jetbrains.mps.lang.smodel.structure.SEnumerationMemberType" flags="in" index="2ZThk1" />
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
@@ -336,6 +342,14 @@
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
+        <child id="1153944400369" name="variable" index="2Gsz3X" />
+        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
+      </concept>
+      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
+        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
+      </concept>
       <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
       <concept id="1235566831861" name="jetbrains.mps.baseLanguage.collections.structure.AllOperation" flags="nn" index="2HxqBE" />
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
@@ -362,7 +376,9 @@
       </concept>
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
+      <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
         <child id="1197932505799" name="map" index="3ElQJh" />
         <child id="1197932525128" name="key" index="3ElVtu" />
@@ -5390,6 +5406,755 @@
       </node>
     </node>
     <node concept="2tJIrI" id="5dSoB2LVCju" role="jymVt" />
+  </node>
+  <node concept="312cEu" id="4oS6BnMcix1">
+    <property role="TrG5h" value="StringRepresentation" />
+    <node concept="2tJIrI" id="4oS6BnMcj2h" role="jymVt" />
+    <node concept="3clFbW" id="4oS6BnMcMsd" role="jymVt">
+      <node concept="3cqZAl" id="4oS6BnMcMse" role="3clF45" />
+      <node concept="3clFbS" id="4oS6BnMcMsg" role="3clF47">
+        <node concept="1VxSAg" id="4oS6BnMcMvH" role="3cqZAp">
+          <ref role="37wK5l" node="4oS6BnMcj2J" resolve="StringRepresentation" />
+          <node concept="3cmrfG" id="4oS6BnMcMx_" role="37wK5m">
+            <property role="3cmrfH" value="16" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMcMp4" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMd2W$" role="jymVt" />
+    <node concept="3clFbW" id="4oS6BnMd2Zk" role="jymVt">
+      <node concept="3cqZAl" id="4oS6BnMd2Zl" role="3clF45" />
+      <node concept="3clFbS" id="4oS6BnMd2Zm" role="3clF47">
+        <node concept="XkiVB" id="4oS6BnMd3eE" role="3cqZAp">
+          <ref role="37wK5l" to="kpbf:~TextAreaImpl.&lt;init&gt;(java.lang.StringBuilder,java.lang.String,char,int)" resolve="TextAreaImpl" />
+          <node concept="2ShNRf" id="4oS6BnMd3i5" role="37wK5m">
+            <node concept="1pGfFk" id="4oS6BnMd3vU" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;(java.lang.String)" resolve="StringBuilder" />
+              <node concept="37vLTw" id="4oS6BnMd3zl" role="37wK5m">
+                <ref role="3cqZAo" node="4oS6BnMd37j" resolve="initialText" />
+              </node>
+            </node>
+          </node>
+          <node concept="Xl_RD" id="4oS6BnMd3IP" role="37wK5m">
+            <property role="Xl_RC" value="\n" />
+          </node>
+          <node concept="1Xhbcc" id="4oS6BnMd3N9" role="37wK5m">
+            <property role="1XhdNS" value=" " />
+          </node>
+          <node concept="3cmrfG" id="4oS6BnMd3Q7" role="37wK5m">
+            <property role="3cmrfH" value="2" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMd2Zp" role="1B3o_S" />
+      <node concept="37vLTG" id="4oS6BnMd37j" role="3clF46">
+        <property role="TrG5h" value="initialText" />
+        <node concept="17QB3L" id="4oS6BnMd37i" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMcMlS" role="jymVt" />
+    <node concept="3clFbW" id="4oS6BnMcj2J" role="jymVt">
+      <node concept="3cqZAl" id="4oS6BnMcj2K" role="3clF45" />
+      <node concept="3clFbS" id="4oS6BnMcj2M" role="3clF47">
+        <node concept="XkiVB" id="4oS6BnMcj40" role="3cqZAp">
+          <ref role="37wK5l" to="kpbf:~TextAreaImpl.&lt;init&gt;(java.lang.StringBuilder,java.lang.String,char,int)" resolve="TextAreaImpl" />
+          <node concept="2ShNRf" id="4oS6BnMcj5m" role="37wK5m">
+            <node concept="1pGfFk" id="4oS6BnMcjih" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="wyt6:~StringBuilder.&lt;init&gt;(int)" resolve="StringBuilder" />
+              <node concept="37vLTw" id="4oS6BnMcjjI" role="37wK5m">
+                <ref role="3cqZAo" node="4oS6BnMcj3d" resolve="size" />
+              </node>
+            </node>
+          </node>
+          <node concept="Xl_RD" id="4oS6BnMcjlj" role="37wK5m">
+            <property role="Xl_RC" value="\n" />
+          </node>
+          <node concept="1Xhbcc" id="4oS6BnMcjmT" role="37wK5m">
+            <property role="1XhdNS" value=" " />
+          </node>
+          <node concept="3cmrfG" id="4oS6BnMcjpS" role="37wK5m">
+            <property role="3cmrfH" value="2" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMcj2_" role="1B3o_S" />
+      <node concept="37vLTG" id="4oS6BnMcj3d" role="3clF46">
+        <property role="TrG5h" value="size" />
+        <node concept="10Oyi0" id="4oS6BnMcj3c" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMcj$L" role="jymVt" />
+    <node concept="2YIFZL" id="4oS6BnMcjBJ" role="jymVt">
+      <property role="TrG5h" value="forShortSentence" />
+      <node concept="3clFbS" id="4oS6BnMcjBM" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMcjDv" role="3cqZAp">
+          <node concept="2ShNRf" id="4oS6BnMcjDt" role="3clFbG">
+            <node concept="1pGfFk" id="4oS6BnMck2I" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" node="4oS6BnMcj2J" resolve="StringRepresentation" />
+              <node concept="3cmrfG" id="4oS6BnMck4q" role="37wK5m">
+                <property role="3cmrfH" value="32" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMcj_Z" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMcjBn" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMck5C" role="jymVt" />
+    <node concept="2YIFZL" id="4oS6BnMcka3" role="jymVt">
+      <property role="TrG5h" value="forSentence" />
+      <node concept="3clFbS" id="4oS6BnMcka6" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMckcm" role="3cqZAp">
+          <node concept="2ShNRf" id="4oS6BnMckck" role="3clFbG">
+            <node concept="1pGfFk" id="4oS6BnMck__" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" node="4oS6BnMcj2J" resolve="StringRepresentation" />
+              <node concept="3cmrfG" id="4oS6BnMckNL" role="37wK5m">
+                <property role="3cmrfH" value="64" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMck7n" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMck9q" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMckXj" role="jymVt" />
+    <node concept="2YIFZL" id="4oS6BnMcl4R" role="jymVt">
+      <property role="TrG5h" value="forMultipleSentences" />
+      <node concept="3clFbS" id="4oS6BnMcl4U" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMcl7B" role="3cqZAp">
+          <node concept="2ShNRf" id="4oS6BnMcl7_" role="3clFbG">
+            <node concept="1pGfFk" id="4oS6BnMclkx" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" node="4oS6BnMcj2J" resolve="StringRepresentation" />
+              <node concept="3cmrfG" id="4oS6BnMclnu" role="37wK5m">
+                <property role="3cmrfH" value="128" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMcl1_" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMcl3X" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMclyO" role="jymVt" />
+    <node concept="2YIFZL" id="4oS6BnMclDB" role="jymVt">
+      <property role="TrG5h" value="forALotOfText" />
+      <node concept="3clFbS" id="4oS6BnMclDE" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMclGR" role="3cqZAp">
+          <node concept="2ShNRf" id="4oS6BnMclGP" role="3clFbG">
+            <node concept="1pGfFk" id="4oS6BnMclVY" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" node="4oS6BnMcj2J" resolve="StringRepresentation" />
+              <node concept="3cmrfG" id="4oS6BnMclWS" role="37wK5m">
+                <property role="3cmrfH" value="2048" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMcl_x" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMclCs" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMfmHN" role="jymVt" />
+    <node concept="3clFb_" id="4oS6BnMfnH9" role="jymVt">
+      <property role="TrG5h" value="appendWithSpace" />
+      <node concept="3clFbS" id="4oS6BnMfnHc" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMfoGJ" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMfoGI" role="3clFbG">
+            <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+            <node concept="Xl_RD" id="4oS6BnMfp1f" role="37wK5m">
+              <property role="Xl_RC" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMfpKi" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMfpKg" role="3clFbG">
+            <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+            <node concept="37vLTw" id="4oS6BnMfq7k" role="37wK5m">
+              <ref role="3cqZAo" node="4oS6BnMfoqb" resolve="seq" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMfra8" role="3cqZAp">
+          <node concept="Xjq3P" id="4oS6BnMfra6" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMfnns" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMfnBd" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+      <node concept="37vLTG" id="4oS6BnMfoqb" role="3clF46">
+        <property role="TrG5h" value="seq" />
+        <node concept="3uibUv" id="4oS6BnMfoqa" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~CharSequence" resolve="CharSequence" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMft94" role="jymVt" />
+    <node concept="3clFb_" id="4oS6BnMeeyx" role="jymVt">
+      <property role="TrG5h" value="appendVertically" />
+      <node concept="3clFbS" id="4oS6BnMeey$" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMegGX" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMegGW" role="3clFbG">
+            <ref role="37wK5l" node="4oS6BnMfzqu" resolve="appendNodes" />
+            <node concept="37vLTw" id="4oS6BnMegT2" role="37wK5m">
+              <ref role="3cqZAo" node="4oS6BnMegqE" resolve="nodes" />
+            </node>
+            <node concept="Xl_RD" id="4oS6BnMehbP" role="37wK5m">
+              <property role="Xl_RC" value="\n" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMeelG" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMeeuY" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+      <node concept="37vLTG" id="4oS6BnMegqE" role="3clF46">
+        <property role="TrG5h" value="nodes" />
+        <node concept="A3Dl8" id="4oS6BnMeA2a" role="1tU5fm">
+          <node concept="3Tqbb2" id="4oS6BnMeAeX" role="A3Ik2" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMeBzB" role="jymVt" />
+    <node concept="3clFb_" id="4oS6BnMfukf" role="jymVt">
+      <property role="TrG5h" value="appendVerticallyWithSpace" />
+      <node concept="3clFbS" id="4oS6BnMfukg" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMfwam" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMfwak" role="3clFbG">
+            <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+            <node concept="Xl_RD" id="4oS6BnMfwFn" role="37wK5m">
+              <property role="Xl_RC" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMfBrL" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMfBrJ" role="3clFbG">
+            <ref role="37wK5l" node="4oS6BnMeeyx" resolve="appendVertically" />
+            <node concept="37vLTw" id="4oS6BnMfBZi" role="37wK5m">
+              <ref role="3cqZAo" node="4oS6BnMfukn" resolve="nodes" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMfukl" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMfukm" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+      <node concept="37vLTG" id="4oS6BnMfukn" role="3clF46">
+        <property role="TrG5h" value="nodes" />
+        <node concept="A3Dl8" id="4oS6BnMfuko" role="1tU5fm">
+          <node concept="3Tqbb2" id="4oS6BnMfukp" role="A3Ik2" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMfu2x" role="jymVt" />
+    <node concept="3clFb_" id="4oS6BnMeBiR" role="jymVt">
+      <property role="TrG5h" value="appendHorizontally" />
+      <node concept="3clFbS" id="4oS6BnMeBiS" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMeBiT" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMeBiU" role="3clFbG">
+            <ref role="37wK5l" node="4oS6BnMfzqu" resolve="appendNodes" />
+            <node concept="37vLTw" id="4oS6BnMeBiV" role="37wK5m">
+              <ref role="3cqZAo" node="4oS6BnMeBiZ" resolve="nodes" />
+            </node>
+            <node concept="Xl_RD" id="4oS6BnMeBiW" role="37wK5m">
+              <property role="Xl_RC" value=" " />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMeBiX" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMeBiY" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+      <node concept="37vLTG" id="4oS6BnMeBiZ" role="3clF46">
+        <property role="TrG5h" value="nodes" />
+        <node concept="A3Dl8" id="4oS6BnMeBj0" role="1tU5fm">
+          <node concept="3Tqbb2" id="4oS6BnMeBj1" role="A3Ik2" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMfxEr" role="jymVt" />
+    <node concept="3clFb_" id="4oS6BnMfxgk" role="jymVt">
+      <property role="TrG5h" value="appendHorizontallyWithSpace" />
+      <node concept="3clFbS" id="4oS6BnMfxgl" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMfyHT" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMfyHR" role="3clFbG">
+            <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+            <node concept="Xl_RD" id="4oS6BnMfz4L" role="37wK5m">
+              <property role="Xl_RC" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMfG_V" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMfG_T" role="3clFbG">
+            <ref role="37wK5l" node="4oS6BnMeBiR" resolve="appendHorizontally" />
+            <node concept="37vLTw" id="4oS6BnMfH7W" role="37wK5m">
+              <ref role="3cqZAo" node="4oS6BnMfxgs" resolve="nodes" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMfxgq" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMfxgr" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+      <node concept="37vLTG" id="4oS6BnMfxgs" role="3clF46">
+        <property role="TrG5h" value="nodes" />
+        <node concept="A3Dl8" id="4oS6BnMfxgt" role="1tU5fm">
+          <node concept="3Tqbb2" id="4oS6BnMfxgu" role="A3Ik2" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMi1NZ" role="jymVt" />
+    <node concept="3clFb_" id="4oS6BnMjbhG" role="jymVt">
+      <property role="TrG5h" value="append" />
+      <node concept="3clFbS" id="4oS6BnMjbhH" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMjbhL" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMjbhM" role="3clFbG">
+            <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+            <node concept="2YIFZM" id="4oS6BnMjbhN" role="37wK5m">
+              <ref role="37wK5l" to="wyt6:~String.valueOf(int)" resolve="valueOf" />
+              <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+              <node concept="37vLTw" id="4oS6BnMjbhO" role="37wK5m">
+                <ref role="3cqZAo" node="4oS6BnMjbhT" resolve="number" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMjbhP" role="3cqZAp">
+          <node concept="Xjq3P" id="4oS6BnMjbhQ" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMjbhR" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMjbhS" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+      <node concept="37vLTG" id="4oS6BnMjbhT" role="3clF46">
+        <property role="TrG5h" value="number" />
+        <node concept="10Oyi0" id="4oS6BnMjbhU" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMjaog" role="jymVt" />
+    <node concept="3clFb_" id="4oS6BnMi0im" role="jymVt">
+      <property role="TrG5h" value="appendWithSpace" />
+      <node concept="3clFbS" id="4oS6BnMi0in" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMi0io" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMi0ip" role="3clFbG">
+            <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+            <node concept="Xl_RD" id="4oS6BnMi0iq" role="37wK5m">
+              <property role="Xl_RC" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMi0ir" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMi0is" role="3clFbG">
+            <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+            <node concept="2YIFZM" id="4oS6BnMi771" role="37wK5m">
+              <ref role="37wK5l" to="wyt6:~String.valueOf(int)" resolve="valueOf" />
+              <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+              <node concept="37vLTw" id="4oS6BnMi8I1" role="37wK5m">
+                <ref role="3cqZAo" node="4oS6BnMi0iw" resolve="number" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMihhn" role="3cqZAp">
+          <node concept="Xjq3P" id="4oS6BnMihhl" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMi0iu" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMi0iv" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+      <node concept="37vLTG" id="4oS6BnMi0iw" role="3clF46">
+        <property role="TrG5h" value="number" />
+        <node concept="10Oyi0" id="4oS6BnMi3os" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMedYB" role="jymVt" />
+    <node concept="3clFb_" id="4oS6BnMgdrs" role="jymVt">
+      <property role="TrG5h" value="append" />
+      <node concept="3clFbS" id="4oS6BnMgdrt" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMgjLS" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMgjLQ" role="3clFbG">
+            <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+            <node concept="2OqwBi" id="4oS6BnMgmrN" role="37wK5m">
+              <node concept="37vLTw" id="4oS6BnMgkzJ" role="2Oq$k0">
+                <ref role="3cqZAo" node="4oS6BnMgdrI" resolve="node" />
+              </node>
+              <node concept="2qgKlT" id="4oS6BnMgn4O" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMgsCp" role="3cqZAp">
+          <node concept="Xjq3P" id="4oS6BnMgsCn" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMgdrG" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMgdrH" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+      <node concept="37vLTG" id="4oS6BnMgdrI" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="4oS6BnMghQq" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMh1MR" role="jymVt" />
+    <node concept="3clFb_" id="4oS6BnMgZBe" role="jymVt">
+      <property role="TrG5h" value="appendWithSpace" />
+      <node concept="3clFbS" id="4oS6BnMgZBf" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMh6rs" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMh6rq" role="3clFbG">
+            <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+            <node concept="Xl_RD" id="4oS6BnMh781" role="37wK5m">
+              <property role="Xl_RC" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMhaoG" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMhaoE" role="3clFbG">
+            <ref role="37wK5l" node="4oS6BnMgdrs" resolve="append" />
+            <node concept="37vLTw" id="4oS6BnMhbSo" role="37wK5m">
+              <ref role="3cqZAo" node="4oS6BnMgZBp" resolve="node" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMgZBn" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMgZBo" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+      <node concept="37vLTG" id="4oS6BnMgZBp" role="3clF46">
+        <property role="TrG5h" value="node" />
+        <node concept="3Tqbb2" id="4oS6BnMgZBq" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMgPzN" role="jymVt" />
+    <node concept="3clFb_" id="4oS6BnMgGx8" role="jymVt">
+      <property role="TrG5h" value="append" />
+      <node concept="3clFbS" id="4oS6BnMgGx9" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMgGxa" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMgGxb" role="3clFbG">
+            <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+            <node concept="2OqwBi" id="4oS6BnMgGxc" role="37wK5m">
+              <node concept="37vLTw" id="4oS6BnMgGxd" role="2Oq$k0">
+                <ref role="3cqZAo" node="4oS6BnMgGxj" resolve="node" />
+              </node>
+              <node concept="liA8E" id="4oS6BnMgLHO" role="2OqNvi">
+                <ref role="37wK5l" to="c17a:~SEnumerationLiteral.getPresentation()" resolve="getPresentation" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMgGxf" role="3cqZAp">
+          <node concept="Xjq3P" id="4oS6BnMgGxg" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMgGxh" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMgGxi" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+      <node concept="37vLTG" id="4oS6BnMgGxj" role="3clF46">
+        <property role="TrG5h" value="enumMember" />
+        <node concept="2ZThk1" id="4oS6BnMgJgM" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMgRsM" role="jymVt" />
+    <node concept="3clFb_" id="4oS6BnMgQjs" role="jymVt">
+      <property role="TrG5h" value="appendWithSpace" />
+      <node concept="3clFbS" id="4oS6BnMgQjt" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMgUJm" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMgUJk" role="3clFbG">
+            <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+            <node concept="2OqwBi" id="4oS6BnMgWe4" role="37wK5m">
+              <node concept="37vLTw" id="4oS6BnMgVrL" role="2Oq$k0">
+                <ref role="3cqZAo" node="4oS6BnMgQjB" resolve="enumMember" />
+              </node>
+              <node concept="liA8E" id="4oS6BnMgWWE" role="2OqNvi">
+                <ref role="37wK5l" to="c17a:~SEnumerationLiteral.getPresentation()" resolve="getPresentation" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMgQjz" role="3cqZAp">
+          <node concept="Xjq3P" id="4oS6BnMgQj$" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMgQj_" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMgQjA" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+      <node concept="37vLTG" id="4oS6BnMgQjB" role="3clF46">
+        <property role="TrG5h" value="enumMember" />
+        <node concept="2ZThk1" id="4oS6BnMgQjC" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMgdrr" role="jymVt" />
+    <node concept="3clFb_" id="4oS6BnMdvcE" role="jymVt">
+      <property role="TrG5h" value="append" />
+      <node concept="3clFbS" id="4oS6BnMdvcH" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMemO5" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMemO3" role="3clFbG">
+            <ref role="37wK5l" node="4oS6BnMehtj" resolve="appenList" />
+            <node concept="2OqwBi" id="4oS6BnMeosg" role="37wK5m">
+              <node concept="37vLTw" id="4oS6BnMen8b" role="2Oq$k0">
+                <ref role="3cqZAo" node="4oS6BnMdvit" resolve="nodes" />
+              </node>
+              <node concept="3$u5V9" id="4oS6BnMeqn1" role="2OqNvi">
+                <node concept="1bVj0M" id="4oS6BnMeqn3" role="23t8la">
+                  <node concept="3clFbS" id="4oS6BnMeqn4" role="1bW5cS">
+                    <node concept="3clFbF" id="4oS6BnMet1s" role="3cqZAp">
+                      <node concept="2OqwBi" id="4oS6BnMet_D" role="3clFbG">
+                        <node concept="37vLTw" id="4oS6BnMet1r" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4oS6BnMeqn5" resolve="it" />
+                        </node>
+                        <node concept="2qgKlT" id="4oS6BnMexlf" role="2OqNvi">
+                          <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="4oS6BnMeqn5" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="4oS6BnMeqn6" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="4oS6BnMeyGv" role="37wK5m">
+              <ref role="3cqZAo" node="4oS6BnMdvqK" resolve="separator" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMduqY" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMdv3e" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+      <node concept="37vLTG" id="4oS6BnMdvit" role="3clF46">
+        <property role="TrG5h" value="nodes" />
+        <node concept="A3Dl8" id="4oS6BnMe_7U" role="1tU5fm">
+          <node concept="3Tqbb2" id="4oS6BnMe_7W" role="A3Ik2" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4oS6BnMdvqK" role="3clF46">
+        <property role="TrG5h" value="separator" />
+        <node concept="3uibUv" id="4oS6BnMdEEo" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~CharSequence" resolve="CharSequence" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMgclf" role="jymVt" />
+    <node concept="3clFb_" id="4oS6BnMfzqu" role="jymVt">
+      <property role="TrG5h" value="appendWithSpace" />
+      <node concept="3clFbS" id="4oS6BnMfzqv" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMf_VS" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMf_VQ" role="3clFbG">
+            <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+            <node concept="Xl_RD" id="4oS6BnMfAox" role="37wK5m">
+              <property role="Xl_RC" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMfICE" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMfICC" role="3clFbG">
+            <ref role="37wK5l" node="4oS6BnMdvcE" resolve="appendNodes" />
+            <node concept="37vLTw" id="4oS6BnMfJc1" role="37wK5m">
+              <ref role="3cqZAo" node="4oS6BnMfzqK" resolve="nodes" />
+            </node>
+            <node concept="37vLTw" id="4oS6BnMfJE1" role="37wK5m">
+              <ref role="3cqZAo" node="4oS6BnMfzqN" resolve="separator" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMfzqI" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMfzqJ" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+      <node concept="37vLTG" id="4oS6BnMfzqK" role="3clF46">
+        <property role="TrG5h" value="nodes" />
+        <node concept="A3Dl8" id="4oS6BnMfzqL" role="1tU5fm">
+          <node concept="3Tqbb2" id="4oS6BnMfzqM" role="A3Ik2" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="4oS6BnMfzqN" role="3clF46">
+        <property role="TrG5h" value="separator" />
+        <node concept="3uibUv" id="4oS6BnMfzqO" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~CharSequence" resolve="CharSequence" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMei0S" role="jymVt" />
+    <node concept="3clFb_" id="4oS6BnMehtj" role="jymVt">
+      <property role="TrG5h" value="appendList" />
+      <node concept="3clFbS" id="4oS6BnMehtk" role="3clF47">
+        <node concept="3cpWs8" id="4oS6BnMehtl" role="3cqZAp">
+          <node concept="3cpWsn" id="4oS6BnMehtm" role="3cpWs9">
+            <property role="TrG5h" value="last" />
+            <node concept="2OqwBi" id="4oS6BnMehto" role="33vP2m">
+              <node concept="37vLTw" id="4oS6BnMehtp" role="2Oq$k0">
+                <ref role="3cqZAo" node="4oS6BnMehtK" resolve="nodes" />
+              </node>
+              <node concept="1yVyf7" id="4oS6BnMehtq" role="2OqNvi" />
+            </node>
+            <node concept="3uibUv" id="4oS6BnMelUG" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~CharSequence" resolve="CharSequence" />
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="4oS6BnMehtr" role="3cqZAp">
+          <node concept="2GrKxI" id="4oS6BnMehts" role="2Gsz3X">
+            <property role="TrG5h" value="item" />
+          </node>
+          <node concept="37vLTw" id="4oS6BnMehtt" role="2GsD0m">
+            <ref role="3cqZAo" node="4oS6BnMehtK" resolve="nodes" />
+          </node>
+          <node concept="3clFbS" id="4oS6BnMehtu" role="2LFqv$">
+            <node concept="3clFbF" id="4oS6BnMehtv" role="3cqZAp">
+              <node concept="1rXfSq" id="4oS6BnMehtw" role="3clFbG">
+                <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+                <node concept="2GrUjf" id="4oS6BnMehty" role="37wK5m">
+                  <ref role="2Gs0qQ" node="4oS6BnMehts" resolve="item" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="4oS6BnMeht$" role="3cqZAp">
+              <node concept="3clFbS" id="4oS6BnMeht_" role="3clFbx">
+                <node concept="3clFbF" id="4oS6BnMehtA" role="3cqZAp">
+                  <node concept="1rXfSq" id="4oS6BnMehtB" role="3clFbG">
+                    <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+                    <node concept="37vLTw" id="4oS6BnMehtC" role="37wK5m">
+                      <ref role="3cqZAo" node="4oS6BnMehtM" resolve="separator" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3y3z36" id="4oS6BnMehtD" role="3clFbw">
+                <node concept="37vLTw" id="4oS6BnMehtE" role="3uHU7w">
+                  <ref role="3cqZAo" node="4oS6BnMehtm" resolve="last" />
+                </node>
+                <node concept="2GrUjf" id="4oS6BnMehtF" role="3uHU7B">
+                  <ref role="2Gs0qQ" node="4oS6BnMehts" resolve="item" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="4oS6BnMehtG" role="3cqZAp">
+          <node concept="Xjq3P" id="4oS6BnMehtH" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMehtI" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMehtJ" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+      <node concept="37vLTG" id="4oS6BnMehtK" role="3clF46">
+        <property role="TrG5h" value="nodes" />
+        <node concept="A3Dl8" id="4oS6BnMe$Rd" role="1tU5fm">
+          <node concept="3uibUv" id="4oS6BnMe$Rf" role="A3Ik2">
+            <ref role="3uigEE" to="wyt6:~CharSequence" resolve="CharSequence" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4oS6BnMehtM" role="3clF46">
+        <property role="TrG5h" value="separator" />
+        <node concept="3uibUv" id="4oS6BnMehtN" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~CharSequence" resolve="CharSequence" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMfKYr" role="jymVt" />
+    <node concept="3clFb_" id="4oS6BnMfM6E" role="jymVt">
+      <property role="TrG5h" value="appendListWithSpace" />
+      <node concept="37vLTG" id="4oS6BnMfM$W" role="3clF46">
+        <property role="TrG5h" value="nodes" />
+        <node concept="A3Dl8" id="4oS6BnMfM$X" role="1tU5fm">
+          <node concept="3uibUv" id="4oS6BnMfM$Y" role="A3Ik2">
+            <ref role="3uigEE" to="wyt6:~CharSequence" resolve="CharSequence" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4oS6BnMfMY9" role="3clF46">
+        <property role="TrG5h" value="separator" />
+        <node concept="3uibUv" id="4oS6BnMfMYa" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~CharSequence" resolve="CharSequence" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="4oS6BnMfM6H" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMfNLX" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMfNLW" role="3clFbG">
+            <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
+            <node concept="Xl_RD" id="4oS6BnMfOr9" role="37wK5m">
+              <property role="Xl_RC" value=" " />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4oS6BnMfPgo" role="3cqZAp">
+          <node concept="1rXfSq" id="4oS6BnMfPgm" role="3clFbG">
+            <ref role="37wK5l" node="4oS6BnMehtj" resolve="appendList" />
+            <node concept="37vLTw" id="4oS6BnMfPO8" role="37wK5m">
+              <ref role="3cqZAo" node="4oS6BnMfM$W" resolve="nodes" />
+            </node>
+            <node concept="37vLTw" id="4oS6BnMfQik" role="37wK5m">
+              <ref role="3cqZAo" node="4oS6BnMfMY9" resolve="separator" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4oS6BnMfLsw" role="1B3o_S" />
+      <node concept="3uibUv" id="4oS6BnMfLUE" role="3clF45">
+        <ref role="3uigEE" node="4oS6BnMcix1" resolve="StringRepresentation" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4oS6BnMUQrb" role="jymVt" />
+    <node concept="3Tm1VV" id="4oS6BnMcix2" role="1B3o_S" />
+    <node concept="3uibUv" id="4oS6BnMciym" role="1zkMxy">
+      <ref role="3uigEE" to="kpbf:~TextAreaImpl" resolve="TextAreaImpl" />
+    </node>
+    <node concept="3clFb_" id="4oS6BnMUIdM" role="jymVt">
+      <property role="TrG5h" value="toString" />
+      <node concept="3Tm1VV" id="4oS6BnMUIdN" role="1B3o_S" />
+      <node concept="17QB3L" id="4oS6BnMVv_y" role="3clF45" />
+      <node concept="3clFbS" id="4oS6BnMUIdS" role="3clF47">
+        <node concept="3clFbF" id="4oS6BnMUVsO" role="3cqZAp">
+          <node concept="2OqwBi" id="4oS6BnMVbFy" role="3clFbG">
+            <node concept="2OqwBi" id="4oS6BnMUVVS" role="2Oq$k0">
+              <node concept="Xjq3P" id="4oS6BnMUVsN" role="2Oq$k0" />
+              <node concept="liA8E" id="4oS6BnMUZMw" role="2OqNvi">
+                <ref role="37wK5l" to="kpbf:~TextAreaImpl.value()" resolve="value" />
+              </node>
+            </node>
+            <node concept="liA8E" id="4oS6BnMVfuK" role="2OqNvi">
+              <ref role="37wK5l" to="wyt6:~CharSequence.toString()" resolve="toString" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="4oS6BnMUIdT" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.runtime/models/runtime.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.runtime/models/runtime.mps
@@ -5611,7 +5611,7 @@
       <node concept="3clFbS" id="4oS6BnMeey$" role="3clF47">
         <node concept="3clFbF" id="4oS6BnMegGX" role="3cqZAp">
           <node concept="1rXfSq" id="4oS6BnMegGW" role="3clFbG">
-            <ref role="37wK5l" node="4oS6BnMfzqu" resolve="appendNodes" />
+            <ref role="37wK5l" node="4oS6BnMfzqu" resolve="appendWithSpace" />
             <node concept="37vLTw" id="4oS6BnMegT2" role="37wK5m">
               <ref role="3cqZAo" node="4oS6BnMegqE" resolve="nodes" />
             </node>
@@ -5670,7 +5670,7 @@
       <node concept="3clFbS" id="4oS6BnMeBiS" role="3clF47">
         <node concept="3clFbF" id="4oS6BnMeBiT" role="3cqZAp">
           <node concept="1rXfSq" id="4oS6BnMeBiU" role="3clFbG">
-            <ref role="37wK5l" node="4oS6BnMfzqu" resolve="appendNodes" />
+            <ref role="37wK5l" node="4oS6BnMfzqu" resolve="appendWithSpace" />
             <node concept="37vLTw" id="4oS6BnMeBiV" role="37wK5m">
               <ref role="3cqZAo" node="4oS6BnMeBiZ" resolve="nodes" />
             </node>
@@ -5858,7 +5858,7 @@
             <ref role="37wK5l" to="kpbf:~TextAreaImpl.append(java.lang.CharSequence)" resolve="append" />
             <node concept="2OqwBi" id="4oS6BnMgGxc" role="37wK5m">
               <node concept="37vLTw" id="4oS6BnMgGxd" role="2Oq$k0">
-                <ref role="3cqZAo" node="4oS6BnMgGxj" resolve="node" />
+                <ref role="3cqZAo" node="4oS6BnMgGxj" resolve="enumMember" />
               </node>
               <node concept="liA8E" id="4oS6BnMgLHO" role="2OqNvi">
                 <ref role="37wK5l" to="c17a:~SEnumerationLiteral.getPresentation()" resolve="getPresentation" />
@@ -5915,7 +5915,7 @@
       <node concept="3clFbS" id="4oS6BnMdvcH" role="3clF47">
         <node concept="3clFbF" id="4oS6BnMemO5" role="3cqZAp">
           <node concept="1rXfSq" id="4oS6BnMemO3" role="3clFbG">
-            <ref role="37wK5l" node="4oS6BnMehtj" resolve="appenList" />
+            <ref role="37wK5l" node="4oS6BnMehtj" resolve="appendList" />
             <node concept="2OqwBi" id="4oS6BnMeosg" role="37wK5m">
               <node concept="37vLTw" id="4oS6BnMen8b" role="2Oq$k0">
                 <ref role="3cqZAo" node="4oS6BnMdvit" resolve="nodes" />
@@ -5978,7 +5978,7 @@
         </node>
         <node concept="3clFbF" id="4oS6BnMfICE" role="3cqZAp">
           <node concept="1rXfSq" id="4oS6BnMfICC" role="3clFbG">
-            <ref role="37wK5l" node="4oS6BnMdvcE" resolve="appendNodes" />
+            <ref role="37wK5l" node="4oS6BnMdvcE" resolve="append" />
             <node concept="37vLTw" id="4oS6BnMfJc1" role="37wK5m">
               <ref role="3cqZAo" node="4oS6BnMfzqK" resolve="nodes" />
             </node>
@@ -6152,7 +6152,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="4oS6BnMUIdT" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.runtime/org.iets3.core.expr.base.runtime.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.base.runtime/org.iets3.core.expr.base.runtime.msd
@@ -14,6 +14,7 @@
     <dependency reexport="false">cfaa4966-b7d5-4b69-b66a-309a6e1a7290(org.iets3.core.expr.base)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)</dependency>
+    <dependency reexport="true">7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -35,6 +36,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.interpreter/org.iets3.core.expr.collections.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.collections.interpreter/org.iets3.core.expr.collections.interpreter.msd
@@ -42,6 +42,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.data.interpreter/org.iets3.core.expr.data.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.data.interpreter/org.iets3.core.expr.data.interpreter.msd
@@ -40,6 +40,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.datetime.interpreter/org.iets3.core.expr.datetime.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.datetime.interpreter/org.iets3.core.expr.datetime.interpreter.msd
@@ -38,6 +38,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.math.interpreter/org.iets3.core.expr.math.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.math.interpreter/org.iets3.core.expr.math.interpreter.msd
@@ -47,6 +47,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.interpreter/org.iets3.core.expr.simpleTypes.interpreter.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.interpreter/org.iets3.core.expr.simpleTypes.interpreter.msd
@@ -40,6 +40,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.stringvalidation.runtime/org.iets3.core.expr.stringvalidation.runtime.msd
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.stringvalidation.runtime/org.iets3.core.expr.stringvalidation.runtime.msd
@@ -23,7 +23,11 @@
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="dbe08fb5-334d-4b64-86a0-622406fa0e87(org.iets3.core.expr.base.runtime)" version="0" />
     <module reference="00ca1323-762b-4f39-ab5a-6a6bd602dc4b(org.iets3.core.expr.base.shared.runtime)" version="0" />
     <module reference="f38b69a3-1d33-4f9b-84e0-ac1095df2998(org.iets3.core.expr.stringvalidation.runtime)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -3632,6 +3632,16 @@
             <ref role="3bR37D" to="90a9:PE3B26QCrP" resolve="org.apache.commons" />
           </node>
         </node>
+        <node concept="1SiIV0" id="4oS6BnMciFy" role="3bR37C">
+          <node concept="3bR9La" id="4oS6BnMciFz" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:rD7wKO5Iy" resolve="MPS.TextGen" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4oS6BnMdjcr" role="3bR37C">
+          <node concept="3bR9La" id="4oS6BnMdjcs" role="1SiIV1">
+            <ref role="3bR37D" node="4C_RnzfEE1P" resolve="org.iets3.core.expr.base.runtime" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="3qKzW8QxJyw" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -3760,6 +3770,12 @@
         <node concept="1SiIV0" id="3qKzW8QxKM0" role="3bR37C">
           <node concept="3bR9La" id="3qKzW8QxKM1" role="1SiIV1">
             <ref role="3bR37D" node="3qKzW8QxJyw" resolve="org.iets3.core.expr.base.shared.runtime" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4oS6BnMciFU" role="3bR37C">
+          <node concept="3bR9La" id="4oS6BnMciFV" role="1SiIV1">
+            <property role="3bR36h" value="true" />
+            <ref role="3bR37D" to="ffeo:rD7wKO5Iy" resolve="MPS.TextGen" />
           </node>
         </node>
       </node>
@@ -5525,6 +5541,11 @@
             <node concept="3qWCbU" id="1RMC8GHEwGb" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4oS6BnMQ8h5" role="3bR37C">
+          <node concept="3bR9La" id="4oS6BnMQ8h6" role="1SiIV1">
+            <ref role="3bR37D" node="4C_RnzfEE1P" resolve="org.iets3.core.expr.base.runtime" />
           </node>
         </node>
       </node>
@@ -12978,6 +12999,11 @@
             </node>
           </node>
         </node>
+        <node concept="1SiIV0" id="4oS6BnMm8J6" role="3bR37C">
+          <node concept="3bR9La" id="4oS6BnMm8J7" role="1SiIV1">
+            <ref role="3bR37D" node="4C_RnzfEE1P" resolve="org.iets3.core.expr.base.runtime" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="7AsetSAoeHb" role="2G$12L">
         <property role="BnDLt" value="true" />
@@ -13869,7 +13895,6 @@
         <property role="BnDLt" value="true" />
         <property role="TrG5h" value="org.iets3.opensource.build.gentests.rt" />
         <property role="3LESm3" value="e70ad515-8ff0-4a50-8cb4-41406f14e348" />
-        <property role="2GAjPV" value="true" />
         <node concept="398BVA" id="3ZBI8Awh4x5" role="3LF7KH">
           <ref role="398BVh" node="5wLtKNeTaqD" resolve="iets3.lang.opensource" />
           <node concept="2Ry0Ak" id="3ZBI8Awh4x6" role="iGT6I">
@@ -16147,6 +16172,16 @@
           <ref role="3bR37D" node="sIFyDYEAVO" resolve="org.iets3.core.expr.base" />
         </node>
       </node>
+      <node concept="1SiIV0" id="4oS6BnMcj0l" role="3bR37C">
+        <node concept="3bR9La" id="4oS6BnMcj0m" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:rD7wKO5Iy" resolve="MPS.TextGen" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="4oS6BnMdjxc" role="3bR37C">
+        <node concept="3bR9La" id="4oS6BnMdjxd" role="1SiIV1">
+          <ref role="3bR37D" node="sIFyDYEApj" resolve="org.iets3.core.expr.base.runtime" />
+        </node>
+      </node>
     </node>
     <node concept="1E1JtD" id="1YwzPHwBxrz" role="3989C9">
       <property role="BnDLt" value="true" />
@@ -16300,6 +16335,12 @@
       <node concept="1SiIV0" id="sIFyDYEApD" role="3bR37C">
         <node concept="3bR9La" id="sIFyDYEApE" role="1SiIV1">
           <ref role="3bR37D" node="sIFyDYEAtA" resolve="org.iets3.core.expr.base.shared.runtime" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="4oS6BnMcj0H" role="3bR37C">
+        <node concept="3bR9La" id="4oS6BnMcj0I" role="1SiIV1">
+          <property role="3bR36h" value="true" />
+          <ref role="3bR37D" to="ffeo:rD7wKO5Iy" resolve="MPS.TextGen" />
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/test.in.expr.os.msd
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/test.in.expr.os.msd
@@ -115,6 +115,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os.comma/test.ts.expr.os.comma.msd
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os.comma/test.ts.expr.os.comma.msd
@@ -62,6 +62,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/test.ts.expr.os.msd
@@ -109,6 +109,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />


### PR DESCRIPTION
The `renderReadable`/`getPresentation` implementations were improved and are now equivalent in all concepts. I am not sure why we need `renderReadable` in the first place. `getPresentation` should be enough.