### PR TITLE
enhanced compatibility between number and int/real types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@ The project does _not_ follow Semantic Versioning and the changes are documented
   - presence condition in artifact
   - left-hand-side condition in an ITabularVarPoint
 - Allow to set `reportsFilenamePrefix` for the `ICustomRunnerConfig` interface
+- Support vertical layout of enum declarations without values
 
 ### Changed
 
 - Variability: The automatic execution of solver checking for tabular variation points (eg. feature decision tables) has been switched off. Now the solver check can be executed manually via "Run/Evaluate/Check manually" from the context menu. We will work on improving stability and performance for this feature and plan to reactivate it back later.
-
+- Enhanced compatibility between number and int/real types
 
 ## March 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,16 +23,17 @@ The project does _not_ follow Semantic Versioning and the changes are documented
   - left-hand-side condition in an ITabularVarPoint
 - Allow to set `reportsFilenamePrefix` for the `ICustomRunnerConfig` interface
 - Physical units (language `org.iets3.core.expr.typetags.physunits`): Implicit conversion rules are now supported in typesystem and interpreter. E.g., with the implicit conversion rules defined in `SIDerivedUnits` an expression like `(7 min + 1234 sec) < 0.5 h` is perfectly valid and can be evaluated by the interpreter.
+- Support vertical layout of enum declarations without values
 
 ### Changed
 
 - Variability: The automatic execution of solver checking for tabular variation points (eg. feature decision tables) has been switched off. Now the solver check can be executed manually via "Run/Evaluate/Check manually" from the context menu. We will work on improving stability and performance for this feature and plan to reactivate it back later.
+- Enhanced compatibility between number and int/real types
 
 ### Fixed
 
 - Variability: Restored workaround for using for-all-variants checking rules outside the IDE (e.g., on a build server). Due to MPS-34340, the for-all-variants checking cannot be done outside the IDE if the model under check has more than one root nodes.
 - Variability: After calling intention 'Adapt This Configuration to the Extended Configuration' inherited attributes were set to manual. This bug has been fixed.
-
 
 ## March 2026
 

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
@@ -301,6 +301,7 @@
       <concept id="1175517767210" name="jetbrains.mps.lang.typesystem.structure.ReportErrorStatement" flags="nn" index="2MkqsV">
         <child id="1175517851849" name="errorString" index="2MkJ7o" />
       </concept>
+      <concept id="4649457259824694112" name="jetbrains.mps.lang.typesystem.structure.TypesystemEquationStatementAnnotation" flags="ng" index="MG7fu" />
       <concept id="1175594888091" name="jetbrains.mps.lang.typesystem.structure.TypeCheckerAccessExpression" flags="nn" index="2QUAEa" />
       <concept id="1205762105978" name="jetbrains.mps.lang.typesystem.structure.WhenConcreteVariableDeclaration" flags="ng" index="2X1qdy" />
       <concept id="1205762656241" name="jetbrains.mps.lang.typesystem.structure.WhenConcreteVariableReference" flags="nn" index="2X3wrD">
@@ -7030,6 +7031,9 @@
                         <ref role="2X3Bk0" node="46cplYwOkUY" resolve="sub" />
                       </node>
                     </node>
+                  </node>
+                  <node concept="MG7fu" id="5WXTlJEkgv9" role="lGtFl">
+                    <property role="TrG5h" value="IncompatibleType" />
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.base/models/typesystem.mps
@@ -302,6 +302,7 @@
       <concept id="1175517767210" name="jetbrains.mps.lang.typesystem.structure.ReportErrorStatement" flags="nn" index="2MkqsV">
         <child id="1175517851849" name="errorString" index="2MkJ7o" />
       </concept>
+      <concept id="4649457259824694112" name="jetbrains.mps.lang.typesystem.structure.TypesystemEquationStatementAnnotation" flags="ng" index="MG7fu" />
       <concept id="1175594888091" name="jetbrains.mps.lang.typesystem.structure.TypeCheckerAccessExpression" flags="nn" index="2QUAEa" />
       <concept id="1205762105978" name="jetbrains.mps.lang.typesystem.structure.WhenConcreteVariableDeclaration" flags="ng" index="2X1qdy" />
       <concept id="1205762656241" name="jetbrains.mps.lang.typesystem.structure.WhenConcreteVariableReference" flags="nn" index="2X3wrD">
@@ -760,7 +761,6 @@
                     <node concept="3cpWs8" id="3eH6BL3YdV4" role="3cqZAp">
                       <node concept="3cpWsn" id="3eH6BL3YdV5" role="3cpWs9">
                         <property role="TrG5h" value="errorMessage" />
-                        <node concept="17QB3L" id="5b_AnPYaFes" role="1tU5fm" />
                         <node concept="2YIFZM" id="3eH6BL4dXbX" role="33vP2m">
                           <ref role="37wK5l" to="gdgh:3eH6BL4dyR5" resolve="cannotBeAppliedToTypesMessage" />
                           <ref role="1Pybhc" to="gdgh:3eH6BL4bSKS" resolve="ErrorCheckingUtil" />
@@ -780,6 +780,7 @@
                             <ref role="3cqZAo" node="5ya_dKpNDIj" resolve="rt" />
                           </node>
                         </node>
+                        <node concept="17QB3L" id="5b_AnPYaFes" role="1tU5fm" />
                       </node>
                     </node>
                     <node concept="3clFbH" id="7Wtc_Q2kYSf" role="3cqZAp" />
@@ -7032,6 +7033,9 @@
                         <ref role="2X3Bk0" node="46cplYwOkUY" resolve="sub" />
                       </node>
                     </node>
+                  </node>
+                  <node concept="MG7fu" id="5WXTlJEkgv9" role="lGtFl">
+                    <property role="TrG5h" value="IncompatibleType" />
                   </node>
                 </node>
               </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.core.expr.simpleTypes/models/typesystem.mps
@@ -5633,5 +5633,99 @@
       <ref role="1YaFvo" to="5qo5:2xPWNWpoRmG" resolve="StringTypeWithConstraint" />
     </node>
   </node>
+  <node concept="35pCF_" id="5WXTlJEeP2F">
+    <property role="3GE5qa" value="numeric" />
+    <property role="TrG5h" value="replaceIntegerType" />
+    <node concept="1YaCAy" id="5WXTlJEePrE" role="35pZ6h">
+      <property role="TrG5h" value="numberType" />
+      <ref role="1YaFvo" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+    </node>
+    <node concept="3clFbS" id="5WXTlJEeP2H" role="2sgrp5" />
+    <node concept="1YaCAy" id="5WXTlJEeP2J" role="1YuTPh">
+      <property role="TrG5h" value="integerType" />
+      <ref role="1YaFvo" to="5qo5:4rZeNQ6Oerp" resolve="IntegerType" />
+    </node>
+    <node concept="1xSnZT" id="5WXTlJEeQpi" role="1xSnZW">
+      <node concept="3clFbS" id="5WXTlJEeQpj" role="2VODD2">
+        <node concept="3clFbF" id="5WXTlJEeQCv" role="3cqZAp">
+          <node concept="1Wc70l" id="5WXTlJEfPuO" role="3clFbG">
+            <node concept="2OqwBi" id="5WXTlJEfQaz" role="3uHU7w">
+              <node concept="1YBJjd" id="5WXTlJEfPww" role="2Oq$k0">
+                <ref role="1YBMHb" node="5WXTlJEePrE" resolve="numberType" />
+              </node>
+              <node concept="2qgKlT" id="5WXTlJEfRgg" role="2OqNvi">
+                <ref role="37wK5l" to="b1h1:2NHHcg2D9Nd" resolve="isPositiveInfinity" />
+              </node>
+            </node>
+            <node concept="1Wc70l" id="5WXTlJEfues" role="3uHU7B">
+              <node concept="2OqwBi" id="5WXTlJEeQV0" role="3uHU7B">
+                <node concept="1YBJjd" id="5WXTlJEeQCu" role="2Oq$k0">
+                  <ref role="1YBMHb" node="5WXTlJEePrE" resolve="numberType" />
+                </node>
+                <node concept="2qgKlT" id="5WXTlJEeSVe" role="2OqNvi">
+                  <ref role="37wK5l" to="b1h1:3p6$WoEh1ch" resolve="isInt" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5WXTlJEfuMq" role="3uHU7w">
+                <node concept="1YBJjd" id="5WXTlJEfuyc" role="2Oq$k0">
+                  <ref role="1YBMHb" node="5WXTlJEePrE" resolve="numberType" />
+                </node>
+                <node concept="2qgKlT" id="5WXTlJEfv9N" role="2OqNvi">
+                  <ref role="37wK5l" to="b1h1:2NHHcg2Dg5B" resolve="isNegativeInfinity" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="35pCF_" id="5WXTlJEkrjE">
+    <property role="3GE5qa" value="numeric" />
+    <property role="TrG5h" value="replaceRealType" />
+    <node concept="3clFbS" id="5WXTlJEkrjG" role="2sgrp5" />
+    <node concept="1YaCAy" id="5WXTlJEkrjI" role="1YuTPh">
+      <property role="TrG5h" value="realType" />
+      <ref role="1YaFvo" to="5qo5:4rZeNQ6Oetc" resolve="RealType" />
+    </node>
+    <node concept="1YaCAy" id="5WXTlJEkrl5" role="35pZ6h">
+      <property role="TrG5h" value="numberType" />
+      <ref role="1YaFvo" to="5qo5:78hTg1$P0UC" resolve="NumberType" />
+    </node>
+    <node concept="1xSnZT" id="5WXTlJEkrlp" role="1xSnZW">
+      <node concept="3clFbS" id="5WXTlJEkrlq" role="2VODD2">
+        <node concept="3clFbF" id="5WXTlJEkrBa" role="3cqZAp">
+          <node concept="1Wc70l" id="5WXTlJEkvHE" role="3clFbG">
+            <node concept="1Wc70l" id="5WXTlJEktOP" role="3uHU7B">
+              <node concept="2OqwBi" id="5WXTlJEks6J" role="3uHU7B">
+                <node concept="1YBJjd" id="5WXTlJEkrB9" role="2Oq$k0">
+                  <ref role="1YBMHb" node="5WXTlJEkrl5" resolve="numberType" />
+                </node>
+                <node concept="2qgKlT" id="5WXTlJEkstC" role="2OqNvi">
+                  <ref role="37wK5l" to="b1h1:7Wa2sv3Gi_T" resolve="isInfinitePrecision" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="5WXTlJEktVc" role="3uHU7w">
+                <node concept="1YBJjd" id="5WXTlJEktVd" role="2Oq$k0">
+                  <ref role="1YBMHb" node="5WXTlJEkrl5" resolve="numberType" />
+                </node>
+                <node concept="2qgKlT" id="5WXTlJEktVe" role="2OqNvi">
+                  <ref role="37wK5l" to="b1h1:2NHHcg2Dg5B" resolve="isNegativeInfinity" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="5WXTlJEkvOT" role="3uHU7w">
+              <node concept="1YBJjd" id="5WXTlJEkvOU" role="2Oq$k0">
+                <ref role="1YBMHb" node="5WXTlJEkrl5" resolve="numberType" />
+              </node>
+              <node concept="2qgKlT" id="5WXTlJEkvOV" role="2OqNvi">
+                <ref role="37wK5l" to="b1h1:2NHHcg2D9Nd" resolve="isPositiveInfinity" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
 </model>
 

--- a/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.ts.expr.os/models/test/ts/expr/os/m1@tests.mps
@@ -6945,7 +6945,265 @@
             </node>
           </node>
         </node>
+        <node concept="_ixoA" id="5WXTlJEk7ta" role="_iOnC" />
+        <node concept="1Ws0TD" id="5WXTlJEk7te" role="_iOnC">
+          <property role="1WsWdv" value="real / int to number types compatibility" />
+        </node>
+        <node concept="_ixoA" id="5WXTlJEkacp" role="_iOnC" />
+        <node concept="2zPypq" id="5WXTlJEkaPl" role="_iOnC">
+          <property role="TrG5h" value="realNum" />
+          <node concept="30bXRB" id="5WXTlJEkaQ0" role="2lDidJ">
+            <property role="30bXRw" value="42.2" />
+          </node>
+          <node concept="30bXLL" id="5WXTlJEkaRM" role="2zM23F" />
+        </node>
+        <node concept="2zPypq" id="5WXTlJEkaQu" role="_iOnC">
+          <property role="TrG5h" value="intNum" />
+          <node concept="30bXRB" id="5WXTlJEkaT_" role="2lDidJ">
+            <property role="30bXRw" value="42" />
+          </node>
+          <node concept="30bXR$" id="5WXTlJEkaSE" role="2zM23F" />
+        </node>
+        <node concept="_ixoA" id="5WXTlJEkaV5" role="_iOnC" />
+        <node concept="2zPypq" id="5WXTlJEkaUh" role="_iOnC">
+          <property role="TrG5h" value="realToGenericNum" />
+          <node concept="_emDc" id="5WXTlJEkaVf" role="2lDidJ">
+            <ref role="_emDf" node="5WXTlJEkaPl" resolve="realNum" />
+            <node concept="7CXmI" id="5WXTlJEkaVw" role="lGtFl">
+              <node concept="2DdRWr" id="5WXTlJEkgk2" role="7EUXB">
+                <node concept="MGsTx" id="5WXTlJEkgk3" role="MJxsd">
+                  <ref role="39XzEq" to="t4jv:5aHkq2w4P8w" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="mLuIC" id="5WXTlJEkaUW" role="2zM23F" />
+        </node>
+        <node concept="2zPypq" id="5WXTlJElpNu" role="_iOnC">
+          <property role="TrG5h" value="realToPrecNum" />
+          <node concept="_emDc" id="5WXTlJElpNv" role="2lDidJ">
+            <ref role="_emDf" node="5WXTlJEkaPl" resolve="realNum" />
+            <node concept="7CXmI" id="5WXTlJElpRS" role="lGtFl">
+              <node concept="2DdRWr" id="5WXTlJElviw" role="7EUXB">
+                <node concept="MGsTx" id="5WXTlJElvix" role="MJxsd">
+                  <ref role="39XzEq" to="t4jv:5aHkq2w4P8w" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="mLuIC" id="5WXTlJElpNw" role="2zM23F">
+            <node concept="2gteS_" id="5WXTlJElpNx" role="2gteVg">
+              <property role="2gteVv" value="10" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5WXTlJEkhIe" role="_iOnC">
+          <property role="TrG5h" value="realToInfPrecNum" />
+          <node concept="_emDc" id="5WXTlJEkhJj" role="2lDidJ">
+            <ref role="_emDf" node="5WXTlJEkaPl" resolve="realNum" />
+          </node>
+          <node concept="mLuIC" id="5WXTlJEkhIC" role="2zM23F">
+            <node concept="2gteS_" id="5WXTlJEkhIN" role="2gteVg">
+              <property role="2gteVv" value="inf" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5WXTlJElymC" role="_iOnC">
+          <property role="TrG5h" value="realToInfRangeInfPrecNum" />
+          <node concept="_emDc" id="5WXTlJElyoq" role="2lDidJ">
+            <ref role="_emDf" node="5WXTlJEkaPl" resolve="realNum" />
+          </node>
+          <node concept="mLuIC" id="5WXTlJElyn5" role="2zM23F">
+            <node concept="2gteSX" id="5WXTlJElyng" role="2gteSx" />
+            <node concept="2gteS_" id="5WXTlJElynG" role="2gteVg">
+              <property role="2gteVv" value="inf" />
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="5WXTlJElKR4" role="_iOnC" />
+        <node concept="2zPypq" id="5WXTlJEkhHe" role="_iOnC">
+          <property role="TrG5h" value="intToGenericNum" />
+          <node concept="_emDc" id="5WXTlJEkhHP" role="2lDidJ">
+            <ref role="_emDf" node="5WXTlJEkaQu" resolve="intNum" />
+          </node>
+          <node concept="mLuIC" id="5WXTlJEkhHx" role="2zM23F" />
+        </node>
+        <node concept="2zPypq" id="5WXTlJElBO7" role="_iOnC">
+          <property role="TrG5h" value="intToZeroPrecNum" />
+          <node concept="_emDc" id="5WXTlJElBO8" role="2lDidJ">
+            <ref role="_emDf" node="5WXTlJEkaQu" resolve="intNum" />
+          </node>
+          <node concept="mLuIC" id="5WXTlJElBO9" role="2zM23F">
+            <node concept="2gteS_" id="5WXTlJElBT2" role="2gteVg">
+              <property role="2gteVv" value="0" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5WXTlJElBV9" role="_iOnC">
+          <property role="TrG5h" value="intToInfRangeZeroPrecNum" />
+          <node concept="_emDc" id="5WXTlJElBVa" role="2lDidJ">
+            <ref role="_emDf" node="5WXTlJEkaQu" resolve="intNum" />
+          </node>
+          <node concept="mLuIC" id="5WXTlJElBVb" role="2zM23F">
+            <node concept="2gteS_" id="5WXTlJElBVc" role="2gteVg">
+              <property role="2gteVv" value="0" />
+            </node>
+            <node concept="2gteSX" id="5WXTlJElBVz" role="2gteSx" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="5WXTlJElFjK" role="_iOnC">
+          <property role="TrG5h" value="intToPrecNum" />
+          <node concept="_emDc" id="5WXTlJElFkT" role="2lDidJ">
+            <ref role="_emDf" node="5WXTlJEkaQu" resolve="intNum" />
+            <node concept="7CXmI" id="5WXTlJElFlj" role="lGtFl">
+              <node concept="2DdRWr" id="5WXTlJElKNl" role="7EUXB">
+                <node concept="MGsTx" id="5WXTlJElKNm" role="MJxsd">
+                  <ref role="39XzEq" to="t4jv:5aHkq2w4P8w" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="mLuIC" id="5WXTlJElFkb" role="2zM23F">
+            <node concept="2gteS_" id="5WXTlJElFkm" role="2gteVg">
+              <property role="2gteVv" value="10" />
+            </node>
+          </node>
+        </node>
+        <node concept="_ixoA" id="5WXTlJElKPe" role="_iOnC" />
+        <node concept="1Ws0TD" id="5WXTlJElPtx" role="_iOnC">
+          <property role="1WsWdv" value="number to real / int types compatibility" />
+        </node>
+        <node concept="_ixoA" id="5WXTlJElPtL" role="_iOnC" />
+        <node concept="2zPypq" id="5WXTlJElL35" role="_iOnC">
+          <property role="TrG5h" value="genericNum" />
+          <node concept="30bXRB" id="5WXTlJElL3B" role="2lDidJ">
+            <property role="30bXRw" value="42" />
+          </node>
+          <node concept="mLuIC" id="5WXTlJElL3q" role="2zM23F" />
+        </node>
+        <node concept="2zPypq" id="5WXTlJElLNf" role="_iOnC">
+          <property role="TrG5h" value="precNum" />
+          <node concept="30bXRB" id="5WXTlJElLNg" role="2lDidJ">
+            <property role="30bXRw" value="42.2" />
+          </node>
+          <node concept="mLuIC" id="5WXTlJElLNh" role="2zM23F">
+            <node concept="2gteS_" id="5WXTlJElLOv" role="2gteVg">
+              <property role="2gteVv" value="10" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5WXTlJElOIk" role="_iOnC">
+          <property role="TrG5h" value="infPrecNum" />
+          <node concept="30bXRB" id="5WXTlJElOIl" role="2lDidJ">
+            <property role="30bXRw" value="42.2" />
+          </node>
+          <node concept="mLuIC" id="5WXTlJElOIm" role="2zM23F">
+            <node concept="2gteS_" id="5WXTlJElOIn" role="2gteVg">
+              <property role="2gteVv" value="inf" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5WXTlJElP4M" role="_iOnC">
+          <property role="TrG5h" value="infRangeInfPrecNum" />
+          <node concept="30bXRB" id="5WXTlJElP4N" role="2lDidJ">
+            <property role="30bXRw" value="42.2" />
+          </node>
+          <node concept="mLuIC" id="5WXTlJElP4O" role="2zM23F">
+            <node concept="2gteS_" id="5WXTlJElP4P" role="2gteVg">
+              <property role="2gteVv" value="inf" />
+            </node>
+            <node concept="2gteSX" id="5WXTlJElP7L" role="2gteSx" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="5WXTlJElPMI" role="_iOnC">
+          <property role="TrG5h" value="zeroPrecNum" />
+          <node concept="30bXRB" id="5WXTlJElPMJ" role="2lDidJ">
+            <property role="30bXRw" value="42" />
+          </node>
+          <node concept="mLuIC" id="5WXTlJElPMK" role="2zM23F">
+            <node concept="2gteS_" id="5WXTlJElPML" role="2gteVg">
+              <property role="2gteVv" value="0" />
+            </node>
+          </node>
+        </node>
+        <node concept="2zPypq" id="5WXTlJElRqG" role="_iOnC">
+          <property role="TrG5h" value="infRangeZeroPrecNum" />
+          <node concept="30bXRB" id="5WXTlJElRqH" role="2lDidJ">
+            <property role="30bXRw" value="42" />
+          </node>
+          <node concept="mLuIC" id="5WXTlJElPu5" role="2zM23F">
+            <node concept="2gteS_" id="5WXTlJElPu6" role="2gteVg">
+              <property role="2gteVv" value="0" />
+            </node>
+            <node concept="2gteSX" id="5WXTlJElPu7" role="2gteSx" />
+          </node>
+        </node>
         <node concept="_ixoA" id="17MOwOjM$LU" role="_iOnC" />
+        <node concept="2zPypq" id="5WXTlJElKPL" role="_iOnC">
+          <property role="TrG5h" value="genericNumToReal" />
+          <node concept="_emDc" id="5WXTlJElKPM" role="2lDidJ">
+            <ref role="_emDf" node="5WXTlJElL35" resolve="genericNum" />
+          </node>
+          <node concept="30bXLL" id="5WXTlJElL03" role="2zM23F" />
+        </node>
+        <node concept="2zPypq" id="5WXTlJElKPE" role="_iOnC">
+          <property role="TrG5h" value="precNumToReal" />
+          <node concept="30bXLL" id="5WXTlJElLCv" role="2zM23F" />
+          <node concept="_emDc" id="5WXTlJElP4n" role="2lDidJ">
+            <ref role="_emDf" node="5WXTlJElLNf" resolve="precNum" />
+          </node>
+        </node>
+        <node concept="2zPypq" id="5WXTlJElKPA" role="_iOnC">
+          <property role="TrG5h" value="infPrecNumToReal" />
+          <node concept="_emDc" id="5WXTlJElKPB" role="2lDidJ">
+            <ref role="_emDf" node="5WXTlJElOIk" resolve="infPrecNum" />
+          </node>
+          <node concept="30bXLL" id="5WXTlJElOFT" role="2zM23F" />
+        </node>
+        <node concept="2zPypq" id="5WXTlJElKPx" role="_iOnC">
+          <property role="TrG5h" value="infRangeInfPrecNumToReal" />
+          <node concept="_emDc" id="5WXTlJElKPy" role="2lDidJ">
+            <ref role="_emDf" node="5WXTlJElP4M" resolve="infRangeInfPrecNum" />
+          </node>
+          <node concept="30bXLL" id="5WXTlJElPcn" role="2zM23F" />
+        </node>
+        <node concept="_ixoA" id="5WXTlJElFk9" role="_iOnC" />
+        <node concept="2zPypq" id="5WXTlJElPtW" role="_iOnC">
+          <property role="TrG5h" value="genericNumToInt" />
+          <node concept="_emDc" id="5WXTlJElPtX" role="2lDidJ">
+            <ref role="_emDf" node="5WXTlJElL35" resolve="genericNum" />
+          </node>
+          <node concept="30bXR$" id="5WXTlJElP_s" role="2zM23F" />
+        </node>
+        <node concept="2zPypq" id="5WXTlJElPtZ" role="_iOnC">
+          <property role="TrG5h" value="zeroPrecNumToInt" />
+          <node concept="_emDc" id="5WXTlJElPu0" role="2lDidJ">
+            <ref role="_emDf" node="5WXTlJElPMI" resolve="zeroPrecNum" />
+          </node>
+          <node concept="30bXR$" id="5WXTlJElPJ7" role="2zM23F" />
+        </node>
+        <node concept="2zPypq" id="5WXTlJElPu3" role="_iOnC">
+          <property role="TrG5h" value="infRangeZeroPrecNumToInt" />
+          <node concept="_emDc" id="5WXTlJElPu4" role="2lDidJ">
+            <ref role="_emDf" node="5WXTlJElRqG" resolve="infRangeZeroPrecNum" />
+          </node>
+          <node concept="30bXR$" id="5WXTlJElQQK" role="2zM23F" />
+        </node>
+        <node concept="2zPypq" id="5WXTlJElPu8" role="_iOnC">
+          <property role="TrG5h" value="precNumToInt" />
+          <node concept="_emDc" id="5WXTlJElPu9" role="2lDidJ">
+            <ref role="_emDf" node="5WXTlJElLNf" resolve="precNum" />
+            <node concept="7CXmI" id="5WXTlJElPua" role="lGtFl">
+              <node concept="2DdRWr" id="5WXTlJElPub" role="7EUXB">
+                <node concept="MGsTx" id="5WXTlJElPuc" role="MJxsd">
+                  <ref role="39XzEq" to="t4jv:5aHkq2w4P8w" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="30bXR$" id="5WXTlJElS9$" role="2zM23F" />
+        </node>
+        <node concept="_ixoA" id="5WXTlJElPtN" role="_iOnC" />
         <node concept="7CXmI" id="6rdp$3y_pdc" role="lGtFl">
           <node concept="7OXhh" id="6rdp$3y_pdd" role="7EUXB">
             <property role="G7GLP" value="true" />


### PR DESCRIPTION
Currently, `real` and `int` types have correct subtyping rules for the number type allowing to assign `number` with precision zero to `int` and any number to `real`, but not vice versa, i.e. assigning `int` to a `number` or `number{0}` is not allowed and also assigning `real` to `number{inf}` is not supported yet. This PR adds additional typesystem support for those cases.