### PR TITLE
Allow to modify interpreter report file name prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
   - default expression of another attribute in feature model
   - presence condition in artifact
   - left-hand-side condition in an ITabularVarPoint
+- Allow to set `reportsFilenamePrefix` for the `ICustomRunnerConfig` interface
 
 ### Changed
 

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.junit.interpreter.run.configuration/models/xml4JUnit.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.junit.interpreter.run.configuration/models/xml4JUnit.mps
@@ -9075,13 +9075,13 @@
   <node concept="312cEu" id="5oK6Fmqm$Nt">
     <property role="TrG5h" value="TestExecutorConfigForCommandLine" />
     <node concept="2tJIrI" id="62vWlLjtsGh" role="jymVt" />
-    <node concept="Wx3nA" id="5oK6Fmqm_m$" role="jymVt">
+    <node concept="312cEg" id="6eihi2LdOHc" role="jymVt">
       <property role="TrG5h" value="myReportsFilenamePrefix" />
-      <node concept="17QB3L" id="5oK6Fmqm_m_" role="1tU5fm" />
-      <node concept="3Tm6S6" id="5oK6Fmqm_mA" role="1B3o_S" />
-      <node concept="Xl_RD" id="5oK6Fmqm_mB" role="33vP2m">
+      <node concept="17QB3L" id="6eihi2LdOHf" role="1tU5fm" />
+      <node concept="Xl_RD" id="6eihi2LdOHh" role="33vP2m">
         <property role="Xl_RC" value="InterpreterTestSuite" />
       </node>
+      <node concept="3Tm6S6" id="6eihi2LdOHg" role="1B3o_S" />
     </node>
     <node concept="Wx3nA" id="5oK6Fmqm_mC" role="jymVt">
       <property role="TrG5h" value="outputPathMacro" />
@@ -9163,19 +9163,51 @@
       </node>
       <node concept="17QB3L" id="5oK6FmqmMyP" role="3clF45" />
       <node concept="3Tm1VV" id="5oK6FmqmMyQ" role="1B3o_S" />
+      <node concept="2AHcQZ" id="6EUkQCWUHfM" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
     </node>
-    <node concept="2tJIrI" id="5oK6FmqmLBs" role="jymVt" />
     <node concept="3clFb_" id="5oK6FmqmLS7" role="jymVt">
       <property role="TrG5h" value="getReportFileNamePrefix" />
       <node concept="3clFbS" id="5oK6FmqmLSa" role="3clF47">
         <node concept="3cpWs6" id="5oK6FmqmLWd" role="3cqZAp">
           <node concept="37vLTw" id="5oK6FmqmM0H" role="3cqZAk">
-            <ref role="3cqZAo" node="5oK6Fmqm_m$" resolve="myReportsFilenamePrefix" />
+            <ref role="3cqZAo" node="6eihi2LdOHc" resolve="myReportsFilenamePrefix" />
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="5oK6FmqmLEV" role="1B3o_S" />
       <node concept="17QB3L" id="5oK6FmqmLHO" role="3clF45" />
+      <node concept="2AHcQZ" id="6EUkQCWUGHT" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="6eihi2LdWgX" role="jymVt">
+      <property role="TrG5h" value="setReportFileNamePrefix" />
+      <node concept="3clFbS" id="6eihi2LdWh0" role="3clF47">
+        <node concept="3clFbF" id="6eihi2LdXmY" role="3cqZAp">
+          <node concept="37vLTI" id="6eihi2Le22m" role="3clFbG">
+            <node concept="37vLTw" id="6eihi2Le2$i" role="37vLTx">
+              <ref role="3cqZAo" node="6eihi2LdWKC" resolve="input" />
+            </node>
+            <node concept="2OqwBi" id="6eihi2LdXA_" role="37vLTJ">
+              <node concept="Xjq3P" id="6eihi2LdXmX" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6eihi2LdZJy" role="2OqNvi">
+                <ref role="2Oxat5" node="6eihi2LdOHc" resolve="myReportsFilenamePrefix" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6eihi2LdVjA" role="1B3o_S" />
+      <node concept="3cqZAl" id="6eihi2LdVOh" role="3clF45" />
+      <node concept="37vLTG" id="6eihi2LdWKC" role="3clF46">
+        <property role="TrG5h" value="prefix" />
+        <node concept="17QB3L" id="6EUkQCWR4Oc" role="1tU5fm" />
+      </node>
+      <node concept="2AHcQZ" id="6EUkQCWUG4B" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
     </node>
     <node concept="3Tm1VV" id="5oK6Fmqm$Nu" role="1B3o_S" />
     <node concept="3uibUv" id="62vWlLjj9TO" role="EKbjA">
@@ -9311,6 +9343,16 @@
       <node concept="3clFbS" id="62vWlLjj9JF" role="3clF47" />
       <node concept="17QB3L" id="62vWlLjj9JI" role="3clF45" />
       <node concept="3Tm1VV" id="62vWlLjj9JJ" role="1B3o_S" />
+    </node>
+    <node concept="3clFb_" id="6EUkQCWUEn_" role="jymVt">
+      <property role="TrG5h" value="setReportFileNamePrefix" />
+      <node concept="3clFbS" id="6EUkQCWUEnC" role="3clF47" />
+      <node concept="3Tm1VV" id="6EUkQCWUEnD" role="1B3o_S" />
+      <node concept="3cqZAl" id="6EUkQCWUEiL" role="3clF45" />
+      <node concept="37vLTG" id="6EUkQCWUEuj" role="3clF46">
+        <property role="TrG5h" value="prefix" />
+        <node concept="17QB3L" id="6EUkQCWUEui" role="1tU5fm" />
+      </node>
     </node>
     <node concept="3clFb_" id="62vWlLjj9N0" role="jymVt">
       <property role="TrG5h" value="getReportFileNamePrefix" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.junit.interpreter.run.configuration/models/xml4JUnit.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.junit.interpreter.run.configuration/models/xml4JUnit.mps
@@ -9164,7 +9164,7 @@
       <node concept="17QB3L" id="5oK6FmqmMyP" role="3clF45" />
       <node concept="3Tm1VV" id="5oK6FmqmMyQ" role="1B3o_S" />
       <node concept="2AHcQZ" id="6EUkQCWUHfM" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="5oK6FmqmLS7" role="jymVt">
@@ -9179,7 +9179,7 @@
       <node concept="3Tm1VV" id="5oK6FmqmLEV" role="1B3o_S" />
       <node concept="17QB3L" id="5oK6FmqmLHO" role="3clF45" />
       <node concept="2AHcQZ" id="6EUkQCWUGHT" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3clFb_" id="6eihi2LdWgX" role="jymVt">
@@ -9188,7 +9188,7 @@
         <node concept="3clFbF" id="6eihi2LdXmY" role="3cqZAp">
           <node concept="37vLTI" id="6eihi2Le22m" role="3clFbG">
             <node concept="37vLTw" id="6eihi2Le2$i" role="37vLTx">
-              <ref role="3cqZAo" node="6eihi2LdWKC" resolve="input" />
+              <ref role="3cqZAo" node="6eihi2LdWKC" resolve="prefix" />
             </node>
             <node concept="2OqwBi" id="6eihi2LdXA_" role="37vLTJ">
               <node concept="Xjq3P" id="6eihi2LdXmX" role="2Oq$k0" />
@@ -9206,7 +9206,7 @@
         <node concept="17QB3L" id="6EUkQCWR4Oc" role="1tU5fm" />
       </node>
       <node concept="2AHcQZ" id="6EUkQCWUG4B" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
     <node concept="3Tm1VV" id="5oK6Fmqm$Nu" role="1B3o_S" />
@@ -10383,7 +10383,7 @@
         </node>
       </node>
       <node concept="2AHcQZ" id="xF7sV3vf5r" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" />
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.junit.interpreter.run.configuration/models/xml4JUnit.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.junit.interpreter.run.configuration/models/xml4JUnit.mps
@@ -10359,6 +10359,33 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
+    <node concept="3clFb_" id="xF7sV3vf5k" role="jymVt">
+      <property role="TrG5h" value="setReportFileNamePrefix" />
+      <node concept="3Tm1VV" id="xF7sV3vf5m" role="1B3o_S" />
+      <node concept="3cqZAl" id="xF7sV3vf5n" role="3clF45" />
+      <node concept="37vLTG" id="xF7sV3vf5o" role="3clF46">
+        <property role="TrG5h" value="prefix" />
+        <node concept="17QB3L" id="xF7sV3vf5p" role="1tU5fm" />
+      </node>
+      <node concept="3clFbS" id="xF7sV3vf5q" role="3clF47">
+        <node concept="3clFbF" id="xF7sV3vfKu" role="3cqZAp">
+          <node concept="37vLTI" id="xF7sV3vh0G" role="3clFbG">
+            <node concept="37vLTw" id="xF7sV3vhjQ" role="37vLTx">
+              <ref role="3cqZAo" node="xF7sV3vf5o" resolve="prefix" />
+            </node>
+            <node concept="2OqwBi" id="xF7sV3vjJG" role="37vLTJ">
+              <node concept="Xjq3P" id="xF7sV3vjm3" role="2Oq$k0" />
+              <node concept="SiP3y" id="xF7sV3vlRK" role="2OqNvi">
+                <ref role="3cqZAo" node="62vWlLjtsLP" resolve="myReportsFilenamePrefix" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="xF7sV3vf5r" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" />
+      </node>
+    </node>
   </node>
 </model>
 


### PR DESCRIPTION
Adds getter and setter to [`myReportsFilenamePrefix`](http://127.0.0.1:63320/node?ref=r%3A3b363c34-a1ec-4ae6-92cc-95c0273ad0c2%28xml4JUnit%29%2F7174873163069082444) in `TestExecutorConfigForCommandLine`.

<img width="1523" height="163" alt="image" src="https://github.com/user-attachments/assets/bad3b3d7-e7c2-45a2-9342-9c42bca65112" />
