### PR TITLE
Consider logical child in mps34340 workaround in for all variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## May 2026
+
+### Fixed
+
+- Variability: Fix workaround for using for-all-variants checking rules outside the IDE (e.g., on a build server). Due to MPS-34340, the for-all-variants checking cannot be done outside the IDE if the model under check has more than one root nodes. This bugfix includes roots of LogicalChildren in the list of used root nodes.
+
+
 ## April 2026
 
 ### Added
@@ -45,8 +52,8 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 - Variability: The class hierarchy implementing `IRenamer` has been improved and documented. This interface is being used for tailoring the renaming behavior of the variability filtering algorithms.
 - Variability: Remove deprecated concepts `FeatureModelConfiguration_old`, and all related concepts. These concepts have been introduced when one proto-language for variability has been split into two languages, one for feature models and one for configurations. This happened end of 2024, and the deprecation window is now closing.
 - Variability: The variability.os plugin no longer depends on the potentially slow tracing language.
-- The physical units language `org.iets3.core.expr.typetags.physunits` has been refactored internally (logic has not been changed). 
-- The behaviour methods of `IValidNamedConcept` for umlauts, paragraphs and apostrophes in language `org.iets3.core.base` were refactored internally and allow now customization via extension point. 
+- The physical units language `org.iets3.core.expr.typetags.physunits` has been refactored internally (logic has not been changed).
+- The behaviour methods of `IValidNamedConcept` for umlauts, paragraphs and apostrophes in language `org.iets3.core.base` were refactored internally and allow now customization via extension point.
 
 ### Fixed
 - Add missing deps. to SBOM
@@ -133,7 +140,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 ### Added
 
-- Data tables, binary and multi-criteria decision tables now support deletion, copying and pasting when multiple cells are selected with the mouse. 
+- Data tables, binary and multi-criteria decision tables now support deletion, copying and pasting when multiple cells are selected with the mouse.
 
 
 ## July 2025
@@ -142,7 +149,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 - Expressions of ShortLambdas are now correctly updated and used for interpretation after they are changed
 - API for coverage calculation and restored original functionality. Coverage is now calculated during interpreter execution
-- Duplicated colors for PARTIAL and IGNORED 
+- Duplicated colors for PARTIAL and IGNORED
 
 ### Added
 
@@ -181,7 +188,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 ### Fixed
 
-- Plugin org.iets3.safety was renamed to org.iets3.safety.os fixing the name collision with a plugin in org.iets3.core 
+- Plugin org.iets3.safety was renamed to org.iets3.safety.os fixing the name collision with a plugin in org.iets3.core
 
 - A NullPointerException was fixed for cases where a node implementing IValidNamedConcept had no name.
 - When calculating the supertype of number types, the precision is now correctly set to infinite when one of the types has an infinite precision.
@@ -257,7 +264,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 - The physical units B and b were renamed to byte and bit to avoid confusion.
 - Breaking change: The units of digital information were split into 3 different libraries: UnitsOfInformationIEC, UnitsOfInformationJEDEC, UnitsOfInformationMetric. They are still considered part of the derived units.
 
-### Added 
+### Added
 
 - Physical units now also support metric scaling for only the positive and negative prefixes. Scaling can also be overwritten for units by overwritten `IUnitLangConfig#getOverwrittenScaling` for the extension point `PhysUnitLangConfig`.
 - Execution of Test by Interpreter can be done without generation and compilation.
@@ -291,7 +298,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 ### Changed
 
-- The `noConvert` expressions in the physunit language doesn't strip the unit anymore. Use the `stripUnit` expression for that. 
+- The `noConvert` expressions in the physunit language doesn't strip the unit anymore. Use the `stripUnit` expression for that.
 
 ## September 2024
 
@@ -376,7 +383,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 
 ### Changed
 
-- `ComponentKind#canbeContent(conceptNode<>)` was deprecated in favour of `ComponentKind#canbeContent(concept<>)` 
+- `ComponentKind#canbeContent(conceptNode<>)` was deprecated in favour of `ComponentKind#canbeContent(concept<>)`
 - `Component#canBeInComponentContent(conceptNode<>)` was deprecated in favour of `Component#canBeInComponentContent(concept<>)`
 
 ### Added
@@ -389,7 +396,7 @@ The project does _not_ follow Semantic Versioning and the changes are documented
 ### Added
 
 - *MessageDefiniton* uses *extensionPoint/IdentifierConfigurator/* that allows the user to decide to use german umlauts and paragraphs in it.
-- This extensionPoint got a new method to select which implementation will be chosen. 
+- This extensionPoint got a new method to select which implementation will be chosen.
 - A new (experimental) language `org.iets3.core.expr.typetags.physunits` was added that should eventually replace the old unit language. Read the documentation in `org.iets3.core.expr.typetags.physunits.documentation` to learn more about the features of the new language.
 
 ### Fixed

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.artifacts.base/models/org.iets3.variability.artifacts.base.plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.artifacts.base/models/org.iets3.variability.artifacts.base.plugin.mps
@@ -13275,7 +13275,7 @@
     </node>
     <node concept="2tJIrI" id="4pGaDIglX0F" role="jymVt" />
     <node concept="2YIFZL" id="4pGaDIgmOzB" role="jymVt">
-      <property role="TrG5h" value="artifactGroupWithLogicalChildren" />
+      <property role="TrG5h" value="artifactGroupIncludingLogicalChildren" />
       <node concept="37vLTG" id="4pGaDIgmPgo" role="3clF46">
         <property role="TrG5h" value="mainArtifact" />
         <node concept="3Tqbb2" id="4pGaDIgmPgp" role="1tU5fm">
@@ -13304,7 +13304,7 @@
         </node>
         <node concept="3cpWs6" id="4pGaDIgrZNC" role="3cqZAp">
           <node concept="1rXfSq" id="1q2b1nq0DBO" role="3cqZAk">
-            <ref role="37wK5l" node="4pGaDIgrZNy" resolve="artifactGroupWithLogicalChildren" />
+            <ref role="37wK5l" node="4pGaDIgrZNy" resolve="artifactGroupIncludingLogicalChildren" />
             <node concept="37vLTw" id="4pGaDIgrZNA" role="37wK5m">
               <ref role="3cqZAo" node="4pGaDIgmUeC" resolve="artifactGroup" />
             </node>
@@ -13318,7 +13318,7 @@
     </node>
     <node concept="2tJIrI" id="4pGaDIgs0W5" role="jymVt" />
     <node concept="2YIFZL" id="4pGaDIgrZNy" role="jymVt">
-      <property role="TrG5h" value="artifactGroupWithLogicalChildren" />
+      <property role="TrG5h" value="artifactGroupIncludingLogicalChildren" />
       <node concept="3Tm1VV" id="4pGaDIgrZNz" role="1B3o_S" />
       <node concept="A3Dl8" id="4pGaDIgrZN$" role="3clF45">
         <node concept="3Tqbb2" id="4pGaDIgrZN_" role="A3Ik2" />

--- a/code/languages/org.iets3.opensource/solutions/org.iets3.variability.artifacts.typesystem.runtime/models/org.iets3.variability.artifacts.typesystem.runtime.plugin.mps
+++ b/code/languages/org.iets3.opensource/solutions/org.iets3.variability.artifacts.typesystem.runtime/models/org.iets3.variability.artifacts.typesystem.runtime.plugin.mps
@@ -1353,13 +1353,13 @@
         </node>
         <node concept="3cpWs8" id="5hMo5PmOBzN" role="3cqZAp">
           <node concept="3cpWsn" id="5hMo5PmOBzO" role="3cpWs9">
-            <property role="TrG5h" value="artifactGroupLogical" />
+            <property role="TrG5h" value="allArtifactGroup" />
             <node concept="3vKaQO" id="4pGaDIgIgzD" role="1tU5fm">
               <node concept="3Tqbb2" id="4pGaDIgIgzF" role="3O5elw" />
             </node>
             <node concept="2OqwBi" id="4lHDM39xYJ_" role="33vP2m">
               <node concept="2YIFZM" id="4pGaDIgsoi2" role="2Oq$k0">
-                <ref role="37wK5l" to="eagd:4pGaDIgrZNy" resolve="artifactGroupWithLogicalChildren" />
+                <ref role="37wK5l" to="eagd:4pGaDIgrZNy" resolve="artifactGroupIncludingLogicalChildren" />
                 <ref role="1Pybhc" to="eagd:4pGaDIglRIz" resolve="IVAAUtil" />
                 <node concept="37vLTw" id="24YzBBJVNYd" role="37wK5m">
                   <ref role="3cqZAo" node="24YzBBJVE6u" resolve="artifactGroup" />
@@ -1518,8 +1518,8 @@
               </node>
               <node concept="liA8E" id="5hMo5PmRzbe" role="2OqNvi">
                 <ref role="37wK5l" node="5hMo5PmNklQ" resolve="canDoMulticheck" />
-                <node concept="37vLTw" id="5hMo5PmRBWB" role="37wK5m">
-                  <ref role="3cqZAo" node="24YzBBJVE6u" resolve="artifactGroup" />
+                <node concept="37vLTw" id="5vB1gFotsFq" role="37wK5m">
+                  <ref role="3cqZAo" node="5hMo5PmOBzO" resolve="allArtifactGroup" />
                 </node>
               </node>
             </node>
@@ -1649,7 +1649,7 @@
                   <ref role="37wK5l" to="eagd:7n4AitrhwSh" resolve="createFromNodeGroup" />
                   <ref role="1Pybhc" to="eagd:7n4Aitrl88z" resolve="RootNodesCopy" />
                   <node concept="37vLTw" id="7n4AitrqctQ" role="37wK5m">
-                    <ref role="3cqZAo" node="5hMo5PmOBzO" resolve="artifactGroupLogical" />
+                    <ref role="3cqZAo" node="5hMo5PmOBzO" resolve="allArtifactGroup" />
                   </node>
                 </node>
               </node>


### PR DESCRIPTION
Use artifact group including logical children in the condition that test if it run multi check, so that it works around a bug existing in MPS.

solves  #1774