### PR TITLE
renovate: orchestrate version updates via PRs on maintenance and master branches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,10 +43,7 @@
     {
       // MPS: separate minor and patch updates in order to disable minor but leave patch updates enabled
       "matchPackageNames": ["com.jetbrains:mps"],
-      "separateMinorPatch": true,
-      // MPS: disable major and minor updates, only enable patch updates
-      "matchUpdateTypes": ["major", "minor"],
-      "enabled": false
+      "separateMinorPatch": true
     },
 
     {
@@ -55,6 +52,7 @@
       "matchBaseBranches": ["!master"],
       "enabled": false
     },
+
     // Disallow mps-gradle-plugin v2
     {
       "matchPackageNames": ["de.itemis.mps:mps-gradle-plugin"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,12 +3,16 @@
   "extends": [
     "config:recommended"
   ],
+  // Renovate master and recent maintenance branches. When updating the maintenance branch pattern, update the rule
+  // disabling approvals for the earliest maintenance branch.
+  "baseBranches": ["master", "/^maintenance/mps202[4-9][0-9]/"],
+  
   "packageRules": [
     // Rules are evaluated top to bottom, all matching rules are applied
 
     {
       "matchPackageNames": [
-        "com.jetbrains:mps",
+        "com.jetbrains.mps:mps-prerelease",
         "org.mpsqa:all-in-one",
         "com.mbeddr:platform"
       ],
@@ -25,7 +29,7 @@
       // Disable major and minor updates of MPS libraries and MPS (e.g. 2024.1 -> 2024.3). Leave patch updates enabled
       // thanks to the previous rule.
       "matchPackageNames": [
-        "com.jetbrains:mps",
+        "com.jetbrains:mps-prerelease",
         "org.mpsqa:all-in-one",
         "com.mbeddr:platform"
       ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -41,12 +41,6 @@
     },
 
     {
-      // MPS: separate minor and patch updates in order to disable minor but leave patch updates enabled
-      "matchPackageNames": ["com.jetbrains:mps"],
-      "separateMinorPatch": true
-    },
-
-    {
       // Disable JBR updates on maintenance branches
       "matchPackageNames": ["com.jetbrains.jdk:*"],
       "matchBaseBranches": ["!master"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,7 +32,6 @@
       // Disable major and minor updates of MPS libraries and MPS (e.g. 2024.1 -> 2024.3). Leave patch updates enabled
       // thanks to the previous rule.
       "matchPackageNames": [
-        "com.jetbrains.mps:mps-prerelease", // Master branch
         "com.jetbrains:mps",                // Maintenance branches
         "org.mpsqa:all-in-one",
         "com.mbeddr:platform"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,16 +3,19 @@
   "extends": [
     "config:recommended"
   ],
+  // enable dashboards for orchestration
+  "dependencyDashboard": true,
   // Renovate master and recent maintenance branches. When updating the maintenance branch pattern, update the rule
   // disabling approvals for the earliest maintenance branch.
   "baseBranches": ["master", "/^maintenance/mps202[4-9][0-9]/"],
-  
+
   "packageRules": [
     // Rules are evaluated top to bottom, all matching rules are applied
 
     {
       "matchPackageNames": [
-        "com.jetbrains.mps:mps-prerelease",
+        "com.jetbrains.mps:mps-prerelease", // Master branch
+        "com.jetbrains:mps",                // Maintenance branches
         "org.mpsqa:all-in-one",
         "com.mbeddr:platform"
       ],
@@ -29,7 +32,8 @@
       // Disable major and minor updates of MPS libraries and MPS (e.g. 2024.1 -> 2024.3). Leave patch updates enabled
       // thanks to the previous rule.
       "matchPackageNames": [
-        "com.jetbrains:mps-prerelease",
+        "com.jetbrains.mps:mps-prerelease", // Master branch
+        "com.jetbrains:mps",                // Maintenance branches
         "org.mpsqa:all-in-one",
         "com.mbeddr:platform"
       ],
@@ -37,10 +41,46 @@
       "enabled": false
     },
 
+    {
+      // MPS: separate minor and patch updates in order to disable minor but leave patch updates enabled
+      "matchPackageNames": ["com.jetbrains:mps"],
+      "separateMinorPatch": true,
+      // MPS: disable major and minor updates, only enable patch updates
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+
+    {
+      // Disable JBR updates on maintenance branches
+      "matchPackageNames": ["com.jetbrains.jdk:*"],
+      "matchBaseBranches": ["!master"],
+      "enabled": false
+    },
     // Disallow mps-gradle-plugin v2
     {
       "matchPackageNames": ["de.itemis.mps:mps-gradle-plugin"],
       "allowedVersions": "!/^2\\./"
+    },
+
+    {
+      // Group all minor/patch third-party dependencies together (overrides the grouping above for minor and patch updates)
+      "matchManagers": ["gradle"],
+      "matchPackageNames": ["!com.jetbrains*"], // Exclude MPS and JBR
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "third-party-minor",
+    },
+
+    {
+      // Group all GitHub Actions updates together
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
+
+    // Updates to the earliest supported maintenance branch do not need approval.
+    {
+      "matchBaseBranches": ["maintenance/mps20241"],
+      "dependencyDashboardApproval": false
     }
+
   ],
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,7 +15,6 @@
 
     {
       "matchPackageNames": [
-        "com.jetbrains.mps:mps-prerelease", // Master branch
         "com.jetbrains:mps",                // Maintenance branches
         "org.mpsqa:all-in-one",
         "com.mbeddr:platform"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,7 @@
   ],
   // enable dashboards for orchestration
   "dependencyDashboard": true,
+  "dependencyDashboardApproval": true,
   // Renovate master and recent maintenance branches. When updating the maintenance branch pattern, update the rule
   // disabling approvals for the earliest maintenance branch.
   "baseBranches": ["master", "/^maintenance/mps202[4-9][0-9]/"],

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
 mpsVersion = "253.28294.10374"
-mpsQaVersion = "9999.9.+"
+mpsQaVersion = "9999.9.1264.2b2934b"
 # if you want to build against a specific mbeddr branch, prepend it here with a dot.
 # NOTE: instances of '/' in the branch name need to be replaced by '-'
 # example: mbeddrVersion="feature-my_new_feature.2023.2.+"
-mbeddrVersion = "9999.9.+"
+mbeddrVersion = "9999.9.26390.7f24448"
 
 jbr = "21.0.6-b895.109"
 


### PR DESCRIPTION
Fixes #1667 for master

In this PR we provide a renovate configuration that should work for all our current maintenance branches. 
In addition we introduce fixed versions for mbeddr.platform and mps-qa to enable renovate bot to create PRs for updating those artifacts. 

Corresponding PRs which cleanup no longer needed renovate configus on [2024.1](https://github.com/IETS3/iets3.opensource/pull/1669) and [2025.1](https://github.com/IETS3/iets3.opensource/pull/1670) will be marged after this one.