### PR TITLE
Some extensions for the o.i.req.core language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The project does _not_ follow Semantic Versioning and the changes are documented
   - Configurations might become inconsistent due to errors during manual conflict merges. A couple of model checks have been added to detect this. Additionally, there are quickfixes to fix such errors.
   - The internal storage of configurations has changed, this requires a language migration. Note that after the execution of the migration, extended configurations must be adapted via intention to their changed base configuration.
 - A VCS merge hint has been added for the `__hash` property (e.g., for variant configurations). This avoids merge conflicts which cannot be resolved manually anyway (in those cases, the hash value has to be recomputed anyway).
+- Requirements modeling (language `org.iets3.req.core`)
+  - It now supports a "requires" relation, which can express that a requirement needs other requirements as a precondition.
+  - The requirements chunk provides a flag "hide empty child requirements sections" (in the inspector). If selected, the flag hides empty child requirements sections in the tabular requirements view.
+  - Some additional internal changes (e.g., implementation of `ICanHide` interface, needed for variability support).
 
 ### Fixed
 - Improved the readability of lists by enforcing a new line when a threshold of three elements per list is exeeded.

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/behavior.mps
@@ -12,6 +12,7 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="2c95" ref="r:5f7188a9-e7b4-4a2e-bef9-38d2cf379fdc(com.mbeddr.doc.structure)" />
     <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
+    <import index="btm1" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3(org.apache.commons/)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
     <import index="4gky" ref="r:e1dfab1d-c7a7-43e7-9f26-028afd483e82(com.mbeddr.doc.behavior)" implicit="true" />
   </imports>
@@ -57,6 +58,7 @@
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
@@ -78,6 +80,7 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
@@ -86,7 +89,9 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
@@ -101,6 +106,9 @@
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
@@ -118,6 +126,7 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1204834851141" name="jetbrains.mps.lang.smodel.structure.PoundExpression" flags="ng" index="25Kdxt">
@@ -126,11 +135,15 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC">
         <reference id="1139880128956" name="concept" index="1A9B2P" />
       </concept>
+      <concept id="1173122760281" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorsOperation" flags="nn" index="z$bX8" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
@@ -150,6 +163,7 @@
       <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
         <reference id="1139877738879" name="concept" index="1A0vxQ" />
       </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
       <concept id="1182511038748" name="jetbrains.mps.lang.smodel.structure.Model_NodesIncludingImportedOperation" flags="nn" index="1j9C0f">
         <child id="6750920497477143623" name="conceptArgument" index="3MHPCF" />
@@ -159,6 +173,10 @@
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="334628810661441841" name="jetbrains.mps.lang.smodel.structure.AsSConcept" flags="nn" index="1rGIog" />
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
@@ -195,6 +213,7 @@
       </concept>
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
     </language>
   </registry>
   <node concept="13h7C7" id="4tXyFaWwpiP">
@@ -790,6 +809,112 @@
       <node concept="3clFbS" id="6Q6YvW0IOIv" role="3clF47">
         <node concept="3cpWs6" id="6Q6YvW0IQck" role="3cqZAp">
           <node concept="3clFbT" id="6Q6YvW0IQcp" role="3cqZAk" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4zL1IiCQnzF" role="13h7CS">
+      <property role="TrG5h" value="getIndent" />
+      <property role="13i0it" value="true" />
+      <node concept="3Tm1VV" id="4zL1IiCQnzG" role="1B3o_S" />
+      <node concept="17QB3L" id="4zL1IiCQpcZ" role="3clF45" />
+      <node concept="3clFbS" id="4zL1IiCQnzI" role="3clF47">
+        <node concept="3cpWs8" id="3FGEpLFjzYM" role="3cqZAp">
+          <node concept="3cpWsn" id="3FGEpLFjzYN" role="3cpWs9">
+            <property role="TrG5h" value="c" />
+            <node concept="10Oyi0" id="3FGEpLFjzYO" role="1tU5fm" />
+            <node concept="2OqwBi" id="3FGEpLFjzYP" role="33vP2m">
+              <node concept="2OqwBi" id="3FGEpLFjzYQ" role="2Oq$k0">
+                <node concept="13iPFW" id="4zL1IiCQw$3" role="2Oq$k0" />
+                <node concept="z$bX8" id="3FGEpLFjzYS" role="2OqNvi">
+                  <node concept="1xMEDy" id="3FGEpLFjzYT" role="1xVPHs">
+                    <node concept="chp4Y" id="3FGEpLFjzYU" role="ri$Ld">
+                      <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="34oBXx" id="3FGEpLFjzYV" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3FGEpLFjzYW" role="3cqZAp">
+          <node concept="2YIFZM" id="3FGEpLFjzYX" role="3clFbG">
+            <ref role="37wK5l" to="btm1:~StringUtils.repeat(java.lang.String,int)" resolve="repeat" />
+            <ref role="1Pybhc" to="btm1:~StringUtils" resolve="StringUtils" />
+            <node concept="Xl_RD" id="3FGEpLFjzYY" role="37wK5m">
+              <property role="Xl_RC" value="  " />
+            </node>
+            <node concept="37vLTw" id="3FGEpLFjzYZ" role="37wK5m">
+              <ref role="3cqZAo" node="3FGEpLFjzYN" resolve="c" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4zL1IiCStbX" role="13h7CS">
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="showChildReqs" />
+      <node concept="3Tm1VV" id="4zL1IiCStbY" role="1B3o_S" />
+      <node concept="10P_77" id="4zL1IiCSuM1" role="3clF45" />
+      <node concept="3clFbS" id="4zL1IiCStc0" role="3clF47">
+        <node concept="3cpWs8" id="4zL1IiCSvDC" role="3cqZAp">
+          <node concept="3cpWsn" id="4zL1IiCSvDD" role="3cpWs9">
+            <property role="TrG5h" value="chunk" />
+            <node concept="3Tqbb2" id="4zL1IiCSvDc" role="1tU5fm">
+              <ref role="ehGHo" to="plfp:4tXyFaWwpis" resolve="RequirementsChunk" />
+            </node>
+            <node concept="2OqwBi" id="4zL1IiCSvDE" role="33vP2m">
+              <node concept="13iPFW" id="4zL1IiCSvDF" role="2Oq$k0" />
+              <node concept="2Xjw5R" id="4zL1IiCSvDG" role="2OqNvi">
+                <node concept="1xMEDy" id="4zL1IiCSvDH" role="1xVPHs">
+                  <node concept="chp4Y" id="4zL1IiCSvDI" role="ri$Ld">
+                    <ref role="cht4Q" to="plfp:4tXyFaWwpis" resolve="RequirementsChunk" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4zL1IiCSBn1" role="3cqZAp">
+          <node concept="3clFbS" id="4zL1IiCSBn3" role="3clFbx">
+            <node concept="3cpWs6" id="4zL1IiCSC1R" role="3cqZAp">
+              <node concept="3clFbT" id="4zL1IiCSC4M" role="3cqZAk">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="4zL1IiCSBMX" role="3clFbw">
+            <node concept="37vLTw" id="4zL1IiCSBon" role="2Oq$k0">
+              <ref role="3cqZAo" node="4zL1IiCSvDD" resolve="chunk" />
+            </node>
+            <node concept="3w_OXm" id="4zL1IiCSBQY" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="4zL1IiCSC6k" role="3cqZAp" />
+        <node concept="3clFbF" id="4zL1IiCSvJO" role="3cqZAp">
+          <node concept="3fqX7Q" id="4zL1IiCSRVM" role="3clFbG">
+            <node concept="1eOMI4" id="4zL1IiCSRVO" role="3fr31v">
+              <node concept="1Wc70l" id="4zL1IiCSRVP" role="1eOMHV">
+                <node concept="2OqwBi" id="4zL1IiCSRVQ" role="3uHU7w">
+                  <node concept="2OqwBi" id="4zL1IiCSRVR" role="2Oq$k0">
+                    <node concept="13iPFW" id="4zL1IiCSRVS" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="4zL1IiCSRVT" role="2OqNvi">
+                      <ref role="3TtcxE" to="plfp:4tXyFaWxWA_" resolve="requirements" />
+                    </node>
+                  </node>
+                  <node concept="1v1jN8" id="4zL1IiCSRVU" role="2OqNvi" />
+                </node>
+                <node concept="2OqwBi" id="4zL1IiCSRVV" role="3uHU7B">
+                  <node concept="37vLTw" id="4zL1IiCSRVW" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4zL1IiCSvDD" resolve="chunk" />
+                  </node>
+                  <node concept="3TrcHB" id="4zL1IiCSRVX" role="2OqNvi">
+                    <ref role="3TsBF5" to="plfp:4zL1IiCSr1P" resolve="hideEmptyChildReqsSection" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/editor.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/editor.mps
@@ -13,6 +13,7 @@
     <use id="b1c7d06f-525d-43b5-9b0a-2fc8f7f076ba" name="jetbrains.mps.editor.contextActionsTool.lang.menus" version="0" />
     <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
     <use id="1919c723-b60b-4592-9318-9ce96d91da44" name="de.itemis.mps.editor.celllayout" version="0" />
+    <use id="f89904fb-9486-43a1-865e-5ad0375a8a88" name="de.itemis.mps.editor.bool" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -29,6 +30,7 @@
     <import index="ze1i" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.runtime(MPS.Core/)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
+    <import index="iu5m" ref="r:b554eb27-deaf-43a2-bc2f-156358b859cc(com.mbeddr.mpsutil.editor.displayControl.behavior)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" implicit="true" />
     <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" implicit="true" />
@@ -72,6 +74,7 @@
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
       <concept id="1237375020029" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineChildrenStyleClassItem" flags="ln" index="pj6Ft" />
+      <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
@@ -166,6 +169,7 @@
       </concept>
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
         <property id="1130859485024" name="attractsFocus" index="1cu_pB" />
+        <child id="1142887637401" name="renderingCondition" index="pqm2j" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
         <property id="1160590353935" name="usesFolding" index="S$Qs1" />
@@ -386,6 +390,7 @@
       <concept id="1397920687865593407" name="de.slisson.mps.tables.structure.PartialTable" flags="ng" index="2r0Tta">
         <child id="1397920687865593523" name="cells" index="2r0Tv6" />
       </concept>
+      <concept id="1397920687866011705" name="de.slisson.mps.tables.structure.QueryParameter_Node" flags="ng" index="2r2w_c" />
       <concept id="1397920687864997170" name="de.slisson.mps.tables.structure.TableNodeCollection" flags="ng" index="2reCL7">
         <child id="1397920687864997171" name="childTableNodes" index="2reCL6" />
       </concept>
@@ -399,6 +404,9 @@
       <concept id="1397920687865064509" name="de.slisson.mps.tables.structure.ChildCollection" flags="ng" index="2reSl8">
         <property id="2704268044258142829" name="placeholderText" index="1YXhso" />
         <reference id="1397920687864997201" name="linkDeclaration" index="2reCK$" />
+      </concept>
+      <concept id="1397920687864865353" name="de.slisson.mps.tables.structure.ITableNode" flags="ngI" index="2rf8GW">
+        <child id="8843513109888016181" name="condition" index="3NQet$" />
       </concept>
       <concept id="1397920687864683158" name="de.slisson.mps.tables.structure.Table" flags="ng" index="2rfBfz">
         <child id="1397920687864865354" name="cells" index="2rf8GZ" />
@@ -419,6 +427,10 @@
       <concept id="6466068411884348300" name="de.slisson.mps.tables.structure.EditorCellHeader" flags="ng" index="1A0rlU">
         <child id="6466068411884348445" name="editorCell" index="1A0rbF" />
       </concept>
+      <concept id="8843513109888016587" name="de.slisson.mps.tables.structure.TableNodeCondition" flags="ig" index="3NQdyq" />
+    </language>
+    <language id="f89904fb-9486-43a1-865e-5ad0375a8a88" name="de.itemis.mps.editor.bool">
+      <concept id="4900677560559655527" name="de.itemis.mps.editor.bool.structure.CellModel_Checkbox" flags="sg" stub="416014060004381438" index="27S6Sx" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
@@ -432,7 +444,6 @@
         <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
       </concept>
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
-      <concept id="1173122760281" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorsOperation" flags="nn" index="z$bX8" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
         <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
@@ -713,6 +724,18 @@
       <node concept="pj6Ft" id="2tlTgwfCxS9" role="3F10Kt">
         <property role="VOm3f" value="true" />
       </node>
+      <node concept="pkWqt" id="4zL1IiCWJ_a" role="pqm2j">
+        <node concept="3clFbS" id="4zL1IiCWJ_b" role="2VODD2">
+          <node concept="3clFbF" id="4zL1IiCWKA6" role="3cqZAp">
+            <node concept="2OqwBi" id="4zL1IiCWL7p" role="3clFbG">
+              <node concept="pncrf" id="4zL1IiCWKA5" role="2Oq$k0" />
+              <node concept="2qgKlT" id="4zL1IiCWLC9" role="2OqNvi">
+                <ref role="37wK5l" to="iu5m:5I8v_DCodq4" resolve="isVisible" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2aJ2om" id="7Dcax7AhwZc" role="CpUAK">
       <ref role="2$4xQ3" to="r4b4:7xesQBpJXuT" resolve="presentationMode" />
@@ -958,6 +981,9 @@
         <ref role="1NtTu8" to="plfp:4tXyFaWxWA_" resolve="requirements" />
         <node concept="2iRkQZ" id="4tXyFaWwBeG" role="2czzBx" />
       </node>
+    </node>
+    <node concept="PMmxH" id="4zL1IiCU8Cv" role="6VMZX">
+      <ref role="PMmxG" node="4zL1IiCU8Cn" resolve="ReqChunkDetails" />
     </node>
   </node>
   <node concept="24kQdi" id="4tXyFaWy3Kt">
@@ -1600,6 +1626,18 @@
       <node concept="pj6Ft" id="2tlTgwfCwlW" role="3F10Kt">
         <property role="VOm3f" value="true" />
       </node>
+      <node concept="pkWqt" id="4zL1IiCWDQF" role="pqm2j">
+        <node concept="3clFbS" id="4zL1IiCWDQG" role="2VODD2">
+          <node concept="3clFbF" id="4zL1IiCWDV7" role="3cqZAp">
+            <node concept="2OqwBi" id="4zL1IiCWFMN" role="3clFbG">
+              <node concept="pncrf" id="4zL1IiCWDV6" role="2Oq$k0" />
+              <node concept="2qgKlT" id="4zL1IiCWHdk" role="2OqNvi">
+                <ref role="37wK5l" to="iu5m:5I8v_DCodq4" resolve="isVisible" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
   <node concept="24kQdi" id="5Zn2KFQSRwN">
@@ -1838,7 +1876,7 @@
     <node concept="2BsEeg" id="4Etk_BWudyK" role="2ABdcP">
       <property role="2gpH_U" value="true" />
       <property role="TrG5h" value="tableWithDetails" />
-      <property role="2BUmq6" value="Requirements Table" />
+      <property role="2BUmq6" value="Requirements Table Details" />
     </node>
   </node>
   <node concept="24kQdi" id="4Etk_BWvNJv">
@@ -1957,6 +1995,9 @@
     <node concept="2aJ2om" id="4Etk_BWvNOj" role="CpUAK">
       <ref role="2$4xQ3" node="4Etk_BWn_aB" resolve="table" />
     </node>
+    <node concept="PMmxH" id="4zL1IiCU9xU" role="6VMZX">
+      <ref role="PMmxG" node="4zL1IiCU8Cn" resolve="ReqChunkDetails" />
+    </node>
   </node>
   <node concept="24kQdi" id="3FGEpLFhUZy">
     <ref role="1XX52x" to="plfp:4tXyFaWwpmT" resolve="DefaultRequirement" />
@@ -1969,34 +2010,11 @@
                 <node concept="1HfYo3" id="3FGEpLFj5_u" role="1HlULh">
                   <node concept="3TQlhw" id="3FGEpLFj5_w" role="1Hhtcw">
                     <node concept="3clFbS" id="3FGEpLFj5_y" role="2VODD2">
-                      <node concept="3cpWs8" id="3FGEpLFjaDL" role="3cqZAp">
-                        <node concept="3cpWsn" id="3FGEpLFjaDM" role="3cpWs9">
-                          <property role="TrG5h" value="c" />
-                          <node concept="10Oyi0" id="3FGEpLFjaDH" role="1tU5fm" />
-                          <node concept="2OqwBi" id="3FGEpLFjaDN" role="33vP2m">
-                            <node concept="2OqwBi" id="3FGEpLFjaDO" role="2Oq$k0">
-                              <node concept="pncrf" id="3FGEpLFjaDP" role="2Oq$k0" />
-                              <node concept="z$bX8" id="3FGEpLFjaDQ" role="2OqNvi">
-                                <node concept="1xMEDy" id="3FGEpLFjaDR" role="1xVPHs">
-                                  <node concept="chp4Y" id="3FGEpLFjaDS" role="ri$Ld">
-                                    <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="34oBXx" id="3FGEpLFjaDT" role="2OqNvi" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbF" id="3FGEpLFjoX8" role="3cqZAp">
-                        <node concept="2YIFZM" id="3FGEpLFjp2z" role="3clFbG">
-                          <ref role="37wK5l" to="btm1:~StringUtils.repeat(java.lang.String,int)" resolve="repeat" />
-                          <ref role="1Pybhc" to="btm1:~StringUtils" resolve="StringUtils" />
-                          <node concept="Xl_RD" id="3FGEpLFjp3P" role="37wK5m">
-                            <property role="Xl_RC" value="  " />
-                          </node>
-                          <node concept="37vLTw" id="3FGEpLFjp6C" role="37wK5m">
-                            <ref role="3cqZAo" node="3FGEpLFjaDM" resolve="c" />
+                      <node concept="3clFbF" id="4zL1IiCQDZb" role="3cqZAp">
+                        <node concept="2OqwBi" id="4zL1IiCQDZc" role="3clFbG">
+                          <node concept="pncrf" id="4zL1IiCQDZd" role="2Oq$k0" />
+                          <node concept="2qgKlT" id="4zL1IiCQDZe" role="2OqNvi">
+                            <ref role="37wK5l" to="bemq:4zL1IiCQnzF" resolve="getIndent" />
                           </node>
                         </node>
                       </node>
@@ -2134,6 +2152,30 @@
         </node>
         <node concept="2reSaE" id="3FGEpLFhW2p" role="2reCL6">
           <ref role="2reCK$" to="plfp:4tXyFaWxWA_" resolve="requirements" />
+          <node concept="3NQdyq" id="4zL1IiCSTfB" role="3NQet$">
+            <node concept="3clFbS" id="4zL1IiCSTfC" role="2VODD2">
+              <node concept="3clFbF" id="4zL1IiCSTxx" role="3cqZAp">
+                <node concept="2OqwBi" id="4zL1IiCSU1E" role="3clFbG">
+                  <node concept="2r2w_c" id="4zL1IiCSTxw" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="4zL1IiCSUGp" role="2OqNvi">
+                    <ref role="37wK5l" to="bemq:4zL1IiCStbX" resolve="showChildReqs" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3NQdyq" id="4zL1IiCW_T4" role="3NQet$">
+          <node concept="3clFbS" id="4zL1IiCW_T5" role="2VODD2">
+            <node concept="3clFbF" id="4zL1IiCW_Zs" role="3cqZAp">
+              <node concept="2OqwBi" id="4zL1IiCWAwJ" role="3clFbG">
+                <node concept="2r2w_c" id="4zL1IiCW_Zr" role="2Oq$k0" />
+                <node concept="2qgKlT" id="4zL1IiCWBez" role="2OqNvi">
+                  <ref role="37wK5l" to="iu5m:5I8v_DCodq4" resolve="isVisible" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
       </node>
     </node>
@@ -2152,34 +2194,11 @@
                 <node concept="1HfYo3" id="3FGEpLFjzYJ" role="1HlULh">
                   <node concept="3TQlhw" id="3FGEpLFjzYK" role="1Hhtcw">
                     <node concept="3clFbS" id="3FGEpLFjzYL" role="2VODD2">
-                      <node concept="3cpWs8" id="3FGEpLFjzYM" role="3cqZAp">
-                        <node concept="3cpWsn" id="3FGEpLFjzYN" role="3cpWs9">
-                          <property role="TrG5h" value="c" />
-                          <node concept="10Oyi0" id="3FGEpLFjzYO" role="1tU5fm" />
-                          <node concept="2OqwBi" id="3FGEpLFjzYP" role="33vP2m">
-                            <node concept="2OqwBi" id="3FGEpLFjzYQ" role="2Oq$k0">
-                              <node concept="pncrf" id="3FGEpLFjzYR" role="2Oq$k0" />
-                              <node concept="z$bX8" id="3FGEpLFjzYS" role="2OqNvi">
-                                <node concept="1xMEDy" id="3FGEpLFjzYT" role="1xVPHs">
-                                  <node concept="chp4Y" id="3FGEpLFjzYU" role="ri$Ld">
-                                    <ref role="cht4Q" to="plfp:4tXyFaWwpmI" resolve="AbstractRequirement" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="34oBXx" id="3FGEpLFjzYV" role="2OqNvi" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbF" id="3FGEpLFjzYW" role="3cqZAp">
-                        <node concept="2YIFZM" id="3FGEpLFjzYX" role="3clFbG">
-                          <ref role="37wK5l" to="btm1:~StringUtils.repeat(java.lang.String,int)" resolve="repeat" />
-                          <ref role="1Pybhc" to="btm1:~StringUtils" resolve="StringUtils" />
-                          <node concept="Xl_RD" id="3FGEpLFjzYY" role="37wK5m">
-                            <property role="Xl_RC" value="  " />
-                          </node>
-                          <node concept="37vLTw" id="3FGEpLFjzYZ" role="37wK5m">
-                            <ref role="3cqZAo" node="3FGEpLFjzYN" resolve="c" />
+                      <node concept="3clFbF" id="4zL1IiCQzxN" role="3cqZAp">
+                        <node concept="2OqwBi" id="4zL1IiCQ$55" role="3clFbG">
+                          <node concept="pncrf" id="4zL1IiCQzxM" role="2Oq$k0" />
+                          <node concept="2qgKlT" id="4zL1IiCQAvB" role="2OqNvi">
+                            <ref role="37wK5l" to="bemq:4zL1IiCQnzF" resolve="getIndent" />
                           </node>
                         </node>
                       </node>
@@ -2324,6 +2343,30 @@
         <node concept="2reSaE" id="3FGEpLFjzZH" role="2reCL6">
           <property role="1YXhso" value="&lt;add child requirements&gt;" />
           <ref role="2reCK$" to="plfp:4tXyFaWxWA_" resolve="requirements" />
+          <node concept="3NQdyq" id="4zL1IiCSVbO" role="3NQet$">
+            <node concept="3clFbS" id="4zL1IiCSVbP" role="2VODD2">
+              <node concept="3clFbF" id="4zL1IiCSVtI" role="3cqZAp">
+                <node concept="2OqwBi" id="4zL1IiCSVXR" role="3clFbG">
+                  <node concept="2r2w_c" id="4zL1IiCSVtH" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="4zL1IiCSWry" role="2OqNvi">
+                    <ref role="37wK5l" to="bemq:4zL1IiCStbX" resolve="showChildReqs" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3NQdyq" id="4zL1IiCWzht" role="3NQet$">
+          <node concept="3clFbS" id="4zL1IiCWzhu" role="2VODD2">
+            <node concept="3clFbF" id="4zL1IiCWzUv" role="3cqZAp">
+              <node concept="2OqwBi" id="4zL1IiCW$rM" role="3clFbG">
+                <node concept="2r2w_c" id="4zL1IiCWzUu" role="2Oq$k0" />
+                <node concept="2qgKlT" id="4zL1IiCW$UK" role="2OqNvi">
+                  <ref role="37wK5l" to="iu5m:5I8v_DCodq4" resolve="isVisible" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
       </node>
     </node>
@@ -3713,6 +3756,25 @@
     </node>
     <node concept="2tJIrI" id="5Zn2KFQQ$_U" role="jymVt" />
     <node concept="3Tm1VV" id="5Zn2KFQQ$_C" role="1B3o_S" />
+  </node>
+  <node concept="PKFIW" id="4zL1IiCU8Cn">
+    <property role="TrG5h" value="ReqChunkDetails" />
+    <ref role="1XX52x" to="plfp:4tXyFaWwpis" resolve="RequirementsChunk" />
+    <node concept="3EZMnI" id="4zL1IiCU8Co" role="2wV5jI">
+      <node concept="2iRkQZ" id="4zL1IiCU8Cp" role="2iSdaV" />
+      <node concept="3F0ifn" id="4zL1IiCU8Cq" role="3EZMnx">
+        <property role="3F0ifm" value="Additional options:" />
+      </node>
+      <node concept="3EZMnI" id="4zL1IiCU8Cr" role="3EZMnx">
+        <node concept="2iRfu4" id="4zL1IiCU8Cs" role="2iSdaV" />
+        <node concept="27S6Sx" id="4zL1IiCU8Ct" role="3EZMnx">
+          <ref role="1NtTu8" to="plfp:4zL1IiCSr1P" resolve="hideEmptyChildReqsSection" />
+        </node>
+        <node concept="3F0ifn" id="4zL1IiCU8Cu" role="3EZMnx">
+          <property role="3F0ifm" value="hide child requirements section, if empty" />
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/structure.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.core/models/structure.mps
@@ -9,6 +9,7 @@
     <import index="vs0r" ref="r:f7764ca4-8c75-4049-922b-08516400a727(com.mbeddr.core.base.structure)" />
     <import index="2c95" ref="r:5f7188a9-e7b4-4a2e-bef9-38d2cf379fdc(com.mbeddr.doc.structure)" />
     <import index="4kwy" ref="r:657c9fde-2f36-4e61-ae17-20f02b8630ad(org.iets3.core.base.structure)" />
+    <import index="s8pm" ref="r:1a263161-b47f-4c8c-8169-e2033bd674f4(com.mbeddr.mpsutil.editor.displayControl.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="cayy" ref="r:c1f7e681-4373-4429-b23f-337a1dd93658(org.iets3.core.users.structure)" implicit="true" />
   </imports>
@@ -82,6 +83,11 @@
     <node concept="1QGGSu" id="4llm6dDjViS" role="rwd14">
       <property role="1iqoE4" value="${module}/icons/reqchunk.png" />
     </node>
+    <node concept="1TJgyi" id="4zL1IiCSr1P" role="1TKVEl">
+      <property role="IQ2nx" value="5255989819273752693" />
+      <property role="TrG5h" value="hideEmptyChildReqsSection" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
   </node>
   <node concept="1TIwiD" id="4tXyFaWwpmI">
     <property role="TrG5h" value="AbstractRequirement" />
@@ -121,6 +127,9 @@
     </node>
     <node concept="PrWs8" id="4tXyFaWxW_j" role="PzmwI">
       <ref role="PrY4T" node="4tXyFaWxW_f" resolve="IReqContainer" />
+    </node>
+    <node concept="PrWs8" id="4zL1IiCWyBW" role="PzmwI">
+      <ref role="PrY4T" to="s8pm:54QlSGoaifp" resolve="ICanHide" />
     </node>
     <node concept="1TJgyj" id="4tXyFaWy3Jw" role="1TKVEi">
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -319,7 +328,7 @@
     <property role="TrG5h" value="RelKindConflicts" />
     <property role="34LRSv" value="conflicts with" />
     <property role="EcuMT" value="6906000695315637437" />
-    <property role="R4oN_" value="a conflict with relation kind" />
+    <property role="R4oN_" value="a &quot;conflicts with&quot; relation kind" />
     <ref role="1TJDcQ" node="5Zn2KFQSUik" resolve="RelationKind" />
   </node>
   <node concept="1TIwiD" id="5Zn2KFQSUqC">
@@ -384,6 +393,14 @@
   <node concept="PlHQZ" id="4OH$Ti$mobC">
     <property role="EcuMT" value="5561263381494203112" />
     <property role="TrG5h" value="IReqContextLabelProvider" />
+  </node>
+  <node concept="1TIwiD" id="4zL1IiCVfJB">
+    <property role="EcuMT" value="5255989819274492903" />
+    <property role="3GE5qa" value="rel" />
+    <property role="TrG5h" value="RelKindRequires" />
+    <property role="34LRSv" value="requires" />
+    <property role="R4oN_" value="a &quot;requires&quot; relation kind" />
+    <ref role="1TJDcQ" node="5Zn2KFQSUik" resolve="RelationKind" />
   </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.req.core/org.iets3.req.core.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.req.core/org.iets3.req.core.mpl
@@ -21,6 +21,7 @@
     <dependency reexport="false">8e4e17de-bc10-4a34-a376-a243fbde540e(org.iets3.glossary)</dependency>
     <dependency reexport="false">92d2ea16-5a42-4fdf-a676-c7604efe3504(de.slisson.mps.richtext)</dependency>
     <dependency reexport="false">b0f8641f-bd77-4421-8425-30d9088a82f7(org.apache.commons)</dependency>
+    <dependency reexport="false">5fef253e-34b0-443d-8035-9a2928b716d3(com.mbeddr.mpsutil.editor.displayControl)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:120e1c9d-4e27-4478-b2af-b2c3bd3850b0:com.mbeddr.mpsutil.editor.querylist" version="0" />
@@ -28,6 +29,7 @@
     <language slang="l:b4f35ed8-45af-4efa-abe4-00ac26956e69:com.mbeddr.mpsutil.grammarcells.runtimelang" version="0" />
     <language slang="l:b92f861d-0184-446d-b88b-6dcf0e070241:com.mbeddr.mpsutil.intentions" version="0" />
     <language slang="l:62a3babb-5d40-4920-897f-d4144dc99c9d:com.mbeddr.mpsutil.userstyles" version="0" />
+    <language slang="l:f89904fb-9486-43a1-865e-5ad0375a8a88:de.itemis.mps.editor.bool" version="0" />
     <language slang="l:1919c723-b60b-4592-9318-9ce96d91da44:de.itemis.mps.editor.celllayout" version="0" />
     <language slang="l:7e450f4e-1ac3-41ef-a851-4598161bdb94:de.slisson.mps.tables" version="0" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -76,6 +78,7 @@
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="2374bc90-7e37-41f1-a9c4-c2e35194c36a(com.mbeddr.doc)" version="0" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />
+    <module reference="5fef253e-34b0-443d-8035-9a2928b716d3(com.mbeddr.mpsutil.editor.displayControl)" version="0" />
     <module reference="d3a0fd26-445a-466c-900e-10444ddfed52(com.mbeddr.mpsutil.filepicker)" version="0" />
     <module reference="d09a16fb-1d68-4a92-a5a4-20b4b2f86a62(com.mbeddr.mpsutil.jung)" version="0" />
     <module reference="b4d28e19-7d2d-47e9-943e-3a41f97a0e52(com.mbeddr.mpsutil.plantuml.node)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -760,6 +760,9 @@
       <node concept="m$_yC" id="3HtH8S1CeZC" role="m$_yJ">
         <ref role="m$_y1" node="5wLtKNeT2TB" resolve="org.iets3.req.os" />
       </node>
+      <node concept="m$_yC" id="4zL1IiCXS9J" role="m$_yJ">
+        <ref role="m$_y1" to="al5i:3Ol24ijlxoL" resolve="com.mbeddr.mpsutil.editor.displayControl" />
+      </node>
       <node concept="m$_yC" id="35CkgbOeHKL" role="m$_yJ">
         <ref role="m$_y1" to="90a9:F1NWDqr5lJ" resolve="de.itemis.mps.grammarcells" />
       </node>
@@ -1106,6 +1109,9 @@
       </node>
       <node concept="m$_yC" id="5wLtKNeT97z" role="m$_yJ">
         <ref role="m$_y1" to="al5i:7tNo_gxoK8h" resolve="com.mbeddr.doc" />
+      </node>
+      <node concept="m$_yC" id="4zL1IiCXSbo" role="m$_yJ">
+        <ref role="m$_y1" to="al5i:3Ol24ijlxoL" resolve="com.mbeddr.mpsutil.editor.displayControl" />
       </node>
       <node concept="m$_yC" id="5wLtKNeT9bv" role="m$_yJ">
         <ref role="m$_y1" node="5wLtKNeSRRD" resolve="org.iets3.core.os" />
@@ -15244,6 +15250,11 @@
             <node concept="3qWCbU" id="1RMC8GHEx2C" role="3LXTna">
               <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
             </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4zL1IiCXS25" role="3bR37C">
+          <node concept="3bR9La" id="4zL1IiCXS26" role="1SiIV1">
+            <ref role="3bR37D" to="al5i:3uPnK4iE1MQ" resolve="com.mbeddr.mpsutil.editor.displayControl" />
           </node>
         </node>
       </node>


### PR DESCRIPTION
This PR provides some extensions for the `org.iets3.req.core` language. Some of these extensions are needed for variability implementation, some are generically useful. See ticket #1495 for details. 

All user-facing changes are explained in CHANGELOG.md.

Closes #1495.
