### PR TITLE
Variability: Improve IRenamer hierarchy and add documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 ### Changed
 
-- Variability: Improve performance of opening big variant configurations in editor (by switching off editor hints which are not needed).
+- Variability: The performance of opening big variant configurations in editor has been improved (by switching off editor hints which are not needed).
+- Variability: The class hierarchy implementing `IRenamer` has been improved and documented. This interface is being used for tailoring the renaming behavior of the variability filtering algorithms.
 
 
 ## January 2026

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.artifacts.base/models/org.iets3.variability.artifacts.base.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.artifacts.base/models/org.iets3.variability.artifacts.base.behavior.mps
@@ -10575,7 +10575,7 @@
     </node>
     <node concept="2tJIrI" id="2vmYTIOMtnm" role="jymVt" />
     <node concept="3clFb_" id="2vmYTIOM2Rn" role="jymVt">
-      <property role="TrG5h" value="instantationPath" />
+      <property role="TrG5h" value="instantiationPath" />
       <node concept="_YKpA" id="2vmYTIOM2Ro" role="3clF45">
         <node concept="3qUE_q" id="2vmYTIORlQc" role="_ZDj9">
           <node concept="3uibUv" id="2vmYTIORlQd" role="3qUE_r">
@@ -10603,8 +10603,8 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="3uibUv" id="2vmYTIOLZnn" role="EKbjA">
-      <ref role="3uigEE" to="eagd:2vmYTIOLCIe" resolve="IInstantationContext" />
+    <node concept="3uibUv" id="1yzsogE7WAc" role="EKbjA">
+      <ref role="3uigEE" to="eagd:2vmYTIOLCIe" resolve="IInstantiationContext" />
     </node>
   </node>
   <node concept="312cEu" id="1h_GRFcXM1h">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.artifacts.base/models/org.iets3.variability.artifacts.base.plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.artifacts.base/models/org.iets3.variability.artifacts.base.plugin.mps
@@ -191,6 +191,7 @@
       </concept>
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <property id="1075300953594" name="abstractClass" index="1sVAO0" />
         <property id="1221565133444" name="isFinal" index="1EXbeo" />
         <child id="1095933932569" name="implementedInterface" index="EKbjA" />
         <child id="1165602531693" name="superclass" index="1zkMxy" />
@@ -443,6 +444,9 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1204834851141" name="jetbrains.mps.lang.smodel.structure.PoundExpression" flags="ng" index="25Kdxt">
+        <child id="1204834868751" name="expression" index="25KhWn" />
+      </concept>
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
@@ -14388,10 +14392,10 @@
   </node>
   <node concept="3HP615" id="2vmYTIOLCIe">
     <property role="3GE5qa" value="skeleton.builder" />
-    <property role="TrG5h" value="IInstantationContext" />
+    <property role="TrG5h" value="IInstantiationContext" />
     <node concept="2tJIrI" id="2vmYTIOLCJw" role="jymVt" />
     <node concept="3clFb_" id="2vmYTIOLCKn" role="jymVt">
-      <property role="TrG5h" value="instantationPath" />
+      <property role="TrG5h" value="instantiationPath" />
       <node concept="_YKpA" id="2vmYTIOLCOz" role="3clF45">
         <node concept="3qUE_q" id="2vmYTIORkSp" role="_ZDj9">
           <node concept="3uibUv" id="2vmYTIORkSq" role="3qUE_r">
@@ -15144,10 +15148,66 @@
   <node concept="3HP615" id="1lgF22rJdhj">
     <property role="2bfB8j" value="true" />
     <property role="TrG5h" value="IRenamer" />
-    <property role="3GE5qa" value="filtering" />
+    <property role="3GE5qa" value="filtering.renamer" />
     <node concept="3clFb_" id="1lgF22rJmF6" role="jymVt">
       <property role="TrG5h" value="rename" />
-      <node concept="3clFbS" id="1lgF22rJmF9" role="3clF47" />
+      <node concept="3clFbS" id="1lgF22rJmF9" role="3clF47">
+        <node concept="3SKdUt" id="1yzsogEdgEF" role="3cqZAp">
+          <node concept="1PaTwC" id="1yzsogEdgEG" role="1aUNEU">
+            <node concept="3oM_SD" id="1yzsogEdgEH" role="1PaTwD">
+              <property role="3oM_SC" value="do" />
+            </node>
+            <node concept="3oM_SD" id="1yzsogEdhGJ" role="1PaTwD">
+              <property role="3oM_SC" value="nothing" />
+            </node>
+            <node concept="3oM_SD" id="1yzsogEdhJE" role="1PaTwD">
+              <property role="3oM_SC" value="(we" />
+            </node>
+            <node concept="3oM_SD" id="1yzsogEdhM_" role="1PaTwD">
+              <property role="3oM_SC" value="have" />
+            </node>
+            <node concept="3oM_SD" id="1yzsogEdhPx" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="1yzsogEdhPy" role="1PaTwD">
+              <property role="3oM_SC" value="provide" />
+            </node>
+            <node concept="3oM_SD" id="1yzsogEdhSw" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="1yzsogEdhSx" role="1PaTwD">
+              <property role="3oM_SC" value="default" />
+            </node>
+            <node concept="3oM_SD" id="1yzsogEdiwd" role="1PaTwD">
+              <property role="3oM_SC" value="allowing" />
+            </node>
+            <node concept="3oM_SD" id="1yzsogEdhYz" role="1PaTwD">
+              <property role="3oM_SC" value="existing" />
+            </node>
+            <node concept="3oM_SD" id="1yzsogEdidP" role="1PaTwD">
+              <property role="3oM_SC" value="implementers" />
+            </node>
+            <node concept="3oM_SD" id="1yzsogEdin4" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="1yzsogEdizx" role="1PaTwD">
+              <property role="3oM_SC" value="switch" />
+            </node>
+            <node concept="3oM_SD" id="1yzsogEdiAQ" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="1yzsogEdiAR" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="1yzsogEdiDY" role="1PaTwD">
+              <property role="3oM_SC" value="new" />
+            </node>
+            <node concept="3oM_SD" id="1yzsogEdiDZ" role="1PaTwD">
+              <property role="3oM_SC" value="method" />
+            </node>
+          </node>
+        </node>
+      </node>
       <node concept="3Tm1VV" id="1lgF22rJmFa" role="1B3o_S" />
       <node concept="3cqZAl" id="1lgF22rJmAp" role="3clF45" />
       <node concept="37vLTG" id="1lgF22rJnDC" role="3clF46">
@@ -15168,7 +15228,14 @@
       </node>
       <node concept="2AHcQZ" id="2vmYTIPrmRM" role="2AJF6D">
         <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+        <node concept="2B6LJw" id="1yzsogEncQU" role="2B76xF">
+          <ref role="2B6OnR" to="wyt6:~Deprecated.since()" resolve="since" />
+          <node concept="Xl_RD" id="1yzsogEnhr5" role="2B70Vg">
+            <property role="Xl_RC" value="2025-06-25" />
+          </node>
+        </node>
       </node>
+      <node concept="2JFqV2" id="1yzsogEdezZ" role="2frcjj" />
     </node>
     <node concept="2tJIrI" id="2vmYTIPd_XV" role="jymVt" />
     <node concept="3clFb_" id="2vmYTIPdRIN" role="jymVt">
@@ -15211,12 +15278,141 @@
       <node concept="37vLTG" id="2vmYTIPez6Y" role="3clF46">
         <property role="TrG5h" value="context" />
         <node concept="3uibUv" id="2vmYTIPeESr" role="1tU5fm">
-          <ref role="3uigEE" node="2vmYTIOLCIe" resolve="IInstantationContext" />
+          <ref role="3uigEE" node="2vmYTIOLCIe" resolve="IInstantiationContext" />
+        </node>
+      </node>
+      <node concept="P$JXv" id="1yzsogEc82a" role="lGtFl">
+        <node concept="TZ5HA" id="1yzsogEc82b" role="TZ5H$">
+          <node concept="1dT_AC" id="1yzsogEc82c" role="1dT_Ay">
+            <property role="1dT_AB" value="This method is called during variability filtering, allowing the application code to rename" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="1yzsogEcaKs" role="TZ5H$">
+          <node concept="1dT_AC" id="1yzsogEcaKt" role="1dT_Ay">
+            <property role="1dT_AB" value="instantiated nodes. It provides some additional arguments which can be used by the renaming-logic." />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1yzsogEc82d" role="3nqlJM">
+          <property role="TUZQ4" value="the instantiated node being created" />
+          <node concept="zr_55" id="1yzsogEc82f" role="zr_5Q">
+            <ref role="zr_51" node="2vmYTIPemf6" resolve="newInstance" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1yzsogEc82g" role="3nqlJM">
+          <property role="TUZQ4" value="all instances which have been created up to now" />
+          <node concept="zr_55" id="1yzsogEc82i" role="zr_5Q">
+            <ref role="zr_51" node="2vmYTIPemf8" resolve="oldInstances" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1yzsogEc82j" role="3nqlJM">
+          <property role="TUZQ4" value="the pivot node on which the instantiation is based" />
+          <node concept="zr_55" id="1yzsogEc82l" role="zr_5Q">
+            <ref role="zr_51" node="3UdWAXoggOU" resolve="artifactPivot" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1yzsogEc82m" role="3nqlJM">
+          <property role="TUZQ4" value="the instantiation context (a nested path of pivot nodes)" />
+          <node concept="zr_55" id="1yzsogEc82o" role="zr_5Q">
+            <ref role="zr_51" node="2vmYTIPez6Y" resolve="context" />
+          </node>
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="hp_ygEfg8c" role="jymVt" />
     <node concept="2tJIrI" id="hp_ygEfg9v" role="jymVt" />
+    <node concept="2YIFZL" id="1yzsogE2uwO" role="jymVt">
+      <property role="TrG5h" value="hasNameClash" />
+      <node concept="3clFbS" id="6HIBxZkRGLK" role="3clF47">
+        <node concept="3clFbF" id="ELtOWhtt8H" role="3cqZAp">
+          <node concept="2OqwBi" id="6HIBxZkRGLM" role="3clFbG">
+            <node concept="1eOMI4" id="6HIBxZkRGLO" role="2Oq$k0">
+              <node concept="2OqwBi" id="6HIBxZkRGLP" role="1eOMHV">
+                <node concept="37vLTw" id="6HIBxZkRGMm" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6HIBxZkRGMj" resolve="existingInstances" />
+                </node>
+                <node concept="v3k3i" id="6HIBxZkRGLR" role="2OqNvi">
+                  <node concept="25Kdxt" id="ELtOWhsPWI" role="v3oSu">
+                    <node concept="2OqwBi" id="ELtOWhtm65" role="25KhWn">
+                      <node concept="37vLTw" id="ELtOWhtkdm" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6HIBxZkRTL3" resolve="newInstance" />
+                      </node>
+                      <node concept="2yIwOk" id="ELtOWhtobz" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2HwmR7" id="6HIBxZkRGM6" role="2OqNvi">
+              <node concept="1bVj0M" id="6HIBxZkRGM7" role="23t8la">
+                <node concept="3clFbS" id="6HIBxZkRGM8" role="1bW5cS">
+                  <node concept="3clFbF" id="6HIBxZkRGM9" role="3cqZAp">
+                    <node concept="17R0WA" id="6HIBxZkRGMa" role="3clFbG">
+                      <node concept="2OqwBi" id="6HIBxZkRGMb" role="3uHU7w">
+                        <node concept="3TrcHB" id="6HIBxZkRGMd" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                        <node concept="37vLTw" id="6HIBxZkSv_5" role="2Oq$k0">
+                          <ref role="3cqZAo" node="6HIBxZkRTL3" resolve="newInstance" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="6HIBxZkRGMe" role="3uHU7B">
+                        <node concept="37vLTw" id="6HIBxZkRGMf" role="2Oq$k0">
+                          <ref role="3cqZAo" node="2r1kIC$yAz_" resolve="it" />
+                        </node>
+                        <node concept="3TrcHB" id="6HIBxZkRGMg" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="2r1kIC$yAz_" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="2r1kIC$yAzA" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6HIBxZkRGMj" role="3clF46">
+        <property role="TrG5h" value="existingInstances" />
+        <node concept="2hMVRd" id="6HIBxZkRGMk" role="1tU5fm">
+          <node concept="3Tqbb2" id="6HIBxZkRGMl" role="2hN53Y" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6HIBxZkRTL3" role="3clF46">
+        <property role="TrG5h" value="newInstance" />
+        <node concept="3Tqbb2" id="6HIBxZkRZv2" role="1tU5fm">
+          <ref role="ehGHo" to="tpck:h0TrEE$" resolve="INamedConcept" />
+        </node>
+      </node>
+      <node concept="10P_77" id="6HIBxZkRGMq" role="3clF45" />
+      <node concept="3Tm1VV" id="1yzsogE2y8v" role="1B3o_S" />
+      <node concept="P$JXv" id="1yzsogE2CL$" role="lGtFl">
+        <node concept="TZ5HA" id="1yzsogE2CL_" role="TZ5H$">
+          <node concept="1dT_AC" id="1yzsogE2CLA" role="1dT_Ay">
+            <property role="1dT_AB" value="Helper function to check if among the existing instances is one with the same name as newInstance." />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1yzsogE2CLB" role="3nqlJM">
+          <property role="TUZQ4" value="the existing instances" />
+          <node concept="zr_55" id="1yzsogE2CLD" role="zr_5Q">
+            <ref role="zr_51" node="6HIBxZkRGMj" resolve="existingInstances" />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="1yzsogE2CLE" role="3nqlJM">
+          <property role="TUZQ4" value="the new instance to check" />
+          <node concept="zr_55" id="1yzsogE2CLG" role="zr_5Q">
+            <ref role="zr_51" node="6HIBxZkRTL3" resolve="newInstance" />
+          </node>
+        </node>
+        <node concept="x79VA" id="1yzsogE2CLH" role="3nqlJM">
+          <property role="x79VB" value="true if the name already exists" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1yzsogE2Aqg" role="jymVt" />
     <node concept="3Tm1VV" id="1lgF22rJ6c0" role="1B3o_S" />
     <node concept="2YIFZL" id="hp_ygEg1bU" role="jymVt">
       <property role="TrG5h" value="prefixFor" />
@@ -15236,7 +15432,7 @@
                     <ref role="3cqZAo" node="hp_ygEg1bX" resolve="context" />
                   </node>
                   <node concept="liA8E" id="hp_ygEg1cb" role="2OqNvi">
-                    <ref role="37wK5l" node="2vmYTIOLCKn" resolve="instantationPath" />
+                    <ref role="37wK5l" node="2vmYTIOLCKn" resolve="instantiationPath" />
                   </node>
                 </node>
                 <node concept="3$u5V9" id="hp_ygEg1cc" role="2OqNvi">
@@ -15395,7 +15591,7 @@
       <node concept="37vLTG" id="hp_ygEg1bX" role="3clF46">
         <property role="TrG5h" value="context" />
         <node concept="3uibUv" id="hp_ygEg1bY" role="1tU5fm">
-          <ref role="3uigEE" node="2vmYTIOLCIe" resolve="IInstantationContext" />
+          <ref role="3uigEE" node="2vmYTIOLCIe" resolve="IInstantiationContext" />
         </node>
       </node>
       <node concept="37vLTG" id="hp_ygEg1bZ" role="3clF46">
@@ -15428,25 +15624,9 @@
     </node>
   </node>
   <node concept="312cEu" id="1lgF22rHJj5">
-    <property role="TrG5h" value="Renamer" />
-    <property role="3GE5qa" value="filtering" />
+    <property role="TrG5h" value="DefaultRenamer" />
+    <property role="3GE5qa" value="filtering.renamer" />
     <node concept="2tJIrI" id="44egA1liflQ" role="jymVt" />
-    <node concept="312cEg" id="44egA1lf43N" role="jymVt">
-      <property role="TrG5h" value="noInstancesPerOrigNode" />
-      <node concept="3Tm6S6" id="44egA1lf43O" role="1B3o_S" />
-      <node concept="2YIFZM" id="44egA1lf43P" role="33vP2m">
-        <ref role="37wK5l" to="3o3z:~Maps.newHashMap()" resolve="newHashMap" />
-        <ref role="1Pybhc" to="3o3z:~Maps" resolve="Maps" />
-      </node>
-      <node concept="3uibUv" id="44egA1lf43Q" role="1tU5fm">
-        <ref role="3uigEE" to="33ny:~Map" resolve="Map" />
-        <node concept="3Tqbb2" id="44egA1lf43R" role="11_B2D" />
-        <node concept="3uibUv" id="44egA1lf43S" role="11_B2D">
-          <ref role="3uigEE" to="qhup:~MutableInt" resolve="MutableInt" />
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="44egA1leY$R" role="jymVt" />
     <node concept="3clFb_" id="1lgF22rKkUp" role="jymVt">
       <property role="TrG5h" value="rename" />
       <node concept="3Tm1VV" id="1lgF22rKkUr" role="1B3o_S" />
@@ -15467,6 +15647,12 @@
         <property role="TrG5h" value="artifactRoot" />
         <node concept="3Tqbb2" id="1lgF22rKVkm" role="1tU5fm" />
       </node>
+      <node concept="37vLTG" id="1yzsogEdcdU" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <node concept="3uibUv" id="1yzsogEdcdV" role="1tU5fm">
+          <ref role="3uigEE" node="2vmYTIOLCIe" resolve="IInstantiationContext" />
+        </node>
+      </node>
       <node concept="3clFbS" id="1lgF22rKkUv" role="3clF47">
         <node concept="3cpWs8" id="1GuQqCw3W$w" role="3cqZAp">
           <node concept="3cpWsn" id="1GuQqCw3W$x" role="3cpWs9">
@@ -15476,7 +15662,7 @@
             </node>
             <node concept="2OqwBi" id="1GuQqCw3W$z" role="33vP2m">
               <node concept="liA8E" id="1GuQqCwpcGl" role="2OqNvi">
-                <ref role="37wK5l" node="44egA1lfkSs" resolve="instanceCounterFor" />
+                <ref role="37wK5l" node="1yzsogE4n45" resolve="instanceCounterFor" />
                 <node concept="37vLTw" id="1GuQqCwpjIJ" role="37wK5m">
                   <ref role="3cqZAo" node="1lgF22rKObN" resolve="artifactRoot" />
                 </node>
@@ -15535,12 +15721,13 @@
               </node>
             </node>
           </node>
-          <node concept="1rXfSq" id="6HIBxZkTuFr" role="3clFbw">
-            <ref role="37wK5l" node="6HIBxZkRGMo" resolve="hasNameClash" />
-            <node concept="37vLTw" id="44egA1li1DG" role="37wK5m">
+          <node concept="2YIFZM" id="1yzsogE6Pa7" role="3clFbw">
+            <ref role="37wK5l" node="1yzsogE2uwO" resolve="hasNameClash" />
+            <ref role="1Pybhc" node="1lgF22rJdhj" resolve="IRenamer" />
+            <node concept="37vLTw" id="1yzsogE6Qol" role="37wK5m">
               <ref role="3cqZAo" node="44egA1lhJtZ" resolve="oldInstances" />
             </node>
-            <node concept="37vLTw" id="1lgF22rL84f" role="37wK5m">
+            <node concept="37vLTw" id="1yzsogE6Qom" role="37wK5m">
               <ref role="3cqZAo" node="1lgF22rKkUt" resolve="newInstance" />
             </node>
           </node>
@@ -15550,153 +15737,22 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="2tJIrI" id="44egA1lfs1B" role="jymVt" />
-    <node concept="3clFb_" id="44egA1lfkSs" role="jymVt">
-      <property role="TrG5h" value="instanceCounterFor" />
-      <node concept="37vLTG" id="44egA1lfkSt" role="3clF46">
-        <property role="TrG5h" value="n" />
-        <node concept="3Tqbb2" id="44egA1lfkSu" role="1tU5fm" />
-      </node>
-      <node concept="3uibUv" id="44egA1lfkSv" role="3clF45">
-        <ref role="3uigEE" to="qhup:~MutableInt" resolve="MutableInt" />
-      </node>
-      <node concept="3Tm6S6" id="44egA1lf_o3" role="1B3o_S" />
-      <node concept="3clFbS" id="44egA1lfkSx" role="3clF47">
-        <node concept="3clFbF" id="44egA1lfkSy" role="3cqZAp">
-          <node concept="2OqwBi" id="44egA1lfkSz" role="3clFbG">
-            <node concept="2OqwBi" id="44egA1lfkS$" role="2Oq$k0">
-              <node concept="Xjq3P" id="44egA1lfkS_" role="2Oq$k0" />
-              <node concept="2OwXpG" id="44egA1lfkSA" role="2OqNvi">
-                <ref role="2Oxat5" node="44egA1lf43N" resolve="noInstancesPerOrigNode" />
-              </node>
-            </node>
-            <node concept="liA8E" id="44egA1lfkSB" role="2OqNvi">
-              <ref role="37wK5l" to="33ny:~Map.computeIfAbsent(java.lang.Object,java.util.function.Function)" resolve="computeIfAbsent" />
-              <node concept="37vLTw" id="44egA1lfkSC" role="37wK5m">
-                <ref role="3cqZAo" node="44egA1lfkSt" resolve="n" />
-              </node>
-              <node concept="1bVj0M" id="44egA1lfkSD" role="37wK5m">
-                <node concept="37vLTG" id="44egA1lfkSE" role="1bW2Oz">
-                  <property role="TrG5h" value="n" />
-                  <node concept="3Tqbb2" id="44egA1lfkSF" role="1tU5fm" />
-                </node>
-                <node concept="3clFbS" id="44egA1lfkSG" role="1bW5cS">
-                  <node concept="3clFbF" id="44egA1lfkSH" role="3cqZAp">
-                    <node concept="2ShNRf" id="44egA1lfkSI" role="3clFbG">
-                      <node concept="1pGfFk" id="44egA1lfkSJ" role="2ShVmc">
-                        <ref role="37wK5l" to="qhup:~MutableInt.&lt;init&gt;(int)" resolve="MutableInt" />
-                        <node concept="3cmrfG" id="44egA1lfkSK" role="37wK5m">
-                          <property role="3cmrfH" value="0" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="44egA1lfaVC" role="jymVt" />
-    <node concept="2tJIrI" id="1lgF22rK2Y9" role="jymVt" />
-    <node concept="3uibUv" id="1lgF22rJP$K" role="EKbjA">
-      <ref role="3uigEE" node="1lgF22rJdhj" resolve="IRenamer" />
-    </node>
-    <node concept="3clFb_" id="6HIBxZkRGMo" role="jymVt">
-      <property role="TrG5h" value="hasNameClash" />
-      <node concept="3Tm6S6" id="6HIBxZkRGMp" role="1B3o_S" />
-      <node concept="10P_77" id="6HIBxZkRGMq" role="3clF45" />
-      <node concept="37vLTG" id="6HIBxZkRGMj" role="3clF46">
-        <property role="TrG5h" value="instances" />
-        <node concept="2hMVRd" id="6HIBxZkRGMk" role="1tU5fm">
-          <node concept="3Tqbb2" id="6HIBxZkRGMl" role="2hN53Y" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="6HIBxZkRTL3" role="3clF46">
-        <property role="TrG5h" value="newInstance" />
-        <node concept="3Tqbb2" id="6HIBxZkRZv2" role="1tU5fm">
-          <ref role="ehGHo" to="tpck:h0TrEE$" resolve="INamedConcept" />
-        </node>
-      </node>
-      <node concept="3clFbS" id="6HIBxZkRGLK" role="3clF47">
-        <node concept="3cpWs6" id="6HIBxZkRGLL" role="3cqZAp">
-          <node concept="2OqwBi" id="6HIBxZkRGLM" role="3cqZAk">
-            <node concept="2OqwBi" id="6HIBxZkRGLN" role="2Oq$k0">
-              <node concept="1eOMI4" id="6HIBxZkRGLO" role="2Oq$k0">
-                <node concept="2OqwBi" id="6HIBxZkRGLP" role="1eOMHV">
-                  <node concept="37vLTw" id="6HIBxZkRGMm" role="2Oq$k0">
-                    <ref role="3cqZAo" node="6HIBxZkRGMj" resolve="instances" />
-                  </node>
-                  <node concept="v3k3i" id="6HIBxZkRGLR" role="2OqNvi">
-                    <node concept="chp4Y" id="6HIBxZkRGLS" role="v3oSu">
-                      <ref role="cht4Q" to="tpck:h0TrEE$" resolve="INamedConcept" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3zZkjj" id="6HIBxZkRGLT" role="2OqNvi">
-                <node concept="1bVj0M" id="6HIBxZkRGLU" role="23t8la">
-                  <node concept="3clFbS" id="6HIBxZkRGLV" role="1bW5cS">
-                    <node concept="3clFbF" id="6HIBxZkRGLW" role="3cqZAp">
-                      <node concept="17R0WA" id="6HIBxZkRGLX" role="3clFbG">
-                        <node concept="2OqwBi" id="6HIBxZkRGLY" role="3uHU7B">
-                          <node concept="37vLTw" id="6HIBxZkRGLZ" role="2Oq$k0">
-                            <ref role="3cqZAo" node="2r1kIC$yAzz" resolve="it" />
-                          </node>
-                          <node concept="2yIwOk" id="6HIBxZkRGM0" role="2OqNvi" />
-                        </node>
-                        <node concept="2OqwBi" id="6HIBxZkRGM1" role="3uHU7w">
-                          <node concept="37vLTw" id="6HIBxZkSjE3" role="2Oq$k0">
-                            <ref role="3cqZAo" node="6HIBxZkRTL3" resolve="newInstance" />
-                          </node>
-                          <node concept="2yIwOk" id="6HIBxZkRGM3" role="2OqNvi" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="gl6BB" id="2r1kIC$yAzz" role="1bW2Oz">
-                    <property role="TrG5h" value="it" />
-                    <node concept="2jxLKc" id="2r1kIC$yAz$" role="1tU5fm" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="2HwmR7" id="6HIBxZkRGM6" role="2OqNvi">
-              <node concept="1bVj0M" id="6HIBxZkRGM7" role="23t8la">
-                <node concept="3clFbS" id="6HIBxZkRGM8" role="1bW5cS">
-                  <node concept="3clFbF" id="6HIBxZkRGM9" role="3cqZAp">
-                    <node concept="17R0WA" id="6HIBxZkRGMa" role="3clFbG">
-                      <node concept="2OqwBi" id="6HIBxZkRGMb" role="3uHU7w">
-                        <node concept="3TrcHB" id="6HIBxZkRGMd" role="2OqNvi">
-                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                        </node>
-                        <node concept="37vLTw" id="6HIBxZkSv_5" role="2Oq$k0">
-                          <ref role="3cqZAo" node="6HIBxZkRTL3" resolve="newInstance" />
-                        </node>
-                      </node>
-                      <node concept="2OqwBi" id="6HIBxZkRGMe" role="3uHU7B">
-                        <node concept="37vLTw" id="6HIBxZkRGMf" role="2Oq$k0">
-                          <ref role="3cqZAo" node="2r1kIC$yAz_" resolve="it" />
-                        </node>
-                        <node concept="3TrcHB" id="6HIBxZkRGMg" role="2OqNvi">
-                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="gl6BB" id="2r1kIC$yAz_" role="1bW2Oz">
-                  <property role="TrG5h" value="it" />
-                  <node concept="2jxLKc" id="2r1kIC$yAzA" role="1tU5fm" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
     <node concept="3Tm1VV" id="35o5AzKZ5sT" role="1B3o_S" />
+    <node concept="3uibUv" id="1yzsogE4xMK" role="1zkMxy">
+      <ref role="3uigEE" node="1yzsogE4n3d" resolve="AbstractRenamer" />
+    </node>
+    <node concept="3UR2Jj" id="1yzsogE4OxT" role="lGtFl">
+      <node concept="TZ5HA" id="1yzsogE4OxU" role="TZ5H$">
+        <node concept="1dT_AC" id="1yzsogE4OxV" role="1dT_Ay">
+          <property role="1dT_AB" value="This renamer does not change the name of the first instance. Subsequent instances are renamed with an" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="1yzsogE4Ql0" role="TZ5H$">
+        <node concept="1dT_AC" id="1yzsogE4Ql1" role="1dT_Ay">
+          <property role="1dT_AB" value="integer suffix starting from 2. " />
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="312cEu" id="7xQHGgVP0D3">
     <property role="TrG5h" value="FilterParams" />
@@ -16058,7 +16114,7 @@
               <node concept="2ShNRf" id="3vI4D5kM_01" role="37vLTx">
                 <node concept="HV5vD" id="3vI4D5kN9zs" role="2ShVmc">
                   <property role="373rjd" value="true" />
-                  <ref role="HV5vE" node="1lgF22rHJj5" resolve="Renamer" />
+                  <ref role="HV5vE" node="1lgF22rHJj5" resolve="DefaultRenamer" />
                 </node>
               </node>
               <node concept="2OqwBi" id="3vI4D5kMztr" role="37vLTJ">
@@ -16950,6 +17006,179 @@
         </node>
       </node>
     </node>
+  </node>
+  <node concept="312cEu" id="1yzsogE4k9t">
+    <property role="TrG5h" value="ConsistentRenamer" />
+    <property role="3GE5qa" value="filtering.renamer" />
+    <node concept="2tJIrI" id="1yzsogE4k9u" role="jymVt" />
+    <node concept="3clFb_" id="1yzsogE4k9A" role="jymVt">
+      <property role="TrG5h" value="rename" />
+      <node concept="3Tm1VV" id="1yzsogE4k9B" role="1B3o_S" />
+      <node concept="3cqZAl" id="1yzsogE4k9C" role="3clF45" />
+      <node concept="37vLTG" id="1yzsogE4k9D" role="3clF46">
+        <property role="TrG5h" value="newInstance" />
+        <node concept="3Tqbb2" id="1yzsogE4k9E" role="1tU5fm">
+          <ref role="ehGHo" to="tpck:h0TrEE$" resolve="INamedConcept" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1yzsogE4k9F" role="3clF46">
+        <property role="TrG5h" value="oldInstances" />
+        <node concept="2hMVRd" id="1yzsogE4k9G" role="1tU5fm">
+          <node concept="3Tqbb2" id="1yzsogE4k9H" role="2hN53Y" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1yzsogE4k9I" role="3clF46">
+        <property role="TrG5h" value="artifactRoot" />
+        <node concept="3Tqbb2" id="1yzsogE4k9J" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="1yzsogEdk3O" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <node concept="3uibUv" id="1yzsogEdk3P" role="1tU5fm">
+          <ref role="3uigEE" node="2vmYTIOLCIe" resolve="IInstantiationContext" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="1yzsogE4k9K" role="3clF47">
+        <node concept="3cpWs8" id="1yzsogE4k9L" role="3cqZAp">
+          <node concept="3cpWsn" id="1yzsogE4k9M" role="3cpWs9">
+            <property role="TrG5h" value="instanceIdx" />
+            <node concept="3uibUv" id="1yzsogE4k9N" role="1tU5fm">
+              <ref role="3uigEE" to="qhup:~MutableInt" resolve="MutableInt" />
+            </node>
+            <node concept="2OqwBi" id="1yzsogE4k9O" role="33vP2m">
+              <node concept="liA8E" id="1yzsogE4k9P" role="2OqNvi">
+                <ref role="37wK5l" node="1yzsogE4n45" resolve="instanceCounterFor" />
+                <node concept="37vLTw" id="1yzsogE4k9Q" role="37wK5m">
+                  <ref role="3cqZAo" node="1yzsogE4k9I" resolve="artifactRoot" />
+                </node>
+              </node>
+              <node concept="Xjq3P" id="1yzsogE4k9R" role="2Oq$k0" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1yzsogE4k9S" role="3cqZAp">
+          <node concept="2OqwBi" id="1yzsogE4k9T" role="3clFbG">
+            <node concept="37vLTw" id="1yzsogE4k9U" role="2Oq$k0">
+              <ref role="3cqZAo" node="1yzsogE4k9M" resolve="instanceIdx" />
+            </node>
+            <node concept="liA8E" id="1yzsogE4k9V" role="2OqNvi">
+              <ref role="37wK5l" to="qhup:~MutableInt.increment()" resolve="increment" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1yzsogE4ka6" role="3cqZAp">
+          <node concept="d57v9" id="1yzsogE4ka7" role="3clFbG">
+            <node concept="3cpWs3" id="1yzsogE4ka8" role="37vLTx">
+              <node concept="Xl_RD" id="1yzsogE4kaa" role="3uHU7B">
+                <property role="Xl_RC" value="_" />
+              </node>
+              <node concept="2OqwBi" id="1yzsogE4ka2" role="3uHU7w">
+                <node concept="37vLTw" id="1yzsogE4ka3" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1yzsogE4k9M" resolve="instanceIdx" />
+                </node>
+                <node concept="liA8E" id="1yzsogE4ka4" role="2OqNvi">
+                  <ref role="37wK5l" to="qhup:~MutableInt.intValue()" resolve="intValue" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="1yzsogE4kab" role="37vLTJ">
+              <node concept="37vLTw" id="1yzsogE4kac" role="2Oq$k0">
+                <ref role="3cqZAo" node="1yzsogE4k9D" resolve="newInstance" />
+              </node>
+              <node concept="3TrcHB" id="1yzsogE4kad" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1yzsogE4kaj" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="1yzsogE4kaF" role="1B3o_S" />
+    <node concept="3uibUv" id="1yzsogE4BJS" role="1zkMxy">
+      <ref role="3uigEE" node="1yzsogE4n3d" resolve="AbstractRenamer" />
+    </node>
+    <node concept="3UR2Jj" id="1yzsogE4TAH" role="lGtFl">
+      <node concept="TZ5HA" id="1yzsogE4Uas" role="TZ5H$">
+        <node concept="1dT_AC" id="1yzsogE4Uat" role="1dT_Ay">
+          <property role="1dT_AB" value="This renamer adds a suffix to all instances, starting with the integer 1." />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="1yzsogE4n3d">
+    <property role="TrG5h" value="AbstractRenamer" />
+    <property role="3GE5qa" value="filtering.renamer" />
+    <property role="1sVAO0" value="true" />
+    <node concept="2tJIrI" id="1yzsogE4n3e" role="jymVt" />
+    <node concept="312cEg" id="1yzsogE4n3f" role="jymVt">
+      <property role="TrG5h" value="noInstancesPerOrigNode" />
+      <node concept="3Tm6S6" id="1yzsogE4sDL" role="1B3o_S" />
+      <node concept="2YIFZM" id="1yzsogE4n3h" role="33vP2m">
+        <ref role="37wK5l" to="3o3z:~Maps.newHashMap()" resolve="newHashMap" />
+        <ref role="1Pybhc" to="3o3z:~Maps" resolve="Maps" />
+      </node>
+      <node concept="3uibUv" id="1yzsogE4n3i" role="1tU5fm">
+        <ref role="3uigEE" to="33ny:~Map" resolve="Map" />
+        <node concept="3Tqbb2" id="1yzsogE4n3j" role="11_B2D" />
+        <node concept="3uibUv" id="1yzsogE4n3k" role="11_B2D">
+          <ref role="3uigEE" to="qhup:~MutableInt" resolve="MutableInt" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1yzsogE4n44" role="jymVt" />
+    <node concept="3clFb_" id="1yzsogE4n45" role="jymVt">
+      <property role="TrG5h" value="instanceCounterFor" />
+      <node concept="37vLTG" id="1yzsogE4n46" role="3clF46">
+        <property role="TrG5h" value="n" />
+        <node concept="3Tqbb2" id="1yzsogE4n47" role="1tU5fm" />
+      </node>
+      <node concept="3uibUv" id="1yzsogE4n48" role="3clF45">
+        <ref role="3uigEE" to="qhup:~MutableInt" resolve="MutableInt" />
+      </node>
+      <node concept="3Tmbuc" id="1yzsogE4tD8" role="1B3o_S" />
+      <node concept="3clFbS" id="1yzsogE4n4a" role="3clF47">
+        <node concept="3clFbF" id="1yzsogE4n4b" role="3cqZAp">
+          <node concept="2OqwBi" id="1yzsogE4n4c" role="3clFbG">
+            <node concept="2OqwBi" id="1yzsogE4n4d" role="2Oq$k0">
+              <node concept="Xjq3P" id="1yzsogE4n4e" role="2Oq$k0" />
+              <node concept="2OwXpG" id="1yzsogE4n4f" role="2OqNvi">
+                <ref role="2Oxat5" node="1yzsogE4n3f" resolve="noInstancesPerOrigNode" />
+              </node>
+            </node>
+            <node concept="liA8E" id="1yzsogE4n4g" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Map.computeIfAbsent(java.lang.Object,java.util.function.Function)" resolve="computeIfAbsent" />
+              <node concept="37vLTw" id="1yzsogE4n4h" role="37wK5m">
+                <ref role="3cqZAo" node="1yzsogE4n46" resolve="n" />
+              </node>
+              <node concept="1bVj0M" id="1yzsogE4n4i" role="37wK5m">
+                <node concept="37vLTG" id="1yzsogE4n4j" role="1bW2Oz">
+                  <property role="TrG5h" value="n" />
+                  <node concept="3Tqbb2" id="1yzsogE4n4k" role="1tU5fm" />
+                </node>
+                <node concept="3clFbS" id="1yzsogE4n4l" role="1bW5cS">
+                  <node concept="3clFbF" id="1yzsogE4n4m" role="3cqZAp">
+                    <node concept="2ShNRf" id="1yzsogE4n4n" role="3clFbG">
+                      <node concept="1pGfFk" id="1yzsogE4n4o" role="2ShVmc">
+                        <ref role="37wK5l" to="qhup:~MutableInt.&lt;init&gt;(int)" resolve="MutableInt" />
+                        <node concept="3cmrfG" id="1yzsogE4n4p" role="37wK5m">
+                          <property role="3cmrfH" value="0" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3uibUv" id="1yzsogE4n4q" role="EKbjA">
+      <ref role="3uigEE" node="1lgF22rJdhj" resolve="IRenamer" />
+    </node>
+    <node concept="3Tm1VV" id="1yzsogE4n4r" role="1B3o_S" />
   </node>
 </model>
 


### PR DESCRIPTION
This PR improves and extends the `IRenamer` class hierarchy and adds a lot of javadoc. It also allows client code to remove the deprecated method `IRenamer.rename()`.

This will not have a direct impact on the functionality of IETS3 variability, but with a upcoming version of IETS3.Core the semantics of the `IRenamer.rename()` API (the non-deprecated one) will change slightly. The new documentation already reflects this.

CHANGELOG has been updated.

This solves #1625.