### PR TITLE
replace modelcheck with MpsCheck

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -260,7 +260,7 @@ tasks.assemble {
 }
 
 val migrate by tasks.registering(MpsMigrate::class) {
-    dependsOn(resolveMPS, "resolveMpsForModelcheck", tasks.downloadJbr, buildLanguages, buildAndRunTests)
+    dependsOn(resolveMPS, tasks.downloadJbr, buildLanguages, buildAndRunTests)
     javaLauncher.set(tasks.downloadJbr.get().javaLauncher)
     haltOnPrecheckFailure.set(false)
     haltOnDependencyError.set(false)
@@ -273,7 +273,7 @@ val migrate by tasks.registering(MpsMigrate::class) {
 
 val remigrate by tasks.registering(Remigrate::class) {
     mustRunAfter(migrate, buildLanguages, buildAndRunTests)
-    dependsOn(resolveMPS, "resolveMpsForModelcheck", tasks.downloadJbr)
+    dependsOn(resolveMPS, tasks.downloadJbr)
     javaLauncher.set(tasks.downloadJbr.get().javaLauncher)
     mpsHome.set(mpsHomeDir)
     projectDirectories.from("code/languages/org.iets3.opensource")


### PR DESCRIPTION
To get rid of the dependency to the model check plugin we migrate to MpsCheck instead. This is already done on master, but not on 2024.1 and 2025.1.  Maintenance 2025.1 will be updated via cascading merge