### PR TITLE
Update MPS to 2024.1.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-mpsVersion = "2024.1.3"
+mpsVersion = "2024.1.6"
 mpsQaVersion = "2024.1.+"
 # if you want to build against a specific mbeddr branch, prepend it here with a dot.
 # NOTE: instances of '/' in the branch name need to be replaced by '-'


### PR DESCRIPTION
MPS 2024.1.6 has stricter checks for plugin dependencies. Dependencies were already adjusted in #1624.