### PR TITLE
Add extension point for the logic of combining variability configurations, plus some refactorings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented in this file.
 Format of the log is _loosely_ based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 The project does _not_ follow Semantic Versioning and the changes are documented in reverse chronological order, grouped by calendar month.
 
+## June 2026
+
+### Added
+
+- Variability: Introduced extension point `configCombinationLogicExtPoint` (interface `IConfigCombinationLogic`) to make the logic of combining configurations (via `extends`, `abstract` and referenced sub-configurations) configurable per application.
+- Variability: Configuration checking for referenced abstract sub-configurations now respects the active combination logic, and configuration hashing was extended to cover a configuration together with all configurations reachable from it.
+
+
 ## May 2026
 
 ### Fixed

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.base/models/org.iets3.variability.base.plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.base/models/org.iets3.variability.base.plugin.mps
@@ -23,13 +23,11 @@
     <import index="hnhi" ref="r:d354209e-0bea-497f-b905-d66f72900fa8(org.iets3.analysis.base.plugin)" />
     <import index="l80j" ref="r:9e71c0de-f9ab-4b67-96cc-7d9c857513f6(org.iets3.analysis.base.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="82uw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.function(JDK/)" />
     <import index="90d" ref="r:421d64ed-8024-497f-aeab-8bddeb389dd2(jetbrains.mps.lang.extension.methods)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
-        <child id="1082485599096" name="statements" index="9aQI4" />
-      </concept>
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -78,7 +76,9 @@
         <child id="1070534760952" name="componentType" index="10Q1$1" />
       </concept>
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
+        <property id="1075300953594" name="abstractClass" index="1sVAO0" />
         <child id="1095933932569" name="implementedInterface" index="EKbjA" />
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
@@ -86,6 +86,15 @@
       </concept>
       <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1109279763828" name="jetbrains.mps.baseLanguage.structure.TypeVariableDeclaration" flags="ng" index="16euLQ">
+        <child id="1214996921760" name="bound" index="3ztrMU" />
+      </concept>
+      <concept id="1109279851642" name="jetbrains.mps.baseLanguage.structure.GenericDeclaration" flags="ng" index="16eOlS">
+        <child id="1109279881614" name="typeVariableDeclaration" index="16eVyc" />
+      </concept>
+      <concept id="1109283449304" name="jetbrains.mps.baseLanguage.structure.TypeVariableReference" flags="in" index="16syzq">
+        <reference id="1109283546497" name="typeVariableDeclaration" index="16sUi3" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -109,16 +118,13 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
-        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
-      </concept>
-      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
-        <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
@@ -130,6 +136,7 @@
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
+      <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
@@ -142,6 +149,7 @@
       <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -151,6 +159,11 @@
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1107796713796" name="jetbrains.mps.baseLanguage.structure.Interface" flags="ig" index="3HP615" />
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
       <concept id="1163670490218" name="jetbrains.mps.baseLanguage.structure.SwitchStatement" flags="nn" index="3KaCP$">
         <child id="1163670592366" name="defaultBlock" index="3Kb1Dw" />
         <child id="1163670766145" name="expression" index="3KbGdf" />
@@ -165,6 +178,7 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
     </language>
     <language id="c0080a47-7e37-4558-bee9-9ae18e690549" name="jetbrains.mps.lang.extension">
       <concept id="6626851894249711936" name="jetbrains.mps.lang.extension.structure.ExtensionPointExpression" flags="nn" index="2O5UvJ">
@@ -187,12 +201,14 @@
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
+      <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="nn" index="1Bd96e" />
     </language>
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
       <concept id="6832197706140896242" name="jetbrains.mps.baseLanguage.javadoc.structure.FieldDocComment" flags="ng" index="z59LJ" />
       <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
         <child id="8465538089690331502" name="body" index="TZ5H$" />
       </concept>
+      <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
         <child id="8970989240999019149" name="part" index="1dT_Ay" />
       </concept>
@@ -272,7 +288,6 @@
       </concept>
       <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
-      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
     </language>
   </registry>
   <node concept="312cEu" id="5CL_dkjhqW1">
@@ -378,80 +393,29 @@
                 </node>
               </node>
             </node>
-            <node concept="3cpWs8" id="26cjRACVUHx" role="3cqZAp">
-              <node concept="3cpWsn" id="26cjRACVUHy" role="3cpWs9">
-                <property role="TrG5h" value="handlers" />
-                <node concept="A3Dl8" id="26cjRACVUHz" role="1tU5fm">
-                  <node concept="3uibUv" id="307NTAd03TP" role="A3Ik2">
-                    <ref role="3uigEE" to="quv7:307NTAcYTHv" resolve="IETS3VariabilitySettings" />
-                  </node>
+            <node concept="3clFbF" id="7Sbg4UjQSiv" role="3cqZAp">
+              <node concept="37vLTI" id="7Sbg4UjQTbx" role="3clFbG">
+                <node concept="37vLTw" id="7Sbg4UjQSit" role="37vLTJ">
+                  <ref role="3cqZAo" node="26cjRACVUHk" resolve="settings" />
                 </node>
-                <node concept="2OqwBi" id="26cjRACVUH_" role="33vP2m">
-                  <node concept="2OqwBi" id="26cjRACVUHA" role="2Oq$k0">
-                    <node concept="37vLTw" id="26cjRACVUHB" role="2Oq$k0">
+                <node concept="2YIFZM" id="7Sbg4UjPS9a" role="37vLTx">
+                  <ref role="1Pybhc" node="7Sbg4UjPNNA" resolve="AbstractExtensionProvider" />
+                  <ref role="37wK5l" node="7Sbg4UjP$Z3" resolve="instanceByPriority" />
+                  <node concept="2OqwBi" id="7Sbg4UjQQqS" role="37wK5m">
+                    <node concept="37vLTw" id="7Sbg4UjPS9b" role="2Oq$k0">
                       <ref role="3cqZAo" node="26cjRACVUHu" resolve="ep" />
                     </node>
-                    <node concept="SfwO_" id="26cjRACVUHC" role="2OqNvi" />
+                    <node concept="SfwO_" id="7Sbg4UjQR2e" role="2OqNvi" />
                   </node>
-                  <node concept="2S7cBI" id="26cjRACVUHD" role="2OqNvi">
-                    <node concept="1bVj0M" id="26cjRACVUHE" role="23t8la">
-                      <node concept="3clFbS" id="26cjRACVUHF" role="1bW5cS">
-                        <node concept="3clFbF" id="26cjRACVUHG" role="3cqZAp">
-                          <node concept="2OqwBi" id="26cjRACVUHH" role="3clFbG">
-                            <node concept="37vLTw" id="26cjRACVUHI" role="2Oq$k0">
-                              <ref role="3cqZAo" node="2r1kIC$yAmo" resolve="it" />
-                            </node>
-                            <node concept="liA8E" id="26cjRACVUHJ" role="2OqNvi">
-                              <ref role="37wK5l" to="quv7:26cjRACVPUy" resolve="getPriorityLevel" />
-                            </node>
+                  <node concept="1bVj0M" id="7Sbg4UjPS9c" role="37wK5m">
+                    <node concept="3clFbS" id="7Sbg4UjPS9d" role="1bW5cS">
+                      <node concept="3clFbF" id="7Sbg4UjPS9e" role="3cqZAp">
+                        <node concept="2ShNRf" id="7Sbg4UjPS9f" role="3clFbG">
+                          <node concept="HV5vD" id="7Sbg4UjPS9g" role="2ShVmc">
+                            <property role="373rjd" value="true" />
+                            <ref role="HV5vE" to="quv7:307NTAcZvpY" resolve="DefaultIETS3VariabilitySettings" />
                           </node>
                         </node>
-                      </node>
-                      <node concept="gl6BB" id="2r1kIC$yAmo" role="1bW2Oz">
-                        <property role="TrG5h" value="it" />
-                        <node concept="2jxLKc" id="2r1kIC$yAmp" role="1tU5fm" />
-                      </node>
-                    </node>
-                    <node concept="1nlBCl" id="26cjRACVUHM" role="2S7zOq">
-                      <property role="3clFbU" value="false" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="26cjRACW1E$" role="3cqZAp">
-              <node concept="3clFbS" id="26cjRACW1EA" role="3clFbx">
-                <node concept="3clFbF" id="26cjRACW2Pz" role="3cqZAp">
-                  <node concept="37vLTI" id="26cjRACW36E" role="3clFbG">
-                    <node concept="2ShNRf" id="26cjRACW389" role="37vLTx">
-                      <node concept="HV5vD" id="26cjRACW3I5" role="2ShVmc">
-                        <ref role="HV5vE" to="quv7:307NTAcZvpY" resolve="DefaultIETS3VariabilitySettings" />
-                      </node>
-                    </node>
-                    <node concept="37vLTw" id="307NTAcZFOs" role="37vLTJ">
-                      <ref role="3cqZAo" node="26cjRACVUHk" resolve="settings" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="26cjRACW2hY" role="3clFbw">
-                <node concept="37vLTw" id="26cjRACW24i" role="2Oq$k0">
-                  <ref role="3cqZAo" node="26cjRACVUHy" resolve="handlers" />
-                </node>
-                <node concept="1v1jN8" id="26cjRACW2EZ" role="2OqNvi" />
-              </node>
-              <node concept="9aQIb" id="26cjRACW3S9" role="9aQIa">
-                <node concept="3clFbS" id="26cjRACW3Sa" role="9aQI4">
-                  <node concept="3clFbF" id="26cjRACVUHN" role="3cqZAp">
-                    <node concept="37vLTI" id="26cjRACVUHO" role="3clFbG">
-                      <node concept="37vLTw" id="307NTAcZFOw" role="37vLTJ">
-                        <ref role="3cqZAo" node="26cjRACVUHk" resolve="settings" />
-                      </node>
-                      <node concept="2OqwBi" id="26cjRACVUHQ" role="37vLTx">
-                        <node concept="37vLTw" id="26cjRACVUHR" role="2Oq$k0">
-                          <ref role="3cqZAo" node="26cjRACVUHy" resolve="handlers" />
-                        </node>
-                        <node concept="1uHKPH" id="26cjRACVUHS" role="2OqNvi" />
                       </node>
                     </node>
                   </node>
@@ -974,6 +938,9 @@
         </node>
       </node>
     </node>
+    <node concept="3uibUv" id="7Sbg4UjQKDs" role="1zkMxy">
+      <ref role="3uigEE" node="7Sbg4UjPNNA" resolve="AbstractExtensionProvider" />
+    </node>
   </node>
   <node concept="312cEu" id="1awlAPQY0wq">
     <property role="TrG5h" value="SolverNotRunTaskFactory" />
@@ -1276,6 +1243,332 @@
           <property role="1dT_AB" value="but also to store the data in memory for tests." />
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="3HP615" id="7Sbg4UjPubL">
+    <property role="TrG5h" value="IExtensionWithPriority" />
+    <property role="3GE5qa" value="extensionPoints" />
+    <node concept="Wx3nA" id="7Sbg4UjOCYU" role="jymVt">
+      <property role="TrG5h" value="DEFAULT_PRIORITY" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm1VV" id="7Sbg4UjOCYV" role="1B3o_S" />
+      <node concept="10Oyi0" id="7Sbg4UjOCYW" role="1tU5fm" />
+      <node concept="3cmrfG" id="7Sbg4UjOCYX" role="33vP2m">
+        <property role="3cmrfH" value="0" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7Sbg4UjPuhH" role="jymVt" />
+    <node concept="3clFb_" id="7Sbg4UjOD0U" role="jymVt">
+      <property role="TrG5h" value="priority" />
+      <node concept="10Oyi0" id="7Sbg4UjOD0V" role="3clF45" />
+      <node concept="3Tm1VV" id="7Sbg4UjOD0W" role="1B3o_S" />
+      <node concept="3clFbS" id="7Sbg4UjOD0X" role="3clF47" />
+      <node concept="P$JXv" id="7Sbg4UjOD0Y" role="lGtFl">
+        <node concept="TZ5HA" id="7Sbg4UjOD0Z" role="TZ5H$">
+          <node concept="1dT_AC" id="7Sbg4UjOD10" role="1dT_Ay">
+            <property role="1dT_AB" value="The extension implementation with the highest priority wins." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="7Sbg4UjPubM" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="7Sbg4UjPvkH">
+    <property role="3GE5qa" value="extensionPoints" />
+    <property role="TrG5h" value="AbstractExtensionWithPriority" />
+    <property role="1sVAO0" value="true" />
+    <node concept="2tJIrI" id="7Sbg4UjP$NV" role="jymVt" />
+    <node concept="3Tm1VV" id="7Sbg4UjPvkI" role="1B3o_S" />
+    <node concept="3uibUv" id="7Sbg4UjPvll" role="EKbjA">
+      <ref role="3uigEE" node="7Sbg4UjPubL" resolve="IExtensionWithPriority" />
+    </node>
+    <node concept="3clFb_" id="7Sbg4UjPwLB" role="jymVt">
+      <property role="TrG5h" value="priority" />
+      <node concept="10Oyi0" id="7Sbg4UjPwLC" role="3clF45" />
+      <node concept="3Tm1VV" id="7Sbg4UjPwLD" role="1B3o_S" />
+      <node concept="3clFbS" id="7Sbg4UjPwLI" role="3clF47">
+        <node concept="3clFbF" id="7Sbg4UjPwLL" role="3cqZAp">
+          <node concept="37vLTw" id="7Sbg4UjPzFU" role="3clFbG">
+            <ref role="3cqZAo" node="7Sbg4UjOCYU" resolve="DEFAULT_PRIORITY" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7Sbg4UjPwLJ" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="7Sbg4UjPNNA">
+    <property role="3GE5qa" value="extensionPoints" />
+    <property role="TrG5h" value="AbstractExtensionProvider" />
+    <property role="1sVAO0" value="true" />
+    <node concept="2tJIrI" id="7Sbg4UjPObc" role="jymVt" />
+    <node concept="2YIFZL" id="7Sbg4UjP$Z3" role="jymVt">
+      <property role="TrG5h" value="instanceByPriority" />
+      <node concept="37vLTG" id="7Sbg4UjPKpw" role="3clF46">
+        <property role="TrG5h" value="extensions" />
+        <node concept="A3Dl8" id="7Sbg4UjPKZH" role="1tU5fm">
+          <node concept="16syzq" id="7Sbg4UjPLh7" role="A3Ik2">
+            <ref role="16sUi3" node="7Sbg4UjP_4t" resolve="R" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="7Sbg4UjPE$Y" role="3clF46">
+        <property role="TrG5h" value="defaultSupplier" />
+        <node concept="3uibUv" id="7Sbg4UjPEWE" role="1tU5fm">
+          <ref role="3uigEE" to="82uw:~Supplier" resolve="Supplier" />
+          <node concept="16syzq" id="7Sbg4UjPF$N" role="11_B2D">
+            <ref role="16sUi3" node="7Sbg4UjP_4t" resolve="R" />
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbS" id="7Sbg4UjP$Z6" role="3clF47">
+        <node concept="3cpWs8" id="4qv99IrBJ3T" role="3cqZAp">
+          <node concept="3cpWsn" id="4qv99IrBJ3U" role="3cpWs9">
+            <property role="TrG5h" value="ep" />
+            <node concept="16syzq" id="7Sbg4UjP_Jx" role="1tU5fm">
+              <ref role="16sUi3" node="7Sbg4UjP_4t" resolve="R" />
+            </node>
+            <node concept="2OqwBi" id="4qv99IrBJ3V" role="33vP2m">
+              <node concept="2OqwBi" id="4qv99IrBJ3W" role="2Oq$k0">
+                <node concept="37vLTw" id="7Sbg4UjPMeT" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7Sbg4UjPKpw" resolve="extensions" />
+                </node>
+                <node concept="2S7cBI" id="4qv99IrBJ40" role="2OqNvi">
+                  <node concept="1bVj0M" id="4qv99IrBJ41" role="23t8la">
+                    <node concept="3clFbS" id="4qv99IrBJ42" role="1bW5cS">
+                      <node concept="3clFbF" id="4qv99IrBJ43" role="3cqZAp">
+                        <node concept="2OqwBi" id="4qv99IrBJ44" role="3clFbG">
+                          <node concept="37vLTw" id="4qv99IrBJ45" role="2Oq$k0">
+                            <ref role="3cqZAo" node="2FZhxW1aEb9" resolve="it" />
+                          </node>
+                          <node concept="liA8E" id="4qv99IrBJ46" role="2OqNvi">
+                            <ref role="37wK5l" node="7Sbg4UjOD0U" resolve="priority" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="2FZhxW1aEb9" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="2FZhxW1aEba" role="1tU5fm" />
+                    </node>
+                  </node>
+                  <node concept="1nlBCl" id="29cIrQKmYPA" role="2S7zOq" />
+                </node>
+              </node>
+              <node concept="1uHKPH" id="29cIrQKn0vr" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1e_Qt5_BTi" role="3cqZAp" />
+        <node concept="3SKdUt" id="3bE2i5JypcP" role="3cqZAp">
+          <node concept="1PaTwC" id="3bE2i5JypcQ" role="1aUNEU">
+            <node concept="3oM_SD" id="3bE2i5Jypff" role="1PaTwD">
+              <property role="3oM_SC" value="null" />
+            </node>
+            <node concept="3oM_SD" id="3bE2i5JypCM" role="1PaTwD">
+              <property role="3oM_SC" value="case" />
+            </node>
+            <node concept="3oM_SD" id="3bE2i5JypD8" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="3bE2i5JypDv" role="1PaTwD">
+              <property role="3oM_SC" value="fallback," />
+            </node>
+            <node concept="3oM_SD" id="3bE2i5Jypfh" role="1PaTwD">
+              <property role="3oM_SC" value="should" />
+            </node>
+            <node concept="3oM_SD" id="3bE2i5Jypfk" role="1PaTwD">
+              <property role="3oM_SC" value="not" />
+            </node>
+            <node concept="3oM_SD" id="3bE2i5Jypfo" role="1PaTwD">
+              <property role="3oM_SC" value="happen" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4qv99IrBJoK" role="3cqZAp">
+          <node concept="3K4zz7" id="4qv99IrBK2L" role="3clFbG">
+            <node concept="2OqwBi" id="7Sbg4UjPJiW" role="3K4E3e">
+              <node concept="37vLTw" id="7Sbg4UjPInz" role="2Oq$k0">
+                <ref role="3cqZAo" node="7Sbg4UjPE$Y" resolve="defaultSupplier" />
+              </node>
+              <node concept="liA8E" id="7Sbg4UjPKgu" role="2OqNvi">
+                <ref role="37wK5l" to="82uw:~Supplier.get()" resolve="get" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="4qv99IrBMks" role="3K4GZi">
+              <ref role="3cqZAo" node="4qv99IrBJ3U" resolve="ep" />
+            </node>
+            <node concept="3clFbC" id="4qv99IrBJNT" role="3K4Cdx">
+              <node concept="10Nm6u" id="4qv99IrBJTZ" role="3uHU7w" />
+              <node concept="37vLTw" id="4qv99IrBJoI" role="3uHU7B">
+                <ref role="3cqZAo" node="4qv99IrBJ3U" resolve="ep" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="7Sbg4UjQMjW" role="1B3o_S" />
+      <node concept="16syzq" id="7Sbg4UjP_8m" role="3clF45">
+        <ref role="16sUi3" node="7Sbg4UjP_4t" resolve="R" />
+      </node>
+      <node concept="16euLQ" id="7Sbg4UjP_4t" role="16eVyc">
+        <property role="TrG5h" value="R" />
+        <node concept="3uibUv" id="7Sbg4UjP_6r" role="3ztrMU">
+          <ref role="3uigEE" node="7Sbg4UjPubL" resolve="IExtensionWithPriority" />
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="7Sbg4UjPNNB" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="1e_Qt5zgHq">
+    <property role="3GE5qa" value="extensionPoints" />
+    <property role="TrG5h" value="TestableExtensionWithPriority" />
+    <property role="1sVAO0" value="true" />
+    <node concept="Wx3nA" id="6vXjBkn_5Nh" role="jymVt">
+      <property role="TrG5h" value="PRIO_INACTIVE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tmbuc" id="7Sbg4UjRfjy" role="1B3o_S" />
+      <node concept="10Oyi0" id="6vXjBkn_5F6" role="1tU5fm" />
+      <node concept="3cpWsd" id="4O1MtdoPc8s" role="33vP2m">
+        <node concept="3cmrfG" id="4O1MtdoPc96" role="3uHU7w">
+          <property role="3cmrfH" value="10000" />
+        </node>
+        <node concept="37vLTw" id="7Sbg4UjR0jW" role="3uHU7B">
+          <ref role="3cqZAo" node="7Sbg4UjOCYU" resolve="DEFAULT_PRIORITY" />
+        </node>
+      </node>
+    </node>
+    <node concept="Wx3nA" id="6vXjBkn_fMH" role="jymVt">
+      <property role="TrG5h" value="PRIO_ACTIVE" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tmbuc" id="7Sbg4UjRgr8" role="1B3o_S" />
+      <node concept="10Oyi0" id="6vXjBkn_fDU" role="1tU5fm" />
+      <node concept="3cpWs3" id="6vXjBkn_hTx" role="33vP2m">
+        <node concept="3cmrfG" id="6vXjBkn_hTZ" role="3uHU7w">
+          <property role="3cmrfH" value="10000" />
+        </node>
+        <node concept="37vLTw" id="7Sbg4UjR0ka" role="3uHU7B">
+          <ref role="3cqZAo" node="7Sbg4UjOCYU" resolve="DEFAULT_PRIORITY" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6vXjBkn_6W0" role="jymVt" />
+    <node concept="Wx3nA" id="6vXjBknsopM" role="jymVt">
+      <property role="TrG5h" value="myPriority" />
+      <node concept="10Oyi0" id="6vXjBknm_Ib" role="1tU5fm" />
+      <node concept="3Tm6S6" id="7Sbg4UjRq81" role="1B3o_S" />
+      <node concept="37vLTw" id="7Sbg4UjR0ko" role="33vP2m">
+        <ref role="3cqZAo" node="6vXjBkn_5Nh" resolve="PRIO_INACTIVE" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6vXjBknmzzz" role="jymVt" />
+    <node concept="2YIFZL" id="6vXjBkn_pIp" role="jymVt">
+      <property role="TrG5h" value="doTest" />
+      <node concept="3clFbS" id="6vXjBkn_pIs" role="3clF47">
+        <node concept="3clFbF" id="6vXjBkn_r2Y" role="3cqZAp">
+          <node concept="1rXfSq" id="6vXjBkn_r2W" role="3clFbG">
+            <ref role="37wK5l" node="6vXjBknCaFI" resolve="switchOn" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="6vXjBkn_rIM" role="3cqZAp">
+          <node concept="2OqwBi" id="6vXjBkn_s46" role="3clFbG">
+            <node concept="37vLTw" id="6vXjBkn_rIK" role="2Oq$k0">
+              <ref role="3cqZAo" node="6vXjBkn_q9r" resolve="action" />
+            </node>
+            <node concept="1Bd96e" id="6vXjBkn_sy4" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3clFbF" id="6vXjBkn_qCm" role="3cqZAp">
+          <node concept="1rXfSq" id="6vXjBkn_qCl" role="3clFbG">
+            <ref role="37wK5l" node="6vXjBkn$Q8Y" resolve="switchOff" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6vXjBkn_p1l" role="1B3o_S" />
+      <node concept="3cqZAl" id="6vXjBkn_p_e" role="3clF45" />
+      <node concept="37vLTG" id="6vXjBkn_q9r" role="3clF46">
+        <property role="TrG5h" value="action" />
+        <node concept="1ajhzC" id="6vXjBkn_q9p" role="1tU5fm">
+          <node concept="3cqZAl" id="6vXjBkn_qo9" role="1ajl9A" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6vXjBknC7ja" role="jymVt" />
+    <node concept="2YIFZL" id="6vXjBknCaFI" role="jymVt">
+      <property role="TrG5h" value="switchOn" />
+      <node concept="3clFbS" id="6vXjBknCaFL" role="3clF47">
+        <node concept="3clFbF" id="7Sbg4UjRo6G" role="3cqZAp">
+          <node concept="37vLTI" id="7Sbg4UjRo6H" role="3clFbG">
+            <node concept="37vLTw" id="6vXjBkn$_aF" role="37vLTJ">
+              <ref role="3cqZAo" node="6vXjBknsopM" resolve="myPriority" />
+            </node>
+            <node concept="37vLTw" id="6vXjBkn$HQX" role="37vLTx">
+              <ref role="3cqZAo" node="6vXjBkn_fMH" resolve="PRIO_ACTIVE" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6vXjBknC9LN" role="1B3o_S" />
+      <node concept="3cqZAl" id="6vXjBknCavt" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="6vXjBkn$Ndm" role="jymVt" />
+    <node concept="2YIFZL" id="6vXjBkn$Q8Y" role="jymVt">
+      <property role="TrG5h" value="switchOff" />
+      <node concept="3clFbS" id="6vXjBkn$Q91" role="3clF47">
+        <node concept="3clFbF" id="6vXjBkn$SaR" role="3cqZAp">
+          <node concept="37vLTI" id="6vXjBkn$Wzf" role="3clFbG">
+            <node concept="37vLTw" id="7Sbg4UjR0lg" role="37vLTx">
+              <ref role="3cqZAo" node="6vXjBkn_5Nh" resolve="PRIO_INACTIVE" />
+            </node>
+            <node concept="37vLTw" id="7Sbg4UjR0lu" role="37vLTJ">
+              <ref role="3cqZAo" node="6vXjBknsopM" resolve="myPriority" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6vXjBkn$OLE" role="1B3o_S" />
+      <node concept="3cqZAl" id="6vXjBkn$PXw" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="1e_Qt5zgHr" role="1B3o_S" />
+    <node concept="3uibUv" id="7Sbg4UjR7_0" role="EKbjA">
+      <ref role="3uigEE" node="7Sbg4UjPubL" resolve="IExtensionWithPriority" />
+    </node>
+    <node concept="2tJIrI" id="1e_Qt5$Bhg" role="jymVt" />
+    <node concept="3clFb_" id="1e_Qt5$A79" role="jymVt">
+      <property role="TrG5h" value="priority" />
+      <node concept="10Oyi0" id="1e_Qt5$A7a" role="3clF45" />
+      <node concept="3Tm1VV" id="1e_Qt5$A7b" role="1B3o_S" />
+      <node concept="3clFbS" id="1e_Qt5$A7g" role="3clF47">
+        <node concept="3clFbF" id="1e_Qt5$A7j" role="3cqZAp">
+          <node concept="37vLTw" id="6vXjBknmNve" role="3clFbG">
+            <ref role="3cqZAo" node="6vXjBknsopM" resolve="myPriority" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="1e_Qt5$A7h" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3UR2Jj" id="4O1MtdoMvrC" role="lGtFl">
+      <node concept="TZ5HA" id="4O1MtdoMvrD" role="TZ5H$">
+        <node concept="1dT_AC" id="4O1MtdoMvrE" role="1dT_Ay">
+          <property role="1dT_AB" value="Abstract base class for extension implementations in tests." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="4O1MtdoMxVJ" role="TZ5H$">
+        <node concept="1dT_AC" id="4O1MtdoMxVK" role="1dT_Ay">
+          <property role="1dT_AB" value="" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="4O1MtdoMyQt" role="TZ5H$">
+        <node concept="1dT_AC" id="4O1MtdoMyQu" role="1dT_Ay">
+          <property role="1dT_AB" value="Using a typical pattern, the priority of the extension can be changed by tests in order to activate it." />
+        </node>
+      </node>
+    </node>
+    <node concept="3uibUv" id="7Sbg4UjR9d6" role="1zkMxy">
+      <ref role="3uigEE" node="7Sbg4UjPvkH" resolve="AbstractExtensionWithPriority" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.behavior.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.behavior.mps
@@ -6878,11 +6878,16 @@
       <node concept="3Tm1VV" id="2SUMz4mKzNr" role="1B3o_S" />
       <node concept="10Oyi0" id="2SUMz4mKJUH" role="3clF45" />
       <node concept="3clFbS" id="2SUMz4mKzNt" role="3clF47">
-        <node concept="3clFbF" id="49LV9yw3Nns" role="3cqZAp">
-          <node concept="2YIFZM" id="50qksmF6Nv_" role="3clFbG">
-            <ref role="37wK5l" node="49LV9yvwLdc" resolve="computeHashOfSolverRelevantData" />
-            <ref role="1Pybhc" node="49LV9yvww2v" resolve="FeatureModelConfHashUtil" />
-            <node concept="13iPFW" id="49LV9yw3VNy" role="37wK5m" />
+        <node concept="3clFbF" id="6u_oBd1IrdY" role="3cqZAp">
+          <node concept="2OqwBi" id="6u_oBd1Iwuh" role="3clFbG">
+            <node concept="2YIFZM" id="6u_oBd1IrHQ" role="2Oq$k0">
+              <ref role="37wK5l" node="6u_oBd1HBzc" resolve="of" />
+              <ref role="1Pybhc" node="49LV9yvww2v" resolve="SolverRelevantDataHashing" />
+              <node concept="13iPFW" id="6u_oBd1IscS" role="37wK5m" />
+            </node>
+            <node concept="liA8E" id="6u_oBd1IxxI" role="2OqNvi">
+              <ref role="37wK5l" node="6u_oBd1GUw3" resolve="computeHash" />
+            </node>
           </node>
         </node>
       </node>
@@ -6892,11 +6897,16 @@
       <node concept="3Tm1VV" id="2SUMz4mMQji" role="1B3o_S" />
       <node concept="10Oyi0" id="2SUMz4mN7N6" role="3clF45" />
       <node concept="3clFbS" id="2SUMz4mMQjk" role="3clF47">
-        <node concept="3clFbF" id="49LV9yw3evW" role="3cqZAp">
-          <node concept="2YIFZM" id="50qksmF6NvB" role="3clFbG">
-            <ref role="37wK5l" node="49LV9yw3mlz" resolve="hashOfSolverRelevantData" />
-            <ref role="1Pybhc" node="49LV9yvww2v" resolve="FeatureModelConfHashUtil" />
-            <node concept="13iPFW" id="49LV9yw3uJ6" role="37wK5m" />
+        <node concept="3clFbF" id="6u_oBd1I$9T" role="3cqZAp">
+          <node concept="2OqwBi" id="6u_oBd1JLxc" role="3clFbG">
+            <node concept="2YIFZM" id="6u_oBd1I$E0" role="2Oq$k0">
+              <ref role="37wK5l" node="6u_oBd1HBzc" resolve="of" />
+              <ref role="1Pybhc" node="49LV9yvww2v" resolve="SolverRelevantDataHashing" />
+              <node concept="13iPFW" id="6u_oBd1JKCx" role="37wK5m" />
+            </node>
+            <node concept="liA8E" id="6u_oBd1JOoD" role="2OqNvi">
+              <ref role="37wK5l" node="6u_oBd1HghI" resolve="getHash" />
+            </node>
           </node>
         </node>
       </node>
@@ -22730,333 +22740,81 @@
     <node concept="3Tm1VV" id="6mDcvZjFuHo" role="1B3o_S" />
   </node>
   <node concept="312cEu" id="49LV9yvww2v">
-    <property role="3GE5qa" value="util" />
-    <property role="TrG5h" value="FeatureModelConfHashUtil" />
+    <property role="3GE5qa" value="util.hashing" />
+    <property role="TrG5h" value="SolverRelevantDataHashing" />
     <node concept="2tJIrI" id="49LV9yvww4l" role="jymVt" />
-    <node concept="Wx3nA" id="49LV9yvFSVa" role="jymVt">
-      <property role="TrG5h" value="hashId" />
-      <property role="3TUv4t" value="true" />
-      <node concept="17QB3L" id="49LV9yvFSVc" role="1tU5fm" />
-      <node concept="Xl_RD" id="49LV9yvFSVd" role="33vP2m">
-        <property role="Xl_RC" value="HashOfSolverRelevantData" />
-      </node>
-      <node concept="3Tm6S6" id="49LV9yvFTuR" role="1B3o_S" />
-    </node>
-    <node concept="2tJIrI" id="49LV9yvwAkI" role="jymVt" />
-    <node concept="2YIFZL" id="49LV9yvwKqG" role="jymVt">
-      <property role="TrG5h" value="setHashOfSolverRelevantData" />
-      <node concept="3clFbS" id="49LV9yvwKqK" role="3clF47">
-        <node concept="3cpWs8" id="49LV9yvwKqL" role="3cqZAp">
-          <node concept="3cpWsn" id="49LV9yvwKqM" role="3cpWs9">
-            <property role="TrG5h" value="hash" />
-            <node concept="3uibUv" id="49LV9yvwKqN" role="1tU5fm">
-              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="49LV9yvwKqO" role="3cqZAp">
-          <node concept="37vLTI" id="49LV9yvwKqP" role="3clFbG">
-            <node concept="37vLTw" id="49LV9yvwKqR" role="37vLTJ">
-              <ref role="3cqZAo" node="49LV9yvwKqM" resolve="hash" />
-            </node>
-            <node concept="2YIFZM" id="49LV9yvwLMp" role="37vLTx">
-              <ref role="37wK5l" node="49LV9yvwLdc" resolve="computeHashOfSolverRelevantData" />
-              <ref role="1Pybhc" node="49LV9yvww2v" resolve="FeatureModelConfHashUtil" />
-              <node concept="37vLTw" id="49LV9yvwLYl" role="37wK5m">
-                <ref role="3cqZAo" node="49LV9yvwKqI" resolve="fmc" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="49LV9yvwKqS" role="3cqZAp">
-          <node concept="2OqwBi" id="49LV9yvwKqT" role="3clFbG">
-            <node concept="liA8E" id="49LV9yvwKqU" role="2OqNvi">
-              <ref role="37wK5l" to="mhbf:~SNode.putUserObject(java.lang.Object,java.lang.Object)" resolve="putUserObject" />
-              <node concept="37vLTw" id="49LV9yvFTmv" role="37wK5m">
-                <ref role="3cqZAo" node="49LV9yvFSVa" resolve="hashId" />
-              </node>
-              <node concept="37vLTw" id="49LV9yvwKqW" role="37wK5m">
-                <ref role="3cqZAo" node="49LV9yvwKqM" resolve="hash" />
-              </node>
-            </node>
-            <node concept="2JrnkZ" id="49LV9yvwKqX" role="2Oq$k0">
-              <node concept="37vLTw" id="49LV9yvwKqY" role="2JrQYb">
-                <ref role="3cqZAo" node="49LV9yvwKqI" resolve="fmc" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs6" id="49LV9yvwKqZ" role="3cqZAp">
-          <node concept="37vLTw" id="49LV9yvwKr0" role="3cqZAk">
-            <ref role="3cqZAo" node="49LV9yvwKqM" resolve="hash" />
-          </node>
-        </node>
-      </node>
-      <node concept="3uibUv" id="49LV9yvwKr1" role="3clF45">
-        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-      </node>
-      <node concept="37vLTG" id="49LV9yvwKqI" role="3clF46">
-        <property role="TrG5h" value="fmc" />
-        <node concept="3Tqbb2" id="49LV9yvwKqJ" role="1tU5fm">
+    <node concept="2YIFZL" id="6u_oBd1HBzc" role="jymVt">
+      <property role="TrG5h" value="of" />
+      <node concept="37vLTG" id="6u_oBd1HCs3" role="3clF46">
+        <property role="TrG5h" value="config" />
+        <node concept="3Tqbb2" id="6u_oBd1HCs4" role="1tU5fm">
           <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
         </node>
       </node>
-      <node concept="3Tm1VV" id="6mDcvZk5bJ3" role="1B3o_S" />
+      <node concept="3clFbS" id="6u_oBd1HBzf" role="3clF47">
+        <node concept="3clFbF" id="6u_oBd1HCZq" role="3cqZAp">
+          <node concept="2ShNRf" id="6u_oBd1HCZo" role="3clFbG">
+            <node concept="1pGfFk" id="6u_oBd1HZzJ" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" node="6u_oBd1GK2z" resolve="SolverRelevantDataHashing" />
+              <node concept="37vLTw" id="6u_oBd1HZGZ" role="37wK5m">
+                <ref role="3cqZAo" node="6u_oBd1HCs3" resolve="config" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6u_oBd1H$EM" role="1B3o_S" />
+      <node concept="3uibUv" id="6u_oBd1HA3v" role="3clF45">
+        <ref role="3uigEE" node="49LV9yvww2v" resolve="SolverRelevantDataHashing" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6u_oBd1I0XW" role="jymVt" />
+    <node concept="3clFbW" id="6u_oBd1GK2z" role="jymVt">
+      <node concept="3cqZAl" id="6u_oBd1GK2_" role="3clF45" />
+      <node concept="3Tm6S6" id="6u_oBd1I2uE" role="1B3o_S" />
+      <node concept="3clFbS" id="6u_oBd1GK2B" role="3clF47">
+        <node concept="XkiVB" id="6u_oBd1GOKQ" role="3cqZAp">
+          <ref role="37wK5l" node="6u_oBd1G6du" resolve="AbstractConfigHashing" />
+          <node concept="Xl_RD" id="6u_oBd1GPix" role="37wK5m">
+            <property role="Xl_RC" value="HashOfSolverRelevantData" />
+          </node>
+          <node concept="37vLTw" id="6u_oBd1GQ0N" role="37wK5m">
+            <ref role="3cqZAo" node="6u_oBd1GMbC" resolve="config" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6u_oBd1GMbC" role="3clF46">
+        <property role="TrG5h" value="config" />
+        <node concept="3Tqbb2" id="6u_oBd1GMex" role="1tU5fm">
+          <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="49LV9yvwAkP" role="jymVt" />
-    <node concept="2YIFZL" id="49LV9yvwLdc" role="jymVt">
-      <property role="TrG5h" value="computeHashOfSolverRelevantData" />
-      <node concept="3clFbS" id="49LV9yvwLdg" role="3clF47">
-        <node concept="3cpWs8" id="49LV9yvwLdh" role="3cqZAp">
-          <node concept="3cpWsn" id="49LV9yvwLdi" role="3cpWs9">
-            <property role="TrG5h" value="subfeatureConfigurations" />
-            <node concept="_YKpA" id="49LV9yvwLdj" role="1tU5fm">
-              <node concept="3Tqbb2" id="49LV9yvwLdk" role="_ZDj9">
-                <ref role="ehGHo" to="4ndm:30ECcbtES_0" resolve="AbstractFeatureConfiguration" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="49LV9yvwLdl" role="33vP2m">
-              <node concept="2OqwBi" id="49LV9yvwLdm" role="2Oq$k0">
-                <node concept="37vLTw" id="49LV9yvwLdn" role="2Oq$k0">
-                  <ref role="3cqZAo" node="49LV9yvwLde" resolve="fmc" />
-                </node>
-                <node concept="2qgKlT" id="Jt_9puZ$8E" role="2OqNvi">
-                  <ref role="37wK5l" node="7Sn21ZwO0hh" resolve="descendantLocalConfigItems" />
-                </node>
-              </node>
-              <node concept="ANE8D" id="49LV9yvwLdp" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="49LV9yvwLdq" role="3cqZAp">
-          <node concept="3cpWsn" id="49LV9yvwLdr" role="3cpWs9">
-            <property role="TrG5h" value="selStates" />
-            <node concept="_YKpA" id="49LV9yvwLds" role="1tU5fm">
-              <node concept="3uibUv" id="49LV9yvwLdt" role="_ZDj9">
-                <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="49LV9yvwLdu" role="33vP2m">
-              <node concept="2OqwBi" id="49LV9yvwLdv" role="2Oq$k0">
-                <node concept="37vLTw" id="49LV9yvwLdw" role="2Oq$k0">
-                  <ref role="3cqZAo" node="49LV9yvwLdi" resolve="subfeatureConfigurations" />
-                </node>
-                <node concept="3$u5V9" id="49LV9yvwLdx" role="2OqNvi">
-                  <node concept="1bVj0M" id="49LV9yvwLdy" role="23t8la">
-                    <node concept="3clFbS" id="49LV9yvwLdz" role="1bW5cS">
-                      <node concept="3clFbF" id="49LV9yvwLd$" role="3cqZAp">
-                        <node concept="10QFUN" id="49LV9yvwLd_" role="3clFbG">
-                          <node concept="3uibUv" id="49LV9yvwLdA" role="10QFUM">
-                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                          </node>
-                          <node concept="2OqwBi" id="Jt_9pubL5e" role="10QFUP">
-                            <node concept="2OqwBi" id="49LV9yvwLdB" role="2Oq$k0">
-                              <node concept="37vLTw" id="49LV9yvwLdC" role="2Oq$k0">
-                                <ref role="3cqZAo" node="4YqPvJUBHyK" resolve="it" />
-                              </node>
-                              <node concept="3TrcHB" id="49LV9yvwLdD" role="2OqNvi">
-                                <ref role="3TsBF5" to="4ndm:59FNqAPCJNr" resolve="selectionState" />
-                              </node>
-                            </node>
-                            <node concept="liA8E" id="Jt_9pubMdw" role="2OqNvi">
-                              <ref role="37wK5l" to="c17a:~SEnumerationLiteral.getOrdinal()" resolve="getOrdinal" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="gl6BB" id="4YqPvJUBHyK" role="1bW2Oz">
-                      <property role="TrG5h" value="it" />
-                      <node concept="2jxLKc" id="4YqPvJUBHyL" role="1tU5fm" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="ANE8D" id="49LV9yvwLdG" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="49LV9yvwLdH" role="3cqZAp">
-          <node concept="3cpWsn" id="49LV9yvwLdI" role="3cpWs9">
-            <property role="TrG5h" value="attributeAssignmentPaired" />
-            <node concept="_YKpA" id="49LV9yvwLdJ" role="1tU5fm">
-              <node concept="3uibUv" id="49LV9yvwLdK" role="_ZDj9">
-                <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="49LV9yvwLdL" role="33vP2m">
-              <node concept="2OqwBi" id="49LV9yvwLdM" role="2Oq$k0">
-                <node concept="1eOMI4" id="49LV9yvwLdN" role="2Oq$k0">
-                  <node concept="2OqwBi" id="49LV9yvwLdO" role="1eOMHV">
-                    <node concept="2OqwBi" id="49LV9yvwLdP" role="2Oq$k0">
-                      <node concept="37vLTw" id="49LV9yvwLdQ" role="2Oq$k0">
-                        <ref role="3cqZAo" node="49LV9yvwLdi" resolve="subfeatureConfigurations" />
-                      </node>
-                      <node concept="3goQfb" id="49LV9yvwLdR" role="2OqNvi">
-                        <node concept="1bVj0M" id="49LV9yvwLdS" role="23t8la">
-                          <node concept="3clFbS" id="49LV9yvwLdT" role="1bW5cS">
-                            <node concept="3clFbF" id="49LV9yvwLdU" role="3cqZAp">
-                              <node concept="2OqwBi" id="49LV9yvwLdV" role="3clFbG">
-                                <node concept="37vLTw" id="49LV9yvwLdW" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="4YqPvJUBHyM" resolve="it" />
-                                </node>
-                                <node concept="2qgKlT" id="49LV9yvwLdX" role="2OqNvi">
-                                  <ref role="37wK5l" node="30ECcbtQkN2" resolve="attributeAssignments" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="gl6BB" id="4YqPvJUBHyM" role="1bW2Oz">
-                            <property role="TrG5h" value="it" />
-                            <node concept="2jxLKc" id="4YqPvJUBHyN" role="1tU5fm" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="ANE8D" id="49LV9yvwLe0" role="2OqNvi" />
-                  </node>
-                </node>
-                <node concept="3$u5V9" id="49LV9yvwLe1" role="2OqNvi">
-                  <node concept="1bVj0M" id="49LV9yvwLe2" role="23t8la">
-                    <node concept="3clFbS" id="49LV9yvwLe3" role="1bW5cS">
-                      <node concept="3clFbF" id="49LV9yvwLe4" role="3cqZAp">
-                        <node concept="10QFUN" id="49LV9yvwLe5" role="3clFbG">
-                          <node concept="3uibUv" id="49LV9yvwLe6" role="10QFUM">
-                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                          </node>
-                          <node concept="2YIFZM" id="49LV9yvwLe7" role="10QFUP">
-                            <ref role="37wK5l" to="1qo3:~Pair.of(java.lang.Object,java.lang.Object)" resolve="of" />
-                            <ref role="1Pybhc" to="1qo3:~Pair" resolve="Pair" />
-                            <node concept="2OqwBi" id="49LV9yvwLe8" role="37wK5m">
-                              <node concept="37vLTw" id="49LV9yvwLe9" role="2Oq$k0">
-                                <ref role="3cqZAo" node="4YqPvJUBHyO" resolve="it" />
-                              </node>
-                              <node concept="3TrEf2" id="49LV9yvwLea" role="2OqNvi">
-                                <ref role="3Tt5mk" to="4ndm:30ECcbtMzQ8" resolve="attribute" />
-                              </node>
-                            </node>
-                            <node concept="2OqwBi" id="49LV9yvwLeb" role="37wK5m">
-                              <node concept="37vLTw" id="49LV9yvwLec" role="2Oq$k0">
-                                <ref role="3cqZAo" node="4YqPvJUBHyO" resolve="it" />
-                              </node>
-                              <node concept="3TrEf2" id="49LV9yvwLed" role="2OqNvi">
-                                <ref role="3Tt5mk" to="4ndm:30ECcbtOuaE" resolve="value" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="gl6BB" id="4YqPvJUBHyO" role="1bW2Oz">
-                      <property role="TrG5h" value="it" />
-                      <node concept="2jxLKc" id="4YqPvJUBHyP" role="1tU5fm" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="ANE8D" id="49LV9yvwLeg" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="49LV9yvwLeh" role="3cqZAp" />
-        <node concept="3clFbF" id="49LV9yvwLei" role="3cqZAp">
-          <node concept="2YIFZM" id="49LV9yvwLej" role="3clFbG">
-            <ref role="37wK5l" to="33ny:~Objects.hashCode(java.lang.Object)" resolve="hashCode" />
-            <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
-            <node concept="2OqwBi" id="49LV9yvwLek" role="37wK5m">
-              <node concept="2OqwBi" id="49LV9yvwLel" role="2Oq$k0">
-                <node concept="37vLTw" id="49LV9yvwLem" role="2Oq$k0">
-                  <ref role="3cqZAo" node="49LV9yvwLdr" resolve="selStates" />
-                </node>
-                <node concept="4Tj9Z" id="49LV9yvwLen" role="2OqNvi">
-                  <node concept="37vLTw" id="49LV9yvwLeo" role="576Qk">
-                    <ref role="3cqZAo" node="49LV9yvwLdI" resolve="attributeAssignmentPaired" />
-                  </node>
-                </node>
-              </node>
-              <node concept="ANE8D" id="49LV9yvwLep" role="2OqNvi" />
+    <node concept="3clFb_" id="6u_oBd1GUw3" role="jymVt">
+      <property role="TrG5h" value="computeHash" />
+      <node concept="3Tm1VV" id="6u_oBd1GUw5" role="1B3o_S" />
+      <node concept="10Oyi0" id="6u_oBd1GUw6" role="3clF45" />
+      <node concept="3clFbS" id="6u_oBd1GUw7" role="3clF47">
+        <node concept="3clFbF" id="6u_oBd24oFN" role="3cqZAp">
+          <node concept="2YIFZM" id="6u_oBd24oZl" role="3clFbG">
+            <ref role="1Pybhc" node="6u_oBd1FoKQ" resolve="AbstractConfigHashing" />
+            <ref role="37wK5l" node="6u_oBd24gsf" resolve="computeHashForLocalConfig" />
+            <node concept="37vLTw" id="6u_oBd24pu6" role="37wK5m">
+              <ref role="3cqZAo" node="6u_oBd1G4I6" resolve="config" />
             </node>
           </node>
         </node>
       </node>
-      <node concept="10Oyi0" id="49LV9yvwLeq" role="3clF45" />
-      <node concept="37vLTG" id="49LV9yvwLde" role="3clF46">
-        <property role="TrG5h" value="fmc" />
-        <node concept="3Tqbb2" id="49LV9yvwLdf" role="1tU5fm">
-          <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
-        </node>
+      <node concept="2AHcQZ" id="6u_oBd1GUw8" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
-      <node concept="3Tm1VV" id="6mDcvZk3eGd" role="1B3o_S" />
     </node>
-    <node concept="2tJIrI" id="49LV9yvG9u6" role="jymVt" />
-    <node concept="2YIFZL" id="49LV9yw3mlz" role="jymVt">
-      <property role="TrG5h" value="hashOfSolverRelevantData" />
-      <node concept="3clFbS" id="49LV9yw3mlB" role="3clF47">
-        <node concept="3cpWs8" id="49LV9yw3mlC" role="3cqZAp">
-          <node concept="3cpWsn" id="49LV9yw3mlD" role="3cpWs9">
-            <property role="TrG5h" value="hash" />
-            <node concept="3uibUv" id="49LV9yw3mlE" role="1tU5fm">
-              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-            </node>
-            <node concept="2OqwBi" id="49LV9yw3mlF" role="33vP2m">
-              <node concept="2JrnkZ" id="49LV9yw3mlG" role="2Oq$k0">
-                <node concept="37vLTw" id="49LV9yw3mlH" role="2JrQYb">
-                  <ref role="3cqZAo" node="49LV9yw3ml_" resolve="fmc" />
-                </node>
-              </node>
-              <node concept="liA8E" id="49LV9yw3mlI" role="2OqNvi">
-                <ref role="37wK5l" to="mhbf:~SNode.getUserObject(java.lang.Object)" resolve="getUserObject" />
-                <node concept="37vLTw" id="49LV9yw3mlJ" role="37wK5m">
-                  <ref role="3cqZAo" node="49LV9yvFSVa" resolve="hashId" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbJ" id="49LV9yw3mlK" role="3cqZAp">
-          <node concept="3clFbS" id="49LV9yw3mlL" role="3clFbx">
-            <node concept="3clFbF" id="49LV9yw3mlM" role="3cqZAp">
-              <node concept="37vLTI" id="49LV9yw3mlN" role="3clFbG">
-                <node concept="37vLTw" id="49LV9yw3mlO" role="37vLTJ">
-                  <ref role="3cqZAo" node="49LV9yw3mlD" resolve="hash" />
-                </node>
-                <node concept="2YIFZM" id="49LV9yw3mlP" role="37vLTx">
-                  <ref role="37wK5l" node="49LV9yvwKqG" resolve="setHashOfSolverRelevantData" />
-                  <ref role="1Pybhc" node="49LV9yvww2v" resolve="FeatureModelConfHashUtil" />
-                  <node concept="37vLTw" id="49LV9yw3mlQ" role="37wK5m">
-                    <ref role="3cqZAo" node="49LV9yw3ml_" resolve="fmc" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbC" id="49LV9yw3mlR" role="3clFbw">
-            <node concept="10Nm6u" id="49LV9yw3mlS" role="3uHU7w" />
-            <node concept="37vLTw" id="49LV9yw3mlT" role="3uHU7B">
-              <ref role="3cqZAo" node="49LV9yw3mlD" resolve="hash" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="49LV9yw3mlU" role="3cqZAp">
-          <node concept="10QFUN" id="49LV9yw3mlV" role="3clFbG">
-            <node concept="10Oyi0" id="49LV9yw3mlW" role="10QFUM" />
-            <node concept="37vLTw" id="49LV9yw3mlX" role="10QFUP">
-              <ref role="3cqZAo" node="49LV9yw3mlD" resolve="hash" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="10Oyi0" id="49LV9yw3mlY" role="3clF45" />
-      <node concept="37vLTG" id="49LV9yw3ml_" role="3clF46">
-        <property role="TrG5h" value="fmc" />
-        <node concept="3Tqbb2" id="49LV9yw3mlA" role="1tU5fm">
-          <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="6mDcvZk3se_" role="1B3o_S" />
-    </node>
-    <node concept="2tJIrI" id="49LV9yvwFY8" role="jymVt" />
     <node concept="3Tm1VV" id="49LV9yvww2w" role="1B3o_S" />
+    <node concept="3uibUv" id="6u_oBd1Gwmp" role="1zkMxy">
+      <ref role="3uigEE" node="6u_oBd1FoKQ" resolve="AbstractConfigHashing" />
+    </node>
   </node>
   <node concept="312cEu" id="3yqPF1bN$uE">
     <property role="TrG5h" value="FeatureExprEvaluator" />
@@ -27105,6 +26863,869 @@
       <node concept="37vLTG" id="5BtXES5qtAg" role="3clF46">
         <property role="TrG5h" value="tTotal" />
         <node concept="3cpWsb" id="5BtXES5qtAh" role="1tU5fm" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="6u_oBd1FoKQ">
+    <property role="3GE5qa" value="util.hashing" />
+    <property role="TrG5h" value="AbstractConfigHashing" />
+    <property role="1sVAO0" value="true" />
+    <node concept="2tJIrI" id="6u_oBd1Fw8M" role="jymVt" />
+    <node concept="312cEg" id="6u_oBd1GzWZ" role="jymVt">
+      <property role="TrG5h" value="tag" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="6u_oBd1Gypf" role="1B3o_S" />
+      <node concept="17QB3L" id="6u_oBd1Gzt_" role="1tU5fm" />
+    </node>
+    <node concept="312cEg" id="6u_oBd1G4I6" role="jymVt">
+      <property role="TrG5h" value="config" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tmbuc" id="6u_oBd1Ha$q" role="1B3o_S" />
+      <node concept="3Tqbb2" id="6u_oBd1G3K$" role="1tU5fm">
+        <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6u_oBd1G5Gn" role="jymVt" />
+    <node concept="3clFbW" id="6u_oBd1G6du" role="jymVt">
+      <node concept="37vLTG" id="6u_oBd1GDU6" role="3clF46">
+        <property role="TrG5h" value="tag" />
+        <node concept="17QB3L" id="6u_oBd1GEuV" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6u_oBd1G6Lj" role="3clF46">
+        <property role="TrG5h" value="config" />
+        <node concept="3Tqbb2" id="6u_oBd1G7hx" role="1tU5fm">
+          <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+        </node>
+      </node>
+      <node concept="3cqZAl" id="6u_oBd1G6dw" role="3clF45" />
+      <node concept="3Tmbuc" id="6u_oBd1I_qr" role="1B3o_S" />
+      <node concept="3clFbS" id="6u_oBd1G6dy" role="3clF47">
+        <node concept="3clFbF" id="6u_oBd1G_34" role="3cqZAp">
+          <node concept="37vLTI" id="6u_oBd1GC5O" role="3clFbG">
+            <node concept="37vLTw" id="6u_oBd1GCC8" role="37vLTx">
+              <ref role="3cqZAo" node="6u_oBd1GDU6" resolve="tag" />
+            </node>
+            <node concept="2OqwBi" id="6u_oBd1G_dt" role="37vLTJ">
+              <node concept="Xjq3P" id="6u_oBd1G_32" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6u_oBd1G_R9" role="2OqNvi">
+                <ref role="2Oxat5" node="6u_oBd1GzWZ" resolve="tag" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6u_oBd1G8Mt" role="3cqZAp">
+          <node concept="37vLTI" id="6u_oBd1GasF" role="3clFbG">
+            <node concept="37vLTw" id="6u_oBd1GazD" role="37vLTx">
+              <ref role="3cqZAo" node="6u_oBd1G6Lj" resolve="config" />
+            </node>
+            <node concept="2OqwBi" id="6u_oBd1G8TZ" role="37vLTJ">
+              <node concept="Xjq3P" id="6u_oBd1G8Ms" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6u_oBd1G95h" role="2OqNvi">
+                <ref role="2Oxat5" node="6u_oBd1G4I6" resolve="config" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6u_oBd1Gb30" role="jymVt" />
+    <node concept="3clFb_" id="6u_oBd1GeQH" role="jymVt">
+      <property role="TrG5h" value="computeHash" />
+      <property role="1EzhhJ" value="true" />
+      <node concept="3clFbS" id="6u_oBd1GeQK" role="3clF47" />
+      <node concept="3Tm1VV" id="6u_oBd1GdOs" role="1B3o_S" />
+      <node concept="10Oyi0" id="6u_oBd1Genp" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="6u_oBd1GZyI" role="jymVt" />
+    <node concept="3clFb_" id="6u_oBd1G27W" role="jymVt">
+      <property role="TrG5h" value="setHash" />
+      <node concept="3clFbS" id="6u_oBd1G27Z" role="3clF47">
+        <node concept="3cpWs8" id="6u_oBd1GfY5" role="3cqZAp">
+          <node concept="3cpWsn" id="6u_oBd1GfY8" role="3cpWs9">
+            <property role="TrG5h" value="hash" />
+            <node concept="10Oyi0" id="6u_oBd1GfY4" role="1tU5fm" />
+            <node concept="1rXfSq" id="6u_oBd1Gh32" role="33vP2m">
+              <ref role="37wK5l" node="6u_oBd1GeQH" resolve="computeHash" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6u_oBd1Gi8E" role="3cqZAp">
+          <node concept="2OqwBi" id="6u_oBd1Gj1I" role="3clFbG">
+            <node concept="liA8E" id="6u_oBd1GjNB" role="2OqNvi">
+              <ref role="37wK5l" to="mhbf:~SNode.putUserObject(java.lang.Object,java.lang.Object)" resolve="putUserObject" />
+              <node concept="37vLTw" id="6u_oBd1GS62" role="37wK5m">
+                <ref role="3cqZAo" node="6u_oBd1GzWZ" resolve="tag" />
+              </node>
+              <node concept="37vLTw" id="6u_oBd1GSPA" role="37wK5m">
+                <ref role="3cqZAo" node="6u_oBd1GfY8" resolve="hash" />
+              </node>
+            </node>
+            <node concept="2JrnkZ" id="6u_oBd1Gj1N" role="2Oq$k0">
+              <node concept="37vLTw" id="6u_oBd1Gi8C" role="2JrQYb">
+                <ref role="3cqZAo" node="6u_oBd1G4I6" resolve="config" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6u_oBd1GTHF" role="3cqZAp">
+          <node concept="37vLTw" id="6u_oBd1GTHD" role="3clFbG">
+            <ref role="3cqZAo" node="6u_oBd1GfY8" resolve="hash" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6u_oBd1FL03" role="1B3o_S" />
+      <node concept="10Oyi0" id="6u_oBd1G1CE" role="3clF45" />
+    </node>
+    <node concept="2tJIrI" id="6u_oBd1HebA" role="jymVt" />
+    <node concept="3clFb_" id="6u_oBd1HghI" role="jymVt">
+      <property role="TrG5h" value="getHash" />
+      <node concept="3clFbS" id="6u_oBd1HghL" role="3clF47">
+        <node concept="3cpWs8" id="6u_oBd1HhNu" role="3cqZAp">
+          <node concept="3cpWsn" id="6u_oBd1HhNv" role="3cpWs9">
+            <property role="TrG5h" value="hashObj" />
+            <node concept="3uibUv" id="6u_oBd1HhNw" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+            </node>
+            <node concept="2OqwBi" id="6u_oBd1HkLn" role="33vP2m">
+              <node concept="liA8E" id="6u_oBd1Hlv6" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SNode.getUserObject(java.lang.Object)" resolve="getUserObject" />
+                <node concept="37vLTw" id="6u_oBd1Hm3N" role="37wK5m">
+                  <ref role="3cqZAo" node="6u_oBd1GzWZ" resolve="tag" />
+                </node>
+              </node>
+              <node concept="2JrnkZ" id="6u_oBd1HkLs" role="2Oq$k0">
+                <node concept="37vLTw" id="6u_oBd1HjY0" role="2JrQYb">
+                  <ref role="3cqZAo" node="6u_oBd1G4I6" resolve="config" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6u_oBd1HnHC" role="3cqZAp">
+          <node concept="3clFbS" id="6u_oBd1HnHE" role="3clFbx">
+            <node concept="3cpWs6" id="6u_oBd1Hrmu" role="3cqZAp">
+              <node concept="10QFUN" id="6u_oBd1Ht5g" role="3cqZAk">
+                <node concept="10Oyi0" id="6u_oBd1HtCF" role="10QFUM" />
+                <node concept="37vLTw" id="6u_oBd1Hs2F" role="10QFUP">
+                  <ref role="3cqZAo" node="6u_oBd1HhNv" resolve="hashObj" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="6u_oBd1Hq$L" role="3clFbw">
+            <node concept="37vLTw" id="6u_oBd1HolO" role="3uHU7B">
+              <ref role="3cqZAo" node="6u_oBd1HhNv" resolve="hashObj" />
+            </node>
+            <node concept="10Nm6u" id="6u_oBd1HpUN" role="3uHU7w" />
+          </node>
+          <node concept="9aQIb" id="6u_oBd1HvKL" role="9aQIa">
+            <node concept="3clFbS" id="6u_oBd1HvKM" role="9aQI4">
+              <node concept="3cpWs6" id="6u_oBd1HwG6" role="3cqZAp">
+                <node concept="1rXfSq" id="6u_oBd1HxQs" role="3cqZAk">
+                  <ref role="37wK5l" node="6u_oBd1G27W" resolve="setHash" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6u_oBd1HeUk" role="1B3o_S" />
+      <node concept="10Oyi0" id="6u_oBd1HftQ" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="6u_oBd1FoKR" role="1B3o_S" />
+    <node concept="3UR2Jj" id="6u_oBd1M0Ck" role="lGtFl">
+      <node concept="TZ5HA" id="6u_oBd1M0Cl" role="TZ5H$">
+        <node concept="1dT_AC" id="6u_oBd1M0Cm" role="1dT_Ay">
+          <property role="1dT_AB" value="Base class for lazily computing and caching a hash of a FeatureModelConfiguration." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="6u_oBd1M0Cn" role="TZ5H$">
+        <node concept="1dT_AC" id="6u_oBd1M0Co" role="1dT_Ay">
+          <property role="1dT_AB" value="" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="6u_oBd1M0Cp" role="TZ5H$">
+        <node concept="1dT_AC" id="6u_oBd1M0Cq" role="1dT_Ay">
+          <property role="1dT_AB" value="The hash is stored as a user object on the config node, keyed by `tag`, so several independent" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="6u_oBd1M0Cr" role="TZ5H$">
+        <node concept="1dT_AC" id="6u_oBd1M0Cs" role="1dT_Ay">
+          <property role="1dT_AB" value="hashes can coexist on one configuration. User objects are in-memory only, hence the cache is" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="6u_oBd1M0Ct" role="TZ5H$">
+        <node concept="1dT_AC" id="6u_oBd1M0Cu" role="1dT_Ay">
+          <property role="1dT_AB" value="per-session and not persisted with the model." />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="6u_oBd1M0Cv" role="TZ5H$">
+        <node concept="1dT_AC" id="6u_oBd1M0Cw" role="1dT_Ay">
+          <property role="1dT_AB" value="" />
+        </node>
+      </node>
+      <node concept="TZ5HA" id="6u_oBd1M0Cx" role="TZ5H$">
+        <node concept="1dT_AC" id="6u_oBd1M0Cy" role="1dT_Ay">
+          <property role="1dT_AB" value="Subclasses implement computeHash(); getHash() reads-or-computes lazily, setHash() forces recomputation." />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6u_oBd246wn" role="jymVt" />
+    <node concept="2YIFZL" id="6u_oBd24gsf" role="jymVt">
+      <property role="TrG5h" value="computeHashForLocalConfig" />
+      <node concept="37vLTG" id="6u_oBd24hpG" role="3clF46">
+        <property role="TrG5h" value="config" />
+        <node concept="3Tqbb2" id="6u_oBd24i65" role="1tU5fm">
+          <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="6u_oBd246Gm" role="3clF47">
+        <node concept="3cpWs8" id="6u_oBd246Gn" role="3cqZAp">
+          <node concept="3cpWsn" id="6u_oBd246Go" role="3cpWs9">
+            <property role="TrG5h" value="subfeatureConfigurations" />
+            <node concept="_YKpA" id="6u_oBd246Gp" role="1tU5fm">
+              <node concept="3Tqbb2" id="6u_oBd246Gq" role="_ZDj9">
+                <ref role="ehGHo" to="4ndm:30ECcbtES_0" resolve="AbstractFeatureConfiguration" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6u_oBd246Gr" role="33vP2m">
+              <node concept="2OqwBi" id="6u_oBd246Gs" role="2Oq$k0">
+                <node concept="37vLTw" id="6u_oBd246Gt" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6u_oBd24hpG" resolve="config" />
+                </node>
+                <node concept="2qgKlT" id="6u_oBd246Gu" role="2OqNvi">
+                  <ref role="37wK5l" node="7Sn21ZwO0hh" resolve="descendantLocalConfigItems" />
+                </node>
+              </node>
+              <node concept="ANE8D" id="6u_oBd246Gv" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6u_oBd246Gw" role="3cqZAp">
+          <node concept="3cpWsn" id="6u_oBd246Gx" role="3cpWs9">
+            <property role="TrG5h" value="selStates" />
+            <node concept="_YKpA" id="6u_oBd246Gy" role="1tU5fm">
+              <node concept="3uibUv" id="6u_oBd246Gz" role="_ZDj9">
+                <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6u_oBd246G$" role="33vP2m">
+              <node concept="2OqwBi" id="6u_oBd246G_" role="2Oq$k0">
+                <node concept="37vLTw" id="6u_oBd246GA" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6u_oBd246Go" resolve="subfeatureConfigurations" />
+                </node>
+                <node concept="3$u5V9" id="6u_oBd246GB" role="2OqNvi">
+                  <node concept="1bVj0M" id="6u_oBd246GC" role="23t8la">
+                    <node concept="3clFbS" id="6u_oBd246GD" role="1bW5cS">
+                      <node concept="3clFbF" id="6u_oBd246GE" role="3cqZAp">
+                        <node concept="10QFUN" id="6u_oBd246GF" role="3clFbG">
+                          <node concept="3uibUv" id="6u_oBd246GG" role="10QFUM">
+                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                          </node>
+                          <node concept="2OqwBi" id="6u_oBd246GH" role="10QFUP">
+                            <node concept="2OqwBi" id="6u_oBd246GI" role="2Oq$k0">
+                              <node concept="37vLTw" id="6u_oBd246GJ" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6u_oBd246GM" resolve="it" />
+                              </node>
+                              <node concept="3TrcHB" id="6u_oBd246GK" role="2OqNvi">
+                                <ref role="3TsBF5" to="4ndm:59FNqAPCJNr" resolve="selectionState" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="6u_oBd246GL" role="2OqNvi">
+                              <ref role="37wK5l" to="c17a:~SEnumerationLiteral.getOrdinal()" resolve="getOrdinal" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="6u_oBd246GM" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="6u_oBd246GN" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="ANE8D" id="6u_oBd246GO" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="6u_oBd246GP" role="3cqZAp">
+          <node concept="3cpWsn" id="6u_oBd246GQ" role="3cpWs9">
+            <property role="TrG5h" value="attributeAssignmentPaired" />
+            <node concept="_YKpA" id="6u_oBd246GR" role="1tU5fm">
+              <node concept="3uibUv" id="6u_oBd246GS" role="_ZDj9">
+                <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6u_oBd246GT" role="33vP2m">
+              <node concept="2OqwBi" id="6u_oBd246GU" role="2Oq$k0">
+                <node concept="1eOMI4" id="6u_oBd246GV" role="2Oq$k0">
+                  <node concept="2OqwBi" id="6u_oBd246GW" role="1eOMHV">
+                    <node concept="2OqwBi" id="6u_oBd246GX" role="2Oq$k0">
+                      <node concept="37vLTw" id="6u_oBd246GY" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6u_oBd246Go" resolve="subfeatureConfigurations" />
+                      </node>
+                      <node concept="3goQfb" id="6u_oBd246GZ" role="2OqNvi">
+                        <node concept="1bVj0M" id="6u_oBd246H0" role="23t8la">
+                          <node concept="3clFbS" id="6u_oBd246H1" role="1bW5cS">
+                            <node concept="3clFbF" id="6u_oBd246H2" role="3cqZAp">
+                              <node concept="2OqwBi" id="6u_oBd246H3" role="3clFbG">
+                                <node concept="37vLTw" id="6u_oBd246H4" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="6u_oBd246H6" resolve="it" />
+                                </node>
+                                <node concept="2qgKlT" id="6u_oBd246H5" role="2OqNvi">
+                                  <ref role="37wK5l" node="30ECcbtQkN2" resolve="attributeAssignments" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="gl6BB" id="6u_oBd246H6" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="6u_oBd246H7" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="ANE8D" id="6u_oBd246H8" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="3$u5V9" id="6u_oBd246H9" role="2OqNvi">
+                  <node concept="1bVj0M" id="6u_oBd246Ha" role="23t8la">
+                    <node concept="3clFbS" id="6u_oBd246Hb" role="1bW5cS">
+                      <node concept="3clFbF" id="6u_oBd246Hc" role="3cqZAp">
+                        <node concept="10QFUN" id="6u_oBd246Hd" role="3clFbG">
+                          <node concept="3uibUv" id="6u_oBd246He" role="10QFUM">
+                            <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                          </node>
+                          <node concept="2YIFZM" id="6u_oBd246Hf" role="10QFUP">
+                            <ref role="37wK5l" to="1qo3:~Pair.of(java.lang.Object,java.lang.Object)" resolve="of" />
+                            <ref role="1Pybhc" to="1qo3:~Pair" resolve="Pair" />
+                            <node concept="2OqwBi" id="6u_oBd246Hg" role="37wK5m">
+                              <node concept="37vLTw" id="6u_oBd246Hh" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6u_oBd246Hm" resolve="it" />
+                              </node>
+                              <node concept="3TrEf2" id="6u_oBd246Hi" role="2OqNvi">
+                                <ref role="3Tt5mk" to="4ndm:30ECcbtMzQ8" resolve="attribute" />
+                              </node>
+                            </node>
+                            <node concept="2OqwBi" id="6u_oBd246Hj" role="37wK5m">
+                              <node concept="37vLTw" id="6u_oBd246Hk" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6u_oBd246Hm" resolve="it" />
+                              </node>
+                              <node concept="3TrEf2" id="6u_oBd246Hl" role="2OqNvi">
+                                <ref role="3Tt5mk" to="4ndm:30ECcbtOuaE" resolve="value" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="6u_oBd246Hm" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="6u_oBd246Hn" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="ANE8D" id="6u_oBd246Ho" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6u_oBd246Hp" role="3cqZAp" />
+        <node concept="3clFbF" id="6u_oBd246Hq" role="3cqZAp">
+          <node concept="2YIFZM" id="6u_oBd246Hr" role="3clFbG">
+            <ref role="37wK5l" to="33ny:~Objects.hashCode(java.lang.Object)" resolve="hashCode" />
+            <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
+            <node concept="2OqwBi" id="6u_oBd246Hs" role="37wK5m">
+              <node concept="2OqwBi" id="6u_oBd246Ht" role="2Oq$k0">
+                <node concept="37vLTw" id="6u_oBd246Hu" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6u_oBd246Gx" resolve="selStates" />
+                </node>
+                <node concept="4Tj9Z" id="6u_oBd246Hv" role="2OqNvi">
+                  <node concept="37vLTw" id="6u_oBd246Hw" role="576Qk">
+                    <ref role="3cqZAo" node="6u_oBd246GQ" resolve="attributeAssignmentPaired" />
+                  </node>
+                </node>
+              </node>
+              <node concept="ANE8D" id="6u_oBd246Hx" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="6u_oBd246Gl" role="3clF45" />
+      <node concept="3Tm1VV" id="6u_oBd246Gk" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="6u_oBd246_Z" role="jymVt" />
+  </node>
+  <node concept="312cEu" id="6u_oBd1PAPk">
+    <property role="3GE5qa" value="util.hashing" />
+    <property role="TrG5h" value="AllDetailsHashing" />
+    <node concept="2tJIrI" id="6u_oBd1PAPl" role="jymVt" />
+    <node concept="2YIFZL" id="6u_oBd1PAPm" role="jymVt">
+      <property role="TrG5h" value="of" />
+      <node concept="37vLTG" id="6u_oBd1PAPn" role="3clF46">
+        <property role="TrG5h" value="config" />
+        <node concept="3Tqbb2" id="6u_oBd1PAPo" role="1tU5fm">
+          <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="6u_oBd1PAPp" role="3clF47">
+        <node concept="3clFbF" id="6u_oBd1PAPq" role="3cqZAp">
+          <node concept="2ShNRf" id="6u_oBd1PAPr" role="3clFbG">
+            <node concept="1pGfFk" id="6u_oBd1PAPs" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" node="6u_oBd1PAPx" resolve="AllDetailsHashing" />
+              <node concept="37vLTw" id="6u_oBd1PAPt" role="37wK5m">
+                <ref role="3cqZAo" node="6u_oBd1PAPn" resolve="config" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6u_oBd1PAPu" role="1B3o_S" />
+      <node concept="3uibUv" id="6u_oBd1PAPv" role="3clF45">
+        <ref role="3uigEE" node="6u_oBd1PAPk" resolve="AllDetailsHashing" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6u_oBd1PAPw" role="jymVt" />
+    <node concept="3clFbW" id="6u_oBd1PAPx" role="jymVt">
+      <node concept="3cqZAl" id="6u_oBd1PAPy" role="3clF45" />
+      <node concept="3Tm6S6" id="6u_oBd1PAPz" role="1B3o_S" />
+      <node concept="3clFbS" id="6u_oBd1PAP$" role="3clF47">
+        <node concept="XkiVB" id="6u_oBd1PAP_" role="3cqZAp">
+          <ref role="37wK5l" node="6u_oBd1G6du" resolve="AbstractConfigHashing" />
+          <node concept="Xl_RD" id="6u_oBd1PAPA" role="37wK5m">
+            <property role="Xl_RC" value="HashOfAllDetails" />
+          </node>
+          <node concept="37vLTw" id="6u_oBd1PAPB" role="37wK5m">
+            <ref role="3cqZAo" node="6u_oBd1PAPC" resolve="config" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6u_oBd1PAPC" role="3clF46">
+        <property role="TrG5h" value="config" />
+        <node concept="3Tqbb2" id="6u_oBd1PAPD" role="1tU5fm">
+          <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6u_oBd1PAPE" role="jymVt" />
+    <node concept="3clFb_" id="6u_oBd1PAPF" role="jymVt">
+      <property role="TrG5h" value="computeHash" />
+      <node concept="3Tm1VV" id="6u_oBd1PAPG" role="1B3o_S" />
+      <node concept="10Oyi0" id="6u_oBd1PAPH" role="3clF45" />
+      <node concept="3clFbS" id="6u_oBd1PAPI" role="3clF47">
+        <node concept="3cpWs8" id="6u_oBd1VSZL" role="3cqZAp">
+          <node concept="3cpWsn" id="6u_oBd1VSZM" role="3cpWs9">
+            <property role="TrG5h" value="traversalFMC" />
+            <node concept="3uibUv" id="6u_oBd1VSZN" role="1tU5fm">
+              <ref role="3uigEE" node="6u_oBd1UBfD" resolve="AllReachableConfigTraversal" />
+            </node>
+            <node concept="2ShNRf" id="6u_oBd1VUxk" role="33vP2m">
+              <node concept="HV5vD" id="6u_oBd22Xnz" role="2ShVmc">
+                <property role="373rjd" value="true" />
+                <ref role="HV5vE" node="6u_oBd1UBfD" resolve="AllReachableConfigTraversal" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3_nVufMYySq" role="3cqZAp">
+          <node concept="2OqwBi" id="3_nVufMZA17" role="3clFbG">
+            <node concept="37vLTw" id="3_nVufMZxvg" role="2Oq$k0">
+              <ref role="3cqZAo" node="6u_oBd1VSZM" resolve="traversalFMC" />
+            </node>
+            <node concept="liA8E" id="3_nVufMZAkT" role="2OqNvi">
+              <ref role="37wK5l" to="7wpd:5Hb7SE23SD3" resolve="doBreadthFirst" />
+              <node concept="37vLTw" id="6u_oBd23wqP" role="37wK5m">
+                <ref role="3cqZAo" node="6u_oBd1G4I6" resolve="config" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6u_oBd259Dv" role="3cqZAp" />
+        <node concept="3cpWs8" id="6u_oBd250lI" role="3cqZAp">
+          <node concept="3cpWsn" id="6u_oBd250lJ" role="3cpWs9">
+            <property role="TrG5h" value="hashCodes" />
+            <node concept="3uibUv" id="6u_oBd251eZ" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~List" resolve="List" />
+              <node concept="3uibUv" id="6u_oBd252dw" role="11_B2D">
+                <ref role="3uigEE" to="wyt6:~Integer" resolve="Integer" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6u_oBd250lK" role="33vP2m">
+              <node concept="ANE8D" id="6u_oBd250lM" role="2OqNvi" />
+              <node concept="2OqwBi" id="6u_oBd24xSA" role="2Oq$k0">
+                <node concept="2OqwBi" id="6u_oBd24xSB" role="2Oq$k0">
+                  <node concept="37vLTw" id="6u_oBd24xSC" role="2Oq$k0">
+                    <ref role="3cqZAo" node="6u_oBd1VSZM" resolve="traversalFMC" />
+                  </node>
+                  <node concept="liA8E" id="6u_oBd24xSD" role="2OqNvi">
+                    <ref role="37wK5l" node="6u_oBd1VJp_" resolve="getResult" />
+                  </node>
+                </node>
+                <node concept="3$u5V9" id="6u_oBd24xSE" role="2OqNvi">
+                  <node concept="1bVj0M" id="6u_oBd24xSF" role="23t8la">
+                    <node concept="3clFbS" id="6u_oBd24xSG" role="1bW5cS">
+                      <node concept="3clFbF" id="6u_oBd24xSH" role="3cqZAp">
+                        <node concept="2YIFZM" id="6u_oBd24xSI" role="3clFbG">
+                          <ref role="1Pybhc" node="6u_oBd1FoKQ" resolve="AbstractConfigHashing" />
+                          <ref role="37wK5l" node="6u_oBd24gsf" resolve="computeHashForLocalConfig" />
+                          <node concept="37vLTw" id="6u_oBd24xSJ" role="37wK5m">
+                            <ref role="3cqZAo" node="6u_oBd24xSK" resolve="it" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="6u_oBd24xSK" role="1bW2Oz">
+                      <property role="TrG5h" value="it" />
+                      <node concept="2jxLKc" id="6u_oBd24xSL" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="6u_oBd24TOe" role="3cqZAp">
+          <node concept="2OqwBi" id="6u_oBd255S7" role="3clFbG">
+            <node concept="37vLTw" id="6u_oBd250lN" role="2Oq$k0">
+              <ref role="3cqZAo" node="6u_oBd250lJ" resolve="hashCodes" />
+            </node>
+            <node concept="liA8E" id="6u_oBd257eI" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~List.hashCode()" resolve="hashCode" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6u_oBd1PAQU" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="6u_oBd1PAQV" role="1B3o_S" />
+    <node concept="3uibUv" id="6u_oBd1PAQW" role="1zkMxy">
+      <ref role="3uigEE" node="6u_oBd1FoKQ" resolve="AbstractConfigHashing" />
+    </node>
+  </node>
+  <node concept="312cEu" id="6u_oBd1UBfD">
+    <property role="3GE5qa" value="util" />
+    <property role="TrG5h" value="AllReachableConfigTraversal" />
+    <node concept="2tJIrI" id="6u_oBd1VWXV" role="jymVt" />
+    <node concept="312cEg" id="6u_oBd26Lg0" role="jymVt">
+      <property role="TrG5h" value="forEach" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="6u_oBd26J3O" role="1B3o_S" />
+      <node concept="1ajhzC" id="6u_oBd26OQB" role="1tU5fm">
+        <node concept="3cqZAl" id="6u_oBd26OQC" role="1ajl9A" />
+        <node concept="3Tqbb2" id="6u_oBd26OQD" role="1ajw0F">
+          <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6u_oBd26RRU" role="jymVt" />
+    <node concept="3clFbW" id="6u_oBd279Ia" role="jymVt">
+      <node concept="3cqZAl" id="6u_oBd279Ic" role="3clF45" />
+      <node concept="3Tm1VV" id="6u_oBd279Id" role="1B3o_S" />
+      <node concept="3clFbS" id="6u_oBd279Ie" role="3clF47">
+        <node concept="1VxSAg" id="6u_oBd27d1c" role="3cqZAp">
+          <ref role="37wK5l" node="6u_oBd26tuG" resolve="AllReachableConfigTraversal" />
+          <node concept="10Nm6u" id="6u_oBd27f2$" role="37wK5m" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6u_oBd27gnQ" role="jymVt" />
+    <node concept="3clFbW" id="6u_oBd26tuG" role="jymVt">
+      <node concept="3cqZAl" id="6u_oBd26tuI" role="3clF45" />
+      <node concept="3Tm1VV" id="6u_oBd26tuJ" role="1B3o_S" />
+      <node concept="3clFbS" id="6u_oBd26tuK" role="3clF47">
+        <node concept="3clFbF" id="6u_oBd26WFa" role="3cqZAp">
+          <node concept="37vLTI" id="6u_oBd27105" role="3clFbG">
+            <node concept="37vLTw" id="6u_oBd2721J" role="37vLTx">
+              <ref role="3cqZAo" node="6u_oBd26vQs" resolve="forEach" />
+            </node>
+            <node concept="2OqwBi" id="6u_oBd26Xmx" role="37vLTJ">
+              <node concept="Xjq3P" id="6u_oBd26WF9" role="2Oq$k0" />
+              <node concept="2OwXpG" id="6u_oBd26ZzE" role="2OqNvi">
+                <ref role="2Oxat5" node="6u_oBd26Lg0" resolve="forEach" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6u_oBd26vQs" role="3clF46">
+        <property role="TrG5h" value="forEach" />
+        <node concept="1ajhzC" id="6u_oBd26vQq" role="1tU5fm">
+          <node concept="3cqZAl" id="6u_oBd26$8z" role="1ajl9A" />
+          <node concept="3Tqbb2" id="6u_oBd26A0T" role="1ajw0F">
+            <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6u_oBd26rWg" role="jymVt" />
+    <node concept="3Tm1VV" id="6u_oBd1UBfE" role="1B3o_S" />
+    <node concept="3uibUv" id="6u_oBd1UBqI" role="1zkMxy">
+      <ref role="3uigEE" to="7wpd:5Hb7SE23e8T" resolve="Traversal" />
+      <node concept="3Tqbb2" id="6u_oBd1UBVJ" role="11_B2D">
+        <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+      </node>
+    </node>
+    <node concept="3clFb_" id="6u_oBd1UC9P" role="jymVt">
+      <property role="TrG5h" value="successorsOf" />
+      <node concept="A3Dl8" id="6u_oBd1UC9R" role="3clF45">
+        <node concept="3Tqbb2" id="6u_oBd1UCa6" role="A3Ik2">
+          <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+        </node>
+      </node>
+      <node concept="3Tmbuc" id="6u_oBd1UC9T" role="1B3o_S" />
+      <node concept="37vLTG" id="6u_oBd1UC9U" role="3clF46">
+        <property role="TrG5h" value="cfg" />
+        <node concept="3Tqbb2" id="6u_oBd1UCa7" role="1tU5fm">
+          <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="6u_oBd1UCa8" role="3clF47">
+        <node concept="3SKdUt" id="6u_oBd27kyJ" role="3cqZAp">
+          <node concept="1PaTwC" id="6u_oBd27kyK" role="1aUNEU">
+            <node concept="3oM_SD" id="6u_oBd27kyL" role="1PaTwD">
+              <property role="3oM_SC" value="execute" />
+            </node>
+            <node concept="3oM_SD" id="6u_oBd27lpf" role="1PaTwD">
+              <property role="3oM_SC" value="foreach-action," />
+            </node>
+            <node concept="3oM_SD" id="6u_oBd27lqV" role="1PaTwD">
+              <property role="3oM_SC" value="if" />
+            </node>
+            <node concept="3oM_SD" id="6u_oBd27lrc" role="1PaTwD">
+              <property role="3oM_SC" value="any" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="6u_oBd27mFR" role="3cqZAp">
+          <node concept="3clFbS" id="6u_oBd27mFT" role="3clFbx">
+            <node concept="3clFbF" id="6u_oBd27xe3" role="3cqZAp">
+              <node concept="2OqwBi" id="6u_oBd27yrB" role="3clFbG">
+                <node concept="37vLTw" id="6u_oBd27xe1" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6u_oBd26Lg0" resolve="forEach" />
+                </node>
+                <node concept="1Bd96e" id="6u_oBd27zOC" role="2OqNvi">
+                  <node concept="37vLTw" id="6u_oBd27_cG" role="1BdPVh">
+                    <ref role="3cqZAo" node="6u_oBd1UC9U" resolve="cfg" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="6u_oBd27sKE" role="3clFbw">
+            <node concept="10Nm6u" id="6u_oBd27v$h" role="3uHU7w" />
+            <node concept="37vLTw" id="6u_oBd27onf" role="3uHU7B">
+              <ref role="3cqZAo" node="6u_oBd26Lg0" resolve="forEach" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6u_oBd27js_" role="3cqZAp" />
+        <node concept="3SKdUt" id="5Bs$p$uZrs1" role="3cqZAp">
+          <node concept="1PaTwC" id="5Bs$p$uZrs2" role="1aUNEU">
+            <node concept="3oM_SD" id="5Bs$p$uZwPl" role="1PaTwD">
+              <property role="3oM_SC" value="add" />
+            </node>
+            <node concept="3oM_SD" id="5Bs$p$uZ$eK" role="1PaTwD">
+              <property role="3oM_SC" value="config" />
+            </node>
+            <node concept="3oM_SD" id="4$KkN8iBtU$" role="1PaTwD">
+              <property role="3oM_SC" value="which" />
+            </node>
+            <node concept="3oM_SD" id="4$KkN8iBwEC" role="1PaTwD">
+              <property role="3oM_SC" value="os" />
+            </node>
+            <node concept="3oM_SD" id="4$KkN8iBwED" role="1PaTwD">
+              <property role="3oM_SC" value="extended," />
+            </node>
+            <node concept="3oM_SD" id="4$KkN8iBwEE" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="4$KkN8iBCgc" role="1PaTwD">
+              <property role="3oM_SC" value="ones" />
+            </node>
+            <node concept="3oM_SD" id="4$KkN8iBFKW" role="1PaTwD">
+              <property role="3oM_SC" value="which" />
+            </node>
+            <node concept="3oM_SD" id="4$KkN8iBLfB" role="1PaTwD">
+              <property role="3oM_SC" value="are" />
+            </node>
+            <node concept="3oM_SD" id="4$KkN8iBNIC" role="1PaTwD">
+              <property role="3oM_SC" value="used," />
+            </node>
+            <node concept="3oM_SD" id="4$KkN8iBR5J" role="1PaTwD">
+              <property role="3oM_SC" value="and" />
+            </node>
+            <node concept="3oM_SD" id="4$KkN8iBR5K" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="4$KkN8iBTZG" role="1PaTwD">
+              <property role="3oM_SC" value="referenced" />
+            </node>
+            <node concept="3oM_SD" id="4$KkN8iBY0$" role="1PaTwD">
+              <property role="3oM_SC" value="configs" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3_nVufNmbXG" role="3cqZAp">
+          <node concept="3cpWsn" id="3_nVufNmbXH" role="3cpWs9">
+            <property role="TrG5h" value="extended" />
+            <node concept="3Tqbb2" id="3_nVufNmbD5" role="1tU5fm">
+              <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+            </node>
+            <node concept="2EnYce" id="6u_oBd1V_ON" role="33vP2m">
+              <node concept="2OqwBi" id="3_nVufNmbXJ" role="2Oq$k0">
+                <node concept="37vLTw" id="3_nVufNmbXK" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6u_oBd1UC9U" resolve="cfg" />
+                </node>
+                <node concept="3TrEf2" id="3_nVufNmbXL" role="2OqNvi">
+                  <ref role="3Tt5mk" to="4ndm:4onczE6iX1P" resolve="extendedFMC" />
+                </node>
+              </node>
+              <node concept="3TrEf2" id="3_nVufNmbXM" role="2OqNvi">
+                <ref role="3Tt5mk" to="4ndm:4onczE6iX19" resolve="config" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4$KkN8i_Bwa" role="3cqZAp">
+          <node concept="3cpWsn" id="4$KkN8i_Bwb" role="3cpWs9">
+            <property role="TrG5h" value="used" />
+            <node concept="A3Dl8" id="4$KkN8i_Bhm" role="1tU5fm">
+              <node concept="3Tqbb2" id="4$KkN8i_Bhp" role="A3Ik2">
+                <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4$KkN8i_Bwc" role="33vP2m">
+              <node concept="2OqwBi" id="4$KkN8i_Bwd" role="2Oq$k0">
+                <node concept="37vLTw" id="4$KkN8i_Bwe" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6u_oBd1UC9U" resolve="cfg" />
+                </node>
+                <node concept="2qgKlT" id="4$KkN8i_Bwf" role="2OqNvi">
+                  <ref role="37wK5l" node="3j7vM_E99Ji" resolve="getValidUsedConfigs" />
+                </node>
+              </node>
+              <node concept="3$u5V9" id="4$KkN8i_Bwg" role="2OqNvi">
+                <node concept="1bVj0M" id="4$KkN8i_Bwh" role="23t8la">
+                  <node concept="3clFbS" id="4$KkN8i_Bwi" role="1bW5cS">
+                    <node concept="3clFbF" id="4$KkN8i_Bwj" role="3cqZAp">
+                      <node concept="2OqwBi" id="4$KkN8i_Bwk" role="3clFbG">
+                        <node concept="37vLTw" id="4$KkN8i_Bwl" role="2Oq$k0">
+                          <ref role="3cqZAo" node="VAcoNEeGFu" resolve="it" />
+                        </node>
+                        <node concept="3TrEf2" id="4$KkN8i_Bwm" role="2OqNvi">
+                          <ref role="3Tt5mk" to="4ndm:7PHwTKCpF7e" resolve="config" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="VAcoNEeGFu" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="VAcoNEeGFv" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4$KkN8i_N_9" role="3cqZAp">
+          <node concept="3cpWsn" id="4$KkN8i_N_a" role="3cpWs9">
+            <property role="TrG5h" value="referenced" />
+            <node concept="A3Dl8" id="4$KkN8i_Nqm" role="1tU5fm">
+              <node concept="3Tqbb2" id="4$KkN8i_Nqp" role="A3Ik2">
+                <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4$KkN8i_N_b" role="33vP2m">
+              <node concept="2OqwBi" id="4$KkN8i_N_c" role="2Oq$k0">
+                <node concept="37vLTw" id="4$KkN8i_N_d" role="2Oq$k0">
+                  <ref role="3cqZAo" node="6u_oBd1UC9U" resolve="cfg" />
+                </node>
+                <node concept="2Rf3mk" id="4$KkN8i_N_e" role="2OqNvi">
+                  <node concept="1xMEDy" id="4$KkN8i_N_f" role="1xVPHs">
+                    <node concept="chp4Y" id="4$KkN8i_N_g" role="ri$Ld">
+                      <ref role="cht4Q" to="4ndm:5NPKd17BIPE" resolve="FeatureModelConfigurationRef" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3$u5V9" id="4$KkN8i_N_h" role="2OqNvi">
+                <node concept="1bVj0M" id="4$KkN8i_N_i" role="23t8la">
+                  <node concept="3clFbS" id="4$KkN8i_N_j" role="1bW5cS">
+                    <node concept="3clFbF" id="4$KkN8i_N_k" role="3cqZAp">
+                      <node concept="2OqwBi" id="4$KkN8i_N_l" role="3clFbG">
+                        <node concept="37vLTw" id="4$KkN8i_N_m" role="2Oq$k0">
+                          <ref role="3cqZAo" node="VAcoNEeGFw" resolve="it" />
+                        </node>
+                        <node concept="3TrEf2" id="4$KkN8i_N_n" role="2OqNvi">
+                          <ref role="3Tt5mk" to="4ndm:5NPKd17BIPF" resolve="config" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="VAcoNEeGFw" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="VAcoNEeGFx" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4$KkN8iAdwK" role="3cqZAp">
+          <node concept="2OqwBi" id="4$KkN8iAZ7y" role="3clFbG">
+            <node concept="2OqwBi" id="6u_oBd1VAYn" role="2Oq$k0">
+              <node concept="2OqwBi" id="4$KkN8iALPl" role="2Oq$k0">
+                <node concept="2OqwBi" id="4$KkN8iAAnw" role="2Oq$k0">
+                  <node concept="2ShNRf" id="4$KkN8iAdwG" role="2Oq$k0">
+                    <node concept="2HTt$P" id="4$KkN8iAjud" role="2ShVmc">
+                      <node concept="3Tqbb2" id="4$KkN8iAom5" role="2HTBi0">
+                        <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+                      </node>
+                      <node concept="37vLTw" id="4$KkN8iAxtC" role="2HTEbv">
+                        <ref role="3cqZAo" node="3_nVufNmbXH" resolve="extended" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="4Tj9Z" id="4$KkN8iAG5z" role="2OqNvi">
+                    <node concept="37vLTw" id="4$KkN8iAIWm" role="576Qk">
+                      <ref role="3cqZAo" node="4$KkN8i_Bwb" resolve="used" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="4Tj9Z" id="4$KkN8iAReO" role="2OqNvi">
+                  <node concept="37vLTw" id="4$KkN8iAVfv" role="576Qk">
+                    <ref role="3cqZAo" node="4$KkN8i_N_a" resolve="referenced" />
+                  </node>
+                </node>
+              </node>
+              <node concept="1KnU$U" id="6u_oBd1VGxg" role="2OqNvi" />
+            </node>
+            <node concept="1VAtEI" id="4$KkN8iB6y8" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="6u_oBd1UCa9" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="6u_oBd1VHq9" role="jymVt" />
+    <node concept="3clFb_" id="6u_oBd1VJp_" role="jymVt">
+      <property role="TrG5h" value="getResult" />
+      <node concept="3clFbS" id="6u_oBd1VJpC" role="3clF47">
+        <node concept="3clFbF" id="6u_oBd1VKEj" role="3cqZAp">
+          <node concept="1rXfSq" id="6u_oBd1VKEi" role="3clFbG">
+            <ref role="37wK5l" to="7wpd:5Hb7SE2msls" resolve="getVisited" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6u_oBd1VIkC" role="1B3o_S" />
+      <node concept="A3Dl8" id="6u_oBd1VKT0" role="3clF45">
+        <node concept="3Tqbb2" id="6u_oBd1VKT3" role="A3Ik2">
+          <ref role="ehGHo" to="4ndm:5NPKd17BG$l" resolve="FeatureModelConfiguration" />
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.plugin.mps
@@ -54,6 +54,7 @@
     <import index="rppw" ref="r:720d563d-1633-46b3-a98e-08d2fde4c4a8(org.iets3.core.expr.typetags.physunits.behavior)" />
     <import index="i3ya" ref="r:4f64e2f0-6a4e-4db3-b3bf-7977f44949b6(org.iets3.core.expr.typetags.physunits.structure)" />
     <import index="qlm2" ref="r:c0482758-b46b-48c3-8482-fa4a3115b53b(org.iets3.core.expr.typetags.behavior)" />
+    <import index="2rbz" ref="r:aeef8772-8af4-45c3-a762-623d4009d953(org.iets3.variability.base.plugin)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -258,7 +259,9 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
-      <concept id="1107796713796" name="jetbrains.mps.baseLanguage.structure.Interface" flags="ig" index="3HP615" />
+      <concept id="1107796713796" name="jetbrains.mps.baseLanguage.structure.Interface" flags="ig" index="3HP615">
+        <child id="1107797138135" name="extendedInterface" index="3HQHJm" />
+      </concept>
       <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
         <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
         <child id="8276990574886367509" name="finallyClause" index="1zxBo6" />
@@ -9778,12 +9781,17 @@
                                           </node>
                                         </node>
                                       </node>
-                                      <node concept="3clFbF" id="2BePqP6gdlr" role="3cqZAp">
-                                        <node concept="2YIFZM" id="1Vm2qfKKDKa" role="3clFbG">
-                                          <ref role="37wK5l" to="lte6:49LV9yvwKqG" resolve="setHashOfSolverRelevantData" />
-                                          <ref role="1Pybhc" to="lte6:49LV9yvww2v" resolve="FeatureModelConfHashUtil" />
-                                          <node concept="37vLTw" id="2BePqP6gj9V" role="37wK5m">
-                                            <ref role="3cqZAo" node="2BePqP5KhiC" resolve="fmc" />
+                                      <node concept="3clFbF" id="6u_oBd1J0Qh" role="3cqZAp">
+                                        <node concept="2OqwBi" id="6u_oBd1Jnsb" role="3clFbG">
+                                          <node concept="2YIFZM" id="6u_oBd1J8oe" role="2Oq$k0">
+                                            <ref role="37wK5l" to="lte6:6u_oBd1HBzc" resolve="of" />
+                                            <ref role="1Pybhc" to="lte6:49LV9yvww2v" resolve="SolverRelevantDataHashing" />
+                                            <node concept="37vLTw" id="6u_oBd1JfyM" role="37wK5m">
+                                              <ref role="3cqZAo" node="2BePqP5KhiC" resolve="fmc" />
+                                            </node>
+                                          </node>
+                                          <node concept="liA8E" id="6u_oBd1Jwlx" role="2OqNvi">
+                                            <ref role="37wK5l" to="lte6:6u_oBd1G27W" resolve="setHash" />
                                           </node>
                                         </node>
                                       </node>
@@ -11808,25 +11816,15 @@
     <node concept="3Tm1VV" id="1GjSFjiD0H1" role="1B3o_S" />
   </node>
   <node concept="vrV6u" id="1e_Qt5z9Qg">
-    <property role="3GE5qa" value="tailoring" />
+    <property role="3GE5qa" value="tailoring.names" />
     <property role="TrG5h" value="enrichedConfigNameLogicExtPoint" />
     <node concept="3uibUv" id="1e_Qt5$A4I" role="luc8K">
       <ref role="3uigEE" node="1e_Qt5zas$" resolve="IEnrichedConfigNameLogic" />
     </node>
   </node>
   <node concept="3HP615" id="1e_Qt5zas$">
-    <property role="3GE5qa" value="tailoring" />
+    <property role="3GE5qa" value="tailoring.names" />
     <property role="TrG5h" value="IEnrichedConfigNameLogic" />
-    <node concept="Wx3nA" id="6vXjBknmRAN" role="jymVt">
-      <property role="TrG5h" value="DEFAULT_PRIORITY" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tm1VV" id="6vXjBknmRAO" role="1B3o_S" />
-      <node concept="10Oyi0" id="6vXjBknmRtl" role="1tU5fm" />
-      <node concept="3cmrfG" id="6vXjBknmRLU" role="33vP2m">
-        <property role="3cmrfH" value="0" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="1e_Qt5zEII" role="jymVt" />
     <node concept="3clFb_" id="6vXjBknacek" role="jymVt">
       <property role="TrG5h" value="hasActualEnrichedName" />
       <node concept="37vLTG" id="6vXjBknacuZ" role="3clF46">
@@ -11934,20 +11932,6 @@
         </node>
       </node>
     </node>
-    <node concept="2tJIrI" id="1e_Qt5$zhQ" role="jymVt" />
-    <node concept="3clFb_" id="1e_Qt5$ziC" role="jymVt">
-      <property role="TrG5h" value="priority" />
-      <node concept="10Oyi0" id="1e_Qt5$ziD" role="3clF45" />
-      <node concept="3Tm1VV" id="1e_Qt5$ziE" role="1B3o_S" />
-      <node concept="3clFbS" id="1e_Qt5$ziF" role="3clF47" />
-      <node concept="P$JXv" id="1e_Qt5$ziI" role="lGtFl">
-        <node concept="TZ5HA" id="1e_Qt5$ziJ" role="TZ5H$">
-          <node concept="1dT_AC" id="1e_Qt5$ziK" role="1dT_Ay">
-            <property role="1dT_AB" value="The extension implementation with the highest priority wins." />
-          </node>
-        </node>
-      </node>
-    </node>
     <node concept="3Tm1VV" id="1e_Qt5zas_" role="1B3o_S" />
     <node concept="3UR2Jj" id="4O1MtdoPj5h" role="lGtFl">
       <node concept="TZ5HA" id="4O1MtdoPj5i" role="TZ5H$">
@@ -11956,9 +11940,12 @@
         </node>
       </node>
     </node>
+    <node concept="3uibUv" id="7Sbg4UjPuEf" role="3HQHJm">
+      <ref role="3uigEE" to="2rbz:7Sbg4UjPubL" resolve="IExtensionWithPriority" />
+    </node>
   </node>
   <node concept="312cEu" id="1e_Qt5zgHq">
-    <property role="3GE5qa" value="tailoring" />
+    <property role="3GE5qa" value="tailoring.names" />
     <property role="TrG5h" value="DefaultEnrichedConfigNameLogic" />
     <node concept="2tJIrI" id="1e_Qt5$B0d" role="jymVt" />
     <node concept="3clFb_" id="6vXjBknadV1" role="jymVt">
@@ -12050,111 +12037,50 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="2tJIrI" id="1e_Qt5$Bhg" role="jymVt" />
-    <node concept="3clFb_" id="1e_Qt5$A79" role="jymVt">
-      <property role="TrG5h" value="priority" />
-      <node concept="10Oyi0" id="1e_Qt5$A7a" role="3clF45" />
-      <node concept="3Tm1VV" id="1e_Qt5$A7b" role="1B3o_S" />
-      <node concept="3clFbS" id="1e_Qt5$A7g" role="3clF47">
-        <node concept="3clFbF" id="1e_Qt5$A7j" role="3cqZAp">
-          <node concept="37vLTw" id="6vXjBknmUPE" role="3clFbG">
-            <ref role="3cqZAo" node="6vXjBknmRAN" resolve="DEFAULT_PRIORITY" />
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="1e_Qt5$A7h" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
+    <node concept="3uibUv" id="7Sbg4UjP$mp" role="1zkMxy">
+      <ref role="3uigEE" to="2rbz:7Sbg4UjPvkH" resolve="AbstractExtensionWithPriority" />
     </node>
   </node>
   <node concept="312cEu" id="1e_Qt5_v$e">
     <property role="TrG5h" value="EnrichedConfigNames" />
-    <property role="3GE5qa" value="tailoring" />
+    <property role="3GE5qa" value="tailoring.names" />
     <node concept="2tJIrI" id="1e_Qt5_Gcq" role="jymVt" />
     <node concept="2YIFZL" id="4qv99IrBnzk" role="jymVt">
       <property role="TrG5h" value="instance" />
       <node concept="3clFbS" id="4qv99IrBnzn" role="3clF47">
-        <node concept="3cpWs8" id="4qv99IrBJ3T" role="3cqZAp">
-          <node concept="3cpWsn" id="4qv99IrBJ3U" role="3cpWs9">
-            <property role="TrG5h" value="ep" />
-            <node concept="3uibUv" id="4qv99IrBJ1H" role="1tU5fm">
-              <ref role="3uigEE" node="1e_Qt5zas$" resolve="IEnrichedConfigNameLogic" />
-            </node>
-            <node concept="2OqwBi" id="4qv99IrBJ3V" role="33vP2m">
-              <node concept="2OqwBi" id="4qv99IrBJ3W" role="2Oq$k0">
-                <node concept="2OqwBi" id="4qv99IrBJ3X" role="2Oq$k0">
-                  <node concept="2O5UvJ" id="4qv99IrBJ3Y" role="2Oq$k0">
-                    <ref role="2O5UnU" node="1e_Qt5z9Qg" resolve="enrichedConfigNameLogicExtPoint" />
-                  </node>
-                  <node concept="SfwO_" id="4qv99IrBJ3Z" role="2OqNvi" />
-                </node>
-                <node concept="2S7cBI" id="4qv99IrBJ40" role="2OqNvi">
-                  <node concept="1bVj0M" id="4qv99IrBJ41" role="23t8la">
-                    <node concept="3clFbS" id="4qv99IrBJ42" role="1bW5cS">
-                      <node concept="3clFbF" id="4qv99IrBJ43" role="3cqZAp">
-                        <node concept="2OqwBi" id="4qv99IrBJ44" role="3clFbG">
-                          <node concept="37vLTw" id="4qv99IrBJ45" role="2Oq$k0">
-                            <ref role="3cqZAo" node="2FZhxW1aEb9" resolve="it" />
-                          </node>
-                          <node concept="liA8E" id="4qv99IrBJ46" role="2OqNvi">
-                            <ref role="37wK5l" node="1e_Qt5$ziC" resolve="priority" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="gl6BB" id="2FZhxW1aEb9" role="1bW2Oz">
-                      <property role="TrG5h" value="it" />
-                      <node concept="2jxLKc" id="2FZhxW1aEba" role="1tU5fm" />
-                    </node>
-                  </node>
-                  <node concept="1nlBCl" id="29cIrQKmYPA" role="2S7zOq" />
-                </node>
+        <node concept="3cpWs8" id="7Sbg4UjPQDx" role="3cqZAp">
+          <node concept="3cpWsn" id="7Sbg4UjPQDy" role="3cpWs9">
+            <property role="TrG5h" value="extensions" />
+            <node concept="A3Dl8" id="7Sbg4UjPQCf" role="1tU5fm">
+              <node concept="3uibUv" id="7Sbg4UjPQCi" role="A3Ik2">
+                <ref role="3uigEE" node="1e_Qt5zas$" resolve="IEnrichedConfigNameLogic" />
               </node>
-              <node concept="1uHKPH" id="29cIrQKn0vr" role="2OqNvi" />
+            </node>
+            <node concept="2OqwBi" id="7Sbg4UjPQDz" role="33vP2m">
+              <node concept="2O5UvJ" id="7Sbg4UjPQD$" role="2Oq$k0">
+                <ref role="2O5UnU" node="1e_Qt5z9Qg" resolve="enrichedConfigNameLogicExtPoint" />
+              </node>
+              <node concept="SfwO_" id="7Sbg4UjPQD_" role="2OqNvi" />
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="1e_Qt5_BTi" role="3cqZAp" />
-        <node concept="3SKdUt" id="3bE2i5JypcP" role="3cqZAp">
-          <node concept="1PaTwC" id="3bE2i5JypcQ" role="1aUNEU">
-            <node concept="3oM_SD" id="3bE2i5Jypff" role="1PaTwD">
-              <property role="3oM_SC" value="null" />
+        <node concept="3clFbF" id="7Sbg4UjPPjW" role="3cqZAp">
+          <node concept="2YIFZM" id="7Sbg4UjPPv$" role="3clFbG">
+            <ref role="1Pybhc" to="2rbz:7Sbg4UjPNNA" resolve="AbstractExtensionProvider" />
+            <ref role="37wK5l" to="2rbz:7Sbg4UjP$Z3" resolve="instanceByPriority" />
+            <node concept="37vLTw" id="7Sbg4UjPQDA" role="37wK5m">
+              <ref role="3cqZAo" node="7Sbg4UjPQDy" resolve="extensions" />
             </node>
-            <node concept="3oM_SD" id="3bE2i5JypCM" role="1PaTwD">
-              <property role="3oM_SC" value="case" />
-            </node>
-            <node concept="3oM_SD" id="3bE2i5JypD8" role="1PaTwD">
-              <property role="3oM_SC" value="is" />
-            </node>
-            <node concept="3oM_SD" id="3bE2i5JypDv" role="1PaTwD">
-              <property role="3oM_SC" value="fallback," />
-            </node>
-            <node concept="3oM_SD" id="3bE2i5Jypfh" role="1PaTwD">
-              <property role="3oM_SC" value="should" />
-            </node>
-            <node concept="3oM_SD" id="3bE2i5Jypfk" role="1PaTwD">
-              <property role="3oM_SC" value="not" />
-            </node>
-            <node concept="3oM_SD" id="3bE2i5Jypfo" role="1PaTwD">
-              <property role="3oM_SC" value="happen" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="4qv99IrBJoK" role="3cqZAp">
-          <node concept="3K4zz7" id="4qv99IrBK2L" role="3clFbG">
-            <node concept="2ShNRf" id="4qv99IrBK8j" role="3K4E3e">
-              <node concept="HV5vD" id="4qv99IrBMfR" role="2ShVmc">
-                <property role="373rjd" value="true" />
-                <ref role="HV5vE" node="1e_Qt5zgHq" resolve="DefaultEnrichedConfigNameLogic" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="4qv99IrBMks" role="3K4GZi">
-              <ref role="3cqZAo" node="4qv99IrBJ3U" resolve="ep" />
-            </node>
-            <node concept="3clFbC" id="4qv99IrBJNT" role="3K4Cdx">
-              <node concept="10Nm6u" id="4qv99IrBJTZ" role="3uHU7w" />
-              <node concept="37vLTw" id="4qv99IrBJoI" role="3uHU7B">
-                <ref role="3cqZAo" node="4qv99IrBJ3U" resolve="ep" />
+            <node concept="1bVj0M" id="7Sbg4UjPPUD" role="37wK5m">
+              <node concept="3clFbS" id="7Sbg4UjPPUJ" role="1bW5cS">
+                <node concept="3clFbF" id="7Sbg4UjPQvr" role="3cqZAp">
+                  <node concept="2ShNRf" id="7Sbg4UjPQvt" role="3clFbG">
+                    <node concept="HV5vD" id="7Sbg4UjPQvv" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="HV5vE" node="1e_Qt5zgHq" resolve="DefaultEnrichedConfigNameLogic" />
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -12166,10 +12092,13 @@
       </node>
     </node>
     <node concept="3Tm1VV" id="1e_Qt5_v$f" role="1B3o_S" />
+    <node concept="3uibUv" id="7Sbg4UjPOxM" role="1zkMxy">
+      <ref role="3uigEE" to="2rbz:7Sbg4UjPNNA" resolve="AbstractExtensionProvider" />
+    </node>
   </node>
   <node concept="1lYeZD" id="7TK9se3Zi5c">
     <property role="TrG5h" value="DefaultEnrichedConfigNameLogicExtension" />
-    <property role="3GE5qa" value="tailoring" />
+    <property role="3GE5qa" value="tailoring.names" />
     <ref role="1lYe$Y" node="1e_Qt5z9Qg" resolve="enrichedConfigNameLogicExtPoint" />
     <node concept="3Tm1VV" id="7TK9se3Zi5d" role="1B3o_S" />
     <node concept="2tJIrI" id="7TK9se3Zi5e" role="jymVt" />
@@ -12200,6 +12129,149 @@
         <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
         <ref role="1QQUv3" node="7TK9se3Zi5i" resolve="get" />
       </node>
+    </node>
+  </node>
+  <node concept="vrV6u" id="7Sbg4UjOAZ$">
+    <property role="3GE5qa" value="tailoring.logic" />
+    <property role="TrG5h" value="configCombinationLogicExtPoint" />
+    <node concept="3uibUv" id="7Sbg4UjOAZ_" role="luc8K">
+      <ref role="3uigEE" node="7Sbg4UjOBdB" resolve="IConfigCombinationLogic" />
+    </node>
+  </node>
+  <node concept="3HP615" id="7Sbg4UjOBdB">
+    <property role="TrG5h" value="IConfigCombinationLogic" />
+    <property role="3GE5qa" value="tailoring.logic" />
+    <node concept="2tJIrI" id="7Sbg4UjOD1r" role="jymVt" />
+    <node concept="3clFb_" id="7Sbg4UjOEaG" role="jymVt">
+      <property role="TrG5h" value="allowAbstractSubConfigs" />
+      <node concept="3clFbS" id="7Sbg4UjOEaJ" role="3clF47" />
+      <node concept="3Tm1VV" id="7Sbg4UjOEaK" role="1B3o_S" />
+      <node concept="10P_77" id="7Sbg4UjOEaf" role="3clF45" />
+    </node>
+    <node concept="3Tm1VV" id="7Sbg4UjOBdC" role="1B3o_S" />
+    <node concept="3UR2Jj" id="7Sbg4UjOCX6" role="lGtFl">
+      <node concept="TZ5HA" id="7Sbg4UjOCX7" role="TZ5H$">
+        <node concept="1dT_AC" id="7Sbg4UjOCX8" role="1dT_Ay">
+          <property role="1dT_AB" value="Extension API definition for EP &quot;configCombinationLogicExtPoint&quot;" />
+        </node>
+      </node>
+    </node>
+    <node concept="3uibUv" id="7Sbg4UjPuLf" role="3HQHJm">
+      <ref role="3uigEE" to="2rbz:7Sbg4UjPubL" resolve="IExtensionWithPriority" />
+    </node>
+  </node>
+  <node concept="312cEu" id="7Sbg4UjOCBA">
+    <property role="3GE5qa" value="tailoring.logic" />
+    <property role="TrG5h" value="DefaultConfigCombinationLogic" />
+    <node concept="3clFb_" id="7Sbg4UjOEe7" role="jymVt">
+      <property role="TrG5h" value="allowAbstractSubConfigs" />
+      <node concept="3Tm1VV" id="7Sbg4UjOEe9" role="1B3o_S" />
+      <node concept="10P_77" id="7Sbg4UjOEea" role="3clF45" />
+      <node concept="3clFbS" id="7Sbg4UjOEeb" role="3clF47">
+        <node concept="3clFbF" id="7Sbg4UjOEee" role="3cqZAp">
+          <node concept="3clFbT" id="7Sbg4UjOEed" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7Sbg4UjOEec" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="7Sbg4UjOCBB" role="1B3o_S" />
+    <node concept="3uibUv" id="7Sbg4UjOCCM" role="EKbjA">
+      <ref role="3uigEE" node="7Sbg4UjOBdB" resolve="IConfigCombinationLogic" />
+    </node>
+    <node concept="3uibUv" id="7Sbg4UjPvro" role="1zkMxy">
+      <ref role="3uigEE" to="2rbz:7Sbg4UjPvkH" resolve="AbstractExtensionWithPriority" />
+    </node>
+  </node>
+  <node concept="1lYeZD" id="7Sbg4UjOGdF">
+    <property role="TrG5h" value="DefaultConfigCombinationLogicExtension" />
+    <property role="3GE5qa" value="tailoring.logic" />
+    <ref role="1lYe$Y" node="7Sbg4UjOAZ$" resolve="configCombinationLogicExtPoint" />
+    <node concept="3Tm1VV" id="7Sbg4UjOGdG" role="1B3o_S" />
+    <node concept="2tJIrI" id="7Sbg4UjOGdH" role="jymVt" />
+    <node concept="3tTeZs" id="7Sbg4UjOGdI" role="jymVt">
+      <property role="3tTeZt" value="activate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0CPy" resolve="activate" />
+    </node>
+    <node concept="3tTeZs" id="7Sbg4UjOGdJ" role="jymVt">
+      <property role="3tTeZt" value="deactivate" />
+      <ref role="3tTeZr" to="90d:3zLwYDe0BDO" resolve="deactivate" />
+    </node>
+    <node concept="2tJIrI" id="7Sbg4UjOGdK" role="jymVt" />
+    <node concept="q3mfD" id="7Sbg4UjOGdL" role="jymVt">
+      <property role="TrG5h" value="get" />
+      <ref role="2VtyIY" to="90d:3zLwYDe0svr" resolve="get" />
+      <node concept="3Tm1VV" id="7Sbg4UjOGdM" role="1B3o_S" />
+      <node concept="3clFbS" id="7Sbg4UjOGdN" role="3clF47">
+        <node concept="3cpWs6" id="7Sbg4UjOGdO" role="3cqZAp">
+          <node concept="2ShNRf" id="7Sbg4UjOGdP" role="3cqZAk">
+            <node concept="HV5vD" id="7Sbg4UjOGdQ" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="HV5vE" node="7Sbg4UjOCBA" resolve="DefaultConfigCombinationLogic" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="q3mfm" id="7Sbg4UjOGdR" role="3clF45">
+        <ref role="q3mfh" to="90d:3zLwYDe0sv$" />
+        <ref role="1QQUv3" node="7Sbg4UjOGdL" resolve="get" />
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="7Sbg4UjP3T$">
+    <property role="TrG5h" value="ConfigCombinationLogic" />
+    <property role="3GE5qa" value="tailoring.logic" />
+    <node concept="2tJIrI" id="7Sbg4UjP3T_" role="jymVt" />
+    <node concept="2YIFZL" id="7Sbg4UjPS90" role="jymVt">
+      <property role="TrG5h" value="instance" />
+      <node concept="3clFbS" id="7Sbg4UjPS91" role="3clF47">
+        <node concept="3cpWs8" id="7Sbg4UjPS92" role="3cqZAp">
+          <node concept="3cpWsn" id="7Sbg4UjPS93" role="3cpWs9">
+            <property role="TrG5h" value="extensions" />
+            <node concept="A3Dl8" id="7Sbg4UjPS94" role="1tU5fm">
+              <node concept="3uibUv" id="7Sbg4UjPS95" role="A3Ik2">
+                <ref role="3uigEE" node="7Sbg4UjOBdB" resolve="IConfigCombinationLogic" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="7Sbg4UjPS96" role="33vP2m">
+              <node concept="2O5UvJ" id="7Sbg4UjPS97" role="2Oq$k0">
+                <ref role="2O5UnU" node="7Sbg4UjOAZ$" resolve="configCombinationLogicExtPoint" />
+              </node>
+              <node concept="SfwO_" id="7Sbg4UjPS98" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7Sbg4UjPS99" role="3cqZAp">
+          <node concept="2YIFZM" id="7Sbg4UjPS9a" role="3clFbG">
+            <ref role="1Pybhc" to="2rbz:7Sbg4UjPNNA" resolve="AbstractExtensionProvider" />
+            <ref role="37wK5l" to="2rbz:7Sbg4UjP$Z3" resolve="instanceByPriority" />
+            <node concept="37vLTw" id="7Sbg4UjPS9b" role="37wK5m">
+              <ref role="3cqZAo" node="7Sbg4UjPS93" resolve="extensions" />
+            </node>
+            <node concept="1bVj0M" id="7Sbg4UjPS9c" role="37wK5m">
+              <node concept="3clFbS" id="7Sbg4UjPS9d" role="1bW5cS">
+                <node concept="3clFbF" id="7Sbg4UjPS9e" role="3cqZAp">
+                  <node concept="2ShNRf" id="7Sbg4UjPS9f" role="3clFbG">
+                    <node concept="HV5vD" id="7Sbg4UjPS9g" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="HV5vE" node="7Sbg4UjOCBA" resolve="DefaultConfigCombinationLogic" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7Sbg4UjPS9h" role="1B3o_S" />
+      <node concept="3uibUv" id="7Sbg4UjPS9i" role="3clF45">
+        <ref role="3uigEE" node="7Sbg4UjOBdB" resolve="IConfigCombinationLogic" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="7Sbg4UjP3Uf" role="1B3o_S" />
+    <node concept="3uibUv" id="7Sbg4UjPS$D" role="1zkMxy">
+      <ref role="3uigEE" to="2rbz:7Sbg4UjPNNA" resolve="AbstractExtensionProvider" />
     </node>
   </node>
 </model>

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.typesystem.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.configuration.base/models/org.iets3.variability.configuration.base.typesystem.mps
@@ -2509,136 +2509,152 @@
       <node concept="3clFbH" id="3jDeZf7s1IK" role="3cqZAp" />
       <node concept="3clFbJ" id="34IieWHir4o" role="3cqZAp">
         <node concept="3clFbS" id="34IieWHir4p" role="3clFbx">
-          <node concept="3SKdUt" id="4lyl69nsTIJ" role="3cqZAp">
-            <node concept="1PaTwC" id="4lyl69nsTIK" role="1aUNEU">
-              <node concept="3oM_SD" id="4lyl69nsUuP" role="1PaTwD">
-                <property role="3oM_SC" value="If" />
-              </node>
-              <node concept="3oM_SD" id="4lyl69nsUuR" role="1PaTwD">
-                <property role="3oM_SC" value="a" />
-              </node>
-              <node concept="3oM_SD" id="4lyl69nsUv3" role="1PaTwD">
-                <property role="3oM_SC" value="abstract" />
-              </node>
-              <node concept="3oM_SD" id="4lyl69nsUv7" role="1PaTwD">
-                <property role="3oM_SC" value="config" />
-              </node>
-              <node concept="3oM_SD" id="4lyl69nsUvc" role="1PaTwD">
-                <property role="3oM_SC" value="is" />
-              </node>
-              <node concept="3oM_SD" id="4lyl69nsUvi" role="1PaTwD">
-                <property role="3oM_SC" value="referenced" />
-              </node>
-              <node concept="3oM_SD" id="4lyl69nsUvp" role="1PaTwD">
-                <property role="3oM_SC" value="the" />
-              </node>
-              <node concept="3oM_SD" id="4lyl69nsUvx" role="1PaTwD">
-                <property role="3oM_SC" value="config" />
-              </node>
-              <node concept="3oM_SD" id="4lyl69nsUvE" role="1PaTwD">
-                <property role="3oM_SC" value="itself" />
-              </node>
-              <node concept="3oM_SD" id="4lyl69nsUvO" role="1PaTwD">
-                <property role="3oM_SC" value="must" />
-              </node>
-              <node concept="3oM_SD" id="4lyl69nsUvZ" role="1PaTwD">
-                <property role="3oM_SC" value="be" />
-              </node>
-              <node concept="3oM_SD" id="4lyl69nsUwb" role="1PaTwD">
-                <property role="3oM_SC" value="abstract" />
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWs8" id="4lyl69nenjY" role="3cqZAp">
-            <node concept="3cpWsn" id="4lyl69nenjZ" role="3cpWs9">
-              <property role="TrG5h" value="abstractFMI" />
-              <node concept="3Tqbb2" id="4lyl69nenj7" role="1tU5fm">
-                <ref role="ehGHo" to="4ndm:5NPKd17BIPE" resolve="FeatureModelConfigurationRef" />
-              </node>
-              <node concept="2OqwBi" id="4lyl69nenk0" role="33vP2m">
-                <node concept="2OqwBi" id="4lyl69nenk1" role="2Oq$k0">
-                  <node concept="1YBJjd" id="4lyl69nenk2" role="2Oq$k0">
-                    <ref role="1YBMHb" node="4u9Rq0kmn8n" resolve="fmc" />
+          <node concept="3clFbJ" id="6Y8yTZltiwH" role="3cqZAp">
+            <node concept="3clFbS" id="6Y8yTZltiwJ" role="3clFbx">
+              <node concept="3SKdUt" id="4lyl69nsTIJ" role="3cqZAp">
+                <node concept="1PaTwC" id="4lyl69nsTIK" role="1aUNEU">
+                  <node concept="3oM_SD" id="4lyl69nsUuP" role="1PaTwD">
+                    <property role="3oM_SC" value="If" />
                   </node>
-                  <node concept="2Rf3mk" id="4lyl69nenk3" role="2OqNvi">
-                    <node concept="1xMEDy" id="4lyl69nenk4" role="1xVPHs">
-                      <node concept="chp4Y" id="4lyl69nenk5" role="ri$Ld">
-                        <ref role="cht4Q" to="4ndm:5NPKd17BIPE" resolve="FeatureModelConfigurationRef" />
-                      </node>
-                    </node>
+                  <node concept="3oM_SD" id="4lyl69nsUuR" role="1PaTwD">
+                    <property role="3oM_SC" value="a" />
+                  </node>
+                  <node concept="3oM_SD" id="4lyl69nsUv3" role="1PaTwD">
+                    <property role="3oM_SC" value="abstract" />
+                  </node>
+                  <node concept="3oM_SD" id="4lyl69nsUv7" role="1PaTwD">
+                    <property role="3oM_SC" value="config" />
+                  </node>
+                  <node concept="3oM_SD" id="4lyl69nsUvc" role="1PaTwD">
+                    <property role="3oM_SC" value="is" />
+                  </node>
+                  <node concept="3oM_SD" id="4lyl69nsUvi" role="1PaTwD">
+                    <property role="3oM_SC" value="referenced" />
+                  </node>
+                  <node concept="3oM_SD" id="4lyl69nsUvp" role="1PaTwD">
+                    <property role="3oM_SC" value="the" />
+                  </node>
+                  <node concept="3oM_SD" id="4lyl69nsUvx" role="1PaTwD">
+                    <property role="3oM_SC" value="config" />
+                  </node>
+                  <node concept="3oM_SD" id="4lyl69nsUvE" role="1PaTwD">
+                    <property role="3oM_SC" value="itself" />
+                  </node>
+                  <node concept="3oM_SD" id="4lyl69nsUvO" role="1PaTwD">
+                    <property role="3oM_SC" value="must" />
+                  </node>
+                  <node concept="3oM_SD" id="4lyl69nsUvZ" role="1PaTwD">
+                    <property role="3oM_SC" value="be" />
+                  </node>
+                  <node concept="3oM_SD" id="4lyl69nsUwb" role="1PaTwD">
+                    <property role="3oM_SC" value="abstract" />
                   </node>
                 </node>
-                <node concept="1z4cxt" id="4lyl69nenk6" role="2OqNvi">
-                  <node concept="1bVj0M" id="4lyl69nenk7" role="23t8la">
-                    <node concept="3clFbS" id="4lyl69nenk8" role="1bW5cS">
-                      <node concept="3clFbF" id="4lyl69nenk9" role="3cqZAp">
-                        <node concept="2OqwBi" id="4lyl69nenka" role="3clFbG">
-                          <node concept="2OqwBi" id="4lyl69nenkb" role="2Oq$k0">
-                            <node concept="37vLTw" id="4lyl69nenkc" role="2Oq$k0">
-                              <ref role="3cqZAo" node="4lyl69nenkf" resolve="it" />
-                            </node>
-                            <node concept="3TrEf2" id="4lyl69nenkd" role="2OqNvi">
-                              <ref role="3Tt5mk" to="4ndm:5NPKd17BIPF" resolve="config" />
-                            </node>
-                          </node>
-                          <node concept="3TrcHB" id="4lyl69nenke" role="2OqNvi">
-                            <ref role="3TsBF5" to="4ndm:4onczE5U5c$" resolve="abstract" />
+              </node>
+              <node concept="3cpWs8" id="4lyl69nenjY" role="3cqZAp">
+                <node concept="3cpWsn" id="4lyl69nenjZ" role="3cpWs9">
+                  <property role="TrG5h" value="abstractFMI" />
+                  <node concept="3Tqbb2" id="4lyl69nenj7" role="1tU5fm">
+                    <ref role="ehGHo" to="4ndm:5NPKd17BIPE" resolve="FeatureModelConfigurationRef" />
+                  </node>
+                  <node concept="2OqwBi" id="4lyl69nenk0" role="33vP2m">
+                    <node concept="2OqwBi" id="4lyl69nenk1" role="2Oq$k0">
+                      <node concept="1YBJjd" id="4lyl69nenk2" role="2Oq$k0">
+                        <ref role="1YBMHb" node="4u9Rq0kmn8n" resolve="fmc" />
+                      </node>
+                      <node concept="2Rf3mk" id="4lyl69nenk3" role="2OqNvi">
+                        <node concept="1xMEDy" id="4lyl69nenk4" role="1xVPHs">
+                          <node concept="chp4Y" id="4lyl69nenk5" role="ri$Ld">
+                            <ref role="cht4Q" to="4ndm:5NPKd17BIPE" resolve="FeatureModelConfigurationRef" />
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="gl6BB" id="4lyl69nenkf" role="1bW2Oz">
-                      <property role="TrG5h" value="it" />
-                      <node concept="2jxLKc" id="4lyl69nenkg" role="1tU5fm" />
+                    <node concept="1z4cxt" id="4lyl69nenk6" role="2OqNvi">
+                      <node concept="1bVj0M" id="4lyl69nenk7" role="23t8la">
+                        <node concept="3clFbS" id="4lyl69nenk8" role="1bW5cS">
+                          <node concept="3clFbF" id="4lyl69nenk9" role="3cqZAp">
+                            <node concept="2OqwBi" id="4lyl69nenka" role="3clFbG">
+                              <node concept="2OqwBi" id="4lyl69nenkb" role="2Oq$k0">
+                                <node concept="37vLTw" id="4lyl69nenkc" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="4lyl69nenkf" resolve="it" />
+                                </node>
+                                <node concept="3TrEf2" id="4lyl69nenkd" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="4ndm:5NPKd17BIPF" resolve="config" />
+                                </node>
+                              </node>
+                              <node concept="3TrcHB" id="4lyl69nenke" role="2OqNvi">
+                                <ref role="3TsBF5" to="4ndm:4onczE5U5c$" resolve="abstract" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="gl6BB" id="4lyl69nenkf" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="4lyl69nenkg" role="1tU5fm" />
+                        </node>
+                      </node>
                     </node>
                   </node>
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="3clFbJ" id="4lyl69nepEu" role="3cqZAp">
-            <node concept="3clFbS" id="4lyl69nepEw" role="3clFbx">
-              <node concept="2MkqsV" id="4lyl69neqzF" role="3cqZAp">
-                <node concept="3cpWs3" id="4lyl69nerAd" role="2MkJ7o">
-                  <node concept="Xl_RD" id="4lyl69neqzU" role="3uHU7B">
-                    <property role="Xl_RC" value="Needs to be abstract, at least one abstract Feature Model Configuration referenced. " />
-                  </node>
-                  <node concept="2OqwBi" id="4lyl69nerVt" role="3uHU7w">
-                    <node concept="2OqwBi" id="4lyl69nerSi" role="2Oq$k0">
-                      <node concept="37vLTw" id="4lyl69nerAv" role="2Oq$k0">
-                        <ref role="3cqZAo" node="4lyl69nenjZ" resolve="abstractFMI" />
+              <node concept="3clFbJ" id="4lyl69nepEu" role="3cqZAp">
+                <node concept="3clFbS" id="4lyl69nepEw" role="3clFbx">
+                  <node concept="2MkqsV" id="4lyl69neqzF" role="3cqZAp">
+                    <node concept="3cpWs3" id="4lyl69nerAd" role="2MkJ7o">
+                      <node concept="Xl_RD" id="4lyl69neqzU" role="3uHU7B">
+                        <property role="Xl_RC" value="Needs to be abstract, at least one abstract Feature Model Configuration referenced. " />
                       </node>
-                      <node concept="3TrEf2" id="4lyl69nerUg" role="2OqNvi">
-                        <ref role="3Tt5mk" to="4ndm:5NPKd17BIPF" resolve="config" />
+                      <node concept="2OqwBi" id="4lyl69nerVt" role="3uHU7w">
+                        <node concept="2OqwBi" id="4lyl69nerSi" role="2Oq$k0">
+                          <node concept="37vLTw" id="4lyl69nerAv" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4lyl69nenjZ" resolve="abstractFMI" />
+                          </node>
+                          <node concept="3TrEf2" id="4lyl69nerUg" role="2OqNvi">
+                            <ref role="3Tt5mk" to="4ndm:5NPKd17BIPF" resolve="config" />
+                          </node>
+                        </node>
+                        <node concept="3TrcHB" id="4lyl69nerYw" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
                       </node>
                     </node>
-                    <node concept="3TrcHB" id="4lyl69nerYw" role="2OqNvi">
-                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="1YBJjd" id="4lyl69nesse" role="1urrMF">
-                  <ref role="1YBMHb" node="4u9Rq0kmn8n" resolve="fmc" />
-                </node>
-                <node concept="3Cnw8n" id="4lyl69nFvRs" role="1urrFz">
-                  <ref role="QpYPw" node="4lyl69nFqBj" resolve="fix_MakeConfigAbstract" />
-                  <node concept="3CnSsL" id="4lyl69nFxst" role="3Coj4f">
-                    <ref role="QkamJ" node="4lyl69nFr3h" resolve="fmc" />
-                    <node concept="1YBJjd" id="4lyl69nFxsE" role="3CoRuB">
+                    <node concept="1YBJjd" id="4lyl69nesse" role="1urrMF">
                       <ref role="1YBMHb" node="4u9Rq0kmn8n" resolve="fmc" />
                     </node>
+                    <node concept="3Cnw8n" id="4lyl69nFvRs" role="1urrFz">
+                      <ref role="QpYPw" node="4lyl69nFqBj" resolve="fix_MakeConfigAbstract" />
+                      <node concept="3CnSsL" id="4lyl69nFxst" role="3Coj4f">
+                        <ref role="QkamJ" node="4lyl69nFr3h" resolve="fmc" />
+                        <node concept="1YBJjd" id="4lyl69nFxsE" role="3CoRuB">
+                          <ref role="1YBMHb" node="4u9Rq0kmn8n" resolve="fmc" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3cpWs6" id="XsXh$lOFMN" role="3cqZAp" />
+                </node>
+                <node concept="3y3z36" id="4lyl69neqqk" role="3clFbw">
+                  <node concept="10Nm6u" id="4lyl69neqwV" role="3uHU7w" />
+                  <node concept="37vLTw" id="4lyl69neqpO" role="3uHU7B">
+                    <ref role="3cqZAo" node="4lyl69nenjZ" resolve="abstractFMI" />
                   </node>
                 </node>
               </node>
-              <node concept="3cpWs6" id="XsXh$lOFMN" role="3cqZAp" />
             </node>
-            <node concept="3y3z36" id="4lyl69neqqk" role="3clFbw">
-              <node concept="10Nm6u" id="4lyl69neqwV" role="3uHU7w" />
-              <node concept="37vLTw" id="4lyl69neqpO" role="3uHU7B">
-                <ref role="3cqZAo" node="4lyl69nenjZ" resolve="abstractFMI" />
+            <node concept="3fqX7Q" id="6Y8yTZltpJo" role="3clFbw">
+              <node concept="2OqwBi" id="6Y8yTZltpJq" role="3fr31v">
+                <node concept="2YIFZM" id="6Y8yTZltpJr" role="2Oq$k0">
+                  <ref role="37wK5l" to="ch50:7Sbg4UjPS90" resolve="instance" />
+                  <ref role="1Pybhc" to="ch50:7Sbg4UjP3T$" resolve="ConfigCombinationLogic" />
+                </node>
+                <node concept="liA8E" id="6Y8yTZltpJs" role="2OqNvi">
+                  <ref role="37wK5l" to="ch50:7Sbg4UjOEaG" resolve="allowAbstractSubConfigs" />
+                </node>
               </node>
             </node>
           </node>
+          <node concept="3clFbH" id="6Y8yTZlttUq" role="3cqZAp" />
           <node concept="3SKdUt" id="73vFf09CZ5u" role="3cqZAp">
             <node concept="1PaTwC" id="73vFf09CZ5v" role="1aUNEU">
               <node concept="3oM_SD" id="73vFf09CZYI" role="1PaTwD">

--- a/code/languages/org.iets3.opensource/languages/org.iets3.variability.featuremodel.base/models/org.iets3.variability.featuremodel.base.plugin.mps
+++ b/code/languages/org.iets3.opensource/languages/org.iets3.variability.featuremodel.base/models/org.iets3.variability.featuremodel.base.plugin.mps
@@ -41,6 +41,7 @@
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="rmn3" ref="r:2f587aa6-2d3f-4726-9564-7648183caf97(org.iets3.variability.base.structure)" />
     <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
+    <import index="2rbz" ref="r:aeef8772-8af4-45c3-a762-623d4009d953(org.iets3.variability.base.plugin)" />
   </imports>
   <registry>
     <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
@@ -76,9 +77,14 @@
       </concept>
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+        <child id="1188214630783" name="value" index="2B76xF" />
       </concept>
       <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="1188214545140" name="jetbrains.mps.baseLanguage.structure.AnnotationInstanceValue" flags="ng" index="2B6LJw">
+        <reference id="1188214555875" name="key" index="2B6OnR" />
+        <child id="1188214607812" name="value" index="2B70Vg" />
       </concept>
       <concept id="1095950406618" name="jetbrains.mps.baseLanguage.structure.DivExpression" flags="nn" index="FJ1c_" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
@@ -133,6 +139,7 @@
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <property id="1075300953594" name="abstractClass" index="1sVAO0" />
         <property id="1221565133444" name="isFinal" index="1EXbeo" />
+        <child id="1095933932569" name="implementedInterface" index="EKbjA" />
         <child id="1165602531693" name="superclass" index="1zkMxy" />
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
@@ -296,6 +303,9 @@
       </concept>
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
         <child id="8970989240999019149" name="part" index="1dT_Ay" />
+      </concept>
+      <concept id="8465538089690331492" name="jetbrains.mps.baseLanguage.javadoc.structure.DeprecatedBlockDocTag" flags="ng" index="TZ5HI">
+        <child id="2667874559098216723" name="text" index="3HnX3l" />
       </concept>
       <concept id="8970989240999019143" name="jetbrains.mps.baseLanguage.javadoc.structure.TextCommentLinePart" flags="ng" index="1dT_AC">
         <property id="8970989240999019144" name="text" index="1dT_AB" />
@@ -6287,10 +6297,108 @@
     <node concept="2tJIrI" id="307NTAcZrTN" role="jymVt" />
     <node concept="3clFb_" id="26cjRACVPUy" role="jymVt">
       <property role="TrG5h" value="getPriorityLevel" />
-      <property role="1EzhhJ" value="true" />
       <node concept="10Oyi0" id="26cjRACVPUz" role="3clF45" />
       <node concept="3Tm1VV" id="26cjRACVPU$" role="1B3o_S" />
-      <node concept="3clFbS" id="26cjRACVPU_" role="3clF47" />
+      <node concept="3clFbS" id="26cjRACVPU_" role="3clF47">
+        <node concept="3clFbF" id="7Sbg4UjQsVA" role="3cqZAp">
+          <node concept="37vLTw" id="7Sbg4UjQsV_" role="3clFbG">
+            <ref role="3cqZAo" to="2rbz:7Sbg4UjOCYU" resolve="DEFAULT_PRIORITY" />
+          </node>
+        </node>
+      </node>
+      <node concept="P$JXv" id="7Sbg4UjQlit" role="lGtFl">
+        <node concept="TZ5HI" id="7Sbg4UjQliu" role="3nqlJM">
+          <node concept="TZ5HA" id="7Sbg4UjQliv" role="3HnX3l">
+            <node concept="1dT_AC" id="7Sbg4UjQoWe" role="1dT_Ay">
+              <property role="1dT_AB" value="Replaced by IExtensionWithPriority.priority()" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="7Sbg4UjQliw" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Deprecated" resolve="Deprecated" />
+        <node concept="2B6LJw" id="7Sbg4UjQlog" role="2B76xF">
+          <ref role="2B6OnR" to="wyt6:~Deprecated.since()" resolve="since" />
+          <node concept="Xl_RD" id="7Sbg4UjQoVd" role="2B70Vg">
+            <property role="Xl_RC" value="2026-05-21" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="7Sbg4UjQts4" role="jymVt" />
+    <node concept="3clFb_" id="7Sbg4UjQtyE" role="jymVt">
+      <property role="TrG5h" value="priority" />
+      <node concept="10Oyi0" id="7Sbg4UjQtyF" role="3clF45" />
+      <node concept="3Tm1VV" id="7Sbg4UjQtyG" role="1B3o_S" />
+      <node concept="2AHcQZ" id="7Sbg4UjQtyK" role="2AJF6D">
+        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+      </node>
+      <node concept="3clFbS" id="7Sbg4UjQtyL" role="3clF47">
+        <node concept="3SKdUt" id="7Sbg4UjQEJJ" role="3cqZAp">
+          <node concept="1PaTwC" id="7Sbg4UjQEJK" role="1aUNEU">
+            <node concept="3oM_SD" id="7Sbg4UjQESL" role="1PaTwD">
+              <property role="3oM_SC" value="forward" />
+            </node>
+            <node concept="3oM_SD" id="7Sbg4UjQET2" role="1PaTwD">
+              <property role="3oM_SC" value="to" />
+            </node>
+            <node concept="3oM_SD" id="7Sbg4UjQET4" role="1PaTwD">
+              <property role="3oM_SC" value="old" />
+            </node>
+            <node concept="3oM_SD" id="7Sbg4UjQETl" role="1PaTwD">
+              <property role="3oM_SC" value="method" />
+            </node>
+            <node concept="3oM_SD" id="7Sbg4UjQETm" role="1PaTwD">
+              <property role="3oM_SC" value="as" />
+            </node>
+            <node concept="3oM_SD" id="7Sbg4UjQETB" role="1PaTwD">
+              <property role="3oM_SC" value="some" />
+            </node>
+            <node concept="3oM_SD" id="7Sbg4UjQETC" role="1PaTwD">
+              <property role="3oM_SC" value="extension" />
+            </node>
+            <node concept="3oM_SD" id="7Sbg4UjQETT" role="1PaTwD">
+              <property role="3oM_SC" value="points" />
+            </node>
+            <node concept="3oM_SD" id="7Sbg4UjQEUa" role="1PaTwD">
+              <property role="3oM_SC" value="might" />
+            </node>
+            <node concept="3oM_SD" id="7Sbg4UjQEUr" role="1PaTwD">
+              <property role="3oM_SC" value="override" />
+            </node>
+            <node concept="3oM_SD" id="7Sbg4UjQEUW" role="1PaTwD">
+              <property role="3oM_SC" value="it" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7Sbg4UjQEbu" role="3cqZAp">
+          <node concept="1rXfSq" id="7Sbg4UjQEbt" role="3clFbG">
+            <ref role="37wK5l" node="26cjRACVPUy" resolve="getPriorityLevel" />
+          </node>
+        </node>
+      </node>
+      <node concept="P$JXv" id="7Sbg4UjQG3Y" role="lGtFl">
+        <node concept="TZ5HA" id="7Sbg4UjQG3Z" role="TZ5H$">
+          <node concept="1dT_AC" id="7Sbg4UjQG40" role="1dT_Ay">
+            <property role="1dT_AB" value="Newer extensions of this class can override priority()." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7Sbg4UjQGmD" role="TZ5H$">
+          <node concept="1dT_AC" id="7Sbg4UjQGmE" role="1dT_Ay">
+            <property role="1dT_AB" value="Older extensions still can use getPriorityLevel(), but should migrate to the new one." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7Sbg4UjQGwB" role="TZ5H$">
+          <node concept="1dT_AC" id="7Sbg4UjQGwC" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="7Sbg4UjQGwD" role="TZ5H$">
+          <node concept="1dT_AC" id="7Sbg4UjQGwE" role="1dT_Ay">
+            <property role="1dT_AB" value="TODO: Delete this implementation as soon as deprecation window for getPriorityLevel() closes." />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2tJIrI" id="307NTAd047q" role="jymVt" />
     <node concept="3clFb_" id="307NTAcZu5B" role="jymVt">
@@ -6388,29 +6496,19 @@
         <node concept="1dT_AC" id="7SixFixkY7U" role="1dT_Ay" />
       </node>
     </node>
+    <node concept="3uibUv" id="7Sbg4UjQl5y" role="EKbjA">
+      <ref role="3uigEE" to="2rbz:7Sbg4UjPubL" resolve="IExtensionWithPriority" />
+    </node>
+    <node concept="3uibUv" id="7Sbg4UjQpBC" role="1zkMxy">
+      <ref role="3uigEE" to="2rbz:7Sbg4UjPvkH" resolve="AbstractExtensionWithPriority" />
+    </node>
   </node>
   <node concept="312cEu" id="307NTAcZvpY">
     <property role="3GE5qa" value="tailoring" />
     <property role="TrG5h" value="DefaultIETS3VariabilitySettings" />
-    <node concept="2tJIrI" id="307NTAd04rZ" role="jymVt" />
     <node concept="3Tm1VV" id="307NTAcZvpZ" role="1B3o_S" />
     <node concept="3uibUv" id="307NTAcZvrW" role="1zkMxy">
       <ref role="3uigEE" node="307NTAcYTHv" resolve="IETS3VariabilitySettings" />
-    </node>
-    <node concept="3clFb_" id="26cjRACVSeU" role="jymVt">
-      <property role="TrG5h" value="getPriorityLevel" />
-      <node concept="10Oyi0" id="26cjRACVSeV" role="3clF45" />
-      <node concept="3Tm1VV" id="26cjRACVSeW" role="1B3o_S" />
-      <node concept="3clFbS" id="26cjRACVSeY" role="3clF47">
-        <node concept="3clFbF" id="26cjRACVSxu" role="3cqZAp">
-          <node concept="3cmrfG" id="26cjRACVSxt" role="3clFbG">
-            <property role="3cmrfH" value="0" />
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="26cjRACVSeZ" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
     </node>
     <node concept="2tJIrI" id="307NTAd04ui" role="jymVt" />
     <node concept="3clFb_" id="307NTAdNFOi" role="jymVt">

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base.ext/models/test.org.iets3.variability.configuration.base.ext.plugin.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base.ext/models/test.org.iets3.variability.configuration.base.ext.plugin.mps
@@ -22,6 +22,7 @@
     <import index="tp5g" ref="r:00000000-0000-4000-0000-011c89590388(jetbrains.mps.lang.test.structure)" />
     <import index="tp6m" ref="r:00000000-0000-4000-0000-011c895903a2(jetbrains.mps.lang.test.runtime)" />
     <import index="2gg1" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.errors(MPS.Core/)" />
+    <import index="2rbz" ref="r:aeef8772-8af4-45c3-a762-623d4009d953(org.iets3.variability.base.plugin)" />
     <import index="hwgx" ref="r:fd2980c8-676c-4b19-b524-18c70e02f8b7(com.mbeddr.core.base.behavior)" implicit="true" />
   </imports>
   <registry>
@@ -61,13 +62,15 @@
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
-      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <child id="1095933932569" name="implementedInterface" index="EKbjA" />
+        <child id="1165602531693" name="superclass" index="1zkMxy" />
       </concept>
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
-        <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
       <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
@@ -102,9 +105,6 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
-      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
-        <property id="1068580320021" name="value" index="3cmrfH" />
-      </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
@@ -112,7 +112,6 @@
       <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
-      <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="nn" index="1gVbGN">
@@ -151,14 +150,10 @@
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
-      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
-        <child id="1199542457201" name="resultType" index="1ajl9A" />
-      </concept>
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
-      <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="nn" index="1Bd96e" />
     </language>
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
       <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
@@ -256,43 +251,6 @@
   <node concept="312cEu" id="1e_Qt5zgHq">
     <property role="3GE5qa" value="tailoring" />
     <property role="TrG5h" value="SomeEnrichedNameLogic" />
-    <node concept="Wx3nA" id="6vXjBkn_5Nh" role="jymVt">
-      <property role="TrG5h" value="PRIO_INACTIVE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tm6S6" id="6vXjBkn_4vS" role="1B3o_S" />
-      <node concept="10Oyi0" id="6vXjBkn_5F6" role="1tU5fm" />
-      <node concept="3cpWsd" id="4O1MtdoPc8s" role="33vP2m">
-        <node concept="3cmrfG" id="4O1MtdoPc96" role="3uHU7w">
-          <property role="3cmrfH" value="10000" />
-        </node>
-        <node concept="37vLTw" id="4O1MtdoPaf3" role="3uHU7B">
-          <ref role="3cqZAo" to="ch50:6vXjBknmRAN" resolve="DEFAULT_PRIORITY" />
-        </node>
-      </node>
-    </node>
-    <node concept="Wx3nA" id="6vXjBkn_fMH" role="jymVt">
-      <property role="TrG5h" value="PRIO_ACTIVE" />
-      <property role="3TUv4t" value="true" />
-      <node concept="3Tm6S6" id="6vXjBkn_eY7" role="1B3o_S" />
-      <node concept="10Oyi0" id="6vXjBkn_fDU" role="1tU5fm" />
-      <node concept="3cpWs3" id="6vXjBkn_hTx" role="33vP2m">
-        <node concept="3cmrfG" id="6vXjBkn_hTZ" role="3uHU7w">
-          <property role="3cmrfH" value="10000" />
-        </node>
-        <node concept="37vLTw" id="6vXjBkn_ger" role="3uHU7B">
-          <ref role="3cqZAo" to="ch50:6vXjBknmRAN" resolve="DEFAULT_PRIORITY" />
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="6vXjBkn_6W0" role="jymVt" />
-    <node concept="Wx3nA" id="6vXjBknsopM" role="jymVt">
-      <property role="TrG5h" value="myPriority" />
-      <node concept="10Oyi0" id="6vXjBknm_Ib" role="1tU5fm" />
-      <node concept="3Tm6S6" id="6vXjBkn$wH_" role="1B3o_S" />
-      <node concept="37vLTw" id="6vXjBkn_ae9" role="33vP2m">
-        <ref role="3cqZAo" node="6vXjBkn_5Nh" resolve="PRIO_INACTIVE" />
-      </node>
-    </node>
     <node concept="Wx3nA" id="6vXjBknspw1" role="jymVt">
       <property role="TrG5h" value="useEnrichedNameForUniqueness" />
       <node concept="10P_77" id="6vXjBknn7N9" role="1tU5fm" />
@@ -300,53 +258,6 @@
       <node concept="3clFbT" id="6vXjBknn9nN" role="33vP2m" />
     </node>
     <node concept="2tJIrI" id="6vXjBknmzzz" role="jymVt" />
-    <node concept="2YIFZL" id="6vXjBkn_pIp" role="jymVt">
-      <property role="TrG5h" value="doTest" />
-      <node concept="3clFbS" id="6vXjBkn_pIs" role="3clF47">
-        <node concept="3clFbF" id="6vXjBkn_r2Y" role="3cqZAp">
-          <node concept="1rXfSq" id="6vXjBkn_r2W" role="3clFbG">
-            <ref role="37wK5l" node="6vXjBkn$$9u" resolve="switchOn" />
-            <node concept="3clFbT" id="6vXjBkn_rj7" role="37wK5m" />
-          </node>
-        </node>
-        <node concept="3clFbF" id="6vXjBkn_rIM" role="3cqZAp">
-          <node concept="2OqwBi" id="6vXjBkn_s46" role="3clFbG">
-            <node concept="37vLTw" id="6vXjBkn_rIK" role="2Oq$k0">
-              <ref role="3cqZAo" node="6vXjBkn_q9r" resolve="action" />
-            </node>
-            <node concept="1Bd96e" id="6vXjBkn_sy4" role="2OqNvi" />
-          </node>
-        </node>
-        <node concept="3clFbF" id="6vXjBkn_qCm" role="3cqZAp">
-          <node concept="1rXfSq" id="6vXjBkn_qCl" role="3clFbG">
-            <ref role="37wK5l" node="6vXjBkn$Q8Y" resolve="switchOff" />
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="6vXjBkn_p1l" role="1B3o_S" />
-      <node concept="3cqZAl" id="6vXjBkn_p_e" role="3clF45" />
-      <node concept="37vLTG" id="6vXjBkn_q9r" role="3clF46">
-        <property role="TrG5h" value="action" />
-        <node concept="1ajhzC" id="6vXjBkn_q9p" role="1tU5fm">
-          <node concept="3cqZAl" id="6vXjBkn_qo9" role="1ajl9A" />
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="6vXjBknC7ja" role="jymVt" />
-    <node concept="2YIFZL" id="6vXjBknCaFI" role="jymVt">
-      <property role="TrG5h" value="switchOn" />
-      <node concept="3clFbS" id="6vXjBknCaFL" role="3clF47">
-        <node concept="3clFbF" id="6vXjBknCbkF" role="3cqZAp">
-          <node concept="1rXfSq" id="6vXjBknCbkE" role="3clFbG">
-            <ref role="37wK5l" node="6vXjBkn$$9u" resolve="switchOn" />
-            <node concept="3clFbT" id="6vXjBknCbG8" role="37wK5m" />
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="6vXjBknC9LN" role="1B3o_S" />
-      <node concept="3cqZAl" id="6vXjBknCavt" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="6vXjBkn_sIV" role="jymVt" />
     <node concept="2YIFZL" id="6vXjBkn$$9u" role="jymVt">
       <property role="TrG5h" value="switchOn" />
       <node concept="37vLTG" id="6vXjBkn$L8e" role="3clF46">
@@ -354,16 +265,6 @@
         <node concept="10P_77" id="6vXjBkn$L8f" role="1tU5fm" />
       </node>
       <node concept="3clFbS" id="6vXjBkn$$9x" role="3clF47">
-        <node concept="3clFbF" id="6vXjBkn$_aG" role="3cqZAp">
-          <node concept="37vLTI" id="6vXjBkn$Bfv" role="3clFbG">
-            <node concept="37vLTw" id="6vXjBkn$_aF" role="37vLTJ">
-              <ref role="3cqZAo" node="6vXjBknsopM" resolve="myPriority" />
-            </node>
-            <node concept="37vLTw" id="6vXjBkn$HQX" role="37vLTx">
-              <ref role="3cqZAo" node="6vXjBkn_fMH" resolve="PRIO_ACTIVE" />
-            </node>
-          </node>
-        </node>
         <node concept="3clFbF" id="6vXjBkn$Lzm" role="3cqZAp">
           <node concept="37vLTI" id="6vXjBkn$MMm" role="3clFbG">
             <node concept="37vLTw" id="6vXjBkn$N0S" role="37vLTx">
@@ -374,6 +275,12 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbF" id="7Sbg4UjRsDm" role="3cqZAp">
+          <node concept="2YIFZM" id="7Sbg4UjRsM0" role="3clFbG">
+            <ref role="1Pybhc" to="2rbz:1e_Qt5zgHq" resolve="TestableExtensionWithPriority" />
+            <ref role="37wK5l" to="2rbz:6vXjBknCaFI" resolve="switchOn" />
+          </node>
+        </node>
       </node>
       <node concept="3Tm1VV" id="6vXjBkn$zrQ" role="1B3o_S" />
       <node concept="3cqZAl" id="6vXjBkn$zZV" role="3clF45" />
@@ -382,14 +289,10 @@
     <node concept="2YIFZL" id="6vXjBkn$Q8Y" role="jymVt">
       <property role="TrG5h" value="switchOff" />
       <node concept="3clFbS" id="6vXjBkn$Q91" role="3clF47">
-        <node concept="3clFbF" id="6vXjBkn$SaR" role="3cqZAp">
-          <node concept="37vLTI" id="6vXjBkn$Wzf" role="3clFbG">
-            <node concept="37vLTw" id="6vXjBkn_dQt" role="37vLTx">
-              <ref role="3cqZAo" node="6vXjBkn_5Nh" resolve="PRIO_INACTIVE" />
-            </node>
-            <node concept="37vLTw" id="6vXjBkn$SaQ" role="37vLTJ">
-              <ref role="3cqZAo" node="6vXjBknsopM" resolve="myPriority" />
-            </node>
+        <node concept="3clFbF" id="7Sbg4UjRtC7" role="3cqZAp">
+          <node concept="2YIFZM" id="7Sbg4UjRtLQ" role="3clFbG">
+            <ref role="37wK5l" to="2rbz:6vXjBkn$Q8Y" resolve="switchOff" />
+            <ref role="1Pybhc" to="2rbz:1e_Qt5zgHq" resolve="TestableExtensionWithPriority" />
           </node>
         </node>
         <node concept="3clFbF" id="6vXjBkn$Zys" role="3cqZAp">
@@ -769,22 +672,6 @@
         <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
       </node>
     </node>
-    <node concept="2tJIrI" id="1e_Qt5$Bhg" role="jymVt" />
-    <node concept="3clFb_" id="1e_Qt5$A79" role="jymVt">
-      <property role="TrG5h" value="priority" />
-      <node concept="10Oyi0" id="1e_Qt5$A7a" role="3clF45" />
-      <node concept="3Tm1VV" id="1e_Qt5$A7b" role="1B3o_S" />
-      <node concept="3clFbS" id="1e_Qt5$A7g" role="3clF47">
-        <node concept="3clFbF" id="1e_Qt5$A7j" role="3cqZAp">
-          <node concept="37vLTw" id="6vXjBknmNve" role="3clFbG">
-            <ref role="3cqZAo" node="6vXjBknsopM" resolve="myPriority" />
-          </node>
-        </node>
-      </node>
-      <node concept="2AHcQZ" id="1e_Qt5$A7h" role="2AJF6D">
-        <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
-      </node>
-    </node>
     <node concept="3UR2Jj" id="4O1MtdoMvrC" role="lGtFl">
       <node concept="TZ5HA" id="4O1MtdoMvrD" role="TZ5H$">
         <node concept="1dT_AC" id="4O1MtdoMvrE" role="1dT_Ay">
@@ -801,6 +688,9 @@
           <property role="1dT_AB" value="Using a typical pattern, the priority of the extension can be changed by tests in order to activate it." />
         </node>
       </node>
+    </node>
+    <node concept="3uibUv" id="7Sbg4UjRel9" role="1zkMxy">
+      <ref role="3uigEE" to="2rbz:1e_Qt5zgHq" resolve="TestableExtensionWithPriority" />
     </node>
   </node>
   <node concept="1lYeZD" id="7TK9se3Zi5c">

--- a/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.enrichedNames@tests.mps
+++ b/code/languages/org.iets3.opensource/tests/test.org.iets3.variability.configuration.base/models/test.org.iets3.variability.configuration.base.enrichedNames@tests.mps
@@ -27,6 +27,7 @@
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="tp5g" ref="r:00000000-0000-4000-0000-011c89590388(jetbrains.mps.lang.test.structure)" />
     <import index="rmn3" ref="r:2f587aa6-2d3f-4726-9564-7648183caf97(org.iets3.variability.base.structure)" />
+    <import index="2rbz" ref="r:aeef8772-8af4-45c3-a762-623d4009d953(org.iets3.variability.base.plugin)" implicit="true" />
   </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
@@ -339,7 +340,7 @@
       <node concept="3clFbS" id="6vXjBknwW_G" role="3clF47">
         <node concept="3clFbF" id="6vXjBkn_nqD" role="3cqZAp">
           <node concept="2YIFZM" id="6vXjBkn_xQr" role="3clFbG">
-            <ref role="37wK5l" to="qqx9:6vXjBkn_pIp" resolve="doTest" />
+            <ref role="37wK5l" to="2rbz:6vXjBkn_pIp" resolve="doTest" />
             <ref role="1Pybhc" to="qqx9:1e_Qt5zgHq" resolve="SomeEnrichedNameLogic" />
             <node concept="1bVj0M" id="6vXjBkn_xSV" role="37wK5m">
               <node concept="3clFbS" id="6vXjBkn_xSZ" role="1bW5cS">
@@ -1075,7 +1076,7 @@
       <node concept="3clFbS" id="6vXjBknBa3p" role="2VODD2">
         <node concept="3clFbF" id="6vXjBknBa4u" role="3cqZAp">
           <node concept="2YIFZM" id="6vXjBknCpUi" role="3clFbG">
-            <ref role="37wK5l" to="qqx9:6vXjBknCaFI" resolve="switchOn" />
+            <ref role="37wK5l" to="2rbz:6vXjBknCaFI" resolve="switchOn" />
             <ref role="1Pybhc" to="qqx9:1e_Qt5zgHq" resolve="SomeEnrichedNameLogic" />
           </node>
         </node>
@@ -1265,8 +1266,8 @@
     <node concept="0EjCn" id="6vXjBknCr6$" role="0EEgL">
       <node concept="3clFbS" id="6vXjBknCr6_" role="2VODD2">
         <node concept="3clFbF" id="6vXjBknCr6A" role="3cqZAp">
-          <node concept="2YIFZM" id="6vXjBknCr6B" role="3clFbG">
-            <ref role="37wK5l" to="qqx9:6vXjBknCaFI" resolve="switchOn" />
+          <node concept="2YIFZM" id="7Sbg4UjSevU" role="3clFbG">
+            <ref role="37wK5l" to="2rbz:6vXjBknCaFI" resolve="switchOn" />
             <ref role="1Pybhc" to="qqx9:1e_Qt5zgHq" resolve="SomeEnrichedNameLogic" />
           </node>
         </node>
@@ -1275,7 +1276,7 @@
     <node concept="0EjCo" id="6vXjBknCr6C" role="0EEgW">
       <node concept="3clFbS" id="6vXjBknCr6D" role="2VODD2">
         <node concept="3clFbF" id="6vXjBknCr6E" role="3cqZAp">
-          <node concept="2YIFZM" id="6vXjBknCr6F" role="3clFbG">
+          <node concept="2YIFZM" id="7Sbg4UjSexk" role="3clFbG">
             <ref role="37wK5l" to="qqx9:6vXjBkn$Q8Y" resolve="switchOff" />
             <ref role="1Pybhc" to="qqx9:1e_Qt5zgHq" resolve="SomeEnrichedNameLogic" />
           </node>
@@ -1780,7 +1781,7 @@
       <node concept="3clFbS" id="4O1MtdoK7L_" role="2VODD2">
         <node concept="3clFbF" id="4O1MtdoK7LA" role="3cqZAp">
           <node concept="2YIFZM" id="4O1MtdoK7LB" role="3clFbG">
-            <ref role="37wK5l" to="qqx9:6vXjBknCaFI" resolve="switchOn" />
+            <ref role="37wK5l" to="2rbz:6vXjBknCaFI" resolve="switchOn" />
             <ref role="1Pybhc" to="qqx9:1e_Qt5zgHq" resolve="SomeEnrichedNameLogic" />
           </node>
         </node>


### PR DESCRIPTION
## Summary

Combining configurations (via `extends`, `abstract`, and references to sub-configurations) needs to vary per application — the single standard methodology is not enough (#1794). This PR introduces the extension point **`configCombinationLogicExtPoint`** with interface **`IConfigCombinationLogic`** so the combination logic becomes configurable per application, generalises the priority-based extension-point infrastructure it builds on, makes the configuration checking depend on the active logic, and adds a hashing scheme covering a configuration together with all configurations reachable from it.

Resolves #1794. This PR is required by companion PR IETS3/iets3.core#1755.

## Changes

**New `configCombinationLogicExtPoint` extension point** — `org.iets3.variability.configuration.base.plugin`
- New extension point `configCombinationLogicExtPoint` with API `IConfigCombinationLogic` (currently `allowAbstractSubConfigs(): boolean`), letting each application plug in its own configuration-combining rules.
- Default behaviour via `DefaultConfigCombinationLogic`.

**Configuration checking now depends on the extension point** — `org.iets3.variability.configuration.base.typesystem`
- `check_FeatureModelConfiguration` flags referenced abstract sub-configurations only when the active `IConfigCombinationLogic` disallows them (`allowAbstractSubConfigs()`), so applications that permit abstract sub-configs no longer get false errors.

**Reusable priority-based extension-point base** — `org.iets3.variability.base.plugin`
- New `IExtensionWithPriority` interface with `AbstractExtensionWithPriority` / `AbstractExtensionProvider` base classes, factoring out the "pick the registered extension with the highest priority" pattern that was previously hard-wired into the enriched-config-name logic.
- The existing enriched-config-name extension point (`enrichedConfigNameLogicExtPoint`) was refactored onto this shared base.
- Added `TestableExtensionWithPriority`.

**Hashing over a config and all reachable configs** — `org.iets3.variability.configuration.base.behavior`
- Refactored the transient per-config hash storage into a small hierarchy: new base `AbstractConfigHashing` with `SolverRelevantDataHashing` (reworked) and `AllDetailsHashing` (new); the hash is cached on the configuration node and recomputed only when the source changes.
- New `AllReachableConfigTraversal` helper (a `Traversal<FeatureModelConfiguration>` following sub-config references) that visits a configuration and every configuration reachable from it.
- The new traversal is used from the companion PR in IETS3.Core (see above).
