### PR TITLE
fix: interpreter of `StringInterpolationExpr` added additional spaces

### DIFF
--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.simpleTypes/generator/template/org.iets3.core.expr.genjava.simpleTypes.generator.main@generator.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.genjava.simpleTypes/generator/template/org.iets3.core.expr.genjava.simpleTypes.generator.main@generator.mps
@@ -33,10 +33,6 @@
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
-      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
-        <child id="1068498886297" name="rValue" index="37vLTx" />
-        <child id="1068498886295" name="lValue" index="37vLTJ" />
-      </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
@@ -86,7 +82,6 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
-      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
@@ -132,7 +127,6 @@
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
-      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
@@ -169,9 +163,6 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
-      <concept id="1200397529627" name="jetbrains.mps.baseLanguage.structure.CharConstant" flags="nn" index="1Xhbcc">
-        <property id="1200397540847" name="charConstant" index="1XhdNS" />
-      </concept>
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
         <child id="1201186121363" name="typeParameter" index="2Ghqu4" />
@@ -4109,13 +4100,6 @@
                         </node>
                       </node>
                     </node>
-                    <node concept="3cpWs8" id="39iG6BGz$wn" role="3cqZAp">
-                      <node concept="3cpWsn" id="39iG6BGz$wq" role="3cpWs9">
-                        <property role="TrG5h" value="delayedSpace" />
-                        <node concept="10P_77" id="4ZjVa_SayoT" role="1tU5fm" />
-                        <node concept="3clFbT" id="4ZjVa_Sa__u" role="33vP2m" />
-                      </node>
-                    </node>
                     <node concept="3clFbH" id="4ZjVa_SaKUO" role="3cqZAp" />
                     <node concept="9aQIb" id="4ZjVa_SaQ2M" role="3cqZAp">
                       <node concept="3clFbS" id="4ZjVa_SaQ2O" role="9aQI4">
@@ -4134,55 +4118,6 @@
                             </node>
                           </node>
                         </node>
-                        <node concept="3clFbJ" id="39iG6BGzGl1" role="3cqZAp">
-                          <node concept="3clFbS" id="39iG6BGzGl3" role="3clFbx">
-                            <node concept="3clFbF" id="39iG6BGzL9M" role="3cqZAp">
-                              <node concept="2OqwBi" id="39iG6BGzLqi" role="3clFbG">
-                                <node concept="37vLTw" id="39iG6BGzL9K" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="4ZjVa_S9IpQ" resolve="sb" />
-                                </node>
-                                <node concept="liA8E" id="39iG6BGzLVo" role="2OqNvi">
-                                  <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
-                                  <node concept="1Xhbcc" id="4ZjVa_SbFep" role="37wK5m">
-                                    <property role="1XhdNS" value=" " />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="22lmx$" id="4ZjVa_Sf9WD" role="3clFbw">
-                            <node concept="3eOSWO" id="4ZjVa_SffSI" role="3uHU7B">
-                              <node concept="3cmrfG" id="4ZjVa_SffSL" role="3uHU7w">
-                                <property role="3cmrfH" value="0" />
-                              </node>
-                              <node concept="2OqwBi" id="4ZjVa_SfcCS" role="3uHU7B">
-                                <node concept="37vLTw" id="4ZjVa_SfbGi" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="4ZjVa_S9IpQ" resolve="sb" />
-                                </node>
-                                <node concept="liA8E" id="4ZjVa_Sfdh3" role="2OqNvi">
-                                  <ref role="37wK5l" to="wyt6:~AbstractStringBuilder.length()" resolve="length" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="1eOMI4" id="4ZjVa_Sfk6X" role="3uHU7w">
-                              <node concept="1Wc70l" id="39iG6BGzJT4" role="1eOMHV">
-                                <node concept="3fqX7Q" id="4ZjVa_Sgt1y" role="3uHU7B">
-                                  <node concept="2OqwBi" id="4ZjVa_Sgt1$" role="3fr31v">
-                                    <node concept="37vLTw" id="4ZjVa_Sgt1_" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="39iG6BGzHpe" resolve="content" />
-                                    </node>
-                                    <node concept="liA8E" id="4ZjVa_Sgt1A" role="2OqNvi">
-                                      <ref role="37wK5l" to="wyt6:~String.isEmpty()" resolve="isEmpty" />
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="37vLTw" id="4ZjVa_SbDzq" role="3uHU7w">
-                                  <ref role="3cqZAo" node="39iG6BGz$wq" resolve="delayedSpace" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
                         <node concept="3clFbF" id="7cphKbL9t_H" role="3cqZAp">
                           <node concept="2OqwBi" id="7cphKbL9tQ1" role="3clFbG">
                             <node concept="37vLTw" id="7cphKbL9t_F" role="2Oq$k0">
@@ -4193,16 +4128,6 @@
                               <node concept="37vLTw" id="39iG6BGzHpj" role="37wK5m">
                                 <ref role="3cqZAo" node="39iG6BGzHpe" resolve="content" />
                               </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3clFbF" id="39iG6BGz_lh" role="3cqZAp">
-                          <node concept="37vLTI" id="39iG6BGzA8c" role="3clFbG">
-                            <node concept="3clFbT" id="4ZjVa_Sc1Xm" role="37vLTx">
-                              <property role="3clFbU" value="true" />
-                            </node>
-                            <node concept="37vLTw" id="4ZjVa_SbZDv" role="37vLTJ">
-                              <ref role="3cqZAo" node="39iG6BGz$wq" resolve="delayedSpace" />
                             </node>
                           </node>
                         </node>
@@ -4281,34 +4206,6 @@
                         <node concept="gft3U" id="4ZjVa_Sc6z6" role="UU_$l">
                           <node concept="9aQIb" id="4ZjVa_Sc8ZZ" role="gfFT$">
                             <node concept="3clFbS" id="4ZjVa_Sc900" role="9aQI4">
-                              <node concept="3clFbJ" id="39iG6BGzAub" role="3cqZAp">
-                                <node concept="3clFbS" id="39iG6BGzAud" role="3clFbx">
-                                  <node concept="3clFbF" id="39iG6BGzBdU" role="3cqZAp">
-                                    <node concept="2OqwBi" id="39iG6BGzBuq" role="3clFbG">
-                                      <node concept="37vLTw" id="39iG6BGzBdS" role="2Oq$k0">
-                                        <ref role="3cqZAo" node="4ZjVa_S9IpQ" resolve="sb" />
-                                      </node>
-                                      <node concept="liA8E" id="39iG6BGzBZw" role="2OqNvi">
-                                        <ref role="37wK5l" to="wyt6:~StringBuilder.append(char)" resolve="append" />
-                                        <node concept="1Xhbcc" id="4ZjVa_SdJw6" role="37wK5m">
-                                          <property role="1XhdNS" value=" " />
-                                        </node>
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="3clFbF" id="39iG6BGzOq8" role="3cqZAp">
-                                    <node concept="37vLTI" id="39iG6BGzP4_" role="3clFbG">
-                                      <node concept="3clFbT" id="4ZjVa_SdRfi" role="37vLTx" />
-                                      <node concept="37vLTw" id="4ZjVa_SdOK7" role="37vLTJ">
-                                        <ref role="3cqZAo" node="39iG6BGz$wq" resolve="delayedSpace" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="37vLTw" id="4ZjVa_SdCfJ" role="3clFbw">
-                                  <ref role="3cqZAo" node="39iG6BGz$wq" resolve="delayedSpace" />
-                                </node>
-                              </node>
                               <node concept="3clFbF" id="7cphKbL9uTw" role="3cqZAp">
                                 <node concept="2OqwBi" id="7cphKbL9v9G" role="3clFbG">
                                   <node concept="37vLTw" id="7cphKbL9uTv" role="2Oq$k0">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/behavior.mps
@@ -148,7 +148,6 @@
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
-        <child id="1206060520071" name="elsifClauses" index="3eNLev" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
@@ -170,10 +169,6 @@
       <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
-        <child id="1206060619838" name="condition" index="3eO9$A" />
-        <child id="1206060644605" name="statementList" index="3eOfB_" />
-      </concept>
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
@@ -6700,15 +6695,6 @@
             <node concept="10Nm6u" id="39iG6BG13lH" role="33vP2m" />
           </node>
         </node>
-        <node concept="3cpWs8" id="39iG6BG3xBn" role="3cqZAp">
-          <node concept="3cpWsn" id="39iG6BG3xBq" role="3cpWs9">
-            <property role="TrG5h" value="lastToken" />
-            <node concept="3Tqbb2" id="39iG6BG3xBl" role="1tU5fm">
-              <ref role="ehGHo" to="hm2y:6sdnDbSla17" resolve="Expression" />
-            </node>
-            <node concept="10Nm6u" id="39iG6BG3zS9" role="33vP2m" />
-          </node>
-        </node>
         <node concept="2Gpval" id="39iG6BG0XI1" role="3cqZAp">
           <node concept="2GrKxI" id="39iG6BG0XI3" role="2Gsz3X">
             <property role="TrG5h" value="w" />
@@ -6735,149 +6721,22 @@
             </node>
             <node concept="3clFbJ" id="39iG6BG10tD" role="3cqZAp">
               <node concept="3clFbS" id="39iG6BG10tF" role="3clFbx">
-                <node concept="3clFbJ" id="39iG6BG3LHU" role="3cqZAp">
-                  <node concept="3clFbS" id="39iG6BG3LHW" role="3clFbx">
-                    <node concept="3clFbF" id="39iG6BG3Mms" role="3cqZAp">
-                      <node concept="37vLTI" id="39iG6BG3Phu" role="3clFbG">
-                        <node concept="2OqwBi" id="39iG6BG3Nns" role="37vLTJ">
-                          <node concept="1PxgMI" id="39iG6BG3N93" role="2Oq$k0">
-                            <node concept="chp4Y" id="39iG6BG3N9S" role="3oSUPX">
-                              <ref role="cht4Q" to="5qo5:4rZeNQ6OYR8" resolve="StringLiteral" />
-                            </node>
-                            <node concept="37vLTw" id="39iG6BG3Mmq" role="1m5AlR">
-                              <ref role="3cqZAo" node="39iG6BG3xBq" resolve="lastToken" />
-                            </node>
-                          </node>
-                          <node concept="3TrcHB" id="39iG6BG3NEX" role="2OqNvi">
-                            <ref role="3TsBF5" to="5qo5:4rZeNQ6OYRb" resolve="value" />
-                          </node>
+                <node concept="3clFbF" id="IYj_dZ_cLk" role="3cqZAp">
+                  <node concept="37vLTI" id="IYj_dZ_cLl" role="3clFbG">
+                    <node concept="37vLTw" id="IYj_dZ_cLm" role="37vLTJ">
+                      <ref role="3cqZAo" node="39iG6BG14jO" resolve="token" />
+                    </node>
+                    <node concept="2OqwBi" id="IYj_dZ_cLn" role="37vLTx">
+                      <node concept="1PxgMI" id="IYj_dZ_cLo" role="2Oq$k0">
+                        <node concept="chp4Y" id="IYj_dZ_cLp" role="3oSUPX">
+                          <ref role="cht4Q" to="5qo5:7cphKbL6izy" resolve="InterpolExprWord" />
                         </node>
-                        <node concept="3cpWs3" id="39iG6BG3Rb1" role="37vLTx">
-                          <node concept="Xl_RD" id="39iG6BG3RgM" role="3uHU7w">
-                            <property role="Xl_RC" value=" " />
-                          </node>
-                          <node concept="2OqwBi" id="39iG6BG3Pvn" role="3uHU7B">
-                            <node concept="1PxgMI" id="39iG6BG3Pvo" role="2Oq$k0">
-                              <node concept="chp4Y" id="39iG6BG3Pvp" role="3oSUPX">
-                                <ref role="cht4Q" to="5qo5:4rZeNQ6OYR8" resolve="StringLiteral" />
-                              </node>
-                              <node concept="37vLTw" id="39iG6BG3Pvq" role="1m5AlR">
-                                <ref role="3cqZAo" node="39iG6BG3xBq" resolve="lastToken" />
-                              </node>
-                            </node>
-                            <node concept="3TrcHB" id="39iG6BG3Pvr" role="2OqNvi">
-                              <ref role="3TsBF5" to="5qo5:4rZeNQ6OYRb" resolve="value" />
-                            </node>
-                          </node>
+                        <node concept="2GrUjf" id="IYj_dZ_cLq" role="1m5AlR">
+                          <ref role="2Gs0qQ" node="39iG6BG0XI3" resolve="w" />
                         </node>
                       </node>
-                    </node>
-                    <node concept="3clFbF" id="39iG6BG17zJ" role="3cqZAp">
-                      <node concept="37vLTI" id="39iG6BG17Qb" role="3clFbG">
-                        <node concept="37vLTw" id="39iG6BG17zH" role="37vLTJ">
-                          <ref role="3cqZAo" node="39iG6BG14jO" resolve="token" />
-                        </node>
-                        <node concept="2OqwBi" id="39iG6BG11Hh" role="37vLTx">
-                          <node concept="1PxgMI" id="39iG6BG11lS" role="2Oq$k0">
-                            <node concept="chp4Y" id="39iG6BG11to" role="3oSUPX">
-                              <ref role="cht4Q" to="5qo5:7cphKbL6izy" resolve="InterpolExprWord" />
-                            </node>
-                            <node concept="2GrUjf" id="39iG6BG10GI" role="1m5AlR">
-                              <ref role="2Gs0qQ" node="39iG6BG0XI3" resolve="w" />
-                            </node>
-                          </node>
-                          <node concept="3TrEf2" id="39iG6BG11ZZ" role="2OqNvi">
-                            <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="39iG6BG3LTf" role="3clFbw">
-                    <node concept="37vLTw" id="39iG6BG3LIF" role="2Oq$k0">
-                      <ref role="3cqZAo" node="39iG6BG3xBq" resolve="lastToken" />
-                    </node>
-                    <node concept="1mIQ4w" id="39iG6BG3McU" role="2OqNvi">
-                      <node concept="chp4Y" id="39iG6BG3Mfu" role="cj9EA">
-                        <ref role="cht4Q" to="5qo5:4rZeNQ6OYR8" resolve="StringLiteral" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3eNFk2" id="IYj_dZ_bTh" role="3eNLev">
-                    <node concept="2OqwBi" id="IYj_dZ_eVK" role="3eO9$A">
-                      <node concept="37vLTw" id="IYj_dZ_c0r" role="2Oq$k0">
-                        <ref role="3cqZAo" node="39iG6BG3xBq" resolve="lastToken" />
-                      </node>
-                      <node concept="3x8VRR" id="IYj_dZ_ffr" role="2OqNvi" />
-                    </node>
-                    <node concept="3clFbS" id="IYj_dZ_bTj" role="3eOfB_">
-                      <node concept="3clFbF" id="IYj_dZ_dab" role="3cqZAp">
-                        <node concept="37vLTI" id="IYj_dZ_dac" role="3clFbG">
-                          <node concept="37vLTw" id="IYj_dZ_dad" role="37vLTJ">
-                            <ref role="3cqZAo" node="39iG6BG14jO" resolve="token" />
-                          </node>
-                          <node concept="2pJPEk" id="IYj_dZ_dU1" role="37vLTx">
-                            <node concept="2pJPED" id="IYj_dZ_dXQ" role="2pJPEn">
-                              <ref role="2pJxaS" to="hm2y:4rZeNQ6MqjM" resolve="PlusExpression" />
-                              <node concept="2pIpSj" id="IYj_dZ_e2c" role="2pJxcM">
-                                <ref role="2pIpSl" to="hm2y:4rZeNQ6MpKm" resolve="left" />
-                                <node concept="2pJPED" id="IYj_dZ_e6B" role="28nt2d">
-                                  <ref role="2pJxaS" to="5qo5:4rZeNQ6OYR8" resolve="StringLiteral" />
-                                  <node concept="2pJxcG" id="IYj_dZ_e8M" role="2pJxcM">
-                                    <ref role="2pJxcJ" to="5qo5:4rZeNQ6OYRb" resolve="value" />
-                                    <node concept="WxPPo" id="uuJ7IpZtwB" role="28ntcv">
-                                      <node concept="Xl_RD" id="IYj_dZ_e98" role="WxPPp">
-                                        <property role="Xl_RC" value=" " />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="2pIpSj" id="IYj_dZ_eg5" role="2pJxcM">
-                                <ref role="2pIpSl" to="hm2y:4rZeNQ6MpKo" resolve="right" />
-                                <node concept="36biLy" id="IYj_dZ_ekG" role="28nt2d">
-                                  <node concept="2OqwBi" id="IYj_dZ_dae" role="36biLW">
-                                    <node concept="1PxgMI" id="IYj_dZ_daf" role="2Oq$k0">
-                                      <node concept="chp4Y" id="IYj_dZ_dag" role="3oSUPX">
-                                        <ref role="cht4Q" to="5qo5:7cphKbL6izy" resolve="InterpolExprWord" />
-                                      </node>
-                                      <node concept="2GrUjf" id="IYj_dZ_dah" role="1m5AlR">
-                                        <ref role="2Gs0qQ" node="39iG6BG0XI3" resolve="w" />
-                                      </node>
-                                    </node>
-                                    <node concept="3TrEf2" id="IYj_dZ_dai" role="2OqNvi">
-                                      <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="9aQIb" id="IYj_dZ_cCp" role="9aQIa">
-                    <node concept="3clFbS" id="IYj_dZ_cCq" role="9aQI4">
-                      <node concept="3clFbF" id="IYj_dZ_cLk" role="3cqZAp">
-                        <node concept="37vLTI" id="IYj_dZ_cLl" role="3clFbG">
-                          <node concept="37vLTw" id="IYj_dZ_cLm" role="37vLTJ">
-                            <ref role="3cqZAo" node="39iG6BG14jO" resolve="token" />
-                          </node>
-                          <node concept="2OqwBi" id="IYj_dZ_cLn" role="37vLTx">
-                            <node concept="1PxgMI" id="IYj_dZ_cLo" role="2Oq$k0">
-                              <node concept="chp4Y" id="IYj_dZ_cLp" role="3oSUPX">
-                                <ref role="cht4Q" to="5qo5:7cphKbL6izy" resolve="InterpolExprWord" />
-                              </node>
-                              <node concept="2GrUjf" id="IYj_dZ_cLq" role="1m5AlR">
-                                <ref role="2Gs0qQ" node="39iG6BG0XI3" resolve="w" />
-                              </node>
-                            </node>
-                            <node concept="3TrEf2" id="IYj_dZ_cLr" role="2OqNvi">
-                              <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
-                            </node>
-                          </node>
-                        </node>
+                      <node concept="3TrEf2" id="IYj_dZ_cLr" role="2OqNvi">
+                        <ref role="3Tt5mk" to="hm2y:3G_qVqIw4zp" resolve="expr" />
                       </node>
                     </node>
                   </node>
@@ -6920,49 +6779,6 @@
                       <node concept="17RlXB" id="IYj_dZ$9xe" role="2OqNvi" />
                     </node>
                   </node>
-                  <node concept="3cpWs8" id="39iG6BG3JqD" role="3cqZAp">
-                    <node concept="3cpWsn" id="39iG6BG3JqG" role="3cpWs9">
-                      <property role="TrG5h" value="prefix" />
-                      <node concept="17QB3L" id="39iG6BG3JqB" role="1tU5fm" />
-                      <node concept="Xl_RD" id="39iG6BG3JBg" role="33vP2m">
-                        <property role="Xl_RC" value="" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbJ" id="39iG6BG3Dxc" role="3cqZAp">
-                    <node concept="3clFbS" id="39iG6BG3Dxe" role="3clFbx">
-                      <node concept="3clFbF" id="39iG6BG3JBA" role="3cqZAp">
-                        <node concept="37vLTI" id="39iG6BG3KdN" role="3clFbG">
-                          <node concept="Xl_RD" id="39iG6BG3Keh" role="37vLTx">
-                            <property role="Xl_RC" value=" " />
-                          </node>
-                          <node concept="37vLTw" id="39iG6BG3JB$" role="37vLTJ">
-                            <ref role="3cqZAo" node="39iG6BG3JqG" resolve="prefix" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="1Wc70l" id="39iG6BG4PUu" role="3clFbw">
-                      <node concept="3y3z36" id="39iG6BG4Qu7" role="3uHU7B">
-                        <node concept="10Nm6u" id="39iG6BG4Q$U" role="3uHU7w" />
-                        <node concept="37vLTw" id="39iG6BG4Q1t" role="3uHU7B">
-                          <ref role="3cqZAo" node="39iG6BG3xBq" resolve="lastToken" />
-                        </node>
-                      </node>
-                      <node concept="3fqX7Q" id="39iG6BG3Krx" role="3uHU7w">
-                        <node concept="2OqwBi" id="39iG6BG3Krz" role="3fr31v">
-                          <node concept="37vLTw" id="39iG6BG3Kr$" role="2Oq$k0">
-                            <ref role="3cqZAo" node="39iG6BG3xBq" resolve="lastToken" />
-                          </node>
-                          <node concept="1mIQ4w" id="39iG6BG3Kr_" role="2OqNvi">
-                            <node concept="chp4Y" id="39iG6BG3KrA" role="cj9EA">
-                              <ref role="cht4Q" to="5qo5:4rZeNQ6OYR8" resolve="StringLiteral" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
                   <node concept="3clFbF" id="39iG6BG16Oq" role="3cqZAp">
                     <node concept="37vLTI" id="39iG6BG17as" role="3clFbG">
                       <node concept="37vLTw" id="39iG6BG16Oo" role="37vLTJ">
@@ -6974,13 +6790,8 @@
                           <node concept="2pJxcG" id="39iG6BG12Fc" role="2pJxcM">
                             <ref role="2pJxcJ" to="5qo5:4rZeNQ6OYRb" resolve="value" />
                             <node concept="WxPPo" id="uuJ7IpZtwC" role="28ntcv">
-                              <node concept="3cpWs3" id="39iG6BG3Lgw" role="WxPPp">
-                                <node concept="37vLTw" id="39iG6BG3LuD" role="3uHU7B">
-                                  <ref role="3cqZAo" node="39iG6BG3JqG" resolve="prefix" />
-                                </node>
-                                <node concept="37vLTw" id="IYj_dZ$7cL" role="3uHU7w">
-                                  <ref role="3cqZAo" node="IYj_dZ$7cH" resolve="content" />
-                                </node>
+                              <node concept="37vLTw" id="IYj_dZ$7cL" role="WxPPp">
+                                <ref role="3cqZAo" node="IYj_dZ$7cH" resolve="content" />
                               </node>
                             </node>
                           </node>
@@ -7040,16 +6851,6 @@
                       </node>
                     </node>
                   </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="39iG6BG3Ekx" role="3cqZAp">
-              <node concept="37vLTI" id="39iG6BG3EV9" role="3clFbG">
-                <node concept="37vLTw" id="39iG6BG3EVG" role="37vLTx">
-                  <ref role="3cqZAo" node="39iG6BG14jO" resolve="token" />
-                </node>
-                <node concept="37vLTw" id="39iG6BG3Ekv" role="37vLTJ">
-                  <ref role="3cqZAo" node="39iG6BG3xBq" resolve="lastToken" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.interpreter/models/plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.core.expr.simpleTypes.interpreter/models/plugin.mps
@@ -87,7 +87,6 @@
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="1225271369338" name="jetbrains.mps.baseLanguage.structure.IsEmptyOperation" flags="nn" index="17RlXB" />
-      <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -342,13 +341,6 @@
                 </node>
               </node>
             </node>
-            <node concept="3cpWs8" id="39iG6BGz$wn" role="3cqZAp">
-              <node concept="3cpWsn" id="39iG6BGz$wq" role="3cpWs9">
-                <property role="TrG5h" value="delayed_token" />
-                <node concept="17QB3L" id="39iG6BGz$wl" role="1tU5fm" />
-                <node concept="10Nm6u" id="39iG6BGzBdl" role="33vP2m" />
-              </node>
-            </node>
             <node concept="2Gpval" id="7cphKbL9otm" role="3cqZAp">
               <node concept="2GrKxI" id="7cphKbL9otn" role="2Gsz3X">
                 <property role="TrG5h" value="w" />
@@ -365,25 +357,6 @@
                 </node>
               </node>
               <node concept="3clFbS" id="7cphKbL9otp" role="2LFqv$">
-                <node concept="3cpWs8" id="39iG6BGvRHq" role="3cqZAp">
-                  <node concept="3cpWsn" id="39iG6BGvRHr" role="3cpWs9">
-                    <property role="TrG5h" value="is_first" />
-                    <node concept="10P_77" id="39iG6BGvRGZ" role="1tU5fm" />
-                    <node concept="3clFbC" id="39iG6BGzuEP" role="33vP2m">
-                      <node concept="3cmrfG" id="39iG6BGzvee" role="3uHU7w">
-                        <property role="3cmrfH" value="0" />
-                      </node>
-                      <node concept="2OqwBi" id="39iG6BGzq5$" role="3uHU7B">
-                        <node concept="37vLTw" id="39iG6BGzp7U" role="2Oq$k0">
-                          <ref role="3cqZAo" node="7cphKbL9pKD" resolve="sb" />
-                        </node>
-                        <node concept="liA8E" id="39iG6BGzqLI" role="2OqNvi">
-                          <ref role="37wK5l" to="wyt6:~AbstractStringBuilder.length()" resolve="length" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
                 <node concept="3clFbJ" id="7cphKbL9qHb" role="3cqZAp">
                   <node concept="2OqwBi" id="7cphKbL9sdb" role="3clFbw">
                     <node concept="2GrUjf" id="7cphKbL9s2H" role="2Oq$k0">
@@ -396,7 +369,6 @@
                     </node>
                   </node>
                   <node concept="3clFbS" id="7cphKbL9qHd" role="3clFbx">
-                    <node concept="3clFbH" id="39iG6BGzG7S" role="3cqZAp" />
                     <node concept="3cpWs8" id="7cphKbL9tnU" role="3cqZAp">
                       <node concept="3cpWsn" id="7cphKbL9tnV" role="3cpWs9">
                         <property role="TrG5h" value="r" />
@@ -415,82 +387,6 @@
                         </node>
                       </node>
                     </node>
-                    <node concept="3cpWs8" id="39iG6BGzHpd" role="3cqZAp">
-                      <node concept="3cpWsn" id="39iG6BGzHpe" role="3cpWs9">
-                        <property role="TrG5h" value="content" />
-                        <node concept="17QB3L" id="39iG6BGzIND" role="1tU5fm" />
-                        <node concept="2OqwBi" id="39iG6BGzHpf" role="33vP2m">
-                          <node concept="37vLTw" id="39iG6BGzHpg" role="2Oq$k0">
-                            <ref role="3cqZAo" node="7cphKbL9tnV" resolve="r" />
-                          </node>
-                          <node concept="liA8E" id="39iG6BGzHph" role="2OqNvi">
-                            <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbJ" id="39iG6BGzGl1" role="3cqZAp">
-                      <node concept="3clFbS" id="39iG6BGzGl3" role="3clFbx">
-                        <node concept="3clFbF" id="39iG6BGzL9M" role="3cqZAp">
-                          <node concept="2OqwBi" id="39iG6BGzLqi" role="3clFbG">
-                            <node concept="37vLTw" id="39iG6BGzL9K" role="2Oq$k0">
-                              <ref role="3cqZAo" node="7cphKbL9pKD" resolve="sb" />
-                            </node>
-                            <node concept="liA8E" id="39iG6BGzLVo" role="2OqNvi">
-                              <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
-                              <node concept="37vLTw" id="39iG6BGzLWF" role="37wK5m">
-                                <ref role="3cqZAo" node="39iG6BGz$wq" resolve="delayed_token" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3clFbF" id="39iG6BGzNIA" role="3cqZAp">
-                          <node concept="37vLTI" id="39iG6BGzOkL" role="3clFbG">
-                            <node concept="10Nm6u" id="39iG6BGzOl5" role="37vLTx" />
-                            <node concept="37vLTw" id="39iG6BGzNI$" role="37vLTJ">
-                              <ref role="3cqZAo" node="39iG6BGz$wq" resolve="delayed_token" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="1Wc70l" id="39iG6BGzJT4" role="3clFbw">
-                        <node concept="2OqwBi" id="39iG6BGzKf_" role="3uHU7B">
-                          <node concept="37vLTw" id="39iG6BGzJTS" role="2Oq$k0">
-                            <ref role="3cqZAo" node="39iG6BGzHpe" resolve="content" />
-                          </node>
-                          <node concept="17RvpY" id="39iG6BGzKPt" role="2OqNvi" />
-                        </node>
-                        <node concept="3y3z36" id="39iG6BGzHcu" role="3uHU7w">
-                          <node concept="10Nm6u" id="39iG6BGzHcN" role="3uHU7w" />
-                          <node concept="37vLTw" id="39iG6BGzGyx" role="3uHU7B">
-                            <ref role="3cqZAo" node="39iG6BGz$wq" resolve="delayed_token" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3eNFk2" id="39iG6BGzM4$" role="3eNLev">
-                        <node concept="3fqX7Q" id="39iG6BGzM5A" role="3eO9$A">
-                          <node concept="37vLTw" id="39iG6BGzM5S" role="3fr31v">
-                            <ref role="3cqZAo" node="39iG6BGvRHr" resolve="is_first" />
-                          </node>
-                        </node>
-                        <node concept="3clFbS" id="39iG6BGzM4A" role="3eOfB_">
-                          <node concept="3clFbF" id="39iG6BGwcGJ" role="3cqZAp">
-                            <node concept="2OqwBi" id="39iG6BGwcXf" role="3clFbG">
-                              <node concept="37vLTw" id="39iG6BGwcGH" role="2Oq$k0">
-                                <ref role="3cqZAo" node="7cphKbL9pKD" resolve="sb" />
-                              </node>
-                              <node concept="liA8E" id="39iG6BGwdul" role="2OqNvi">
-                                <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
-                                <node concept="Xl_RD" id="39iG6BGwdvw" role="37wK5m">
-                                  <property role="Xl_RC" value=" " />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbH" id="39iG6BGzIA3" role="3cqZAp" />
                     <node concept="3clFbF" id="7cphKbL9t_H" role="3cqZAp">
                       <node concept="2OqwBi" id="7cphKbL9tQ1" role="3clFbG">
                         <node concept="37vLTw" id="7cphKbL9t_F" role="2Oq$k0">
@@ -498,78 +394,20 @@
                         </node>
                         <node concept="liA8E" id="7cphKbL9uds" role="2OqNvi">
                           <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
-                          <node concept="37vLTw" id="39iG6BGzHpj" role="37wK5m">
-                            <ref role="3cqZAo" node="39iG6BGzHpe" resolve="content" />
+                          <node concept="2OqwBi" id="10pVaEUAycu" role="37wK5m">
+                            <node concept="37vLTw" id="10pVaEUAycv" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7cphKbL9tnV" resolve="r" />
+                            </node>
+                            <node concept="liA8E" id="10pVaEUAycw" role="2OqNvi">
+                              <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                            </node>
                           </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="39iG6BGz_lh" role="3cqZAp">
-                      <node concept="37vLTI" id="39iG6BGzA8c" role="3clFbG">
-                        <node concept="Xl_RD" id="39iG6BGzA8w" role="37vLTx">
-                          <property role="Xl_RC" value=" " />
-                        </node>
-                        <node concept="37vLTw" id="39iG6BGz_lf" role="37vLTJ">
-                          <ref role="3cqZAo" node="39iG6BGz$wq" resolve="delayed_token" />
                         </node>
                       </node>
                     </node>
                   </node>
                   <node concept="9aQIb" id="7cphKbL9uFS" role="9aQIa">
                     <node concept="3clFbS" id="7cphKbL9uFT" role="9aQI4">
-                      <node concept="3cpWs8" id="39iG6BGzCkh" role="3cqZAp">
-                        <node concept="3cpWsn" id="39iG6BGzCki" role="3cpWs9">
-                          <property role="TrG5h" value="content" />
-                          <node concept="17QB3L" id="39iG6BGzCka" role="1tU5fm" />
-                          <node concept="2OqwBi" id="39iG6BGzCkj" role="33vP2m">
-                            <node concept="2GrUjf" id="39iG6BGzCkk" role="2Oq$k0">
-                              <ref role="2Gs0qQ" node="7cphKbL9otn" resolve="w" />
-                            </node>
-                            <node concept="2qgKlT" id="39iG6BGzCkl" role="2OqNvi">
-                              <ref role="37wK5l" to="tbr6:3Q5enzfMT4t" resolve="toTextString" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3clFbJ" id="39iG6BGzAub" role="3cqZAp">
-                        <node concept="3clFbS" id="39iG6BGzAud" role="3clFbx">
-                          <node concept="3clFbF" id="39iG6BGzBdU" role="3cqZAp">
-                            <node concept="2OqwBi" id="39iG6BGzBuq" role="3clFbG">
-                              <node concept="37vLTw" id="39iG6BGzBdS" role="2Oq$k0">
-                                <ref role="3cqZAo" node="7cphKbL9pKD" resolve="sb" />
-                              </node>
-                              <node concept="liA8E" id="39iG6BGzBZw" role="2OqNvi">
-                                <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
-                                <node concept="37vLTw" id="39iG6BGzC0N" role="37wK5m">
-                                  <ref role="3cqZAo" node="39iG6BGz$wq" resolve="delayed_token" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="3clFbF" id="39iG6BGzOq8" role="3cqZAp">
-                            <node concept="37vLTI" id="39iG6BGzP4_" role="3clFbG">
-                              <node concept="10Nm6u" id="39iG6BGzP4T" role="37vLTx" />
-                              <node concept="37vLTw" id="39iG6BGzOq6" role="37vLTJ">
-                                <ref role="3cqZAo" node="39iG6BGz$wq" resolve="delayed_token" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="1Wc70l" id="39iG6BGzEt8" role="3clFbw">
-                          <node concept="2OqwBi" id="39iG6BGzFPV" role="3uHU7B">
-                            <node concept="37vLTw" id="39iG6BGzFPW" role="2Oq$k0">
-                              <ref role="3cqZAo" node="39iG6BGzCki" resolve="content" />
-                            </node>
-                            <node concept="17RvpY" id="39iG6BGzL9c" role="2OqNvi" />
-                          </node>
-                          <node concept="3y3z36" id="39iG6BGzBce" role="3uHU7w">
-                            <node concept="10Nm6u" id="39iG6BGzBcz" role="3uHU7w" />
-                            <node concept="37vLTw" id="39iG6BGzAyp" role="3uHU7B">
-                              <ref role="3cqZAo" node="39iG6BGz$wq" resolve="delayed_token" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
                       <node concept="3clFbF" id="7cphKbL9uTw" role="3cqZAp">
                         <node concept="2OqwBi" id="7cphKbL9v9G" role="3clFbG">
                           <node concept="37vLTw" id="7cphKbL9uTv" role="2Oq$k0">
@@ -577,8 +415,13 @@
                           </node>
                           <node concept="liA8E" id="7cphKbL9vx7" role="2OqNvi">
                             <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
-                            <node concept="37vLTw" id="39iG6BGzCkm" role="37wK5m">
-                              <ref role="3cqZAo" node="39iG6BGzCki" resolve="content" />
+                            <node concept="2OqwBi" id="10pVaEUABWd" role="37wK5m">
+                              <node concept="2GrUjf" id="10pVaEUABWe" role="2Oq$k0">
+                                <ref role="2Gs0qQ" node="7cphKbL9otn" resolve="w" />
+                              </node>
+                              <node concept="2qgKlT" id="10pVaEUABWf" role="2OqNvi">
+                                <ref role="37wK5l" to="tbr6:3Q5enzfMT4t" resolve="toTextString" />
+                              </node>
                             </node>
                           </node>
                         </node>

--- a/code/languages/org.iets3.opensource/tests/test.ex.core.expr.genjava/models/messages@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ex.core.expr.genjava/models/messages@tests.mps
@@ -852,7 +852,7 @@
         <node concept="2206d8" id="3vxfdxbrKDD" role="2lDidJ">
           <node concept="19SGf9" id="3vxfdxbrKDE" role="2206d9">
             <node concept="19SUe$" id="3vxfdxbrKDF" role="19SJt6">
-              <property role="19SUeA" value="m4" />
+              <property role="19SUeA" value="m4 " />
             </node>
             <node concept="2206Zw" id="3vxfdxbrKEX" role="19SJt6">
               <node concept="1WQOXJ" id="3vxfdxbrKFg" role="2lDidJ">
@@ -890,7 +890,7 @@
         <node concept="2206d8" id="3vxfdxbthSy" role="2lDidJ">
           <node concept="19SGf9" id="3vxfdxbthSz" role="2206d9">
             <node concept="19SUe$" id="3vxfdxbthS$" role="19SJt6">
-              <property role="19SUeA" value="m4" />
+              <property role="19SUeA" value="m4 " />
             </node>
             <node concept="2206Zw" id="3vxfdxbthS_" role="19SJt6">
               <node concept="1WQOXJ" id="3vxfdxbthSA" role="2lDidJ">
@@ -931,7 +931,7 @@
           <node concept="2206d8" id="3vxfdxburFY" role="2lDidJ">
             <node concept="19SGf9" id="3vxfdxburG0" role="2206d9">
               <node concept="19SUe$" id="3vxfdxburG1" role="19SJt6">
-                <property role="19SUeA" value="m6" />
+                <property role="19SUeA" value="m6 " />
               </node>
               <node concept="2206Zw" id="3vxfdxburGd" role="19SJt6">
                 <node concept="1WQOXJ" id="3vxfdxburGx" role="2lDidJ">
@@ -939,7 +939,7 @@
                 </node>
               </node>
               <node concept="19SUe$" id="3vxfdxbus75" role="19SJt6">
-                <property role="19SUeA" value="m6" />
+                <property role="19SUeA" value=" m6 " />
               </node>
               <node concept="2206Zw" id="3vxfdxbus73" role="19SJt6">
                 <node concept="1WQOXJ" id="3vxfdxbus7_" role="2lDidJ">
@@ -983,7 +983,7 @@
       <node concept="2206d8" id="1CNpG_h8gzy" role="2lDidJ">
         <node concept="19SGf9" id="1CNpG_h8gz$" role="2206d9">
           <node concept="19SUe$" id="1CNpG_h8gz_" role="19SJt6">
-            <property role="19SUeA" value="This is the" />
+            <property role="19SUeA" value="This is the " />
           </node>
           <node concept="2206Zw" id="1CNpG_h8gzL" role="19SJt6">
             <node concept="1WQOXJ" id="1CNpG_h8g$4" role="2lDidJ">
@@ -1005,7 +1005,7 @@
       <node concept="2206d8" id="1CNpG_h8F6S" role="2lDidJ">
         <node concept="19SGf9" id="1CNpG_h8F6T" role="2206d9">
           <node concept="19SUe$" id="1CNpG_h8F6U" role="19SJt6">
-            <property role="19SUeA" value="This is a lot of" />
+            <property role="19SUeA" value="This is a lot of " />
           </node>
           <node concept="2206Zw" id="1CNpG_h8F6V" role="19SJt6">
             <node concept="1WQOXJ" id="1CNpG_h8F6W" role="2lDidJ">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/messages@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/messages@tests.mps
@@ -1091,7 +1091,7 @@
         <node concept="2206d8" id="3vxfdxbrKDD" role="2lDidJ">
           <node concept="19SGf9" id="3vxfdxbrKDE" role="2206d9">
             <node concept="19SUe$" id="3vxfdxbrKDF" role="19SJt6">
-              <property role="19SUeA" value="m4" />
+              <property role="19SUeA" value="m4 " />
             </node>
             <node concept="2206Zw" id="3vxfdxbrKEX" role="19SJt6">
               <node concept="1WQOXJ" id="3vxfdxbrKFg" role="2lDidJ">
@@ -1129,7 +1129,7 @@
         <node concept="2206d8" id="3vxfdxbthSy" role="2lDidJ">
           <node concept="19SGf9" id="3vxfdxbthSz" role="2206d9">
             <node concept="19SUe$" id="3vxfdxbthS$" role="19SJt6">
-              <property role="19SUeA" value="m4" />
+              <property role="19SUeA" value="m4 " />
             </node>
             <node concept="2206Zw" id="3vxfdxbthS_" role="19SJt6">
               <node concept="1WQOXJ" id="3vxfdxbthSA" role="2lDidJ">
@@ -1170,7 +1170,7 @@
           <node concept="2206d8" id="3vxfdxburFY" role="2lDidJ">
             <node concept="19SGf9" id="3vxfdxburG0" role="2206d9">
               <node concept="19SUe$" id="3vxfdxburG1" role="19SJt6">
-                <property role="19SUeA" value="m6" />
+                <property role="19SUeA" value="m6 " />
               </node>
               <node concept="2206Zw" id="3vxfdxburGd" role="19SJt6">
                 <node concept="1WQOXJ" id="3vxfdxburGx" role="2lDidJ">
@@ -1178,7 +1178,7 @@
                 </node>
               </node>
               <node concept="19SUe$" id="3vxfdxbus75" role="19SJt6">
-                <property role="19SUeA" value="m6" />
+                <property role="19SUeA" value=" m6 " />
               </node>
               <node concept="2206Zw" id="3vxfdxbus73" role="19SJt6">
                 <node concept="1WQOXJ" id="3vxfdxbus7_" role="2lDidJ">
@@ -1222,7 +1222,7 @@
       <node concept="2206d8" id="1CNpG_h8gzy" role="2lDidJ">
         <node concept="19SGf9" id="1CNpG_h8gz$" role="2206d9">
           <node concept="19SUe$" id="1CNpG_h8gz_" role="19SJt6">
-            <property role="19SUeA" value="This is the" />
+            <property role="19SUeA" value="This is the " />
           </node>
           <node concept="2206Zw" id="1CNpG_h8gzL" role="19SJt6">
             <node concept="1WQOXJ" id="1CNpG_h8g$4" role="2lDidJ">
@@ -1244,7 +1244,7 @@
       <node concept="2206d8" id="1CNpG_h8F6S" role="2lDidJ">
         <node concept="19SGf9" id="1CNpG_h8F6T" role="2206d9">
           <node concept="19SUe$" id="1CNpG_h8F6U" role="19SJt6">
-            <property role="19SUeA" value="This is a lot of" />
+            <property role="19SUeA" value="This is a lot of " />
           </node>
           <node concept="2206Zw" id="1CNpG_h8F6V" role="19SJt6">
             <node concept="1WQOXJ" id="1CNpG_h8F6W" role="2lDidJ">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.records@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.records@tests.mps
@@ -2341,7 +2341,7 @@
               <node concept="2206d8" id="4ptnK4ii18c" role="2lDidJ">
                 <node concept="19SGf9" id="4ptnK4ii18e" role="2206d9">
                   <node concept="19SUe$" id="4ptnK4ii18f" role="19SJt6">
-                    <property role="19SUeA" value="The author" />
+                    <property role="19SUeA" value="The author " />
                   </node>
                   <node concept="2206Zw" id="4ptnK4ii2NU" role="19SJt6">
                     <node concept="1QScDb" id="4ptnK4ii2PL" role="2lDidJ">
@@ -2352,7 +2352,7 @@
                     </node>
                   </node>
                   <node concept="19SUe$" id="4ptnK4ii2NX" role="19SJt6">
-                    <property role="19SUeA" value="has published in" />
+                    <property role="19SUeA" value=" has published in " />
                   </node>
                   <node concept="2206Zw" id="4ptnK4ii4L2" role="19SJt6">
                     <node concept="1QScDb" id="4ptnK4ipC$O" role="2lDidJ">

--- a/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.strings@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.in.expr.os/models/test.in.expr.os.strings@tests.mps
@@ -10,6 +10,11 @@
   </languages>
   <imports />
   <registry>
+    <language id="7b68d745-a7b8-48b9-bd9c-05c0f8725a35" name="org.iets3.core.base">
+      <concept id="7831630342157089621" name="org.iets3.core.base.structure.IDetectNeedToRunManually" flags="ngI" index="0Rz4o">
+        <property id="7831630342157089649" name="__hash" index="0Rz4W" />
+      </concept>
+    </language>
     <language id="cfaa4966-b7d5-4b69-b66a-309a6e1a7290" name="org.iets3.core.expr.base">
       <concept id="4261931054731905240" name="org.iets3.core.expr.base.structure.IContainExpressionParam" flags="ngI" index="2lDidI">
         <child id="4261931054731905241" name="expr" index="2lDidJ" />
@@ -890,10 +895,11 @@
     <node concept="_ixoA" id="1EIbarKbUZU" role="_iOnB" />
     <node concept="2zPypq" id="7cphKbL8wvv" role="_iOnB">
       <property role="TrG5h" value="i1" />
+      <property role="0Rz4W" value="-2092563943" />
       <node concept="2206d8" id="7cphKbL8wyz" role="2lDidJ">
         <node concept="19SGf9" id="7cphKbL8wy_" role="2206d9">
           <node concept="19SUe$" id="7cphKbL8wyA" role="19SJt6">
-            <property role="19SUeA" value="Here" />
+            <property role="19SUeA" value="Here " />
           </node>
           <node concept="2206Zw" id="7cphKbL9fti" role="19SJt6">
             <node concept="_emDc" id="7cphKbL9ftA" role="2lDidJ">
@@ -901,17 +907,18 @@
             </node>
           </node>
           <node concept="19SUe$" id="7cphKbL9ftl" role="19SJt6">
-            <property role="19SUeA" value="X" />
+            <property role="19SUeA" value=" X" />
           </node>
         </node>
       </node>
     </node>
     <node concept="2zPypq" id="39iG6BG5RyW" role="_iOnB">
       <property role="TrG5h" value="i2" />
+      <property role="0Rz4W" value="1187901536" />
       <node concept="2206d8" id="39iG6BG5RLQ" role="2lDidJ">
         <node concept="19SGf9" id="39iG6BG5RLS" role="2206d9">
           <node concept="19SUe$" id="39iG6BG5RLT" role="19SJt6">
-            <property role="19SUeA" value="  with some   space   upfront" />
+            <property role="19SUeA" value="  with some   space   upfront " />
           </node>
           <node concept="2206Zw" id="39iG6BG5RM8" role="19SJt6">
             <node concept="_emDc" id="39iG6BG5RMv" role="2lDidJ">
@@ -919,13 +926,14 @@
             </node>
           </node>
           <node concept="19SUe$" id="39iG6BG5RMb" role="19SJt6">
-            <property role="19SUeA" value="and some behind   " />
+            <property role="19SUeA" value=" and some behind   " />
           </node>
         </node>
       </node>
     </node>
     <node concept="2zPypq" id="39iG6BG5UAH" role="_iOnB">
       <property role="TrG5h" value="i3" />
+      <property role="0Rz4W" value="1555862946" />
       <node concept="2206d8" id="39iG6BG5UQ8" role="2lDidJ">
         <node concept="19SGf9" id="39iG6BG5UQa" role="2206d9">
           <node concept="19SUe$" id="39iG6BG5UQt" role="19SJt6" />
@@ -935,17 +943,18 @@
             </node>
           </node>
           <node concept="19SUe$" id="39iG6BG5UQu" role="19SJt6">
-            <property role="19SUeA" value="at the beginning" />
+            <property role="19SUeA" value=" at the beginning" />
           </node>
         </node>
       </node>
     </node>
     <node concept="2zPypq" id="39iG6BG5V6v" role="_iOnB">
       <property role="TrG5h" value="i4" />
+      <property role="0Rz4W" value="-1641907464" />
       <node concept="2206d8" id="39iG6BG5Vmj" role="2lDidJ">
         <node concept="19SGf9" id="39iG6BG5Vml" role="2206d9">
           <node concept="19SUe$" id="39iG6BG5Vmm" role="19SJt6">
-            <property role="19SUeA" value="at the end" />
+            <property role="19SUeA" value="at the end " />
           </node>
           <node concept="2206Zw" id="39iG6BG5Vm_" role="19SJt6">
             <node concept="_emDc" id="39iG6BG5VmW" role="2lDidJ">
@@ -958,6 +967,7 @@
     </node>
     <node concept="2zPypq" id="39iG6BG5ZfT" role="_iOnB">
       <property role="TrG5h" value="i5" />
+      <property role="0Rz4W" value="2113603419" />
       <node concept="2206d8" id="39iG6BGyHPu" role="2lDidJ">
         <node concept="19SGf9" id="39iG6BGyHPw" role="2206d9">
           <node concept="19SUe$" id="39iG6BGyHPP" role="19SJt6" />
@@ -977,24 +987,27 @@
     </node>
     <node concept="2zPypq" id="IYj_dZsNZE" role="_iOnB">
       <property role="TrG5h" value="i6" />
+      <property role="0Rz4W" value="-329301861" />
       <node concept="2206d8" id="IYj_dZsOpP" role="2lDidJ">
         <node concept="19SGf9" id="IYj_dZsOpR" role="2206d9">
           <node concept="19SUe$" id="IYj_dZsOpS" role="19SJt6">
-            <property role="19SUeA" value="  with deliberate" />
+            <property role="19SUeA" value="  with deliberate " />
           </node>
           <node concept="2206Zw" id="IYj_dZsOrO" role="19SJt6">
             <node concept="_emDc" id="IYj_dZsOrP" role="2lDidJ">
               <ref role="_emDf" node="39iG6BG5ZL9" resolve="f" />
             </node>
           </node>
-          <node concept="19SUe$" id="IYj_dZsPwk" role="19SJt6" />
+          <node concept="19SUe$" id="IYj_dZsPwk" role="19SJt6">
+            <property role="19SUeA" value=" " />
+          </node>
           <node concept="2206Zw" id="IYj_dZsPwg" role="19SJt6">
             <node concept="_emDc" id="IYj_dZsPx5" role="2lDidJ">
               <ref role="_emDf" node="39iG6BG60iG" resolve="g" />
             </node>
           </node>
           <node concept="19SUe$" id="IYj_dZsPwj" role="19SJt6">
-            <property role="19SUeA" value="spaces   " />
+            <property role="19SUeA" value=" spaces   " />
           </node>
         </node>
       </node>


### PR DESCRIPTION
It produced additional spaces around instances of `InterpolExprWord`. The main issue is is that the produced string doesn't match what is shown in the editor.

Even if this was intended, there would be no way to specify a string that doesn't have spaces around `InterpolExprWord` instances. That's why this has to be a bug. If the user wants these spaces, they should be typed explicitly.