### PR TITLE
Fix error for name of newly created feature model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 ### Fixed
 
 - Fixed a bug in the `execTestsByInterpreter` task which would result in a wrong JNA path
+- Variability: Newly created feature models will not show a "Property constraint violation" error anymore.
 
 
 ## February 2026

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.featuremodel.base/models/org.iets3.variability.featuremodel.base.constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.featuremodel.base/models/org.iets3.variability.featuremodel.base.constraints.mps
@@ -348,7 +348,7 @@
                   <node concept="2OqwBi" id="7SXl9kEJJPk" role="2Oq$k0">
                     <node concept="EsrRn" id="7SXl9kEJJPl" role="2Oq$k0" />
                     <node concept="3TrEf2" id="7SXl9kEJJPm" role="2OqNvi">
-                      <ref role="3Tt5mk" to="s6b7:3tsFshP5Ecc" />
+                      <ref role="3Tt5mk" to="s6b7:3tsFshP5Ecc" resolve="root" />
                     </node>
                   </node>
                   <node concept="3TrcHB" id="7SXl9kEJJPn" role="2OqNvi">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.featuremodel.base/models/org.iets3.variability.featuremodel.base.constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.featuremodel.base/models/org.iets3.variability.featuremodel.base.constraints.mps
@@ -323,16 +323,48 @@
       <ref role="EomxK" to="tpck:h0TrG11" resolve="name" />
       <node concept="Eqf_E" id="3tsFshP61NO" role="EtsB7">
         <node concept="3clFbS" id="3tsFshP61NP" role="2VODD2">
-          <node concept="3clFbF" id="3tsFshP61OY" role="3cqZAp">
-            <node concept="2OqwBi" id="3tsFshP62hf" role="3clFbG">
-              <node concept="2OqwBi" id="3tsFshP61SV" role="2Oq$k0">
-                <node concept="EsrRn" id="3tsFshP61OX" role="2Oq$k0" />
-                <node concept="3TrEf2" id="3tsFshP626V" role="2OqNvi">
-                  <ref role="3Tt5mk" to="s6b7:3tsFshP5Ecc" resolve="root" />
+          <node concept="3clFbF" id="25bCHl4QMjm" role="3cqZAp">
+            <node concept="3K4zz7" id="25bCHl4R5DC" role="3clFbG">
+              <node concept="Xl_RD" id="25bCHl4R93_" role="3K4E3e">
+                <property role="Xl_RC" value="NO_NAME" />
+              </node>
+              <node concept="1eOMI4" id="25bCHl4Reyc" role="3K4Cdx">
+                <node concept="22lmx$" id="25bCHl4QTMv" role="1eOMHV">
+                  <node concept="2OqwBi" id="25bCHl4R15A" role="3uHU7w">
+                    <node concept="2OqwBi" id="25bCHl4QYzX" role="2Oq$k0">
+                      <node concept="2OqwBi" id="25bCHl4QW5A" role="2Oq$k0">
+                        <node concept="EsrRn" id="25bCHl4QUga" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="25bCHl4QXJ3" role="2OqNvi">
+                          <ref role="3Tt5mk" to="s6b7:3tsFshP5Ecc" resolve="root" />
+                        </node>
+                      </node>
+                      <node concept="3TrcHB" id="25bCHl4QZB7" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                      </node>
+                    </node>
+                    <node concept="17RlXB" id="25bCHl4R3k_" role="2OqNvi" />
+                  </node>
+                  <node concept="2OqwBi" id="25bCHl4QQoH" role="3uHU7B">
+                    <node concept="2OqwBi" id="25bCHl4QMWA" role="2Oq$k0">
+                      <node concept="EsrRn" id="25bCHl4QMjl" role="2Oq$k0" />
+                      <node concept="3TrEf2" id="25bCHl4QPOu" role="2OqNvi">
+                        <ref role="3Tt5mk" to="s6b7:3tsFshP5Ecc" resolve="root" />
+                      </node>
+                    </node>
+                    <node concept="3w_OXm" id="25bCHl4QRXU" role="2OqNvi" />
+                  </node>
                 </node>
               </node>
-              <node concept="3TrcHB" id="3tsFshP62q1" role="2OqNvi">
-                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              <node concept="2OqwBi" id="3tsFshP62hf" role="3K4GZi">
+                <node concept="2OqwBi" id="3tsFshP61SV" role="2Oq$k0">
+                  <node concept="EsrRn" id="3tsFshP61OX" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="3tsFshP626V" role="2OqNvi">
+                    <ref role="3Tt5mk" to="s6b7:3tsFshP5Ecc" resolve="root" />
+                  </node>
+                </node>
+                <node concept="3TrcHB" id="3tsFshP62q1" role="2OqNvi">
+                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                </node>
               </node>
             </node>
           </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.featuremodel.base/models/org.iets3.variability.featuremodel.base.constraints.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.featuremodel.base/models/org.iets3.variability.featuremodel.base.constraints.mps
@@ -21,6 +21,8 @@
     <import index="700h" ref="r:61b1de80-490d-4fee-8e95-b956503290e9(org.iets3.core.expr.collections.structure)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="n8u2" ref="r:452e57fa-fd4c-45a8-b9ba-964614a5a66e(org.iets3.variability.base.behavior)" />
+    <import index="n8ay" ref="39983771-4e9b-401b-a1a9-1da6c777c843/java:org.apache.commons.lang(MPS.ThirdParty/)" />
+    <import index="btm1" ref="b0f8641f-bd77-4421-8425-30d9088a82f7/java:org.apache.commons.lang3(org.apache.commons/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" implicit="true" />
@@ -328,33 +330,6 @@
               <node concept="Xl_RD" id="25bCHl4R93_" role="3K4E3e">
                 <property role="Xl_RC" value="NO_NAME" />
               </node>
-              <node concept="1eOMI4" id="25bCHl4Reyc" role="3K4Cdx">
-                <node concept="22lmx$" id="25bCHl4QTMv" role="1eOMHV">
-                  <node concept="2OqwBi" id="25bCHl4R15A" role="3uHU7w">
-                    <node concept="2OqwBi" id="25bCHl4QYzX" role="2Oq$k0">
-                      <node concept="2OqwBi" id="25bCHl4QW5A" role="2Oq$k0">
-                        <node concept="EsrRn" id="25bCHl4QUga" role="2Oq$k0" />
-                        <node concept="3TrEf2" id="25bCHl4QXJ3" role="2OqNvi">
-                          <ref role="3Tt5mk" to="s6b7:3tsFshP5Ecc" resolve="root" />
-                        </node>
-                      </node>
-                      <node concept="3TrcHB" id="25bCHl4QZB7" role="2OqNvi">
-                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                      </node>
-                    </node>
-                    <node concept="17RlXB" id="25bCHl4R3k_" role="2OqNvi" />
-                  </node>
-                  <node concept="2OqwBi" id="25bCHl4QQoH" role="3uHU7B">
-                    <node concept="2OqwBi" id="25bCHl4QMWA" role="2Oq$k0">
-                      <node concept="EsrRn" id="25bCHl4QMjl" role="2Oq$k0" />
-                      <node concept="3TrEf2" id="25bCHl4QPOu" role="2OqNvi">
-                        <ref role="3Tt5mk" to="s6b7:3tsFshP5Ecc" resolve="root" />
-                      </node>
-                    </node>
-                    <node concept="3w_OXm" id="25bCHl4QRXU" role="2OqNvi" />
-                  </node>
-                </node>
-              </node>
               <node concept="2OqwBi" id="3tsFshP62hf" role="3K4GZi">
                 <node concept="2OqwBi" id="3tsFshP61SV" role="2Oq$k0">
                   <node concept="EsrRn" id="3tsFshP61OX" role="2Oq$k0" />
@@ -364,6 +339,21 @@
                 </node>
                 <node concept="3TrcHB" id="3tsFshP62q1" role="2OqNvi">
                   <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                </node>
+              </node>
+              <node concept="2YIFZM" id="7SXl9kEJJmM" role="3K4Cdx">
+                <ref role="37wK5l" to="btm1:~StringUtils.isEmpty(java.lang.CharSequence)" resolve="isEmpty" />
+                <ref role="1Pybhc" to="btm1:~StringUtils" resolve="StringUtils" />
+                <node concept="2OqwBi" id="7SXl9kEJJPj" role="37wK5m">
+                  <node concept="2OqwBi" id="7SXl9kEJJPk" role="2Oq$k0">
+                    <node concept="EsrRn" id="7SXl9kEJJPl" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="7SXl9kEJJPm" role="2OqNvi">
+                      <ref role="3Tt5mk" to="s6b7:3tsFshP5Ecc" />
+                    </node>
+                  </node>
+                  <node concept="3TrcHB" id="7SXl9kEJJPn" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.featuremodel.base/org.iets3.variability.featuremodel.base.mpl
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.featuremodel.base/org.iets3.variability.featuremodel.base.mpl
@@ -38,6 +38,7 @@
     <dependency reexport="false">8e98f4e2-decf-4e97-bf80-9109e8b759ee(jetbrains.mps.lang.constraints.rules.runtime)</dependency>
     <dependency reexport="false">9b66c5c9-38bf-4315-a96f-9f4e212c69cb(org.iets3.variability.base)</dependency>
     <dependency reexport="false">6fd1293f-7f65-4ffd-99dc-4719eca7c171(jetbrains.mps.ide.vcs.platform)</dependency>
+    <dependency reexport="false">39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d4280a54-f6df-4383-aa41-d1b2bffa7eb1:com.mbeddr.core.base" version="6" />
@@ -118,6 +119,7 @@
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="7124e466-fc92-4803-a656-d7a6b7eb3910(MPS.TextGen)" version="0" />
+    <module reference="39983771-4e9b-401b-a1a9-1da6c777c843(MPS.ThirdParty)" version="0" />
     <module reference="d4280a54-f6df-4383-aa41-d1b2bffa7eb1(com.mbeddr.core.base)" version="3" />
     <module reference="9e24fcdc-a232-4d24-8c95-1f525946191a(com.mbeddr.core.base.pluginSolution)" version="0" />
     <module reference="63e0e566-5131-447e-90e3-12ea330e1a00(com.mbeddr.mpsutil.blutil)" version="0" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.opensource.build/models/org/iets3/opensource/build/build.mps
@@ -2350,6 +2350,11 @@
             <ref role="3bR37D" to="ffeo:39HJr_hyEzS" resolve="jetbrains.mps.ide.vcs.platform" />
           </node>
         </node>
+        <node concept="1SiIV0" id="7SXl9kEJO9L" role="3bR37C">
+          <node concept="3bR9La" id="7SXl9kEJO9M" role="1SiIV1">
+            <ref role="3bR37D" to="90a9:3$A0JaN5bpX" resolve="MPS.ThirdParty" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="7B3y$vlfY21" role="2G$12L">
         <property role="BnDLt" value="true" />


### PR DESCRIPTION
The root feature of a newly created feature model deliberately lacks a name, thus an error is shown. This is correct.

However, the name of the feature model itself is derived from the root feature's name via a get-property constraint. As both the feature model concept and the root feature concept are implementing `IValidNamedConcept`, the non-existent name of a new root feature will cause a second error for the name of the feature model. This second error will not vanish automatically after some valid name is entered, only after F5 is pressed additionally. 

This PR fixes the problem by assigning a specific `NO_NAME` name to feature models without root feature or with root features with an invalid name.

This solves #1713.
