### PR TITLE
Fix wrong infinite precision for number types with prefixed units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 ### Fixed
 
-- Physical units: The units `Joule`, `Coulomb` and `Watt` can now have also prefixes with negative metric scaling, e.g., `mW` (Milliwatt). Additionally, some typos have been corrected in the physical units documentation.
+- Physical units:
+  - The units `Joule`, `Coulomb` and `Watt` can now have also prefixes with negative metric scaling, e.g., `mW` (Milliwatt). Additionally, some typos have been corrected in the physical units documentation.
+  - The precision of number types with prefixed units (e.g. `mW` or `km`) was always set to `infinite` by the typesystem. Now, the precision is as precise as possible.
 
 
 ## December 2025

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
@@ -10,6 +10,7 @@
     <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="5" />
     <use id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples" version="-1" />
     <use id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core" version="2" />
+    <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -221,6 +222,18 @@
         <property id="1200397540847" name="charConstant" index="1XhdNS" />
       </concept>
     </language>
+    <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
+        <child id="8465538089690331502" name="body" index="TZ5H$" />
+      </concept>
+      <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
+      <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
+        <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
+        <property id="8970989240999019144" name="text" index="1dT_AB" />
+      </concept>
+    </language>
     <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
       <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
         <reference id="5455284157994012188" name="link" index="2pIpSl" />
@@ -287,6 +300,7 @@
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
@@ -2608,6 +2622,38 @@
               <node concept="3TrcHB" id="2NHHcg2FpLp" role="2OqNvi">
                 <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
               </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="5bmRS0nolm$" role="13h7CS">
+      <property role="TrG5h" value="getSinglePointRange" />
+      <node concept="3Tm1VV" id="5bmRS0nolm_" role="1B3o_S" />
+      <node concept="17QB3L" id="5bmRS0norni" role="3clF45" />
+      <node concept="3clFbS" id="5bmRS0nolmB" role="3clF47">
+        <node concept="3clFbF" id="5bmRS0norEP" role="3cqZAp">
+          <node concept="3K4zz7" id="5bmRS0nov0u" role="3clFbG">
+            <node concept="10Nm6u" id="5bmRS0novfz" role="3K4E3e" />
+            <node concept="2OqwBi" id="5bmRS0nowlw" role="3K4GZi">
+              <node concept="2OqwBi" id="5bmRS0novKY" role="2Oq$k0">
+                <node concept="13iPFW" id="5bmRS0novuC" role="2Oq$k0" />
+                <node concept="3TrEf2" id="5bmRS0now7G" role="2OqNvi">
+                  <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="5bmRS0nowKw" role="2OqNvi">
+                <ref role="37wK5l" node="5bmRS0nnZlw" resolve="getSinglePoint" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="5bmRS0not0i" role="3K4Cdx">
+              <node concept="2OqwBi" id="5bmRS0norWG" role="2Oq$k0">
+                <node concept="13iPFW" id="5bmRS0norEO" role="2Oq$k0" />
+                <node concept="3TrEf2" id="5bmRS0nosmu" role="2OqNvi">
+                  <ref role="3Tt5mk" to="5qo5:19PglA20qXS" resolve="range" />
+                </node>
+              </node>
+              <node concept="3w_OXm" id="5bmRS0notmh" role="2OqNvi" />
             </node>
           </node>
         </node>
@@ -6133,6 +6179,79 @@
         <property role="TrG5h" value="value" />
         <node concept="3uibUv" id="57Dr2jFHsJZ" role="1tU5fm">
           <ref role="3uigEE" to="xlxw:~BigDecimal" resolve="BigDecimal" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="5bmRS0nmV1W" role="13h7CS">
+      <property role="TrG5h" value="isSinglePoint" />
+      <node concept="3Tm1VV" id="5bmRS0nmV1X" role="1B3o_S" />
+      <node concept="10P_77" id="5bmRS0nmVIY" role="3clF45" />
+      <node concept="3clFbS" id="5bmRS0nmV1Z" role="3clF47">
+        <node concept="3clFbF" id="5bmRS0nnS5Y" role="3cqZAp">
+          <node concept="1Wc70l" id="5bmRS0nnUgP" role="3clFbG">
+            <node concept="17R0WA" id="5bmRS0nnY40" role="3uHU7w">
+              <node concept="2OqwBi" id="5bmRS0nnZdZ" role="3uHU7w">
+                <node concept="13iPFW" id="5bmRS0nnYMh" role="2Oq$k0" />
+                <node concept="3TrcHB" id="5bmRS0nnZi7" role="2OqNvi">
+                  <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5bmRS0nnUS_" role="3uHU7B">
+                <node concept="13iPFW" id="5bmRS0nnUvi" role="2Oq$k0" />
+                <node concept="3TrcHB" id="5bmRS0nnVbE" role="2OqNvi">
+                  <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+                </node>
+              </node>
+            </node>
+            <node concept="1Wc70l" id="5bmRS0nnS60" role="3uHU7B">
+              <node concept="2OqwBi" id="2T4l13I8CGo" role="3uHU7B">
+                <node concept="2OqwBi" id="2T4l13I8Amy" role="2Oq$k0">
+                  <node concept="13iPFW" id="2T4l13I8_U5" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="2T4l13I8AZL" role="2OqNvi">
+                    <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+                  </node>
+                </node>
+                <node concept="17RvpY" id="2T4l13I8DHP" role="2OqNvi" />
+              </node>
+              <node concept="2OqwBi" id="2T4l13I8GIy" role="3uHU7w">
+                <node concept="2OqwBi" id="2T4l13I8EBZ" role="2Oq$k0">
+                  <node concept="13iPFW" id="2T4l13I8EbJ" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="2T4l13I8ERn" role="2OqNvi">
+                    <ref role="3TsBF5" to="5qo5:19PglA20qXK" resolve="max" />
+                  </node>
+                </node>
+                <node concept="17RvpY" id="2T4l13I8HJL" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="P$JXv" id="2T4l13I94XN" role="lGtFl">
+        <node concept="TZ5HA" id="2T4l13I94XO" role="TZ5H$">
+          <node concept="1dT_AC" id="2T4l13I94XP" role="1dT_Ay">
+            <property role="1dT_AB" value="Check if range is an exact point, i.e., min==max and none of them is infinity." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="5bmRS0nnZlw" role="13h7CS">
+      <property role="TrG5h" value="getSinglePoint" />
+      <node concept="3Tm1VV" id="5bmRS0nnZlx" role="1B3o_S" />
+      <node concept="17QB3L" id="5bmRS0no07s" role="3clF45" />
+      <node concept="3clFbS" id="5bmRS0nnZlz" role="3clF47">
+        <node concept="3clFbF" id="5bmRS0no0az" role="3cqZAp">
+          <node concept="3K4zz7" id="5bmRS0no0aj" role="3clFbG">
+            <node concept="BsUDl" id="5bmRS0no0aZ" role="3K4Cdx">
+              <ref role="37wK5l" node="5bmRS0nmV1W" resolve="isSinglePoint" />
+            </node>
+            <node concept="2OqwBi" id="5bmRS0no0kY" role="3K4E3e">
+              <node concept="13iPFW" id="5bmRS0no0bI" role="2Oq$k0" />
+              <node concept="3TrcHB" id="5bmRS0no0xL" role="2OqNvi">
+                <ref role="3TsBF5" to="5qo5:19PglA20qXJ" resolve="min" />
+              </node>
+            </node>
+            <node concept="10Nm6u" id="5bmRS0no0$y" role="3K4GZi" />
+          </node>
         </node>
       </node>
     </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.typetags.physunits/models/org.iets3.core.expr.typetags.physunits.typesystem.mps
@@ -12526,13 +12526,31 @@
                       </node>
                     </node>
                     <node concept="3clFbS" id="1eut2uTTmN9" role="Jncv$">
-                      <node concept="3clFbF" id="57Dr2jEauCO" role="3cqZAp">
-                        <node concept="2OqwBi" id="57Dr2jEauRz" role="3clFbG">
-                          <node concept="Jnkvi" id="57Dr2jEauCM" role="2Oq$k0">
-                            <ref role="1M0zk5" node="1eut2uTTmNj" resolve="numberType" />
+                      <node concept="3cpWs8" id="4k4qgMYV0Nd" role="3cqZAp">
+                        <node concept="3cpWsn" id="4k4qgMYV0Ne" role="3cpWs9">
+                          <property role="TrG5h" value="base" />
+                          <node concept="10Oyi0" id="4k4qgMYUZ7a" role="1tU5fm" />
+                          <node concept="2OqwBi" id="4k4qgMYV0Nf" role="33vP2m">
+                            <node concept="37vLTw" id="4k4qgMYV0Ng" role="2Oq$k0">
+                              <ref role="3cqZAo" node="ijdpu3bl3M" resolve="manager" />
+                            </node>
+                            <node concept="liA8E" id="4k4qgMYV0Nh" role="2OqNvi">
+                              <ref role="37wK5l" to="rppw:6RONOaUhe_q" resolve="getBase" />
+                            </node>
                           </node>
-                          <node concept="2qgKlT" id="57Dr2jEavhd" role="2OqNvi">
-                            <ref role="37wK5l" to="b1h1:7Wa2sv3G6bK" resolve="setInfinitePrecision" />
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="4k4qgMYV4Lx" role="3cqZAp">
+                        <node concept="3cpWsn" id="4k4qgMYV4Ly" role="3cpWs9">
+                          <property role="TrG5h" value="exp" />
+                          <node concept="10Oyi0" id="4k4qgMYV4tM" role="1tU5fm" />
+                          <node concept="2OqwBi" id="4k4qgMYV4Lz" role="33vP2m">
+                            <node concept="37vLTw" id="4k4qgMYV4L$" role="2Oq$k0">
+                              <ref role="3cqZAo" node="1eut2uTTmMl" resolve="prefix" />
+                            </node>
+                            <node concept="2sxana" id="4k4qgMYV4L_" role="2OqNvi">
+                              <ref role="2sxfKC" to="rppw:2hbaSyB0ITv" resolve="factor" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -12554,24 +12572,209 @@
                               <node concept="2YIFZM" id="57Dr2jFZTFQ" role="37wK5m">
                                 <ref role="37wK5l" to="xlxw:~BigDecimal.valueOf(long)" resolve="valueOf" />
                                 <ref role="1Pybhc" to="xlxw:~BigDecimal" resolve="BigDecimal" />
-                                <node concept="2OqwBi" id="57Dr2jFZUy6" role="37wK5m">
-                                  <node concept="37vLTw" id="57Dr2jFZUy7" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="ijdpu3bl3M" resolve="manager" />
-                                  </node>
-                                  <node concept="liA8E" id="57Dr2jFZUy8" role="2OqNvi">
-                                    <ref role="37wK5l" to="rppw:6RONOaUhe_q" resolve="getBase" />
-                                  </node>
+                                <node concept="37vLTw" id="4k4qgMYV0Ni" role="37wK5m">
+                                  <ref role="3cqZAo" node="4k4qgMYV0Ne" resolve="base" />
                                 </node>
                               </node>
                               <node concept="2YIFZM" id="57Dr2jFZTFU" role="37wK5m">
                                 <ref role="37wK5l" to="xlxw:~BigDecimal.valueOf(long)" resolve="valueOf" />
                                 <ref role="1Pybhc" to="xlxw:~BigDecimal" resolve="BigDecimal" />
-                                <node concept="2OqwBi" id="57Dr2jFZV1K" role="37wK5m">
-                                  <node concept="37vLTw" id="57Dr2jFZV1L" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="1eut2uTTmMl" resolve="prefix" />
+                                <node concept="37vLTw" id="4k4qgMYV4LA" role="37wK5m">
+                                  <ref role="3cqZAo" node="4k4qgMYV4Ly" resolve="exp" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbH" id="5bmRS0ntsD4" role="3cqZAp" />
+                      <node concept="3cpWs8" id="5bmRS0npcN_" role="3cqZAp">
+                        <node concept="3cpWsn" id="5bmRS0npcNA" role="3cpWs9">
+                          <property role="TrG5h" value="singlePointRange" />
+                          <node concept="17QB3L" id="5bmRS0npcEq" role="1tU5fm" />
+                          <node concept="2OqwBi" id="5bmRS0npcNB" role="33vP2m">
+                            <node concept="Jnkvi" id="5bmRS0npcNC" role="2Oq$k0">
+                              <ref role="1M0zk5" node="1eut2uTTmNj" resolve="numberType" />
+                            </node>
+                            <node concept="2qgKlT" id="5bmRS0npcND" role="2OqNvi">
+                              <ref role="37wK5l" to="b1h1:5bmRS0nolm$" resolve="getSinglePointRange" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbJ" id="5bmRS0nmAat" role="3cqZAp">
+                        <node concept="3clFbS" id="5bmRS0nmAav" role="3clFbx">
+                          <node concept="3SKdUt" id="5bmRS0nv30o" role="3cqZAp">
+                            <node concept="1PaTwC" id="5bmRS0nv30p" role="1aUNEU">
+                              <node concept="3oM_SD" id="5bmRS0nv30q" role="1PaTwD">
+                                <property role="3oM_SC" value="compute" />
+                              </node>
+                              <node concept="3oM_SD" id="5bmRS0nv34s" role="1PaTwD">
+                                <property role="3oM_SC" value="precision" />
+                              </node>
+                              <node concept="3oM_SD" id="5bmRS0nv38e" role="1PaTwD">
+                                <property role="3oM_SC" value="from" />
+                              </node>
+                              <node concept="3oM_SD" id="5bmRS0nv3bZ" role="1PaTwD">
+                                <property role="3oM_SC" value="range," />
+                              </node>
+                              <node concept="3oM_SD" id="5bmRS0nv3fK" role="1PaTwD">
+                                <property role="3oM_SC" value="if" />
+                              </node>
+                              <node concept="3oM_SD" id="5bmRS0nv3fL" role="1PaTwD">
+                                <property role="3oM_SC" value="range" />
+                              </node>
+                              <node concept="3oM_SD" id="5bmRS0nv3jy" role="1PaTwD">
+                                <property role="3oM_SC" value="is" />
+                              </node>
+                              <node concept="3oM_SD" id="5bmRS0nv3jz" role="1PaTwD">
+                                <property role="3oM_SC" value="a" />
+                              </node>
+                              <node concept="3oM_SD" id="5bmRS0nv3j$" role="1PaTwD">
+                                <property role="3oM_SC" value="constant" />
+                              </node>
+                              <node concept="3oM_SD" id="5bmRS0nv3nl" role="1PaTwD">
+                                <property role="3oM_SC" value="value" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="5bmRS0nprNY" role="3cqZAp">
+                            <node concept="2OqwBi" id="5bmRS0nps_j" role="3clFbG">
+                              <node concept="Jnkvi" id="5bmRS0nprNW" role="2Oq$k0">
+                                <ref role="1M0zk5" node="1eut2uTTmNj" resolve="numberType" />
+                              </node>
+                              <node concept="2qgKlT" id="5bmRS0npwZU" role="2OqNvi">
+                                <ref role="37wK5l" to="b1h1:2RZ2I9pAbPi" resolve="setPrecisionFromValue" />
+                                <node concept="37vLTw" id="5bmRS0npx9e" role="37wK5m">
+                                  <ref role="3cqZAo" node="5bmRS0npcNA" resolve="singlePointRange" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="5bmRS0npmOO" role="3clFbw">
+                          <node concept="37vLTw" id="5bmRS0npl_q" role="2Oq$k0">
+                            <ref role="3cqZAo" node="5bmRS0npcNA" resolve="singlePointRange" />
+                          </node>
+                          <node concept="17RvpY" id="5bmRS0npnRm" role="2OqNvi" />
+                        </node>
+                        <node concept="9aQIb" id="5bmRS0npnZ7" role="9aQIa">
+                          <node concept="3clFbS" id="5bmRS0npnZ8" role="9aQI4">
+                            <node concept="3SKdUt" id="5bmRS0nv6m$" role="3cqZAp">
+                              <node concept="1PaTwC" id="5bmRS0nv6m_" role="1aUNEU">
+                                <node concept="3oM_SD" id="5bmRS0nv9dl" role="1PaTwD">
+                                  <property role="3oM_SC" value="otherwise" />
+                                </node>
+                                <node concept="3oM_SD" id="5bmRS0nv9dm" role="1PaTwD">
+                                  <property role="3oM_SC" value="compute" />
+                                </node>
+                                <node concept="3oM_SD" id="5bmRS0nv9h8" role="1PaTwD">
+                                  <property role="3oM_SC" value="precision" />
+                                </node>
+                                <node concept="3oM_SD" id="5bmRS0nv9Uu" role="1PaTwD">
+                                  <property role="3oM_SC" value="from" />
+                                </node>
+                                <node concept="3oM_SD" id="5bmRS0nv9Uv" role="1PaTwD">
+                                  <property role="3oM_SC" value="old" />
+                                </node>
+                                <node concept="3oM_SD" id="5bmRS0nv9Yg" role="1PaTwD">
+                                  <property role="3oM_SC" value="precision" />
+                                </node>
+                                <node concept="3oM_SD" id="5bmRS0nva21" role="1PaTwD">
+                                  <property role="3oM_SC" value="and" />
+                                </node>
+                                <node concept="3oM_SD" id="5bmRS0nva9$" role="1PaTwD">
+                                  <property role="3oM_SC" value="multiplication" />
+                                </node>
+                                <node concept="3oM_SD" id="5bmRS0nvah5" role="1PaTwD">
+                                  <property role="3oM_SC" value="due" />
+                                </node>
+                                <node concept="3oM_SD" id="5bmRS0nvah6" role="1PaTwD">
+                                  <property role="3oM_SC" value="to" />
+                                </node>
+                                <node concept="3oM_SD" id="5bmRS0nvakR" role="1PaTwD">
+                                  <property role="3oM_SC" value="unit" />
+                                </node>
+                                <node concept="3oM_SD" id="5bmRS0nvaw8" role="1PaTwD">
+                                  <property role="3oM_SC" value="prefix" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3cpWs8" id="4k4qgMYW49W" role="3cqZAp">
+                              <node concept="3cpWsn" id="4k4qgMYW49Z" role="3cpWs9">
+                                <property role="TrG5h" value="exp10" />
+                                <node concept="10Oyi0" id="4k4qgMYW49U" role="1tU5fm" />
+                                <node concept="3K4zz7" id="4k4qgMYW4Na" role="33vP2m">
+                                  <node concept="1eOMI4" id="4k4qgMYWlTQ" role="3K4Cdx">
+                                    <node concept="3clFbC" id="4k4qgMYW74L" role="1eOMHV">
+                                      <node concept="3cmrfG" id="4k4qgMYW74O" role="3uHU7w">
+                                        <property role="3cmrfH" value="10" />
+                                      </node>
+                                      <node concept="37vLTw" id="4k4qgMYW4Nu" role="3uHU7B">
+                                        <ref role="3cqZAo" node="4k4qgMYV0Ne" resolve="base" />
+                                      </node>
+                                    </node>
                                   </node>
-                                  <node concept="2sxana" id="57Dr2jFZV1M" role="2OqNvi">
-                                    <ref role="2sxfKC" to="rppw:2hbaSyB0ITv" resolve="factor" />
+                                  <node concept="37vLTw" id="4k4qgMYW96c" role="3K4E3e">
+                                    <ref role="3cqZAo" node="4k4qgMYV4Ly" resolve="exp" />
+                                  </node>
+                                  <node concept="10QFUN" id="4k4qgMYWfkm" role="3K4GZi">
+                                    <node concept="10Oyi0" id="4k4qgMYWfkn" role="10QFUM" />
+                                    <node concept="2YIFZM" id="4k4qgMYWfko" role="10QFUP">
+                                      <ref role="37wK5l" to="wyt6:~Math.ceil(double)" resolve="ceil" />
+                                      <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                                      <node concept="17qRlL" id="4k4qgMYWfkp" role="37wK5m">
+                                        <node concept="37vLTw" id="4k4qgMYWfkq" role="3uHU7B">
+                                          <ref role="3cqZAo" node="4k4qgMYV4Ly" resolve="exp" />
+                                        </node>
+                                        <node concept="2YIFZM" id="4k4qgMYWfkr" role="3uHU7w">
+                                          <ref role="37wK5l" to="wyt6:~Math.log10(double)" resolve="log10" />
+                                          <ref role="1Pybhc" to="wyt6:~Math" resolve="Math" />
+                                          <node concept="37vLTw" id="4k4qgMYWfks" role="37wK5m">
+                                            <ref role="3cqZAo" node="4k4qgMYV0Ne" resolve="base" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3cpWs8" id="4k4qgMYVo6D" role="3cqZAp">
+                              <node concept="3cpWsn" id="4k4qgMYVo6G" role="3cpWs9">
+                                <property role="TrG5h" value="oldPrec" />
+                                <node concept="10Oyi0" id="4k4qgMYVo6B" role="1tU5fm" />
+                                <node concept="2OqwBi" id="4k4qgMYVrKv" role="33vP2m">
+                                  <node concept="Jnkvi" id="4k4qgMYVqZy" role="2Oq$k0">
+                                    <ref role="1M0zk5" node="1eut2uTTmNj" resolve="numberType" />
+                                  </node>
+                                  <node concept="2qgKlT" id="4k4qgMYVvzv" role="2OqNvi">
+                                    <ref role="37wK5l" to="b1h1:19PglA20ASE" resolve="precision" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="4k4qgMYVhgs" role="3cqZAp">
+                              <node concept="2OqwBi" id="4k4qgMYVhvv" role="3clFbG">
+                                <node concept="Jnkvi" id="4k4qgMYVhgq" role="2Oq$k0">
+                                  <ref role="1M0zk5" node="1eut2uTTmNj" resolve="numberType" />
+                                </node>
+                                <node concept="2qgKlT" id="4k4qgMYVl5W" role="2OqNvi">
+                                  <ref role="37wK5l" to="b1h1:19PglA21KtA" resolve="setPrecision" />
+                                  <node concept="2YIFZM" id="4k4qgMYVDUi" role="37wK5m">
+                                    <ref role="37wK5l" to="wyt6:~Integer.max(int,int)" resolve="max" />
+                                    <ref role="1Pybhc" to="wyt6:~Integer" resolve="Integer" />
+                                    <node concept="3cmrfG" id="4k4qgMYVE00" role="37wK5m">
+                                      <property role="3cmrfH" value="0" />
+                                    </node>
+                                    <node concept="3cpWsd" id="4k4qgMYVBL2" role="37wK5m">
+                                      <node concept="37vLTw" id="4k4qgMYVyrz" role="3uHU7B">
+                                        <ref role="3cqZAo" node="4k4qgMYVo6G" resolve="oldPrec" />
+                                      </node>
+                                      <node concept="37vLTw" id="4k4qgMYW$FY" role="3uHU7w">
+                                        <ref role="3cqZAo" node="4k4qgMYW49Z" resolve="exp10" />
+                                      </node>
+                                    </node>
                                   </node>
                                 </node>
                               </node>

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.phyunits@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test.ts.expr.os.phyunits@tests.mps
@@ -5521,6 +5521,137 @@
             </node>
           </node>
         </node>
+        <node concept="_ixoA" id="5bmRS0n8fDE" role="_iOnC" />
+        <node concept="2zPypq" id="5bmRS0naD1U" role="_iOnC">
+          <property role="TrG5h" value="x1" />
+          <node concept="1YnStw" id="5bmRS0nbbk7" role="2lDidJ">
+            <node concept="CIsGf" id="5bmRS0nbbk6" role="2c7tTI">
+              <node concept="CIsvn" id="5bmRS0nbbk5" role="CIi4h">
+                <property role="1xG2w7" value="k" />
+                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="5bmRS0naZ3m" role="2lDidJ">
+              <property role="30bXRw" value="12" />
+            </node>
+          </node>
+          <node concept="2c7tTJ" id="5bmRS0naYQS" role="2zM23F">
+            <node concept="CIsGf" id="5bmRS0naYRh" role="2c7tTI">
+              <node concept="CIsvn" id="5bmRS0naYRg" role="CIi4h">
+                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
+              </node>
+            </node>
+            <node concept="mLuIC" id="5bmRS0naYQH" role="2c7tTw" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="5bmRS0nbxVv" role="_iOnC">
+          <property role="TrG5h" value="x2" />
+          <node concept="30dDZf" id="5bmRS0nbVLn" role="2lDidJ">
+            <node concept="1YnStw" id="5bmRS0nbXCq" role="30dEs_">
+              <node concept="CIsGf" id="5bmRS0nbXz5" role="2c7tTI">
+                <node concept="CIsvn" id="5bmRS0nbXz6" role="CIi4h">
+                  <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="5bmRS0nbVVJ" role="2lDidJ">
+                <property role="30bXRw" value="300" />
+              </node>
+            </node>
+            <node concept="1YnStw" id="5bmRS0nbVyq" role="30dEsF">
+              <node concept="CIsGf" id="5bmRS0nbVyp" role="2c7tTI">
+                <node concept="CIsvn" id="5bmRS0nbVyo" role="CIi4h">
+                  <property role="1xG2w7" value="k" />
+                  <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
+                </node>
+              </node>
+              <node concept="30bXRB" id="5bmRS0nbUcR" role="2lDidJ">
+                <property role="30bXRw" value="2" />
+              </node>
+            </node>
+          </node>
+          <node concept="2c7tTJ" id="5bmRS0nbUay" role="2zM23F">
+            <node concept="CIsGf" id="5bmRS0nbUbe" role="2c7tTI">
+              <node concept="CIsvn" id="5bmRS0nbUbd" role="CIi4h">
+                <ref role="CIi3I" to="8ps7:14aBVbN55En" resolve="byte" />
+              </node>
+            </node>
+            <node concept="mLuIC" id="5bmRS0nbUag" role="2c7tTw" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="5bmRS0n8m2h" role="_iOnC">
+          <property role="TrG5h" value="y1" />
+          <node concept="1YnStw" id="5bmRS0n8srW" role="2lDidJ">
+            <node concept="CIsGf" id="5bmRS0n8srV" role="2c7tTI">
+              <node concept="CIsvn" id="5bmRS0n8srU" role="CIi4h">
+                <property role="1xG2w7" value="k" />
+                <ref role="CIi3I" to="8ps7:3xM68GMigWr" resolve="m" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="5bmRS0n8o_M" role="2lDidJ">
+              <property role="30bXRw" value="2" />
+            </node>
+          </node>
+          <node concept="2c7tTJ" id="5bmRS0n8o$G" role="2zM23F">
+            <node concept="CIsGf" id="5bmRS0n8o_5" role="2c7tTI">
+              <node concept="CIsvn" id="5bmRS0n8o_4" role="CIi4h">
+                <ref role="CIi3I" to="8ps7:3xM68GMigWr" resolve="m" />
+              </node>
+            </node>
+            <node concept="mLuIC" id="5bmRS0n8o$x" role="2c7tTw" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="5bmRS0neE0x" role="_iOnC">
+          <property role="TrG5h" value="y2" />
+          <node concept="1YnStw" id="5bmRS0neE0y" role="2lDidJ">
+            <node concept="CIsGf" id="5bmRS0neE0z" role="2c7tTI">
+              <node concept="CIsvn" id="5bmRS0nfMWf" role="CIi4h">
+                <property role="1xG2w7" value="c" />
+                <ref role="CIi3I" to="8ps7:3xM68GMigWr" resolve="m" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="5bmRS0neE0_" role="2lDidJ">
+              <property role="30bXRw" value="7" />
+            </node>
+          </node>
+          <node concept="2c7tTJ" id="5bmRS0neE0A" role="2zM23F">
+            <node concept="CIsGf" id="5bmRS0neE0B" role="2c7tTI">
+              <node concept="CIsvn" id="5bmRS0neE0C" role="CIi4h">
+                <ref role="CIi3I" to="8ps7:3xM68GMigWr" resolve="m" />
+              </node>
+            </node>
+            <node concept="mLuIC" id="5bmRS0neE0D" role="2c7tTw">
+              <node concept="2gteS_" id="5bmRS0nfc_q" role="2gteVg">
+                <property role="2gteVv" value="2" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5bmRS0n8EdR" role="_iOnC">
+          <property role="TrG5h" value="z" />
+          <node concept="1YnStw" id="5bmRS0naey$" role="2lDidJ">
+            <node concept="CIsGf" id="5bmRS0naeyz" role="2c7tTI">
+              <node concept="CIsvn" id="5bmRS0nahp_" role="CIi4h">
+                <property role="1xG2w7" value="m" />
+                <ref role="CIi3I" to="8ps7:3xM68GMigZI" resolve="F" />
+              </node>
+            </node>
+            <node concept="30bXRB" id="5bmRS0n8NiN" role="2lDidJ">
+              <property role="30bXRw" value="900" />
+            </node>
+          </node>
+          <node concept="2c7tTJ" id="5bmRS0n8Hzs" role="2zM23F">
+            <node concept="CIsGf" id="5bmRS0n8HzP" role="2c7tTI">
+              <node concept="CIsvn" id="5bmRS0n8HzO" role="CIi4h">
+                <ref role="CIi3I" to="8ps7:3xM68GMigZI" resolve="F" />
+              </node>
+            </node>
+            <node concept="mLuIC" id="5bmRS0n8Hzh" role="2c7tTw">
+              <node concept="2gteS_" id="5bmRS0nggTF" role="2gteVg">
+                <property role="2gteVv" value="1" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="7CXmI" id="2S3ZC$oC8QF" role="lGtFl">
           <node concept="7OXhh" id="2S3ZC$oC8QG" role="7EUXB" />
         </node>
@@ -5732,7 +5863,7 @@
       <ref role="3GEb4d" to="8ps7:3xM68GMigWg" resolve="SIBaseUnits" />
     </node>
     <node concept="3GEVxB" id="7DfYVnlh04B" role="3i6evy">
-      <ref role="3GEb4d" node="7DfYVnlgZTZ" resolve="Quanities" />
+      <ref role="3GEb4d" node="7DfYVnlgZTZ" resolve="Quantities" />
     </node>
   </node>
   <node concept="1lH9Xt" id="74SLKElsaBA">
@@ -9439,7 +9570,7 @@
     </node>
   </node>
   <node concept="_iOnV" id="7DfYVnlgZTZ">
-    <property role="TrG5h" value="Quanities" />
+    <property role="TrG5h" value="Quantities" />
     <node concept="Rn5op" id="1FkCRmRXPku" role="_iOnC">
       <property role="TrG5h" value="millimetre" />
     </node>


### PR DESCRIPTION
This PR extends  some tests for physunits to reproduce the problem of infinite precision for types of prefixed units. It provides the fix, and updates the CHANGELOG accordingly.

This solves #1593.
