### PR TITLE
copy required type of `IShortLambdaContainer` to avoid it being stolen from its parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
   - The units `Joule`, `Coulomb` and `Watt` can now have also prefixes with negative metric scaling, e.g., `mW` (Milliwatt). Additionally, some typos have been corrected in the physical units documentation.
   - The precision of number types with prefixed units (e.g. `mW` or `km`) was always set to `infinite` by the typesystem. Now, the precision is as precise as possible.
 - Variability: Viewer for skeleton trees has been improved (better error reporting, more stable, does not break on nodes which are string literals).
+- ShortLambda Interpreter: Fixed a bug which resulted in a `RuntimeErrorType` when interpreting ShortLambdas.
 
 ## December 2025
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.lambda/models/plugin.mps
@@ -2796,8 +2796,11 @@
         </node>
         <node concept="3clFbF" id="5s__jxDPOrl" role="3cqZAp">
           <node concept="37vLTI" id="5s__jxDPVYt" role="3clFbG">
-            <node concept="37vLTw" id="5s__jxDPXKc" role="37vLTx">
-              <ref role="3cqZAo" node="7cphKbKO6qs" resolve="ttt" />
+            <node concept="2OqwBi" id="2UmCUZmeiLx" role="37vLTx">
+              <node concept="37vLTw" id="5s__jxDPXKc" role="2Oq$k0">
+                <ref role="3cqZAo" node="7cphKbKO6qs" resolve="ttt" />
+              </node>
+              <node concept="1$rogu" id="2UmCUZmelqy" role="2OqNvi" />
             </node>
             <node concept="2OqwBi" id="5s__jxDPQwi" role="37vLTJ">
               <node concept="37vLTw" id="5s__jxDPOrj" role="2Oq$k0">


### PR DESCRIPTION
Simply adds a `.copy` to [this node](http://127.0.0.1:63320/node?ref=r%3A51edfe99-0380-475c-a3e9-1d4425eac12f%28org.iets3.core.expr.lambda.plugin%29%2F6279589324964486156):

<img width="1159" height="341" alt="image" src="https://github.com/user-attachments/assets/0df63bcf-d698-4106-aa4d-19ac99c3e26f" />

Does not impact other versions.

Fixes #1606.